### PR TITLE
Feature/expose heavy quark check

### DIFF
--- a/include/invert_quda.h
+++ b/include/invert_quda.h
@@ -53,6 +53,9 @@ namespace quda {
     i.e., how long do we want to keep trying to converge */
     int max_res_increase_total;
 
+    /**< After how many iterations shall the heavy quark residual be updated */
+    int heavy_quark_check;
+
     /**< Enable pipeline solver */
     int pipeline;
 
@@ -160,7 +163,8 @@ namespace quda {
       inv_type_precondition(param.inv_type_precondition), 
       residual_type(param.residual_type), use_init_guess(param.use_init_guess),
       delta(param.reliable_delta), use_sloppy_partial_accumulator(param.use_sloppy_partial_accumulator), 
-      max_res_increase(param.max_res_increase), max_res_increase_total(param.max_res_increase_total), pipeline(param.pipeline), tol(param.tol), tol_restart(param.tol_restart), tol_hq(param.tol_hq), 
+      max_res_increase(param.max_res_increase), max_res_increase_total(param.max_res_increase_total), heavy_quark_check(param.heavy_quark_check), pipeline(param.pipeline),
+      tol(param.tol), tol_restart(param.tol_restart), tol_hq(param.tol_hq),
       true_res(param.true_res), true_res_hq(param.true_res_hq),
       maxiter(param.maxiter), iter(param.iter), 
       precision(param.cuda_prec), precision_sloppy(param.cuda_prec_sloppy), 

--- a/include/quda.h
+++ b/include/quda.h
@@ -118,6 +118,9 @@ extern "C" {
     i.e., how long do we want to keep trying to converge */
     int max_res_increase_total;
 
+    /**< After how many iterations shall the heavy quark residual be updated */
+    int heavy_quark_check;
+
     int pipeline; /**< Whether to use a pipelined solver with less global sums */
 
     int num_offset; /**< Number of offsets in the multi-shift solver */

--- a/lib/check_params.h
+++ b/lib/check_params.h
@@ -214,10 +214,12 @@ void printQudaInvertParam(QudaInvertParam *param) {
   P(use_sloppy_partial_accumulator, 0); /**< Default is to use a high-precision accumulator (not yet supported in all solvers) */
   P(max_res_increase, 1); /**< Default is to allow one consecutive residual increase */
   P(max_res_increase_total, 10); /**< Default is to allow ten residual increase */
-#else
+  P(heavy_quark_check, 10); /**< Default is to update heavy quark residual after 10 iterations */
+ #else
   P(use_sloppy_partial_accumulator, INVALID_INT);
   P(max_res_increase, INVALID_INT);
   P(max_res_increase_total, INVALID_INT);
+  P(heavy_quark_check, INVALID_INT);
 #endif
 
 #ifndef CHECK_PARAM

--- a/lib/inv_bicgstab_quda.cpp
+++ b/lib/inv_bicgstab_quda.cpp
@@ -146,7 +146,7 @@ namespace quda {
     const bool use_heavy_quark_res = 
       (param.residual_type & QUDA_HEAVY_QUARK_RESIDUAL) ? true : false;
     double heavy_quark_res = use_heavy_quark_res ? sqrt(HeavyQuarkResidualNormCuda(x,r).z) : 0.0;
-    int heavy_quark_check = 10; // how often to check the heavy quark residual
+    const int heavy_quark_check = param.heavy_quark_check; // how often to check the heavy quark residual
 
     double delta = param.delta;
 

--- a/lib/inv_cg_quda.cpp
+++ b/lib/inv_cg_quda.cpp
@@ -114,7 +114,7 @@ namespace quda {
       heavy_quark_res = sqrt(HeavyQuarkResidualNormCuda(x, r).z);
       heavy_quark_res_old = heavy_quark_res; // heavy quark residual
     }
-    const int heavy_quark_check = 1; // how often to check the heavy quark residual
+    const int heavy_quark_check = param.heavy_quark_check; // how often to check the heavy quark residual
 
     double alpha=0.0, beta=0.0;
     double pAp;

--- a/lib/inv_eigcg_quda.cpp
+++ b/lib/inv_eigcg_quda.cpp
@@ -500,7 +500,7 @@ namespace quda {
 
     double heavy_quark_res = 0.0; // heavy quark residual
     if(use_heavy_quark_res) heavy_quark_res = sqrt(HeavyQuarkResidualNormCuda(x,r).z);
-    int heavy_quark_check = 10; // how often to check the heavy quark residual
+    const int heavy_quark_check = param.heavy_quark_check; // how often to check the heavy quark residual
 
     double alpha=1.0, beta=0.0;
  

--- a/lib/milc_interface.cpp
+++ b/lib/milc_interface.cpp
@@ -834,6 +834,9 @@ void qudaInvert(int external_precision,
   setInvertParams(localDim, host_precision, device_precision, device_precision_sloppy, device_precision_precondition,
       mass, target_res, target_res_hq, inv_args.max_iter, reliable_delta, local_parity, verbosity, QUDA_CG_INVERTER, &invertParam);
   invertParam.use_sloppy_partial_accumulator = 0;
+  if (invertParam.residual_type == QUDA_HEAVY_QUARK_RESIDUAL) invertParam.heavy_quark_check = 1;
+
+
 
   ColorSpinorParam csParam;
   setColorSpinorParams(localDim, host_precision, &csParam);
@@ -1140,6 +1143,7 @@ void qudaCloverInvert(int external_precision,
 
   invertParam.tol =  target_residual;
   invertParam.tol_hq = target_fermilab_residual;
+  if (invertParam.residual_type == QUDA_HEAVY_QUARK_RESIDUAL) invertParam.heavy_quark_check = 1;
 
   // solution types
   invertParam.solution_type      = QUDA_MAT_SOLUTION;

--- a/lib/quda_fortran.F90
+++ b/lib/quda_fortran.F90
@@ -53,15 +53,15 @@ module quda_fortran
      real(8) :: gauge_gib
 
      integer(4) :: preserve_gauge ! Used by link fattening
-    
+
      ! Set the staggered phase type of the links
      QudaStaggeredPhase :: staggered_phase_type
      ! Whether the staggered phase has already been applied to the links
-     integer(4) :: staggered_phase_applied 
+     integer(4) :: staggered_phase_applied
 
      integer(4) :: overlap ! width of domain overlap
 
-     integer(4) :: use_resident_gauge  ! Use the resident gauge field 
+     integer(4) :: use_resident_gauge  ! Use the resident gauge field
      integer(4) :: use_resident_mom    ! Use the resident mom field
      integer(4) :: make_resident_gauge ! Make the gauge field resident
      integer(4) :: make_resident_mom   ! Make the mom field resident
@@ -70,43 +70,44 @@ module quda_fortran
 
   ! This module corresponds to the QudaInvertParam struct in quda.h
   type quda_invert_param
-     
+
      QudaFieldLocation :: input_location  ! The location of the input field
-     QudaFieldLocation :: output_location ! The location of the output field 
-     
+     QudaFieldLocation :: output_location ! The location of the output field
+
      QudaDslashType :: dslash_type
      QudaInverterType :: inv_type
-     
-     real(8) :: mass  ! Used for staggered only 
-     real(8) :: kappa ! Used for Wilson and Wilson-clover 
-     
-     real(8) :: m5    ! Domain wall height 
-     integer(4) :: Ls       ! Extent of the 5th dimension (for domain wall) 
-     
-     real(8), dimension(QUDA_MAX_DWF_LS) :: b_5 ! MDWF coefficients 
+
+     real(8) :: mass  ! Used for staggered only
+     real(8) :: kappa ! Used for Wilson and Wilson-clover
+
+     real(8) :: m5    ! Domain wall height
+     integer(4) :: Ls       ! Extent of the 5th dimension (for domain wall)
+
+     real(8), dimension(QUDA_MAX_DWF_LS) :: b_5 ! MDWF coefficients
      real(8), dimension(QUDA_MAX_DWF_LS) :: c_5 ! will be used only for the mobius type of Fermion
 
-     real(8) :: mu    ! Twisted mass parameter 
+     real(8) :: mu    ! Twisted mass parameter
      real(8) :: epsilon ! Twisted mass parameter
-     QudaTwistFlavorType :: twist_flavor  ! Twisted mass flavor 
-     
+     QudaTwistFlavorType :: twist_flavor  ! Twisted mass flavor
+
      real(8) :: tol ! Requested L2 residual norm
-     real(8) :: tol_restart ! Solver tolerance in the L2 residual norm (used to restart InitCG) 
+     real(8) :: tol_restart ! Solver tolerance in the L2 residual norm (used to restart InitCG)
      real(8) :: tol_hq ! Requested heavy quark residual norm
      real(8) :: true_res ! Actual L2 residual norm achieved in solver
      real(8) :: true_res_hq ! Actual heavy quark residual norm achieved in solver
      integer(4) :: maxiter
-     real(8) :: reliable_delta ! Reliable update tolerance 
+     real(8) :: reliable_delta ! Reliable update tolerance
      integer(4) :: use_sloppy_partial_accumulator ! Whether to keep the partial solution accumuator in sloppy precision
      integer(4) :: max_res_increase ! How many residual increases we tolerate when doing reliable updates
      integer(4) :: max_res_increase_total ! Total number of residual increases we tolerate
+     integer(4) :: heavy_quark_check ! After how many iterations shall the heavy quark residual be updated
      integer(4) :: pipeline ! Whether to enable pipeline solver option
-     integer(4) :: num_offset ! Number of offsets in the multi-shift solver 
-    
-     integer(4) :: overlap ! width of domain overlaps 
-     real(8), dimension(QUDA_MAX_MULTI_SHIFT) :: offset ! Offsets for multi-shift solver 
-     real(8), dimension(QUDA_MAX_MULTI_SHIFT) :: tol_offset ! Solver tolerance for each offset 
-     
+     integer(4) :: num_offset ! Number of offsets in the multi-shift solver
+
+     integer(4) :: overlap ! width of domain overlaps
+     real(8), dimension(QUDA_MAX_MULTI_SHIFT) :: offset ! Offsets for multi-shift solver
+     real(8), dimension(QUDA_MAX_MULTI_SHIFT) :: tol_offset ! Solver tolerance for each offset
+
      ! Solver tolerance for each shift when refinement is applied using the heavy-quark residual
      real(8), dimension(QUDA_MAX_MULTI_SHIFT) :: tol_hq_offset
 
@@ -116,86 +117,86 @@ module quda_fortran
      ! Actual heavy quark residual norm achieved in solver for each offset
      real(8), dimension(QUDA_MAX_MULTI_SHIFT) :: true_res_hq_offset
 
-     QudaSolutionType :: solution_type  ! Type of system to solve 
-     QudaSolveType :: solve_type        ! How to solve it 
+     QudaSolutionType :: solution_type  ! Type of system to solve
+     QudaSolveType :: solve_type        ! How to solve it
      QudaMatPCType :: matpc_type
      QudaDagType :: dagger
      QudaMassNormalization :: mass_normalization
 
      QudaSolverNormalization :: solver_normalization
      QudaPreserveSource :: preserve_source
-     
+
      QudaPrecision :: cpu_prec
      QudaPrecision :: cuda_prec
      QudaPrecision :: cuda_prec_sloppy
      QudaPrecision :: cuda_prec_precondition
-     
+
      QudaDiracFieldOrder :: dirac_order
-     
-     ! Gamma basis of the input and output host fields 
+
+     ! Gamma basis of the input and output host fields
      QudaGammaBasis :: gamma_basis
-     
+
      QudaFieldLocation :: clover_location            ! The location of the clover field
      QudaPrecision :: clover_cpu_prec
      QudaPrecision :: clover_cuda_prec
      QudaPrecision :: clover_cuda_prec_sloppy
      QudaPrecision :: clover_cuda_prec_precondition
-     
+
      QudaCloverFieldOrder :: clover_order
      QudaUseInitGuess :: use_init_guess
-    
-     real(8) :: clover_coeff ! Coefficient of the clover term 
-     integer(4) :: compute_clover_trlog ! Whether to compute the trace log of the clover term
-     real(8), dimension(2) :: trlogA    ! The trace log of the clover term (even/odd computed separately) 
 
-     QudaVerbosity :: verbosity    
-     
+     real(8) :: clover_coeff ! Coefficient of the clover term
+     integer(4) :: compute_clover_trlog ! Whether to compute the trace log of the clover term
+     real(8), dimension(2) :: trlogA    ! The trace log of the clover term (even/odd computed separately)
+
+     QudaVerbosity :: verbosity
+
      integer(4) :: sp_pad
      integer(4) :: cl_pad
-     
+
      integer(4) :: iter
      real(8) :: spinor_gib
      real(8) :: clover_gib
      real(8) :: gflops
      real(8) :: secs
-     
-     ! Enable auto-tuning? 
+
+     ! Enable auto-tuning?
      QudaTune :: tune
-    
+
      ! Number of steps in s-step algorithms
      integer(4) :: nsteps
-   
-     ! Maximum size of Krylov space used by solver 
+
+     ! Maximum size of Krylov space used by solver
      integer(4) :: gcr_nkrylov
-     
+
      ! The following parameters are related to the domain-decomposed preconditioner.
-     
+
      ! The inner Krylov solver used in the preconditioner.  Set to
      ! QUDA_INVALID_INVERTER to disable the preconditioner entirely.
      QudaInverterType :: inv_type_precondition
-    
+
 
      ! Dslash used in the inner Krylov solver
      QudaDslashType :: dslash_type_precondition
- 
-     ! Verbosity of the inner Krylov solver 
+
+     ! Verbosity of the inner Krylov solver
      QudaVerbosity :: verbosity_precondition
-     
-     ! Tolerance in the inner solver 
+
+     ! Tolerance in the inner solver
      real(8) :: tol_precondition
-     
-     ! Maximum number of iterations allowed in the inner solver 
+
+     ! Maximum number of iterations allowed in the inner solver
      integer(4) :: maxiter_precondition
-     
-     ! Relaxation parameter used in GCR-DD (default = 1.0) 
+
+     ! Relaxation parameter used in GCR-DD (default = 1.0)
      real(8) :: omega
-     
-     ! Number of preconditioner cycles to perform per iteration 
+
+     ! Number of preconditioner cycles to perform per iteration
      integer(4) :: precondition_cycle
-     
-     ! Whether to use additive or multiplicative Schwarz preconditioning 
+
+     ! Whether to use additive or multiplicative Schwarz preconditioning
      QudaSchwarzType :: schwarz_type
-     
+
      ! Whether to use the Fermilab heavy-quark residual or standard residual to gauge convergence
      QudaResidualType ::residual_type
 
@@ -206,6 +207,6 @@ module quda_fortran
      integer(4)::rhs_idx
      integer(4)::deflation_grid !total deflation space is nev*deflation_grid
   end type quda_invert_param
-   
+
 end module quda_fortran
 !===============================================================================


### PR DESCRIPTION
This exposed the parameter `heavy_quark_check` used in solvers in the quda interface.
The default value is 10 as previously hardcoded in the solver implementations.

For MILC applications (i.e. that use the milc_interface) the value is set to 1 if a solver is called with only the fermilab / heavy-quark residual specified.