### PR TITLE
Fix off-by-one error in single-GPU, CUDA<5.5 stream init.

### DIFF
--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -314,7 +314,7 @@ void initQudaMemory()
   }
   cudaStreamCreateWithPriority(&streams[Nstream-1], cudaStreamDefault, leastPriority);
 #else
-  for (int i=0; i<Nstream-1; i++) {
+  for (int i=0; i<Nstream; i++) {
     cudaStreamCreate(&streams[i]);
   }
 #endif


### PR DESCRIPTION
Otherwise you get e.g.:
ERROR: (CUDA) invalid resource handle (cuda_color_spinor_field.cu:53 in cudaColorSpinorField())
Thanks!
