### PR TITLE
Always link with pthreads library for building of google test API.

### DIFF
--- a/make.inc.in
+++ b/make.inc.in
@@ -180,10 +180,7 @@ ifeq ($(strip $(POSIX_THREADS)), yes)
   COPT += -DPTHREADS
 endif
 
-ifeq ($(strip $(POSIX_THREADS)), yes)
-  LIB += -lpthread
-endif
-
+LIB += -lpthread
 
 ifeq ($(strip $(BUILD_WILSON_DIRAC)), yes)
   NVCCOPT += -DGPU_WILSON_DIRAC


### PR DESCRIPTION
This fixes a bug on some systems where the pthreads library isn't automatically linked with the executable (POSIX threads are used by the Google Test API).