### PR TITLE
Feature/printversion

### DIFF
--- a/configure
+++ b/configure
@@ -651,6 +651,7 @@ CPPFLAGS
 LDFLAGS
 CFLAGS
 CC
+GIT
 target_alias
 host_alias
 build_alias
@@ -1949,6 +1950,43 @@ ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
+
+
+# Extract the first word of "git", so it can be a program name with args.
+set dummy git; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_GIT+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test -n "$GIT"; then
+  ac_cv_prog_GIT="$GIT" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_prog_GIT="git"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+fi
+fi
+GIT=$ac_cv_prog_GIT
+if test -n "$GIT"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $GIT" >&5
+$as_echo "$GIT" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,6 @@
 AC_INIT([quda],[0.7],[quda-developers@googlegroups.com])
 
+AC_CHECK_PROG([GIT],[git],git)
 
 dnl Specify CUDA Location
 AC_ARG_WITH(cuda,

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -143,6 +143,15 @@ CORE = $(QUDA_CORE:%=dslash_core/%)
 CUDA_VERSION = $(shell awk '/\#define CUDA_VERSION/{print $$3}' $(CUDA_INSTALL_PATH)/include/cuda.h)
 HASH = \"cpu_arch=$(strip $(CPU_ARCH)),gpu_arch=$(strip $(GPU_ARCH)),cuda_version=$(strip $(CUDA_VERSION))\"
 
+
+DGITVERSION =
+ifeq ($(strip $(GIT)), git)
+	GITVERSION = $(shell git describe --long --dirty 2> /dev/null)
+ifneq ($(GITVERSION),)
+	  DGITVERSION = -DGITVERSION=\"$(GITVERSION)\"
+endif
+endif
+
 # limit maximum number of registers in BLAS routines to increase occupancy
 ifneq (,$(filter $(strip $(GPU_ARCH)),sm_20 sm_21 sm_30))
   MAXREG =
@@ -153,8 +162,8 @@ endif
 all: $(QUDA)
 
 
-$(QUDA): $(QUDA_OBJS) ../make.inc
-	ar cru $@ $(QUDA_OBJS)
+$(QUDA): $(QUDA_OBJS) version.o ../make.inc
+	ar cru $@  version.o $(QUDA_OBJS)
 
 gen:
 	$(PYTHON) generate/dslash_cuda_gen.py
@@ -172,6 +181,12 @@ gen:
 
 clean:
 	-rm -f *.o $(QUDA)
+
+version.o: version.cpp $(HDRS) $(QUDA_OBJS)
+	$(CXX) $(CXXFLAGS) $(DGITVERSION) $< -c -o $@
+
+interface_quda.o: interface_quda.cpp $(HDRS)
+	$(CXX) $(CXXFLAGS) $(DGITVERSION) $< -c -o $@
 
 tune.o: tune.cpp $(HDRS)
 	$(CXX) $(CXXFLAGS) -DQUDA_HASH=$(HASH) $< -c -o $@

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -425,9 +425,25 @@ void initQudaMemory()
   loadTuneCache(getVerbosity());
 }
 
+#define STR_(x) #x
+#define STR(x) STR_(x)
+  static const std::string quda_version = STR(QUDA_VERSION_MAJOR) "." STR(QUDA_VERSION_MINOR) "." STR(QUDA_VERSION_SUBMINOR);
+#undef STR
+#undef STR_
+
+extern char* gitversion;
+
 void initQuda(int dev)
 {
   profileInit.Start(QUDA_PROFILE_TOTAL);
+
+  if (getVerbosity() >= QUDA_SUMMARIZE) {
+#ifdef GITVERSION
+    printfQuda("QUDA %s (git %s)\n",quda_version.c_str(),gitversion);
+#else
+    printfQuda("QUDA %s\n",quda_version.c_str());
+#endif
+  }
 
   // initialize communications topology, if not already done explicitly via initCommsGridQuda()
   if (!comms_initialized) init_default_comms();

--- a/lib/version.cpp
+++ b/lib/version.cpp
@@ -1,0 +1,5 @@
+#ifdef GITVERSION
+const char* gitversion = GITVERSION ;
+#else
+const char* gitversion;
+#endif

--- a/make.inc.in
+++ b/make.inc.in
@@ -9,6 +9,7 @@ QDPXX_LIBS = @QDPXX_LIBS@
 CPU_ARCH = @CPU_ARCH@  	  # x86 or x86_64
 GPU_ARCH = @GPU_ARCH@	  # sm_13, sm_20, sm_21, sm_30, or sm_35
 OS       = @QUDA_OS@	  # linux or osx
+GIT      = @GIT@
 
 PYTHON = @QUDA_PYTHON@	  # python 2.5 or later required for 'make gen'
 


### PR DESCRIPTION
Print QUDA version number when quda is initialized.
If git is detected add output from git describe like
`v0.7.0-1-g9527547` i.e. `tag-number of commits since tag-sha-[dirty]`.
`dirty` is added if the repository contains uncommitted changes.