### PR TITLE
Hotfix/cray fortran

### DIFF
--- a/include/util_quda.h
+++ b/include/util_quda.h
@@ -53,13 +53,15 @@ char *getPrintBuffer();
 } while (0)
 
 #define warningQuda(...) do {                                   \
-  sprintf(getPrintBuffer(), __VA_ARGS__);			\
-  if (comm_rank() == 0) {                                       \
-    fprintf(getOutputFile(), "%sWARNING: ", getOutputPrefix()); \
-    fprintf(getOutputFile(), "%s", getPrintBuffer());		\
-    fprintf(getOutputFile(), "\n");                             \
-    fflush(getOutputFile());                                    \
-  }                                                             \
+  if (getVerbosity() > QUDA_SILENT) {				\
+    sprintf(getPrintBuffer(), __VA_ARGS__);			\
+    if (comm_rank() == 0) {					\
+      fprintf(getOutputFile(), "%sWARNING: ", getOutputPrefix());	\
+      fprintf(getOutputFile(), "%s", getPrintBuffer());			\
+      fprintf(getOutputFile(), "\n");					\
+      fflush(getOutputFile());						\
+    }									\
+  }									\
 } while (0)
 
 #else
@@ -82,10 +84,12 @@ char *getPrintBuffer();
 } while (0)
 
 #define warningQuda(...) do {                                 \
-  fprintf(getOutputFile(), "%sWARNING: ", getOutputPrefix()); \
-  fprintf(getOutputFile(), __VA_ARGS__);                      \
-  fprintf(getOutputFile(), "\n");                             \
-  fflush(getOutputFile());                                    \
+  if (getVerbosity() > QUDA_SILENT) {			      \
+    fprintf(getOutputFile(), "%sWARNING: ", getOutputPrefix()); \
+    fprintf(getOutputFile(), __VA_ARGS__);                      \
+    fprintf(getOutputFile(), "\n");                             \
+    fflush(getOutputFile());                                    \
+  }								\
 } while (0)
 
 #endif // MULTI_GPU

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -272,6 +272,6 @@ copy_gauge_half.o: copy_gauge_half.cu copy_gauge_inc.cu $(HDRS)
 
 quda_fortran.o: quda_fortran.F90 ../include/enum_quda_fortran.h
 	$(CC) -Wall -E -I../include $< > $*.f90
-	$(F90) -c -fno-range-check $*.f90
+	$(F90) -c $*.f90
 
 .PHONY: all gen clean


### PR DESCRIPTION
Closes issues #285 and #286:
* Compilation of Fortran interface on Cray systems
* Warnings are only printed when verbosity is greater than silent