### PR TITLE
Small fix for APE smearing

### DIFF
--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -5267,13 +5267,14 @@ void performAPEnStep(unsigned int nSteps, double alpha)
   if (gaugeSmeared == NULL) {
 //    gaugeSmeared = new cudaGaugeField(gParamEx);
     gaugeSmeared = new cudaGaugeField(gParam);
-    #ifdef MULTI_GPU
-      copyExtendedGauge(*gaugeSmeared, *extendedGaugeResident, QUDA_CUDA_FIELD_LOCATION);
-      gaugeSmeared->exchangeExtendedGhost(R,true);
-    #else
-      gaugeSmeared->copy(*gaugePrecise);
-    #endif
   }
+
+  #ifdef MULTI_GPU
+    copyExtendedGauge(*gaugeSmeared, *extendedGaugeResident, QUDA_CUDA_FIELD_LOCATION);
+    gaugeSmeared->exchangeExtendedGhost(R,true);
+  #else
+    gaugeSmeared->copy(*gaugePrecise);
+  #endif
 
   cudaGaugeField *cudaGaugeTemp = NULL;
   cudaGaugeTemp = new cudaGaugeField(gParam);


### PR DESCRIPTION
A call to the APE smearing funciton would create a new gauge field called gaugeSmeared, copy gaugePrecise there, and perform the APE steps, saving the final result in gaugeSmeared and leaving gaugePrecise untouched. A subsequent call to the APE smearing function will start smearing again the fields in gaugeSmeared (which are already smeared), instead of reloading the gaugePrecise field. I think this is not what we want, although this can be the object of discussion.