### PR TITLE
When using threaded dslash, threaded MPI must be used.

### DIFF
--- a/tests/test_util.cpp
+++ b/tests/test_util.cpp
@@ -55,7 +55,13 @@ void initComms(int argc, char **argv, const int *commDims)
   QMP_declare_logical_topology(commDims, 4);
 
 #elif defined(MPI_COMMS)
+#ifdef PTHREADS
+  int provided;
+  MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
+#else
   MPI_Init(&argc, &argv);
+#endif
+
 #endif
   initCommsGridQuda(4, commDims, NULL, NULL);
   initRand();


### PR DESCRIPTION
This fixes a bug that caused irreproducible behaviour with MVAPICH when the threaded dslash is enabled.