### PR TITLE
Feature/milc interface cloverinvert

### DIFF
--- a/lib/inv_bicgstab_quda.cpp
+++ b/lib/inv_bicgstab_quda.cpp
@@ -146,7 +146,7 @@ namespace quda {
     const bool use_heavy_quark_res = 
       (param.residual_type & QUDA_HEAVY_QUARK_RESIDUAL) ? true : false;
     double heavy_quark_res = use_heavy_quark_res ? sqrt(HeavyQuarkResidualNormCuda(x,r).z) : 0.0;
-    int heavy_quark_check = 10; // how often to check the heavy quark residual
+    const int heavy_quark_check = 1; // how often to check the heavy quark residual
 
     double delta = param.delta;
 

--- a/lib/inv_bicgstab_quda.cpp
+++ b/lib/inv_bicgstab_quda.cpp
@@ -146,7 +146,7 @@ namespace quda {
     const bool use_heavy_quark_res = 
       (param.residual_type & QUDA_HEAVY_QUARK_RESIDUAL) ? true : false;
     double heavy_quark_res = use_heavy_quark_res ? sqrt(HeavyQuarkResidualNormCuda(x,r).z) : 0.0;
-    const int heavy_quark_check = 1; // how often to check the heavy quark residual
+    int heavy_quark_check = 10; // how often to check the heavy quark residual
 
     double delta = param.delta;
 

--- a/lib/milc_interface.cpp
+++ b/lib/milc_interface.cpp
@@ -1007,7 +1007,7 @@ void setInvertParam(QudaInvertParam &invertParam, QudaInvertArgs_t &inv_args,
     device_precision_sloppy = device_precision;
   }
  
-   
+  static const QudaVerbosity verbosity = getVerbosity();
 
   invertParam.dslash_type                   = QUDA_CLOVER_WILSON_DSLASH;
   invertParam.kappa                         = kappa;
@@ -1018,8 +1018,8 @@ void setInvertParam(QudaInvertParam &invertParam, QudaInvertArgs_t &inv_args,
   invertParam.maxiter                       = inv_args.max_iter;
 
   invertParam.cuda_prec_precondition        = device_precision_sloppy;
-  invertParam.verbosity_precondition        = QUDA_SILENT;
-  invertParam.verbosity        = QUDA_SILENT;
+  invertParam.verbosity_precondition        = verbosity;
+  invertParam.verbosity        = verbosity;
   invertParam.cpu_prec                      = host_precision;
   invertParam.cuda_prec                     = device_precision;
   invertParam.cuda_prec_sloppy              = device_precision_sloppy;

--- a/lib/milc_interface.cpp
+++ b/lib/milc_interface.cpp
@@ -11,7 +11,7 @@
 #include <dslash_quda.h>
 
 #define MAX(a,b) ((a)>(b)?(a):(b))
-#define BUILD_MILC_INTERFACE
+
 #ifdef BUILD_MILC_INTERFACE
 
 static bool initialized = false;
@@ -485,7 +485,7 @@ static void setInvertParams(const int dim[4],
   invertParam->gamma_basis = QUDA_DEGRAND_ROSSI_GAMMA_BASIS; // not used, but required by the code.
   invertParam->dirac_order = QUDA_DIRAC_ORDER;
 
-  invertParam->dslash_type = QUDA_STAGGERED_DSLASH;
+  invertParam->dslash_type = QUDA_ASQTAD_DSLASH;
   invertParam->tune = QUDA_TUNE_YES;
   invertParam->gflops = 0.0;
 


### PR DESCRIPTION
This allows qudaCloverInvert to be call with only a fermilab / heavy-quark residual to be specified. 
It goes back to issues reported by Carleton.

If removed the change to the frequency of `heavy_quark_check` from this branch and created #243 to track this.

