### PR TITLE
remove call to cudaSetDeviceFlags(cudaDeviceMapHost) as it is implici…

### DIFF
--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -381,12 +381,6 @@ void initQudaDevice(int dev) {
   }
 #endif
 
-  // if the device supports host-mapped memory, then enable this
-#ifndef USE_QDPJIT
-  if(deviceProp.canMapHostMemory) cudaSetDeviceFlags(cudaDeviceMapHost);
-  checkCudaError();
-#endif
-
   cudaDeviceSetCacheConfig(cudaFuncCachePreferL1);
   //cudaDeviceSetSharedMemConfig(cudaSharedMemBankSizeEightByte);
   cudaGetDeviceProperties(&deviceProp, dev);


### PR DESCRIPTION
…t for the runtime API and might cause issues with CUDA aware MPI (already created CUDA context).

See #197 for some longer discussion on this.