### PR TITLE
New FloatNOrder, gauge fixing and some pure gauge gauge configuration routines

### DIFF
--- a/include/gauge_tools.h
+++ b/include/gauge_tools.h
@@ -1,4 +1,14 @@
 namespace quda {
   double	plaquette	(const GaugeField& data, QudaFieldLocation location);
   void		APEStep		(GaugeField &dataDs, const GaugeField& dataOr, double alpha, QudaFieldLocation location);
+
+  
+  void gaugefixingOVR( cudaGaugeField& data, const unsigned int gauge_dir, \
+    const unsigned int Nsteps, const unsigned int verbose_interval, const double relax_boost, \
+    const double tolerance, const unsigned int reunit_interval, const unsigned int stopWtheta);
+
+
+  void gaugefixingFFT( cudaGaugeField& data, const unsigned int gauge_dir, \
+    const unsigned int Nsteps, const unsigned int verbose_interval, const double alpha, const unsigned int autotune, \
+    const double tolerance, const unsigned int stopWtheta) ;
 }

--- a/include/hisq_links_quda.h
+++ b/include/hisq_links_quda.h
@@ -49,6 +49,9 @@ void unitarizeLinksCPU(const QudaGaugeParam& param,
 
 bool isUnitary(const QudaGaugeParam& param, cpuGaugeField& field, double max_error);
 
+
+void unitarizeLinksQuda(cudaGaugeField& links, int* fails);
+
 } // namespace quda
 
 

--- a/include/pgauge_monte.h
+++ b/include/pgauge_monte.h
@@ -1,0 +1,28 @@
+#ifndef _MONTE_H
+#define _MONTE_H
+
+
+
+#include <random.h>
+#include <quda.h>
+
+
+
+namespace quda {
+  
+  double2 Plaquette( cudaGaugeField& data) ;
+  void Monte( cudaGaugeField& data, cuRNGState *rngstate, double Beta, unsigned int nhb, unsigned int nover);
+  void InitGaugeField( cudaGaugeField& data);
+  void InitGaugeField( cudaGaugeField& data, cuRNGState *rngstate);
+
+  /*Exchange "borders" between nodes
+  int R[4] = {0,0,0,0};
+  for(int dir=0; dir<4; ++dir) if(comm_dim_partitioned(dir)) R[dir] = 2;
+  Although the radius border is 2, it only updates the interior radius border, i.e., at 1 and X[d-2]
+  where X[d] already includes the Radius border, and don't update at 0 and X[d-1] faces  */
+  void PGaugeExchange( cudaGaugeField& data, const int dir, const int parity);
+  void PGaugeExchangeFree();
+
+}
+
+#endif 

--- a/include/quda.h
+++ b/include/quda.h
@@ -733,6 +733,31 @@ extern "C" {
 
   void performAPEnStep(unsigned int nSteps, double alpha);
   double plaqCuda();
+
+
+
+int computeGaugeFixingOVRQuda(void* gauge,
+                      const unsigned int gauge_dir,  
+                      const unsigned int Nsteps, 
+                      const unsigned int verbose_interval, 
+                      const double relax_boost, 
+                      const double tolerance, 
+                      const unsigned int reunit_interval, 
+                      const unsigned int stopWtheta, 
+                      QudaGaugeParam* param, 
+                      double* timeinfo);
+
+int computeGaugeFixingFFTQuda(void* gauge,
+                      const unsigned int gauge_dir,  
+                      const unsigned int Nsteps, 
+                      const unsigned int verbose_interval, 
+                      const double alpha,
+                      const unsigned int autotune, 
+                      const double tolerance,  
+                      const unsigned int stopWtheta, 
+                      QudaGaugeParam* param, 
+                      double* timeinfo);
+
   /**
   * Open/Close MAGMA library
   *

--- a/include/quda_milc_interface.h
+++ b/include/quda_milc_interface.h
@@ -237,6 +237,34 @@ extern "C" {
 
   void* qudaCreateGaugeField(void* gauge, int geometry, int precision);
 
+
+
+
+void qudaGaugeFixingOVR( const int precision,
+    const unsigned int gauge_dir, 
+    const int Nsteps,
+    const int verbose_interval,
+    const double relax_boost,
+    const double tolerance,
+    const unsigned int reunit_interval,
+    const unsigned int stopWtheta,
+    void* milc_sitelink
+    );
+
+
+
+void qudaGaugeFixingFFT( int precision,
+    unsigned int gauge_dir, 
+    int Nsteps,
+    int verbose_interval,
+    double alpha,
+    unsigned int autotune,
+    double tolerance,
+    unsigned int stopWtheta,
+    void* milc_sitelink
+    );
+
+
   void qudaSaveGaugeField(void* gauge, void* inGauge);
 
   void qudaDestroyGaugeField(void* gauge);

--- a/include/random.h
+++ b/include/random.h
@@ -1,0 +1,140 @@
+
+#ifndef RANDOM_GPU_H
+#define RANDOM_GPU_H
+
+//#include <stdio.h>
+//#include <string.h>
+//#include <iostream>
+#include <curand_kernel.h>
+
+namespace quda {
+
+#if defined(XORWOW)
+typedef struct curandStateXORWOW cuRNGState;
+#elif defined(MRG32k3a)
+typedef struct curandStateMRG32k3a cuRNGState;
+#else
+typedef struct curandStateMRG32k3a cuRNGState;
+#endif
+
+/**
+    @brief Class declaration to initialize and hold CURAND RNG states
+*/
+class RNG {
+public:
+    RNG(int rng_sizes, int seedin, int XX[4]);
+    RNG(int rng_sizes, int seedin);
+    /*! free array */
+    void Release(); 
+    /*! initialize curand rng states with seed */
+    void Init();
+    /*! @brief return curand rng array size */
+    int Size(){ return rng_size;};
+    int Node_Offset(){ return node_offset;};
+    int Seed(){ return seed;};
+    cuRNGState* State(){ return state;};
+private:
+    /*! array with current curand rng state */
+    cuRNGState *state;
+    /*! initial rng seed */
+    int seed;
+    /*! @brief number of curand states */
+    int rng_size;  
+    /*! @brief offset in the index, in case of multigpus */
+    int node_offset;
+    int X[4];
+    /*! @brief allocate curand rng states array in device memory */
+    void AllocateRNG();
+    /*! @brief CURAND array states initialization */
+    void INITRNG(int rng_sizes, int seedin, int offsetin);
+};
+
+
+
+
+
+/**
+   @brief Return a random number between a and b
+   @param state curand rng state
+   @param a lower range
+   @param b upper range
+   @return  random number in range a,b
+*/
+template<class Real>
+inline  __device__ Real Random(cuRNGState &state, Real a, Real b){
+    Real res;
+    return res;
+}
+ 
+template<>
+inline  __device__ float Random<float>(cuRNGState &state, float a, float b){
+    return a + (b - a) * curand_uniform(&state);
+}
+
+template<>
+inline  __device__ double Random<double>(cuRNGState &state, double a, double b){
+    return a + (b - a) * curand_uniform_double(&state);
+}
+
+/**
+   @brief Return a random number between 0 and 1
+   @param state curand rng state
+   @return  random number in range 0,1
+*/
+template<class Real>
+inline  __device__ Real Random(cuRNGState &state){
+    Real res;
+    return res;
+}
+ 
+template<>
+inline  __device__ float Random<float>(cuRNGState &state){
+    return curand_uniform(&state);
+}
+
+template<>
+inline  __device__ double Random<double>(cuRNGState &state){
+    return curand_uniform_double(&state);
+}
+
+
+template<class Real>
+struct uniform { };
+template<>
+struct uniform<float> {
+    __device__
+        static inline float rand(cuRNGState &state) {
+        return curand_uniform(&state);
+    }
+};
+template<>
+struct uniform<double> {
+    __device__
+        static inline double rand(cuRNGState &state) {
+        return curand_uniform_double(&state);
+    }
+};
+
+
+
+template<class Real>
+struct normal { };
+template<>
+struct normal<float> {
+    __device__
+        static inline float rand(cuRNGState &state) {
+        return curand_normal(&state);
+    }
+};
+template<>
+struct normal<double> {
+    __device__
+        static inline double rand(cuRNGState &state) {
+        return curand_normal_double(&state);
+    }
+};
+
+
+}
+
+#endif 

--- a/lib/CUFFT_Plans.h
+++ b/lib/CUFFT_Plans.h
@@ -1,0 +1,101 @@
+
+#ifndef CUFFT_PLANS_H
+#define CUFFT_PLANS_H
+
+#include <quda_internal.h>
+#include <quda_matrix.h>
+#include <cufft.h>
+
+/*-------------------------------------------------------------------------------*/
+#define CUFFT_SAFE_CALL( call) {                                      \
+    cufftResult err = call;                                         \
+    if( CUFFT_SUCCESS != err) {                                     \
+        fprintf(stderr, "CUFFT error in file '%s' in line %i.\n",   \
+                __FILE__, __LINE__);                                \
+        exit(EXIT_FAILURE);                                         \
+    } }
+/*-------------------------------------------------------------------------------*/
+
+
+
+
+inline void ApplyFFT(cufftHandle &plan, float2 *data_in, float2 *data_out, int direction){
+
+    CUFFT_SAFE_CALL(cufftExecC2C(plan, (cufftComplex *)data_in, (cufftComplex *)data_out, direction));
+}
+
+inline void ApplyFFT(cufftHandle &plan, double2 *data_in, double2 *data_out, int direction){
+
+    CUFFT_SAFE_CALL(cufftExecZ2Z(plan, (cufftDoubleComplex *)data_in, (cufftDoubleComplex *)data_out, direction));
+}
+
+
+
+void SetPlanFFTMany( cufftHandle &plan, int4 size, int dim, float2 *data){
+    switch(dim){
+    case 1:		
+    {int n[1] = {size.w};
+            cufftPlanMany(&plan, 1, n, NULL, 1, 0, NULL, 1, 0, CUFFT_C2C, size.x * size.y * size.z);
+    }
+    break;
+    case 3:
+    {int n[3] = {size.x, size.y, size.z};
+        cufftPlanMany(&plan, 3, n, NULL, 1, 0, NULL, 1, 0, CUFFT_C2C, size.w);
+    }
+    break;
+    }
+    //printf("Created %dD FFT Plan in Single Precision\n", dim);
+}
+
+inline void SetPlanFFTMany( cufftHandle &plan, int4 size, int dim, double2 *data){
+    switch(dim){
+    case 1:		
+    {int n[1] = {size.w};
+            cufftPlanMany(&plan, 1, n, NULL, 1, 0, NULL, 1, 0, CUFFT_Z2Z, size.x * size.y * size.z);
+    }
+    break;
+    case 3:
+    {int n[3] = {size.x, size.y, size.z};
+        cufftPlanMany(&plan, 3, n, NULL, 1, 0, NULL, 1, 0, CUFFT_Z2Z, size.w);
+    }
+    break;
+    }
+    //printf("Created %dD FFT Plan in Double Precision\n", dim);
+}
+
+
+inline void SetPlanFFT2DMany( cufftHandle &plan, int4 size, int dim, float2 *data){
+    switch(dim){
+    case 0:		
+    {int n[2] = {size.w, size.z};
+            cufftPlanMany(&plan, 2, n, NULL, 1, 0, NULL, 1, 0, CUFFT_C2C, size.x * size.y);
+    }
+    break;
+    case 1:
+    {int n[2] = {size.y, size.x};
+        cufftPlanMany(&plan, 2, n, NULL, 1, 0, NULL, 1, 0, CUFFT_C2C, size.z * size.w);
+    }
+    break;
+    }
+    //printf("Created 2D FFT Plan in Single Precision\n");
+}
+
+inline void SetPlanFFT2DMany( cufftHandle &plan, int4 size, int dim, double2 *data){
+    switch(dim){
+    case 0:		
+    {int n[2] = {size.w, size.z};
+            cufftPlanMany(&plan, 2, n, NULL, 1, 0, NULL, 1, 0, CUFFT_Z2Z, size.x * size.y);
+    }
+    break;
+    case 1:
+    {int n[2] = {size.y, size.x};
+        cufftPlanMany(&plan, 2, n, NULL, 1, 0, NULL, 1, 0, CUFFT_Z2Z, size.z * size.w);
+    }
+    break;
+    }
+    //printf("Created 2D FFT Plan in Double Precision\n");
+}
+
+
+#endif
+

--- a/lib/CUFFT_Plans.h
+++ b/lib/CUFFT_Plans.h
@@ -72,7 +72,7 @@ inline void SetPlanFFT2DMany( cufftHandle &plan, int4 size, int dim, float2 *dat
     }
     break;
     case 1:
-    {int n[2] = {size.y, size.x};
+    {int n[2] = {size.x, size.y};
         cufftPlanMany(&plan, 2, n, NULL, 1, 0, NULL, 1, 0, CUFFT_C2C, size.z * size.w);
     }
     break;
@@ -88,7 +88,7 @@ inline void SetPlanFFT2DMany( cufftHandle &plan, int4 size, int dim, double2 *da
     }
     break;
     case 1:
-    {int n[2] = {size.y, size.x};
+    {int n[2] = {size.x, size.y};
         cufftPlanMany(&plan, 2, n, NULL, 1, 0, NULL, 1, 0, CUFFT_Z2Z, size.z * size.w);
     }
     break;

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -2,7 +2,9 @@ include ../make.inc
 
 QUDA = libquda.a
 
-QUDA_OBJS = gauge_phase.o timer.o malloc.o solver.o			\
+QUDA_OBJS = pgauge_exchange.o pgauge_init.o pgauge_plaquette.o \
+	pgauge_heatbath.o random.o gauge_fix_ovr_extra.o gauge_fix_fft.o gauge_fix_ovr.o \
+    gauge_phase.o timer.o malloc.o solver.o			\
 	inv_bicgstab_quda.o inv_cg_quda.o inv_multi_cg_quda.o		\
 	inv_eigcg_quda.o gauge_ape.o gauge_plaq.o inv_gcr_quda.o	\
 	inv_mr_quda.o inv_sd_quda.o inv_xsd_quda.o inv_pcg_quda.o	\
@@ -45,7 +47,8 @@ QUDA_HDRS = blas_quda.h clover_field.h color_spinor_field.h convert.h	\
 	texture.h eig_variables.h numa_affinity.h misc_helpers.h	\
 	fermion_force_quda.h malloc_quda.h gauge_field_order.h		\
 	clover_field_order.h color_spinor_field_order.h			\
-	staggered_oprod.h lanczos_quda.h ritz_quda.h blas_magma.h
+	staggered_oprod.h lanczos_quda.h ritz_quda.h blas_magma.h \
+	random.h pgauge_monte.h
 
 
 # These are only inlined into blas_quda.cu

--- a/lib/copy_gauge_extended.cu
+++ b/lib/copy_gauge_extended.cu
@@ -9,72 +9,100 @@ namespace quda {
   struct CopyGaugeExArg {
     OutOrder out;
     const InOrder in;
-    int E[QUDA_MAX_DIM]; // geometry of extended gauge field
-    int X[QUDA_MAX_DIM]; // geometry of the normal gauge field
+    int Xin[QUDA_MAX_DIM]; 
+    int Xout[QUDA_MAX_DIM];
     int volume;
     int volumeEx;
     int nDim;
     int geometry;
     int faceVolumeCB[QUDA_MAX_DIM];
-    CopyGaugeExArg(const OutOrder &out, const InOrder &in, const int *E, const int *X, 
-		   const int *faceVolumeCB, int nDim, int geometry) 
-      : out(out), in(in), volume(2*in.volumeCB), volumeEx(2*out.volumeCB), 
-	nDim(nDim), geometry(geometry) {
+    bool regularToextended;
+    CopyGaugeExArg(const OutOrder &out, const InOrder &in, const int *Xout, const int *Xin, 
+       const int *faceVolumeCB, int nDim, int geometry) 
+      : out(out), in(in), 
+  nDim(nDim), geometry(geometry) {
       for (int d=0; d<nDim; d++) {
-	this->E[d] = E[d];
-	this->X[d] = X[d];
-	this->faceVolumeCB[d] = faceVolumeCB[d];
+  this->Xout[d] = Xout[d];
+  this->Xin[d] = Xin[d];
+  this->faceVolumeCB[d] = faceVolumeCB[d];
+      }
+      if(out.volumeCB > in.volumeCB){
+        this->volume = 2*in.volumeCB;
+        this->volumeEx = 2*out.volumeCB;
+        this->regularToextended = true;
+      }
+      else{
+        this->volume = 2*out.volumeCB;
+        this->volumeEx = 2*in.volumeCB;
+        this->regularToextended = false;
       }
     }
+
   };
 
   /**
-     Copy a regular gauge field into an extended gauge field
+     Copy a regular/extended gauge field into an extended/regular gauge field
   */
-  template <typename FloatOut, typename FloatIn, int length, typename OutOrder, typename InOrder>
+  template <typename FloatOut, typename FloatIn, int length, typename OutOrder, typename InOrder, bool regularToextended>
   __device__ __host__ void copyGaugeEx(CopyGaugeExArg<OutOrder,InOrder> &arg, int X, int parity) {
     typedef typename mapper<FloatIn>::type RegTypeIn;
     typedef typename mapper<FloatOut>::type RegTypeOut;
 
     int x[4];
     int R[4];
-    for (int d=0; d<4; d++) R[d] = (arg.E[d] - arg.X[d]) >> 1;
-    
-    int za = X/(arg.X[0]/2);
-    int x0h = X - za*(arg.X[0]/2);
-    int zb = za/arg.X[1];
-    x[1] = za - zb*arg.X[1];
-    x[3] = zb / arg.X[2];
-    x[2] = zb - x[3]*arg.X[2];
-    x[0] = 2*x0h + ((x[1] + x[2] + x[3] + parity) & 1);
-    
-    // Y is the cb spatial index into the extended gauge field
-    int Y = ((((x[3]+R[3])*arg.E[2] + (x[2]+R[2]))*arg.E[1] + (x[1]+R[1]))*arg.E[0]+(x[0]+R[0])) >> 1;
-    
+    int xin, xout;
+    if(regularToextended){
+      //regular to extended
+      for (int d=0; d<4; d++) R[d] = (arg.Xout[d] - arg.Xin[d]) >> 1;
+      int za = X/(arg.Xin[0]/2);
+      int x0h = X - za*(arg.Xin[0]/2);
+      int zb = za/arg.Xin[1];
+      x[1] = za - zb*arg.Xin[1];
+      x[3] = zb / arg.Xin[2];
+      x[2] = zb - x[3]*arg.Xin[2];
+      x[0] = 2*x0h + ((x[1] + x[2] + x[3] + parity) & 1);
+      // Y is the cb spatial index into the extended gauge field
+      xout = ((((x[3]+R[3])*arg.Xout[2] + (x[2]+R[2]))*arg.Xout[1] + (x[1]+R[1]))*arg.Xout[0]+(x[0]+R[0])) >> 1;
+      xin = X;
+    }
+    else{
+      //extended to regular gauge
+      for (int d=0; d<4; d++) R[d] = (arg.Xin[d] - arg.Xout[d]) >> 1; 
+      int za = X/(arg.Xout[0]/2);
+      int x0h = X - za*(arg.Xout[0]/2);
+      int zb = za/arg.Xout[1];
+      x[1] = za - zb*arg.Xout[1];
+      x[3] = zb / arg.Xout[2];
+      x[2] = zb - x[3]*arg.Xout[2];
+      x[0] = 2*x0h + ((x[1] + x[2] + x[3] + parity) & 1);
+      // Y is the cb spatial index into the extended gauge field
+      xin = ((((x[3]+R[3])*arg.Xin[2] + (x[2]+R[2]))*arg.Xin[1] + (x[1]+R[1]))*arg.Xin[0]+(x[0]+R[0])) >> 1;
+      xout = X;     
+    } 
     for(int d=0; d<arg.geometry; d++){
       RegTypeIn in[length];
       RegTypeOut out[length];
-      arg.in.load(in, X, d, parity);
+      arg.in.load(in, xin, d, parity);
       for (int i=0; i<length; i++) out[i] = in[i];
-      arg.out.save(out, Y, d, parity);
+      arg.out.save(out, xout, d, parity);
     }//dir
   }
 
-  template <typename FloatOut, typename FloatIn, int length, typename OutOrder, typename InOrder>
+  template <typename FloatOut, typename FloatIn, int length, typename OutOrder, typename InOrder, bool regularToextended>
   void copyGaugeEx(CopyGaugeExArg<OutOrder,InOrder> arg) {
     for (int parity=0; parity<2; parity++) {
       for(int X=0; X<arg.volume/2; X++){
-	copyGaugeEx<FloatOut, FloatIn, length, OutOrder, InOrder>(arg, X, parity);
+  copyGaugeEx<FloatOut, FloatIn, length, OutOrder, InOrder, regularToextended>(arg, X, parity);
       }
     }
   }
 
-  template <typename FloatOut, typename FloatIn, int length, typename OutOrder, typename InOrder>
+  template <typename FloatOut, typename FloatIn, int length, typename OutOrder, typename InOrder, bool regularToextended>
   __global__ void copyGaugeExKernel(CopyGaugeExArg<OutOrder,InOrder> arg) {
     for (int parity=0; parity<2; parity++) {
       int X = blockIdx.x * blockDim.x + threadIdx.x;
       if (X >= arg.volume/2) return;
-      copyGaugeEx<FloatOut, FloatIn, length, OutOrder, InOrder>(arg, X, parity);
+      copyGaugeEx<FloatOut, FloatIn, length, OutOrder, InOrder, regularToextended>(arg, X, parity);
     }
   }
 
@@ -101,14 +129,18 @@ namespace quda {
     void apply(const cudaStream_t &stream) {
       TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
 
+
       if (location == QUDA_CPU_FIELD_LOCATION) {
-	copyGaugeEx<FloatOut, FloatIn, length>(arg);
+  if(arg.regularToextended) copyGaugeEx<FloatOut, FloatIn, length, OutOrder, InOrder, true>(arg);
+  else copyGaugeEx<FloatOut, FloatIn, length, OutOrder, InOrder, false>(arg);
       } else if (location == QUDA_CUDA_FIELD_LOCATION) {
 #if (__COMPUTE_CAPABILITY__ >= 200)
-	copyGaugeExKernel<FloatOut, FloatIn, length, OutOrder, InOrder> 
-	  <<<tp.grid, tp.block, tp.shared_bytes, stream>>>(arg);
+   if(arg.regularToextended) copyGaugeExKernel<FloatOut, FloatIn, length, OutOrder, InOrder, true> 
+    <<<tp.grid, tp.block, tp.shared_bytes, stream>>>(arg);
+   else copyGaugeExKernel<FloatOut, FloatIn, length, OutOrder, InOrder, false> 
+    <<<tp.grid, tp.block, tp.shared_bytes, stream>>>(arg);
 #else
-	errorQuda("Extended gauge copy not supported on pre-Fermi architecture");
+  errorQuda("Extended gauge copy not supported on pre-Fermi architecture");
 #endif
       }
     }

--- a/lib/gauge_fix_fft.cu
+++ b/lib/gauge_fix_fft.cu
@@ -1,0 +1,1150 @@
+#include <quda_internal.h>
+#include <quda_matrix.h>
+#include <tune_quda.h>
+#include <gauge_field.h>
+#include <gauge_field_order.h>
+#include <cub/cub.cuh> 
+#include <launch_kernel.cuh>
+
+#include <device_functions.h>
+
+#include <cufft.h>
+#include <CUFFT_Plans.h>
+
+
+
+namespace quda {
+
+
+
+
+#ifndef FL_UNITARIZE_PI
+#define FL_UNITARIZE_PI 3.14159265358979323846
+#endif
+
+
+
+#define GAUGEFIXING_SITE_MATRIX_LOAD_TEX 1
+
+
+
+texture<float2, 1, cudaReadModeElementType> GXTexSingle;
+texture<int4, 1, cudaReadModeElementType> GXTexDouble;
+texture<float2, 1, cudaReadModeElementType> DELTATexSingle;
+texture<int4, 1, cudaReadModeElementType> DELTATexDouble;
+
+
+template <class T> 
+inline __device__ T TEXTURE_GX(int id){
+	return 0.0;
+}
+template <>
+inline __device__ typename ComplexTypeId<float>::Type TEXTURE_GX<typename ComplexTypeId<float>::Type>(int id){
+	return tex1Dfetch(GXTexSingle, id);
+}
+template <>
+inline __device__ typename ComplexTypeId<double>::Type TEXTURE_GX<typename ComplexTypeId<double>::Type>(int id){
+    int4 u = tex1Dfetch(GXTexDouble, id);
+    return  makeComplex(__hiloint2double(u.y, u.x), __hiloint2double(u.w, u.z));
+}
+template <class T> 
+inline __device__ T TEXTURE_DELTA(int id){
+	return 0.0;
+}
+template <>
+inline __device__ typename ComplexTypeId<float>::Type TEXTURE_DELTA<typename ComplexTypeId<float>::Type>(int id){
+	return tex1Dfetch(DELTATexSingle, id);
+}
+template <>
+inline __device__ typename ComplexTypeId<double>::Type TEXTURE_DELTA<typename ComplexTypeId<double>::Type>(int id){
+    int4 u = tex1Dfetch(DELTATexDouble, id);
+    return  makeComplex(__hiloint2double(u.y, u.x), __hiloint2double(u.w, u.z));
+}
+
+static void BindTex(typename ComplexTypeId<float>::Type *delta, typename ComplexTypeId<float>::Type *gx, size_t bytes){
+	#if (GAUGEFIXING_SITE_MATRIX_LOAD_TEX == 1)
+	cudaBindTexture(0, GXTexSingle, gx, bytes);
+	cudaBindTexture(0, DELTATexSingle, delta, bytes);
+	#endif
+}
+static void BindTex(typename ComplexTypeId<double>::Type *delta, typename ComplexTypeId<double>::Type *gx, size_t bytes){
+	#if (GAUGEFIXING_SITE_MATRIX_LOAD_TEX == 1)
+	cudaBindTexture(0, GXTexDouble, gx, bytes);
+	cudaBindTexture(0, DELTATexDouble, delta, bytes);
+	#endif
+}
+
+static void UnBindTex(typename ComplexTypeId<float>::Type *delta, typename ComplexTypeId<float>::Type *gx){
+	#if (GAUGEFIXING_SITE_MATRIX_LOAD_TEX == 1)
+	cudaUnbindTexture(GXTexSingle);
+	cudaUnbindTexture(DELTATexSingle);
+	#endif
+}
+static void UnBindTex(typename ComplexTypeId<double>::Type *delta, typename ComplexTypeId<double>::Type *gx){
+	#if (GAUGEFIXING_SITE_MATRIX_LOAD_TEX == 1)
+	cudaUnbindTexture(GXTexDouble);
+	cudaUnbindTexture(DELTATexDouble);
+	#endif
+}
+
+
+template<class T>
+__device__ __host__ inline Matrix<T,3> getSubTraceUnit(const Matrix<T,3>& a){
+	T tr = (a(0,0) + a(1,1) + a(2,2)) / 3.0;
+	Matrix<T,3> res;
+	res(0,0) = a(0,0)- tr; res(0,1) = a(0,1); res(0,2) = a(0,2);
+	res(1,0) = a(1,0); res(1,1) = a(1,1)-tr; res(1,2) = a(1,2);
+	res(2,0) = a(2,0); res(2,1) = a(2,1); res(2,2) = a(2,2)-tr;
+	return res;
+}
+
+template<class T>
+__device__ __host__ inline void SubTraceUnit(Matrix<T,3>& a){
+	T tr = (a(0,0) + a(1,1) + a(2,2)) / 3.0;
+	a(0,0)-= tr; a(1,1) -= tr; a(2,2) -= tr;
+}
+
+template<class T>
+__device__ __host__ inline double getRealTraceUVdagger(const Matrix<T,3>& a, const Matrix<T,3>& b){
+	double sum = (double)(a(0,0).x * b(0,0).x  + a(0,0).y * b(0,0).y);
+	sum += (double)(a(0,1).x * b(0,1).x  + a(0,1).y * b(0,1).y);
+	sum += (double)(a(0,2).x * b(0,2).x  + a(0,2).y * b(0,2).y);
+	sum += (double)(a(1,0).x * b(1,0).x  + a(1,0).y * b(1,0).y);
+	sum += (double)(a(1,1).x * b(1,1).x  + a(1,1).y * b(1,1).y);
+	sum += (double)(a(1,2).x * b(1,2).x  + a(1,2).y * b(1,2).y);
+	sum += (double)(a(2,0).x * b(2,0).x  + a(2,0).y * b(2,0).y);
+	sum += (double)(a(2,1).x * b(2,1).x  + a(2,1).y * b(2,1).y);
+	sum += (double)(a(2,2).x * b(2,2).x  + a(2,2).y * b(2,2).y);
+	return sum;
+}
+
+
+static  __inline__ __device__ double atomicAdd(double *addr, double val){
+	double old=*addr, assumed;
+	do {
+		assumed = old;
+		old = __longlong_as_double( atomicCAS((unsigned long long int*)addr,
+				__double_as_longlong(assumed),
+				__double_as_longlong(val+assumed)));
+	} while( __double_as_longlong(assumed)!=__double_as_longlong(old) );
+
+	return old;
+}
+
+static  __inline__ __device__ double2 atomicAdd(double2 *addr, double2 val){
+	double2 old=*addr;
+	old.x = atomicAdd((double*)addr, val.x);
+	old.y = atomicAdd((double*)addr+1, val.y);
+	return old;
+}
+
+
+#if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 200
+		//CUDA 6.5 NOT DETECTING ATOMICADD FOR FLOAT TYPE!!!!!!!
+static __inline__ __device__ float atomicAdd(float *address, float val)
+{
+	return __fAtomicAdd(address, val);
+}
+#endif /* !__CUDA_ARCH__ || __CUDA_ARCH__ >= 200 */
+
+
+
+template <typename T>
+struct Summ {
+	__host__ __device__ __forceinline__ T operator()(const T &a, const T &b){
+		return a + b;
+	}
+};
+template <>
+struct Summ<double2>{
+	__host__ __device__ __forceinline__ double2 operator()(const double2 &a, const double2 &b){
+		return make_double2(a.x+b.x, a.y+b.y);
+	}
+};
+
+
+
+
+static __device__ __host__ inline int linkIndex3(int x[], int dx[], const int X[4]) {
+	int y[4];
+	for (int i=0; i<4; i++) y[i] = (x[i] + dx[i] + X[i]) % X[i];
+	int idx = (((y[3]*X[2] + y[2])*X[1] + y[1])*X[0] + y[0]) >> 1;
+	return idx;
+}
+static __device__ __host__ inline int linkIndex(int x[], const int X[4]) {
+	int idx = (((x[3]*X[2] + x[2])*X[1] + x[1])*X[0] + x[0]) >> 1;
+	return idx;
+}
+static __device__ __host__ inline int linkIndexM1(int x[], const int X[4], const int mu) {
+	int y[4];
+	for (int i=0; i<4; i++) y[i] = x[i];
+	y[mu] = (y[mu] -1 + X[mu]) % X[mu];
+	int idx = (((y[3]*X[2] + y[2])*X[1] + y[1])*X[0] + y[0]) >> 1;
+	return idx;
+}
+
+static __device__ __host__ inline int linkIndexP1(int x[], const int X[4], const int mu) {
+	int y[4];
+	for (int i=0; i<4; i++) y[i] = x[i];
+	y[mu] = (y[mu] +1 + X[mu]) % X[mu];
+	int idx = (((y[3]*X[2] + y[2])*X[1] + y[1])*X[0] + y[0]) >> 1;
+	return idx;
+}
+
+
+static __device__ __host__ inline void getCoords3(int x[4], int cb_index, const int X[4], int parity) {
+	/*x[3] = cb_index/(X[2]*X[1]*X[0]/2);
+	x[2] = (cb_index/(X[1]*X[0]/2)) % X[2];
+	x[1] = (cb_index/(X[0]/2)) % X[1];
+	x[0] = 2*(cb_index%(X[0]/2)) + ((x[3]+x[2]+x[1]+parity)&1);*/
+	int za = (cb_index / (X[0]/2));
+	int zb =  (za / X[1]);
+	x[1] = za - zb * X[1];
+	x[3] = (zb / X[2]);
+	x[2] = zb - x[3] * X[2];
+	int x1odd = (x[1] + x[2] + x[3] + parity) & 1;
+	x[0] = (2 * cb_index + x1odd)  - za * X[0];
+	return;
+}
+
+
+static __device__ __host__ inline int getCoords(int cb_index, const int X[4], int parity) {
+	int za = (cb_index / (X[0]/2));
+	int zb =  (za / X[1]);
+	int x1 = za - zb * X[1];
+	int x3 = (zb / X[2]);
+	int x2 = zb - x3 * X[2];
+	int x1odd = (x1 + x2 + x3 + parity) & 1;
+	return 2 * cb_index + x1odd;
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+template <typename Cmplx>
+struct GaugeFixFFTRotateArg {
+	int threads; // number of active threads required
+	int X[4]; // grid dimensions
+	Cmplx *tmp0;
+	Cmplx *tmp1;
+	GaugeFixFFTRotateArg(const cudaGaugeField &data){
+		for(int dir=0; dir<4; ++dir) X[dir] = data.X()[dir];
+		threads = X[0]*X[1]*X[2]*X[3];
+		tmp0 = 0;
+		tmp1 = 0;
+	}
+};
+
+
+
+template <int direction, typename Cmplx> 
+__global__ void fft_rotate_kernel_2D2D(GaugeFixFFTRotateArg<Cmplx> arg){//Cmplx *data_in, Cmplx *data_out){ 
+	int id = blockIdx.x * blockDim.x + threadIdx.x;
+	if(id >= arg.threads) return;
+	if(direction == 0){
+		int x3 = id/(arg.X[0] * arg.X[1] * arg.X[2]);
+		int x2 = (id/(arg.X[0] * arg.X[1])) % arg.X[2];
+		int x1 = (id/arg.X[0]) % arg.X[1];
+		int x0 = id % arg.X[0];
+
+		int id  =  x0 + (x1 + (x2 + x3 * arg.X[2]) * arg.X[1]) * arg.X[0];
+		int id_out =  x2 + (x3 +  (x0 + x1 * arg.X[0]) * arg.X[3]) * arg.X[2];   
+		arg.tmp1[id_out] = arg.tmp0[id];    
+		//data_out[id_out] = data_in[id];
+	}
+	if(direction==1){ 
+
+		int x1 = id/(arg.X[2] * arg.X[3] * arg.X[0]);
+		int x0 = (id/(arg.X[2] * arg.X[3])) % arg.X[0];
+		int x3 = (id/arg.X[2]) % arg.X[3];
+		int x2 = id % arg.X[2];
+
+
+
+		int id  =  x2 + (x3 +  (x0 + x1 * arg.X[0]) * arg.X[3]) * arg.X[2]; 
+		int id_out =  x0 + (x1 + (x2 + x3 * arg.X[2]) * arg.X[1]) * arg.X[0];    
+		arg.tmp1[id_out] = arg.tmp0[id];    
+		//data_out[id_out] = data_in[id];
+	}
+}
+
+
+
+
+
+
+template<typename Cmplx>
+class GaugeFixFFTRotate : Tunable {
+	GaugeFixFFTRotateArg<Cmplx> arg;
+	unsigned int direction;
+	mutable char aux_string[128]; // used as a label in the autotuner
+private:
+	unsigned int sharedBytesPerThread() const { return 0; }
+	unsigned int sharedBytesPerBlock(const TuneParam &param) const { return 0; }
+	bool tuneSharedBytes() const { return false; } // Don't tune shared memory
+	bool tuneGridDim() const { return false; } // Don't tune the grid dimensions.
+	unsigned int minThreads() const { return arg.threads; }
+
+public:
+	GaugeFixFFTRotate(GaugeFixFFTRotateArg<Cmplx> &arg)
+: arg(arg) {
+		direction = 0;
+	}
+	~GaugeFixFFTRotate () {}
+	void setDirection(unsigned int dir, Cmplx *data_in, Cmplx *data_out){
+		direction = dir;
+		arg.tmp0 = data_in;
+		arg.tmp1 = data_out;
+	}
+
+	void apply(const cudaStream_t &stream){
+		TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
+		if(direction == 0)
+			fft_rotate_kernel_2D2D<0, Cmplx><<<tp.grid, tp.block, 0, stream>>>(arg);
+		else if(direction == 1) 
+			fft_rotate_kernel_2D2D<1, Cmplx><<<tp.grid, tp.block, 0, stream>>>(arg);
+		else 
+			errorQuda("Error in GaugeFixFFTRotate option.\n");
+	}
+
+	TuneKey tuneKey() const {
+		std::stringstream vol;
+		vol << arg.X[0] << "x";
+		vol << arg.X[1] << "x";
+		vol << arg.X[2] << "x";
+		vol << arg.X[3];
+		sprintf(aux_string,"threads=%d,prec=%d",arg.threads, sizeof(Cmplx) / 2);
+		return TuneKey(vol.str().c_str(), typeid(*this).name(), aux_string);
+
+	}
+	std::string paramString(const TuneParam &param) const {
+		std::stringstream ps;
+		ps << "block=(" << param.block.x << "," << param.block.y << "," << param.block.z << ")";
+		ps << "shared=" << param.shared_bytes;
+		return ps.str();
+	}
+	void preTune(){}
+	void postTune(){}
+	long long flops() const { return 0; }
+	long long bytes() const { return 2LL * sizeof(Cmplx) * arg.threads; } 
+
+}; 
+
+
+
+
+
+
+
+
+
+
+template <typename Cmplx, typename Gauge>
+struct GaugeFixQualityArg {
+	int threads; // number of active threads required
+	int X[4]; // grid dimensions
+	Gauge dataOr;
+	Cmplx *delta;
+	double2 *quality;
+	double2 *quality_h;
+
+	GaugeFixQualityArg(const Gauge &dataOr, const cudaGaugeField &data, Cmplx *delta)
+	: dataOr(dataOr), delta(delta) {
+	//: dataOr(dataOr), delta(delta), quality_h(static_cast<double2*>(pinned_malloc(sizeof(double2)))) {
+
+		for(int dir=0; dir<4; ++dir) X[dir] = data.X()[dir];
+
+		threads = X[0]*X[1]*X[2]*X[3];
+		//cudaHostGetDevicePointer(&quality, quality_h, 0);
+	    quality = (double2*)device_malloc(sizeof(double2));
+	    quality_h = (double2*)safe_malloc(sizeof(double2));
+	}
+	double getAction(){return quality_h[0].x;}
+	double getTheta(){return quality_h[0].y;}
+};
+
+
+
+template<int blockSize, unsigned int Elems, typename Float, typename Gauge, int gauge_dir>
+__global__ void computeFix_quality(GaugeFixQualityArg<typename ComplexTypeId<Float>::Type, Gauge> argQ){
+	int idx = threadIdx.x + blockIdx.x*blockDim.x;
+
+	typedef cub::BlockReduce<double2, blockSize> BlockReduce;
+	__shared__ typename BlockReduce::TempStorage temp_storage;
+
+	double2 data = make_double2(0.0,0.0);
+	if(idx < argQ.threads) {
+		typedef typename ComplexTypeId<Float>::Type Cmplx;
+		int parity = 0;
+		if(idx >= argQ.threads/2) {
+			parity = 1;
+			idx -= argQ.threads/2;
+		}
+		//int X[4]; 
+		//for(int dr=0; dr<4; ++dr) X[dr] = argQ.X[dr];
+		int x[4];
+		getCoords3(x, idx, argQ.X, parity);   
+		Matrix<Cmplx,3> delta;
+		setZero(&delta);
+		//idx = linkIndex(x,X);
+		for (int mu = 0; mu < gauge_dir; mu++) { 
+			Matrix<Cmplx,3> U; 
+			argQ.dataOr.load((Float*)(U.data),idx, mu, parity);
+			delta -= U;
+		}
+		//18*gauge_dir
+		data.x = -delta(0,0).x - delta(1,1).x - delta(2,2).x ;
+		//2
+		for (int mu = 0; mu < gauge_dir; mu++) {
+			Matrix<Cmplx,3> U; 
+			argQ.dataOr.load((Float*)(U.data),linkIndexM1(x,argQ.X,mu), mu, 1 - parity);
+			delta += U;
+		}
+		//18*gauge_dir
+		delta -= conj(delta);
+		//18
+		//SAVE DELTA!!!!!
+		SubTraceUnit(delta);
+		idx = getCoords(idx, argQ.X, parity);
+		for(int i = 0; i < Elems; i++) argQ.delta[idx + i * argQ.threads] = delta.data[i];
+		//12
+		data.y = getRealTraceUVdagger(delta, delta);
+		//35
+		//T=36*gauge_dir+65
+	}
+	double2 aggregate = BlockReduce(temp_storage).Reduce(data, Summ<double2>());
+	if (threadIdx.x == 0) atomicAdd(argQ.quality, aggregate);
+}
+
+
+
+template<unsigned int Elems, typename Float, typename Gauge, int gauge_dir>
+class GaugeFixQuality : Tunable {
+	GaugeFixQualityArg<typename ComplexTypeId<Float>::Type, Gauge> argQ;
+	mutable char aux_string[128]; // used as a label in the autotuner
+private:
+	unsigned int sharedBytesPerThread() const { return 0; }
+	unsigned int sharedBytesPerBlock(const TuneParam &param) const { return 0; }
+	bool tuneSharedBytes() const { return false; } // Don't tune shared memory
+	bool tuneGridDim() const { return false; } // Don't tune the grid dimensions.
+	unsigned int minThreads() const { return argQ.threads; }
+
+public:
+	GaugeFixQuality(GaugeFixQualityArg<typename ComplexTypeId<Float>::Type, Gauge> &argQ)
+: argQ(argQ) {}
+	~GaugeFixQuality () { host_free(argQ.quality_h);device_free(argQ.quality);}
+
+	void apply(const cudaStream_t &stream){
+		TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
+		//argQ.quality_h[0] = make_double2(0.0,0.0);
+      	cudaMemset(argQ.quality, 0, sizeof(double2));
+		LAUNCH_KERNEL(computeFix_quality, tp, stream, argQ, Elems, Float, Gauge, gauge_dir);
+      	cudaMemcpy(argQ.quality_h, argQ.quality, sizeof(double2), cudaMemcpyDeviceToHost);
+		//cudaDeviceSynchronize();
+		argQ.quality_h[0].x  /= (double)(3*gauge_dir*argQ.threads);
+		argQ.quality_h[0].y  /= (double)(3*argQ.threads);
+	}
+
+	TuneKey tuneKey() const {
+		std::stringstream vol;
+		vol << argQ.X[0] << "x";
+		vol << argQ.X[1] << "x";
+		vol << argQ.X[2] << "x";
+		vol << argQ.X[3];
+		sprintf(aux_string,"threads=%d,prec=%d,gaugedir=%d",argQ.threads, sizeof(Float),gauge_dir);
+		return TuneKey(vol.str().c_str(), typeid(*this).name(), aux_string);
+
+	}
+	std::string paramString(const TuneParam &param) const {
+		std::stringstream ps;
+		ps << "block=(" << param.block.x << "," << param.block.y << "," << param.block.z << ")";
+		ps << "shared=" << param.shared_bytes;
+		return ps.str();
+	}
+	void preTune(){}
+	void postTune(){}
+	long long flops() const { return (36LL*gauge_dir+65LL)*argQ.threads; }// Only correct if there is no link reconstruction, no cub reduction accounted also
+	long long bytes() const { return (2LL*gauge_dir + 2LL) * Elems * argQ.threads * sizeof(Float); } //Not accounting the reduction!!!
+
+}; 
+
+
+
+template <typename Float>
+struct GaugeFixArg {
+	int threads; // number of active threads required
+	int X[4]; // grid dimensions
+  	cudaGaugeField &data;
+	Float *invpsq;
+	typename ComplexTypeId<Float>::Type *delta;
+	typename ComplexTypeId<Float>::Type *gx;
+
+	GaugeFixArg( cudaGaugeField &data, const unsigned int Elems) : data(data){
+		for(int dir=0; dir<4; ++dir) X[dir] = data.X()[dir];
+		threads = X[0]*X[1]*X[2]*X[3];
+		cudaMalloc((void**)&invpsq, sizeof(Float) * threads);
+		cudaMalloc((void**)&delta, sizeof(typename ComplexTypeId<Float>::Type) * threads * Elems);
+		cudaMalloc((void**)&gx, sizeof(typename ComplexTypeId<Float>::Type) * threads * Elems);
+		BindTex(delta, gx, sizeof(typename ComplexTypeId<Float>::Type) * threads * Elems);
+	}
+	void free(){
+		cudaFree(invpsq);
+		cudaFree(delta);
+		cudaFree(gx);
+		UnBindTex(delta, gx);
+	}
+};
+
+
+
+
+template <typename Float> 
+__global__ void kernel_gauge_set_invpsq(GaugeFixArg<Float> arg){
+	int id = blockIdx.x * blockDim.x + threadIdx.x;
+	if(id >= arg.threads) return;
+	int x1 = id/(arg.X[2] * arg.X[3] * arg.X[0]);
+	int x0 = (id/(arg.X[2] * arg.X[3])) % arg.X[0];
+	int x3 = (id/arg.X[2]) % arg.X[3];
+	int x2 = id % arg.X[2];
+	//id  =  x2 + (x3 +  (x0 + x1 * arg.X[0]) * arg.X[3]) * arg.X[2]; 
+	Float sx = sin( (Float)x0 * FL_UNITARIZE_PI / (Float)arg.X[0]);
+	Float sy = sin( (Float)x1 * FL_UNITARIZE_PI / (Float)arg.X[1]);
+	Float sz = sin( (Float)x2 * FL_UNITARIZE_PI / (Float)arg.X[2]);
+	Float st = sin( (Float)x3 * FL_UNITARIZE_PI / (Float)arg.X[3]);
+	Float sinsq = sx * sx + sy * sy + sz * sz + st * st;
+	Float prcfact = 0.0;
+	//The FFT normalization is done here
+	if ( sinsq > 0.00001 )   prcfact = 4.0 / (sinsq * (Float)arg.threads);   
+	arg.invpsq[id] = prcfact;
+}
+
+
+template<typename Float>
+class GaugeFixSETINVPSP : Tunable {
+	GaugeFixArg<Float> arg;
+	mutable char aux_string[128]; // used as a label in the autotuner
+private:
+	unsigned int sharedBytesPerThread() const { return 0; }
+	unsigned int sharedBytesPerBlock(const TuneParam &param) const { return 0; }
+	bool tuneSharedBytes() const { return false; } // Don't tune shared memory
+	bool tuneGridDim() const { return false; } // Don't tune the grid dimensions.
+	unsigned int minThreads() const { return arg.threads; }
+
+public:
+	GaugeFixSETINVPSP(GaugeFixArg<Float> &arg) : arg(arg) {    }
+	~GaugeFixSETINVPSP () { }
+
+	void apply(const cudaStream_t &stream){
+		TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
+		kernel_gauge_set_invpsq<Float><<<tp.grid, tp.block, 0, stream>>>(arg);
+	}
+
+	TuneKey tuneKey() const {
+		std::stringstream vol;
+		vol << arg.X[0] << "x";
+		vol << arg.X[1] << "x";
+		vol << arg.X[2] << "x";
+		vol << arg.X[3];
+		sprintf(aux_string,"threads=%d,prec=%d",arg.threads, sizeof(Float));
+		return TuneKey(vol.str().c_str(), typeid(*this).name(), aux_string);
+
+	}
+	std::string paramString(const TuneParam &param) const {
+		std::stringstream ps;
+		ps << "block=(" << param.block.x << "," << param.block.y << "," << param.block.z << ")";
+		ps << "shared=" << param.shared_bytes;
+		return ps.str();
+	}
+	void preTune(){}
+	void postTune(){}
+	long long flops() const { return 21 * arg.threads; }
+	long long bytes() const { return sizeof(Float) * arg.threads; } 
+
+}; 
+
+template<typename Float>
+__global__ void kernel_gauge_mult_norm_2D(GaugeFixArg<Float> arg){
+	int id = blockIdx.x * blockDim.x + threadIdx.x;
+	if(id < arg.threads) arg.gx[id] = arg.gx[id] * arg.invpsq[id]; 
+}
+
+
+template<typename Float>
+class GaugeFixINVPSP : Tunable {
+	GaugeFixArg<Float> arg;
+	mutable char aux_string[128]; // used as a label in the autotuner
+private:
+	unsigned int sharedBytesPerThread() const { return 0; }
+	unsigned int sharedBytesPerBlock(const TuneParam &param) const { return 0; }
+	bool tuneSharedBytes() const { return false; } // Don't tune shared memory
+	bool tuneGridDim() const { return false; } // Don't tune the grid dimensions.
+	unsigned int minThreads() const { return arg.threads; }
+
+public:
+	GaugeFixINVPSP(GaugeFixArg<Float> &arg)
+: arg(arg){ 
+    cudaFuncSetCacheConfig( kernel_gauge_mult_norm_2D<Float>,   cudaFuncCachePreferL1);   }
+	~GaugeFixINVPSP () {}
+
+	void apply(const cudaStream_t &stream){
+		TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
+		kernel_gauge_mult_norm_2D<Float><<<tp.grid, tp.block, 0, stream>>>(arg);
+	}
+
+	TuneKey tuneKey() const {
+		std::stringstream vol;
+		vol << arg.X[0] << "x";
+		vol << arg.X[1] << "x";
+		vol << arg.X[2] << "x";
+		vol << arg.X[3];
+		sprintf(aux_string,"threads=%d,prec=%d",arg.threads, sizeof(Float));
+		return TuneKey(vol.str().c_str(), typeid(*this).name(), aux_string);
+
+	}
+	std::string paramString(const TuneParam &param) const {
+		std::stringstream ps;
+		ps << "block=(" << param.block.x << "," << param.block.y << "," << param.block.z << ")";
+		ps << "shared=" << param.shared_bytes;
+		return ps.str();
+	}
+	void preTune(){
+		//since delta contents are irrelevant at this point, we can swap gx with delta
+		typename ComplexTypeId<Float>::Type *tmp = arg.gx;
+		arg.gx = arg.delta;
+		arg.delta = tmp;
+	}
+	void postTune(){
+		arg.gx = arg.delta;
+	}
+	long long flops() const { return 2LL * arg.threads; }
+	long long bytes() const { return 5LL * sizeof(Float) * arg.threads; } 
+
+}; 
+
+
+
+
+
+
+
+template<typename Cmplx>
+__device__ __host__ inline typename RealTypeId<Cmplx>::Type Abs2(const Cmplx & a){
+	return a.x * a.x + a.y * a.y;
+}
+
+
+
+template <typename Float> 
+__host__ __device__ inline void reunit_link( Matrix<typename ComplexTypeId<Float>::Type,3> &U ){
+
+	typedef typename ComplexTypeId<Float>::Type Cmplx;
+
+	Cmplx t2 = makeComplex((Float)0.0, (Float)0.0);
+	Float t1 = 0.0;
+	//first normalize first row
+	//sum of squares of row
+#pragma unroll
+	for(int c = 0; c < 3; c++)    t1 += Abs2(U(0, c));
+	t1 = (Float)1.0 / sqrt(t1);
+	//14
+	//used to normalize row
+#pragma unroll
+	for(int c = 0; c < 3; c++)    U(0,c) *= t1;
+	//6      
+#pragma unroll
+	for(int c = 0; c < 3; c++)    t2 += Conj(U(0,c)) * U(1,c);
+	//24
+#pragma unroll
+	for(int c = 0; c < 3; c++)    U(1,c) -= t2 * U(0,c);
+	//24
+	//normalize second row
+	//sum of squares of row
+	t1 = 0.0;
+#pragma unroll
+	for(int c = 0; c < 3; c++)    t1 += Abs2(U(1,c));
+	t1 = (Float)1.0 / sqrt(t1);
+	//14
+	//used to normalize row
+#pragma unroll
+	for(int c = 0; c < 3; c++)    U(1, c) *= t1;
+	//6      
+	//Reconstruct lat row
+	U(2,0) = Conj(U(0,1) * U(1,2) - U(0,2) * U(1,1));
+	U(2,1) = Conj(U(0,2) * U(1,0) - U(0,0) * U(1,2));
+	U(2,2) = Conj(U(0,0) * U(1,1) - U(0,1) * U(1,0));
+	//42
+	//T=130
+}
+
+
+
+
+
+template <unsigned int Elems, typename Float> 
+__global__ void kernel_gauge_GX(GaugeFixArg<Float> arg, Float half_alpha){
+
+	int id = blockIdx.x * blockDim.x + threadIdx.x;
+
+	if(id >= arg.threads) return;
+
+	typedef typename ComplexTypeId<Float>::Type Cmplx;
+
+	Matrix<Cmplx,3> de;
+	for(int i = 0; i < Elems; i++){
+		#if (GAUGEFIXING_SITE_MATRIX_LOAD_TEX == 1)
+		de.data[i] = TEXTURE_DELTA<Cmplx>(id + i * arg.threads);
+		#else
+		de.data[i] = arg.delta[id + i * arg.threads];
+		#endif
+	} 
+	if(Elems==6){    
+		de(2,0) = Conj(de(0,1) * de(1,2) - de(0,2) * de(1,1));
+		de(2,1) = Conj(de(0,2) * de(1,0) - de(0,0) * de(1,2));
+		de(2,2) = Conj(de(0,0) * de(1,1) - de(0,1) * de(1,0));
+		//42
+	}
+	Matrix<Cmplx,3> g;
+	setIdentity(&g);
+	g += de * half_alpha;
+	//36
+	reunit_link<Float>( g );
+	//130
+	//gx is represented in even/odd order
+	//normal lattice index to even/odd index
+	int x3 = id/(arg.X[0] * arg.X[1] * arg.X[2]);
+	int x2 = (id/(arg.X[0] * arg.X[1])) % arg.X[2];
+	int x1 = (id/arg.X[0]) % arg.X[1];
+	int x0 = id % arg.X[0];
+	id  =  (x0 + (x1 + (x2 + x3 * arg.X[2]) * arg.X[1]) * arg.X[0]) >> 1;
+	id += ((x0 + x1 + x2 + x3) & 1 ) * arg.threads / 2;
+
+	for(int i = 0; i < Elems; i++) arg.gx[id + i * arg.threads] = g.data[i];  
+	//T=166 for Elems 9
+	//T=208 for Elems 6
+}
+
+
+
+
+template<unsigned int Elems, typename Float>
+class GaugeFix_GX : Tunable {
+	GaugeFixArg<Float> arg;
+	Float half_alpha;
+	mutable char aux_string[128]; // used as a label in the autotuner
+private:
+	unsigned int sharedBytesPerThread() const { return 0; }
+	unsigned int sharedBytesPerBlock(const TuneParam &param) const { return 0; }
+	bool tuneSharedBytes() const { return false; } // Don't tune shared memory
+	bool tuneGridDim() const { return false; } // Don't tune the grid dimensions.
+	unsigned int minThreads() const { return arg.threads; }
+
+public:
+	GaugeFix_GX(GaugeFixArg<Float> &arg, Float alpha)
+: arg(arg) {  half_alpha = alpha * 0.5;
+    cudaFuncSetCacheConfig( kernel_gauge_GX<Elems, Float>,   cudaFuncCachePreferL1);  }
+	~GaugeFix_GX () { }
+
+	void setAlpha(Float alpha){ half_alpha = alpha * 0.5; }
+
+
+	void apply(const cudaStream_t &stream){
+		TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
+		kernel_gauge_GX<Elems, Float><<<tp.grid, tp.block, 0, stream>>>(arg, half_alpha);
+	}
+
+	TuneKey tuneKey() const {
+		std::stringstream vol;
+		vol << arg.X[0] << "x";
+		vol << arg.X[1] << "x";
+		vol << arg.X[2] << "x";
+		vol << arg.X[3];
+		sprintf(aux_string,"threads=%d,prec=%d",arg.threads, sizeof(Float));
+		return TuneKey(vol.str().c_str(), typeid(*this).name(), aux_string);
+
+	}
+	std::string paramString(const TuneParam &param) const {
+		std::stringstream ps;
+		ps << "block=(" << param.block.x << "," << param.block.y << "," << param.block.z << ")";
+		ps << "shared=" << param.shared_bytes;
+		return ps.str();
+	}
+	void preTune(){}
+	void postTune(){}
+	long long flops() const { 
+		if(Elems==6)  return 208LL * arg.threads;
+		else          return 166LL * arg.threads;
+	}
+  long long bytes() const { return 4LL * Elems * sizeof(Float) * arg.threads; }
+
+}; 
+
+
+template <unsigned int Elems, typename Float, typename Gauge> 
+__global__ void kernel_gauge_fix_U_EO( GaugeFixArg<Float> arg, Gauge dataOr){
+	int idd = threadIdx.x + blockIdx.x*blockDim.x;
+
+	if(idd >= arg.threads) return;
+
+	int parity = 0;
+	int id = idd;
+	if(idd >= arg.threads / 2){
+		parity = 1;
+		id -= arg.threads / 2;
+	}
+	typedef typename ComplexTypeId<Float>::Type Cmplx;
+
+	Matrix<Cmplx,3> g;
+	//for(int i = 0; i < Elems; i++) g.data[i] = arg.gx[idd + i * arg.threads]; 
+	for(int i = 0; i < Elems; i++){
+		#if (GAUGEFIXING_SITE_MATRIX_LOAD_TEX == 1)
+		g.data[i] = TEXTURE_GX<Cmplx>(idd + i * arg.threads);
+		#else
+		g.data[i] = arg.gx[idd + i * arg.threads];
+		#endif
+	}
+	if(Elems==6){    
+		g(2,0) = Conj(g(0,1) * g(1,2) - g(0,2) * g(1,1));
+		g(2,1) = Conj(g(0,2) * g(1,0) - g(0,0) * g(1,2));
+		g(2,2) = Conj(g(0,0) * g(1,1) - g(0,1) * g(1,0));
+		//42
+	}
+	int x[4];
+	getCoords3(x, id, arg.X, parity); 
+	for(int mu = 0; mu < 4; mu++){
+		Matrix<Cmplx,3> U;
+		Matrix<Cmplx,3> g0;
+		dataOr.load((Float*)(U.data),id, mu, parity);
+		U = g * U;
+		//198
+		int idm1 = linkIndexP1(x,arg.X,mu);
+		idm1 += (1 - parity) * arg.threads / 2;
+		//for(int i = 0; i < Elems; i++) g0.data[i] = arg.gx[idm1 + i * arg.threads];
+		for(int i = 0; i < Elems; i++){
+			#if (GAUGEFIXING_SITE_MATRIX_LOAD_TEX == 1)
+			g0.data[i] = TEXTURE_GX<Cmplx>(idm1 + i * arg.threads);
+			#else
+			g0.data[i] = arg.gx[idm1 + i * arg.threads];
+			#endif
+		}
+		if(Elems==6){    
+			g0(2,0) = Conj(g0(0,1) * g0(1,2) - g0(0,2) * g0(1,1));
+			g0(2,1) = Conj(g0(0,2) * g0(1,0) - g0(0,0) * g0(1,2));
+			g0(2,2) = Conj(g0(0,0) * g0(1,1) - g0(0,1) * g0(1,0));
+			//42
+		}
+		U = U * conj(g0);
+		//198
+		dataOr.save((Float*)(U.data),id, mu, parity);
+	}
+	//T=42+4*(198*2+42) Elems=6
+	//T=4*(198*2) Elems=9
+	//Not accounting here the reconstruction of the gauge if 12 or 8!!!!!!
+}
+
+
+template<unsigned int Elems, typename Float, typename Gauge>
+class GaugeFix : Tunable {
+	GaugeFixArg<Float> arg;
+	Gauge dataOr;
+	mutable char aux_string[128]; // used as a label in the autotuner
+private:
+	unsigned int sharedBytesPerThread() const { return 0; }
+	unsigned int sharedBytesPerBlock(const TuneParam &param) const { return 0; }
+	bool tuneSharedBytes() const { return false; } // Don't tune shared memory
+	bool tuneGridDim() const { return false; } // Don't tune the grid dimensions.
+	unsigned int minThreads() const { return arg.threads; }
+
+public:
+	GaugeFix(Gauge &dataOr, GaugeFixArg<Float> &arg)
+: dataOr(dataOr), arg(arg) { 
+    cudaFuncSetCacheConfig( kernel_gauge_fix_U_EO<Elems, Float, Gauge>,   cudaFuncCachePreferL1);
+   }
+	~GaugeFix () { }
+
+
+	void apply(const cudaStream_t &stream){
+		TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
+		kernel_gauge_fix_U_EO<Elems, Float, Gauge><<<tp.grid, tp.block, 0, stream>>>(arg, dataOr);
+	}
+
+	TuneKey tuneKey() const {
+		std::stringstream vol;
+		vol << arg.X[0] << "x";
+		vol << arg.X[1] << "x";
+		vol << arg.X[2] << "x";
+		vol << arg.X[3];
+		sprintf(aux_string,"threads=%d,prec=%d",arg.threads, sizeof(Float));
+		return TuneKey(vol.str().c_str(), typeid(*this).name(), aux_string);
+
+	}
+	std::string paramString(const TuneParam &param) const {
+		std::stringstream ps;
+		ps << "block=(" << param.block.x << "," << param.block.y << "," << param.block.z << ")";
+		ps << "shared=" << param.shared_bytes;
+		return ps.str();
+	}
+	//need this
+	void preTune() { arg.data.backup(); }
+	void postTune() { arg.data.restore(); }
+	long long flops() const { 
+		if(Elems==6) return 1794LL * arg.threads;
+		else         return 1536LL * arg.threads;
+		//Not accounting here the reconstruction of the gauge if 12 or 8!!!!!! 
+	}
+  	long long bytes() const { return 26LL * Elems * sizeof(Float) * arg.threads;}  
+
+}; 
+
+
+
+
+template<unsigned int Elems, typename Float, typename Gauge, int gauge_dir>
+void gaugefixingFFT( Gauge dataOr,  cudaGaugeField& data, \
+		const unsigned int Nsteps, const unsigned int verbose_interval, \
+		const Float alpha0, const unsigned int autotune, const double tolerance, \
+		const unsigned int stopWtheta) {
+
+	TimeProfile profileGaugeFix("GaugeFixCuda");
+
+	profileGaugeFix.Start(QUDA_PROFILE_COMPUTE);
+
+	Float alpha = alpha0;
+	std::cout << "\tAlpha parameter of the Steepest Descent Method: " << alpha << std::endl;
+	if(autotune) std::cout << "\tAuto tune active: yes" << std::endl;
+	else         std::cout << "\tAuto tune active: no" << std::endl;
+	std::cout << "\tStop criterium: " << tolerance << std::endl;
+	if(stopWtheta) std::cout << "\tStop criterium method: theta" << std::endl;
+	else           std::cout << "\tStop criterium method: Delta" << std::endl;
+	std::cout << "\tMaximum number of iterations: " << Nsteps << std::endl;
+	std::cout << "\tPrint convergence results at every " << verbose_interval << " steps" << std::endl;
+
+
+	typedef typename ComplexTypeId<Float>::Type Cmplx;
+
+	unsigned int delta_pad = data.X()[0] * data.X()[1] * data.X()[2] * data.X()[3];
+	int4 size = make_int4( data.X()[0], data.X()[1], data.X()[2], data.X()[3] );
+	cufftHandle plan_xy;
+	cufftHandle plan_zt;
+
+	GaugeFixArg<Float> arg(data, Elems);
+	SetPlanFFT2DMany( plan_zt, size, 0, arg.delta); //for space and time ZT
+	SetPlanFFT2DMany( plan_xy, size, 1, arg.delta);//with space only XY
+
+
+	GaugeFixFFTRotateArg<Cmplx> arg_rotate(data);
+	GaugeFixFFTRotate<Cmplx> GFRotate(arg_rotate);
+
+	GaugeFixSETINVPSP<Float> setinvpsp(arg);
+	setinvpsp.apply(0);
+	GaugeFixINVPSP<Float> invpsp(arg);
+
+
+	GaugeFix_GX<Elems, Float> calcGX(arg, alpha);
+	GaugeFix<Elems, Float, Gauge> gfix(dataOr, arg);
+
+	GaugeFixQualityArg<Cmplx, Gauge> argQ(dataOr, data, arg.delta);
+	GaugeFixQuality<Elems, Float, Gauge, gauge_dir> gfixquality(argQ);
+
+	gfixquality.apply(0);
+	double action0 = argQ.getAction();
+	printf("Step: %d\tAction: %.16e\ttheta: %.16e\n", 0, argQ.getAction(), argQ.getTheta());
+
+	double diff = 0.0;
+	int iter = 0;
+	for(iter = 0; iter < Nsteps; iter++){
+		for(int k = 0; k < Elems; k++){  
+			//------------------------------------------------------------------------
+			// Set a pointer do the element k in lattice volume
+			// each element is stored with stride lattice volume
+			// it uses gx as temporary array!!!!!!
+			//------------------------------------------------------------------------
+			Cmplx *_array = arg.delta + k * delta_pad;
+			//////  2D FFT + 2D FFT
+			//------------------------------------------------------------------------
+			// Perform FFT on xy plane
+			//------------------------------------------------------------------------
+			ApplyFFT(plan_xy, _array, arg.gx, CUFFT_FORWARD);
+			//------------------------------------------------------------------------
+			// Rotate hypercube, xyzt -> ztxy
+			//------------------------------------------------------------------------
+			GFRotate.setDirection(0, arg.gx, _array);
+			GFRotate.apply(0);
+			//------------------------------------------------------------------------
+			// Perform FFT on zt plane
+			//------------------------------------------------------------------------      
+			ApplyFFT(plan_zt, _array, arg.gx, CUFFT_FORWARD);
+			//------------------------------------------------------------------------
+			// Normalize FFT and apply pmax^2/p^2
+			//------------------------------------------------------------------------
+			invpsp.apply(0);
+			//------------------------------------------------------------------------
+			// Perform IFFT on zt plane
+			//------------------------------------------------------------------------  
+			ApplyFFT(plan_zt, arg.gx, _array, CUFFT_INVERSE);
+			//------------------------------------------------------------------------
+			// Rotate hypercube, ztxy -> xyzt
+			//------------------------------------------------------------------------
+			GFRotate.setDirection(1, _array, arg.gx);
+			GFRotate.apply(0);  
+			//------------------------------------------------------------------------
+			// Perform IFFT on xy plane
+			//------------------------------------------------------------------------    
+			ApplyFFT(plan_xy, arg.gx, _array, CUFFT_INVERSE);
+		}
+		//------------------------------------------------------------------------
+		// Calculate g(x)
+		//------------------------------------------------------------------------
+		calcGX.apply(0);
+		//------------------------------------------------------------------------
+		// Apply gauge fix to current gauge field
+		//------------------------------------------------------------------------
+		gfix.apply(0);
+		//------------------------------------------------------------------------
+		// Measure gauge quality and recalculate new Delta(x)
+		//------------------------------------------------------------------------
+		gfixquality.apply(0);
+		double action = argQ.getAction();
+		diff = abs(action0 - action);
+		if((iter % verbose_interval) == (verbose_interval - 1))
+			printf("Step: %d\tAction: %.16e\ttheta: %.16e\tDelta: %.16e\n", iter+1, argQ.getAction(), argQ.getTheta(), diff);
+		if ( autotune && ((action - action0) < -1e-14) ) {
+			if(alpha > 0.01){
+				alpha = 0.95 * alpha;
+				calcGX.setAlpha(alpha);
+				printf(">>>>>>>>>>>>>> Warning: changing alpha down -> %.4e\n", alpha );
+			}
+		} 
+		//------------------------------------------------------------------------
+		// Check gauge fix quality criterium
+		//------------------------------------------------------------------------
+		if(stopWtheta) {   if( argQ.getTheta() < tolerance ) break; }
+		else { if( diff < tolerance ) break; }
+
+		action0 = action;
+	}
+	if((iter % verbose_interval) != 0)
+		printf("Step: %d\tAction: %.16e\ttheta: %.16e\tDelta: %.16e\n", iter, argQ.getAction(), argQ.getTheta(), diff);
+
+	arg.free();
+	CUFFT_SAFE_CALL(cufftDestroy(plan_zt));
+	CUFFT_SAFE_CALL(cufftDestroy(plan_xy)); 
+	checkCudaError();
+
+	cudaDeviceSynchronize();
+	profileGaugeFix.Stop(QUDA_PROFILE_COMPUTE);
+	double secs = profileGaugeFix.Last(QUDA_PROFILE_COMPUTE);
+	double fftflop = 5.0 * (log2((double)( data.X()[0] * data.X()[1]) ) + log2( (double)(data.X()[2] * data.X()[3] )));
+	fftflop *= (double)( data.X()[0] * data.X()[1] * data.X()[2] * data.X()[3] );
+	double gflops = setinvpsp.flops() + gfixquality.flops();
+	double gbytes = setinvpsp.bytes() + gfixquality.bytes();
+	double flop = invpsp.flops() * Elems;
+	double byte = invpsp.bytes() * Elems;
+	flop += (GFRotate.flops() + fftflop) * Elems * 2;
+	byte += GFRotate.bytes() * Elems * 4; //includes FFT reads, assuming 1 read and 1 write per site
+	flop += calcGX.flops();
+	byte += calcGX.bytes();
+	flop += gfix.flops();
+	byte += gfix.bytes();
+	flop += gfixquality.flops();
+	byte += gfixquality.bytes();
+	gflops += flop * iter;
+	gbytes += byte * iter;
+	gflops = (gflops*1e-9)/(secs);
+	gbytes = gbytes/(secs*1e9);
+
+
+  	printfQuda("Time: %6.6f s, Gflop/s = %6.1f, GB/s = %6.1f\n", secs, gflops, gbytes);
+
+
+}
+
+template<unsigned int Elems, typename Float, typename Gauge>
+void gaugefixingFFT( Gauge dataOr,  cudaGaugeField& data, const unsigned int gauge_dir, \
+		const unsigned int Nsteps, const unsigned int verbose_interval, const Float alpha, const unsigned int autotune, \
+		const double tolerance, const unsigned int stopWtheta) {
+	if( gauge_dir !=3 ){
+		printf("Starting Landau gauge fixing with FFTs...\n");
+		gaugefixingFFT<Elems, Float, Gauge, 4>(dataOr, data, Nsteps, verbose_interval, alpha, autotune, tolerance, stopWtheta);
+	} 
+	else {        
+		printf("Starting Coulomb gauge fixing with FFTs...\n");
+		gaugefixingFFT<Elems, Float, Gauge, 3>(dataOr, data, Nsteps, verbose_interval, alpha, autotune, tolerance, stopWtheta);
+	}
+}
+
+
+
+template<typename Float>
+void gaugefixingFFT( cudaGaugeField& data, const unsigned int gauge_dir, \
+		const unsigned int Nsteps, const unsigned int verbose_interval, const Float alpha, const unsigned int autotune, \
+		const double tolerance, const unsigned int stopWtheta) {
+
+	// Switching to FloatNOrder for the gauge field in order to support RECONSTRUCT_12
+	// Need to fix this!!
+	//9 and 6 means the number of complex elements used to store g(x) and Delta(x)
+	if(data.Order() == QUDA_FLOAT2_GAUGE_ORDER) {
+		if(data.Reconstruct() == QUDA_RECONSTRUCT_NO) {
+			printf("QUDA_RECONSTRUCT_NO\n");
+			gaugefixingFFT<9, Float>(FloatNOrder<Float, 18, 2, 18>(data), data, gauge_dir, Nsteps, verbose_interval, alpha, autotune, tolerance, stopWtheta);
+		} else if(data.Reconstruct() == QUDA_RECONSTRUCT_12){
+			printf("QUDA_RECONSTRUCT_12\n");
+			gaugefixingFFT<6, Float>(FloatNOrder<Float, 18, 2, 12>(data), data, gauge_dir, Nsteps, verbose_interval, alpha, autotune, tolerance, stopWtheta);
+
+		} else if(data.Reconstruct() == QUDA_RECONSTRUCT_8){
+			printf("QUDA_RECONSTRUCT_8\n");
+			gaugefixingFFT<6, Float>(FloatNOrder<Float, 18, 2,  8>(data), data, gauge_dir, Nsteps, verbose_interval, alpha, autotune, tolerance, stopWtheta);
+
+		} else {
+			errorQuda("Reconstruction type %d of gauge field not supported", data.Reconstruct());
+		}
+	} else if(data.Order() == QUDA_FLOAT4_GAUGE_ORDER) {
+		if(data.Reconstruct() == QUDA_RECONSTRUCT_NO) {
+			printf("QUDA_RECONSTRUCT_NO\n");
+			gaugefixingFFT<9, Float>(FloatNOrder<Float, 18, 4, 18>(data), data, gauge_dir, Nsteps, verbose_interval, alpha, autotune, tolerance, stopWtheta);
+		} else if(data.Reconstruct() == QUDA_RECONSTRUCT_12){
+			printf("QUDA_RECONSTRUCT_12\n");
+			gaugefixingFFT<6, Float>(FloatNOrder<Float, 18, 4, 12>(data), data, gauge_dir, Nsteps, verbose_interval, alpha, autotune, tolerance, stopWtheta);
+		} else if(data.Reconstruct() == QUDA_RECONSTRUCT_8){
+			printf("QUDA_RECONSTRUCT_8\n");
+			gaugefixingFFT<6, Float>(FloatNOrder<Float, 18, 4,  8>(data), data, gauge_dir, Nsteps, verbose_interval, alpha, autotune, tolerance, stopWtheta);
+		} else {
+			errorQuda("Reconstruction type %d of gauge field not supported", data.Reconstruct());
+		}
+	} else {
+		errorQuda("Invalid Gauge Order\n");
+	}
+}
+
+void gaugefixingFFT( cudaGaugeField& data, const unsigned int gauge_dir, \
+		const unsigned int Nsteps, const unsigned int verbose_interval, const double alpha, const unsigned int autotune, \
+		const double tolerance, const unsigned int stopWtheta) {
+
+#ifdef MULTI_GPU
+	if(comm_size() > 1)
+	errorQuda("Gauge Fixing with FFTs in multi-GPU support NOT implemented yet!\n");
+#endif
+	if(data.Precision() == QUDA_HALF_PRECISION) {
+		errorQuda("Half precision not supported\n");
+	}
+	if (data.Precision() == QUDA_SINGLE_PRECISION) {
+		gaugefixingFFT<float> (data, gauge_dir, Nsteps, verbose_interval, (float)alpha, autotune, tolerance, stopWtheta);
+	} else if(data.Precision() == QUDA_DOUBLE_PRECISION) {
+		gaugefixingFFT<double>(data, gauge_dir, Nsteps, verbose_interval, alpha, autotune, tolerance, stopWtheta);
+	} else {
+		errorQuda("Precision %d not supported", data.Precision());
+	}
+
+}
+}

--- a/lib/gauge_fix_fft.cu
+++ b/lib/gauge_fix_fft.cu
@@ -722,7 +722,6 @@ __host__ __device__ inline void reunit_link( Matrix<typename ComplexTypeId<Float
 
 
 #ifdef GAUGEFIXING_DONT_USE_GX
-
 static __device__ __host__ inline int linkNormalIndexP1(int x[], const int X[4], const int mu) {
 	int y[4];
 	for (int i=0; i<4; i++) y[i] = x[i];
@@ -730,9 +729,6 @@ static __device__ __host__ inline int linkNormalIndexP1(int x[], const int X[4],
 	int idx = ((y[3]*X[2] + y[2])*X[1] + y[1])*X[0] + y[0];
 	return idx;
 }
-
-
-
 
 template <typename Float, typename Gauge> 
 __global__ void kernel_gauge_fix_U_EO_NEW( GaugeFixArg<Float> arg, Gauge dataOr, Float half_alpha){
@@ -871,7 +867,7 @@ public:
 		return 2414LL * arg.threads;
 		//Not accounting here the reconstruction of the gauge if 12 or 8!!!!!! 
 	}
-  	long long bytes() const { return ( dataOr.Bytes() + 12LL * sizeof(Float)) * arg.threads;}  
+  	long long bytes() const { return ( dataOr.Bytes()*4LL + 5*12LL * sizeof(Float)) * arg.threads;}  
 
 }; 
 

--- a/lib/gauge_fix_ovr.cu
+++ b/lib/gauge_fix_ovr.cu
@@ -1,0 +1,1841 @@
+#include <quda_internal.h>
+#include <quda_matrix.h>
+#include <tune_quda.h>
+#include <gauge_field.h>
+#include <gauge_field_order.h>
+#include <cub/cub.cuh> 
+#include <launch_kernel.cuh>
+
+#include <device_functions.h>
+
+#include <hisq_links_quda.h> //reunit gauge links!!!!!
+
+#include <comm_quda.h>
+
+
+#include <gauge_fix_ovr_extra.h>
+
+
+#include <gauge_fix_ovr_hit_devf.cuh>
+
+
+namespace quda {
+
+
+
+static int numParams = 18;
+
+#define LAUNCH_KERNEL_GAUGEFIX(kernel, tp, stream, arg, parity, ...)     \
+  if(tp.block.z==0){\
+  switch (tp.block.x) {             \
+  case 256:                \
+    kernel<0, 32,__VA_ARGS__>           \
+      <<< tp.grid.x, tp.block.x, tp.shared_bytes, stream >>>(arg, parity);   \
+    break;                \
+  case 512:                \
+    kernel<0, 64,__VA_ARGS__>           \
+      <<< tp.grid.x, tp.block.x, tp.shared_bytes, stream >>>(arg, parity);   \
+    break;                \
+  case 768:                \
+    kernel<0, 96,__VA_ARGS__>           \
+      <<< tp.grid.x, tp.block.x, tp.shared_bytes, stream >>>(arg, parity);   \
+    break;                \
+  case 1024:               \
+    kernel<0, 128,__VA_ARGS__>            \
+      <<< tp.grid.x, tp.block.x, tp.shared_bytes, stream >>>(arg, parity);   \
+    break;                \
+  default:                \
+    errorQuda("%s not implemented for %d threads", #kernel, tp.block.x); \
+    }\
+  }\
+  else if(tp.block.z==1){\
+  switch (tp.block.x) {             \
+  case 256:                \
+    kernel<1, 32,__VA_ARGS__>           \
+      <<< tp.grid.x, tp.block.x, tp.shared_bytes, stream >>>(arg, parity);   \
+    break;                \
+  case 512:                \
+    kernel<1, 64,__VA_ARGS__>           \
+      <<< tp.grid.x, tp.block.x, tp.shared_bytes, stream >>>(arg, parity);   \
+    break;                \
+  case 768:                \
+    kernel<1, 96,__VA_ARGS__>           \
+      <<< tp.grid.x, tp.block.x, tp.shared_bytes, stream >>>(arg, parity);   \
+    break;                \
+  case 1024:               \
+    kernel<1, 128,__VA_ARGS__>            \
+      <<< tp.grid.x, tp.block.x, tp.shared_bytes, stream >>>(arg, parity);   \
+    break;                \
+  default:                \
+    errorQuda("%s not implemented for %d threads", #kernel, tp.block.x); \
+    }\
+  }\
+  else if(tp.block.z==2){\
+  switch (tp.block.x) {             \
+  case 256:                \
+    kernel<2, 32,__VA_ARGS__>           \
+      <<< tp.grid.x, tp.block.x, tp.shared_bytes, stream >>>(arg, parity);   \
+    break;                \
+  case 512:                \
+    kernel<2, 64,__VA_ARGS__>           \
+      <<< tp.grid.x, tp.block.x, tp.shared_bytes, stream >>>(arg, parity);   \
+    break;                \
+  case 768:                \
+    kernel<2, 96,__VA_ARGS__>           \
+      <<< tp.grid.x, tp.block.x, tp.shared_bytes, stream >>>(arg, parity);   \
+    break;                \
+  case 1024:               \
+    kernel<2, 128,__VA_ARGS__>            \
+      <<< tp.grid.x, tp.block.x, tp.shared_bytes, stream >>>(arg, parity);   \
+    break;                \
+  default:                \
+    errorQuda("%s not implemented for %d threads", #kernel, tp.block.x); \
+    }\
+  }\
+  else if(tp.block.z==3){\
+  switch (tp.block.x) {             \
+  case 128:                \
+    kernel<3, 32,__VA_ARGS__>           \
+      <<< tp.grid.x, tp.block.x, tp.shared_bytes, stream >>>(arg, parity);   \
+    break;                \
+  case 256:                \
+    kernel<3, 64,__VA_ARGS__>           \
+      <<< tp.grid.x, tp.block.x, tp.shared_bytes, stream >>>(arg, parity);   \
+    break;                \
+  case 384:                \
+    kernel<3, 96,__VA_ARGS__>           \
+      <<< tp.grid.x, tp.block.x, tp.shared_bytes, stream >>>(arg, parity);   \
+    break;                \
+  case 512:               \
+    kernel<3, 128,__VA_ARGS__>            \
+      <<< tp.grid.x, tp.block.x, tp.shared_bytes, stream >>>(arg, parity);   \
+    break;                \
+  case 640:               \
+    kernel<3, 160,__VA_ARGS__>            \
+      <<< tp.grid.x, tp.block.x, tp.shared_bytes, stream >>>(arg, parity);   \
+    break;                \
+  case 768:               \
+    kernel<3, 192,__VA_ARGS__>            \
+      <<< tp.grid.x, tp.block.x, tp.shared_bytes, stream >>>(arg, parity);   \
+    break;                \
+  case 896:               \
+    kernel<3, 224,__VA_ARGS__>            \
+      <<< tp.grid.x, tp.block.x, tp.shared_bytes, stream >>>(arg, parity);   \
+    break;                \
+  case 1024:               \
+    kernel<3, 256,__VA_ARGS__>            \
+      <<< tp.grid.x, tp.block.x, tp.shared_bytes, stream >>>(arg, parity);   \
+    break;                \
+  default:                \
+    errorQuda("%s not implemented for %d threads", #kernel, tp.block.x); \
+    }\
+  }\
+  else if(tp.block.z==4){\
+  switch (tp.block.x) {             \
+  case 128:                \
+    kernel<4, 32,__VA_ARGS__>           \
+      <<< tp.grid.x, tp.block.x, tp.shared_bytes, stream >>>(arg, parity);   \
+    break;                \
+  case 256:                \
+    kernel<4, 64,__VA_ARGS__>           \
+      <<< tp.grid.x, tp.block.x, tp.shared_bytes, stream >>>(arg, parity);   \
+    break;                \
+  case 384:                \
+    kernel<4, 96,__VA_ARGS__>           \
+      <<< tp.grid.x, tp.block.x, tp.shared_bytes, stream >>>(arg, parity);   \
+    break;                \
+  case 512:               \
+    kernel<4, 128,__VA_ARGS__>            \
+      <<< tp.grid.x, tp.block.x, tp.shared_bytes, stream >>>(arg, parity);   \
+    break;                \
+  case 640:               \
+    kernel<4, 160,__VA_ARGS__>            \
+      <<< tp.grid.x, tp.block.x, tp.shared_bytes, stream >>>(arg, parity);   \
+    break;                \
+  case 768:               \
+    kernel<4, 192,__VA_ARGS__>            \
+      <<< tp.grid.x, tp.block.x, tp.shared_bytes, stream >>>(arg, parity);   \
+    break;                \
+  case 896:               \
+    kernel<4, 224,__VA_ARGS__>            \
+      <<< tp.grid.x, tp.block.x, tp.shared_bytes, stream >>>(arg, parity);   \
+    break;                \
+  case 1024:               \
+    kernel<4, 256,__VA_ARGS__>            \
+      <<< tp.grid.x, tp.block.x, tp.shared_bytes, stream >>>(arg, parity);   \
+    break;                \
+  default:                \
+    errorQuda("%s not implemented for %d threads", #kernel, tp.block.x); \
+    }\
+  }\
+  else if(tp.block.z==5){\
+  switch (tp.block.x) {             \
+  case 128:                \
+    kernel<5, 32,__VA_ARGS__>           \
+      <<< tp.grid.x, tp.block.x, tp.shared_bytes, stream >>>(arg, parity);   \
+    break;                \
+  case 256:                \
+    kernel<5, 64,__VA_ARGS__>           \
+      <<< tp.grid.x, tp.block.x, tp.shared_bytes, stream >>>(arg, parity);   \
+    break;                \
+  case 384:                \
+    kernel<5, 96,__VA_ARGS__>           \
+      <<< tp.grid.x, tp.block.x, tp.shared_bytes, stream >>>(arg, parity);   \
+    break;                \
+  case 512:               \
+    kernel<5, 128,__VA_ARGS__>            \
+      <<< tp.grid.x, tp.block.x, tp.shared_bytes, stream >>>(arg, parity);   \
+    break;                \
+  case 640:               \
+    kernel<5, 160,__VA_ARGS__>            \
+      <<< tp.grid.x, tp.block.x, tp.shared_bytes, stream >>>(arg, parity);   \
+    break;                \
+  case 768:               \
+    kernel<5, 192,__VA_ARGS__>            \
+      <<< tp.grid.x, tp.block.x, tp.shared_bytes, stream >>>(arg, parity);   \
+    break;                \
+  case 896:               \
+    kernel<5, 224,__VA_ARGS__>            \
+      <<< tp.grid.x, tp.block.x, tp.shared_bytes, stream >>>(arg, parity);   \
+    break;                \
+  case 1024:               \
+    kernel<5, 256,__VA_ARGS__>            \
+      <<< tp.grid.x, tp.block.x, tp.shared_bytes, stream >>>(arg, parity);   \
+    break;                \
+  default:                \
+    errorQuda("%s not implemented for %d threads", #kernel, tp.block.x); \
+    }\
+  }\
+  else{\
+    errorQuda("Not implemented for %d", tp.block.z);\
+  }
+
+
+
+template<class T>
+__device__ __host__ inline Matrix<T,3> getSubTraceUnit(const Matrix<T,3>& a){
+  T tr = (a(0,0) + a(1,1) + a(2,2)) / 3.0;
+  Matrix<T,3> res;
+  res(0,0) = a(0,0)- tr; res(0,1) = a(0,1); res(0,2) = a(0,2);
+  res(1,0) = a(1,0); res(1,1) = a(1,1)-tr; res(1,2) = a(1,2);
+  res(2,0) = a(2,0); res(2,1) = a(2,1); res(2,2) = a(2,2)-tr;
+  return res;
+}
+
+template<class T>
+__device__ __host__ inline void SubTraceUnit(Matrix<T,3>& a){
+  T tr = (a(0,0) + a(1,1) + a(2,2)) / 3.0;
+  a(0,0)-= tr; a(1,1) -= tr; a(2,2) -= tr;
+}
+
+template<class T>
+__device__ __host__ inline double getRealTraceUVdagger(const Matrix<T,3>& a, const Matrix<T,3>& b){
+   double sum = (double)(a(0,0).x * b(0,0).x  + a(0,0).y * b(0,0).y);
+   sum += (double)(a(0,1).x * b(0,1).x  + a(0,1).y * b(0,1).y);
+   sum += (double)(a(0,2).x * b(0,2).x  + a(0,2).y * b(0,2).y);
+   sum += (double)(a(1,0).x * b(1,0).x  + a(1,0).y * b(1,0).y);
+   sum += (double)(a(1,1).x * b(1,1).x  + a(1,1).y * b(1,1).y);
+   sum += (double)(a(1,2).x * b(1,2).x  + a(1,2).y * b(1,2).y);
+   sum += (double)(a(2,0).x * b(2,0).x  + a(2,0).y * b(2,0).y);
+   sum += (double)(a(2,1).x * b(2,1).x  + a(2,1).y * b(2,1).y);
+   sum += (double)(a(2,2).x * b(2,2).x  + a(2,2).y * b(2,2).y);
+  return sum;
+}
+
+
+
+template <typename T>
+struct Summ {
+    __host__ __device__ __forceinline__ T operator()(const T &a, const T &b){
+        return a + b;
+    }
+};
+template <>
+struct Summ<double2>{
+    __host__ __device__ __forceinline__ double2 operator()(const double2 &a, const double2 &b){
+        return make_double2(a.x+b.x, a.y+b.y);
+    }
+};
+
+
+
+
+static __device__ __host__ inline int linkIndex3(int x[], int dx[], const int X[4]) {
+  int y[4];
+  for (int i=0; i<4; i++) y[i] = (x[i] + dx[i] + X[i]) % X[i];
+  int idx = (((y[3]*X[2] + y[2])*X[1] + y[1])*X[0] + y[0]) >> 1;
+  return idx;
+}
+static __device__ __host__ inline int linkIndex(int x[], const int X[4]) {
+  int idx = (((x[3]*X[2] + x[2])*X[1] + x[1])*X[0] + x[0]) >> 1;
+  return idx;
+}
+static __device__ __host__ inline int linkIndexM1(int x[], const int X[4], const int mu) {
+  int y[4];
+  for (int i=0; i<4; i++) y[i] = x[i];
+  y[mu] = (y[mu] -1 + X[mu]) % X[mu];
+  int idx = (((y[3]*X[2] + y[2])*X[1] + y[1])*X[0] + y[0]) >> 1;
+  return idx;
+}
+
+
+static __device__ __host__ inline void getCoords3(int x[4], int cb_index, const int X[4], int parity) {
+  /*x[3] = cb_index/(X[2]*X[1]*X[0]/2);
+  x[2] = (cb_index/(X[1]*X[0]/2)) % X[2];
+  x[1] = (cb_index/(X[0]/2)) % X[1];
+  x[0] = 2*(cb_index%(X[0]/2)) + ((x[3]+x[2]+x[1]+parity)&1);*/
+  int za = (cb_index / (X[0]/2));
+  int zb =  (za / X[1]);
+  x[1] = za - zb * X[1];
+  x[3] = (zb / X[2]);
+  x[2] = zb - x[3] * X[2];
+  int x1odd = (x[1] + x[2] + x[3] + parity) & 1;
+  x[0] = (2 * cb_index + x1odd)  - za * X[0];
+  return;
+}
+
+
+
+
+
+
+
+
+template <typename Gauge>
+struct GaugeFixQualityArg {
+  int threads; // number of active threads required
+  int X[4]; // grid dimensions
+#ifdef MULTI_GPU
+  int border[4]; 
+#endif
+  Gauge dataOr;
+  double2 *quality;
+  double2 *quality_h;
+  GaugeFixQualityArg(const Gauge &dataOr, const cudaGaugeField &data)
+    : dataOr(dataOr) {
+    //: dataOr(dataOr), quality_h(static_cast<double2*>(pinned_malloc(sizeof(double2)))) {
+
+    for(int dir=0; dir<4; ++dir){
+      X[dir] = data.X()[dir] - data.R()[dir]*2;
+      #ifdef MULTI_GPU
+      border[dir] = data.R()[dir];
+      #endif
+    }
+    threads = X[0]*X[1]*X[2]*X[3];
+    quality = (double2*)device_malloc(sizeof(double2));
+    quality_h = (double2*)safe_malloc(sizeof(double2));
+    //cudaHostGetDevicePointer(&quality, quality_h, 0);
+  }
+  double getAction(){return quality_h[0].x;}
+  double getTheta(){return quality_h[0].y;}
+};
+
+
+
+template<int blockSize, typename Float, typename Gauge, int gauge_dir>
+__global__ void computeFix_quality(GaugeFixQualityArg<Gauge> argQ){
+  int idx = threadIdx.x + blockIdx.x*blockDim.x;
+
+  typedef cub::BlockReduce<double2, blockSize> BlockReduce;
+  __shared__ typename BlockReduce::TempStorage temp_storage;
+  
+  //AVOID SHAREDMEM PROBLEMS!!!!!!! cub::BlockReduce<double2, blockSize> not initialize memory with 0? 
+  double2 data = make_double2(0.0,0.0);
+  if(idx < argQ.threads) {
+    typedef typename ComplexTypeId<Float>::Type Cmplx;
+    int parity = 0;
+    if(idx >= argQ.threads/2) {
+      parity = 1;
+      idx -= argQ.threads/2;
+    }
+    int X[4]; 
+    #pragma unroll
+    for(int dr=0; dr<4; ++dr) X[dr] = argQ.X[dr];
+
+    int x[4];
+    getCoords3(x, idx, X, parity);
+#ifdef MULTI_GPU
+    #pragma unroll
+    for(int dr=0; dr<4; ++dr) {
+         x[dr] += argQ.border[dr];
+         X[dr] += 2*argQ.border[dr];
+    }
+#endif
+    Matrix<Cmplx,3> delta;
+    setZero(&delta);
+    idx = linkIndex(x,X);
+  
+    for (int mu = 0; mu < gauge_dir; mu++) { 
+      Matrix<Cmplx,3> U; 
+      argQ.dataOr.load((Float*)(U.data),idx, mu, parity);
+      delta -= U;
+    }
+    //18*gauge_dir
+    data.x = -delta(0,0).x - delta(1,1).x - delta(2,2).x ;
+    //2
+    for (int mu = 0; mu < gauge_dir; mu++) {
+      Matrix<Cmplx,3> U; 
+      argQ.dataOr.load((Float*)(U.data),linkIndexM1(x,X,mu), mu, 1 - parity);
+      delta += U;
+    }
+    //18*gauge_dir
+    delta -= conj(delta);
+    //18
+    SubTraceUnit(delta);
+    //12
+    data.y = getRealTraceUVdagger(delta, delta);
+    //35
+    //T=36*gauge_dir+65
+  }
+  //This must be here for the case when the total number of threads is not multiple of blocksize!!!!
+  //HOW TO pre-initialize temp_storage to 0?
+  double2 aggregate = BlockReduce(temp_storage).Reduce(data, Summ<double2>());
+  if (threadIdx.x == 0) atomicAdd(argQ.quality, aggregate);
+}
+
+
+
+template<typename Float, typename Gauge, int gauge_dir>
+class GaugeFixQuality : Tunable {
+  GaugeFixQualityArg<Gauge> argQ;
+  mutable char aux_string[128]; // used as a label in the autotuner
+  private:
+  unsigned int sharedBytesPerThread() const { return 0; }
+  unsigned int sharedBytesPerBlock(const TuneParam &param) const { return 0; }
+  bool tuneSharedBytes() const { return false; } // Don't tune shared memory
+  bool tuneGridDim() const { return false; } // Don't tune the grid dimensions.
+  unsigned int minThreads() const { return argQ.threads; }
+
+  public:
+  GaugeFixQuality(GaugeFixQualityArg<Gauge> &argQ)
+    : argQ(argQ) {}
+  ~GaugeFixQuality () { host_free(argQ.quality_h);device_free(argQ.quality);}
+
+  void apply(const cudaStream_t &stream){
+      TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
+      //argQ.quality_h[0] = make_double2(0.0,0.0);
+      cudaMemset(argQ.quality, 0, sizeof(double2));
+      LAUNCH_KERNEL(computeFix_quality, tp, stream, argQ, Float, Gauge, gauge_dir);
+      cudaMemcpy(argQ.quality_h, argQ.quality, sizeof(double2), cudaMemcpyDeviceToHost);
+      //cudaDeviceSynchronize();
+      #ifdef MULTI_GPU        
+        if(comm_size() != 1) comm_allreduce_array((double*)argQ.quality_h, 2);
+        const int nNodes = comm_dim(0)*comm_dim(1)*comm_dim(2)*comm_dim(3);
+        argQ.quality_h[0].x  /= (double)(3*gauge_dir*argQ.threads*nNodes);
+        argQ.quality_h[0].y  /= (double)(3*argQ.threads*nNodes);
+      #else
+        argQ.quality_h[0].x  /= (double)(3*gauge_dir*argQ.threads);
+        argQ.quality_h[0].y  /= (double)(3*argQ.threads);
+      #endif
+  }
+
+  TuneKey tuneKey() const {
+    std::stringstream vol;
+    vol << argQ.X[0] << "x";
+    vol << argQ.X[1] << "x";
+    vol << argQ.X[2] << "x";
+    vol << argQ.X[3];
+    sprintf(aux_string,"threads=%d,prec=%d,gaugedir=%d",argQ.threads, sizeof(Float),gauge_dir);
+    return TuneKey(vol.str().c_str(), typeid(*this).name(), aux_string);
+    
+  }
+  std::string paramString(const TuneParam &param) const {
+    std::stringstream ps;
+    ps << "block=(" << param.block.x << "," << param.block.y << "," << param.block.z << ")";
+    ps << "shared=" << param.shared_bytes;
+    return ps.str();
+  }
+  void preTune(){}
+  void postTune(){}
+  long long flops() const { return (36LL*gauge_dir+65LL)*argQ.threads; }// Only correct if there is no link reconstruction, no cub reduction accounted also
+  //long long bytes() const { return (1)*2*gauge_dir*argQ.dataOr.Bytes(); }//no accounting the reduction!!!! argQ.dataOr.Bytes() return 0....
+  long long bytes() const { return 2LL*gauge_dir*argQ.threads*numParams*sizeof(Float); }//no accounting the reduction!!!!
+
+}; 
+
+
+//  template <typename Float, typename Gauge>
+template <typename Float, typename Gauge>
+struct GaugeFixArg {
+  int threads; // number of active threads required
+  int X[4]; // grid dimensions
+#ifdef MULTI_GPU
+  int border[4]; 
+#endif
+  Gauge dataOr;
+  cudaGaugeField &data;
+  const Float relax_boost;
+
+  GaugeFixArg(Gauge &dataOr, cudaGaugeField &data, const Float relax_boost)
+    : dataOr(dataOr), data(data), relax_boost(relax_boost) {
+
+    for(int dir=0; dir<4; ++dir){
+      X[dir] = data.X()[dir] - data.R()[dir]*2;
+      #ifdef MULTI_GPU
+      border[dir] = data.R()[dir];
+      #endif
+    }
+    threads = X[0]*X[1]*X[2]*X[3] >> 1;
+  }
+};
+
+
+
+
+
+template<int ImplementationType, int blockSize, typename Float, typename Gauge, int gauge_dir>
+__global__ void computeFix(GaugeFixArg<Float, Gauge> arg, int parity){
+  int tid = (threadIdx.x + blockSize) % blockSize;  
+  int idx = blockIdx.x * blockSize + tid;
+
+  if(idx >= arg.threads) return;
+
+  typedef typename ComplexTypeId<Float>::Type Cmplx;
+
+  if(ImplementationType<3){
+    int X[4]; 
+    #pragma unroll
+    for(int dr=0; dr<4; ++dr) X[dr] = arg.X[dr];
+
+    int x[4];
+    getCoords3(x, idx, X, parity);
+  #ifdef MULTI_GPU
+    #pragma unroll
+    for(int dr=0; dr<4; ++dr) {
+         x[dr] += arg.border[dr];
+         X[dr] += 2*arg.border[dr];
+    }
+  #endif
+    int mu = (threadIdx.x / blockSize);
+    int oddbit = parity;
+    if(threadIdx.x >= blockSize * 4){
+      mu -= 4;
+      x[mu] = (x[mu] - 1 + X[mu]) % X[mu];
+      oddbit = 1 - parity;
+    }
+    idx = (((x[3]*X[2] + x[2])*X[1] + x[1])*X[0] + x[0]) >> 1;
+    Matrix<Cmplx,3> link;
+    arg.dataOr.load((Float*)(link.data),idx, mu, oddbit);
+    if(ImplementationType==0) GaugeFixHit_NoAtomicAdd<blockSize, Cmplx, Float, gauge_dir, 3>(link, arg.relax_boost, tid);
+    if(ImplementationType==1) GaugeFixHit_AtomicAdd<blockSize, Cmplx, Float, gauge_dir, 3>(link, arg.relax_boost, tid);
+    if(ImplementationType==2)GaugeFixHit_NoAtomicAdd_LessSM<blockSize, Cmplx, Float, gauge_dir, 3>(link, arg.relax_boost, tid);
+    arg.dataOr.save((Float*)(link.data),idx, mu, oddbit);
+  }
+  else{
+    int X[4]; 
+    #pragma unroll
+    for(int dr=0; dr<4; ++dr) X[dr] = arg.X[dr];
+
+    int x[4];
+    getCoords3(x, idx, X, parity);
+  #ifdef MULTI_GPU
+    #pragma unroll
+    for(int dr=0; dr<4; ++dr) {
+         x[dr] += arg.border[dr];
+         X[dr] += 2*arg.border[dr];
+    }
+  #endif
+    int mu = (threadIdx.x / blockSize);
+    idx = (((x[3]*X[2] + x[2])*X[1] + x[1])*X[0] + x[0]) >> 1;
+    Matrix<Cmplx,3> link;
+    arg.dataOr.load((Float*)(link.data),idx, mu, parity);
+
+
+    x[mu] = (x[mu] - 1 + X[mu]) % X[mu];
+    int idx1 = (((x[3]*X[2] + x[2])*X[1] + x[1])*X[0] + x[0]) >> 1;
+    Matrix<Cmplx,3> link1;
+    arg.dataOr.load((Float*)(link1.data),idx1, mu, 1-parity);
+
+    if(ImplementationType==3) GaugeFixHit_NoAtomicAdd<blockSize, Cmplx, Float, gauge_dir, 3>(link, link1, arg.relax_boost, tid);
+    if(ImplementationType==4) GaugeFixHit_AtomicAdd<blockSize, Cmplx, Float, gauge_dir, 3>(link, link1, arg.relax_boost, tid);
+    if(ImplementationType==5)GaugeFixHit_NoAtomicAdd_LessSM<blockSize, Cmplx, Float, gauge_dir, 3>(link, link1, arg.relax_boost, tid);
+
+    arg.dataOr.save((Float*)(link.data),idx, mu, parity);
+    arg.dataOr.save((Float*)(link1.data),idx1, mu, 1-parity);
+
+  }
+}
+
+
+
+
+
+
+template<typename Float, typename Gauge, int gauge_dir>
+class GaugeFix : Tunable {
+  GaugeFixArg<Float, Gauge> arg;
+  int parity;
+  mutable char aux_string[128]; // used as a label in the autotuner
+protected:
+
+  dim3 createGrid   (const dim3 &block) const {
+    unsigned int blockx = block.x / 8;
+    if(block.z > 2) blockx = block.x / 4;
+    unsigned int  gx  = (arg.threads + blockx - 1) / blockx;
+    return  dim3(gx, 1, 1);
+  }
+  bool advanceBlockDim  (TuneParam &param) const {
+    //Use param.block.z to tune and save state for best kernel option
+    // to make use or not of atomicAdd operations and 4 or 8 threads per lattice site!!!
+    const unsigned int min_threads0 = 32 * 8;
+    const unsigned int min_threads1 = 32 * 4;
+    const unsigned int max_threads = 1024; // FIXME: use deviceProp.maxThreadsDim[0];
+    const unsigned int atmadd = 0;
+    unsigned int min_threads = min_threads0;
+    param.block.z += atmadd;    //USE TO SELECT BEST KERNEL OPTION WITH/WITHOUT USING ATOMICADD
+    if(param.block.z > 2) min_threads = 32 * 4;
+    param.block.x += min_threads;
+    param.block.y = 1;    
+    param.grid  = createGrid(param.block);
+
+
+    
+    if  ((param.block.x >= min_threads) && (param.block.x <= max_threads)){
+      if(param.block.z == 0) param.shared_bytes = param.block.x * 4 * sizeof(Float);
+      else if(param.block.z == 1 || param.block.z == 2) param.shared_bytes = param.block.x * 4 * sizeof(Float) / 8;
+      else if(param.block.z == 3) param.shared_bytes = param.block.x * 4 * sizeof(Float);
+      else if(param.block.z == 4 || param.block.z == 5) param.shared_bytes = param.block.x * sizeof(Float);
+      return  true;
+    }
+    else if(param.block.z == 0){
+      param.block.x = min_threads0;   
+      param.block.y = 1;    
+      param.block.z = 1;    //USE FOR ATOMIC ADD
+      param.grid  = createGrid(param.block);
+      param.shared_bytes = param.block.x * 4 * sizeof(Float) / 8;
+      return true;
+    }
+    else if(param.block.z == 1){
+      param.block.x = min_threads0;   
+      param.block.y = 1;    
+      param.block.z = 2;    //USE FOR NO ATOMIC ADD and LESS SHARED MEM
+      param.grid  = createGrid(param.block);
+      param.shared_bytes = param.block.x * 4 * sizeof(Float) / 8;
+      return true;
+    }
+    else if(param.block.z == 2){
+      param.block.x = min_threads1;   
+      param.block.y = 1;    
+      param.block.z = 3;        //USE FOR NO ATOMIC ADD 
+      param.grid  = createGrid(param.block);
+      param.shared_bytes = param.block.x * 4 * sizeof(Float);
+      return true;
+    }
+    else if(param.block.z == 3){
+      param.block.x = min_threads1;   
+      param.block.y = 1;    
+      param.block.z = 4;
+      param.grid  = createGrid(param.block);
+      param.shared_bytes = param.block.x * sizeof(Float);
+      return true;
+    }
+    else if(param.block.z == 4){
+      param.block.x = min_threads1;   
+      param.block.y = 1;    
+      param.block.z = 5;
+      param.grid  = createGrid(param.block);
+      param.shared_bytes = param.block.x * sizeof(Float);
+      return true;
+    }
+    else
+      return  false;
+  }
+  private:
+  unsigned int sharedBytesPerThread() const { 
+    return 0; 
+  }
+  unsigned int sharedBytesPerBlock(const TuneParam &param) const { 
+      if(param.block.z == 0) return param.block.x * 4 * sizeof(Float);
+      else if(param.block.z == 1 || param.block.z == 2) return param.block.x * 4 * sizeof(Float) / 8;
+      else if(param.block.z == 3) return param.block.x * 4 * sizeof(Float);
+      else return param.block.x * sizeof(Float);
+  }
+
+  bool tuneSharedBytes() const { return false; } // Don't tune shared memory
+  bool tuneGridDim() const { return false; } // Don't tune the grid dimensions.
+  unsigned int minThreads() const { return arg.threads; }
+
+  public:
+  virtual void initTuneParam(TuneParam &param) const{
+    param.block = dim3(256, 1, 0);
+    param.grid = createGrid(param.block);
+    param.shared_bytes = param.block.x * 4 * sizeof(Float);
+  }
+
+  GaugeFix(GaugeFixArg<Float, Gauge> &arg) : arg(arg) {
+      int parity = 0;
+    }
+  ~GaugeFix () { }
+  void setParity(const int par){ parity = par; }
+
+  void apply(const cudaStream_t &stream){
+      TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
+    LAUNCH_KERNEL_GAUGEFIX(computeFix, tp, stream, arg, parity, Float, Gauge, gauge_dir);
+  }
+
+  /** Sets default values for when tuning is disabled - this is guaranteed to work, but will be slow */
+  virtual void defaultTuneParam(TuneParam &param) const{ initTuneParam(param); }
+
+  TuneKey tuneKey() const {
+    std::stringstream vol;
+    vol << arg.X[0] << "x";
+    vol << arg.X[1] << "x";
+    vol << arg.X[2] << "x";
+    vol << arg.X[3];
+    sprintf(aux_string,"threads=%d,prec=%d,gaugedir=%d",arg.threads,sizeof(Float),gauge_dir);
+    return TuneKey(vol.str().c_str(), typeid(*this).name(), aux_string);
+  }
+
+  std::string paramString(const TuneParam &param) const {
+    std::stringstream ps;
+    ps << "block=(" << param.block.x << "," << param.block.y << "," << param.block.z << ")";
+    ps << "shared=" << param.shared_bytes;
+    ps << ", atomicadd=" << param.block.z;
+    return ps.str();
+  }
+
+  //need this
+  void preTune() { arg.data.backup(); }
+  void postTune() { arg.data.restore(); }
+  long long flops() const { return 3LL * (22 + 28 * gauge_dir + 224 * 3)*arg.threads; }// Only correct if there is no link reconstruction
+  //long long bytes() const { return (1)*8*2*arg.dataOr.Bytes(); } // Only correct if there is no link reconstruction load+save
+  long long bytes() const { return 8LL*2*arg.threads*numParams*sizeof(Float); }//no accounting the reduction!!!!
+}; 
+
+
+
+
+#ifdef MULTI_GPU
+template <typename Float, typename Gauge>
+struct GaugeFixInteriorPointsArg {
+  int threads; // number of active threads required
+  int X[4]; // grid dimensions
+#ifdef MULTI_GPU
+  int border[4]; 
+#endif
+  Gauge dataOr;
+  cudaGaugeField &data;
+  const Float relax_boost;
+  GaugeFixInteriorPointsArg(Gauge &dataOr, cudaGaugeField &data, const Float relax_boost)
+    : dataOr(dataOr), data(data), relax_boost(relax_boost) {
+
+#ifdef MULTI_GPU   
+    for(int dir=0; dir<4; ++dir){
+      if(comm_dim_partitioned(dir)) border[dir] = data.R()[dir] + 1; //skip BORDER_RADIUS + face border point
+      else border[dir] = 0;
+    }
+    for(int dir=0; dir<4; ++dir) X[dir] = data.X()[dir] - border[dir]*2;
+#else
+    for(int dir=0; dir<4; ++dir) X[dir] = data.X()[dir];
+#endif
+    threads = X[0]*X[1]*X[2]*X[3] >> 1;
+  }
+};
+
+
+
+
+template<int ImplementationType, int blockSize, typename Float, typename Gauge, int gauge_dir>
+__global__ void computeFixInteriorPoints(GaugeFixInteriorPointsArg<Float, Gauge> arg, int parity){
+  int tid = (threadIdx.x + blockSize) % blockSize;  
+  int idx = blockIdx.x * blockSize + tid;
+  if(idx >= arg.threads) return;
+  typedef typename ComplexTypeId<Float>::Type Cmplx;
+  int X[4];
+  #pragma unroll 
+  for(int dr=0; dr<4; ++dr) X[dr] = arg.X[dr];
+  int x[4];
+#ifdef MULTI_GPU
+  int za = (idx / (X[0]/2));
+  int zb =  (za / X[1]);
+  x[1] = za - zb * X[1];
+  x[3] = (zb / X[2]);
+  x[2] = zb - x[3] * X[2];
+  int p=0; for(int dr=0; dr<4; ++dr) p += arg.border[dr]; 
+  p = p & 1;
+  int x1odd = (x[1] + x[2] + x[3] + parity + p) & 1;
+  //int x1odd = (x[1] + x[2] + x[3] + parity) & 1;
+  x[0] = (2 * idx + x1odd)  - za * X[0];
+  for(int dr=0; dr<4; ++dr) {
+       x[dr] += arg.border[dr];
+       X[dr] += 2 * arg.border[dr];
+  }
+#else
+  getCoords3(x, idx, X, parity);
+#endif
+  int mu = (threadIdx.x / blockSize);
+
+  if(ImplementationType<3){
+    if(threadIdx.x >= blockSize * 4){
+      mu -= 4;
+      x[mu] = (x[mu] - 1 + X[mu]) % X[mu];
+      parity = 1 - parity;
+    }
+    idx = (((x[3]*X[2] + x[2])*X[1] + x[1])*X[0] + x[0]) >> 1;
+    Matrix<Cmplx,3> link;
+    arg.dataOr.load((Float*)(link.data),idx, mu, parity);
+    if(ImplementationType==0) GaugeFixHit_NoAtomicAdd<blockSize, Cmplx, Float, gauge_dir, 3>(link, arg.relax_boost, tid);
+    if(ImplementationType==1) GaugeFixHit_AtomicAdd<blockSize, Cmplx, Float, gauge_dir, 3>(link, arg.relax_boost, tid);
+    if(ImplementationType==2)GaugeFixHit_NoAtomicAdd_LessSM<blockSize, Cmplx, Float, gauge_dir, 3>(link, arg.relax_boost, tid);
+    arg.dataOr.save((Float*)(link.data),idx, mu, parity);
+  }
+ else{
+    idx = (((x[3]*X[2] + x[2])*X[1] + x[1])*X[0] + x[0]) >> 1;
+    Matrix<Cmplx,3> link;
+    arg.dataOr.load((Float*)(link.data),idx, mu, parity);
+
+
+    x[mu] = (x[mu] - 1 + X[mu]) % X[mu];
+    int idx1 = (((x[3]*X[2] + x[2])*X[1] + x[1])*X[0] + x[0]) >> 1;
+    Matrix<Cmplx,3> link1;
+    arg.dataOr.load((Float*)(link1.data),idx1, mu, 1-parity);
+
+    if(ImplementationType==3) GaugeFixHit_NoAtomicAdd<blockSize, Cmplx, Float, gauge_dir, 3>(link, link1, arg.relax_boost, tid);
+    if(ImplementationType==4) GaugeFixHit_AtomicAdd<blockSize, Cmplx, Float, gauge_dir, 3>(link, link1, arg.relax_boost, tid);
+    if(ImplementationType==5)GaugeFixHit_NoAtomicAdd_LessSM<blockSize, Cmplx, Float, gauge_dir, 3>(link, link1, arg.relax_boost, tid);
+
+    arg.dataOr.save((Float*)(link.data),idx, mu, parity);
+    arg.dataOr.save((Float*)(link1.data),idx1, mu, 1-parity);
+
+  }
+}
+
+
+
+
+
+
+
+
+template<typename Float, typename Gauge, int gauge_dir>
+class GaugeFixInteriorPoints : Tunable {
+  GaugeFixInteriorPointsArg<Float, Gauge> arg;
+  int parity;
+  mutable char aux_string[128]; // used as a label in the autotuner
+protected:
+
+  dim3 createGrid   (const dim3 &block) const {
+    unsigned int blockx = block.x / 8;
+    if(block.z > 2) blockx = block.x / 4;
+    unsigned int  gx  = (arg.threads + blockx - 1) / blockx;
+    return  dim3(gx, 1, 1);
+  }
+  bool advanceBlockDim  (TuneParam &param) const {
+    //Use param.block.z to tune and save state for best kernel option
+    // to make use or not of atomicAdd operations and 4 or 8 threads per lattice site!!!
+    const unsigned int min_threads0 = 32 * 8;
+    const unsigned int min_threads1 = 32 * 4;
+    const unsigned int max_threads = 1024; // FIXME: use deviceProp.maxThreadsDim[0];
+    const unsigned int atmadd = 0;
+    unsigned int min_threads = min_threads0;
+    param.block.z += atmadd;    //USE TO SELECT BEST KERNEL OPTION WITH/WITHOUT USING ATOMICADD
+    if(param.block.z > 2) min_threads = 32 * 4;
+    param.block.x += min_threads;
+    param.block.y = 1;    
+    param.grid  = createGrid(param.block);
+
+
+    
+    if  ((param.block.x >= min_threads) && (param.block.x <= max_threads)){
+      if(param.block.z == 0) param.shared_bytes = param.block.x * 4 * sizeof(Float);
+      else if(param.block.z == 1 || param.block.z == 2) param.shared_bytes = param.block.x * 4 * sizeof(Float) / 8;
+      else if(param.block.z == 3) param.shared_bytes = param.block.x * 4 * sizeof(Float);
+      else if(param.block.z == 4 || param.block.z == 5) param.shared_bytes = param.block.x * sizeof(Float);
+      return  true;
+    }
+    else if(param.block.z == 0){
+      param.block.x = min_threads0;   
+      param.block.y = 1;    
+      param.block.z = 1;    //USE FOR ATOMIC ADD
+      param.grid  = createGrid(param.block);
+      param.shared_bytes = param.block.x * 4 * sizeof(Float) / 8;
+      return true;
+    }
+    else if(param.block.z == 1){
+      param.block.x = min_threads0;   
+      param.block.y = 1;    
+      param.block.z = 2;    //USE FOR NO ATOMIC ADD and LESS SHARED MEM
+      param.grid  = createGrid(param.block);
+      param.shared_bytes = param.block.x * 4 * sizeof(Float) / 8;
+      return true;
+    }
+    else if(param.block.z == 2){
+      param.block.x = min_threads1;   
+      param.block.y = 1;    
+      param.block.z = 3;        //USE FOR NO ATOMIC ADD 
+      param.grid  = createGrid(param.block);
+      param.shared_bytes = param.block.x * 4 * sizeof(Float);
+      return true;
+    }
+    else if(param.block.z == 3){
+      param.block.x = min_threads1;   
+      param.block.y = 1;    
+      param.block.z = 4;
+      param.grid  = createGrid(param.block);
+      param.shared_bytes = param.block.x * sizeof(Float);
+      return true;
+    }
+    else if(param.block.z == 4){
+      param.block.x = min_threads1;   
+      param.block.y = 1;    
+      param.block.z = 5;
+      param.grid  = createGrid(param.block);
+      param.shared_bytes = param.block.x * sizeof(Float);
+      return true;
+    }
+    else
+      return  false;
+  }
+  private:
+  unsigned int sharedBytesPerThread() const { 
+    return 0; 
+  }
+  unsigned int sharedBytesPerBlock(const TuneParam &param) const { 
+      if(param.block.z == 0) return param.block.x * 4 * sizeof(Float);
+      else if(param.block.z == 1 || param.block.z == 2) return param.block.x * 4 * sizeof(Float) / 8;
+      else if(param.block.z == 3) return param.block.x * 4 * sizeof(Float);
+      else return param.block.x * sizeof(Float);
+  }
+
+  bool tuneSharedBytes() const { return false; } // Don't tune shared memory
+  bool tuneGridDim() const { return false; } // Don't tune the grid dimensions.
+  unsigned int minThreads() const { return arg.threads; }
+
+  public:
+  virtual void initTuneParam(TuneParam &param) const{
+    param.block = dim3(256, 1, 0);
+    param.grid = createGrid(param.block);
+    param.shared_bytes = param.block.x * 4 * sizeof(Float);
+  }
+  GaugeFixInteriorPoints(GaugeFixInteriorPointsArg<Float, Gauge> &arg) : arg(arg) {
+      int parity = 0;
+    }
+  ~GaugeFixInteriorPoints () { }
+  void setParity(const int par){ parity = par; }
+
+  void apply(const cudaStream_t &stream){
+      TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
+    LAUNCH_KERNEL_GAUGEFIX(computeFixInteriorPoints, tp, stream, arg, parity, Float, Gauge, gauge_dir);
+  }
+
+
+  /** Sets default values for when tuning is disabled - this is guaranteed to work, but will be slow */
+  virtual void defaultTuneParam(TuneParam &param) const{ initTuneParam(param); }
+
+  TuneKey tuneKey() const {
+    std::stringstream vol;
+    vol << arg.X[0] << "x";
+    vol << arg.X[1] << "x";
+    vol << arg.X[2] << "x";
+    vol << arg.X[3];
+    sprintf(aux_string,"threads=%d,prec=%d,gaugedir=%d",arg.threads,sizeof(Float),gauge_dir);
+    return TuneKey(vol.str().c_str(), typeid(*this).name(), aux_string);
+  }
+
+  std::string paramString(const TuneParam &param) const {
+    std::stringstream ps;
+    ps << "block=(" << param.block.x << "," << param.block.y << "," << param.block.z << ")";
+    ps << "shared=" << param.shared_bytes;
+    ps << ", atomicadd=" << param.block.z;
+    return ps.str();
+  }
+
+  //need this
+  void preTune() { arg.data.backup(); }
+  void postTune() { arg.data.restore(); }
+  long long flops() const { return 3LL * (22 + 28 * gauge_dir + 224 * 3)*arg.threads; }// Only correct if there is no link reconstruction
+  //long long bytes() const { return (1)*8*2*arg.dataOr.Bytes(); } // Only correct if there is no link reconstruction load+save
+  long long bytes() const { return 8LL*2*arg.threads*numParams*sizeof(Float); } // Only correct if there is no link reconstruction load+save
+}; 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+template <typename Float, typename Gauge>
+struct GaugeFixBorderPointsArg {
+  int threads; // number of active threads required
+  int X[4]; // grid dimensions
+  int border[4]; 
+  int *borderpoints[2];
+  int *faceindicessize[2];
+  size_t faceVolume[4];
+  size_t faceVolumeCB[4];
+  Gauge dataOr;
+  cudaGaugeField &data;
+  const Float relax_boost;
+
+  GaugeFixBorderPointsArg(Gauge &dataOr, cudaGaugeField &data, const Float relax_boost, size_t faceVolume_[4], size_t faceVolumeCB_[4])
+    : dataOr(dataOr), data(data), relax_boost(relax_boost) {
+
+
+    for(int dir=0; dir<4; ++dir){
+      X[dir] = data.X()[dir] - data.R()[dir]*2;
+      border[dir] = data.R()[dir];
+    }
+
+    /*for(int dir=0; dir<4; ++dir){
+      if(comm_dim_partitioned(dir)) border[dir] = BORDER_RADIUS;
+      else border[dir] = 0;
+    }
+    for(int dir=0; dir<4; ++dir) X[dir] = data.X()[dir] - border[dir]*2;*/
+    for(int dir=0; dir<4; ++dir){
+      faceVolume[dir] = faceVolume_[dir];
+      faceVolumeCB[dir] = faceVolumeCB_[dir];
+    }
+    if(comm_size() !=1) PreCalculateLatticeIndices(faceVolume, faceVolumeCB, X, border, threads, borderpoints);
+  }
+};
+
+template<int ImplementationType, int blockSize, typename Float, typename Gauge, int gauge_dir>
+__global__ void computeFixBorderPoints(GaugeFixBorderPointsArg<Float, Gauge> arg, int parity){
+  int tid = (threadIdx.x + blockSize) % blockSize;  
+  int idx = blockIdx.x * blockSize + tid;
+  if(idx >= arg.threads) return;
+  typedef typename ComplexTypeId<Float>::Type Cmplx;
+  int mu = (threadIdx.x / blockSize);
+  idx = arg.borderpoints[parity][idx];
+  int X[4], x[4];
+  x[3] = idx/(arg.X[0] * arg.X[1]  * arg.X[2]);
+  x[2] = (idx/(arg.X[0] * arg.X[1])) % arg.X[2];
+  x[1] = (idx/arg.X[0]) % arg.X[1];
+  x[0] = idx % arg.X[0];
+  #pragma unroll
+  for(int dr=0; dr<4; ++dr) x[dr] += arg.border[dr];
+  #pragma unroll
+  for(int dr=0; dr<4; ++dr) X[dr] = arg.X[dr] + 2 * arg.border[dr];
+
+  if(ImplementationType<3){
+    if(threadIdx.x >= blockSize * 4){
+        mu -= 4;
+        x[mu] = (x[mu] - 1 + X[mu]) % X[mu];
+        parity = 1 - parity;
+    }
+    idx = (((x[3]*X[2] + x[2])*X[1] + x[1])*X[0] + x[0]) >> 1;
+    Matrix<Cmplx,3> link;
+    arg.dataOr.load((Float*)(link.data),idx, mu, parity);
+    if(ImplementationType==0) GaugeFixHit_NoAtomicAdd<blockSize, Cmplx, Float, gauge_dir, 3>(link, arg.relax_boost, tid);
+    if(ImplementationType==1) GaugeFixHit_AtomicAdd<blockSize, Cmplx, Float, gauge_dir, 3>(link, arg.relax_boost, tid);
+    if(ImplementationType==2)GaugeFixHit_NoAtomicAdd_LessSM<blockSize, Cmplx, Float, gauge_dir, 3>(link, arg.relax_boost, tid);
+    arg.dataOr.save((Float*)(link.data),idx, mu, parity);
+  }
+  else{
+    idx = (((x[3]*X[2] + x[2])*X[1] + x[1])*X[0] + x[0]) >> 1;
+    Matrix<Cmplx,3> link;
+    arg.dataOr.load((Float*)(link.data),idx, mu, parity);
+
+
+    x[mu] = (x[mu] - 1 + X[mu]) % X[mu];
+    int idx1 = (((x[3]*X[2] + x[2])*X[1] + x[1])*X[0] + x[0]) >> 1;
+    Matrix<Cmplx,3> link1;
+    arg.dataOr.load((Float*)(link1.data),idx1, mu, 1-parity);
+
+    if(ImplementationType==3) GaugeFixHit_NoAtomicAdd<blockSize, Cmplx, Float, gauge_dir, 3>(link, link1, arg.relax_boost, tid);
+    if(ImplementationType==4) GaugeFixHit_AtomicAdd<blockSize, Cmplx, Float, gauge_dir, 3>(link, link1, arg.relax_boost, tid);
+    if(ImplementationType==5)GaugeFixHit_NoAtomicAdd_LessSM<blockSize, Cmplx, Float, gauge_dir, 3>(link, link1, arg.relax_boost, tid);
+
+    arg.dataOr.save((Float*)(link.data),idx, mu, parity);
+    arg.dataOr.save((Float*)(link1.data),idx1, mu, 1-parity);
+  }
+}
+
+
+
+
+template<typename Float, typename Gauge, int gauge_dir>
+class GaugeFixBorderPoints : Tunable {
+  GaugeFixBorderPointsArg<Float, Gauge> arg;
+  int parity;
+  mutable char aux_string[128]; // used as a label in the autotuner
+protected:
+
+  dim3 createGrid   (const dim3 &block) const {
+    unsigned int blockx = block.x / 8;
+    if(block.z > 2) blockx = block.x / 4;
+    unsigned int  gx  = (arg.threads + blockx - 1) / blockx;
+    return  dim3(gx, 1, 1);
+  }
+  bool advanceBlockDim  (TuneParam &param) const {
+    //Use param.block.z to tune and save state for best kernel option
+    // to make use or not of atomicAdd operations and 4 or 8 threads per lattice site!!!
+    const unsigned int min_threads0 = 32 * 8;
+    const unsigned int min_threads1 = 32 * 4;
+    const unsigned int max_threads = 1024; // FIXME: use deviceProp.maxThreadsDim[0];
+    const unsigned int atmadd = 0;
+    unsigned int min_threads = min_threads0;
+    param.block.z += atmadd;    //USE TO SELECT BEST KERNEL OPTION WITH/WITHOUT USING ATOMICADD
+    if(param.block.z > 2) min_threads = 32 * 4;
+    param.block.x += min_threads;
+    param.block.y = 1;    
+    param.grid  = createGrid(param.block);
+
+
+    
+    if  ((param.block.x >= min_threads) && (param.block.x <= max_threads)){
+      if(param.block.z == 0) param.shared_bytes = param.block.x * 4 * sizeof(Float);
+      else if(param.block.z == 1 || param.block.z == 2) param.shared_bytes = param.block.x * 4 * sizeof(Float) / 8;
+      else if(param.block.z == 3) param.shared_bytes = param.block.x * 4 * sizeof(Float);
+      else if(param.block.z == 4 || param.block.z == 5) param.shared_bytes = param.block.x * sizeof(Float);
+      return  true;
+    }
+    else if(param.block.z == 0){
+      param.block.x = min_threads0;   
+      param.block.y = 1;    
+      param.block.z = 1;    //USE FOR ATOMIC ADD
+      param.grid  = createGrid(param.block);
+      param.shared_bytes = param.block.x * 4 * sizeof(Float) / 8;
+      return true;
+    }
+    else if(param.block.z == 1){
+      param.block.x = min_threads0;   
+      param.block.y = 1;    
+      param.block.z = 2;    //USE FOR NO ATOMIC ADD and LESS SHARED MEM
+      param.grid  = createGrid(param.block);
+      param.shared_bytes = param.block.x * 4 * sizeof(Float) / 8;
+      return true;
+    }
+    else if(param.block.z == 2){
+      param.block.x = min_threads1;   
+      param.block.y = 1;    
+      param.block.z = 3;        //USE FOR NO ATOMIC ADD 
+      param.grid  = createGrid(param.block);
+      param.shared_bytes = param.block.x * 4 * sizeof(Float);
+      return true;
+    }
+    else if(param.block.z == 3){
+      param.block.x = min_threads1;   
+      param.block.y = 1;    
+      param.block.z = 4;
+      param.grid  = createGrid(param.block);
+      param.shared_bytes = param.block.x * sizeof(Float);
+      return true;
+    }
+    else if(param.block.z == 4){
+      param.block.x = min_threads1;   
+      param.block.y = 1;    
+      param.block.z = 5;
+      param.grid  = createGrid(param.block);
+      param.shared_bytes = param.block.x * sizeof(Float);
+      return true;
+    }
+    else
+      return  false;
+  }
+  private:
+  unsigned int sharedBytesPerThread() const { 
+    return 0; 
+  }
+  unsigned int sharedBytesPerBlock(const TuneParam &param) const { 
+      if(param.block.z == 0) return param.block.x * 4 * sizeof(Float);
+      else if(param.block.z == 1 || param.block.z == 2) return param.block.x * 4 * sizeof(Float) / 8;
+      else if(param.block.z == 3) return param.block.x * 4 * sizeof(Float);
+      else return param.block.x * sizeof(Float);
+  }
+
+  bool tuneSharedBytes() const { return false; } // Don't tune shared memory
+  bool tuneGridDim() const { return false; } // Don't tune the grid dimensions.
+  unsigned int minThreads() const { return arg.threads; }
+
+  public:
+  virtual void initTuneParam(TuneParam &param) const{
+    param.block = dim3(256, 1, 0);
+    param.grid = createGrid(param.block);
+    param.shared_bytes = param.block.x * 4 * sizeof(Float);
+  }
+  GaugeFixBorderPoints(GaugeFixBorderPointsArg<Float, Gauge> &arg) : arg(arg) {
+      int parity = 0;
+  }
+  ~GaugeFixBorderPoints () { 
+    if(comm_size() !=1) for(int i = 0; i < 2; i++) cudaFree(arg.borderpoints[i]);
+   }
+  void setParity(const int par){ parity = par; }
+
+  void apply(const cudaStream_t &stream){
+      TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
+    LAUNCH_KERNEL_GAUGEFIX(computeFixBorderPoints, tp, stream, arg, parity, Float, Gauge, gauge_dir);
+  }
+
+  /** Sets default values for when tuning is disabled - this is guaranteed to work, but will be slow */
+  virtual void defaultTuneParam(TuneParam &param) const{ initTuneParam(param); }
+
+  TuneKey tuneKey() const {
+    std::stringstream vol;
+    vol << arg.X[0] << "x";
+    vol << arg.X[1] << "x";
+    vol << arg.X[2] << "x";
+    vol << arg.X[3];
+    sprintf(aux_string,"threads=%d,prec=%d,gaugedir=%d",arg.threads,sizeof(Float),gauge_dir);
+    return TuneKey(vol.str().c_str(), typeid(*this).name(), aux_string);
+  }
+
+  std::string paramString(const TuneParam &param) const {
+    std::stringstream ps;
+    ps << "block=(" << param.block.x << "," << param.block.y << "," << param.block.z << ")";
+    ps << "shared=" << param.shared_bytes;
+    ps << ", atomicadd=" << param.block.z;
+    return ps.str();
+  }
+
+  //need this
+  void preTune() { arg.data.backup(); }
+  void postTune() { arg.data.restore(); }
+  long long flops() const { return 3LL * (22 + 28 * gauge_dir + 224 * 3)*arg.threads; }// Only correct if there is no link reconstruction
+  //long long bytes() const { return (1)*8*2*arg.dataOr.Bytes(); } // Only correct if there is no link reconstruction load+save
+  long long bytes() const { return 8LL*2*arg.threads*numParams*sizeof(Float); } // Only correct if there is no link reconstruction load+save
+
+}; 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+template <typename Gauge>
+struct GaugeFixUnPackArg {
+  int X[4]; // grid dimensions
+#ifdef MULTI_GPU
+  int border[4]; 
+#endif
+  Gauge dataOr;
+  GaugeFixUnPackArg(Gauge &dataOr, cudaGaugeField &data)
+    : dataOr(dataOr) {
+    for(int dir=0; dir<4; ++dir){
+      X[dir] = data.X()[dir] - data.R()[dir]*2;
+      #ifdef MULTI_GPU
+      border[dir] = data.R()[dir];
+      #endif
+    }
+  }
+};
+
+
+template<int NElems, typename Float, typename Gauge, bool pack>
+__global__ void Kernel_UnPackGhost(int size, GaugeFixUnPackArg<Gauge> arg, typename ComplexTypeId<Float>::Type *array, int parity, int face, int dir){
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if(idx >= size) return;
+  int X[4]; 
+  for(int dr=0; dr<4; ++dr) X[dr] = arg.X[dr];
+  int x[4];
+  int za, xodd;
+  int borderid = 0;
+  parity = 1 - parity;
+  switch(face){
+    case 0: //X FACE
+      za = idx / ( X[1] / 2);
+      x[3] = za / X[2];
+      x[2] = za - x[3] * X[2];
+      x[0] = borderid;
+      xodd = (borderid + x[2] + x[3] + parity) & 1;
+      x[1] = (2 * idx + xodd)  - za * X[1];
+    break;
+    case 1: //Y FACE
+      za = idx / ( X[0] / 2);
+      x[3] = za / X[2];
+      x[2] = za - x[3] * X[2];
+      x[1] = borderid;
+      xodd = (borderid  + x[2] + x[3] + parity) & 1;
+      x[0] = (2 * idx + xodd)  - za * X[0];
+    break;
+    case 2: //Z FACE
+      za = idx / ( X[0] / 2);
+      x[3] = za / X[1];
+      x[1] = za - x[3] * X[1];
+      x[2] = borderid;
+      xodd = (borderid  + x[1] + x[3] + parity) & 1;
+      x[0] = (2 * idx + xodd)  - za * X[0];
+    break;
+    case 3: //T FACE
+      za = idx / ( X[0] / 2);
+      x[2] = za / X[1];
+      x[1] = za - x[2] * X[1];
+      x[3] = borderid;
+      xodd = (borderid  + x[1] + x[2] + parity) & 1;
+      x[0] = (2 * idx + xodd)  - za * X[0];
+    break;
+  }
+  for(int dr=0; dr<4; ++dr) {
+       x[dr] += arg.border[dr];
+       X[dr] += 2*arg.border[dr];
+  }
+  x[face] -= 1;
+  parity = 1 - parity;
+  int id = (((x[3]*X[2] + x[2])*X[1] + x[1])*X[0] + x[0]) >> 1;
+  typedef typename ComplexTypeId<Float>::Type Cmplx;
+  typedef typename mapper<Float>::type RegType;
+  RegType tmp[NElems];
+  RegType data[18];
+  if(pack){
+    arg.dataOr.load(data, id, dir, parity);
+    arg.dataOr.reconstruct.Pack(tmp, data, id);
+    for(int i=0; i<NElems/2; ++i) array[idx + size * i] = ((Cmplx*)tmp)[i];
+  }
+else{
+    for(int i=0; i<NElems/2; ++i) ((Cmplx*)tmp)[i] = array[idx + size * i];
+    arg.dataOr.reconstruct.Unpack(data, tmp, id, dir, 0);
+    arg.dataOr.save(data, id, dir, parity);
+  }
+}
+
+
+
+
+template<int NElems, typename Float, typename Gauge, bool pack>
+__global__ void Kernel_UnPackTop(int size, GaugeFixUnPackArg<Gauge> arg, typename ComplexTypeId<Float>::Type *array, int parity, int face, int dir){
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if(idx >= size) return;
+  int X[4]; 
+  for(int dr=0; dr<4; ++dr) X[dr] = arg.X[dr];
+  int x[4];
+  int za, xodd;
+  int borderid = arg.X[face] - 1;
+  switch(face){
+    case 0: //X FACE
+      za = idx / ( X[1] / 2);
+      x[3] = za / X[2];
+      x[2] = za - x[3] * X[2];
+      x[0] = borderid;
+      xodd = (borderid + x[2] + x[3] + parity) & 1;
+      x[1] = (2 * idx + xodd)  - za * X[1];
+    break;
+    case 1: //Y FACE
+      za = idx / ( X[0] / 2);
+      x[3] = za / X[2];
+      x[2] = za - x[3] * X[2];
+      x[1] = borderid;
+      xodd = (borderid  + x[2] + x[3] + parity) & 1;
+      x[0] = (2 * idx + xodd)  - za * X[0];
+    break;
+    case 2: //Z FACE
+      za = idx / ( X[0] / 2);
+      x[3] = za / X[1];
+      x[1] = za - x[3] * X[1];
+      x[2] = borderid;
+      xodd = (borderid  + x[1] + x[3] + parity) & 1;
+      x[0] = (2 * idx + xodd)  - za * X[0];
+    break;
+    case 3: //T FACE
+      za = idx / ( X[0] / 2);
+      x[2] = za / X[1];
+      x[1] = za - x[2] * X[1];
+      x[3] = borderid;
+      xodd = (borderid  + x[1] + x[2] + parity) & 1;
+      x[0] = (2 * idx + xodd)  - za * X[0];
+    break;
+  }
+  for(int dr=0; dr<4; ++dr) {
+       x[dr] += arg.border[dr];
+       X[dr] += 2*arg.border[dr];
+  }
+  int id = (((x[3]*X[2] + x[2])*X[1] + x[1])*X[0] + x[0]) >> 1;
+  typedef typename ComplexTypeId<Float>::Type Cmplx;
+  typedef typename mapper<Float>::type RegType;
+  RegType tmp[NElems];
+  RegType data[18];
+  if(pack){
+    arg.dataOr.load(data, id, dir, parity);
+    arg.dataOr.reconstruct.Pack(tmp, data, id);
+    for(int i=0; i<NElems/2; ++i) array[idx + size * i] = ((Cmplx*)tmp)[i];
+  }
+  else{
+    for(int i=0; i<NElems/2; ++i) ((Cmplx*)tmp)[i] = array[idx + size * i];
+    arg.dataOr.reconstruct.Unpack(data, tmp, id, dir, 0);
+    arg.dataOr.save(data, id, dir, parity);
+  }
+}
+#endif
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+template<typename Float, typename Gauge, int NElems, int gauge_dir>
+void gaugefixingOVR( Gauge dataOr,  cudaGaugeField& data, \
+  const unsigned int Nsteps, const unsigned int verbose_interval, \
+  const Float relax_boost, const double tolerance, \
+  const unsigned int reunit_interval, \
+  const unsigned int stopWtheta) {
+
+
+  TimeProfile profileGaugeFix("GaugeFixCuda");
+
+  profileGaugeFix.Start(QUDA_PROFILE_COMPUTE);
+  double flop = 0;
+  double byte = 0;
+
+  
+
+  printfQuda("\tOverrelaxation boost parameter: %lf\n", (double)relax_boost);
+  printfQuda("\tStop criterium: %lf\n", tolerance);
+  if(stopWtheta) printfQuda("\tStop criterium method: theta\n");
+  else           printfQuda("\tStop criterium method: Delta\n");
+  printfQuda("\tMaximum number of iterations: %d\n", Nsteps);
+  printfQuda("\tReunitarize at every %d steps\n", reunit_interval);
+  printfQuda("\tPrint convergence results at every %d steps\n", verbose_interval);
+
+  
+  const double unitarize_eps = 1e-14;
+  const double max_error = 1e-10;
+  const int reunit_allow_svd = 1;
+  const int reunit_svd_only  = 0;
+  const double svd_rel_error = 1e-6;
+  const double svd_abs_error = 1e-6;
+  setUnitarizeLinksConstants(unitarize_eps, max_error,
+      reunit_allow_svd, reunit_svd_only,
+      svd_rel_error, svd_abs_error);
+  int num_failures=0;
+  int* num_failures_dev;
+  cudaMalloc((void**)&num_failures_dev, sizeof(int));
+  cudaMemset(num_failures_dev, 0, sizeof(int));
+  if(num_failures_dev == NULL) errorQuda("cudaMalloc failed for dev_pointer\n");
+
+  GaugeFixQualityArg<Gauge> argQ(dataOr, data);
+  GaugeFixQuality<Float,Gauge, gauge_dir> GaugeFixQuality(argQ);
+
+
+  GaugeFixArg<Float, Gauge> arg(dataOr, data, relax_boost);
+  GaugeFix<Float,Gauge, gauge_dir> gaugeFix(arg);
+
+
+
+
+
+#ifdef MULTI_GPU
+  void *send[4];
+  void *recv[4];
+  void *sendg[4];
+  void *recvg[4];
+  void *send_d[4];
+  void *recv_d[4];
+  void *sendg_d[4];
+  void *recvg_d[4];
+  void *hostbuffer_h[4];
+  cudaStream_t GFStream[9];
+  size_t offset[4];
+  size_t bytes[4];
+  size_t faceVolume[4];
+  size_t faceVolumeCB[4];
+  // do the exchange
+  MsgHandle *mh_recv_back[4];
+  MsgHandle *mh_recv_fwd[4];
+  MsgHandle *mh_send_fwd[4];
+  MsgHandle *mh_send_back[4];
+  int X[4];
+  dim3 block[4];
+  dim3 grid[4];
+
+  if(comm_size() != 1){
+
+    for(int dir=0; dir<4; ++dir){
+      X[dir] = data.X()[dir] - data.R()[dir]*2;
+      if (!commDimPartitioned(dir) && data.R()[dir] != 0) errorQuda("Not supported!\n");
+    }
+    for (int i=0; i<4; i++) {
+      faceVolume[i] = 1;
+      for (int j=0; j<4; j++) {
+        if (i==j) continue;
+        faceVolume[i] *= X[j];
+      }
+      faceVolumeCB[i] = faceVolume[i]/2;
+    }
+
+    for (int d=0; d<4; d++) {
+      if (!commDimPartitioned(d)) continue;
+      offset[d] = faceVolumeCB[d] * NElems;
+      bytes[d] =  sizeof(Float) * offset[d];
+      send_d[d] = device_malloc(bytes[d]);
+      recv_d[d] = device_malloc(bytes[d]);
+      sendg_d[d] = device_malloc(bytes[d]);
+      recvg_d[d] = device_malloc(bytes[d]);
+      cudaStreamCreate(&GFStream[d]);
+      cudaStreamCreate(&GFStream[4 + d]);
+      #ifndef GPU_COMMS
+      hostbuffer_h[d] = (void*)pinned_malloc(4*bytes[d]);
+      #endif
+      block[d] = make_uint3(128, 1, 1);
+      grid[d] = make_uint3((faceVolumeCB[d] + block[d].x - 1) / block[d].x, 1, 1);
+    }
+    cudaStreamCreate(&GFStream[8]);
+    for (int d=0; d<4; d++) {
+      if (!commDimPartitioned(d)) continue;
+      #ifdef GPU_COMMS
+      recv[d] = recv_d[d];
+      send[d] = send_d[d];
+      recvg[d] = recvg_d[d];
+      sendg[d] = sendg_d[d];
+      #else
+      recv[d] = hostbuffer_h[d];
+      send[d] = static_cast<char*>(hostbuffer_h[d]) + bytes[d];
+      recvg[d] = static_cast<char*>(hostbuffer_h[d]) + 3*bytes[d];
+      sendg[d] = static_cast<char*>(hostbuffer_h[d]) + 2*bytes[d];      
+      #endif
+      mh_recv_back[d] = comm_declare_receive_relative(recv[d], d, -1, bytes[d]);
+      mh_recv_fwd[d]  = comm_declare_receive_relative(recvg[d], d, +1, bytes[d]);
+      mh_send_back[d] = comm_declare_send_relative(sendg[d], d, -1, bytes[d]);
+      mh_send_fwd[d]  = comm_declare_send_relative(send[d], d, +1, bytes[d]);
+    }
+  }
+  GaugeFixUnPackArg<Gauge> dataexarg(dataOr, data);
+  GaugeFixBorderPointsArg<Float, Gauge> argBorder(dataOr, data, relax_boost, faceVolume, faceVolumeCB);
+  GaugeFixBorderPoints<Float,Gauge, gauge_dir> gfixBorderPoints(argBorder);
+  GaugeFixInteriorPointsArg<Float, Gauge> argInt(dataOr, data, relax_boost);
+  GaugeFixInteriorPoints<Float,Gauge, gauge_dir> gfixIntPoints(argInt);
+  #endif
+
+  GaugeFixQuality.apply(0);
+  flop += (double)GaugeFixQuality.flops();
+  byte += (double)GaugeFixQuality.bytes();
+  double action0 = argQ.getAction();
+  printfQuda("Step: %d\tAction: %.16e\ttheta: %.16e\n", 0, argQ.getAction(), argQ.getTheta());
+
+
+unitarizeLinksQuda(data, num_failures_dev);
+      cudaMemcpy(&num_failures, num_failures_dev, sizeof(int), cudaMemcpyDeviceToHost);
+      if(num_failures>0){
+        cudaFree(num_failures_dev); 
+        errorQuda("Error in the unitarization\n"); 
+        exit(1);
+      }
+      cudaMemset(num_failures_dev, 0, sizeof(int));
+
+  int iter = 0;
+  for(iter = 0; iter < Nsteps; iter++){
+    for(int p = 0; p < 2; p++){
+      #ifndef MULTI_GPU      
+        gaugeFix.setParity(p);
+        gaugeFix.apply(0);
+        flop += (double)gaugeFix.flops();
+        byte += (double)gaugeFix.bytes();
+      #else
+      if(comm_size() == 1){
+        gaugeFix.setParity(p);
+        gaugeFix.apply(0);
+        flop += (double)gaugeFix.flops();
+        byte += (double)gaugeFix.bytes();
+      }
+      else{
+        gfixIntPoints.setParity(p);
+        gfixBorderPoints.setParity(p);//compute border points
+        gfixBorderPoints.apply(0);
+        flop += (double)gfixBorderPoints.flops();
+        byte += (double)gfixBorderPoints.bytes();
+        flop += (double)gfixIntPoints.flops();
+        byte += (double)gfixIntPoints.bytes();
+        for (int d=0; d<4; d++) {
+          if (!commDimPartitioned(d)) continue;
+          comm_start(mh_recv_back[d]);  
+          comm_start(mh_recv_fwd[d]);  
+        }   
+        //wait for the update to the halo points before start packing...
+        cudaDeviceSynchronize();
+        for (int d=0; d<4; d++) {
+          if (!commDimPartitioned(d)) continue;
+          //extract top face
+          Kernel_UnPackTop<NElems, Float, Gauge, true><<<grid[d], block[d], 0, GFStream[d]>>>(faceVolumeCB[d], dataexarg, reinterpret_cast<typename ComplexTypeId<Float>::Type*>(send_d[d]), p, d, d);
+          //extract bottom ghost
+          Kernel_UnPackGhost<NElems, Float, Gauge, true><<<grid[d], block[d], 0, GFStream[4+d]>>>(faceVolumeCB[d], dataexarg, reinterpret_cast<typename ComplexTypeId<Float>::Type*>(sendg_d[d]), 1-p, d, d);
+        }  
+        #ifdef GPU_COMMS
+        for (int d=0; d<4; d++) {
+          if (!commDimPartitioned(d)) continue;
+          cudaStreamSynchronize(GFStream[d]);
+          comm_start(mh_send_fwd[d]);
+          cudaStreamSynchronize(GFStream[4+d]);
+          comm_start(mh_send_back[d]);
+        }   
+        #else
+        for (int d=0; d<4; d++) {
+          if (!commDimPartitioned(d)) continue;
+          cudaMemcpyAsync(send[d], send_d[d], bytes[d], cudaMemcpyDeviceToHost, GFStream[d]);
+        }
+        for (int d=0; d<4; d++) {
+          if (!commDimPartitioned(d)) continue;
+          cudaMemcpyAsync(sendg[d], sendg_d[d], bytes[d], cudaMemcpyDeviceToHost, GFStream[4+d]);
+        }    
+        #endif
+        //compute interior points
+        gfixIntPoints.apply(GFStream[8]);
+
+        #ifndef GPU_COMMS
+        for (int d=0; d<4; d++) {
+          if (!commDimPartitioned(d)) continue;
+          cudaStreamSynchronize(GFStream[d]);
+          comm_start(mh_send_fwd[d]);
+          cudaStreamSynchronize(GFStream[4+d]);
+          comm_start(mh_send_back[d]);
+        }
+        for (int d=0; d<4; d++) {
+          if (!commDimPartitioned(d)) continue;
+          comm_wait(mh_recv_back[d]);
+          cudaMemcpyAsync(recv_d[d], recv[d], bytes[d], cudaMemcpyHostToDevice, GFStream[d]);
+        }
+        for (int d=0; d<4; d++) {
+          if (!commDimPartitioned(d)) continue;
+          comm_wait(mh_recv_fwd[d]);
+          cudaMemcpyAsync(recvg_d[d], recvg[d], bytes[d], cudaMemcpyHostToDevice, GFStream[4 + d]);
+        }
+        #endif
+        for (int d=0; d<4; d++) {
+          if (!commDimPartitioned(d)) continue;
+          #ifdef GPU_COMMS
+          comm_wait(mh_recv_back[d]);
+          #endif
+          Kernel_UnPackGhost<NElems, Float, Gauge, false><<<grid[d], block[d], 0, GFStream[d]>>>(faceVolumeCB[d], dataexarg, reinterpret_cast<typename ComplexTypeId<Float>::Type*>(recv_d[d]), p, d, d);
+        }
+        for (int d=0; d<4; d++) {
+          if (!commDimPartitioned(d)) continue;
+          #ifdef GPU_COMMS
+          comm_wait(mh_recv_fwd[d]);
+          #endif
+          Kernel_UnPackTop<NElems, Float, Gauge, false><<<grid[d], block[d], 0, GFStream[4 + d]>>>(faceVolumeCB[d], dataexarg, reinterpret_cast<typename ComplexTypeId<Float>::Type*>(recvg_d[d]), 1-p, d, d); 
+        }
+        for (int d=0; d<4; d++) {
+          if (!commDimPartitioned(d)) continue;
+          comm_wait(mh_send_back[d]);
+          comm_wait(mh_send_fwd[d]);
+          cudaStreamSynchronize(GFStream[d]);
+          cudaStreamSynchronize(GFStream[4+d]);
+        }
+        cudaStreamSynchronize(GFStream[8]);
+      }
+      #endif 
+      /*gaugeFix.setParity(p);
+      gaugeFix.apply(0);
+      flop += (double)gaugeFix.flops();
+      byte += (double)gaugeFix.bytes();
+      #ifdef MULTI_GPU
+      if(comm_size() != 1){//exchange updated top face links in current parity
+        for (int d=0; d<4; d++) {
+          if (!commDimPartitioned(d)) continue;
+          comm_start(mh_recv_back[d]);      
+          //extract top face
+          Kernel_UnPackTop<NElems, Float, Gauge><<<grid[d], block[d]>>>(faceVolumeCB[d], dataexarg, reinterpret_cast<Float*>(send_d[d]), p, d, d, true);
+          #ifndef GPU_COMMS
+          cudaMemcpy(send[d], send_d[d], bytes[d], cudaMemcpyDeviceToHost);
+          #else
+          cudaDeviceSynchronize();
+          #endif
+          comm_start(mh_send_fwd[d]);
+          comm_wait(mh_recv_back[d]);
+          comm_wait(mh_send_fwd[d]);
+          #ifndef GPU_COMMS
+          cudaMemcpy(recv_d[d], recv[d], bytes[d], cudaMemcpyHostToDevice);
+          #endif
+          //inject top face in ghost
+          Kernel_UnPackGhost<NElems, Float, Gauge><<<grid[d], block[d]>>>(faceVolumeCB[d], dataexarg, reinterpret_cast<Float*>(recv_d[d]), p, d, d, false);
+        }
+        //exchange updated ghost links in opposite parity
+        for (int d=0; d<4; d++) {
+          if (!commDimPartitioned(d)) continue;
+          comm_start(mh_recv_fwd[d]);  
+          Kernel_UnPackGhost<NElems, Float, Gauge><<<grid[d], block[d]>>>(faceVolumeCB[d], dataexarg, reinterpret_cast<Float*>(sendg_d[d]), 1-p, d, d, true); 
+          #ifndef GPU_COMMS
+          cudaMemcpy(sendg[d], sendg_d[d], bytes[d], cudaMemcpyDeviceToHost);
+          #else
+          cudaDeviceSynchronize();
+          #endif
+          comm_start(mh_send_back[d]);
+          comm_wait(mh_recv_fwd[d]);
+          comm_wait(mh_send_back[d]);
+          #ifndef GPU_COMMS
+          cudaMemcpy(recvg_d[d], recvg[d], bytes[d], cudaMemcpyHostToDevice);
+          #endif
+          Kernel_UnPackTop<NElems, Float, Gauge><<<grid[d], block[d]>>>(faceVolumeCB[d], dataexarg, reinterpret_cast<Float*>(recvg_d[d]), 1-p, d, d, false);
+        }
+      }
+      #endif*/
+    }
+    if((iter % reunit_interval) == (reunit_interval - 1)) {
+      unitarizeLinksQuda(data, num_failures_dev);
+      cudaMemcpy(&num_failures, num_failures_dev, sizeof(int), cudaMemcpyDeviceToHost);
+      if(num_failures>0){
+        cudaFree(num_failures_dev); 
+        errorQuda("Error in the unitarization\n"); 
+        exit(1);
+      }
+      cudaMemset(num_failures_dev, 0, sizeof(int));
+      //flop += (double)????????????????????????????????????????????????
+      //byte += (double)????????????????????????????????????????????????
+    }
+    GaugeFixQuality.apply(0);
+    flop += (double)GaugeFixQuality.flops();
+    byte += (double)GaugeFixQuality.bytes();
+    double action = argQ.getAction();
+    double diff = abs(action0 - action);
+    if((iter % verbose_interval) == (verbose_interval - 1))
+    printfQuda("Step: %d\tAction: %.16e\ttheta: %.16e\tDelta: %.16e\n", iter+1, argQ.getAction(), argQ.getTheta(), diff);
+    if(stopWtheta){
+      if(argQ.getTheta() < tolerance) break;
+    }
+    else{
+      if(diff < tolerance) break;
+    } 
+    action0 = action;
+  }
+  if((iter % reunit_interval) != 0)  {
+    unitarizeLinksQuda(data, num_failures_dev);
+    cudaMemcpy(&num_failures, num_failures_dev, sizeof(int), cudaMemcpyDeviceToHost);
+    if(num_failures>0){
+      cudaFree(num_failures_dev); 
+      errorQuda("Error in the unitarization\n"); 
+      exit(1);
+    }
+    cudaMemset(num_failures_dev, 0, sizeof(int));
+    //flop += (double)????????????????????????????????????????????????
+    //byte += (double)????????????????????????????????????????????????
+  }
+  if((iter % verbose_interval) != 0){
+    GaugeFixQuality.apply(0);
+    flop += (double)GaugeFixQuality.flops();
+    byte += (double)GaugeFixQuality.bytes();
+    double action = argQ.getAction();
+    double diff = abs(action0 - action);
+    printfQuda("Step: %d\tAction: %.16e\ttheta: %.16e\tDelta: %.16e\n", iter+1, argQ.getAction(), argQ.getTheta(), diff);
+  }
+  cudaFree(num_failures_dev); 
+  #ifdef MULTI_GPU
+  if(comm_size() != 1){
+    for (int d=0; d<4; d++) {
+      if (commDimPartitioned(d)) {
+        comm_free(mh_send_fwd[d]);
+        comm_free(mh_send_back[d]);
+        comm_free(mh_recv_back[d]);
+        comm_free(mh_recv_fwd[d]);
+        device_free(send_d[d]);
+        device_free(recv_d[d]);
+        device_free(sendg_d[d]);
+        device_free(recvg_d[d]);
+        cudaStreamDestroy(GFStream[d]);
+        cudaStreamDestroy(GFStream[4 + d]);
+        #ifndef GPU_COMMS
+        free(hostbuffer_h[d]);
+        #endif
+      }
+    }
+    cudaStreamDestroy(GFStream[8]);
+  }
+  #endif
+  checkCudaError();
+  cudaDeviceSynchronize();
+  profileGaugeFix.Stop(QUDA_PROFILE_COMPUTE);
+  double secs = profileGaugeFix.Last(QUDA_PROFILE_COMPUTE);
+  double gflops = (flop*1e-9)/(secs);
+  double gbytes = byte/(secs*1e9);
+  #ifdef MULTI_GPU
+  printfQuda("Time: %6.6f s, Gflop/s = %6.1f, GB/s = %6.1f\n", secs, gflops*comm_size(), gbytes*comm_size());
+  #else
+  printfQuda("Time: %6.6f s, Gflop/s = %6.1f, GB/s = %6.1f\n", secs, gflops, gbytes);
+  #endif
+  printfQuda("Reunitarization flops and bandwidth not accounted!!!!!!\n");
+}
+
+template<typename Float, int NElems, typename Gauge>
+void gaugefixingOVR( Gauge dataOr,  cudaGaugeField& data, const unsigned int gauge_dir, \
+  const unsigned int Nsteps, const unsigned int verbose_interval, \
+  const Float relax_boost, const double tolerance, const unsigned int reunit_interval, const unsigned int stopWtheta) {
+  if( gauge_dir !=3 ){
+    printfQuda("Starting Landau gauge fixing...\n");
+    gaugefixingOVR<Float, Gauge, NElems, 4>(dataOr, data, Nsteps, verbose_interval, relax_boost, tolerance, reunit_interval, stopWtheta);
+  } 
+  else {        
+    printfQuda("Starting Coulomb gauge fixing...\n");
+    gaugefixingOVR<Float, Gauge, NElems, 3>(dataOr, data, Nsteps, verbose_interval, relax_boost, tolerance, reunit_interval, stopWtheta);
+  }
+}
+
+
+
+template<typename Float>
+void gaugefixingOVR( cudaGaugeField& data, const unsigned int gauge_dir, \
+  const unsigned int Nsteps, const unsigned int verbose_interval, const Float relax_boost, const double tolerance, \
+  const unsigned int reunit_interval, const unsigned int stopWtheta) {
+
+  // Switching to FloatNOrder for the gauge field in order to support RECONSTRUCT_12
+  if(data.Order() == QUDA_FLOAT2_GAUGE_ORDER) {
+    if(data.Reconstruct() == QUDA_RECONSTRUCT_NO) {
+    printfQuda("QUDA_RECONSTRUCT_NO\n");
+      numParams = 18;
+      gaugefixingOVR<Float, 18>(FloatNOrder<Float, 18, 2, 18>(data), data, gauge_dir, Nsteps, verbose_interval, relax_boost, tolerance, reunit_interval, stopWtheta);
+    } else if(data.Reconstruct() == QUDA_RECONSTRUCT_12){
+    printfQuda("QUDA_RECONSTRUCT_12\n");
+      numParams = 12;
+      gaugefixingOVR<Float, 12>(FloatNOrder<Float, 18, 2, 12>(data), data, gauge_dir, Nsteps, verbose_interval, relax_boost, tolerance, reunit_interval, stopWtheta);
+    
+    } else if(data.Reconstruct() == QUDA_RECONSTRUCT_8){
+    printfQuda("QUDA_RECONSTRUCT_8\n");
+      numParams = 8;
+      gaugefixingOVR<Float, 8>(FloatNOrder<Float, 18, 2,  8>(data), data, gauge_dir, Nsteps, verbose_interval, relax_boost, tolerance, reunit_interval, stopWtheta);
+    
+    } else {
+      errorQuda("Reconstruction type %d of gauge field not supported", data.Reconstruct());
+    }
+  } else if(data.Order() == QUDA_FLOAT4_GAUGE_ORDER) {
+    if(data.Reconstruct() == QUDA_RECONSTRUCT_NO) {
+    printfQuda("QUDA_RECONSTRUCT_NO\n");
+      numParams = 18;
+      gaugefixingOVR<Float, 18>(FloatNOrder<Float, 18, 4, 18>(data), data, gauge_dir, Nsteps, verbose_interval, relax_boost, tolerance, reunit_interval, stopWtheta);
+    } else if(data.Reconstruct() == QUDA_RECONSTRUCT_12){
+    printfQuda("QUDA_RECONSTRUCT_12\n");
+      numParams = 12;
+      gaugefixingOVR<Float, 12>(FloatNOrder<Float, 18, 4, 12>(data), data, gauge_dir, Nsteps, verbose_interval, relax_boost, tolerance, reunit_interval, stopWtheta);
+    } else if(data.Reconstruct() == QUDA_RECONSTRUCT_8){
+    printfQuda("QUDA_RECONSTRUCT_8\n");
+      numParams = 8;
+      gaugefixingOVR<Float, 8>(FloatNOrder<Float, 18, 4,  8>(data), data, gauge_dir, Nsteps, verbose_interval, relax_boost, tolerance, reunit_interval, stopWtheta);
+    } else {
+      errorQuda("Reconstruction type %d of gauge field not supported", data.Reconstruct());
+    }
+  } else {
+    errorQuda("Invalid Gauge Order\n");
+  }
+}
+
+  void gaugefixingOVR( cudaGaugeField& data, const unsigned int gauge_dir, \
+    const unsigned int Nsteps, const unsigned int verbose_interval, const double relax_boost, \
+    const double tolerance, const unsigned int reunit_interval, const unsigned int stopWtheta) {
+
+    if(data.Precision() == QUDA_HALF_PRECISION) {
+      errorQuda("Half precision not supported\n");
+    }
+    if (data.Precision() == QUDA_SINGLE_PRECISION) {
+      gaugefixingOVR<float> (data, gauge_dir, Nsteps, verbose_interval, (float)relax_boost, tolerance, reunit_interval, stopWtheta);
+    } else if(data.Precision() == QUDA_DOUBLE_PRECISION) {
+      gaugefixingOVR<double>(data, gauge_dir, Nsteps, verbose_interval, relax_boost, tolerance, reunit_interval, stopWtheta);
+    } else {
+      errorQuda("Precision %d not supported", data.Precision());
+    }
+  }
+
+
+} //namespace quda

--- a/lib/gauge_fix_ovr_extra.cu
+++ b/lib/gauge_fix_ovr_extra.cu
@@ -1,0 +1,123 @@
+
+
+#ifdef MULTI_GPU
+
+
+#include <comm_quda.h>
+
+#include <thrust/device_vector.h>
+#include <thrust/remove.h>
+#include <thrust/unique.h>
+#include <thrust/binary_search.h>
+#include <thrust/sort.h>
+#include <thrust/device_ptr.h>
+#include <thrust/device_malloc.h>
+#include <thrust/device_free.h>
+#include <thrust/device_vector.h>
+
+#include <gauge_fix_ovr_extra.h>
+namespace quda {
+
+
+
+
+struct BorderIdArg {
+  int X[4]; // grid dimensions
+  int border[4]; 
+  BorderIdArg(int X_[4], int border_[4]) {
+    for(int dir=0; dir<4; ++dir) border[dir] = border_[dir];
+    for(int dir=0; dir<4; ++dir) X[dir] = X_[dir];
+  }
+};
+
+__global__ void ComputeBorderPointsActiveFaceIndex(BorderIdArg arg, int *faceindices, int facesize, int faceid, int parity){
+  int idd = blockDim.x * blockIdx.x + threadIdx.x;
+  if(idd < facesize){
+    int borderid = 0;
+    int idx = idd;
+    if(idx >= facesize / 2 ){
+      borderid = arg.X[faceid] - 1;
+      idx -= facesize / 2;
+    }
+    int X[4]; 
+    for(int dr=0; dr<4; ++dr) X[dr] = arg.X[dr];
+    int x[4];
+    int za, xodd;
+    switch(faceid){
+      case 0: //X FACE
+        za = idx / ( X[1] / 2);
+        x[3] = za / X[2];
+        x[2] = za - x[3] * X[2];
+        x[0] = borderid;
+        xodd = (borderid + x[2] + x[3] + parity) & 1;
+        x[1] = (2 * idx + xodd)  - za * X[1];
+      break;
+      case 1: //Y FACE
+        za = idx / ( X[0] / 2);
+        x[3] = za / X[2];
+        x[2] = za - x[3] * X[2];
+        x[1] = borderid;
+        xodd = (borderid + x[2] + x[3] + parity) & 1;
+        x[0] = (2 * idx + xodd)  - za * X[0];
+      break;
+      case 2: //Z FACE
+        za = idx / ( X[0] / 2);
+        x[3] = za / X[1];
+        x[1] = za - x[3] * X[1];
+        x[2] = borderid;
+        xodd = (borderid + x[1] + x[3] + parity) & 1;
+        x[0] = (2 * idx + xodd)  - za * X[0];
+      break;
+      case 3: //T FACE
+        za = idx / ( X[0] / 2);
+        x[2] = za / X[1];
+        x[1] = za - x[2] * X[1];
+        x[3] = borderid;
+        xodd = (borderid + x[1] + x[2] + parity) & 1;
+        x[0] = (2 * idx + xodd)  - za * X[0];
+      break;
+    }
+    idx = (((x[3]*X[2] + x[2])*X[1] + x[1])*X[0] + x[0]);;
+    faceindices[idd] = idx ;
+  }
+}
+
+void PreCalculateLatticeIndices(size_t faceVolume[4], size_t faceVolumeCB[4], int X[4], int border[4], \
+  int &threads, int *borderpoints[2]){
+    BorderIdArg arg(X, border);
+    int nlinksfaces = 0;
+    for(int dir=0; dir<4; ++dir)
+      if(comm_dim_partitioned(dir)) nlinksfaces += faceVolume[dir];
+    thrust::device_ptr<int> array_faceT[2];
+    thrust::device_ptr<int> array_interiorT[2];
+    for(int i = 0; i < 2; i++){//even and odd ids
+      cudaMalloc(&borderpoints[i], nlinksfaces * sizeof(int) );
+      cudaMemset(borderpoints[i], 0, nlinksfaces * sizeof(int) );
+      array_faceT[i] = thrust::device_pointer_cast(borderpoints[i]);
+    }
+    dim3 nthreads(128, 1, 1);
+    int start = 0;
+    for(int dir=0; dir<4; ++dir){
+      if(comm_dim_partitioned(dir)){
+        dim3 blocks((faceVolume[dir] + nthreads.x - 1) / nthreads.x,1,1);
+        for(int oddbit = 0; oddbit < 2; oddbit++)
+            ComputeBorderPointsActiveFaceIndex<<<blocks, nthreads>>>(arg, borderpoints[oddbit] + start, faceVolume[dir], dir, oddbit);
+        start += faceVolume[dir];
+      }
+    }
+    int size[2];
+    for(int i = 0; i < 2; i++){
+      //sort and remove duplicated lattice indices
+      thrust::sort(array_faceT[i], array_faceT[i] + nlinksfaces);
+      thrust::device_ptr<int> new_end = thrust::unique(array_faceT[i], array_faceT[i] + nlinksfaces);
+      size[i] = thrust::raw_pointer_cast(new_end) - thrust::raw_pointer_cast(array_faceT[i]);
+    }
+    if(size[0]==size[1]) threads = size[0];
+    else errorQuda("BORDER: Even and Odd sizes does not match, not supported!!!!, %d:%d",size[0],size[1]);
+}
+
+
+
+}
+
+#endif

--- a/lib/gauge_fix_ovr_extra.h
+++ b/lib/gauge_fix_ovr_extra.h
@@ -1,0 +1,17 @@
+#ifndef _GAUGE_FIX_OVR_EXTRA_H
+#define _GAUGE_FIX_OVR_EXTRA_H
+
+
+#ifdef MULTI_GPU
+#include <map>
+#include <quda_internal.h> some conflicts with thrust library
+
+
+namespace quda {
+  
+void PreCalculateLatticeIndices(size_t faceVolume_[4], size_t faceVolumeCB_[4], int X[4], int border[4], \
+  int &threads, int *borderpoints[2]);
+
+}
+#endif
+#endif 

--- a/lib/gauge_fix_ovr_hit_devf.cuh
+++ b/lib/gauge_fix_ovr_hit_devf.cuh
@@ -1,0 +1,664 @@
+#ifndef _GAUGE_FIX_OVR_HIT_DEVF_H
+#define _GAUGE_FIX_OVR_HIT_DEVF_H
+
+
+#include <quda_internal.h>
+#include <quda_matrix.h>
+#include <device_functions.h>
+
+namespace quda {
+
+
+template<class T>
+struct SharedMemory
+{
+    __device__ inline operator       T*()
+        {
+            extern __shared__ int __smem[];
+            return (T*)__smem;
+        }
+
+    __device__ inline operator const T*() const
+        {
+            extern __shared__ int __smem[];
+            return (T*)__smem;
+        }
+};
+
+template<int NCOLORS>
+static __host__ __device__ inline void   IndexBlock(int block, int &p, int &q){
+  if (NCOLORS == 3){
+    if(block == 0){p=0;q=1;}
+    else if(block == 1){p=1;q=2;}
+    else{p=0;q=2;}
+  }
+  else{ 
+      int i1;
+      int found = 0;
+      int del_i = 0;
+      int index = -1;
+      while ( del_i < (NCOLORS-1) && found == 0 ){
+          del_i++;
+          for ( i1 = 0; i1 < (NCOLORS-del_i); i1++ ){
+              index++;
+              if ( index == block ){
+                  found = 1;
+                  break;
+              }
+          }
+      }
+      q = i1 + del_i;
+      p = i1;
+  }
+}
+
+
+__inline__ __device__ double atomicAdd(double *addr, double val){
+  double old=*addr, assumed;
+  do {
+    assumed = old;
+    old = __longlong_as_double( atomicCAS((unsigned long long int*)addr,
+            __double_as_longlong(assumed),
+            __double_as_longlong(val+assumed)));
+  } while( __double_as_longlong(assumed)!=__double_as_longlong(old) );
+  
+  return old;
+}
+
+__inline__ __device__ double2 atomicAdd(double2 *addr, double2 val){
+    double2 old=*addr;
+    old.x = atomicAdd((double*)addr, val.x);
+    old.y = atomicAdd((double*)addr+1, val.y);
+    return old;
+  }
+
+
+#if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 200
+//CUDA 6.5 NOT DETECTING ATOMICADD FOR FLOAT TYPE!!!!!!!
+__inline__ __device__ float atomicAdd(float *address, float val)
+{
+  return __fAtomicAdd(address, val);
+}
+#endif /* !__CUDA_ARCH__ || __CUDA_ARCH__ >= 200 */
+
+
+
+template<int blockSize, typename Float2, typename Float, int gauge_dir, int NCOLORS>
+__forceinline__ __device__ void GaugeFixHit_AtomicAdd(Matrix<Float2,NCOLORS> &link, const Float relax_boost, const int tid){
+
+  //Container for the four real parameters of SU(2) subgroup in shared memory
+  //__shared__ Float elems[blockSize * 4];
+  Float *elems = SharedMemory<Float>();
+  //initialize shared memory
+  if( threadIdx.x < blockSize * 4) elems[threadIdx.x] = 0.0;
+  __syncthreads();
+
+
+  //Loop over all SU(2) subroups of SU(N)
+  //#pragma unroll
+  for(int block = 0; block < (NCOLORS*(NCOLORS-1)/2); block++){
+    int p, q;
+    //Get the two indices for the SU(N) matrix
+    IndexBlock<NCOLORS>(block, p, q);
+    Float asq = 1.0;
+    if(threadIdx.x < blockSize * 4) asq = -1.0;
+    //FOR COULOMB AND LANDAU!!!!!!!!
+    //if(nu0<gauge_dir){
+    //In terms of thread index
+    if(threadIdx.x < blockSize * gauge_dir || (threadIdx.x >= blockSize * 4 && threadIdx.x < blockSize * (gauge_dir + 4))){
+      //Retrieve the four SU(2) parameters...
+      // a0
+      atomicAdd(elems + tid, (link(p,p)).x + (link(q,q)).x);//a0
+      // a1
+      atomicAdd(elems + tid + blockSize, (link(p,q).y + link(q,p).y) * asq);//a1
+      // a2
+      atomicAdd(elems + tid + blockSize * 2, (link(p,q).x - link(q,p).x) * asq);//a2
+      // a3
+      atomicAdd(elems + tid + blockSize * 3, (link(p,p).y - link(q,q).y) * asq);//a3
+    }//FLOP per lattice site = gauge_dir * 2 * (4 + 7) = gauge_dir * 22
+    __syncthreads();
+    if( threadIdx.x < blockSize){
+      //Over-relaxation boost
+      asq =  elems[threadIdx.x + blockSize] * elems[threadIdx.x + blockSize];
+      asq += elems[threadIdx.x + blockSize * 2] * elems[threadIdx.x + blockSize * 2];
+      asq += elems[threadIdx.x + blockSize * 3] * elems[threadIdx.x + blockSize * 3];
+      Float a0sq = elems[threadIdx.x] * elems[threadIdx.x];
+      Float x = (relax_boost * a0sq + asq) / (a0sq + asq);
+      Float r = rsqrt((a0sq + x * x * asq));
+      elems[threadIdx.x] *= r;
+      elems[threadIdx.x + blockSize] *= x * r;
+      elems[threadIdx.x + blockSize * 2] *= x * r;
+      elems[threadIdx.x + blockSize * 3] *= x * r;
+    }//FLOP per lattice site = 22CUB: "Collective" Software Primitives for CUDA Kernel Development
+    __syncthreads();
+        //_____________
+    if(threadIdx.x < blockSize * 4){
+      Float2 m0;
+      //Do SU(2) hit on all upward links
+      //left multiply an su3_matrix by an su2 matrix
+      //link <- u * link
+      //#pragma unroll 
+      for(int j = 0; j < NCOLORS; j++){
+        m0 = link(p,j);
+        link(p,j) = makeComplex( elems[tid], elems[tid + blockSize * 3] ) * m0 + makeComplex( elems[tid + blockSize * 2], elems[tid + blockSize] ) * link(q,j);
+        link(q,j) = makeComplex(-elems[tid + blockSize * 2], elems[tid + blockSize]) * m0 + makeComplex( elems[tid],-elems[tid + blockSize * 3] ) * link(q,j);
+      }
+    }
+    else{
+      Float2 m0;
+      //Do SU(2) hit on all downward links
+      //right multiply an su3_matrix by an su2 matrix
+      //link <- link * u_adj
+      //#pragma unroll
+      for(int j = 0; j < NCOLORS; j++){
+        m0 = link(j,p);
+        link(j,p) = makeComplex( elems[tid], -elems[tid + blockSize * 3] ) * m0 + makeComplex( elems[tid + blockSize * 2], -elems[tid + blockSize] ) * link(j,q);
+        link(j,q) = makeComplex(-elems[tid + blockSize * 2], -elems[tid + blockSize]) * m0 + makeComplex( elems[tid],elems[tid + blockSize * 3] ) * link(j,q);
+      }
+    }
+        //_____________ //FLOP per lattice site = 8 * NCOLORS * 2 * (2*6+2) = NCOLORS * 224
+    if(block < (NCOLORS*(NCOLORS-1)/2)-1){
+      __syncthreads();
+      //reset shared memory SU(2) elements
+      if( threadIdx.x < blockSize * 4) elems[threadIdx.x] = 0.0;
+      __syncthreads();
+    }
+  }//FLOP per lattice site = (block < NCOLORS * ( NCOLORS - 1) / 2) * (22 + 28 gauge_dir + 224 NCOLORS)
+  //write updated link to global memory
+}
+
+
+
+template<int blockSize, typename Float2, typename Float, int gauge_dir, int NCOLORS>
+__forceinline__ __device__ void GaugeFixHit_NoAtomicAdd(Matrix<Float2,NCOLORS> &link, const Float relax_boost, const int tid){
+
+  //Container for the four real parameters of SU(2) subgroup in shared memory
+  //__shared__ Float elems[blockSize * 4 * 8];
+  Float *elems = SharedMemory<Float>();
+
+
+  //Loop over all SU(2) subroups of SU(N)
+  //#pragma unroll
+  for(int block = 0; block < (NCOLORS * (NCOLORS-1)/2); block++){
+    int p, q;
+    //Get the two indices for the SU(N) matrix
+    IndexBlock<NCOLORS>(block, p, q);
+    /*Float asq = 1.0;
+    if(threadIdx.x < blockSize * 4) asq = -1.0;
+    if(threadIdx.x < blockSize * gauge_dir || (threadIdx.x >= blockSize * 4 && threadIdx.x < blockSize * (gauge_dir + 4))){
+      elems[threadIdx.x] = link(p,p).x + link(q,q).x;
+      elems[threadIdx.x + blockSize * 8] = (link(p,q).y + link(q,p).y) * asq;
+      elems[threadIdx.x + blockSize * 8 * 2] = (link(p,q).x - link(q,p).x) * asq;
+      elems[threadIdx.x + blockSize * 8 * 3] = (link(p,p).y - link(q,q).y) * asq;
+    }*///FLOP per lattice site = gauge_dir * 2 * 7 = gauge_dir * 14
+    if(threadIdx.x < blockSize * gauge_dir){
+      elems[threadIdx.x] = link(p,p).x + link(q,q).x;
+      elems[threadIdx.x + blockSize * 8] = -(link(p,q).y + link(q,p).y);
+      elems[threadIdx.x + blockSize * 8 * 2] = -(link(p,q).x - link(q,p).x);
+      elems[threadIdx.x + blockSize * 8 * 3] = -(link(p,p).y - link(q,q).y);
+    }
+    if((threadIdx.x >= blockSize * 4 && threadIdx.x < blockSize * (gauge_dir + 4))){
+      elems[threadIdx.x] = link(p,p).x + link(q,q).x;
+      elems[threadIdx.x + blockSize * 8] = (link(p,q).y + link(q,p).y);
+      elems[threadIdx.x + blockSize * 8 * 2] = (link(p,q).x - link(q,p).x);
+      elems[threadIdx.x + blockSize * 8 * 3] = (link(p,p).y - link(q,q).y);
+    }
+    //FLOP per lattice site = gauge_dir * 2 * 7 = gauge_dir * 14
+    __syncthreads();
+    if( threadIdx.x < blockSize){
+      Float a0, a1, a2, a3;
+      a0 = 0.0; a1 = 0.0; a2 = 0.0; a3 = 0.0;
+      #pragma unroll
+      for(int i = 0; i < gauge_dir; i++){
+        a0 += elems[tid + i * blockSize] + elems[tid + (i + 4) * blockSize];
+        a1 += elems[tid + i * blockSize + blockSize * 8] + elems[tid + (i + 4) * blockSize + blockSize * 8];
+        a2 += elems[tid + i * blockSize + blockSize * 8 * 2] + elems[tid + (i + 4) * blockSize + blockSize * 8 * 2];
+        a3 += elems[tid + i * blockSize + blockSize * 8 * 3] + elems[tid + (i + 4) * blockSize + blockSize * 8 * 3];
+      } 
+      //Over-relaxation boost
+      Float asq =  a1 * a1 + a2 * a2 + a3 * a3;
+      Float a0sq = a0 * a0;
+      Float x = (relax_boost * a0sq + asq) / (a0sq + asq);
+      Float r = rsqrt((a0sq + x * x * asq));
+      elems[threadIdx.x] = a0 * r;
+      elems[threadIdx.x + blockSize] = a1 * x * r;
+      elems[threadIdx.x + blockSize * 2] = a2 * x * r;
+      elems[threadIdx.x + blockSize * 3] = a3 * x * r;
+    }//FLOP per lattice site = 22 + 8 * 4
+    __syncthreads();
+        //_____________
+    if(threadIdx.x < blockSize * 4){
+      Float2 m0;
+      //Do SU(2) hit on all upward links
+      //left multiply an su3_matrix by an su2 matrix
+      //link <- u * link
+      //#pragma unroll 
+      for(int j = 0; j < NCOLORS; j++){
+        m0 = link(p,j);
+        link(p,j) = makeComplex( elems[tid], elems[tid + blockSize * 3] ) * m0 + makeComplex( elems[tid + blockSize * 2], elems[tid + blockSize] ) * link(q,j);
+        link(q,j) = makeComplex(-elems[tid + blockSize * 2], elems[tid + blockSize]) * m0 + makeComplex( elems[tid],-elems[tid + blockSize * 3] ) * link(q,j);
+      }
+    }
+    else{
+      Float2 m0;
+      //Do SU(2) hit on all downward links
+      //right multiply an su3_matrix by an su2 matrix
+      //link <- link * u_adj
+      //#pragma unroll
+      for(int j = 0; j < NCOLORS; j++){
+        m0 = link(j,p);
+        link(j,p) = makeComplex( elems[tid], -elems[tid + blockSize * 3] ) * m0 + makeComplex( elems[tid + blockSize * 2], -elems[tid + blockSize] ) * link(j,q);
+        link(j,q) = makeComplex(-elems[tid + blockSize * 2], -elems[tid + blockSize]) * m0 + makeComplex( elems[tid],elems[tid + blockSize * 3] ) * link(j,q);
+      }
+    }
+    //_____________ //FLOP per lattice site = 8 * NCOLORS * 2 * (2*6+2) = NCOLORS * 224
+    if(block < (NCOLORS*(NCOLORS-1)/2)-1){ __syncthreads(); }
+  }//FLOP per lattice site = (NCOLORS * ( NCOLORS - 1) / 2) * (22 + 28 gauge_dir + 224 NCOLORS)
+  //write updated link to global memory
+}
+
+
+
+template<int blockSize, typename Float2, typename Float, int gauge_dir, int NCOLORS>
+__forceinline__ __device__ void GaugeFixHit_NoAtomicAdd_LessSM(Matrix<Float2,NCOLORS> &link, const Float relax_boost, const int tid){
+
+  //Container for the four real parameters of SU(2) subgroup in shared memory
+  //__shared__ Float elems[blockSize * 4 * 8];
+  Float *elems = SharedMemory<Float>();
+
+  //Loop over all SU(2) subroups of SU(N)
+  //#pragma unroll
+  for(int block = 0; block < (NCOLORS * (NCOLORS-1)/2); block++){
+    int p, q;
+    //Get the two indices for the SU(N) matrix
+    IndexBlock<NCOLORS>(block, p, q);
+
+    if(threadIdx.x < blockSize){
+      elems[tid] = link(p,p).x + link(q,q).x;
+      elems[tid + blockSize] = -(link(p,q).y + link(q,p).y);
+      elems[tid + blockSize * 2] = -(link(p,q).x - link(q,p).x);
+      elems[tid + blockSize * 3] = -(link(p,p).y - link(q,q).y);
+    }
+    __syncthreads();
+    if(threadIdx.x < blockSize * 2 && threadIdx.x >= blockSize){
+      elems[tid] += link(p,p).x + link(q,q).x;
+      elems[tid + blockSize] -= (link(p,q).y + link(q,p).y);
+      elems[tid + blockSize * 2] -= (link(p,q).x - link(q,p).x);
+      elems[tid + blockSize * 3] -= (link(p,p).y - link(q,q).y);
+    }
+    __syncthreads();
+    if(threadIdx.x < blockSize * 3 && threadIdx.x >= blockSize * 2){
+      elems[tid] += link(p,p).x + link(q,q).x;
+      elems[tid + blockSize] -= (link(p,q).y + link(q,p).y);
+      elems[tid + blockSize * 2] -= (link(p,q).x - link(q,p).x);
+      elems[tid + blockSize * 3] -= (link(p,p).y - link(q,q).y);
+    }
+    if(gauge_dir==4){
+      __syncthreads();
+      if(threadIdx.x < blockSize * 4 && threadIdx.x >= blockSize * 3){
+        elems[tid] += link(p,p).x + link(q,q).x;
+        elems[tid + blockSize] -= (link(p,q).y + link(q,p).y);
+        elems[tid + blockSize * 2] -= (link(p,q).x - link(q,p).x);
+        elems[tid + blockSize * 3] -= (link(p,p).y - link(q,q).y);
+      }
+    }
+    __syncthreads();
+    if(threadIdx.x < blockSize * 5 && threadIdx.x >= blockSize * 4){
+      elems[tid] += link(p,p).x + link(q,q).x;
+      elems[tid + blockSize] += (link(p,q).y + link(q,p).y);
+      elems[tid + blockSize * 2] += (link(p,q).x - link(q,p).x);
+      elems[tid + blockSize * 3] += (link(p,p).y - link(q,q).y);
+    }
+    __syncthreads();
+    if(threadIdx.x < blockSize * 6 && threadIdx.x >= blockSize * 5){
+      elems[tid] += link(p,p).x + link(q,q).x;
+      elems[tid + blockSize] += (link(p,q).y + link(q,p).y);
+      elems[tid + blockSize * 2] += (link(p,q).x - link(q,p).x);
+      elems[tid + blockSize * 3] += (link(p,p).y - link(q,q).y);
+    }
+    __syncthreads();
+    if(threadIdx.x < blockSize * 7 && threadIdx.x >= blockSize * 6){
+      elems[tid] += link(p,p).x + link(q,q).x;
+      elems[tid + blockSize] += (link(p,q).y + link(q,p).y);
+      elems[tid + blockSize * 2] += (link(p,q).x - link(q,p).x);
+      elems[tid + blockSize * 3] += (link(p,p).y - link(q,q).y);
+    }
+    if(gauge_dir==4){
+      __syncthreads();
+      if(threadIdx.x < blockSize * 8 && threadIdx.x >= blockSize * 7){
+        elems[tid] += link(p,p).x + link(q,q).x;
+        elems[tid + blockSize] += (link(p,q).y + link(q,p).y);
+        elems[tid + blockSize * 2] += (link(p,q).x - link(q,p).x);
+        elems[tid + blockSize * 3] += (link(p,p).y - link(q,q).y);
+      }
+    }
+     //FLOP per lattice site = gauge_dir * 2 * 7 = gauge_dir * 14
+    __syncthreads();
+    if( threadIdx.x < blockSize){
+      Float asq =  elems[tid + blockSize] * elems[tid + blockSize];
+      asq += elems[tid + blockSize * 2] * elems[tid + blockSize * 2];
+      asq += elems[tid + blockSize * 3] * elems[tid + blockSize * 3];
+      Float a0sq = elems[tid] * elems[tid];
+      Float x = (relax_boost * a0sq + asq) / (a0sq + asq);
+      Float r = rsqrt((a0sq + x * x * asq));
+      elems[tid] *= r;
+      elems[tid + blockSize] *= x * r;
+      elems[tid + blockSize * 2] *= x * r;
+      elems[tid + blockSize * 3] *= x * r;
+    }//FLOP per lattice site = 22 + 8 * 4
+    __syncthreads();
+        //_____________
+    if(threadIdx.x < blockSize * 4){
+      Float2 m0;
+      //Do SU(2) hit on all upward links
+      //left multiply an su3_matrix by an su2 matrix
+      //link <- u * link
+      //#pragma unroll 
+      for(int j = 0; j < NCOLORS; j++){
+        m0 = link(p,j);
+        link(p,j) = makeComplex( elems[tid], elems[tid + blockSize * 3] ) * m0 + makeComplex( elems[tid + blockSize * 2], elems[tid + blockSize] ) * link(q,j);
+        link(q,j) = makeComplex(-elems[tid + blockSize * 2], elems[tid + blockSize]) * m0 + makeComplex( elems[tid],-elems[tid + blockSize * 3] ) * link(q,j);
+      }
+    }
+    else{
+      Float2 m0;
+      //Do SU(2) hit on all downward links
+      //right multiply an su3_matrix by an su2 matrix
+      //link <- link * u_adj
+      //#pragma unroll
+      for(int j = 0; j < NCOLORS; j++){
+        m0 = link(j,p);
+        link(j,p) = makeComplex( elems[tid], -elems[tid + blockSize * 3] ) * m0 + makeComplex( elems[tid + blockSize * 2], -elems[tid + blockSize] ) * link(j,q);
+        link(j,q) = makeComplex(-elems[tid + blockSize * 2], -elems[tid + blockSize]) * m0 + makeComplex( elems[tid],elems[tid + blockSize * 3] ) * link(j,q);
+      }
+    }
+    //_____________ //FLOP per lattice site = 8 * NCOLORS * 2 * (2*6+2) = NCOLORS * 224
+    if(block < (NCOLORS*(NCOLORS-1)/2)-1){ __syncthreads(); }
+  }//FLOP per lattice site = (NCOLORS * ( NCOLORS - 1) / 2) * (22 + 28 gauge_dir + 224 NCOLORS)
+  //write updated link to global memory
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+template<int blockSize, typename Float2, typename Float, int gauge_dir, int NCOLORS>
+__forceinline__ __device__ void GaugeFixHit_AtomicAdd(Matrix<Float2,NCOLORS> &link, Matrix<Float2,NCOLORS> &link1, const Float relax_boost, const int tid){
+
+  //Container for the four real parameters of SU(2) subgroup in shared memory
+  //__shared__ Float elems[blockSize * 4];
+  Float *elems = SharedMemory<Float>();
+  //initialize shared memory
+  if( threadIdx.x < blockSize * 4) elems[threadIdx.x] = 0.0;
+  __syncthreads();
+
+
+  //Loop over all SU(2) subroups of SU(N)
+  //#pragma unroll
+  for(int block = 0; block < (NCOLORS*(NCOLORS-1)/2); block++){
+    int p, q;
+    //Get the two indices for the SU(N) matrix
+    IndexBlock<NCOLORS>(block, p, q);
+    if(threadIdx.x < blockSize * gauge_dir){
+      //Retrieve the four SU(2) parameters...
+      // a0
+      atomicAdd(elems + tid, (link1(p,p)).x + (link1(q,q)).x + (link(p,p)).x + (link(q,q)).x);//a0
+      // a1
+      atomicAdd(elems + tid + blockSize, (link1(p,q).y + link1(q,p).y) - (link(p,q).y + link(q,p).y));//a1
+      // a2
+      atomicAdd(elems + tid + blockSize * 2, (link1(p,q).x - link1(q,p).x) - (link(p,q).x - link(q,p).x));//a2
+      // a3
+      atomicAdd(elems + tid + blockSize * 3, (link1(p,p).y - link1(q,q).y) - (link(p,p).y - link(q,q).y));//a3
+    }
+    __syncthreads();
+    if( threadIdx.x < blockSize){
+      //Over-relaxation boost
+      Float asq =  elems[threadIdx.x + blockSize] * elems[threadIdx.x + blockSize];
+      asq += elems[threadIdx.x + blockSize * 2] * elems[threadIdx.x + blockSize * 2];
+      asq += elems[threadIdx.x + blockSize * 3] * elems[threadIdx.x + blockSize * 3];
+      Float a0sq = elems[threadIdx.x] * elems[threadIdx.x];
+      Float x = (relax_boost * a0sq + asq) / (a0sq + asq);
+      Float r = rsqrt((a0sq + x * x * asq));
+      elems[threadIdx.x] *= r;
+      elems[threadIdx.x + blockSize] *= x * r;
+      elems[threadIdx.x + blockSize * 2] *= x * r;
+      elems[threadIdx.x + blockSize * 3] *= x * r;
+    }//FLOP per lattice site = 22CUB: "Collective" Software Primitives for CUDA Kernel Development
+    __syncthreads();
+    Float2 m0;
+    //Do SU(2) hit on all upward links
+    //left multiply an su3_matrix by an su2 matrix
+    //link <- u * link
+    //#pragma unroll 
+    for(int j = 0; j < NCOLORS; j++){
+      m0 = link(p,j);
+      link(p,j) = makeComplex( elems[tid], elems[tid + blockSize * 3] ) * m0 + \
+            makeComplex( elems[tid + blockSize * 2], elems[tid + blockSize] ) * link(q,j);
+      link(q,j) = makeComplex(-elems[tid + blockSize * 2], elems[tid + blockSize]) * m0 + \
+            makeComplex( elems[tid],-elems[tid + blockSize * 3] ) * link(q,j);
+    }
+    //Do SU(2) hit on all downward links
+    //right multiply an su3_matrix by an su2 matrix
+    //link <- link * u_adj
+    //#pragma unroll
+    for(int j = 0; j < NCOLORS; j++){
+      m0 = link1(j,p);
+      link1(j,p) = makeComplex( elems[tid], -elems[tid + blockSize * 3] ) * m0 + \
+            makeComplex( elems[tid + blockSize * 2], -elems[tid + blockSize] ) * link1(j,q);
+      link1(j,q) = makeComplex(-elems[tid + blockSize * 2], -elems[tid + blockSize]) * m0 + \
+            makeComplex( elems[tid],elems[tid + blockSize * 3] ) * link1(j,q);
+    }
+    if(block < (NCOLORS*(NCOLORS-1)/2)-1){
+      __syncthreads();
+      //reset shared memory SU(2) elements
+      if( threadIdx.x < blockSize * 4) elems[threadIdx.x] = 0.0;
+      __syncthreads();
+    }
+  }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+template<int blockSize, typename Float2, typename Float, int gauge_dir, int NCOLORS>
+__forceinline__ __device__ void GaugeFixHit_NoAtomicAdd(Matrix<Float2,NCOLORS> &link, Matrix<Float2,NCOLORS> &link1, const Float relax_boost, const int tid){
+
+  //Container for the four real parameters of SU(2) subgroup in shared memory
+  //__shared__ Float elems[blockSize * 4 * 8];
+  Float *elems = SharedMemory<Float>();
+  //Loop over all SU(2) subroups of SU(N)
+  //#pragma unroll
+  for(int block = 0; block < (NCOLORS * (NCOLORS-1)/2); block++){
+    int p, q;
+    //Get the two indices for the SU(N) matrix
+    IndexBlock<NCOLORS>(block, p, q);
+    if(threadIdx.x < blockSize * gauge_dir){
+      elems[threadIdx.x] = link1(p,p).x + link1(q,q).x + link(p,p).x + link(q,q).x;
+      elems[threadIdx.x + blockSize * 4] = (link1(p,q).y + link1(q,p).y) - (link(p,q).y + link(q,p).y);
+      elems[threadIdx.x + blockSize * 4 * 2] = (link1(p,q).x - link1(q,p).x) - (link(p,q).x - link(q,p).x);
+      elems[threadIdx.x + blockSize * 4 * 3] = (link1(p,p).y - link1(q,q).y) - (link(p,p).y - link(q,q).y);
+    }
+    __syncthreads();
+    if( threadIdx.x < blockSize){
+      Float a0, a1, a2, a3;
+      a0 = 0.0; a1 = 0.0; a2 = 0.0; a3 = 0.0;
+      #pragma unroll
+      for(int i = 0; i < gauge_dir; i++){
+        a0 += elems[tid + i * blockSize];
+        a1 += elems[tid + i * blockSize + blockSize * 4];
+        a2 += elems[tid + i * blockSize + blockSize * 4 * 2];
+        a3 += elems[tid + i * blockSize + blockSize * 4 * 3];
+      } 
+      //Over-relaxation boost
+      Float asq =  a1 * a1 + a2 * a2 + a3 * a3;
+      Float a0sq = a0 * a0;
+      Float x = (relax_boost * a0sq + asq) / (a0sq + asq);
+      Float r = rsqrt((a0sq + x * x * asq));
+      elems[threadIdx.x] = a0 * r;
+      elems[threadIdx.x + blockSize] = a1 * x * r;
+      elems[threadIdx.x + blockSize * 2] = a2 * x * r;
+      elems[threadIdx.x + blockSize * 3] = a3 * x * r;
+    }//FLOP per lattice site = 22 + 8 * 4
+    __syncthreads();
+    Float2 m0;
+    //Do SU(2) hit on all upward links
+    //left multiply an su3_matrix by an su2 matrix
+    //link <- u * link
+    //#pragma unroll 
+    for(int j = 0; j < NCOLORS; j++){
+      m0 = link(p,j);
+      link(p,j) = makeComplex( elems[tid], elems[tid + blockSize * 3] ) * m0 + \
+            makeComplex( elems[tid + blockSize * 2], elems[tid + blockSize] ) * link(q,j);
+      link(q,j) = makeComplex(-elems[tid + blockSize * 2], elems[tid + blockSize]) * m0 + \
+            makeComplex( elems[tid],-elems[tid + blockSize * 3] ) * link(q,j);
+    }
+    //Do SU(2) hit on all downward links
+    //right multiply an su3_matrix by an su2 matrix
+    //link <- link * u_adj
+    //#pragma unroll
+    for(int j = 0; j < NCOLORS; j++){
+      m0 = link1(j,p);
+      link1(j,p) = makeComplex( elems[tid], -elems[tid + blockSize * 3] ) * m0 + \
+            makeComplex( elems[tid + blockSize * 2], -elems[tid + blockSize] ) * link1(j,q);
+      link1(j,q) = makeComplex(-elems[tid + blockSize * 2], -elems[tid + blockSize]) * m0 + \
+            makeComplex( elems[tid],elems[tid + blockSize * 3] ) * link1(j,q);
+    }
+    if(block < (NCOLORS*(NCOLORS-1)/2)-1){ __syncthreads(); }
+  }
+}
+
+
+
+template<int blockSize, typename Float2, typename Float, int gauge_dir, int NCOLORS>
+__forceinline__ __device__ void GaugeFixHit_NoAtomicAdd_LessSM(Matrix<Float2,NCOLORS> &link, Matrix<Float2,NCOLORS> &link1, const Float relax_boost, const int tid){
+
+  //Container for the four real parameters of SU(2) subgroup in shared memory
+  //__shared__ Float elems[blockSize * 4 * 8];
+  Float *elems = SharedMemory<Float>();
+
+  //Loop over all SU(2) subroups of SU(N)
+  //#pragma unroll
+  for(int block = 0; block < (NCOLORS * (NCOLORS-1)/2); block++){
+    int p, q;
+    //Get the two indices for the SU(N) matrix
+    IndexBlock<NCOLORS>(block, p, q);
+    if(threadIdx.x < blockSize){
+      elems[tid] = link1(p,p).x + link1(q,q).x + link(p,p).x + link(q,q).x;
+      elems[tid + blockSize] = (link1(p,q).y + link1(q,p).y) - (link(p,q).y + link(q,p).y);
+      elems[tid + blockSize * 2] = (link1(p,q).x - link1(q,p).x) - (link(p,q).x - link(q,p).x);
+      elems[tid + blockSize * 3] = (link1(p,p).y - link1(q,q).y) - (link(p,p).y - link(q,q).y);
+    }
+    __syncthreads();
+    if(threadIdx.x < blockSize * 2 && threadIdx.x >= blockSize){
+      elems[tid] += link1(p,p).x + link1(q,q).x + link(p,p).x + link(q,q).x;
+      elems[tid + blockSize] += (link1(p,q).y + link1(q,p).y) - (link(p,q).y + link(q,p).y);
+      elems[tid + blockSize * 2] += (link1(p,q).x - link1(q,p).x) - (link(p,q).x - link(q,p).x);
+      elems[tid + blockSize * 3] += (link1(p,p).y - link1(q,q).y) - (link(p,p).y - link(q,q).y);
+    }
+    __syncthreads();
+    if(threadIdx.x < blockSize * 3 && threadIdx.x >= blockSize * 2){
+      elems[tid] += link1(p,p).x + link1(q,q).x + link(p,p).x + link(q,q).x;
+      elems[tid + blockSize] += (link1(p,q).y + link1(q,p).y) - (link(p,q).y + link(q,p).y);
+      elems[tid + blockSize * 2] += (link1(p,q).x - link1(q,p).x) - (link(p,q).x - link(q,p).x);
+      elems[tid + blockSize * 3] += (link1(p,p).y - link1(q,q).y) - (link(p,p).y - link(q,q).y);
+    }
+    if(gauge_dir==4){
+      __syncthreads();
+      if(threadIdx.x < blockSize * 4 && threadIdx.x >= blockSize * 3){
+        elems[tid] += link1(p,p).x + link1(q,q).x + link(p,p).x + link(q,q).x;
+        elems[tid + blockSize] += (link1(p,q).y + link1(q,p).y) - (link(p,q).y + link(q,p).y);
+        elems[tid + blockSize * 2] += (link1(p,q).x - link1(q,p).x) - (link(p,q).x - link(q,p).x);
+        elems[tid + blockSize * 3] += (link1(p,p).y - link1(q,q).y) - (link(p,p).y - link(q,q).y);
+      }
+    }
+    __syncthreads();
+    if( threadIdx.x < blockSize){
+      Float asq =  elems[tid + blockSize] * elems[tid + blockSize];
+      asq += elems[tid + blockSize * 2] * elems[tid + blockSize * 2];
+      asq += elems[tid + blockSize * 3] * elems[tid + blockSize * 3];
+      Float a0sq = elems[tid] * elems[tid];
+      Float x = (relax_boost * a0sq + asq) / (a0sq + asq);
+      Float r = rsqrt((a0sq + x * x * asq));
+      elems[tid] *= r;
+      elems[tid + blockSize] *= x * r;
+      elems[tid + blockSize * 2] *= x * r;
+      elems[tid + blockSize * 3] *= x * r;
+    }
+    __syncthreads();
+    Float2 m0;
+    //Do SU(2) hit on all upward links
+    //left multiply an su3_matrix by an su2 matrix
+    //link <- u * link
+    //#pragma unroll 
+    for(int j = 0; j < NCOLORS; j++){
+      m0 = link(p,j);
+      link(p,j) = makeComplex( elems[tid], elems[tid + blockSize * 3] ) * m0 + \
+            makeComplex( elems[tid + blockSize * 2], elems[tid + blockSize] ) * link(q,j);
+      link(q,j) = makeComplex(-elems[tid + blockSize * 2], elems[tid + blockSize]) * m0 + \
+            makeComplex( elems[tid],-elems[tid + blockSize * 3] ) * link(q,j);
+    }
+    //Do SU(2) hit on all downward links
+    //right multiply an su3_matrix by an su2 matrix
+    //link <- link * u_adj
+    //#pragma unroll
+    for(int j = 0; j < NCOLORS; j++){
+      m0 = link1(j,p);
+      link1(j,p) = makeComplex( elems[tid], -elems[tid + blockSize * 3] ) * m0 + \
+            makeComplex( elems[tid + blockSize * 2], -elems[tid + blockSize] ) * link1(j,q);
+      link1(j,q) = makeComplex(-elems[tid + blockSize * 2], -elems[tid + blockSize]) * m0 + \
+            makeComplex( elems[tid],elems[tid + blockSize * 3] ) * link1(j,q);
+    }
+    if(block < (NCOLORS*(NCOLORS-1)/2)-1){ __syncthreads(); }
+  }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+}
+#endif

--- a/lib/pgauge_exchange.cu
+++ b/lib/pgauge_exchange.cu
@@ -1,0 +1,402 @@
+#include <quda_internal.h>
+#include <quda_matrix.h>
+#include <tune_quda.h>
+#include <gauge_field.h>
+#include <gauge_field_order.h>
+#include <cub/cub.cuh> 
+#include <launch_kernel.cuh>
+
+#include <device_functions.h>
+
+#include <hisq_links_quda.h> //reunit gauge links!!!!!
+
+#include <comm_quda.h>
+
+
+#define BORDER_RADIUS 2
+
+namespace quda {
+
+
+static int numParams = 18;
+
+#define LAUNCH_KERNEL_GAUGEFIX(kernel, tp, stream, arg, parity, ...)     \
+  if(tp.block.z==0){\
+  switch (tp.block.x) {             \
+  case 256:                \
+    kernel<0, 32,__VA_ARGS__>           \
+      <<< tp.grid.x, tp.block.x, tp.shared_bytes, stream >>>(arg, parity);   \
+    break;                \
+  case 512:                \
+    kernel<0, 64,__VA_ARGS__>           \
+      <<< tp.grid.x, tp.block.x, tp.shared_bytes, stream >>>(arg, parity);   \
+    break;                \
+  case 768:                \
+    kernel<0, 96,__VA_ARGS__>           \
+      <<< tp.grid.x, tp.block.x, tp.shared_bytes, stream >>>(arg, parity);   \
+    break;                \
+  case 1024:               \
+    kernel<0, 128,__VA_ARGS__>            \
+      <<< tp.grid.x, tp.block.x, tp.shared_bytes, stream >>>(arg, parity);   \
+    break;                \
+  default:                \
+    errorQuda("%s not implemented for %d threads", #kernel, tp.block.x); \
+    }\
+  }\
+  else{\
+  switch (tp.block.x) {             \
+  case 256:                \
+    kernel<1, 32,__VA_ARGS__>           \
+      <<< tp.grid.x, tp.block.x, tp.shared_bytes, stream >>>(arg, parity);   \
+    break;                \
+  case 512:                \
+    kernel<1, 64,__VA_ARGS__>           \
+      <<< tp.grid.x, tp.block.x, tp.shared_bytes, stream >>>(arg, parity);   \
+    break;                \
+  case 768:                \
+    kernel<1, 96,__VA_ARGS__>           \
+      <<< tp.grid.x, tp.block.x, tp.shared_bytes, stream >>>(arg, parity);   \
+    break;                \
+  case 1024:               \
+    kernel<1, 128,__VA_ARGS__>            \
+      <<< tp.grid.x, tp.block.x, tp.shared_bytes, stream >>>(arg, parity);   \
+    break;                \
+  default:                \
+    errorQuda("%s not implemented for %d threads", #kernel, tp.block.x); \
+    }\
+  }
+
+
+
+
+
+
+
+template <typename Gauge>
+struct GaugeFixUnPackArg {
+  int X[4]; // grid dimensions
+#ifdef MULTI_GPU
+  int border[4]; 
+#endif
+  Gauge dataOr;
+  GaugeFixUnPackArg(Gauge &dataOr, cudaGaugeField &data)
+    : dataOr(dataOr) {
+/*#ifdef MULTI_GPU
+    if(comm_size() == 1){
+      for(int dir=0; dir<4; ++dir) border[dir] = 0;
+      for(int dir=0; dir<4; ++dir) X[dir] = data.X()[dir];
+    }
+    else{
+      for(int dir=0; dir<4; ++dir){
+        if(comm_dim_partitioned(dir)) border[dir] = BORDER_RADIUS;
+        else border[dir] = 0;
+      }
+      for(int dir=0; dir<4; ++dir) X[dir] = data.X()[dir] - border[dir]*2;
+    }
+#else*/
+    for(int dir=0; dir<4; ++dir) X[dir] = data.X()[dir];
+//#endif
+  }
+};
+
+
+template<int NElems, typename Float, typename Gauge, bool pack>
+__global__ void Kernel_UnPack(int size, GaugeFixUnPackArg<Gauge> arg, \
+  typename ComplexTypeId<Float>::Type *array, int parity, int face, int dir, int borderid){
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if(idx >= size) return;
+  int X[4]; 
+  for(int dr=0; dr<4; ++dr) X[dr] = arg.X[dr];
+  int x[4];
+  int za, xodd;
+  switch(face){
+    case 0: //X FACE
+      za = idx / ( X[1] / 2);
+      x[3] = za / X[2];
+      x[2] = za - x[3] * X[2];
+      x[0] = borderid;
+      xodd = (borderid + x[2] + x[3] + parity) & 1;
+      x[1] = (2 * idx + xodd)  - za * X[1];
+    break;
+    case 1: //Y FACE
+      za = idx / ( X[0] / 2);
+      x[3] = za / X[2];
+      x[2] = za - x[3] * X[2];
+      x[1] = borderid;
+      xodd = (borderid  + x[2] + x[3] + parity) & 1;
+      x[0] = (2 * idx + xodd)  - za * X[0];
+    break;
+    case 2: //Z FACE
+      za = idx / ( X[0] / 2);
+      x[3] = za / X[1];
+      x[1] = za - x[3] * X[1];
+      x[2] = borderid;
+      xodd = (borderid  + x[1] + x[3] + parity) & 1;
+      x[0] = (2 * idx + xodd)  - za * X[0];
+    break;
+    case 3: //T FACE
+      za = idx / ( X[0] / 2);
+      x[2] = za / X[1];
+      x[1] = za - x[2] * X[1];
+      x[3] = borderid;
+      xodd = (borderid  + x[1] + x[2] + parity) & 1;
+      x[0] = (2 * idx + xodd)  - za * X[0];
+    break;
+  }
+  int id = (((x[3]*X[2] + x[2])*X[1] + x[1])*X[0] + x[0]) >> 1;
+  typedef typename ComplexTypeId<Float>::Type Cmplx;
+  typedef typename mapper<Float>::type RegType;
+  RegType tmp[NElems];
+  RegType data[18];
+  if(pack){
+    arg.dataOr.load(data, id, dir, parity);
+    arg.dataOr.reconstruct.Pack(tmp, data, id);
+    for(int i=0; i<NElems/2; ++i) array[idx + size * i] = ((Cmplx*)tmp)[i];
+  }
+else{
+    for(int i=0; i<NElems/2; ++i) ((Cmplx*)tmp)[i] = array[idx + size * i];
+    arg.dataOr.reconstruct.Unpack(data, tmp, id, dir, 0);
+    arg.dataOr.save(data, id, dir, parity);
+  }
+}
+
+static  void *send[4];
+static  void *recv[4];
+static  void *sendg[4];
+static  void *recvg[4];
+static  void *send_d[4];
+static  void *recv_d[4];
+static  void *sendg_d[4];
+static  void *recvg_d[4];
+static  void *hostbuffer_h[4];
+static  cudaStream_t GFStream[2];
+static  size_t offset[4];
+static  size_t bytes[4];
+static  size_t faceVolume[4];
+static  size_t faceVolumeCB[4];
+  // do the exchange
+static  MsgHandle *mh_recv_back[4];
+static  MsgHandle *mh_recv_fwd[4];
+static  MsgHandle *mh_send_fwd[4];
+static  MsgHandle *mh_send_back[4];
+static  int X[4];
+static  dim3 block[4];
+static  dim3 grid[4];
+static bool notinitialized = true;
+
+
+
+void PGaugeExchangeFree(){
+#ifdef MULTI_GPU
+  if(comm_size() > 1){
+    cudaStreamDestroy(GFStream[0]);
+    cudaStreamDestroy(GFStream[1]);
+    for (int d=0; d<4; d++) {
+      if (commDimPartitioned(d)) {
+        comm_free(mh_send_fwd[d]);
+        comm_free(mh_send_back[d]);
+        comm_free(mh_recv_back[d]);
+        comm_free(mh_recv_fwd[d]);
+        device_free(send_d[d]);
+        device_free(recv_d[d]);
+        device_free(sendg_d[d]);
+        device_free(recvg_d[d]);
+        #ifndef GPU_COMMS
+        free(hostbuffer_h[d]);
+        #endif
+      }
+    }
+    notinitialized = true;
+  }
+#endif
+}
+
+
+template<typename Float, int NElems, typename Gauge>
+void PGaugeExchange( Gauge dataOr,  cudaGaugeField& data, const int dir, const int parity) {
+
+
+#ifdef MULTI_GPU
+  if(notinitialized == false){
+    for (int d=0; d<4; d++){
+    if(X[d] != data.X()[d]){
+      PGaugeExchangeFree();
+      notinitialized = true;
+      printfQuda("PGaugeExchange needs to be reinitialized...\n");
+      break;
+    }
+    }
+  }
+  if(notinitialized){
+    for (int d=0; d<4; d++){
+        X[d] = data.X()[d];
+    }
+    for (int i=0; i<4; i++) {
+      faceVolume[i] = 1;
+      for (int j=0; j<4; j++) {
+        if (i==j) continue;
+        faceVolume[i] *= X[j];
+      }
+      faceVolumeCB[i] = faceVolume[i]/2;
+    }
+
+    cudaStreamCreate(&GFStream[0]);
+    cudaStreamCreate(&GFStream[1]);
+    for (int d=0; d<4; d++) {
+      if (!commDimPartitioned(d)) continue;
+      // store both parities and directions in each
+      offset[d] = faceVolumeCB[d] * NElems;
+      bytes[d] =  sizeof(Float) * offset[d];
+      send_d[d] = device_malloc(bytes[d]);
+      recv_d[d] = device_malloc(bytes[d]);
+      sendg_d[d] = device_malloc(bytes[d]);
+      recvg_d[d] = device_malloc(bytes[d]);
+      #ifndef GPU_COMMS
+      hostbuffer_h[d] = (void*)malloc(4*bytes[d]);
+      #endif
+      block[d] = make_uint3(128, 1, 1);
+      grid[d] = make_uint3((faceVolumeCB[d] + block[d].x - 1) / block[d].x, 1, 1);
+    }
+
+    for (int d=0; d<4; d++) {
+      if (!commDimPartitioned(d)) continue;
+      #ifdef GPU_COMMS
+      recv[d] = recv_d[d];
+      send[d] = send_d[d];
+      recvg[d] = recvg_d[d];
+      sendg[d] = sendg_d[d];
+      #else
+      recv[d] = hostbuffer_h[d];
+      send[d] = static_cast<char*>(hostbuffer_h[d]) + bytes[d];
+      recvg[d] = static_cast<char*>(hostbuffer_h[d]) + 3*bytes[d];
+      sendg[d] = static_cast<char*>(hostbuffer_h[d]) + 2*bytes[d];      
+      #endif
+      // look into storing these for later
+      mh_recv_back[d] = comm_declare_receive_relative(recv[d], d, -1, bytes[d]);
+      mh_recv_fwd[d]  = comm_declare_receive_relative(recvg[d], d, +1, bytes[d]);
+      mh_send_back[d] = comm_declare_send_relative(sendg[d], d, -1, bytes[d]);
+      mh_send_fwd[d]  = comm_declare_send_relative(send[d], d, +1, bytes[d]);
+    }
+    notinitialized = false;
+  }
+  GaugeFixUnPackArg<Gauge> dataexarg(dataOr, data);
+
+
+    for (int d=0; d<4; d++) {
+      if (!commDimPartitioned(d)) continue;
+      comm_start(mh_recv_back[d]);  
+      comm_start(mh_recv_fwd[d]); 
+   
+      //extract top face
+      Kernel_UnPack<NElems, Float, Gauge, true><<<grid[d], block[d], 0, GFStream[0]>>>(\
+        faceVolumeCB[d], dataexarg, reinterpret_cast<typename ComplexTypeId<Float>::Type*>(send_d[d]), parity, d, dir, X[d]-3);
+      //extract bottom
+      Kernel_UnPack<NElems, Float, Gauge, true><<<grid[d], block[d], 0, GFStream[1]>>>(\
+        faceVolumeCB[d], dataexarg, reinterpret_cast<typename ComplexTypeId<Float>::Type*>(sendg_d[d]), parity, d, dir, 2);
+      
+    #ifndef GPU_COMMS
+      cudaMemcpyAsync(send[d], send_d[d], bytes[d], cudaMemcpyDeviceToHost, GFStream[0]);
+      cudaMemcpyAsync(sendg[d], sendg_d[d], bytes[d], cudaMemcpyDeviceToHost, GFStream[1]);
+    #endif
+      cudaStreamSynchronize(GFStream[0]);
+      comm_start(mh_send_fwd[d]);
+
+      cudaStreamSynchronize(GFStream[1]);
+      comm_start(mh_send_back[d]);
+ 
+    #ifndef GPU_COMMS
+      comm_wait(mh_recv_back[d]);
+      cudaMemcpyAsync(recv_d[d], recv[d], bytes[d], cudaMemcpyHostToDevice, GFStream[0]);
+    #endif
+      #ifdef GPU_COMMS
+      comm_wait(mh_recv_back[d]);
+      #endif
+      Kernel_UnPack<NElems, Float, Gauge, false><<<grid[d], block[d], 0, GFStream[0]>>>(\
+        faceVolumeCB[d], dataexarg, reinterpret_cast<typename ComplexTypeId<Float>::Type*>(recv_d[d]), parity, d, dir, 1);
+
+    #ifndef GPU_COMMS
+      comm_wait(mh_recv_fwd[d]);
+      cudaMemcpyAsync(recvg_d[d], recvg[d], bytes[d], cudaMemcpyHostToDevice, GFStream[1]);
+    #endif
+
+      #ifdef GPU_COMMS
+      comm_wait(mh_recv_fwd[d]);
+      #endif
+      Kernel_UnPack<NElems, Float, Gauge, false><<<grid[d], block[d], 0, GFStream[1]>>>(\
+        faceVolumeCB[d], dataexarg, reinterpret_cast<typename ComplexTypeId<Float>::Type*>(recvg_d[d]), parity, d, dir, X[d] - 2); 
+
+      comm_wait(mh_send_back[d]);
+      comm_wait(mh_send_fwd[d]);
+      cudaStreamSynchronize(GFStream[0]);
+      cudaStreamSynchronize(GFStream[1]);
+  }
+  checkCudaError();
+  cudaDeviceSynchronize();
+  #endif
+
+}
+
+
+template<typename Float>
+void PGaugeExchange( cudaGaugeField& data, const int dir, const int parity) {
+
+
+  // Switching to FloatNOrder for the gauge field in order to support RECONSTRUCT_12
+  // Need to fix this!!
+  if(data.Order() == QUDA_FLOAT2_GAUGE_ORDER) {
+    if(data.Reconstruct() == QUDA_RECONSTRUCT_NO) {
+    //printfQuda("QUDA_RECONSTRUCT_NO\n");
+      numParams = 18;
+      PGaugeExchange<Float, 18>(FloatNOrder<Float, 18, 2, 18>(data), data, dir, parity);
+    } else if(data.Reconstruct() == QUDA_RECONSTRUCT_12){
+    //printfQuda("QUDA_RECONSTRUCT_12\n");
+      numParams = 12;
+      PGaugeExchange<Float, 12>(FloatNOrder<Float, 18, 2, 12>(data), data, dir, parity);
+    
+    } else if(data.Reconstruct() == QUDA_RECONSTRUCT_8){
+    //printfQuda("QUDA_RECONSTRUCT_8\n");
+      numParams = 8;
+      PGaugeExchange<Float, 8>(FloatNOrder<Float, 18, 2,  8>(data), data, dir, parity);
+    
+    } else {
+      errorQuda("Reconstruction type %d of gauge field not supported", data.Reconstruct());
+    }
+  } else if(data.Order() == QUDA_FLOAT4_GAUGE_ORDER) {
+    if(data.Reconstruct() == QUDA_RECONSTRUCT_NO) {
+    //printfQuda("QUDA_RECONSTRUCT_NO\n");
+      numParams = 18;
+      PGaugeExchange<Float, 18>(FloatNOrder<Float, 18, 4, 18>(data), data, dir, parity);
+    } else if(data.Reconstruct() == QUDA_RECONSTRUCT_12){
+    //printfQuda("QUDA_RECONSTRUCT_12\n");
+      numParams = 12;
+      PGaugeExchange<Float, 12>(FloatNOrder<Float, 18, 4, 12>(data), data, dir, parity);
+    } else if(data.Reconstruct() == QUDA_RECONSTRUCT_8){
+    //printfQuda("QUDA_RECONSTRUCT_8\n");
+      numParams = 8;
+      PGaugeExchange<Float, 8>(FloatNOrder<Float, 18, 4,  8>(data), data, dir, parity);
+    } else {
+      errorQuda("Reconstruction type %d of gauge field not supported", data.Reconstruct());
+    }
+  } else {
+    errorQuda("Invalid Gauge Order\n");
+  }
+}
+
+  void PGaugeExchange( cudaGaugeField& data, const int dir, const int parity) {
+
+#ifdef MULTI_GPU
+  if(comm_size() > 1){
+    if(data.Precision() == QUDA_HALF_PRECISION) {
+      errorQuda("Half precision not supported\n");
+    }
+    if (data.Precision() == QUDA_SINGLE_PRECISION) {
+      PGaugeExchange<float> (data, dir, parity);
+    } else if(data.Precision() == QUDA_DOUBLE_PRECISION) {
+      PGaugeExchange<double>(data, dir, parity);
+    } else {
+      errorQuda("Precision %d not supported", data.Precision());
+    }
+  }
+#endif
+  }
+}

--- a/lib/pgauge_heatbath.cu
+++ b/lib/pgauge_heatbath.cu
@@ -1,0 +1,999 @@
+#include <quda_internal.h>
+#include <quda_matrix.h>
+#include <tune_quda.h>
+#include <gauge_field.h>
+#include <gauge_field_order.h>
+#include <cub/cub.cuh> 
+#include <launch_kernel.cuh>
+
+#include <device_functions.h>
+
+
+#include <comm_quda.h>
+
+
+#include <pgauge_monte.h> 
+#include <gauge_tools.h>
+
+
+#include <random.h>
+
+
+#define BORDER_RADIUS 2
+
+#ifndef PI
+#define PI    3.1415926535897932384626433832795    // pi
+#endif
+#ifndef PII
+#define PII   6.2831853071795864769252867665590    // 2 * pi
+#endif
+
+namespace quda {
+
+
+
+
+
+
+static  __inline__ __device__ double atomicAdd(double *addr, double val){
+  double old=*addr, assumed;
+  do {
+    assumed = old;
+    old = __longlong_as_double( atomicCAS((unsigned long long int*)addr,
+            __double_as_longlong(assumed),
+            __double_as_longlong(val+assumed)));
+  } while( __double_as_longlong(assumed)!=__double_as_longlong(old) );
+  
+  return old;
+}
+
+static  __inline__ __device__ double2 atomicAdd(double2 *addr, double2 val){
+    double2 old=*addr;
+    old.x = atomicAdd((double*)addr, val.x);
+    old.y = atomicAdd((double*)addr+1, val.y);
+    return old;
+  }
+
+
+#if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 200
+//CUDA 6.5 NOT DETECTING ATOMICADD FOR FLOAT TYPE!!!!!!!
+static __inline__ __device__ float atomicAdd(float *address, float val)
+{
+  return __fAtomicAdd(address, val);
+}
+#endif /* !__CUDA_ARCH__ || __CUDA_ARCH__ >= 200 */
+
+
+
+template <typename T>
+struct Summ {
+    __host__ __device__ __forceinline__ T operator()(const T &a, const T &b){
+        return a + b;
+    }
+};
+template <>
+struct Summ<double2>{
+    __host__ __device__ __forceinline__ double2 operator()(const double2 &a, const double2 &b){
+        return make_double2(a.x+b.x, a.y+b.y);
+    }
+};
+
+
+
+
+/**
+    @brief Calculate the SU(2) index block in the SU(Nc) matrix
+    @param block number to calculate the index's, the total number of blocks is NCOLORS * ( NCOLORS - 1) / 2.
+    @return Returns two index's in int2 type, accessed by .x and .y.
+*/
+template<int NCOLORS>
+__host__ __device__ static inline   int2 IndexBlock(int block){
+    int2 id;
+    int i1;
+    int found = 0;
+    int del_i = 0;
+    int index = -1;
+    while ( del_i < (NCOLORS-1) && found == 0 ){
+        del_i++;
+        for ( i1 = 0; i1 < (NCOLORS-del_i); i1++ ){
+            index++;
+            if ( index == block ){
+                found = 1;
+                break;
+            }
+        }
+    }
+    id.y = i1 + del_i;
+    id.x = i1;
+    return id;
+}
+/**
+    @brief Calculate the SU(2) index block in the SU(Nc) matrix
+    @param block number to calculate de index's, the total number of blocks is NCOLORS * ( NCOLORS - 1) / 2.
+    @param p store the first index
+    @param q store the second index
+*/
+template<int NCOLORS>
+__host__ __device__ static inline void   IndexBlock(int block, int &p, int &q){
+  if (NCOLORS == 3){
+    if(block == 0){p=0;q=1;}
+    else if(block == 1){p=1;q=2;}
+    else{p=0;q=2;}
+  }
+  else if(NCOLORS>3){
+      int i1;
+      int found = 0;
+      int del_i = 0;
+      int index = -1;
+      while ( del_i < (NCOLORS-1) && found == 0 ){
+          del_i++;
+          for ( i1 = 0; i1 < (NCOLORS-del_i); i1++ ){
+              index++;
+              if ( index == block ){
+                  found = 1;
+                  break;
+              }
+          }
+      }
+      q = i1 + del_i;
+      p = i1;
+  }
+}
+
+/**
+    @brief Generate full SU(2) matrix (four real numbers instead of 2x2 complex matrix) and update link matrix.
+    Get from MILC code.
+    @param al weight
+    @param localstate CURAND rng state
+*/
+template <class T>
+__device__ static inline Matrix<T,2> generate_su2_matrix_milc(T al, cuRNGState& localState){
+    T xr1, xr2, xr3, xr4, d, r;
+    int k;
+    xr1 = Random<T>(localState);
+    xr1 = (log((xr1 + 1.e-10)));
+    xr2 = Random<T>(localState);
+    xr2 = (log((xr2 + 1.e-10)));
+    xr3 = Random<T>(localState);
+    xr4 = Random<T>(localState);
+    xr3 = cos(PII*xr3);
+    d = -(xr2  + xr1 * xr3 * xr3 ) / al;
+    //now  beat each  site into submission
+    int nacd = 0;
+    if ((1.00 - 0.5 * d) > xr4 * xr4) nacd=1;
+    if(nacd == 0 && al > 2.0){ //k-p algorithm
+        for(k = 0; k < 20; k++){
+            //get four random numbers (add a small increment to prevent taking log(0.)
+            xr1 = Random<T>(localState);
+            xr1 = (log((xr1 + 1.e-10)));
+            xr2 = Random<T>(localState);
+            xr2 = (log((xr2 + 1.e-10)));
+            xr3 = Random<T>(localState);
+            xr4 = Random<T>(localState);
+            xr3 = cos(PII * xr3);
+            d = -(xr2 + xr1 * xr3 * xr3) / al;
+            if((1.00 - 0.5 * d) > xr4 * xr4) break;
+        }
+    } //endif nacd
+    Matrix<T,2> a;
+    if(nacd == 0 && al <= 2.0){ //creutz algorithm
+        xr3 = exp(-2.0 * al);
+        xr4 = 1.0 - xr3;
+        for(k = 0;k < 20 ; k++){
+            //get two random numbers
+            xr1 = Random<T>(localState);
+            xr2 = Random<T>(localState);
+            r = xr3 + xr4 * xr1; 
+            a(0,0) = 1.00 + log(r) / al;
+            if((1.0 -a(0,0) * a(0,0)) > xr2 * xr2) break;
+        }
+        d = 1.0 - a(0,0);
+    } //endif nacd
+    //generate the four su(2) elements 
+    //find a0  = 1 - d
+    a(0,0) = 1.0 - d;
+    //compute r
+    xr3 = 1.0 - a(0,0) * a(0,0);
+    xr3 = abs(xr3);
+    r = sqrt(xr3);
+    //compute a3
+    a(1,1) = (2.0 * Random<T>(localState) - 1.0) * r;
+    //compute a1 and a2
+    xr1 = xr3 - a(1,1) * a(1,1);
+    xr1 = abs(xr1);
+    xr1 = sqrt(xr1);
+    //xr2 is a random number between 0 and 2*pi
+    xr2 = PII * Random<T>(localState);
+    a(0,1) = xr1 * cos(xr2);
+    a(1,0) = xr1 * sin(xr2);
+    return a;
+}
+
+
+/**
+    @brief Return SU(2) subgroup (4 real numbers) from SU(3) matrix
+    @param tmp1 input SU(3) matrix
+    @param block to retrieve from 0 to 2.
+    @return 4 real numbers
+*/
+template < class T>
+__host__ __device__ static inline Matrix<T,2> get_block_su2( Matrix<typename ComplexTypeId<T>::Type,3> tmp1, int block ){
+    Matrix<T,2> r;
+    switch(block){
+  case 0:
+      r(0,0) = tmp1(0,0).x + tmp1(1,1).x;
+      r(0,1) = tmp1(0,1).y + tmp1(1,0).y;
+      r(1,0) = tmp1(0,1).x - tmp1(1,0).x;
+      r(1,1) = tmp1(0,0).y - tmp1(1,1).y;
+        break;
+  case 1:
+      r(0,0) = tmp1(1,1).x + tmp1(2,2).x;
+      r(0,1) = tmp1(1,2).y + tmp1(2,1).y;
+      r(1,0) = tmp1(1,2).x - tmp1(2,1).x;
+      r(1,1) = tmp1(1,1).y - tmp1(2,2).y;
+        break;
+  case 2:
+      r(0,0) = tmp1(0,0).x + tmp1(2,2).x;
+      r(0,1) = tmp1(0,2).y + tmp1(2,0).y;
+      r(1,0) = tmp1(0,2).x - tmp1(2,0).x;
+      r(1,1) = tmp1(0,0).y - tmp1(2,2).y;
+        break;
+    }
+    return r;
+}
+
+/**
+    @brief Return SU(2) subgroup (4 real numbers) from SU(Nc) matrix
+    @param tmp1 input SU(Nc) matrix
+    @param id the two indices to retrieve SU(2) block
+    @return 4 real numbers
+*/
+template <class T, int NCOLORS>
+__host__ __device__ static inline Matrix<T,2> get_block_su2( Matrix<typename ComplexTypeId<T>::Type,NCOLORS> tmp1, int2 id ){
+    Matrix<T,2> r;
+    r(0,0) = tmp1(id.x,id.x).x + tmp1(id.y,id.y).x;
+    r(0,1) = tmp1(id.x,id.y).y + tmp1(id.y,id.x).y;
+    r(1,0) = tmp1(id.x,id.y).x - tmp1(id.y,id.x).x;
+    r(1,1) = tmp1(id.x,id.x).y - tmp1(id.y,id.y).y;
+    return r;
+}
+
+/**
+    @brief Create a SU(Nc) identity matrix and fills with the SU(2) block
+    @param rr SU(2) matrix represented only by four real numbers
+    @param id the two indices to fill in the SU(3) matrix
+    @return SU(Nc) matrix
+*/
+template <class T, int NCOLORS>
+__host__ __device__ static inline Matrix<typename ComplexTypeId<T>::Type,NCOLORS> block_su2_to_sun( Matrix<T,2> rr, int2 id ){
+    Matrix<typename ComplexTypeId<T>::Type,NCOLORS> tmp1;
+    setIdentity(&tmp1);
+    tmp1(id.x,id.x) = makeComplex( rr(0,0), rr(1,1) );
+    tmp1(id.x,id.y) = makeComplex( rr(1,0), rr(0,1) );
+    tmp1(id.y,id.x) = makeComplex(-rr(1,0), rr(0,1) );
+    tmp1(id.y,id.y) = makeComplex( rr(0,0),-rr(1,1) );
+    return tmp1;
+}
+/**
+    @brief Update the SU(Nc) link with the new SU(2) matrix, link <- u * link
+    @param u SU(2) matrix represented by four real numbers
+    @param link SU(Nc) matrix
+    @param id indices
+*/
+template <class T, int NCOLORS>
+__host__ __device__ static inline void mul_block_sun( Matrix<T,2> u, Matrix<typename ComplexTypeId<T>::Type,NCOLORS> &link, int2 id ){
+    typename ComplexTypeId<T>::Type tmp;
+    for(int j = 0; j < NCOLORS; j++){
+        tmp = makeComplex( u(0,0), u(1,1) ) * link(id.x, j) + makeComplex( u(1,0), u(0,1) ) * link(id.y, j);
+        link(id.y, j) = makeComplex(-u(1,0), u(0,1) ) * link(id.x, j) + makeComplex( u(0,0),-u(1,1) ) * link(id.y, j);
+        link(id.x, j) = tmp;
+    }
+}
+
+/**
+    @brief Update the SU(3) link with the new SU(2) matrix, link <- u * link
+    @param U SU(3) matrix
+    @param a00 element (0,0) of the SU(2) matrix
+    @param a01 element (0,1) of the SU(2) matrix
+    @param a10 element (1,0) of the SU(2) matrix
+    @param a11 element (1,1) of the SU(2) matrix
+    @param block of the SU(3) matrix, 0,1 or 2
+*/
+template <class Cmplx>
+__host__ __device__ static inline void block_su2_to_su3( Matrix<Cmplx,3> &U, Cmplx a00, Cmplx a01, Cmplx a10, Cmplx a11, int block ){
+    Cmplx tmp;
+    switch(block){
+  case 0:
+      tmp = a00 * U(0,0) + a01 * U(1,0);
+      U(1,0) = a10 * U(0,0) + a11 * U(1,0);
+      U(0,0) = tmp;
+      tmp = a00 * U(0,1) + a01 * U(1,1);
+      U(1,1) = a10 * U(0,1) + a11 * U(1,1);
+      U(0,1) = tmp;
+      tmp = a00 * U(0,2) + a01 * U(1,2);
+      U(1,2) = a10 * U(0,2) + a11 * U(1,2);
+      U(0,2) = tmp;
+        break;
+  case 1:
+      tmp = a00 * U(1,0) + a01 * U(2,0);
+      U(2,0) = a10 * U(1,0) + a11 * U(2,0);
+      U(1,0) = tmp;
+      tmp = a00 * U(1,1) + a01 * U(2,1);
+      U(2,1) = a10 * U(1,1) + a11 * U(2,1);
+      U(1,1) = tmp;
+      tmp = a00 * U(1,2) + a01 * U(2,2);
+      U(2,2) = a10 * U(1,2) + a11 * U(2,2);
+      U(1,2) = tmp;
+        break;
+  case 2:
+      tmp = a00 * U(0,0) + a01 * U(2,0);
+      U(2,0) = a10 * U(0,0) + a11 * U(2,0);
+      U(0,0) = tmp;
+      tmp = a00 * U(0,1) + a01 * U(2,1);
+      U(2,1) = a10 * U(0,1) + a11 * U(2,1);
+      U(0,1) = tmp;
+      tmp = a00 * U(0,2) + a01 * U(2,2);
+      U(2,2) = a10 * U(0,2) + a11 * U(2,2);
+      U(0,2) = tmp;
+        break;
+    }
+}
+
+
+
+// v * u^dagger
+template <class Float>
+__host__ __device__ static inline Matrix<Float,2> mulsu2UVDagger(Matrix<Float,2> v, Matrix<Float,2> u){
+    Matrix<Float,2> b;
+    b(0,0) = v(0,0)*u(0,0) + v(0,1)*u(0,1) + v(1,0)*u(1,0) + v(1,1)*u(1,1);
+    b(0,1) = v(0,1)*u(0,0) - v(0,0)*u(0,1) + v(1,0)*u(1,1) - v(1,1)*u(1,0);
+    b(1,0) = v(1,0)*u(0,0) - v(0,0)*u(1,0) + v(1,1)*u(0,1) - v(0,1)*u(1,1);
+    b(1,1) = v(1,1)*u(0,0) - v(0,0)*u(1,1) + v(0,1)*u(1,0) - v(1,0)*u(0,1);
+    return b;
+}
+
+/**
+    @brief Link update by pseudo-heatbath
+    @param U link to be updated
+    @param F staple
+    @param localstate CURAND rng state
+*/
+template <class Float, int NCOLORS>
+__device__ inline void heatBathSUN( Matrix<typename ComplexTypeId<Float>::Type,NCOLORS>& U, Matrix<typename ComplexTypeId<Float>::Type,NCOLORS> F, \
+  cuRNGState& localState, Float BetaOverNc ){
+
+    typedef typename ComplexTypeId<Float>::Type Cmplx;
+if (NCOLORS == 3){
+    //////////////////////////////////////////////////////////////////
+    /* 
+      for( int block = 0; block < NCOLORS; block++ ) {
+      Matrix<typename ComplexTypeId<T>::Type,3> tmp1 = U * F;
+      Matrix<T,2> r = get_block_su2<T>(tmp1, block);
+      T k = sqrt(r(0,0)*r(0,0)+r(0,1)*r(0,1)+r(1,0)*r(1,0)+r(1,1)*r(1,1));
+      T ap = BetaOverNc * k;
+      k = (T)1.0 / k;
+      r *= k;
+      //Matrix<T,2> a = generate_su2_matrix<T4, T>(ap, localState);
+      Matrix<T,2> a = generate_su2_matrix_milc<T>(ap, localState);
+      r = mulsu2UVDagger_4<T>( a, r);
+      ///////////////////////////////////////
+      block_su2_to_su3<T>( U, complex( r(0,0), r(1,1) ), complex( r(1,0), r(0,1) ), complex(-r(1,0), r(0,1) ), complex( r(0,0),-r(1,1) ), block ); 
+      //FLOP_min = (198 + 4 + 15 + 28 + 28 + 84) * 3 = 1071
+      }*/
+    //////////////////////////////////////////////////////////////////
+     
+    for( int block = 0; block < NCOLORS; block++ ) {
+        int p,q;
+        IndexBlock<NCOLORS>(block, p, q);
+        Cmplx a0 = makeComplex((Float)0.0, (Float)0.0);
+        Cmplx a1 = a0;
+        Cmplx a2 = a0;
+        Cmplx a3 = a0;
+         
+        for(int j = 0; j < NCOLORS; j++){
+            a0 += U(p,j) * F(j,p);
+            a1 += U(p,j) * F(j,q);
+            a2 += U(q,j) * F(j,p);
+            a3 += U(q,j) * F(j,q);
+        }
+        Matrix<Float,2> r;
+        r(0,0) = a0.x + a3.x;
+        r(0,1) = a1.y + a2.y;
+        r(1,0) = a1.x - a2.x;
+        r(1,1) = a0.y - a3.y;
+        Float k = sqrt(r(0,0)*r(0,0)+r(0,1)*r(0,1)+r(1,0)*r(1,0)+r(1,1)*r(1,1));;
+        Float ap = BetaOverNc * k;
+        k = 1.0 / k;
+        r *= k;
+        Matrix<Float,2> a = generate_su2_matrix_milc<Float>(ap, localState);
+        r = mulsu2UVDagger<Float>( a, r);
+        ///////////////////////////////////////
+        a0 = makeComplex( r(0,0), r(1,1) );
+        a1 = makeComplex( r(1,0), r(0,1) );
+        a2 = makeComplex(-r(1,0), r(0,1) );
+        a3 = makeComplex( r(0,0),-r(1,1) );
+        Cmplx tmp0;
+         
+        for(int j = 0; j < NCOLORS; j++){
+        tmp0 = a0 * U(p,j) + a1 * U(q,j);
+        U(q,j) = a2 * U(p,j) + a3 * U(q,j);
+        U(p,j) = tmp0;
+        }   
+        //FLOP_min = (NCOLORS * 64 + 19 + 28 + 28) * 3 = NCOLORS * 192 + 225
+    }
+    //////////////////////////////////////////////////////////////////
+}
+else if(NCOLORS>3){
+    //////////////////////////////////////////////////////////////////
+    //TESTED IN SU(4) SP THIS IS WORST
+      Matrix<typename ComplexTypeId<Float>::Type,NCOLORS> M = U * F;
+      for( int block = 0; block < NCOLORS * ( NCOLORS - 1) / 2; block++ ) {
+      int2 id = IndexBlock<NCOLORS>( block );
+      Matrix<Float,2> r = get_block_su2<Float>(M, id);  
+      Float k = sqrt(r(0,0)*r(0,0)+r(0,1)*r(0,1)+r(1,0)*r(1,0)+r(1,1)*r(1,1));
+      Float ap = BetaOverNc * k;
+      k = 1.0 / k;
+      r *= k;
+      Matrix<Float,2> a = generate_su2_matrix_milc<Float>(ap, localState);
+      Matrix<Float,2> rr = mulsu2UVDagger<Float>( a, r);
+      ///////////////////////////////////////   
+      mul_block_sun<Float, NCOLORS>( rr, U, id);
+      mul_block_sun<Float, NCOLORS>( rr, M, id);
+      ///////////////////////////////////////     
+      }
+    /*//TESTED IN SU(4) SP THIS IS FASTER
+    for( int block = 0; block < NCOLORS * ( NCOLORS - 1) / 2; block++ ) {
+      int2 id = IndexBlock<NCOLORS>( block );
+        complex a0 = complex::zero();
+        complex a1 = complex::zero();
+        complex a2 = complex::zero();
+        complex a3 = complex::zero();
+         
+        for(int j = 0; j < NCOLORS; j++){
+            a0 += U(id.x, j) * F.e[j][id.x];
+            a1 += U(id.x, j) * F.e[j][id.y];
+            a2 += U(id.y, j) * F.e[j][id.x];
+            a3 += U(id.y, j) * F.e[j][id.y];
+        }
+        Matrix<T,2> r;
+        r(0,0) = a0.x + a3.x;
+        r(0,1) = a1.y + a2.y;
+        r(1,0) = a1.x - a2.x;
+        r(1,1) = a0.y - a3.y;
+        T k = sqrt(r(0,0)*r(0,0)+r(0,1)*r(0,1)+r(1,0)*r(1,0)+r(1,1)*r(1,1));
+        T ap = BetaOverNc * k;
+        k = (T)1.0 / k;
+        r *= k;
+        //Matrix<T,2> a = generate_su2_matrix<T4, T>(ap, localState);
+        Matrix<T,2> a = generate_su2_matrix_milc<T>(ap, localState);
+        r = mulsu2UVDagger<T>( a, r);
+        mul_block_sun<T>( r, U, id);*/
+        /*///////////////////////////////////////
+          a0 = complex( r(0,0), r(1,1) );
+          a1 = complex( r(1,0), r(0,1) );
+          a2 = complex(-r(1,0), r(0,1) );
+          a3 = complex( r(0,0),-r(1,1) );
+          complex tmp0;
+           
+          for(int j = 0; j < NCOLORS; j++){
+          tmp0 = a0 * U(id.x, j) + a1 * U(id.y, j);
+          U(id.y, j) = a2 * U(id.x, j) + a3 * U(id.y, j);
+          U(id.x, j) = tmp0;
+          } */  
+   // }
+
+}
+    //////////////////////////////////////////////////////////////////
+}
+
+//////////////////////////////////////////////////////////////////////////
+/**
+    @brief Link update by overrelaxation
+    @param U link to be updated
+    @param F staple
+*/
+template <class Float, int NCOLORS>
+__device__ inline void overrelaxationSUN( Matrix<typename ComplexTypeId<Float>::Type,NCOLORS>& U, Matrix<typename ComplexTypeId<Float>::Type,NCOLORS> F ){
+
+    typedef typename ComplexTypeId<Float>::Type Cmplx;
+if (NCOLORS == 3){
+    //////////////////////////////////////////////////////////////////
+    /* 
+      for( int block = 0; block < 3; block++ ) {
+      Matrix<typename ComplexTypeId<T>::Type,3> tmp1 = U * F;
+      Matrix<T,2> r = get_block_su2<T>(tmp1, block);
+      //normalize and conjugate
+      Float norm = 1.0 / sqrt(r(0,0)*r(0,0)+r(0,1)*r(0,1)+r(1,0)*r(1,0)+r(1,1)*r(1,1));;
+      r(0,0) *= norm;
+      r(0,1) *= -norm;
+      r(1,0) *= -norm;
+      r(1,1) *= -norm;
+      ///////////////////////////////////////
+      complex a00 = complex( r(0,0), r(1,1) );
+      complex a01 = complex( r(1,0), r(0,1) );
+      complex a10 = complex(-r(1,0), r(0,1) );
+      complex a11 = complex( r(0,0),-r(1,1) );
+      block_su2_to_su3<T>( U, a00, a01, a10, a11, block );
+      block_su2_to_su3<T>( U, a00, a01, a10, a11, block );
+
+      //FLOP = (198 + 17 + 84 * 2) * 3 = 1149
+      }*/
+    ///////////////////////////////////////////////////////////////////
+    //This version does not need to multiply all matrix at each block: tmp1 = U * F;
+    //////////////////////////////////////////////////////////////////
+     
+    for( int block = 0; block < 3; block++ ) {
+        int p,q;
+        IndexBlock<NCOLORS>(block, p, q);
+        Cmplx a0 = makeComplex((Float)0., (Float)0.);
+        Cmplx a1 = a0;
+        Cmplx a2 = a0;
+        Cmplx a3 = a0;
+         
+        for(int j = 0; j < NCOLORS; j++){
+            a0 += U(p,j) * F(j,p);
+            a1 += U(p,j) * F(j,q);
+            a2 += U(q,j) * F(j,p);
+            a3 += U(q,j) * F(j,q);
+        }
+        Matrix<Float,2> r;
+        r(0,0) = a0.x + a3.x;
+        r(0,1) = a1.y + a2.y;
+        r(1,0) = a1.x - a2.x;
+        r(1,1) = a0.y - a3.y;
+        //normalize and conjugate
+        //r = r.conj_normalize();
+        Float norm = 1.0 / sqrt(r(0,0)*r(0,0)+r(0,1)*r(0,1)+r(1,0)*r(1,0)+r(1,1)*r(1,1));;
+        r(0,0) *= norm;
+        r(0,1) *= -norm;
+        r(1,0) *= -norm;
+        r(1,1) *= -norm;
+
+
+        ///////////////////////////////////////
+        a0 = makeComplex( r(0,0), r(1,1) );
+        a1 = makeComplex( r(1,0), r(0,1) );
+        a2 = makeComplex(-r(1,0), r(0,1) );
+        a3 = makeComplex( r(0,0),-r(1,1) );
+        Cmplx tmp0, tmp1;
+         
+        for(int j = 0; j < NCOLORS; j++){
+        tmp0 = a0 * U(p,j) + a1 * U(q,j);
+        tmp1 = a2 * U(p,j) + a3 * U(q,j);
+        U(p,j) = a0 * tmp0 + a1 * tmp1;
+        U(q,j) = a2 * tmp0 + a3 * tmp1;
+        }
+        //FLOP = (NCOLORS * 88 + 17) * 3
+    }
+    ///////////////////////////////////////////////////////////////////
+}
+else if(NCOLORS>3){
+    ///////////////////////////////////////////////////////////////////
+    Matrix<typename ComplexTypeId<Float>::Type,NCOLORS> M = U * F;
+    for( int block = 0; block < NCOLORS * ( NCOLORS - 1) / 2; block++ ) {
+        int2 id = IndexBlock<NCOLORS>( block );
+        Matrix<Float,2> r = get_block_su2<Float, NCOLORS>(M, id);
+        //normalize and conjugate
+        Float norm = 1.0 / sqrt(r(0,0)*r(0,0)+r(0,1)*r(0,1)+r(1,0)*r(1,0)+r(1,1)*r(1,1));;
+        r(0,0) *= norm;
+        r(0,1) *= -norm;
+        r(1,0) *= -norm;
+        r(1,1) *= -norm;  
+        mul_block_sun<Float, NCOLORS>( r, U, id);
+        mul_block_sun<Float, NCOLORS>( r, U, id);
+        mul_block_sun<Float, NCOLORS>( r, M, id);
+        mul_block_sun<Float, NCOLORS>( r, M, id);
+        ///////////////////////////////////////
+    }
+    /*  //TESTED IN SU(4) SP THIS IS WORST
+        for( int block = 0; block < NCOLORS * ( NCOLORS - 1) / 2; block++ ) {
+      int2 id = IndexBlock<NCOLORS>( block );
+        complex a0 = complex::zero();
+        complex a1 = complex::zero();
+        complex a2 = complex::zero();
+        complex a3 = complex::zero();
+         
+        for(int j = 0; j < NCOLORS; j++){
+    a0 += U(id.x, j) * F.e[j][id.x];
+    a1 += U(id.x, j) * F.e[j][id.y];
+    a2 += U(id.y, j) * F.e[j][id.x];
+    a3 += U(id.y, j) * F.e[j][id.y];
+        }
+        Matrix<T,2> r;
+        r(0,0) = a0.x + a3.x;
+        r(0,1) = a1.y + a2.y;
+        r(1,0) = a1.x - a2.x;
+        r(1,1) = a0.y - a3.y;
+        //normalize and conjugate
+        Float norm = 1.0 / sqrt(r(0,0)*r(0,0)+r(0,1)*r(0,1)+r(1,0)*r(1,0)+r(1,1)*r(1,1));;
+        r(0,0) *= norm;
+        r(0,1) *= -norm;
+        r(1,0) *= -norm;
+        r(1,1) *= -norm;
+        //mul_block_sun<T>( r, U, id);
+        //mul_block_sun<T>( r, U, id);
+        ///////////////////////////////////////
+        a0 = complex( r(0,0), r(1,1) );
+        a1 = complex( r(1,0), r(0,1) );
+        a2 = complex(-r(1,0), r(0,1) );
+        a3 = complex( r(0,0),-r(1,1) );
+        complex tmp0, tmp1;
+         
+        for(int j = 0; j < NCOLORS; j++){
+        tmp0 = a0 * U(id.x, j) + a1 * U(id.y, j);
+        tmp1 = a2 * U(id.x, j) + a3 * U(id.y, j);
+        U(id.x, j) = a0 * tmp0 + a1 * tmp1;
+        U(id.y, j) = a2 * tmp0 + a3 * tmp1;
+        }
+        }
+    */
+}
+}
+
+
+
+
+
+
+
+
+__device__ __host__ inline int linkIndex2(int x[], int dx[], const int X[4]) {
+  int y[4];
+  for (int i=0; i<4; i++) y[i] = (x[i] + dx[i] + X[i]) % X[i];
+  int idx = (((y[3]*X[2] + y[2])*X[1] + y[1])*X[0] + y[0]) >> 1;
+  return idx;
+}
+
+
+
+static __device__ __host__ inline int linkIndex3(int x[], int dx[], const int X[4]) {
+  int y[4];
+  for (int i=0; i<4; i++) y[i] = (x[i] + dx[i] + X[i]) % X[i];
+  int idx = (((y[3]*X[2] + y[2])*X[1] + y[1])*X[0] + y[0]) >> 1;
+  return idx;
+}
+static __device__ __host__ inline int linkIndex(int x[], const int X[4]) {
+  int idx = (((x[3]*X[2] + x[2])*X[1] + x[1])*X[0] + x[0]) >> 1;
+  return idx;
+}
+static __device__ __host__ inline int linkIndexM1(int x[], const int X[4], const int mu) {
+  int y[4];
+  for (int i=0; i<4; i++) y[i] = x[i];
+  y[mu] = (y[mu] -1 + X[mu]) % X[mu];
+  int idx = (((y[3]*X[2] + y[2])*X[1] + y[1])*X[0] + y[0]) >> 1;
+  return idx;
+}
+
+
+
+static __device__ __host__ inline void getCoords3(int x[4], int cb_index, const int X[4], int parity) {
+  /*x[3] = cb_index/(X[2]*X[1]*X[0]/2);
+  x[2] = (cb_index/(X[1]*X[0]/2)) % X[2];
+  x[1] = (cb_index/(X[0]/2)) % X[1];
+  x[0] = 2*(cb_index%(X[0]/2)) + ((x[3]+x[2]+x[1]+parity)&1);*/
+  int za = (cb_index / (X[0]/2));
+  int zb =  (za / X[1]);
+  x[1] = za - zb * X[1];
+  x[3] = (zb / X[2]);
+  x[2] = zb - x[3] * X[2];
+  int x1odd = (x[1] + x[2] + x[3] + parity) & 1;
+  x[0] = (2 * cb_index + x1odd)  - za * X[0];
+  return;
+}
+
+
+
+
+
+
+
+
+
+template <typename Gauge, typename Float, int NCOLORS>
+struct MonteArg {
+  int threads; // number of active threads required
+  int X[4]; // grid dimensions
+#ifdef MULTI_GPU
+  int border[4]; 
+#endif
+  Gauge dataOr;
+  cudaGaugeField &data;
+  Float BetaOverNc;
+  cuRNGState *rngstate;
+  MonteArg(const Gauge &dataOr, cudaGaugeField &data, Float Beta, cuRNGState *rngstate)
+    : dataOr(dataOr), data(data), rngstate(rngstate) {
+    BetaOverNc = Beta / NCOLORS;
+#ifdef MULTI_GPU
+    for(int dir=0; dir<4; ++dir){
+      if(comm_dim_partitioned(dir)) border[dir] = BORDER_RADIUS;
+      else border[dir] = 0;
+    }
+    for(int dir=0; dir<4; ++dir) X[dir] = data.X()[dir] - border[dir]*2;
+#else
+    for(int dir=0; dir<4; ++dir) X[dir] = data.X()[dir];
+#endif
+    threads = X[0]*X[1]*X[2]*X[3] >> 1;
+  }
+};
+
+
+template<typename Float, typename Gauge, int NCOLORS, bool HeatbathOrRelax>
+__global__ void compute_heatBath(MonteArg<Gauge, Float, NCOLORS> arg, int mu, int parity){
+  int idx = threadIdx.x + blockIdx.x*blockDim.x;
+  if(idx >= arg.threads) return;
+    typedef typename ComplexTypeId<Float>::Type Cmplx;
+    int id = idx;
+    int X[4]; 
+    #pragma unroll
+    for(int dr=0; dr<4; ++dr) X[dr] = arg.X[dr];
+
+    int x[4];
+    getCoords3(x, idx, X, parity);
+#ifdef MULTI_GPU
+    #pragma unroll
+    for(int dr=0; dr<4; ++dr) {
+         x[dr] += arg.border[dr];
+         X[dr] += 2*arg.border[dr];
+    }
+    idx = linkIndex(x,X);
+#endif
+
+    Matrix<Cmplx,NCOLORS> staple;
+    setZero(&staple);
+
+    Matrix<Cmplx,NCOLORS> U; 
+    for(int nu = 0; nu < 4; nu++)  if(mu != nu) {
+      int dx[4] = {0, 0, 0, 0};
+      Matrix<Cmplx,NCOLORS> link; 
+      arg.dataOr.load((Float*)(link.data), idx, nu, parity);
+      dx[nu]++;
+      arg.dataOr.load((Float*)(U.data), linkIndex2(x,dx,X), mu, 1-parity);
+      link *= U;
+      dx[nu]--;
+      dx[mu]++;
+      arg.dataOr.load((Float*)(U.data), linkIndex2(x,dx,X), nu, 1-parity);
+      link *= conj(U);
+      staple += link;
+      dx[mu]--;
+      dx[nu]--;
+      arg.dataOr.load((Float*)(link.data), linkIndex2(x,dx,X), nu, 1-parity);
+      arg.dataOr.load((Float*)(U.data), linkIndex2(x,dx,X), mu, 1-parity);
+      link = conj(link) * U;
+      dx[mu]++;
+      arg.dataOr.load((Float*)(U.data), linkIndex2(x,dx,X), nu, parity);
+      link *= U;
+      staple += link;
+    }
+    arg.dataOr.load((Float*)(U.data), idx, mu, parity);
+    if(HeatbathOrRelax) {
+      cuRNGState localState = arg.rngstate[ id ];
+      heatBathSUN<Float, NCOLORS>( U, conj(staple), localState, arg.BetaOverNc );
+      arg.rngstate[ id ] = localState;
+    }
+    else{
+      overrelaxationSUN<Float, NCOLORS>( U, conj(staple) );
+    }   
+    arg.dataOr.save((Float*)(U.data), idx, mu, parity);
+}
+
+
+template<typename Float, typename Gauge, int NCOLORS, int NElems, bool HeatbathOrRelax>
+class GaugeHB : Tunable {
+  MonteArg<Gauge, Float, NCOLORS> arg;
+  int mu;
+  int parity;
+  mutable char aux_string[128]; // used as a label in the autotuner
+  private:
+  unsigned int sharedBytesPerThread() const { return 0; }
+  unsigned int sharedBytesPerBlock(const TuneParam &param) const { return 0; }
+  bool tuneSharedBytes() const { return false; } // Don't tune shared memory
+  bool tuneGridDim() const { return false; } // Don't tune the grid dimensions.
+  unsigned int minThreads() const { return arg.threads; }
+
+  public:
+  GaugeHB(MonteArg<Gauge, Float, NCOLORS> &arg)
+    : arg(arg), mu(0), parity(0) { }
+  /*GaugeHB(MonteArg<Gauge, Float, NCOLORS> &arg, int _mu, int _parity)
+    : arg(arg) {
+    mu = _mu;
+    parity = _parity;
+  }*/
+  ~GaugeHB () { }
+  void SetParam(int _mu, int _parity){
+    mu = _mu;
+    parity = _parity;
+  }
+  void apply(const cudaStream_t &stream){
+      TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
+      compute_heatBath<Float, Gauge, NCOLORS, HeatbathOrRelax ><<<tp.grid,tp.block, 0, stream>>>(arg, mu, parity);
+  }
+
+  TuneKey tuneKey() const {
+    std::stringstream vol;
+    vol << arg.X[0] << "x";
+    vol << arg.X[1] << "x";
+    vol << arg.X[2] << "x";
+    vol << arg.X[3];
+    sprintf(aux_string,"threads=%d,prec=%d",arg.threads, sizeof(Float));
+    return TuneKey(vol.str().c_str(), typeid(*this).name(), aux_string);
+  }
+  std::string paramString(const TuneParam &param) const {
+    std::stringstream ps;
+    ps << "block=(" << param.block.x << "," << param.block.y << "," << param.block.z << ")";
+    ps << "shared=" << param.shared_bytes;
+    return ps.str();
+  }
+  void preTune() { arg.data.backup(); }
+  void postTune() { arg.data.restore(); }
+  long long flops() const { 
+
+    //NEED TO CHECK THIS!!!!!!
+    if(NCOLORS == 3){
+      long long flop = 2268LL;
+      if(HeatbathOrRelax){
+        flop += 801LL;
+      }
+      else{
+        flop += 843LL;
+      }
+      flop *= arg.threads;
+      return flop;
+    }
+    else{
+      long long flop = NCOLORS * NCOLORS * NCOLORS * 84LL;
+      if(HeatbathOrRelax){
+        flop += NCOLORS * NCOLORS * NCOLORS + (NCOLORS * ( NCOLORS - 1) / 2) * (46LL + 48LL+56LL * NCOLORS);
+      }
+      else{
+        flop += NCOLORS * NCOLORS * NCOLORS + (NCOLORS * ( NCOLORS - 1) / 2) * (17LL+112LL * NCOLORS);
+      }
+      flop *= arg.threads;
+      return flop;
+    }
+   }
+  long long bytes() const { 
+    //NEED TO CHECK THIS!!!!!!
+    if(NCOLORS == 3){
+      long long byte = 20LL * NElems * sizeof(Float) ;
+      if(HeatbathOrRelax) byte += 2LL * sizeof(cuRNGState);
+      byte *= arg.threads;
+      return byte;
+    }
+    else{
+      long long byte = 20LL * NCOLORS * NCOLORS * 2 * sizeof(Float);
+      if(HeatbathOrRelax) byte += 2LL * sizeof(cuRNGState);
+      byte *= arg.threads;
+      return byte;
+    }
+   }
+}; 
+
+
+
+
+
+
+
+
+
+template<typename Float, int NElems, int NCOLORS, typename Gauge>
+void Monte( Gauge dataOr,  cudaGaugeField& data, cuRNGState *rngstate, Float Beta, unsigned int nhb, unsigned int nover) {
+
+  TimeProfile profileHBOVR("HeatBath_OR_Relax");
+  MonteArg<Gauge, Float, NCOLORS> montearg(dataOr, data, Beta, rngstate);
+  if (getVerbosity() >= QUDA_SUMMARIZE) profileHBOVR.Start(QUDA_PROFILE_COMPUTE);
+  GaugeHB<Float, Gauge, NCOLORS, NElems, true> hb(montearg);
+  for(int step=0; step<nhb; ++step){
+    for(int parity=0; parity<2; ++parity){
+      for(int mu=0; mu<4; ++mu){
+        hb.SetParam(mu, parity);
+        hb.apply(0);
+        #ifdef MULTI_GPU
+        PGaugeExchange( data, mu, parity);
+        #endif
+      }
+    }
+  }
+  if (getVerbosity() >= QUDA_SUMMARIZE){
+    cudaDeviceSynchronize();
+    profileHBOVR.Stop(QUDA_PROFILE_COMPUTE);
+    double secs = profileHBOVR.Last(QUDA_PROFILE_COMPUTE);
+    double gflops = (hb.flops() * 8 * nhb * 1e-9)/(secs);
+    double gbytes = hb.bytes() * 8 * nhb /(secs*1e9);
+    #ifdef MULTI_GPU
+    printfQuda("HB: Time = %6.6f s, Gflop/s = %6.1f, GB/s = %6.1f\n", secs, gflops*comm_size(), gbytes*comm_size());
+    #else
+    printfQuda("HB: Time = %6.6f s, Gflop/s = %6.1f, GB/s = %6.1f\n", secs, gflops, gbytes);
+    #endif
+  }
+
+  if (getVerbosity() >= QUDA_SUMMARIZE) profileHBOVR.Start(QUDA_PROFILE_COMPUTE);
+  GaugeHB<Float, Gauge, NCOLORS, NElems, false> relax(montearg);
+  for(int step=0; step<nover; ++step){
+    for(int parity=0; parity<2; ++parity){
+      for(int mu=0; mu<4; ++mu){
+        relax.SetParam(mu, parity);
+        relax.apply(0);
+        #ifdef MULTI_GPU
+        PGaugeExchange( data, mu, parity);
+        #endif
+      }
+    }
+  }
+  if (getVerbosity() >= QUDA_SUMMARIZE){
+    cudaDeviceSynchronize();
+    profileHBOVR.Stop(QUDA_PROFILE_COMPUTE);
+    double secs = profileHBOVR.Last(QUDA_PROFILE_COMPUTE);
+    double gflops = (relax.flops() * 8 * nover * 1e-9)/(secs);
+    double gbytes = relax.bytes() * 8 * nover /(secs*1e9);
+    #ifdef MULTI_GPU
+    printfQuda("OVR: Time = %6.6f s, Gflop/s = %6.1f, GB/s = %6.1f\n", secs, gflops*comm_size(), gbytes*comm_size());
+    #else
+    printfQuda("OVR: Time = %6.6f s, Gflop/s = %6.1f, GB/s = %6.1f\n", secs, gflops, gbytes);
+    #endif
+  }
+}
+
+
+
+template<typename Float>
+void Monte( cudaGaugeField& data, cuRNGState *rngstate, Float Beta, unsigned int nhb, unsigned int nover) {
+
+  // Switching to FloatNOrder for the gauge field in order to support RECONSTRUCT_12
+  // Need to fix this!!
+  if(data.Order() == QUDA_FLOAT2_GAUGE_ORDER) {
+    if(data.Reconstruct() == QUDA_RECONSTRUCT_NO) {
+    //printfQuda("QUDA_RECONSTRUCT_NO\n");
+      Monte<Float, 18, 3>(FloatNOrder<Float, 18, 2, 18>(data), data, rngstate, Beta, nhb, nover);
+    } else if(data.Reconstruct() == QUDA_RECONSTRUCT_12){
+    //printfQuda("QUDA_RECONSTRUCT_12\n");
+      Monte<Float, 12, 3>(FloatNOrder<Float, 18, 2, 12>(data), data, rngstate, Beta, nhb, nover);
+    } else if(data.Reconstruct() == QUDA_RECONSTRUCT_8){
+    //printfQuda("QUDA_RECONSTRUCT_8\n");
+      Monte<Float, 8, 3>(FloatNOrder<Float, 18, 2,  8>(data), data, rngstate, Beta, nhb, nover);
+    
+    } else {
+      errorQuda("Reconstruction type %d of gauge field not supported", data.Reconstruct());
+    }
+  } else if(data.Order() == QUDA_FLOAT4_GAUGE_ORDER) {
+    if(data.Reconstruct() == QUDA_RECONSTRUCT_NO) {
+    //printfQuda("QUDA_RECONSTRUCT_NO\n");
+      Monte<Float, 18, 3>(FloatNOrder<Float, 18, 4, 18>(data), data, rngstate, Beta, nhb, nover);
+    } else if(data.Reconstruct() == QUDA_RECONSTRUCT_12){
+    //printfQuda("QUDA_RECONSTRUCT_12\n");
+      Monte<Float, 12, 3>(FloatNOrder<Float, 18, 4, 12>(data), data, rngstate, Beta, nhb, nover);
+    } else if(data.Reconstruct() == QUDA_RECONSTRUCT_8){
+    //printfQuda("QUDA_RECONSTRUCT_8\n");
+      Monte<Float, 8, 3>(FloatNOrder<Float, 18, 4,  8>(data), data, rngstate, Beta, nhb, nover);
+    } else {
+      errorQuda("Reconstruction type %d of gauge field not supported", data.Reconstruct());
+    }
+  } else {
+    errorQuda("Invalid Gauge Order\n");
+  }
+}
+
+
+/** @brief Perform heatbath and overrelaxation. Performs nhb heatbath steps followed by nover overrelaxation steps.
+* 
+* @param[in,out] data Gauge field
+* @param[in,out] rngstate state of the CURAND random number generator
+* @param[in] Beta inverse of the gauge coupling, beta = 2 Nc / g_0^2 
+* @param[in] nhb number of heatbath steps
+* @param[in] nover number of overrelaxation steps
+*/
+void Monte( cudaGaugeField& data, cuRNGState *rngstate, double Beta, unsigned int nhb, unsigned int nover) {
+  if(data.Precision() == QUDA_HALF_PRECISION) {
+    errorQuda("Half precision not supported\n");
+  }
+  if (data.Precision() == QUDA_SINGLE_PRECISION) {
+    Monte<float> (data, rngstate, (float)Beta, nhb, nover);
+  } else if(data.Precision() == QUDA_DOUBLE_PRECISION) {
+    Monte<double>(data, rngstate, Beta, nhb, nover);
+  } else {
+    errorQuda("Precision %d not supported", data.Precision());
+  }
+}
+
+
+}

--- a/lib/pgauge_init.cu
+++ b/lib/pgauge_init.cu
@@ -1,0 +1,591 @@
+#include <quda_internal.h>
+#include <quda_matrix.h>
+#include <tune_quda.h>
+#include <gauge_field.h>
+#include <gauge_field_order.h>
+#include <cub/cub.cuh> 
+#include <launch_kernel.cuh>
+
+#include <device_functions.h>
+
+#include <comm_quda.h>
+
+#include <hisq_links_quda.h> //reunit gauge links!!!!!
+
+#include <pgauge_monte.h> 
+
+
+#include <random.h>
+
+
+#define BORDER_RADIUS 2
+
+#ifndef PI
+#define PI    3.1415926535897932384626433832795    // pi
+#endif
+#ifndef PII
+#define PII   6.2831853071795864769252867665590    // 2 * pi
+#endif
+
+namespace quda {
+
+
+
+
+
+
+
+__device__ __host__ inline int linkIndex2(int x[], int dx[], const int X[4]) {
+  int y[4];
+  for (int i=0; i<4; i++) y[i] = (x[i] + dx[i] + X[i]) % X[i];
+  int idx = (((y[3]*X[2] + y[2])*X[1] + y[1])*X[0] + y[0]) >> 1;
+  return idx;
+}
+
+
+
+static __device__ __host__ inline int linkIndex3(int x[], int dx[], const int X[4]) {
+  int y[4];
+  for (int i=0; i<4; i++) y[i] = (x[i] + dx[i] + X[i]) % X[i];
+  int idx = (((y[3]*X[2] + y[2])*X[1] + y[1])*X[0] + y[0]) >> 1;
+  return idx;
+}
+static __device__ __host__ inline int linkIndex(int x[], const int X[4]) {
+  int idx = (((x[3]*X[2] + x[2])*X[1] + x[1])*X[0] + x[0]) >> 1;
+  return idx;
+}
+static __device__ __host__ inline int linkIndexM1(int x[], const int X[4], const int mu) {
+  int y[4];
+  for (int i=0; i<4; i++) y[i] = x[i];
+  y[mu] = (y[mu] -1 + X[mu]) % X[mu];
+  int idx = (((y[3]*X[2] + y[2])*X[1] + y[1])*X[0] + y[0]) >> 1;
+  return idx;
+}
+
+
+
+static __device__ __host__ inline void getCoords3(int x[4], int cb_index, const int X[4], int parity) {
+  /*x[3] = cb_index/(X[2]*X[1]*X[0]/2);
+  x[2] = (cb_index/(X[1]*X[0]/2)) % X[2];
+  x[1] = (cb_index/(X[0]/2)) % X[1];
+  x[0] = 2*(cb_index%(X[0]/2)) + ((x[3]+x[2]+x[1]+parity)&1);*/
+  int za = (cb_index / (X[0]/2));
+  int zb =  (za / X[1]);
+  x[1] = za - zb * X[1];
+  x[3] = (zb / X[2]);
+  x[2] = zb - x[3] * X[2];
+  int x1odd = (x[1] + x[2] + x[3] + parity) & 1;
+  x[0] = (2 * cb_index + x1odd)  - za * X[0];
+  return;
+}
+
+
+
+
+
+template <typename Gauge>
+struct InitGaugeColdArg {
+  int threads; // number of active threads required
+  int X[4]; // grid dimensions
+  Gauge dataOr;
+  InitGaugeColdArg(const Gauge &dataOr, const cudaGaugeField &data)
+    : dataOr(dataOr) {
+    for(int dir=0; dir<4; ++dir) X[dir] = data.X()[dir];
+    threads = X[0]*X[1]*X[2]*X[3];
+  }
+};
+
+
+
+
+template<typename Float, typename Gauge, int NCOLORS>
+__global__ void compute_InitGauge_ColdStart(InitGaugeColdArg<Gauge> arg){
+  int idx = threadIdx.x + blockIdx.x*blockDim.x;
+  if(idx >= arg.threads) return;
+    typedef typename ComplexTypeId<Float>::Type Cmplx;
+    int parity = 0;
+    if(idx >= arg.threads/2) {
+      parity = 1;
+      idx -= arg.threads/2;
+    }
+    Matrix<Cmplx,NCOLORS> U;
+    setIdentity(&U); 
+    for(int d = 0; d < 4; d++)
+      arg.dataOr.save((Float*)(U.data),idx, d, parity);
+}
+
+
+template<typename Float, typename Gauge, int NCOLORS>
+class InitGaugeCold : Tunable {
+  InitGaugeColdArg<Gauge> arg;
+  mutable char aux_string[128]; // used as a label in the autotuner
+  private:
+  unsigned int sharedBytesPerThread() const { return 0; }
+  unsigned int sharedBytesPerBlock(const TuneParam &param) const { return 0; }
+  bool tuneSharedBytes() const { return false; } // Don't tune shared memory
+  bool tuneGridDim() const { return false; } // Don't tune the grid dimensions.
+  unsigned int minThreads() const { return arg.threads; }
+
+  public:
+  InitGaugeCold(InitGaugeColdArg<Gauge> &arg)
+    : arg(arg) {}
+  ~InitGaugeCold () { }
+
+  void apply(const cudaStream_t &stream){
+      TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
+      compute_InitGauge_ColdStart<Float, Gauge, NCOLORS><<<tp.grid,tp.block>>>(arg);
+      //cudaDeviceSynchronize();
+  }
+
+  TuneKey tuneKey() const {
+    std::stringstream vol;
+    vol << arg.X[0] << "x";
+    vol << arg.X[1] << "x";
+    vol << arg.X[2] << "x";
+    vol << arg.X[3];
+    sprintf(aux_string,"threads=%d,prec=%d",arg.threads, sizeof(Float));
+    return TuneKey(vol.str().c_str(), typeid(*this).name(), aux_string);
+    
+  }
+  std::string paramString(const TuneParam &param) const {
+    std::stringstream ps;
+    ps << "block=(" << param.block.x << "," << param.block.y << "," << param.block.z << ")";
+    ps << "shared=" << param.shared_bytes;
+    return ps.str();
+  }
+  void preTune(){}
+  void postTune(){}
+  long long flops() const { return 0; }// Only correct if there is no link reconstruction, no cub reduction accounted also
+  long long bytes() const { return 0; }//no accounting the reduction!!!!
+
+}; 
+
+template<typename Float, int NCOLORS, typename Gauge>
+void InitGaugeField( Gauge dataOr,  cudaGaugeField& data) {
+  InitGaugeColdArg<Gauge> initarg(dataOr, data);
+  InitGaugeCold<Float, Gauge, NCOLORS> init(initarg);
+  init.apply(0);
+  checkCudaError();
+}
+
+
+
+template<typename Float>
+void InitGaugeField( cudaGaugeField& data) {
+
+  // Switching to FloatNOrder for the gauge field in order to support RECONSTRUCT_12
+  // Need to fix this!!
+  if(data.Order() == QUDA_FLOAT2_GAUGE_ORDER) {
+    if(data.Reconstruct() == QUDA_RECONSTRUCT_NO) {
+    //printfQuda("QUDA_RECONSTRUCT_NO\n");
+      InitGaugeField<Float, 3>(FloatNOrder<Float, 18, 2, 18>(data), data);
+    } else if(data.Reconstruct() == QUDA_RECONSTRUCT_12){
+    //printfQuda("QUDA_RECONSTRUCT_12\n");
+      InitGaugeField<Float, 3>(FloatNOrder<Float, 18, 2, 12>(data), data);
+    
+    } else if(data.Reconstruct() == QUDA_RECONSTRUCT_8){
+    //printfQuda("QUDA_RECONSTRUCT_8\n");
+      InitGaugeField<Float, 3>(FloatNOrder<Float, 18, 2,  8>(data), data);
+    
+    } else {
+      errorQuda("Reconstruction type %d of gauge field not supported", data.Reconstruct());
+    }
+  } else if(data.Order() == QUDA_FLOAT4_GAUGE_ORDER) {
+    if(data.Reconstruct() == QUDA_RECONSTRUCT_NO) {
+    //printfQuda("QUDA_RECONSTRUCT_NO\n");
+      InitGaugeField<Float, 3>(FloatNOrder<Float, 18, 4, 18>(data), data);
+    } else if(data.Reconstruct() == QUDA_RECONSTRUCT_12){
+    //printfQuda("QUDA_RECONSTRUCT_12\n");
+      InitGaugeField<Float, 3>(FloatNOrder<Float, 18, 4, 12>(data), data);
+    } else if(data.Reconstruct() == QUDA_RECONSTRUCT_8){
+    //printfQuda("QUDA_RECONSTRUCT_8\n");
+      InitGaugeField<Float, 3>(FloatNOrder<Float, 18, 4,  8>(data), data);
+    } else {
+      errorQuda("Reconstruction type %d of gauge field not supported", data.Reconstruct());
+    }
+  } else {
+    errorQuda("Invalid Gauge Order\n");
+  }
+}
+
+/** @brief Perform a cold start to the gauge field, identity SU(3) matrix, also fills the ghost links in multi-GPU case (no need to exchange data)
+* 
+* @param[in,out] data Gauge field
+*/
+void InitGaugeField( cudaGaugeField& data) {
+
+/*#ifdef MULTI_GPU
+  errorQuda("Gauge Fixing with multi-GPU support NOT implemented yet!\n");
+#else*/
+  if(data.Precision() == QUDA_HALF_PRECISION) {
+    errorQuda("Half precision not supported\n");
+  }
+  if (data.Precision() == QUDA_SINGLE_PRECISION) {
+    InitGaugeField<float> (data);
+  } else if(data.Precision() == QUDA_DOUBLE_PRECISION) {
+    InitGaugeField<double>(data);
+  } else {
+    errorQuda("Precision %d not supported", data.Precision());
+  }
+//#endif
+}
+
+
+
+
+
+
+
+
+template <typename Gauge>
+struct InitGaugeHotArg {
+  int threads; // number of active threads required
+  int X[4]; // grid dimensions
+  cuRNGState *rngstate;
+#ifdef MULTI_GPU
+  int border[4]; 
+#endif
+  Gauge dataOr;
+  InitGaugeHotArg(const Gauge &dataOr, const cudaGaugeField &data, cuRNGState *rngstate)
+    : dataOr(dataOr), rngstate(rngstate) {
+#ifdef MULTI_GPU
+    for(int dir=0; dir<4; ++dir){
+      if(comm_dim_partitioned(dir)) border[dir] = BORDER_RADIUS;
+      else border[dir] = 0;
+    }
+    for(int dir=0; dir<4; ++dir) X[dir] = data.X()[dir] - border[dir]*2;
+#else
+    for(int dir=0; dir<4; ++dir) X[dir] = data.X()[dir];
+#endif
+    //the optimal number of RNG states in rngstate array must be equal to half the lattice volume
+    //this number is the same used in heatbath...
+    threads = X[0]*X[1]*X[2]*X[3] >> 1;
+  }
+};
+
+
+
+template<typename Cmplx>
+__device__ __host__ static inline typename RealTypeId<Cmplx>::Type Abs2(const Cmplx & a){
+  return a.x * a.x + a.y * a.y;
+}
+
+
+
+template <typename Float> 
+__host__ __device__ static inline void reunit_link( Matrix<typename ComplexTypeId<Float>::Type,3> &U ){
+
+  typedef typename ComplexTypeId<Float>::Type Cmplx;
+
+  Cmplx t2 = makeComplex((Float)0.0, (Float)0.0);
+  Float t1 = 0.0;
+  //first normalize first row
+  //sum of squares of row
+#pragma unroll
+  for(int c = 0; c < 3; c++)    t1 += Abs2(U(0, c));
+  t1 = (Float)1.0 / sqrt(t1);
+  //14
+  //used to normalize row
+#pragma unroll
+  for(int c = 0; c < 3; c++)    U(0,c) *= t1;
+  //6      
+#pragma unroll
+  for(int c = 0; c < 3; c++)    t2 += Conj(U(0,c)) * U(1,c);
+  //24
+#pragma unroll
+  for(int c = 0; c < 3; c++)    U(1,c) -= t2 * U(0,c);
+  //24
+  //normalize second row
+  //sum of squares of row
+  t1 = 0.0;
+#pragma unroll
+  for(int c = 0; c < 3; c++)    t1 += Abs2(U(1,c));
+  t1 = (Float)1.0 / sqrt(t1);
+  //14
+  //used to normalize row
+#pragma unroll
+  for(int c = 0; c < 3; c++)    U(1, c) *= t1;
+  //6      
+  //Reconstruct lat row
+  U(2,0) = Conj(U(0,1) * U(1,2) - U(0,2) * U(1,1));
+  U(2,1) = Conj(U(0,2) * U(1,0) - U(0,0) * U(1,2));
+  U(2,2) = Conj(U(0,0) * U(1,1) - U(0,1) * U(1,0));
+  //42
+  //T=130
+}
+
+
+
+
+
+
+/**
+    @brief Generate the four random real elements of the SU(2) matrix
+    @param localstate CURAND rng state
+    @return four real numbers of the SU(2) matrix
+*/
+template <class T>
+__device__ static inline Matrix<T,2> randomSU2(cuRNGState& localState){
+    Matrix<T,2> a;
+    T aabs, ctheta, stheta, phi;
+    a(0,0) = Random<T>(localState, (T)-1.0, (T)1.0);
+    aabs = sqrt( 1.0 - a(0,0) * a(0,0));
+    ctheta = Random<T>(localState, (T)-1.0, (T)1.0);
+    phi = PII * Random<T>(localState);
+    stheta = ( curand(&localState) & 1 ? 1 : - 1 ) * sqrt( (T)1.0 - ctheta * ctheta );
+    a(0,1) = aabs * stheta * cos( phi );
+    a(1,0) = aabs * stheta * sin( phi );
+    a(1,1) = aabs * ctheta;
+    return a;
+}
+
+
+/**
+    @brief Update the SU(Nc) link with the new SU(2) matrix, link <- u * link
+    @param u SU(2) matrix represented by four real numbers
+    @param link SU(Nc) matrix
+    @param id indices
+*/
+template <class T, int NCOLORS>
+__host__ __device__ static inline void mul_block_sun( Matrix<T,2> u, Matrix<typename ComplexTypeId<T>::Type,NCOLORS> &link, int2 id ){
+    typename ComplexTypeId<T>::Type tmp;
+    for(int j = 0; j < NCOLORS; j++){
+        tmp = makeComplex( u(0,0), u(1,1) ) * link(id.x, j) + makeComplex( u(1,0), u(0,1) ) * link(id.y, j);
+        link(id.y, j) = makeComplex(-u(1,0), u(0,1) ) * link(id.x, j) + makeComplex( u(0,0),-u(1,1) ) * link(id.y, j);
+        link(id.x, j) = tmp;
+    }
+}
+
+
+/**
+    @brief Calculate the SU(2) index block in the SU(Nc) matrix
+    @param block number to calculate the index's, the total number of blocks is NCOLORS * ( NCOLORS - 1) / 2.
+    @return Returns two index's in int2 type, accessed by .x and .y.
+*/
+template<int NCOLORS>
+__host__ __device__ static inline   int2 IndexBlock(int block){
+    int2 id;
+    int i1;
+    int found = 0;
+    int del_i = 0;
+    int index = -1;
+    while ( del_i < (NCOLORS-1) && found == 0 ){
+        del_i++;
+        for ( i1 = 0; i1 < (NCOLORS-del_i); i1++ ){
+            index++;
+            if ( index == block ){
+                found = 1;
+                break;
+            }
+        }
+    }
+    id.y = i1 + del_i;
+    id.x = i1;
+    return id;
+}
+
+/**
+    @brief Generate a SU(Nc) random matrix
+    @param localstate CURAND rng state
+    @return SU(Nc) matrix
+*/
+template <class Float, int NCOLORS>
+__device__ inline Matrix<typename ComplexTypeId<Float>::Type,NCOLORS> randomize( cuRNGState& localState ){
+    Matrix<typename ComplexTypeId<Float>::Type,NCOLORS> U;
+     
+    for(int i=0; i<NCOLORS; i++)
+        for(int j=0; j<NCOLORS; j++)
+            U(i,j) = makeComplex( (Float)(Random<Float>(localState) - 0.5), (Float)(Random<Float>(localState) - 0.5));
+    reunit_link<Float>(U);
+    return U;
+
+    /*setIdentity(&U);
+    for( int block = 0; block < NCOLORS * ( NCOLORS - 1) / 2; block++ ) {
+      Matrix<Float,2> rr = randomSU2<Float>(localState);
+      int2 id = IndexBlock<NCOLORS>( block );
+      mul_block_sun<Float, NCOLORS>(rr, U, id);
+      //U = block_su2_to_su3<Float>( U, a00, a01, a10, a11, block );
+      }
+    return U;*/
+}
+
+template<typename Float, typename Gauge, int NCOLORS>
+__global__ void compute_InitGauge_HotStart(InitGaugeHotArg<Gauge> arg){
+  int idx = threadIdx.x + blockIdx.x*blockDim.x;
+  if(idx >= arg.threads) return;
+  typedef typename ComplexTypeId<Float>::Type Cmplx;
+  #ifdef MULTI_GPU
+  int X[4], x[4]; 
+  for(int dr=0; dr<4; ++dr) X[dr] = arg.X[dr];
+  for(int dr=0; dr<4; ++dr) X[dr] += 2*arg.border[dr]; 
+  int id = idx;
+  cuRNGState localState = arg.rngstate[ id ];
+  #else
+  cuRNGState localState = arg.rngstate[ idx ];
+  #endif
+  for(int parity = 0; parity < 2; parity++){
+    #ifdef MULTI_GPU
+    getCoords3(x, id, arg.X, parity);
+    for(int dr=0; dr<4; ++dr) x[dr] += arg.border[dr];
+    idx = linkIndex(x,X);
+    #endif
+    for(int d = 0; d < 4; d++){
+      Matrix<Cmplx,NCOLORS> U;
+      U = randomize<Float, NCOLORS>(localState);
+      arg.dataOr.save((Float*)(U.data),idx, d, parity);
+    }
+  }
+  #ifdef MULTI_GPU
+  arg.rngstate[ id ] = localState;
+  #else
+  arg.rngstate[ idx ] = localState;
+  #endif
+}
+
+
+
+
+template<typename Float, typename Gauge, int NCOLORS>
+class InitGaugeHot : Tunable {
+  InitGaugeHotArg<Gauge> arg;
+  mutable char aux_string[128]; // used as a label in the autotuner
+  private:
+  unsigned int sharedBytesPerThread() const { return 0; }
+  unsigned int sharedBytesPerBlock(const TuneParam &param) const { return 0; }
+  bool tuneSharedBytes() const { return false; } // Don't tune shared memory
+  bool tuneGridDim() const { return false; } // Don't tune the grid dimensions.
+  unsigned int minThreads() const { return arg.threads; }
+
+  public:
+  InitGaugeHot(InitGaugeHotArg<Gauge> &arg)
+    : arg(arg) {}
+  ~InitGaugeHot () { }
+
+  void apply(const cudaStream_t &stream){
+      TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
+      compute_InitGauge_HotStart<Float, Gauge, NCOLORS><<<tp.grid,tp.block>>>(arg);
+      //cudaDeviceSynchronize();
+  }
+
+  TuneKey tuneKey() const {
+    std::stringstream vol;
+    vol << arg.X[0] << "x";
+    vol << arg.X[1] << "x";
+    vol << arg.X[2] << "x";
+    vol << arg.X[3];
+    sprintf(aux_string,"threads=%d,prec=%d",arg.threads, sizeof(Float));
+    return TuneKey(vol.str().c_str(), typeid(*this).name(), aux_string);
+    
+  }
+  std::string paramString(const TuneParam &param) const {
+    std::stringstream ps;
+    ps << "block=(" << param.block.x << "," << param.block.y << "," << param.block.z << ")";
+    ps << "shared=" << param.shared_bytes;
+    return ps.str();
+  }
+  void preTune(){}
+  void postTune(){}
+  long long flops() const { return 0; }// Only correct if there is no link reconstruction, no cub reduction accounted also
+  long long bytes() const { return 0; }//no accounting the reduction!!!!
+
+}; 
+
+
+
+
+
+template<typename Float, int NCOLORS, typename Gauge>
+void InitGaugeField( Gauge dataOr,  cudaGaugeField& data, cuRNGState *rngstate) {
+  InitGaugeHotArg<Gauge> initarg(dataOr, data, rngstate);
+  InitGaugeHot<Float, Gauge, NCOLORS> init(initarg);
+  init.apply(0);
+  checkCudaError();
+  cudaDeviceSynchronize();
+  int R[4] = {0,0,0,0};
+  for(int dir=0; dir<4; ++dir) if(comm_dim_partitioned(dir)) R[dir] = BORDER_RADIUS;
+
+  data.exchangeExtendedGhost(R,false);
+  /*cudaDeviceSynchronize();
+  const double unitarize_eps = 1e-14;
+  const double max_error = 1e-10;
+  const int reunit_allow_svd = 1;
+  const int reunit_svd_only  = 0;
+  const double svd_rel_error = 1e-6;
+  const double svd_abs_error = 1e-6;
+  setUnitarizeLinksConstants(unitarize_eps, max_error,
+      reunit_allow_svd, reunit_svd_only,
+      svd_rel_error, svd_abs_error);
+  int num_failures=0;
+  int* num_failures_dev;
+  cudaMalloc((void**)&num_failures_dev, sizeof(int));
+  cudaMemset(num_failures_dev, 0, sizeof(int));
+  if(num_failures_dev == NULL) errorQuda("cudaMalloc failed for dev_pointer\n");
+
+  unitarizeLinksQuda(data, num_failures_dev);
+  cudaMemcpy(&num_failures, num_failures_dev, sizeof(int), cudaMemcpyDeviceToHost);
+  if(num_failures>0){
+    cudaFree(num_failures_dev); 
+    errorQuda("Error in the unitarization\n"); 
+    exit(1);
+  }
+  cudaFree(num_failures_dev);*/
+}
+
+
+
+template<typename Float>
+void InitGaugeField( cudaGaugeField& data, cuRNGState *rngstate) {
+
+  // Switching to FloatNOrder for the gauge field in order to support RECONSTRUCT_12
+  // Need to fix this!!
+  if(data.Order() == QUDA_FLOAT2_GAUGE_ORDER) {
+    if(data.Reconstruct() == QUDA_RECONSTRUCT_NO) {
+    //printfQuda("QUDA_RECONSTRUCT_NO\n");
+      InitGaugeField<Float, 3>(FloatNOrder<Float, 18, 2, 18>(data), data, rngstate);
+    } else if(data.Reconstruct() == QUDA_RECONSTRUCT_12){
+    //printfQuda("QUDA_RECONSTRUCT_12\n");
+      InitGaugeField<Float, 3>(FloatNOrder<Float, 18, 2, 12>(data), data, rngstate);
+    
+    } else if(data.Reconstruct() == QUDA_RECONSTRUCT_8){
+    //printfQuda("QUDA_RECONSTRUCT_8\n");
+      InitGaugeField<Float, 3>(FloatNOrder<Float, 18, 2,  8>(data), data, rngstate);
+    
+    } else {
+      errorQuda("Reconstruction type %d of gauge field not supported", data.Reconstruct());
+    }
+  } else if(data.Order() == QUDA_FLOAT4_GAUGE_ORDER) {
+    if(data.Reconstruct() == QUDA_RECONSTRUCT_NO) {
+    //printfQuda("QUDA_RECONSTRUCT_NO\n");
+      InitGaugeField<Float, 3>(FloatNOrder<Float, 18, 4, 18>(data), data, rngstate);
+    } else if(data.Reconstruct() == QUDA_RECONSTRUCT_12){
+    //printfQuda("QUDA_RECONSTRUCT_12\n");
+      InitGaugeField<Float, 3>(FloatNOrder<Float, 18, 4, 12>(data), data, rngstate);
+    } else if(data.Reconstruct() == QUDA_RECONSTRUCT_8){
+    //printfQuda("QUDA_RECONSTRUCT_8\n");
+      InitGaugeField<Float, 3>(FloatNOrder<Float, 18, 4,  8>(data), data, rngstate);
+    } else {
+      errorQuda("Reconstruction type %d of gauge field not supported", data.Reconstruct());
+    }
+  } else {
+    errorQuda("Invalid Gauge Order\n");
+  }
+}
+
+/** @brief Perform a hot start to the gauge field, random SU(3) matrix, followed by reunitarization, also exchange borders links in multi-GPU case.
+* 
+* @param[in,out] data Gauge field
+* @param[in,out] rngstate state of the CURAND random number generator
+*/
+void InitGaugeField( cudaGaugeField& data, cuRNGState *rngstate) {
+  if(data.Precision() == QUDA_HALF_PRECISION) {
+    errorQuda("Half precision not supported\n");
+  }
+  if (data.Precision() == QUDA_SINGLE_PRECISION) {
+    InitGaugeField<float> (data, rngstate);
+  } else if(data.Precision() == QUDA_DOUBLE_PRECISION) {
+    InitGaugeField<double>(data, rngstate);
+  } else {
+    errorQuda("Precision %d not supported", data.Precision());
+  }
+}
+}

--- a/lib/pgauge_plaquette.cu
+++ b/lib/pgauge_plaquette.cu
@@ -1,0 +1,393 @@
+#include <quda_internal.h>
+#include <quda_matrix.h>
+#include <tune_quda.h>
+#include <gauge_field.h>
+#include <gauge_field_order.h>
+#include <cub/cub.cuh> 
+#include <launch_kernel.cuh>
+
+#include <device_functions.h>
+
+#include <hisq_links_quda.h> //reunit gauge links!!!!!
+
+#include <comm_quda.h>
+
+
+#include <pgauge_monte.h> 
+
+
+#include <random.h>
+
+
+#define BORDER_RADIUS 2
+
+#ifndef PI
+#define PI    3.1415926535897932384626433832795    // pi
+#endif
+#ifndef PII
+#define PII   6.2831853071795864769252867665590    // 2 * pi
+#endif
+
+namespace quda {
+
+
+
+
+
+
+static  __inline__ __device__ double atomicAdd(double *addr, double val){
+  double old=*addr, assumed;
+  do {
+    assumed = old;
+    old = __longlong_as_double( atomicCAS((unsigned long long int*)addr,
+            __double_as_longlong(assumed),
+            __double_as_longlong(val+assumed)));
+  } while( __double_as_longlong(assumed)!=__double_as_longlong(old) );
+  
+  return old;
+}
+
+static  __inline__ __device__ double2 atomicAdd(double2 *addr, double2 val){
+    double2 old=*addr;
+    old.x = atomicAdd((double*)addr, val.x);
+    old.y = atomicAdd((double*)addr+1, val.y);
+    return old;
+  }
+
+
+#if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 200
+//CUDA 6.5 NOT DETECTING ATOMICADD FOR FLOAT TYPE!!!!!!!
+static __inline__ __device__ float atomicAdd(float *address, float val)
+{
+  return __fAtomicAdd(address, val);
+}
+#endif /* !__CUDA_ARCH__ || __CUDA_ARCH__ >= 200 */
+
+
+
+template <typename T>
+struct Summ {
+    __host__ __device__ __forceinline__ T operator()(const T &a, const T &b){
+        return a + b;
+    }
+};
+template <>
+struct Summ<double2>{
+    __host__ __device__ __forceinline__ double2 operator()(const double2 &a, const double2 &b){
+        return make_double2(a.x+b.x, a.y+b.y);
+    }
+};
+
+
+
+__device__ __host__ inline int linkIndex2(int x[], int dx[], const int X[4]) {
+  int y[4];
+  for (int i=0; i<4; i++) y[i] = (x[i] + dx[i] + X[i]) % X[i];
+  int idx = (((y[3]*X[2] + y[2])*X[1] + y[1])*X[0] + y[0]) >> 1;
+  return idx;
+}
+
+
+
+static __device__ __host__ inline int linkIndex3(int x[], int dx[], const int X[4]) {
+  int y[4];
+  for (int i=0; i<4; i++) y[i] = (x[i] + dx[i] + X[i]) % X[i];
+  int idx = (((y[3]*X[2] + y[2])*X[1] + y[1])*X[0] + y[0]) >> 1;
+  return idx;
+}
+static __device__ __host__ inline int linkIndex(int x[], const int X[4]) {
+  int idx = (((x[3]*X[2] + x[2])*X[1] + x[1])*X[0] + x[0]) >> 1;
+  return idx;
+}
+static __device__ __host__ inline int linkIndexM1(int x[], const int X[4], const int mu) {
+  int y[4];
+  for (int i=0; i<4; i++) y[i] = x[i];
+  y[mu] = (y[mu] -1 + X[mu]) % X[mu];
+  int idx = (((y[3]*X[2] + y[2])*X[1] + y[1])*X[0] + y[0]) >> 1;
+  return idx;
+}
+
+
+
+static __device__ __host__ inline void getCoords3(int x[4], int cb_index, const int X[4], int parity) {
+  /*x[3] = cb_index/(X[2]*X[1]*X[0]/2);
+  x[2] = (cb_index/(X[1]*X[0]/2)) % X[2];
+  x[1] = (cb_index/(X[0]/2)) % X[1];
+  x[0] = 2*(cb_index%(X[0]/2)) + ((x[3]+x[2]+x[1]+parity)&1);*/
+  int za = (cb_index / (X[0]/2));
+  int zb =  (za / X[1]);
+  x[1] = za - zb * X[1];
+  x[3] = (zb / X[2]);
+  x[2] = zb - x[3] * X[2];
+  int x1odd = (x[1] + x[2] + x[3] + parity) & 1;
+  x[0] = (2 * cb_index + x1odd)  - za * X[0];
+  return;
+}
+
+
+
+
+
+
+
+
+
+
+
+
+template <typename Gauge>
+struct PlaquetteArg {
+  int threads; // number of active threads required
+  int X[4]; // grid dimensions
+#ifdef MULTI_GPU
+  int border[4]; 
+#endif
+  Gauge dataOr;
+  double2 *plaq;
+  double2 *plaq_h;
+  PlaquetteArg(const Gauge &dataOr, const cudaGaugeField &data)
+    : dataOr(dataOr), plaq_h(static_cast<double2*>(pinned_malloc(sizeof(double2)))) {
+#ifdef MULTI_GPU
+    for(int dir=0; dir<4; ++dir){
+      if(comm_dim_partitioned(dir)) border[dir] = BORDER_RADIUS;
+      else border[dir] = 0;
+    }
+    for(int dir=0; dir<4; ++dir) X[dir] = data.X()[dir] - border[dir]*2;
+#else
+    for(int dir=0; dir<4; ++dir) X[dir] = data.X()[dir];
+#endif
+    threads = X[0]*X[1]*X[2]*X[3];
+    cudaHostGetDevicePointer(&plaq, plaq_h, 0);
+  }
+  double2 getPlaq(){return plaq_h[0];}
+};
+
+
+template<class Float>
+__device__ __host__ inline Float getRealTrace(const Matrix<typename ComplexTypeId<Float>::Type,3>& a){
+  return a(0,0).x + a(1,1).x + a(2,2).x;
+}
+
+template<int blockSize, typename Float, typename Gauge, int NCOLORS>
+__global__ void compute_Plaquette(PlaquetteArg<Gauge> arg){
+  int idx = threadIdx.x + blockIdx.x*blockDim.x;
+
+  typedef cub::BlockReduce<double2, blockSize> BlockReduce;
+  __shared__ typename BlockReduce::TempStorage temp_storage;
+  
+  double2 plaq = make_double2(0.0, 0.0);
+  if(idx < arg.threads) {
+    typedef typename ComplexTypeId<Float>::Type Cmplx;
+    int parity = 0;
+    if(idx >= arg.threads/2) {
+      parity = 1;
+      idx -= arg.threads/2;
+    }
+    int X[4]; 
+    #pragma unroll
+    for(int dr=0; dr<4; ++dr) X[dr] = arg.X[dr];
+
+    int x[4];
+    getCoords3(x, idx, X, parity);
+  #ifdef MULTI_GPU
+    #pragma unroll
+    for(int dr=0; dr<4; ++dr) {
+         x[dr] += arg.border[dr];
+         X[dr] += 2*arg.border[dr];
+    }
+    idx = linkIndex(x,X);
+  #endif
+    int dx[4] = {0, 0, 0, 0};
+    for (int mu = 0; mu < 3; mu++) {
+      Matrix<Cmplx,NCOLORS> U1;
+      arg.dataOr.load((Float*)(U1.data), idx, mu, parity);
+      dx[mu]++;
+      int idxmu = linkIndex3(x,dx,X);
+      dx[mu]--;
+      for (int nu = (mu+1); nu < 4; nu++) {
+        Matrix<Cmplx,NCOLORS> U2, U3;
+        arg.dataOr.load((Float*)(U2.data),idxmu, nu, 1-parity);
+        dx[nu]++;
+        arg.dataOr.load((Float*)(U3.data),linkIndex3(x,dx,X), mu, 1-parity);
+        U2 *= conj(U3);
+        dx[nu]--;
+        arg.dataOr.load((Float*)(U3.data),idx, nu, parity);
+        U2 *= conj(U3);
+        U3  = U1 * U2;
+        //if(mu == 3 || nu == 3) plaq.y += getTrace(U3).x;
+        if(nu == 3) plaq.y += getRealTrace<Float>(U3);
+        else plaq.x += getRealTrace<Float>(U3);
+      }
+    }
+  }
+  double2 aggregate = BlockReduce(temp_storage).Reduce(plaq, Summ<double2>());
+  if (threadIdx.x == 0) atomicAdd(arg.plaq, aggregate);
+  //Flops(3) = 6*3*198 + 6*3 + 2*blockDim.x=3582 + 2*blockDim.x
+  //Flops(NCOLORS other case) = 6*3*NCOLORS * NCOLORS * NCOLORS*8 + 6 + NCOLORS*6+2*blockDim.x=144*NCOLORS * NCOLORS * NCOLORS + NCOLORS*6+2*blockDim.x
+  //Bytes = (3 + 6*3) * NCOLORS * NCOLORS * sizeof(Float)*2 + blockDim.x * 8 * 2
+
+}
+
+
+
+template<typename Float, typename Gauge, int NCOLORS>
+class CalcPlaquette : Tunable {
+  PlaquetteArg<Gauge> arg;
+  TuneParam tp;
+  mutable char aux_string[128]; // used as a label in the autotuner
+  private:
+  unsigned int sharedBytesPerThread() const { return 0; }
+  unsigned int sharedBytesPerBlock(const TuneParam &param) const { return 0; }
+  bool tuneSharedBytes() const { return false; } // Don't tune shared memory
+  bool tuneGridDim() const { return false; } // Don't tune the grid dimensions.
+  unsigned int minThreads() const { return arg.threads; }
+
+  public:
+  CalcPlaquette(PlaquetteArg<Gauge> &arg)
+    : arg(arg) {}
+  ~CalcPlaquette () { host_free(arg.plaq_h);}
+
+  void apply(const cudaStream_t &stream){
+      tp = tuneLaunch(*this, getTuning(), getVerbosity());
+      arg.plaq_h[0] = make_double2(0.0,0.0);
+      LAUNCH_KERNEL(compute_Plaquette, tp, stream, arg, Float, Gauge, NCOLORS);
+      cudaDeviceSynchronize();
+      #ifdef MULTI_GPU
+        comm_allreduce_array((double*)arg.plaq_h, 2);
+        const int nNodes = comm_dim(0)*comm_dim(1)*comm_dim(2)*comm_dim(3);
+        arg.plaq_h[0].x  /= (double)(3*NCOLORS*arg.threads*nNodes);
+        arg.plaq_h[0].y  /= (double)(3*NCOLORS*arg.threads*nNodes);
+      #else
+        arg.plaq_h[0].x  /= (double)(3*NCOLORS*arg.threads);
+        arg.plaq_h[0].y  /= (double)(3*NCOLORS*arg.threads);
+      #endif
+  }
+
+  TuneKey tuneKey() const {
+    std::stringstream vol;
+    vol << arg.X[0] << "x";
+    vol << arg.X[1] << "x";
+    vol << arg.X[2] << "x";
+    vol << arg.X[3];
+    sprintf(aux_string,"threads=%d,prec=%d,gaugedir=%d",arg.threads, sizeof(Float));
+    return TuneKey(vol.str().c_str(), typeid(*this).name(), aux_string);
+    
+  }
+  std::string paramString(const TuneParam &param) const {
+    std::stringstream ps;
+    ps << "block=(" << param.block.x << "," << param.block.y << "," << param.block.z << ")";
+    ps << "shared=" << param.shared_bytes;
+    return ps.str();
+  }
+  void preTune(){}
+  void postTune(){}
+  //Flops(3) = 6*3*198 + 6 + 3*2 + 2*blockDim.x=3576 + 2*blockDim.x
+  //Flops(NCOLORS other case) = 6*3*NCOLORS * NCOLORS * NCOLORS*8 + 6 + NCOLORS*2+2*blockDim.x=144*NCOLORS * NCOLORS * NCOLORS + 6 + NCOLORS*2+2*blockDim.x
+  //Bytes = (3 + 6*3) * NCOLORS * NCOLORS * sizeof(Float)*2 + blockDim.x * 8 * 2
+
+  long long flops() const { 
+    if(NCOLORS==3) return 3582LL*arg.threads + 2LL*tp.block.x; 
+    else return 144LL*NCOLORS * NCOLORS * NCOLORS + NCOLORS*6LL+2LL*tp.block.x;
+  }// Only correct if there is no link reconstruction
+  long long bytes() const { return 21LL*NCOLORS * NCOLORS * sizeof(Float)*2*arg.threads + tp.block.x * sizeof(double2); }
+
+}; 
+
+
+
+
+
+template<typename Float, int NCOLORS, typename Gauge>
+double2 Plaquette( Gauge dataOr,  cudaGaugeField& data) {
+
+
+  TimeProfile profileGaugeFix("Plaquette");
+  if (getVerbosity() >= QUDA_SUMMARIZE) profileGaugeFix.Start(QUDA_PROFILE_COMPUTE);
+  PlaquetteArg<Gauge> plaqarg(dataOr, data);
+  CalcPlaquette<Float, Gauge, NCOLORS> plaq(plaqarg);
+  plaq.apply(0);
+  printfQuda("Plaquette: %.16e, %.16e, %.16e\n", plaqarg.getPlaq().x, plaqarg.getPlaq().y, (plaqarg.getPlaq().x+plaqarg.getPlaq().y) / 2);
+  checkCudaError();
+  cudaDeviceSynchronize();
+  if (getVerbosity() >= QUDA_SUMMARIZE){
+    profileGaugeFix.Stop(QUDA_PROFILE_COMPUTE);
+    double secs = profileGaugeFix.Last(QUDA_PROFILE_COMPUTE);
+    double gflops = (plaq.flops()*1e-9)/(secs);
+    double gbytes = plaq.bytes()/(secs*1e9);
+    #ifdef MULTI_GPU
+    printfQuda("Plaq: Time = %6.6f s, Gflop/s = %6.1f, GB/s = %6.1f\n", secs, gflops*comm_size(), gbytes*comm_size());
+    #else
+    printfQuda("Plaq: Time = %6.6f s, Gflop/s = %6.1f, GB/s = %6.1f\n", secs, gflops, gbytes);
+    #endif
+  }
+  return plaqarg.getPlaq();
+}
+
+
+
+template<typename Float>
+double2 Plaquette( cudaGaugeField& data) {
+
+  // Switching to FloatNOrder for the gauge field in order to support RECONSTRUCT_12
+  // Need to fix this!!
+  if(data.Order() == QUDA_FLOAT2_GAUGE_ORDER) {
+    if(data.Reconstruct() == QUDA_RECONSTRUCT_NO) {
+    //printfQuda("QUDA_RECONSTRUCT_NO\n");
+    return  Plaquette<Float, 3>(FloatNOrder<Float, 18, 2, 18>(data), data);
+    } else if(data.Reconstruct() == QUDA_RECONSTRUCT_12){
+    //printfQuda("QUDA_RECONSTRUCT_12\n");
+      return Plaquette<Float, 3>(FloatNOrder<Float, 18, 2, 12>(data), data);
+    
+    } else if(data.Reconstruct() == QUDA_RECONSTRUCT_8){
+    //printfQuda("QUDA_RECONSTRUCT_8\n");
+      return Plaquette<Float, 3>(FloatNOrder<Float, 18, 2,  8>(data), data);
+    
+    } else {
+      errorQuda("Reconstruction type %d of gauge field not supported", data.Reconstruct());
+    }
+  } else if(data.Order() == QUDA_FLOAT4_GAUGE_ORDER) {
+    if(data.Reconstruct() == QUDA_RECONSTRUCT_NO) {
+    //printfQuda("QUDA_RECONSTRUCT_NO\n");
+      return Plaquette<Float, 3>(FloatNOrder<Float, 18, 4, 18>(data), data);
+    } else if(data.Reconstruct() == QUDA_RECONSTRUCT_12){
+    //printfQuda("QUDA_RECONSTRUCT_12\n");
+      return Plaquette<Float, 3>(FloatNOrder<Float, 18, 4, 12>(data), data);
+    } else if(data.Reconstruct() == QUDA_RECONSTRUCT_8){
+    //printfQuda("QUDA_RECONSTRUCT_8\n");
+      return Plaquette<Float, 3>(FloatNOrder<Float, 18, 4,  8>(data), data);
+    } else {
+      errorQuda("Reconstruction type %d of gauge field not supported", data.Reconstruct());
+    }
+  } else {
+    errorQuda("Invalid Gauge Order\n");
+  }
+}
+
+
+/** @brief Calculate the plaquette
+* 
+* @param[in] data Gauge field
+* @returns double2 .x stores the space-space plaquette value and .y stores the space-time plaquette value
+*/
+double2 Plaquette( cudaGaugeField& data) {
+ if(data.Precision() == QUDA_HALF_PRECISION) {
+    errorQuda("Half precision not supported\n");
+  }
+  if (data.Precision() == QUDA_SINGLE_PRECISION) {
+    return Plaquette<float> (data);
+  } else if(data.Precision() == QUDA_DOUBLE_PRECISION) {
+    return Plaquette<double>(data);
+  } else {
+    errorQuda("Precision %d not supported", data.Precision());
+  }
+}
+
+
+
+
+
+
+
+
+
+}

--- a/lib/random.cu
+++ b/lib/random.cu
@@ -1,0 +1,213 @@
+
+#include <stdio.h>
+#include <string.h>
+#include <iostream>
+//#include "cuda_common.h"
+#include "random.h"
+#include <cuda.h>
+#include <quda_internal.h>
+
+#include <comm_quda.h>
+
+
+namespace quda {
+
+
+#define BLOCKSDIVUP(a, b)  (((a)+(b)-1)/(b))
+
+
+dim3 GetBlockDim(size_t threads, size_t size){
+    /*uint blockx = BLOCKSDIVUP(size, threads);
+    uint blocky = 1;
+    if(blockx > PARAMS::GPUGridDimX){
+        blocky = BLOCKSDIVUP(blockx, PARAMS::GPUGridDimX);
+        blockx = PARAMS::GPUGridDimX;
+    }
+    dim3 blocks(blockx,blocky,1);
+    return blocks;*/
+
+    int blockx = BLOCKSDIVUP(size, threads);
+    dim3 blocks(blockx,1,1);
+    return blocks;
+}
+
+
+
+
+#  define CUDA_SAFE_CALL_NO_SYNC( call) {                               \
+        cudaError err = call;                                           \
+        if( cudaSuccess != err) {                                       \
+            fprintf(stderr, "Cuda error in file '%s' in line %i : %s.\n", \
+                    __FILE__, __LINE__, cudaGetErrorString( err) );     \
+            exit(EXIT_FAILURE);                                         \
+        } }
+
+#  define CUDA_SAFE_CALL( call)     CUDA_SAFE_CALL_NO_SYNC(call);   
+
+/**
+    @brief CUDA kernel to initialize CURAND RNG states
+    @param state CURAND RNG state array
+    @param seed initial seed for RNG
+    @param rng_size size of the CURAND RNG state array
+    @param node_offset this parameter is used to skip ahead the index in the sequence, usefull for multigpu. 
+*/
+__global__ void 
+kernel_random(cuRNGState *state, int seed, int rng_size, int node_offset ){
+//#if (__CUDA_ARCH__ >= 300)
+    int id = blockIdx.x * blockDim.x + threadIdx.x;
+/*#else
+    int id = gridDim.x * blockIdx.y + blockIdx.x;
+    id = blockDim.x * id + threadIdx.x; 
+#endif*/
+    if(id < rng_size){
+        /* Each thread gets same seed, a different sequence number, no offset */
+        curand_init(seed, id + node_offset, 0, &state[id]);
+    }
+}
+
+struct rngArg{
+    int comm_dim[4];
+    int comm_coord[4];
+    int X[4];
+};
+
+
+static __device__ __host__ inline void getCoords3(int x[4], int cb_index, const int X[4], int parity) {
+  /*x[3] = cb_index/(X[2]*X[1]*X[0]/2);
+  x[2] = (cb_index/(X[1]*X[0]/2)) % X[2];
+  x[1] = (cb_index/(X[0]/2)) % X[1];
+  x[0] = 2*(cb_index%(X[0]/2)) + ((x[3]+x[2]+x[1]+parity)&1);*/
+  int za = (cb_index / (X[0]/2));
+  int zb =  (za / X[1]);
+  x[1] = za - zb * X[1];
+  x[3] = (zb / X[2]);
+  x[2] = zb - x[3] * X[2];
+  int x1odd = (x[1] + x[2] + x[3] + parity) & 1;
+  x[0] = (2 * cb_index + x1odd)  - za * X[0];
+  return;
+}
+
+
+__global__ void 
+kernel_random(cuRNGState *state, int seed, int rng_size, int node_offset, rngArg arg ){
+//#if (__CUDA_ARCH__ >= 300)
+    int id = blockIdx.x * blockDim.x + threadIdx.x;
+/*#else
+    int id = gridDim.x * blockIdx.y + blockIdx.x;
+    id = blockDim.x * id + threadIdx.x; 
+#endif*/
+    if(id < rng_size){
+        /* Each thread gets same seed, a different sequence number, no offset */
+    #ifndef MULTI_GPU
+        curand_init(seed, id + node_offset, 0, &state[id]);
+    #else
+
+    int x[4];
+    getCoords3(x, id, arg.X, 0);
+    for(int i=0; i<4;i++) x[i] += arg.comm_coord[i] * arg.X[i];
+    int idd = ((((x[3] * arg.comm_dim[2] * arg.X[2] + x[2]) * arg.comm_dim[1] * arg.X[1]) + x[1] ) * arg.comm_dim[0] * arg.X[0] + x[0]) >> 1 ;
+    curand_init(seed, idd, 0, &state[id]);
+    #endif
+    }
+}
+
+/**
+    @brief Call CUDA kernel to initialize CURAND RNG states
+    @param state CURAND RNG state array
+    @param seed initial seed for RNG
+    @param rng_size size of the CURAND RNG state array
+    @param node_offset this parameter is used to skip ahead the index in the sequence, usefull for multigpu. 
+*/
+void launch_kernel_random(cuRNGState *state, int seed, int rng_size, int node_offset, int X[4]){  
+    dim3 nthreads(128,1,1);
+    dim3 nblocks = GetBlockDim(nthreads.x, rng_size);
+    //CUDA_SAFE_CALL(cudaFuncSetCacheConfig( kernel_random,	cudaFuncCachePreferL1));
+    #ifndef MULTI_GPU
+    kernel_random<<<nblocks,nthreads>>>(state, seed, rng_size, node_offset);
+    #else
+    rngArg arg;
+    for(int i=0; i < 4; i++){
+        arg.comm_dim[i] = comm_dim(i);
+        arg.comm_coord[i] = comm_coord(i);
+        arg.X[i] = X[i];
+    }
+    kernel_random<<<nblocks,nthreads>>>(state, seed, rng_size, 0, arg);
+    #endif
+    cudaDeviceSynchronize();
+}
+
+RNG::RNG(int rng_sizes, int seedin){
+    rng_size = rng_sizes;
+    seed = seedin;
+    state = NULL;
+    node_offset = 0;
+    #ifdef MULTI_GPU
+    for(int i=0; i<4;i++) X[i]=0;
+    node_offset = comm_rank() * rng_sizes;
+    #endif
+#if defined(XORWOW)
+    printfQuda("Using curandStateXORWOW\n");
+#elif defined(RG32k3a)
+    printfQuda("Using curandStateMRG32k3a\n");
+#else
+    printfQuda("Using curandStateMRG32k3a\n");
+#endif
+} 
+RNG::RNG(int rng_sizes, int seedin, int XX[4]){
+    rng_size = rng_sizes;
+    seed = seedin;
+    state = NULL;
+    node_offset = 0;
+    #ifdef MULTI_GPU
+    for(int i=0; i<4;i++) X[i]=XX[i];
+    node_offset = comm_rank() * rng_sizes;
+    #endif
+#if defined(XORWOW)
+    printfQuda("Using curandStateXORWOW\n");
+#elif defined(RG32k3a)
+    printfQuda("Using curandStateMRG32k3a\n");
+#else
+    printfQuda("Using curandStateMRG32k3a\n");
+#endif
+} 
+
+
+
+
+/**
+    @brief Initialize CURAND RNG states
+*/
+void RNG::Init(){
+	AllocateRNG();
+	launch_kernel_random(state, seed, rng_size, node_offset, X);
+}		
+					
+
+/**
+    @brief Allocate Device memory for CURAND RNG states
+*/
+void RNG::AllocateRNG(){
+    if(rng_size>0 && state == NULL){
+        //CUDA_SAFE_CALL(cudaMalloc((void **)&state, rng_size * sizeof(cuRNGState)));
+        state = (cuRNGState*)device_malloc(rng_size * sizeof(cuRNGState));
+        CUDA_SAFE_CALL(cudaMemset( state , 0 , rng_size * sizeof(cuRNGState) ));
+        printfQuda("Allocated array of random numbers with rng_size: %.2f MB\n", rng_size * sizeof(cuRNGState)/(float)(1048576));
+    }
+    else{
+        errorQuda("Array of random numbers not allocated, array size: %d !\nExiting...\n",rng_size);
+    }
+}
+/**
+    @brief Release Device memory for CURAND RNG states
+*/
+void RNG::Release(){
+    if(rng_size>0 && state != NULL){
+        //cudaFree(state);
+        device_free(state);
+        printfQuda("Free array of random numbers with rng_size: %.2f MB\n", rng_size * sizeof(cuRNGState)/(float)(1048576));
+        rng_size = 0;
+        state = NULL;
+    }
+}
+
+}

--- a/make.inc.in
+++ b/make.inc.in
@@ -87,13 +87,13 @@ INC = -I$(CUDA_INSTALL_PATH)/include
 
 ifeq ($(strip $(CPU_ARCH)), x86_64)
   ifeq ($(strip $(OS)), osx)
-    LIB = -L$(CUDA_INSTALL_PATH)/lib -lcudart
+    LIB = -L$(CUDA_INSTALL_PATH)/lib -lcudart -lcufft -lcurand
     NVCCOPT = -m64
   else
-    LIB = -L$(CUDA_INSTALL_PATH)/lib64 -lcudart
+    LIB = -L$(CUDA_INSTALL_PATH)/lib64 -lcudart -lcufft -lcurand
   endif
 else
-  LIB = -L$(CUDA_INSTALL_PATH)/lib -lcudart -m32
+  LIB = -L$(CUDA_INSTALL_PATH)/lib -lcudart -lcufft -lcurand -m32
   COPT = -malign-double -m32
   NVCCOPT = -m32
 endif

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -7,7 +7,7 @@ INC += -I../include -I.
 HDRS = blas_reference.h wilson_dslash_reference.h staggered_dslash_reference.h    \
 	domain_wall_dslash_reference.h test_util.h dslash_util.h
 
-TESTS = su3_test pack_test blas_test dslash_test invert_test	\
+TESTS = su3_testing  su3_test pack_test blas_test dslash_test invert_test	\
 	deflation_test						\
 	$(DIRAC_TEST) $(STAGGERED_DIRAC_TEST) $(FATLINK_TEST)	\
 	$(GAUGE_FORCE_TEST) $(FERMION_FORCE_TEST)		\
@@ -32,6 +32,9 @@ staggered_invert_test: staggered_invert_test.o test_util.o staggered_dslash_refe
 	$(CXX) $(LDFLAGS) $^ -o $@ $(LDFLAGS)
 
 su3_test: su3_test.o test_util.o misc.o $(QIO_UTIL) $(QUDA)
+	$(CXX) $(LDFLAGS) $^ -o $@ $(LDFLAGS)
+
+su3_testing: su3_testing.o test_util.o misc.o $(QIO_UTIL)  $(QUDA)
 	$(CXX) $(LDFLAGS) $^ -o $@ $(LDFLAGS)
 
 pack_test: pack_test.o test_util.o misc.o $(QUDA)

--- a/tests/su3_testing.cpp
+++ b/tests/su3_testing.cpp
@@ -7,7 +7,6 @@
 #include <gauge_field.h>
 
 #include <comm_quda.h>
-#include <mpi.h>
 #include <test_util.h>
 #include <gauge_tools.h>
 
@@ -112,12 +111,11 @@ void RunTest(int argc, char **argv) {
   gParamEx.nFace = 1;
   for(int dir=0; dir<4; ++dir) gParamEx.r[dir] = R[dir];
   cudaGaugeField *cudaInGauge = new cudaGaugeField(gParamEx); 
+  printf("Gauge Radius: %d:%d:%d:%d\n", gParamEx.r[0], gParamEx.r[1], gParamEx.r[2], gParamEx.r[3]);
 #else
   cudaGaugeField *cudaInGauge = new cudaGaugeField(gParam);
 #endif
 
-
-  printf("Gauge Radius: %d:%d:%d:%d\n", gParamEx.r[0], gParamEx.r[1], gParamEx.r[2], gParamEx.r[3]);
   printf("Gauge Radius: %d:%d:%d:%d\n", cudaInGauge->R()[0], cudaInGauge->R()[1], cudaInGauge->R()[2], cudaInGauge->R()[3]);
 
   const int *radius;

--- a/tests/su3_testing.cpp
+++ b/tests/su3_testing.cpp
@@ -1,0 +1,320 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <quda.h>
+#include <quda_internal.h>
+#include <gauge_field.h>
+
+#include <comm_quda.h>
+#include <mpi.h>
+#include <test_util.h>
+#include <gauge_tools.h>
+
+#include <pgauge_monte.h>
+#include <random.h>
+#include <hisq_links_quda.h>
+
+
+
+using   namespace quda;
+QudaGaugeParam param;
+
+extern int device;
+extern int xdim;
+extern int ydim;
+extern int zdim;
+extern int tdim;
+extern int gridsize_from_cmdline[];
+extern QudaReconstructType link_recon;
+extern QudaPrecision prec;
+extern char latfile[];
+
+#define MAX(a,b) ((a)>(b)?(a):(b))
+
+
+int* SetReunitarizationConsts(){
+  const double unitarize_eps = 1e-14;
+  const double max_error = 1e-10;
+  const int reunit_allow_svd = 1;
+  const int reunit_svd_only  = 0;
+  const double svd_rel_error = 1e-6;
+  const double svd_abs_error = 1e-6;
+  setUnitarizeLinksConstants(unitarize_eps, max_error,
+      reunit_allow_svd, reunit_svd_only,
+      svd_rel_error, svd_abs_error);
+  int* num_failures_dev;
+  cudaMalloc((void**)&num_failures_dev, sizeof(int));
+  cudaMemset(num_failures_dev, 0, sizeof(int));
+  if(num_failures_dev == NULL) errorQuda("cudaMalloc failed for dev_pointer\n");
+  return num_failures_dev;
+}
+
+
+void RunTest(int argc, char **argv) {
+
+
+  setVerbosity(QUDA_DEBUG_VERBOSE);
+  //setVerbosity(QUDA_SILENT);
+  //setVerbosity(QUDA_VERBOSE);
+  if (true) {
+    printfQuda("Tuning...\n");
+    setTuning(QUDA_TUNE_YES);
+  }
+
+  param = newQudaGaugeParam();
+
+  //Setup Gauge container!!!!!!
+  param.cpu_prec = prec;
+  param.cpu_prec = prec;
+  param.cuda_prec = prec;
+  param.reconstruct = link_recon;
+  param.cuda_prec_sloppy = prec;
+  param.reconstruct_sloppy = link_recon;
+  
+  param.type = QUDA_WILSON_LINKS;
+  param.gauge_order = QUDA_MILC_GAUGE_ORDER;
+
+  param.X[0] = xdim;
+  param.X[1] = ydim;
+  param.X[2] = zdim;
+  param.X[3] = tdim;
+  setDims(param.X);
+
+  param.anisotropy = 1.0;  //don't support anisotropy for now!!!!!!
+  param.t_boundary = QUDA_PERIODIC_T;
+  param.gauge_fix = QUDA_GAUGE_FIXED_NO;
+  param.ga_pad = 0; 
+
+  GaugeFieldParam gParam(0, param);
+  gParam.pad = 0; 
+  gParam.ghostExchange = QUDA_GHOST_EXCHANGE_NO;
+  gParam.create      = QUDA_NULL_FIELD_CREATE;
+  gParam.link_type   = param.type;
+  gParam.reconstruct = param.reconstruct;    
+  gParam.order       = (param.reconstruct == QUDA_RECONSTRUCT_12) ? QUDA_FLOAT4_GAUGE_ORDER : QUDA_FLOAT2_GAUGE_ORDER;
+  //gParam.order       = QUDA_FLOAT2_GAUGE_ORDER;
+  gParam.order       = (param.cuda_prec == QUDA_DOUBLE_PRECISION || param.reconstruct == QUDA_RECONSTRUCT_NO ) ? QUDA_FLOAT2_GAUGE_ORDER : QUDA_FLOAT4_GAUGE_ORDER;
+
+
+#ifdef MULTI_GPU
+  int y[4];
+  int R[4] = {0,0,0,0};
+  for(int dir=0; dir<4; ++dir) if(comm_dim_partitioned(dir)) R[dir] = 2;
+  for(int dir=0; dir<4; ++dir) y[dir] = param.X[dir] + 2 * R[dir];
+  int pad = 0;
+  GaugeFieldParam gParamEx(y, prec, link_recon,
+      pad, QUDA_VECTOR_GEOMETRY, QUDA_GHOST_EXCHANGE_EXTENDED);
+  gParamEx.create = QUDA_ZERO_FIELD_CREATE;
+  gParamEx.order = gParam.order;
+  gParamEx.siteSubset = QUDA_FULL_SITE_SUBSET;
+  gParamEx.t_boundary = gParam.t_boundary;
+  gParamEx.nFace = 1;
+  for(int dir=0; dir<4; ++dir) gParamEx.r[dir] = R[dir];
+  cudaGaugeField *cudaInGauge = new cudaGaugeField(gParamEx); 
+#else
+  cudaGaugeField *cudaInGauge = new cudaGaugeField(gParam);
+#endif
+
+
+  printf("Gauge Radius: %d:%d:%d:%d\n", gParamEx.r[0], gParamEx.r[1], gParamEx.r[2], gParamEx.r[3]);
+  printf("Gauge Radius: %d:%d:%d:%d\n", cudaInGauge->R()[0], cudaInGauge->R()[1], cudaInGauge->R()[2], cudaInGauge->R()[3]);
+
+  const int *radius;
+  radius = cudaInGauge->R();
+  printf("Gauge Radius: %d:%d:%d:%d\n", radius[0], radius[1], radius[2], radius[3]);
+
+  int nsteps = 1;
+  int nhbsteps = 1;
+  int novrsteps = 1;
+  bool coldstart = false;
+
+
+  Timer a0,a1;
+  a0.Start();
+  a1.Start();
+
+  int halfvolume = xdim*ydim*zdim*tdim >> 1;
+  printfQuda("xdim=%d\tydim=%d\tzdim=%d\ttdim=%d\trng_size=%d\n",xdim,ydim,zdim,tdim,halfvolume);
+  RNG randstates(halfvolume, 1234, param.X);
+  randstates.Init();
+  //Reunitarization setup
+  int num_failures=0;
+  int *num_failures_dev = SetReunitarizationConsts();
+
+/*
+  cudaInGauge->exchangeExtendedGhost(R,false);
+
+exit(0);*/
+
+  if(link_recon != QUDA_RECONSTRUCT_8 && coldstart) InitGaugeField( *cudaInGauge);
+  else{
+    InitGaugeField( *cudaInGauge, randstates.State());
+  }
+  Plaquette( *cudaInGauge) ;
+  //double2 plaq = Plaquette( *cudaInGauge) ;
+  //printfQuda("!!!!!: %.16e, %.16e, %.16e\n", plaq.x, plaq.y, (plaq.x+plaq.y) / 2.);
+
+  for(int step=1; step<=nsteps; ++step){
+    printfQuda("Step %d\n",step);
+    Monte( *cudaInGauge, randstates.State(), (double)6.2, nhbsteps, novrsteps);
+    //Reunitarize gauge links...
+    unitarizeLinksQuda(*cudaInGauge, num_failures_dev);
+    cudaMemcpy(&num_failures, num_failures_dev, sizeof(int), cudaMemcpyDeviceToHost);
+    if(num_failures>0){
+      cudaFree(num_failures_dev); 
+      errorQuda("Error in the unitarization\n"); 
+      exit(1);
+    }
+    cudaMemset(num_failures_dev, 0, sizeof(int));
+    Plaquette( *cudaInGauge) ;
+  }
+  a1.Stop();
+  printfQuda("Time Monte -> %.6f s\n", a1.Last());
+
+
+  int reunit_interval = 1000;
+
+
+
+
+  printfQuda("OVR: #########################################Landau\n");
+  //cudaInGauge->backup();
+  //test::gaugefixingOVR_test(*cudaInGauge, 4, 100, 10, 1.5, 0, reunit_interval, 1);
+  //cudaInGauge->restore();
+  gaugefixingOVR(*cudaInGauge, 4, 100, 10, 1.5, 0, reunit_interval, 1);
+  printfQuda("OVR: #########################################Coulomb\n");
+  gaugefixingOVR(*cudaInGauge, 3, 100, 10, 1.5, 0, reunit_interval, 1);
+  //cudaInGauge->restore();
+  //cudaInGauge->backup();
+ // gaugefixingOVR(*cudaInGauge, 3, 100, 10, 1.5, 0, reunit_interval, 1);
+ // test::gaugefixingOVR_test(*cudaInGauge, 3, 100, 10, 1.5, 0, reunit_interval, 1);
+  //cudaInGauge->restore();
+ // cudaInGauge->backup();
+
+  //gaugefixingFFT -> only single GPU...
+  printfQuda("FFT: #########################################Landau\n");
+  if(comm_size() == 1) gaugefixingFFT(*cudaInGauge, 4, 100, 10, 0.08, 0, 0, 1);
+  //cudaInGauge->restore();
+  //cudaInGauge->backup();
+  printfQuda("FFT: #########################################Coulomb\n");
+  if(comm_size() == 1) gaugefixingFFT(*cudaInGauge, 3, 100, 10, 0.08, 0, 0, 1);
+
+  randstates.Release();
+  delete cudaInGauge;
+  cudaFree(num_failures_dev); 
+  PGaugeExchangeFree();
+  a0.Stop();
+  printfQuda("Time -> %.6f s\n", a0.Last());
+
+
+
+
+ // printf("@@@%d:::%d:%d:%d:%d\n",comm_rank(),comm_dim(0),comm_dim(1),comm_dim(2),comm_dim(3));
+ // printf("###%d:::%d:%d:%d:%d\n",comm_rank(),comm_coord(0),comm_coord(1),comm_coord(2),comm_coord(3));
+
+
+
+
+}
+
+
+
+void SU3Test(int argc, char **argv) {
+
+  initQuda(-1);
+  
+if(1){
+  prec = QUDA_SINGLE_PRECISION;
+  link_recon = QUDA_RECONSTRUCT_NO;
+  printfQuda("QUDA_SINGLE_PRECISION#########################################QUDA_RECONSTRUCT_NO\n");
+  RunTest(argc, argv);
+  printfQuda("QUDA_SINGLE_PRECISION#########################################QUDA_RECONSTRUCT_12\n");
+  link_recon = QUDA_RECONSTRUCT_12;
+  RunTest(argc, argv);
+  printfQuda("QUDA_SINGLE_PRECISION#########################################QUDA_RECONSTRUCT_8\n");
+  link_recon = QUDA_RECONSTRUCT_8;
+  RunTest(argc, argv);
+  printfQuda("#########################################\n");
+
+
+  prec = QUDA_DOUBLE_PRECISION;
+  link_recon = QUDA_RECONSTRUCT_NO;
+  printfQuda("QUDA_DOUBLE_PRECISION#########################################QUDA_RECONSTRUCT_NO\n");
+  RunTest(argc, argv);
+  printfQuda("QUDA_DOUBLE_PRECISION#########################################QUDA_RECONSTRUCT_12\n");
+  link_recon = QUDA_RECONSTRUCT_12;
+  RunTest(argc, argv);
+  printfQuda("QUDA_DOUBLE_PRECISION#########################################QUDA_RECONSTRUCT_8\n");
+  link_recon = QUDA_RECONSTRUCT_8;
+  RunTest(argc, argv);
+  printfQuda("#########################################\n");
+}
+else{/*
+  prec = QUDA_DOUBLE_PRECISION;
+  link_recon = QUDA_RECONSTRUCT_NO;
+  printfQuda("QUDA_DOUBLE_PRECISION#########################################QUDA_RECONSTRUCT_NO\n");
+  RunTest(argc, argv);
+  printfQuda("QUDA_DOUBLE_PRECISION#########################################QUDA_RECONSTRUCT_12\n");
+  link_recon = QUDA_RECONSTRUCT_12;;
+  RunTest(argc, argv);
+  printfQuda("#########################################\n");
+  printfQuda("#########################################\n");
+  prec = QUDA_SINGLE_PRECISION;
+  link_recon = QUDA_RECONSTRUCT_NO;
+  printfQuda("QUDA_SINGLE_PRECISION#########################################QUDA_RECONSTRUCT_NO\n");
+  RunTest(argc, argv);
+  printfQuda("QUDA_SINGLE_PRECISION#########################################QUDA_RECONSTRUCT_12\n");
+  link_recon = QUDA_RECONSTRUCT_12;
+  RunTest(argc, argv);
+  printfQuda("#########################################\n");*/
+
+
+
+  prec = QUDA_DOUBLE_PRECISION;
+  link_recon = QUDA_RECONSTRUCT_NO;
+  printfQuda("QUDA_DOUBLE_PRECISION#########################################QUDA_RECONSTRUCT_NO\n");
+  RunTest(argc, argv);
+  printfQuda("#########################################\n");
+  }
+
+  endQuda();
+
+}
+
+
+//mpirun -n 4 su3_testing --xgridsize 1 --ygridsize 1 --zgridsize 1 --tgridsize 4 --xdim 16
+
+//mpirun -n 4 env MV2_USE_CUDA=1 su3_testing --xgridsize 1 --ygridsize 1 --zgridsize 1 --tgridsize 4 --tdim 4
+
+//mpirun -n 8 env MV2_USE_CUDA=1 su3_testing --xgridsize 2 --ygridsize 1 --zgridsize 2 --tgridsize 2 --tdim 8 --xdim 8 --ydim 16 --zdim 8
+
+  int
+main(int argc, char **argv)
+{
+  //default to 18 reconstruct, 8^3 x 8
+  //link_recon = QUDA_RECONSTRUCT_NO;
+  xdim=ydim=zdim=tdim=32;
+  //cpu_prec = prec = QUDA_DOUBLE_PRECISION;
+
+  int i;
+  for (i=1; i<argc; i++){
+    if(process_command_line_option(argc, argv, &i) == 0){
+      continue;
+    }
+
+    fprintf(stderr, "ERROR: Invalid option:%s\n", argv[i]);
+    //usage(argv);
+  }
+
+  initComms(argc, argv, gridsize_from_cmdline);
+
+  //display_test_info();
+  SU3Test(argc, argv);
+
+
+  finalizeComms();
+
+  return EXIT_SUCCESS;
+}
+


### PR DESCRIPTION
Main changes:
Modified unitarize_links_quda.cu in order to support link unitarization for 12/8 parameters
Modified copy_gauge_extended.cu in order to support copy from extended to regular gauge
Modified gauge_field_order.h, FloatNOrder struct optimized for double and single precision
Added gauge fixing to interface_quda.cpp and milc_interface.cpp
Gauge fixing files:
lib: gauge_fix_ovr_extra.cu, gauge_fix_fft.cu, gauge_fix_ovr_extra.h, gauge_fix_ovr.cu,  gauge_fix_ovr_hit_devf.cuh, CUFFT_Plans.h
For pure gauge config generation:
pgauge_exchange.cu,   pgauge_init.cu, pgauge_heatbath.cu, pgauge_plaquette.cu, random.cu
