### PR TITLE
Fix GPU_COMMS for full-field fermions

### DIFF
--- a/lib/cuda_color_spinor_field.cu
+++ b/lib/cuda_color_spinor_field.cu
@@ -217,10 +217,20 @@ namespace quda {
       even = new cudaColorSpinorField(*this, param);
       odd = new cudaColorSpinorField(*this, param);
 
-      // need this hackery for the moment (need to locate the odd pointer half way into the full field)
+      // need this hackery for the moment (need to locate the odd pointers half way into the full field)
       (dynamic_cast<cudaColorSpinorField*>(odd))->v = (void*)((char*)v + bytes/2);
       if (precision == QUDA_HALF_PRECISION) 
 	(dynamic_cast<cudaColorSpinorField*>(odd))->norm = (void*)((char*)norm + norm_bytes/2);
+
+      for(int i=0; i<nDim; ++i){
+        if(commDimPartitioned(i)){
+          (dynamic_cast<cudaColorSpinorField*>(odd))->ghost[i] =
+	    static_cast<char*>((dynamic_cast<cudaColorSpinorField*>(odd))->ghost[i]) + bytes/2;
+          if(precision == QUDA_HALF_PRECISION)
+	    (dynamic_cast<cudaColorSpinorField*>(odd))->ghostNorm[i] =
+	      static_cast<char*>((dynamic_cast<cudaColorSpinorField*>(odd))->ghostNorm[i]) + norm_bytes/2;
+        }
+      }
 
 #ifdef USE_TEXTURE_OBJECTS
       dynamic_cast<cudaColorSpinorField*>(even)->destroyTexObject();


### PR DESCRIPTION
This pull request fixes a problem with GPU_COMMS with full-field fermions.  The ghost pointers need to be updated for the odd subset in a similar way that the v and norm pointers are redirected after the odd subsets have been updated.  This pull request should fix #231.