### PR TITLE
Added direct/inverse labelling to TwistCloverDslashCuda.

### DIFF
--- a/lib/dslash_quda.cu
+++ b/lib/dslash_quda.cu
@@ -431,9 +431,9 @@ class TwistCloverGamma5Cuda : public Tunable {
 
     strcpy(aux_string,in->AuxString());
     if (twist == QUDA_TWIST_GAMMA5_DIRECT) {
-      strcat(aux_string,"direct");
+      strcat(aux_string,",direct");
     } else {
-      strcat(aux_string,"inverse");
+      strcat(aux_string,",inverse");
     }
   }
     virtual ~TwistCloverGamma5Cuda() {


### PR DESCRIPTION
I've added the direct/inverse label but instead of replacing in->AuxString(), I've concatenated the two so we don't lose any information in there.