### PR TITLE
Feature/staggered reconstruct

### DIFF
--- a/lib/dslash_constants.h
+++ b/lib/dslash_constants.h
@@ -437,6 +437,13 @@ void initDslashConstants(TimeProfile &profile)
   float tProjScale_fh = (float)tProjScale_h;
   cudaMemcpyToSymbol(tProjScale_f, &tProjScale_fh, sizeof(float));
 
+  // set these for naive staggered
+  float coeff_fh = 1.0;
+  cudaMemcpyToSymbol(coeff_f, &(coeff_fh), sizeof(float));
+
+  double coeff_h = 1.0;
+  cudaMemcpyToSymbol(coeff, &(coeff_h), sizeof(double));
+  
   checkCudaError();
 
   profile.Stop(QUDA_PROFILE_CONSTANT);

--- a/lib/dslash_core/staggered_dslash_core.h
+++ b/lib/dslash_core/staggered_dslash_core.h
@@ -93,6 +93,7 @@
 
 #else
 
+#if (DD_FAT_RECON == 18) //18 (no) reconstruct
 #define fat00_re FAT0.x
 #define fat00_im FAT0.y
 #define fat01_re FAT1.x
@@ -111,8 +112,28 @@
 #define fat21_im FAT7.y
 #define fat22_re FAT8.x
 #define fat22_im FAT8.y
+#else
+#define fat00_re FAT0.x
+#define fat00_im FAT0.y
+#define fat01_re FAT0.z
+#define fat01_im FAT0.w
+#define fat02_re FAT1.x
+#define fat02_im FAT1.y
+#define fat10_re FAT1.z
+#define fat10_im FAT1.w
+#define fat11_re FAT2.x
+#define fat11_im FAT2.y
+#define fat12_re FAT2.z
+#define fat12_im FAT2.w
+#define fat20_re FAT3.x
+#define fat20_im FAT3.y
+#define fat21_re FAT3.z
+#define fat21_im FAT3.w
+#define fat22_re FAT4.x
+#define fat22_im FAT4.y
+#endif // DD_FAT_RECON
 
-#if (DD_RECON == 18) //18 (no) reconstruct
+#if (DD_LONG_RECON == 18) //18 (no) reconstruct
 #define long00_re LONG0.x
 #define long00_im LONG0.y
 #define long01_re LONG1.x
@@ -330,7 +351,7 @@ spinorFloat o02_im;
   const float& fat_link_max = param.fat_link_max;
 #endif
 
-#if ((DD_RECON==9 || DD_RECON==13) && DD_IMPROVED==1)
+#if ((DD_LONG_RECON==9 || DD_LONG_RECON==13) && DD_IMPROVED==1)
 #if (DD_PREC==0) // double precision
   double PHASE = 0.;
 #else
@@ -384,16 +405,22 @@ spinorFloat o02_im;
   o01_re = o01_im = 0.f;
   o02_re = o02_im = 0.f;
 #endif
-#if((DD_RECON == 13 || DD_RECON == 9) && DD_IMPROVED==1)
-int sign = 1;
+#if(DD_FAT_RECON == 13 || DD_FAT_RECON == 9)
+int fat_sign = 1;
+#endif
+#if((DD_LONG_RECON == 13 || DD_LONG_RECON == 9) && DD_IMPROVED==1)
+int long_sign = 1;
 #endif
 
 {
   //direction: +X
 
 
-#if ((DD_RECON == 12 || DD_RECON == 8) && DD_IMPROVED==1)
-  int sign = (y[3]%2 == 1) ? -1 : 1;
+#if (DD_FAT_RECON == 12 || DD_FAT_RECON == 8)
+  int fat_sign = (y[3]%2 == 1) ? -1 : 1;
+#endif
+#if ((DD_LONG_RECON == 12 || DD_LONG_RECON == 8) && DD_IMPROVED==1)
+  int long_sign = (y[3]%2 == 1) ? -1 : 1;
 #endif
 
   int ga_idx = sid;
@@ -422,6 +449,8 @@ int sign = 1;
     } 
 #endif
     READ_1ST_NBR_SPINOR( SPINORTEX, nbr_idx1, stride1);
+    RECONSTRUCT_FAT_GAUGE_MATRIX(0, fat, sp_idx_1st_nbr, fat_sign);
+
     MAT_MUL_V(A, fat, i);    
     o00_re += A0_re;
     o00_im += A0_im;
@@ -458,8 +487,8 @@ int sign = 1;
 #endif
     spinorFloat2 T0, T1, T2;
     READ_3RD_NBR_SPINOR(T, SPINORTEX, nbr_idx3, stride3);
+    RECONSTRUCT_LONG_GAUGE_MATRIX(0, long, ga_idx, long_sign);
 
-    RECONSTRUCT_GAUGE_MATRIX(0, long, ga_idx, sign);
     MAT_MUL_V(B, long, t);        
     o00_re += B0_re;
     o00_im += B0_im;
@@ -476,8 +505,11 @@ int sign = 1;
 
 {
   // direction: -X
-#if ((DD_RECON == 12 || DD_RECON == 8) && DD_IMPROVED==1)
-  int sign = (y[3]%2 == 1) ? -1 : 1;
+#if (DD_FAT_RECON == 12 || DD_FAT_RECON == 8)
+  int fat_sign = (y[3]%2 == 1) ? -1 : 1;
+#endif
+#if ((DD_LONG_RECON == 12 || DD_LONG_RECON == 8) && DD_IMPROVED==1)
+  int long_sign = (y[3]%2 == 1) ? -1 : 1;
 #endif
   int dir =1;
 
@@ -511,6 +543,7 @@ int sign = 1;
     }
 #endif
     READ_1ST_NBR_SPINOR( SPINORTEX, nbr_idx1, stride1);
+    RECONSTRUCT_FAT_GAUGE_MATRIX(1, fat, sp_idx_1st_nbr, fat_sign);
     ADJ_MAT_MUL_V(A, fat, i);       
     o00_re -= A0_re;
     o00_im -= A0_im;
@@ -554,7 +587,7 @@ int sign = 1;
 
     spinorFloat2 T0, T1, T2;
     READ_3RD_NBR_SPINOR(T, SPINORTEX, nbr_idx3, stride3);  
-    RECONSTRUCT_GAUGE_MATRIX(1, long, sp_idx_3rd_nbr, sign);
+    RECONSTRUCT_LONG_GAUGE_MATRIX(1, long, sp_idx_3rd_nbr, long_sign);
     ADJ_MAT_MUL_V(B, long, t);    
     o00_re -= B0_re;
     o00_im -= B0_im;
@@ -571,8 +604,11 @@ int sign = 1;
 
 {
   //direction: +Y
-#if ((DD_RECON == 12 || DD_RECON == 8) && DD_IMPROVED==1)
-  int sign = ((y[3]+y[0])%2 == 1) ? -1 : 1;
+#if (DD_FAT_RECON == 12 || DD_FAT_RECON == 8)
+  int fat_sign = ((y[3]+y[0])%2 == 1) ? -1 : 1;
+#endif
+#if ((DD_LONG_RECON == 12 || DD_LONG_RECON == 8) && DD_IMPROVED==1)
+  int long_sign = ((y[3]+y[0])%2 == 1) ? -1 : 1;
 #endif
 
   int ga_idx = sid;
@@ -601,6 +637,7 @@ int sign = 1;
     }
 #endif 
     READ_1ST_NBR_SPINOR( SPINORTEX, nbr_idx1, stride1);
+    RECONSTRUCT_FAT_GAUGE_MATRIX(2, fat, sp_idx_1st_nbr, fat_sign);
     MAT_MUL_V(A, fat, i);
     o00_re += A0_re;
     o00_im += A0_im;
@@ -638,7 +675,7 @@ int sign = 1;
     spinorFloat2 T0, T1, T2;
     READ_3RD_NBR_SPINOR(T, SPINORTEX, nbr_idx3, stride3);
 
-    RECONSTRUCT_GAUGE_MATRIX(2, long, ga_idx, sign);
+    RECONSTRUCT_LONG_GAUGE_MATRIX(2, long, ga_idx, long_sign);
     MAT_MUL_V(B, long, t);            
     o00_re += B0_re;
     o00_im += B0_im;
@@ -653,8 +690,11 @@ int sign = 1;
 {
   //direction: -Y
 
-#if ((DD_RECON == 12 || DD_RECON == 8) && DD_IMPROVED==1)
-  int sign = ((y[3]+y[0])%2 == 1) ? -1 : 1;
+#if (DD_FAT_RECON == 12 || DD_FAT_RECON == 8)
+  int fat_sign = ((y[3]+y[0])%2 == 1) ? -1 : 1;
+#endif
+#if ((DD_LONG_RECON == 12 || DD_LONG_RECON == 8) && DD_IMPROVED==1)
+  int long_sign = ((y[3]+y[0])%2 == 1) ? -1 : 1;
 #endif
 
   int dir=3;
@@ -688,6 +728,7 @@ int sign = 1;
     }
 #endif
     READ_1ST_NBR_SPINOR( SPINORTEX, nbr_idx1, stride1);
+    RECONSTRUCT_FAT_GAUGE_MATRIX(3, fat, sp_idx_1st_nbr, fat_sign);
     ADJ_MAT_MUL_V(A, fat, i);
     o00_re -= A0_re;
     o00_im -= A0_im;
@@ -731,7 +772,7 @@ int sign = 1;
     spinorFloat2 T0, T1, T2;
     READ_3RD_NBR_SPINOR(T, SPINORTEX, nbr_idx3, stride3);
 
-    RECONSTRUCT_GAUGE_MATRIX(3, long, sp_idx_3rd_nbr,sign);	    
+    RECONSTRUCT_LONG_GAUGE_MATRIX(3, long, sp_idx_3rd_nbr,long_sign);
     ADJ_MAT_MUL_V(B, long, t);    
     o00_re -= B0_re;
     o00_im -= B0_im;
@@ -746,8 +787,11 @@ int sign = 1;
 {
   //direction: +Z
 
-#if ((DD_RECON == 12 || DD_RECON == 8) && DD_IMPROVED==1)
-  int sign = ((y[3]+y[0]+y[1])%2 == 1) ? -1 : 1;
+#if (DD_FAT_RECON == 12 || DD_FAT_RECON == 8)
+  int fat_sign = ((y[3]+y[0]+y[1])%2 == 1) ? -1 : 1;
+#endif
+#if ((DD_LONG_RECON == 12 || DD_LONG_RECON == 8) && DD_IMPROVED==1)
+  int long_sign = ((y[3]+y[0]+y[1])%2 == 1) ? -1 : 1;
 #endif
 
   int ga_idx = sid;
@@ -776,6 +820,7 @@ int sign = 1;
     }
 #endif
     READ_1ST_NBR_SPINOR( SPINORTEX, nbr_idx1, stride1);
+    RECONSTRUCT_FAT_GAUGE_MATRIX(4, fat, sp_idx_1st_nbr, fat_sign);
     MAT_MUL_V(A, fat, i);	 
     o00_re += A0_re;
     o00_im += A0_im;
@@ -813,7 +858,7 @@ int sign = 1;
     spinorFloat2 T0, T1, T2;
     READ_3RD_NBR_SPINOR(T, SPINORTEX, nbr_idx3, stride3);
 
-    RECONSTRUCT_GAUGE_MATRIX(4, long, ga_idx, sign);    
+    RECONSTRUCT_LONG_GAUGE_MATRIX(4, long, ga_idx, long_sign);
     MAT_MUL_V(B, long, t);        
     o00_re += B0_re;
     o00_im += B0_im;
@@ -829,8 +874,11 @@ int sign = 1;
 {
   //direction: -Z
 
-#if ((DD_RECON == 12 || DD_RECON == 8) && DD_IMPROVED==1)
-  int sign = ((y[3]+y[0]+y[1])%2 == 1) ? -1 : 1;
+#if (DD_FAT_RECON == 12 || DD_FAT_RECON == 8)
+  int fat_sign = ((y[3]+y[0]+y[1])%2 == 1) ? -1 : 1;
+#endif
+#if ((DD_LONG_RECON == 12 || DD_LONG_RECON == 8) && DD_IMPROVED==1)
+  int long_sign = ((y[3]+y[0]+y[1])%2 == 1) ? -1 : 1;
 #endif
 
   int dir = 5;
@@ -865,6 +913,7 @@ int sign = 1;
     }
 #endif
     READ_1ST_NBR_SPINOR( SPINORTEX, nbr_idx1, stride1);
+    RECONSTRUCT_FAT_GAUGE_MATRIX(5, fat, sp_idx_1st_nbr, fat_sign);
     ADJ_MAT_MUL_V(A, fat, i);
     o00_re -= A0_re;
     o00_im -= A0_im;
@@ -908,7 +957,7 @@ int sign = 1;
     spinorFloat2 T0, T1, T2;
     READ_3RD_NBR_SPINOR(T, SPINORTEX, nbr_idx3, stride3);
 
-    RECONSTRUCT_GAUGE_MATRIX(5, long, sp_idx_3rd_nbr,sign);
+    RECONSTRUCT_LONG_GAUGE_MATRIX(5, long, sp_idx_3rd_nbr,long_sign);
     ADJ_MAT_MUL_V(B, long, t);    	    
     o00_re -= B0_re;
     o00_im -= B0_im;
@@ -922,8 +971,11 @@ int sign = 1;
 
 {
   //direction: +T
-#if ((DD_RECON == 12 || DD_RECON == 8) && DD_IMPROVED==1)
-  int sign = (y[3] >= (X4-3)) ? -1 : 1;
+#if (DD_FAT_RECON == 12 || DD_FAT_RECON == 8)
+  int fat_sign = (y[3] >= (X4-1)) ? -1 : 1;
+#endif
+#if ((DD_LONG_RECON == 12 || DD_LONG_RECON == 8) && DD_IMPROVED==1)
+  int long_sign = (y[3] >= (X4-3)) ? -1 : 1;
 #endif
 
   int ga_idx = sid;
@@ -952,6 +1004,7 @@ int sign = 1;
     }
 #endif
     READ_1ST_NBR_SPINOR( SPINORTEX, nbr_idx1, stride1);    
+    RECONSTRUCT_FAT_GAUGE_MATRIX(6, fat, sp_idx_1st_nbr, fat_sign);
     MAT_MUL_V(A, fat, i);
     o00_re += A0_re;
     o00_im += A0_im;
@@ -991,7 +1044,7 @@ int sign = 1;
     spinorFloat2 T0, T1, T2;
     READ_3RD_NBR_SPINOR(T, SPINORTEX, nbr_idx3, stride3); 
 
-    RECONSTRUCT_GAUGE_MATRIX(6, long, ga_idx, sign);
+    RECONSTRUCT_LONG_GAUGE_MATRIX(6, long, ga_idx, long_sign);
     MAT_MUL_V(B, long, t);    
     o00_re += B0_re;
     o00_im += B0_im;
@@ -1005,8 +1058,11 @@ int sign = 1;
 
 {
   //direction: -T
-#if ((DD_RECON == 12 || DD_RECON == 8) && DD_IMPROVED==1)
-  int sign = ( ((y[3]+(X[3]-3))%X[3])>= (X[3]-3) ) ? -1 : 1;
+#if (DD_FAT_RECON == 12 || DD_FAT_RECON == 8)
+  int fat_sign = ( ((y[3]+(X[3]-1))%X[3])>= (X[3]-1) ) ? -1 : 1;
+#endif
+#if ((DD_LONG_RECON == 12 || DD_LONG_RECON == 8) && DD_IMPROVED==1)
+  int long_sign = ( ((y[3]+(X[3]-3))%X[3])>= (X[3]-3) ) ? -1 : 1;
 #endif
 
   int dir = 7;
@@ -1040,6 +1096,7 @@ int sign = 1;
 #endif
     READ_FAT_MATRIX(FATLINK1TEX, dir, fat_idx, fat_stride);
     READ_1ST_NBR_SPINOR( SPINORTEX, nbr_idx1, stride1);
+    RECONSTRUCT_FAT_GAUGE_MATRIX(7, fat, sp_idx_1st_nbr, fat_sign);
     ADJ_MAT_MUL_V(A, fat, i);
     o00_re -= A0_re;
     o00_im -= A0_im;
@@ -1082,7 +1139,7 @@ int sign = 1;
     spinorFloat2 T0, T1, T2;
     READ_3RD_NBR_SPINOR(T, SPINORTEX, nbr_idx3, stride3);       
 
-    RECONSTRUCT_GAUGE_MATRIX(7, long, sp_idx_3rd_nbr, sign);    
+    RECONSTRUCT_LONG_GAUGE_MATRIX(7, long, sp_idx_3rd_nbr, long_sign);
     ADJ_MAT_MUL_V(B, long, t);    
     o00_re -= B0_re;
     o00_im -= B0_im;

--- a/lib/dslash_core/staggered_dslash_core.h
+++ b/lib/dslash_core/staggered_dslash_core.h
@@ -26,6 +26,8 @@
 #define t02_re T2.x
 #define t02_im T2.y
 
+#define time_boundary t_boundary
+
 #else
 
 #define spinorFloat float
@@ -47,6 +49,8 @@
 #define t01_im T1.y
 #define t02_re T2.x
 #define t02_im T2.y
+
+#define time_boundary t_boundary_f
 
 #endif
 
@@ -972,10 +976,10 @@ int long_sign = 1;
 {
   //direction: +T
 #if (DD_FAT_RECON == 12 || DD_FAT_RECON == 8)
-  int fat_sign = (y[3] >= (X4-1)) ? -1 : 1;
+  int fat_sign = (y[3] >= (X4-1)) ? time_boundary : 1;
 #endif
 #if ((DD_LONG_RECON == 12 || DD_LONG_RECON == 8) && DD_IMPROVED==1)
-  int long_sign = (y[3] >= (X4-3)) ? -1 : 1;
+  int long_sign = (y[3] >= (X4-3)) ? time_boundary : 1;
 #endif
 
   int ga_idx = sid;
@@ -1059,10 +1063,10 @@ int long_sign = 1;
 {
   //direction: -T
 #if (DD_FAT_RECON == 12 || DD_FAT_RECON == 8)
-  int fat_sign = ( ((y[3]+(X[3]-1))%X[3])>= (X[3]-1) ) ? -1 : 1;
+  int fat_sign = ( ((y[3]+(X[3]-1))%X[3])>= (X[3]-1) ) ? time_boundary : 1;
 #endif
 #if ((DD_LONG_RECON == 12 || DD_LONG_RECON == 8) && DD_IMPROVED==1)
-  int long_sign = ( ((y[3]+(X[3]-3))%X[3])>= (X[3]-3) ) ? -1 : 1;
+  int long_sign = ( ((y[3]+(X[3]-3))%X[3])>= (X[3]-3) ) ? time_boundary : 1;
 #endif
 
   int dir = 7;

--- a/lib/dslash_core/staggered_fused_exterior_dslash_core.h
+++ b/lib/dslash_core/staggered_fused_exterior_dslash_core.h
@@ -25,6 +25,8 @@
 #define t02_re T2.x
 #define t02_im T2.y
 
+#define time_boundary t_boundary
+
 #else
 
 #define spinorFloat float
@@ -46,6 +48,8 @@
 #define t01_im T1.y
 #define t02_re T2.x
 #define t02_im T2.y
+
+#define time_boundary t_boundary_f
 
 #endif
 
@@ -963,10 +967,10 @@ int long_sign = 1;
 {
   //direction: +T
 #if (DD_FAT_RECON == 12 || DD_FAT_RECON == 8)
-  int fat_sign = (y[3] >= (X4-1)) ? -1 : 1;
+  int fat_sign = (y[3] >= (X4-1)) ? time_boundary : 1;
 #endif
 #if ((DD_LONG_RECON == 12 || DD_LONG_RECON == 8) && DD_IMPROVED==1)
-  int long_sign = (y[3] >= (X4-3)) ? -1 : 1;
+  int long_sign = (y[3] >= (X4-3)) ? time_boundary : 1;
 #endif
 
   int ga_idx = half_idx;

--- a/lib/dslash_core/staggered_fused_exterior_dslash_core.h
+++ b/lib/dslash_core/staggered_fused_exterior_dslash_core.h
@@ -92,6 +92,7 @@
 
 #else
 
+#if (DD_FAT_RECON == 18) //18 (no) reconstruct
 #define fat00_re FAT0.x
 #define fat00_im FAT0.y
 #define fat01_re FAT1.x
@@ -110,8 +111,28 @@
 #define fat21_im FAT7.y
 #define fat22_re FAT8.x
 #define fat22_im FAT8.y
+#else
+#define fat00_re FAT0.x
+#define fat00_im FAT0.y
+#define fat01_re FAT0.z
+#define fat01_im FAT0.w
+#define fat02_re FAT1.x
+#define fat02_im FAT1.y
+#define fat10_re FAT1.z
+#define fat10_im FAT1.w
+#define fat11_re FAT2.x
+#define fat11_im FAT2.y
+#define fat12_re FAT2.z
+#define fat12_im FAT2.w
+#define fat20_re FAT3.x
+#define fat20_im FAT3.y
+#define fat21_re FAT3.z
+#define fat21_im FAT3.w
+#define fat22_re FAT4.x
+#define fat22_im FAT4.y
+#endif // DD_FAT_RECON
 
-#if (DD_RECON == 18) //18 (no) reconstruct
+#if (DD_LONG_RECON == 18) //18 (no) reconstruct
 #define long00_re LONG0.x
 #define long00_im LONG0.y
 #define long01_re LONG1.x
@@ -331,7 +352,7 @@ spinorFloat o02_im;
   const float& fat_link_max = param.fat_link_max;
 #endif
 
-#if ((DD_RECON==9 || DD_RECON==13) && DD_IMPROVED==1)
+#if ((DD_LONG_RECON==9 || DD_LONG_RECON==13) && DD_IMPROVED==1)
 #if (DD_PREC==0) // double precision
   double PHASE = 0.;
 #else
@@ -387,15 +408,21 @@ int full_idx=0;
   o01_re = o01_im = 0.f;
   o02_re = o02_im = 0.f;
 #endif
-#if((DD_RECON == 13 || DD_RECON == 9) && DD_IMPROVED==1)
-int sign = 1;
+#if(DD_FAT_RECON == 13 || DD_FAT_RECON == 9)
+int fat_sign = 1;
+#endif
+#if((DD_LONG_RECON == 13 || DD_LONG_RECON == 9) && DD_IMPROVED==1)
+int long_sign = 1;
 #endif
 
 {
   //direction: +X
 
-#if ((DD_RECON == 12 || DD_RECON == 8) && DD_IMPROVED==1)
-  int sign = (y[3]%2 == 1) ? -1 : 1;
+#if (DD_FAT_RECON == 12 || DD_FAT_RECON == 8)
+  int fat_sign = (y[3]%2 == 1) ? -1 : 1;
+#endif
+#if ((DD_LONG_RECON == 12 || DD_LONG_RECON == 8) && DD_IMPROVED==1)
+  int long_sign = (y[3]%2 == 1) ? -1 : 1;
 #endif
 
   int ga_idx = half_idx;
@@ -423,6 +450,7 @@ int sign = 1;
     }
 #endif
     READ_1ST_NBR_SPINOR( SPINORTEX, nbr_idx1, stride1);
+    RECONSTRUCT_FAT_GAUGE_MATRIX(0, fat, ga_idx, fat_sign);
     MAT_MUL_V(A, fat, i);    
     o00_re += A0_re;
     o00_im += A0_im;
@@ -459,7 +487,7 @@ int sign = 1;
     spinorFloat2 T0, T1, T2;
     READ_3RD_NBR_SPINOR(T, SPINORTEX, nbr_idx3, stride3);
 
-    RECONSTRUCT_GAUGE_MATRIX(0, long, ga_idx, sign);
+    RECONSTRUCT_LONG_GAUGE_MATRIX(0, long, ga_idx, long_sign);
     MAT_MUL_V(B, long, t);        
     o00_re += B0_re;
     o00_im += B0_im;
@@ -476,8 +504,11 @@ int sign = 1;
 
 {
   // direction: -X
-#if ((DD_RECON == 12 || DD_RECON == 8) && DD_IMPROVED==1)
-  int sign = (y[3]%2 == 1) ? -1 : 1;
+#if (DD_FAT_RECON == 12 || DD_FAT_RECON == 8)
+  int fat_sign = (y[3]%2 == 1) ? -1 : 1;
+#endif
+#if ((DD_LONG_RECON == 12 || DD_LONG_RECON == 8) && DD_IMPROVED==1)
+  int long_sign = (y[3]%2 == 1) ? -1 : 1;
 #endif
   int dir =1;
 
@@ -510,6 +541,7 @@ int sign = 1;
     }        
 #endif
     READ_1ST_NBR_SPINOR( SPINORTEX, nbr_idx1, stride1);
+    RECONSTRUCT_FAT_GAUGE_MATRIX(1, fat, ga_idx, fat_sign);
     ADJ_MAT_MUL_V(A, fat, i);       
     o00_re -= A0_re;
     o00_im -= A0_im;
@@ -552,7 +584,7 @@ int sign = 1;
 
     spinorFloat2 T0, T1, T2;
     READ_3RD_NBR_SPINOR(T, SPINORTEX, nbr_idx3, stride3);  
-    RECONSTRUCT_GAUGE_MATRIX(1, long, sp_idx_3rd_nbr, sign);
+    RECONSTRUCT_LONG_GAUGE_MATRIX(1, long, sp_idx_3rd_nbr, long_sign);
     ADJ_MAT_MUL_V(B, long, t);    
     o00_re -= B0_re;
     o00_im -= B0_im;
@@ -569,8 +601,11 @@ int sign = 1;
 
 {
   //direction: +Y
-#if ((DD_RECON == 12 || DD_RECON == 8) && DD_IMPROVED==1)
-  int sign = ((y[3]+y[0])%2 == 1) ? -1 : 1;
+#if (DD_FAT_RECON == 12 || DD_FAT_RECON == 8)
+  int fat_sign = ((y[3]+y[0])%2 == 1) ? -1 : 1;
+#endif
+#if ((DD_LONG_RECON == 12 || DD_LONG_RECON == 8) && DD_IMPROVED==1)
+  int long_sign = ((y[3]+y[0])%2 == 1) ? -1 : 1;
 #endif
 
   int ga_idx = half_idx;
@@ -598,6 +633,7 @@ int sign = 1;
     }      
 #endif 
     READ_1ST_NBR_SPINOR( SPINORTEX, nbr_idx1, stride1);
+    RECONSTRUCT_FAT_GAUGE_MATRIX(2, fat, ga_idx, fat_sign);
     MAT_MUL_V(A, fat, i);
     o00_re += A0_re;
     o00_im += A0_im;
@@ -634,7 +670,7 @@ int sign = 1;
     spinorFloat2 T0, T1, T2;
     READ_3RD_NBR_SPINOR(T, SPINORTEX, nbr_idx3, stride3);
 
-    RECONSTRUCT_GAUGE_MATRIX(2, long, ga_idx, sign);
+    RECONSTRUCT_LONG_GAUGE_MATRIX(2, long, ga_idx, long_sign);
     MAT_MUL_V(B, long, t);            
     o00_re += B0_re;
     o00_im += B0_im;
@@ -649,8 +685,11 @@ int sign = 1;
 {
   //direction: -Y
 
-#if ((DD_RECON == 12 || DD_RECON == 8) && DD_IMPROVED==1)
-  int sign = ((y[3]+y[0])%2 == 1) ? -1 : 1;
+#if (DD_FAT_RECON == 12 || DD_FAT_RECON == 8)
+  int fat_sign = ((y[3]+y[0])%2 == 1) ? -1 : 1;
+#endif
+#if ((DD_LONG_RECON == 12 || DD_LONG_RECON == 8) && DD_IMPROVED==1)
+  int long_sign = ((y[3]+y[0])%2 == 1) ? -1 : 1;
 #endif
 
   int dir=3;
@@ -683,6 +722,7 @@ int sign = 1;
     }              
 #endif
     READ_1ST_NBR_SPINOR( SPINORTEX, nbr_idx1, stride1);
+    RECONSTRUCT_FAT_GAUGE_MATRIX(3, fat, ga_idx, fat_sign);
     ADJ_MAT_MUL_V(A, fat, i);
     o00_re -= A0_re;
     o00_im -= A0_im;
@@ -725,7 +765,7 @@ int sign = 1;
     spinorFloat2 T0, T1, T2;
     READ_3RD_NBR_SPINOR(T, SPINORTEX, nbr_idx3, stride3);
 
-    RECONSTRUCT_GAUGE_MATRIX(3, long, sp_idx_3rd_nbr,sign);	    
+    RECONSTRUCT_LONG_GAUGE_MATRIX(3, long, sp_idx_3rd_nbr,long_sign);
     ADJ_MAT_MUL_V(B, long, t);    
     o00_re -= B0_re;
     o00_im -= B0_im;
@@ -741,8 +781,11 @@ int sign = 1;
 {
   //direction: +Z
 
-#if ((DD_RECON == 12 || DD_RECON == 8) && DD_IMPROVED==1)
-  int sign = ((y[3]+y[0]+y[1])%2 == 1) ? -1 : 1;
+#if (DD_FAT_RECON == 12 || DD_FAT_RECON == 8)
+  int fat_sign = ((y[3]+y[0]+y[1])%2 == 1) ? -1 : 1;
+#endif
+#if ((DD_LONG_RECON == 12 || DD_LONG_RECON == 8) && DD_IMPROVED==1)
+  int long_sign = ((y[3]+y[0]+y[1])%2 == 1) ? -1 : 1;
 #endif
 
   int ga_idx = half_idx;
@@ -770,6 +813,7 @@ int sign = 1;
     }
 #endif
     READ_1ST_NBR_SPINOR( SPINORTEX, nbr_idx1, stride1);
+    RECONSTRUCT_FAT_GAUGE_MATRIX(4, fat, ga_idx, fat_sign);
     MAT_MUL_V(A, fat, i);	 
     o00_re += A0_re;
     o00_im += A0_im;
@@ -806,7 +850,7 @@ int sign = 1;
     spinorFloat2 T0, T1, T2;
     READ_3RD_NBR_SPINOR(T, SPINORTEX, nbr_idx3, stride3);
 
-    RECONSTRUCT_GAUGE_MATRIX(4, long, ga_idx, sign);    
+    RECONSTRUCT_LONG_GAUGE_MATRIX(4, long, ga_idx, long_sign);
     MAT_MUL_V(B, long, t);        
     o00_re += B0_re;
     o00_im += B0_im;
@@ -822,8 +866,11 @@ int sign = 1;
 {
   //direction: -Z
 
-#if ((DD_RECON == 12 || DD_RECON == 8) && DD_IMPROVED==1)
-  int sign = ((y[3]+y[0]+y[1])%2 == 1) ? -1 : 1;
+#if (DD_FAT_RECON == 12 || DD_FAT_RECON == 8)
+  int fat_sign = ((y[3]+y[0]+y[1])%2 == 1) ? -1 : 1;
+#endif
+#if ((DD_LONG_RECON == 12 || DD_LONG_RECON == 8) && DD_IMPROVED==1)
+  int long_sign = ((y[3]+y[0]+y[1])%2 == 1) ? -1 : 1;
 #endif
 
   int dir = 5;
@@ -857,6 +904,7 @@ int sign = 1;
     }
 #endif
     READ_1ST_NBR_SPINOR( SPINORTEX, nbr_idx1, stride1);
+    RECONSTRUCT_FAT_GAUGE_MATRIX(5, fat, ga_idx, fat_sign);
     ADJ_MAT_MUL_V(A, fat, i);
     o00_re -= A0_re;
     o00_im -= A0_im;
@@ -899,7 +947,7 @@ int sign = 1;
     spinorFloat2 T0, T1, T2;
     READ_3RD_NBR_SPINOR(T, SPINORTEX, nbr_idx3, stride3);
 
-    RECONSTRUCT_GAUGE_MATRIX(5, long, sp_idx_3rd_nbr,sign);
+    RECONSTRUCT_LONG_GAUGE_MATRIX(5, long, sp_idx_3rd_nbr,long_sign);
     ADJ_MAT_MUL_V(B, long, t);    	    
     o00_re -= B0_re;
     o00_im -= B0_im;
@@ -914,8 +962,11 @@ int sign = 1;
 
 {
   //direction: +T
-#if ((DD_RECON == 12 || DD_RECON == 8) && DD_IMPROVED==1)
-  int sign = (y[3] >= (X4-3)) ? -1 : 1;
+#if (DD_FAT_RECON == 12 || DD_FAT_RECON == 8)
+  int fat_sign = (y[3] >= (X4-1)) ? -1 : 1;
+#endif
+#if ((DD_LONG_RECON == 12 || DD_LONG_RECON == 8) && DD_IMPROVED==1)
+  int long_sign = (y[3] >= (X4-3)) ? -1 : 1;
 #endif
 
   int ga_idx = half_idx;
@@ -943,6 +994,7 @@ int sign = 1;
     }
 #endif
     READ_1ST_NBR_SPINOR( SPINORTEX, nbr_idx1, stride1);    
+    RECONSTRUCT_FAT_GAUGE_MATRIX(6, fat, ga_idx, fat_sign);
     MAT_MUL_V(A, fat, i);
     o00_re += A0_re;
     o00_im += A0_im;
@@ -981,7 +1033,7 @@ int sign = 1;
     spinorFloat2 T0, T1, T2;
     READ_3RD_NBR_SPINOR(T, SPINORTEX, nbr_idx3, stride3); 
 
-    RECONSTRUCT_GAUGE_MATRIX(6, long, ga_idx, sign);
+    RECONSTRUCT_LONG_GAUGE_MATRIX(6, long, ga_idx, long_sign);
     MAT_MUL_V(B, long, t);    
     o00_re += B0_re;
     o00_im += B0_im;
@@ -995,8 +1047,11 @@ int sign = 1;
 
 {
   //direction: -T
-#if ((DD_RECON == 12 || DD_RECON == 8) && DD_IMPROVED==1)
-  int sign = ( ((y[3]+(X[3]-3))%X[3])>= (X[3]-3) ) ? -1 : 1;
+#if (DD_FAT_RECON == 12 || DD_FAT_RECON == 8)
+  int fat_sign = ( ((y[3]+(X[3]-1))%X[3])>= (X[3]-1) ) ? -1 : 1;
+#endif
+#if ((DD_LONG_RECON == 12 || DD_LONG_RECON == 8) && DD_IMPROVED==1)
+  int long_sign = ( ((y[3]+(X[3]-3))%X[3])>= (X[3]-3) ) ? -1 : 1;
 #endif
 
   int dir = 7;
@@ -1029,6 +1084,7 @@ int sign = 1;
 #endif
     READ_FAT_MATRIX(FATLINK1TEX, dir, fat_idx, fat_stride);
     READ_1ST_NBR_SPINOR( SPINORTEX, nbr_idx1, stride1);
+    RECONSTRUCT_FAT_GAUGE_MATRIX(7, fat, ga_idx, fat_sign);
     ADJ_MAT_MUL_V(A, fat, i);
     o00_re -= A0_re;
     o00_im -= A0_im;
@@ -1068,7 +1124,7 @@ int sign = 1;
     spinorFloat2 T0, T1, T2;
     READ_3RD_NBR_SPINOR(T, SPINORTEX, nbr_idx3, stride3);       
 
-    RECONSTRUCT_GAUGE_MATRIX(7, long, sp_idx_3rd_nbr, sign);    
+    RECONSTRUCT_LONG_GAUGE_MATRIX(7, long, sp_idx_3rd_nbr, long_sign);
     ADJ_MAT_MUL_V(B, long, t);    
     o00_re -= B0_re;
     o00_im -= B0_im;

--- a/lib/dslash_quda.cuh
+++ b/lib/dslash_quda.cuh
@@ -1,10 +1,10 @@
 
-  static FaceBuffer *face[2];
+static FaceBuffer *face[2];
 
-  void setFace(const FaceBuffer &Face1, const FaceBuffer &Face2) {
-    face[0] = (FaceBuffer*)&(Face1); 
-    face[1] = (FaceBuffer*)&(Face2); // nasty
-  }
+void setFace(const FaceBuffer &Face1, const FaceBuffer &Face2) {
+  face[0] = (FaceBuffer*)&(Face1); 
+  face[1] = (FaceBuffer*)&(Face2); // nasty
+}
 
 #define MORE_GENERIC_DSLASH(FUNC, DAG, X, kernel_type, gridDim, blockDim, shared, stream, param,  ...) \
   if (x==0) {								\
@@ -12,7 +12,7 @@
       FUNC ## 18 ## DAG ## Kernel<kernel_type><<<gridDim, blockDim, shared, stream>>> ( __VA_ARGS__ , param); \
     } else if (reconstruct == QUDA_RECONSTRUCT_12) {			\
       FUNC ## 12 ## DAG ## Kernel<kernel_type><<<gridDim, blockDim, shared, stream>>> ( __VA_ARGS__ , param); \
-    } else if (reconstruct == QUDA_RECONSTRUCT_8) {								\
+    } else if (reconstruct == QUDA_RECONSTRUCT_8) {			\
       FUNC ## 8 ## DAG ## Kernel<kernel_type><<<gridDim, blockDim, shared, stream>>> ( __VA_ARGS__, param); \
     }									\
   } else {								\
@@ -29,27 +29,27 @@
 #define MORE_GENERIC_STAGGERED_DSLASH(FUNC, DAG, X, kernel_type, gridDim, blockDim, shared, stream, param,  ...) \
   if (x==0) {								\
     if (reconstruct == QUDA_RECONSTRUCT_NO) {				\
-      FUNC ## 18 ## DAG ## Kernel<kernel_type><<<gridDim, blockDim, shared, stream>>> ( __VA_ARGS__ , param); \
+      FUNC ## 18 ## 18 ## DAG ## Kernel<kernel_type><<<gridDim, blockDim, shared, stream>>> ( __VA_ARGS__ , param); \
     } else if (reconstruct == QUDA_RECONSTRUCT_13) {			\
-      FUNC ## 13 ## DAG ## Kernel<kernel_type><<<gridDim, blockDim, shared, stream>>> ( __VA_ARGS__ , param); \
+      FUNC ## 18 ## 13 ## DAG ## Kernel<kernel_type><<<gridDim, blockDim, shared, stream>>> ( __VA_ARGS__ , param); \
     } else if (reconstruct == QUDA_RECONSTRUCT_12) {			\
-      FUNC ## 12 ## DAG ## Kernel<kernel_type><<<gridDim, blockDim, shared, stream>>> ( __VA_ARGS__ , param); \
-    } else if (reconstruct == QUDA_RECONSTRUCT_9) {								\
-      FUNC ## 9 ## DAG ## Kernel<kernel_type><<<gridDim, blockDim, shared, stream>>> ( __VA_ARGS__, param); \
-    } else if (reconstruct == QUDA_RECONSTRUCT_8) {								\
-      FUNC ## 8 ## DAG ## Kernel<kernel_type><<<gridDim, blockDim, shared, stream>>> ( __VA_ARGS__, param); \
+      FUNC ## 18 ## 12 ## DAG ## Kernel<kernel_type><<<gridDim, blockDim, shared, stream>>> ( __VA_ARGS__ , param); \
+    } else if (reconstruct == QUDA_RECONSTRUCT_9) {			\
+      FUNC ## 18 ## 9 ## DAG ## Kernel<kernel_type><<<gridDim, blockDim, shared, stream>>> ( __VA_ARGS__, param); \
+    } else if (reconstruct == QUDA_RECONSTRUCT_8) {			\
+      FUNC ## 18 ## 8 ## DAG ## Kernel<kernel_type><<<gridDim, blockDim, shared, stream>>> ( __VA_ARGS__, param); \
     }									\
   } else {								\
     if (reconstruct == QUDA_RECONSTRUCT_NO) {				\
-      FUNC ## 18 ## DAG ## X ## Kernel<kernel_type><<<gridDim, blockDim, shared, stream>>> ( __VA_ARGS__, param); \
+      FUNC ## 18 ## 18 ## DAG ## X ## Kernel<kernel_type><<<gridDim, blockDim, shared, stream>>> ( __VA_ARGS__, param); \
     } else if (reconstruct == QUDA_RECONSTRUCT_13) {			\
-      FUNC ## 13 ## DAG ## X ## Kernel<kernel_type><<<gridDim, blockDim, shared, stream>>> ( __VA_ARGS__, param); \
+      FUNC ## 18 ## 13 ## DAG ## X ## Kernel<kernel_type><<<gridDim, blockDim, shared, stream>>> ( __VA_ARGS__, param); \
     } else if (reconstruct == QUDA_RECONSTRUCT_12) {			\
-      FUNC ## 12 ## DAG ## X ## Kernel<kernel_type><<<gridDim, blockDim, shared, stream>>> ( __VA_ARGS__, param); \
+      FUNC ## 18 ## 12 ## DAG ## X ## Kernel<kernel_type><<<gridDim, blockDim, shared, stream>>> ( __VA_ARGS__, param); \
     } else if (reconstruct == QUDA_RECONSTRUCT_9) {			\
-      FUNC ## 9 ## DAG ## X ## Kernel<kernel_type> <<<gridDim, blockDim, shared, stream>>> ( __VA_ARGS__, param); \
+      FUNC ## 18 ## 9 ## DAG ## X ## Kernel<kernel_type> <<<gridDim, blockDim, shared, stream>>> ( __VA_ARGS__, param); \
     } else if (reconstruct == QUDA_RECONSTRUCT_8) {			\
-      FUNC ## 8 ## DAG ## X ## Kernel<kernel_type> <<<gridDim, blockDim, shared, stream>>> ( __VA_ARGS__, param); \
+      FUNC ## 18 ## 8 ## DAG ## X ## Kernel<kernel_type> <<<gridDim, blockDim, shared, stream>>> ( __VA_ARGS__, param); \
     }                                                                   \
   }
 
@@ -58,20 +58,20 @@
 
 #define GENERIC_DSLASH(FUNC, DAG, X, gridDim, blockDim, shared, stream, param,  ...) \
   switch(param.kernel_type) {						\
-    case INTERIOR_KERNEL:							\
-                                                                                MORE_GENERIC_DSLASH(FUNC, DAG, X, INTERIOR_KERNEL, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
-    break;								\
-    default:								\
-                                                                        errorQuda("KernelType %d not defined for single GPU", param.kernel_type); \
+  case INTERIOR_KERNEL:							\
+    MORE_GENERIC_DSLASH(FUNC, DAG, X, INTERIOR_KERNEL, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
+      break;								\
+  default:								\
+    errorQuda("KernelType %d not defined for single GPU", param.kernel_type); \
   }
 
 #define GENERIC_STAGGERED_DSLASH(FUNC, DAG, X, gridDim, blockDim, shared, stream, param,  ...) \
   switch(param.kernel_type) {						\
-    case INTERIOR_KERNEL:							\
-                                                                                MORE_GENERIC_STAGGERED_DSLASH(FUNC, DAG, X, INTERIOR_KERNEL, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
-    break;								\
-    default:								\
-                                                                        errorQuda("KernelType %d not defined for single GPU", param.kernel_type); \
+  case INTERIOR_KERNEL:							\
+    MORE_GENERIC_STAGGERED_DSLASH(FUNC, DAG, X, INTERIOR_KERNEL, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
+      break;								\
+  default:								\
+    errorQuda("KernelType %d not defined for single GPU", param.kernel_type); \
   }
 
 
@@ -79,62 +79,62 @@
 
 #define GENERIC_DSLASH(FUNC, DAG, X, gridDim, blockDim, shared, stream, param,  ...) \
   switch(param.kernel_type) {						\
-    case INTERIOR_KERNEL:							\
-                                                                                MORE_GENERIC_DSLASH(FUNC, DAG, X, INTERIOR_KERNEL,   gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
-    break;								\
-    case EXTERIOR_KERNEL_X:						\
-                                                                        MORE_GENERIC_DSLASH(FUNC, DAG, X, EXTERIOR_KERNEL_X, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
-    break;								\
-    case EXTERIOR_KERNEL_Y:						\
-                                                                        MORE_GENERIC_DSLASH(FUNC, DAG, X, EXTERIOR_KERNEL_Y, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
-    break;								\
-    case EXTERIOR_KERNEL_Z:						\
-                                                                        MORE_GENERIC_DSLASH(FUNC, DAG, X, EXTERIOR_KERNEL_Z, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
-    break;								\
-    case EXTERIOR_KERNEL_T:						\
-                                                                        MORE_GENERIC_DSLASH(FUNC, DAG, X, EXTERIOR_KERNEL_T, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
-    break;								\
-    case EXTERIOR_KERNEL_ALL:						\
-                                                                        MORE_GENERIC_DSLASH(FUNC, DAG, X, EXTERIOR_KERNEL_ALL, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
-    break;								\
+  case INTERIOR_KERNEL:							\
+    MORE_GENERIC_DSLASH(FUNC, DAG, X, INTERIOR_KERNEL,   gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
+      break;								\
+  case EXTERIOR_KERNEL_X:						\
+    MORE_GENERIC_DSLASH(FUNC, DAG, X, EXTERIOR_KERNEL_X, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
+      break;								\
+  case EXTERIOR_KERNEL_Y:						\
+    MORE_GENERIC_DSLASH(FUNC, DAG, X, EXTERIOR_KERNEL_Y, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
+      break;								\
+  case EXTERIOR_KERNEL_Z:						\
+    MORE_GENERIC_DSLASH(FUNC, DAG, X, EXTERIOR_KERNEL_Z, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
+      break;								\
+  case EXTERIOR_KERNEL_T:						\
+    MORE_GENERIC_DSLASH(FUNC, DAG, X, EXTERIOR_KERNEL_T, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
+      break;								\
+  case EXTERIOR_KERNEL_ALL:						\
+    MORE_GENERIC_DSLASH(FUNC, DAG, X, EXTERIOR_KERNEL_ALL, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
+      break;								\
   }
 
 #define GENERIC_STAGGERED_DSLASH(FUNC, DAG, X, gridDim, blockDim, shared, stream, param,  ...) \
   switch(param.kernel_type) {						\
-    case INTERIOR_KERNEL:							\
-                                                                                MORE_GENERIC_STAGGERED_DSLASH(FUNC, DAG, X, INTERIOR_KERNEL,   gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
-    break;								\
-    case EXTERIOR_KERNEL_X:						\
-                                                                        MORE_GENERIC_STAGGERED_DSLASH(FUNC, DAG, X, EXTERIOR_KERNEL_X, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
-    break;								\
-    case EXTERIOR_KERNEL_Y:						\
-                                                                        MORE_GENERIC_STAGGERED_DSLASH(FUNC, DAG, X, EXTERIOR_KERNEL_Y, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
-    break;								\
-    case EXTERIOR_KERNEL_Z:						\
-                                                                        MORE_GENERIC_STAGGERED_DSLASH(FUNC, DAG, X, EXTERIOR_KERNEL_Z, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
-    break;								\
-    case EXTERIOR_KERNEL_T:						\
-                                                                        MORE_GENERIC_STAGGERED_DSLASH(FUNC, DAG, X, EXTERIOR_KERNEL_T, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
-    break;								\
-    case EXTERIOR_KERNEL_ALL:						\
-                                                                        MORE_GENERIC_STAGGERED_DSLASH(FUNC, DAG, X, EXTERIOR_KERNEL_ALL, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
-    break;                                                              \
+  case INTERIOR_KERNEL:							\
+    MORE_GENERIC_STAGGERED_DSLASH(FUNC, DAG, X, INTERIOR_KERNEL,   gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
+      break;								\
+  case EXTERIOR_KERNEL_X:						\
+    MORE_GENERIC_STAGGERED_DSLASH(FUNC, DAG, X, EXTERIOR_KERNEL_X, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
+      break;								\
+  case EXTERIOR_KERNEL_Y:						\
+    MORE_GENERIC_STAGGERED_DSLASH(FUNC, DAG, X, EXTERIOR_KERNEL_Y, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
+      break;								\
+  case EXTERIOR_KERNEL_Z:						\
+    MORE_GENERIC_STAGGERED_DSLASH(FUNC, DAG, X, EXTERIOR_KERNEL_Z, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
+      break;								\
+  case EXTERIOR_KERNEL_T:						\
+    MORE_GENERIC_STAGGERED_DSLASH(FUNC, DAG, X, EXTERIOR_KERNEL_T, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
+      break;								\
+  case EXTERIOR_KERNEL_ALL:						\
+    MORE_GENERIC_STAGGERED_DSLASH(FUNC, DAG, X, EXTERIOR_KERNEL_ALL, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
+      break;								\
   }
 
 
 #endif
 
-  // macro used for dslash types with dagger kernel defined (Wilson, domain wall, etc.)
+// macro used for dslash types with dagger kernel defined (Wilson, domain wall, etc.)
 #define DSLASH(FUNC, gridDim, blockDim, shared, stream, param, ...)	\
   if (!dagger) {							\
     GENERIC_DSLASH(FUNC, , Xpay, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
-  } else {								\
+      } else {								\
     GENERIC_DSLASH(FUNC, Dagger, Xpay, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
-  }
+      }
 
-  // macro used for staggered dslash
+// macro used for staggered dslash
 #define STAGGERED_DSLASH(gridDim, blockDim, shared, stream, param, ...)	\
-  GENERIC_STAGGERED_DSLASH(staggeredDslash, , Axpy, gridDim, blockDim, shared, stream, param, __VA_ARGS__)
+  GENERIC_DSLASH(staggeredDslash, , Axpy, gridDim, blockDim, shared, stream, param, __VA_ARGS__)
 
 #define IMPROVED_STAGGERED_DSLASH(gridDim, blockDim, shared, stream, param, ...) \
   GENERIC_STAGGERED_DSLASH(improvedStaggeredDslash, , Axpy, gridDim, blockDim, shared, stream, param, __VA_ARGS__) 
@@ -152,53 +152,53 @@
 
 #define GENERIC_ASYM_DSLASH(FUNC, DAG, X, gridDim, blockDim, shared, stream, param,  ...) \
   switch(param.kernel_type) {						\
-    case INTERIOR_KERNEL:							\
-                                                                                MORE_GENERIC_ASYM_DSLASH(FUNC, DAG, X, INTERIOR_KERNEL, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
-    break;								\
-    default:								\
-                                                                        errorQuda("KernelType %d not defined for single GPU", param.kernel_type); \
+  case INTERIOR_KERNEL:							\
+    MORE_GENERIC_ASYM_DSLASH(FUNC, DAG, X, INTERIOR_KERNEL, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
+      break;								\
+  default:								\
+    errorQuda("KernelType %d not defined for single GPU", param.kernel_type); \
   }
 
 #else
 
 #define GENERIC_ASYM_DSLASH(FUNC, DAG, X, gridDim, blockDim, shared, stream, param,  ...) \
   switch(param.kernel_type) {						\
-    case INTERIOR_KERNEL:							\
-                                                                                MORE_GENERIC_ASYM_DSLASH(FUNC, DAG, X, INTERIOR_KERNEL,   gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
-    break;								\
-    case EXTERIOR_KERNEL_X:						\
-                                                                        MORE_GENERIC_ASYM_DSLASH(FUNC, DAG, X, EXTERIOR_KERNEL_X, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
-    break;								\
-    case EXTERIOR_KERNEL_Y:						\
-                                                                        MORE_GENERIC_ASYM_DSLASH(FUNC, DAG, X, EXTERIOR_KERNEL_Y, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
-    break;								\
-    case EXTERIOR_KERNEL_Z:						\
-                                                                        MORE_GENERIC_ASYM_DSLASH(FUNC, DAG, X, EXTERIOR_KERNEL_Z, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
-    break;								\
-    case EXTERIOR_KERNEL_T:						\
-                                                                        MORE_GENERIC_ASYM_DSLASH(FUNC, DAG, X, EXTERIOR_KERNEL_T, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
-    break;								\
-    case EXTERIOR_KERNEL_ALL:						\
-                                                                        MORE_GENERIC_ASYM_DSLASH(FUNC, DAG, X, EXTERIOR_KERNEL_ALL, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
-    break;								\
+  case INTERIOR_KERNEL:							\
+    MORE_GENERIC_ASYM_DSLASH(FUNC, DAG, X, INTERIOR_KERNEL,   gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
+      break;								\
+  case EXTERIOR_KERNEL_X:						\
+    MORE_GENERIC_ASYM_DSLASH(FUNC, DAG, X, EXTERIOR_KERNEL_X, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
+      break;								\
+  case EXTERIOR_KERNEL_Y:						\
+    MORE_GENERIC_ASYM_DSLASH(FUNC, DAG, X, EXTERIOR_KERNEL_Y, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
+      break;								\
+  case EXTERIOR_KERNEL_Z:						\
+    MORE_GENERIC_ASYM_DSLASH(FUNC, DAG, X, EXTERIOR_KERNEL_Z, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
+      break;								\
+  case EXTERIOR_KERNEL_T:						\
+    MORE_GENERIC_ASYM_DSLASH(FUNC, DAG, X, EXTERIOR_KERNEL_T, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
+      break;								\
+  case EXTERIOR_KERNEL_ALL:						\
+    MORE_GENERIC_ASYM_DSLASH(FUNC, DAG, X, EXTERIOR_KERNEL_ALL, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
+      break;								\
   }
 
 #endif
 
-  // macro used for dslash types with dagger kernel defined (Wilson, domain wall, etc.)
+// macro used for dslash types with dagger kernel defined (Wilson, domain wall, etc.)
 #define ASYM_DSLASH(FUNC, gridDim, blockDim, shared, stream, param, ...) \
   if (!dagger) {							\
     GENERIC_ASYM_DSLASH(FUNC, , Xpay, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
-  } else {								\
+      } else {								\
     GENERIC_ASYM_DSLASH(FUNC, Dagger, Xpay, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
-  }
+      }
 
 
 
-  //macro used for twisted mass dslash:
+//macro used for twisted mass dslash:
 
 #define MORE_GENERIC_NDEG_TM_DSLASH(FUNC, DAG, X, kernel_type, gridDim, blockDim, shared, stream, param,  ...) \
-  if (x == 0 && d == 0) {								\
+  if (x == 0 && d == 0) {						\
     if (reconstruct == QUDA_RECONSTRUCT_NO) {				\
       FUNC ## 18 ## DAG ## Twist ## Kernel<kernel_type><<<gridDim, blockDim, shared, stream>>> ( __VA_ARGS__ , param); \
     } else if (reconstruct == QUDA_RECONSTRUCT_12) {			\
@@ -206,7 +206,7 @@
     } else {								\
       FUNC ## 8 ## DAG ## Twist ## Kernel<kernel_type><<<gridDim, blockDim, shared, stream>>> ( __VA_ARGS__, param); \
     }									\
-  } else if (x != 0 && d == 0) {								\
+  } else if (x != 0 && d == 0) {					\
     if (reconstruct == QUDA_RECONSTRUCT_NO) {				\
       FUNC ## 18 ## DAG ## Twist ## X ## Kernel<kernel_type><<<gridDim, blockDim, shared, stream>>> ( __VA_ARGS__, param); \
     } else if (reconstruct == QUDA_RECONSTRUCT_12) {			\
@@ -214,7 +214,7 @@
     } else if (reconstruct == QUDA_RECONSTRUCT_8) {			\
       FUNC ## 8 ## DAG ## Twist ## X ## Kernel<kernel_type> <<<gridDim, blockDim, shared, stream>>> ( __VA_ARGS__, param); \
     }									\
-  } else if (x == 0 && d != 0) {								\
+  } else if (x == 0 && d != 0) {					\
     if (reconstruct == QUDA_RECONSTRUCT_NO) {				\
       FUNC ## 18 ## DAG ## Kernel<kernel_type><<<gridDim, blockDim, shared, stream>>> ( __VA_ARGS__ , param); \
     } else if (reconstruct == QUDA_RECONSTRUCT_12) {			\
@@ -236,385 +236,385 @@
 
 #define GENERIC_NDEG_TM_DSLASH(FUNC, DAG, X, gridDim, blockDim, shared, stream, param,  ...) \
   switch(param.kernel_type) {						\
-    case INTERIOR_KERNEL:							\
-                                                                                MORE_GENERIC_NDEG_TM_DSLASH(FUNC, DAG, X, INTERIOR_KERNEL, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
-    break;								\
-    default:								\
-                                                                        errorQuda("KernelType %d not defined for single GPU", param.kernel_type); \
+  case INTERIOR_KERNEL:							\
+    MORE_GENERIC_NDEG_TM_DSLASH(FUNC, DAG, X, INTERIOR_KERNEL, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
+      break;								\
+  default:								\
+    errorQuda("KernelType %d not defined for single GPU", param.kernel_type); \
   }
 
 #else
 
 #define GENERIC_NDEG_TM_DSLASH(FUNC, DAG, X, gridDim, blockDim, shared, stream, param,  ...) \
   switch(param.kernel_type) {						\
-    case INTERIOR_KERNEL:							\
-                                                                                MORE_GENERIC_NDEG_TM_DSLASH(FUNC, DAG, X, INTERIOR_KERNEL,   gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
-    break;								\
-    case EXTERIOR_KERNEL_X:						\
-                                                                        MORE_GENERIC_NDEG_TM_DSLASH(FUNC, DAG, X, EXTERIOR_KERNEL_X, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
-    break;								\
-    case EXTERIOR_KERNEL_Y:						\
-                                                                        MORE_GENERIC_NDEG_TM_DSLASH(FUNC, DAG, X, EXTERIOR_KERNEL_Y, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
-    break;								\
-    case EXTERIOR_KERNEL_Z:						\
-                                                                        MORE_GENERIC_NDEG_TM_DSLASH(FUNC, DAG, X, EXTERIOR_KERNEL_Z, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
-    break;								\
-    case EXTERIOR_KERNEL_T:						\
-                                                                        MORE_GENERIC_NDEG_TM_DSLASH(FUNC, DAG, X, EXTERIOR_KERNEL_T, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
-    break;								\
-    case EXTERIOR_KERNEL_ALL:						\
-                                                                        MORE_GENERIC_NDEG_TM_DSLASH(FUNC, DAG, X, EXTERIOR_KERNEL_ALL, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
-    break;								\
+  case INTERIOR_KERNEL:							\
+    MORE_GENERIC_NDEG_TM_DSLASH(FUNC, DAG, X, INTERIOR_KERNEL,   gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
+      break;								\
+  case EXTERIOR_KERNEL_X:						\
+    MORE_GENERIC_NDEG_TM_DSLASH(FUNC, DAG, X, EXTERIOR_KERNEL_X, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
+      break;								\
+  case EXTERIOR_KERNEL_Y:						\
+    MORE_GENERIC_NDEG_TM_DSLASH(FUNC, DAG, X, EXTERIOR_KERNEL_Y, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
+      break;								\
+  case EXTERIOR_KERNEL_Z:						\
+    MORE_GENERIC_NDEG_TM_DSLASH(FUNC, DAG, X, EXTERIOR_KERNEL_Z, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
+      break;								\
+  case EXTERIOR_KERNEL_T:						\
+    MORE_GENERIC_NDEG_TM_DSLASH(FUNC, DAG, X, EXTERIOR_KERNEL_T, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
+      break;								\
+  case EXTERIOR_KERNEL_ALL:						\
+    MORE_GENERIC_NDEG_TM_DSLASH(FUNC, DAG, X, EXTERIOR_KERNEL_ALL, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
+      break;								\
   }
 
 #endif
 
-#define NDEG_TM_DSLASH(FUNC, gridDim, blockDim, shared, stream, param, ...)	\
+#define NDEG_TM_DSLASH(FUNC, gridDim, blockDim, shared, stream, param, ...) \
   if (!dagger) {							\
     GENERIC_NDEG_TM_DSLASH(FUNC, , Xpay, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
-  } else {								\
+      } else {								\
     GENERIC_NDEG_TM_DSLASH(FUNC, Dagger, Xpay, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
-  }
-  //end of tm dslash macro
-
-
-  // Use an abstract class interface to drive the different CUDA dslash
-  // kernels. All parameters are curried into the derived classes to
-  // allow a simple interface.
-  class DslashCuda : public Tunable {
-
-  protected:
-    cudaColorSpinorField *out;
-    const cudaColorSpinorField *in;
-    const cudaColorSpinorField *x;
-    const QudaReconstructType reconstruct;
-    char *saveOut, *saveOutNorm;
-    const int dagger;
-
-    unsigned int sharedBytesPerBlock(const TuneParam &param) const { return 0; }
-    bool tuneGridDim() const { return false; } // Don't tune the grid dimensions.
-    // all dslashes expect a 4-d volume here (dwf Ls is y thread dimension)
-    unsigned int minThreads() const { return in->X(0) * in->X(1) * in->X(2) * in->X(3); } 
-    char aux[7][TuneKey::aux_n];
-
-    void fillAux(KernelType kernel_type, const char *kernel_str) {
-      strcpy(aux[kernel_type],kernel_str);
-#ifdef MULTI_GPU
-      char comm[5];
-      comm[0] = (dslashParam.commDim[0] ? '1' : '0');
-      comm[1] = (dslashParam.commDim[1] ? '1' : '0');
-      comm[2] = (dslashParam.commDim[2] ? '1' : '0');
-      comm[3] = (dslashParam.commDim[3] ? '1' : '0');
-      comm[4] = '\0'; 
-      strcat(aux[kernel_type],",comm=");
-      strcat(aux[kernel_type],comm);
-      if (kernel_type == INTERIOR_KERNEL) {
-	char ghost[5];
-	ghost[0] = (dslashParam.ghostDim[0] ? '1' : '0');
-	ghost[1] = (dslashParam.ghostDim[1] ? '1' : '0');
-	ghost[2] = (dslashParam.ghostDim[2] ? '1' : '0');
-	ghost[3] = (dslashParam.ghostDim[3] ? '1' : '0');
-	ghost[4] = '\0';
-	strcat(aux[kernel_type],",ghost=");
-	strcat(aux[kernel_type],ghost);
       }
+//end of tm dslash macro
+
+
+// Use an abstract class interface to drive the different CUDA dslash
+// kernels. All parameters are curried into the derived classes to
+// allow a simple interface.
+class DslashCuda : public Tunable {
+
+protected:
+  cudaColorSpinorField *out;
+  const cudaColorSpinorField *in;
+  const cudaColorSpinorField *x;
+  const QudaReconstructType reconstruct;
+  char *saveOut, *saveOutNorm;
+  const int dagger;
+
+  unsigned int sharedBytesPerBlock(const TuneParam &param) const { return 0; }
+  bool tuneGridDim() const { return false; } // Don't tune the grid dimensions.
+  // all dslashes expect a 4-d volume here (dwf Ls is y thread dimension)
+  unsigned int minThreads() const { return in->X(0) * in->X(1) * in->X(2) * in->X(3); } 
+  char aux[7][TuneKey::aux_n];
+
+  void fillAux(KernelType kernel_type, const char *kernel_str) {
+    strcpy(aux[kernel_type],kernel_str);
+#ifdef MULTI_GPU
+    char comm[5];
+    comm[0] = (dslashParam.commDim[0] ? '1' : '0');
+    comm[1] = (dslashParam.commDim[1] ? '1' : '0');
+    comm[2] = (dslashParam.commDim[2] ? '1' : '0');
+    comm[3] = (dslashParam.commDim[3] ? '1' : '0');
+    comm[4] = '\0'; 
+    strcat(aux[kernel_type],",comm=");
+    strcat(aux[kernel_type],comm);
+    if (kernel_type == INTERIOR_KERNEL) {
+      char ghost[5];
+      ghost[0] = (dslashParam.ghostDim[0] ? '1' : '0');
+      ghost[1] = (dslashParam.ghostDim[1] ? '1' : '0');
+      ghost[2] = (dslashParam.ghostDim[2] ? '1' : '0');
+      ghost[3] = (dslashParam.ghostDim[3] ? '1' : '0');
+      ghost[4] = '\0';
+      strcat(aux[kernel_type],",ghost=");
+      strcat(aux[kernel_type],ghost);
+    }
 #endif
 
-      if (reconstruct == QUDA_RECONSTRUCT_NO) 
-	strcat(aux[kernel_type],",reconstruct=18");
-      else if (reconstruct == QUDA_RECONSTRUCT_13) 
-	strcat(aux[kernel_type],",reconstruct=13");
-      else if (reconstruct == QUDA_RECONSTRUCT_12) 
-	strcat(aux[kernel_type],",reconstruct=12");
-      else if (reconstruct == QUDA_RECONSTRUCT_9) 
-	strcat(aux[kernel_type],",reconstruct=9");
-      else if (reconstruct == QUDA_RECONSTRUCT_8) 
-	strcat(aux[kernel_type],",reconstruct=8");
+    if (reconstruct == QUDA_RECONSTRUCT_NO) 
+      strcat(aux[kernel_type],",reconstruct=18");
+    else if (reconstruct == QUDA_RECONSTRUCT_13) 
+      strcat(aux[kernel_type],",reconstruct=13");
+    else if (reconstruct == QUDA_RECONSTRUCT_12) 
+      strcat(aux[kernel_type],",reconstruct=12");
+    else if (reconstruct == QUDA_RECONSTRUCT_9) 
+      strcat(aux[kernel_type],",reconstruct=9");
+    else if (reconstruct == QUDA_RECONSTRUCT_8) 
+      strcat(aux[kernel_type],",reconstruct=8");
 
-      if (x) strcat(aux[kernel_type],",Xpay");
-      if (dagger) strcat(aux[kernel_type],",dagger");
-    }
+    if (x) strcat(aux[kernel_type],",Xpay");
+    if (dagger) strcat(aux[kernel_type],",dagger");
+  }
 
-  public:
-    DslashCuda(cudaColorSpinorField *out, const cudaColorSpinorField *in,
-	       const cudaColorSpinorField *x, const QudaReconstructType reconstruct,
-	       const int dagger) 
-      : out(out), in(in), x(x), reconstruct(reconstruct), 
-	dagger(dagger), saveOut(0), saveOutNorm(0) { 
+public:
+  DslashCuda(cudaColorSpinorField *out, const cudaColorSpinorField *in,
+	     const cudaColorSpinorField *x, const QudaReconstructType reconstruct,
+	     const int dagger) 
+    : out(out), in(in), x(x), reconstruct(reconstruct), 
+      dagger(dagger), saveOut(0), saveOutNorm(0) { 
 
 #ifdef MULTI_GPU 
-      fillAux(INTERIOR_KERNEL, "type=interior");
-      fillAux(EXTERIOR_KERNEL_ALL, "type=exterior_all");
-      fillAux(EXTERIOR_KERNEL_X, "type=exterior_x");
-      fillAux(EXTERIOR_KERNEL_Y, "type=exterior_y");
-      fillAux(EXTERIOR_KERNEL_Z, "type=exterior_z");
-      fillAux(EXTERIOR_KERNEL_T, "type=exterior_t");
+    fillAux(INTERIOR_KERNEL, "type=interior");
+    fillAux(EXTERIOR_KERNEL_ALL, "type=exterior_all");
+    fillAux(EXTERIOR_KERNEL_X, "type=exterior_x");
+    fillAux(EXTERIOR_KERNEL_Y, "type=exterior_y");
+    fillAux(EXTERIOR_KERNEL_Z, "type=exterior_z");
+    fillAux(EXTERIOR_KERNEL_T, "type=exterior_t");
 #else
-      fillAux(INTERIOR_KERNEL, "type=single-GPU");
+    fillAux(INTERIOR_KERNEL, "type=single-GPU");
 #endif // MULTI_GPU
 
-      dslashParam.sp_stride = in->Stride();
+    dslashParam.sp_stride = in->Stride();
 
-      // this sets the communications pattern for the packing kernel
-      setPackComms(dslashParam.commDim);
+    // this sets the communications pattern for the packing kernel
+    setPackComms(dslashParam.commDim);
 
-      for (int i=0; i<4; i++) dslashParam.X[i] = in->X(i);
+    for (int i=0; i<4; i++) dslashParam.X[i] = in->X(i);
 #ifdef GPU_DOMAIN_WALL_DIRAC
-      dslashParam.Ls = in->X(4); // needed by tuneLaunch()
+    dslashParam.Ls = in->X(4); // needed by tuneLaunch()
 #endif
-      // this is a c/b field so double the x dimension
-      dslashParam.X[0] *= 2;
-    }
+    // this is a c/b field so double the x dimension
+    dslashParam.X[0] *= 2;
+  }
 
-    virtual ~DslashCuda() { }
-    virtual TuneKey tuneKey() const  
-    { return TuneKey(in->VolString(), typeid(*this).name(), aux[dslashParam.kernel_type]); }
+  virtual ~DslashCuda() { }
+  virtual TuneKey tuneKey() const  
+  { return TuneKey(in->VolString(), typeid(*this).name(), aux[dslashParam.kernel_type]); }
 
-    std::string paramString(const TuneParam &param) const // Don't bother printing the grid dim.
-    {
-      std::stringstream ps;
-      ps << "block=(" << param.block.x << "," << param.block.y << "," << param.block.z << "), ";
-      ps << "shared=" << param.shared_bytes;
-      return ps.str();
-    }
-    virtual int Nface() { return 2; }
+  std::string paramString(const TuneParam &param) const // Don't bother printing the grid dim.
+  {
+    std::stringstream ps;
+    ps << "block=(" << param.block.x << "," << param.block.y << "," << param.block.z << "), ";
+    ps << "shared=" << param.shared_bytes;
+    return ps.str();
+  }
+  virtual int Nface() { return 2; }
 
-    virtual void preTune()
-    {
-      if (dslashParam.kernel_type != INTERIOR_KERNEL) { // exterior kernel
-	saveOut = new char[out->Bytes()];
-	cudaMemcpy(saveOut, out->V(), out->Bytes(), cudaMemcpyDeviceToHost);
-	if (out->Precision() == QUDA_HALF_PRECISION) {
-	  saveOutNorm = new char[out->NormBytes()];
-	  cudaMemcpy(saveOutNorm, out->Norm(), out->NormBytes(), cudaMemcpyDeviceToHost);
-	}
+  virtual void preTune()
+  {
+    if (dslashParam.kernel_type != INTERIOR_KERNEL) { // exterior kernel
+      saveOut = new char[out->Bytes()];
+      cudaMemcpy(saveOut, out->V(), out->Bytes(), cudaMemcpyDeviceToHost);
+      if (out->Precision() == QUDA_HALF_PRECISION) {
+	saveOutNorm = new char[out->NormBytes()];
+	cudaMemcpy(saveOutNorm, out->Norm(), out->NormBytes(), cudaMemcpyDeviceToHost);
       }
     }
+  }
     
-    virtual void postTune()
-    {
-      if (dslashParam.kernel_type != INTERIOR_KERNEL) { // exterior kernel
-	cudaMemcpy(out->V(), saveOut, out->Bytes(), cudaMemcpyHostToDevice);
-	delete[] saveOut;
-	if (out->Precision() == QUDA_HALF_PRECISION) {
-	  cudaMemcpy(out->Norm(), saveOutNorm, out->NormBytes(), cudaMemcpyHostToDevice);
-	  delete[] saveOutNorm;
-	}
+  virtual void postTune()
+  {
+    if (dslashParam.kernel_type != INTERIOR_KERNEL) { // exterior kernel
+      cudaMemcpy(out->V(), saveOut, out->Bytes(), cudaMemcpyHostToDevice);
+      delete[] saveOut;
+      if (out->Precision() == QUDA_HALF_PRECISION) {
+	cudaMemcpy(out->Norm(), saveOutNorm, out->NormBytes(), cudaMemcpyHostToDevice);
+	delete[] saveOutNorm;
       }
     }
+  }
 
-    /*
-      per direction / dimension flops
-      spin project flops = Nc * Ns
-      SU(3) matrix-vector flops = (8 Nc - 2) * Nc
-      spin reconstruction flops = 2 * Nc * Ns (just an accumulation to all components)
-      xpay = 2 * 2 * Nc * Ns
+  /*
+    per direction / dimension flops
+    spin project flops = Nc * Ns
+    SU(3) matrix-vector flops = (8 Nc - 2) * Nc
+    spin reconstruction flops = 2 * Nc * Ns (just an accumulation to all components)
+    xpay = 2 * 2 * Nc * Ns
       
-      So for the full dslash we have, where for the final spin
-      reconstruct we have -1 since the first direction does not
-      require any accumulation.
+    So for the full dslash we have, where for the final spin
+    reconstruct we have -1 since the first direction does not
+    require any accumulation.
       
-      flops = (2 * Nd * Nc * Ns)  +  (2 * Nd * (Ns/2) * (8*Nc-2) * Nc)  +  ((2 * Nd - 1) * 2 * Nc * Ns)
-      flops_xpay = flops + 2 * 2 * Nc * Ns
+    flops = (2 * Nd * Nc * Ns)  +  (2 * Nd * (Ns/2) * (8*Nc-2) * Nc)  +  ((2 * Nd - 1) * 2 * Nc * Ns)
+    flops_xpay = flops + 2 * 2 * Nc * Ns
       
-      For Wilson this should give 1344 for Nc=3,Ns=2 and 1368 for the xpay equivalent
-    */
-    virtual long long flops() const {
-      int mv_flops = (8 * in->Ncolor() - 2) * in->Ncolor(); // SU(3) matrix-vector flops
-      int num_mv_multiply = in->Nspin() == 4 ? 2 : 1;
-      int ghost_flops = (num_mv_multiply * mv_flops + 2*in->Ncolor()*in->Nspin());
-      int xpay_flops = 2 * 2 * in->Ncolor() * in->Nspin(); // multiply and add per real component
-      int num_dir = 2 * 4;
+    For Wilson this should give 1344 for Nc=3,Ns=2 and 1368 for the xpay equivalent
+  */
+  virtual long long flops() const {
+    int mv_flops = (8 * in->Ncolor() - 2) * in->Ncolor(); // SU(3) matrix-vector flops
+    int num_mv_multiply = in->Nspin() == 4 ? 2 : 1;
+    int ghost_flops = (num_mv_multiply * mv_flops + 2*in->Ncolor()*in->Nspin());
+    int xpay_flops = 2 * 2 * in->Ncolor() * in->Nspin(); // multiply and add per real component
+    int num_dir = 2 * 4;
 
-      long long flops;
-      switch(dslashParam.kernel_type) {
-      case EXTERIOR_KERNEL_X:
-      case EXTERIOR_KERNEL_Y:
-      case EXTERIOR_KERNEL_Z:
-      case EXTERIOR_KERNEL_T:
-	flops = (ghost_flops + (x ? xpay_flops : 0)) * 2 * in->GhostFace()[dslashParam.kernel_type];
+    long long flops;
+    switch(dslashParam.kernel_type) {
+    case EXTERIOR_KERNEL_X:
+    case EXTERIOR_KERNEL_Y:
+    case EXTERIOR_KERNEL_Z:
+    case EXTERIOR_KERNEL_T:
+      flops = (ghost_flops + (x ? xpay_flops : 0)) * 2 * in->GhostFace()[dslashParam.kernel_type];
+      break;
+    case EXTERIOR_KERNEL_ALL:
+      {
+	long long ghost_sites = 2 * (in->GhostFace()[0]+in->GhostFace()[1]+in->GhostFace()[2]+in->GhostFace()[3]);
+	flops = (ghost_flops + (x ? xpay_flops : 0)) * ghost_sites;
 	break;
-      case EXTERIOR_KERNEL_ALL:
-	{
-	  long long ghost_sites = 2 * (in->GhostFace()[0]+in->GhostFace()[1]+in->GhostFace()[2]+in->GhostFace()[3]);
-	  flops = (ghost_flops + (x ? xpay_flops : 0)) * ghost_sites;
-	  break;
-	}
-      case INTERIOR_KERNEL:
-	{
-	  long long sites = in->VolumeCB();
-	  flops = (num_dir*(in->Nspin()/4)*in->Ncolor()*in->Nspin() +   // spin project (=0 for staggered)
-		   num_dir*num_mv_multiply*mv_flops +                   // SU(3) matrix-vector multiplies
-		   ((num_dir-1)*2*in->Ncolor()*in->Nspin())) * sites;   // accumulation
-	  if (x) flops += xpay_flops * sites;
-
-	  // now correct for flops done by exterior kernel
-	  long long ghost_sites = 0;
-	  for (int d=0; d<4; d++) if (dslashParam.commDim[d]) ghost_sites += 2 * in->GhostFace()[d];
-	  flops -= (ghost_flops + (x ? xpay_flops : 0)) * ghost_sites;
-	  
-	  break;
-	}
       }
-      return flops;
-    }
+    case INTERIOR_KERNEL:
+      {
+	long long sites = in->VolumeCB();
+	flops = (num_dir*(in->Nspin()/4)*in->Ncolor()*in->Nspin() +   // spin project (=0 for staggered)
+		 num_dir*num_mv_multiply*mv_flops +                   // SU(3) matrix-vector multiplies
+		 ((num_dir-1)*2*in->Ncolor()*in->Nspin())) * sites;   // accumulation
+	if (x) flops += xpay_flops * sites;
 
-    virtual long long bytes() const {
-      int gauge_bytes = reconstruct * in->Precision();
-      bool isHalf = in->Precision() == sizeof(short) ? true : false;
-      int spinor_bytes = 2 * in->Ncolor() * in->Nspin() * in->Precision() + (isHalf ? sizeof(float) : 0);
-      int proj_spinor_bytes = (in->Nspin()==4 ? 1 : 2) * in->Ncolor() * in->Nspin() * in->Precision() + (isHalf ? sizeof(float) : 0);
-      int ghost_bytes = (proj_spinor_bytes + gauge_bytes) + spinor_bytes;
-      int num_dir = 2 * 4; // set to 4 dimensions since we take care of 5-d fermions in derived classes where necessary
-
-      long long bytes;
-      switch(dslashParam.kernel_type) {
-      case EXTERIOR_KERNEL_X:
-      case EXTERIOR_KERNEL_Y:
-      case EXTERIOR_KERNEL_Z:
-      case EXTERIOR_KERNEL_T:
-	bytes = (ghost_bytes + (x ? spinor_bytes : 0)) * 2 * in->GhostFace()[dslashParam.kernel_type];
+	// now correct for flops done by exterior kernel
+	long long ghost_sites = 0;
+	for (int d=0; d<4; d++) if (dslashParam.commDim[d]) ghost_sites += 2 * in->GhostFace()[d];
+	flops -= (ghost_flops + (x ? xpay_flops : 0)) * ghost_sites;
+	  
 	break;
-      case EXTERIOR_KERNEL_ALL:
-	{
-	  long long ghost_sites = 2 * (in->GhostFace()[0]+in->GhostFace()[1]+in->GhostFace()[2]+in->GhostFace()[3]);
-	  bytes = (ghost_bytes + (x ? spinor_bytes : 0)) * ghost_sites;
-	  break;
-	}
-      case INTERIOR_KERNEL:
-	{
-	  long long sites = in->VolumeCB();
-	  bytes = (num_dir*gauge_bytes + ((num_dir-2)*spinor_bytes + 2*proj_spinor_bytes) + spinor_bytes)*sites;
-	  if (x) bytes += spinor_bytes;
-
-	  // now correct for bytes done by exterior kernel
-	  long long ghost_sites = 0;
-	  for (int d=0; d<4; d++) if (dslashParam.commDim[d]) ghost_sites += 2*in->GhostFace()[d];
-	  bytes -= (ghost_bytes + (x ? spinor_bytes : 0)) * ghost_sites;
-	  
-	  break;
-	}
       }
-      return bytes;
     }
+    return flops;
+  }
+
+  virtual long long bytes() const {
+    int gauge_bytes = reconstruct * in->Precision();
+    bool isHalf = in->Precision() == sizeof(short) ? true : false;
+    int spinor_bytes = 2 * in->Ncolor() * in->Nspin() * in->Precision() + (isHalf ? sizeof(float) : 0);
+    int proj_spinor_bytes = (in->Nspin()==4 ? 1 : 2) * in->Ncolor() * in->Nspin() * in->Precision() + (isHalf ? sizeof(float) : 0);
+    int ghost_bytes = (proj_spinor_bytes + gauge_bytes) + spinor_bytes;
+    int num_dir = 2 * 4; // set to 4 dimensions since we take care of 5-d fermions in derived classes where necessary
+
+    long long bytes;
+    switch(dslashParam.kernel_type) {
+    case EXTERIOR_KERNEL_X:
+    case EXTERIOR_KERNEL_Y:
+    case EXTERIOR_KERNEL_Z:
+    case EXTERIOR_KERNEL_T:
+      bytes = (ghost_bytes + (x ? spinor_bytes : 0)) * 2 * in->GhostFace()[dslashParam.kernel_type];
+      break;
+    case EXTERIOR_KERNEL_ALL:
+      {
+	long long ghost_sites = 2 * (in->GhostFace()[0]+in->GhostFace()[1]+in->GhostFace()[2]+in->GhostFace()[3]);
+	bytes = (ghost_bytes + (x ? spinor_bytes : 0)) * ghost_sites;
+	break;
+      }
+    case INTERIOR_KERNEL:
+      {
+	long long sites = in->VolumeCB();
+	bytes = (num_dir*gauge_bytes + ((num_dir-2)*spinor_bytes + 2*proj_spinor_bytes) + spinor_bytes)*sites;
+	if (x) bytes += spinor_bytes;
+
+	// now correct for bytes done by exterior kernel
+	long long ghost_sites = 0;
+	for (int d=0; d<4; d++) if (dslashParam.commDim[d]) ghost_sites += 2*in->GhostFace()[d];
+	bytes -= (ghost_bytes + (x ? spinor_bytes : 0)) * ghost_sites;
+	  
+	break;
+      }
+    }
+    return bytes;
+  }
 
 
-  };
+};
 
-  /** This derived class is specifically for driving the Dslash kernels
+/** This derived class is specifically for driving the Dslash kernels
     that use shared memory blocking.  This only applies on Fermi and
     upwards, and only for the interior kernels. */
 #if (__COMPUTE_CAPABILITY__ >= 200 && defined(SHARED_WILSON_DSLASH)) 
-  class SharedDslashCuda : public DslashCuda {
-    protected:
-      unsigned int sharedBytesPerBlock(const TuneParam &param) const { return 0; } // FIXME: this isn't quite true, but works
-      bool advanceSharedBytes(TuneParam &param) const { 
-        if (dslashParam.kernel_type != INTERIOR_KERNEL) return DslashCuda::advanceSharedBytes(param);
-        else return false;
-      } // FIXME - shared memory tuning only supported on exterior kernels
+class SharedDslashCuda : public DslashCuda {
+protected:
+  unsigned int sharedBytesPerBlock(const TuneParam &param) const { return 0; } // FIXME: this isn't quite true, but works
+  bool advanceSharedBytes(TuneParam &param) const { 
+    if (dslashParam.kernel_type != INTERIOR_KERNEL) return DslashCuda::advanceSharedBytes(param);
+    else return false;
+  } // FIXME - shared memory tuning only supported on exterior kernels
 
-      /** Helper function to set the shared memory size from the 3-d block size */
-      int sharedBytes(const dim3 &block) const { 
-        int warpSize = 32; // FIXME - query from device properties
-        int block_xy = block.x*block.y;
-        if (block_xy % warpSize != 0) block_xy = ((block_xy / warpSize) + 1)*warpSize;
-        return block_xy*block.z*sharedBytesPerThread();
+  /** Helper function to set the shared memory size from the 3-d block size */
+  int sharedBytes(const dim3 &block) const { 
+    int warpSize = 32; // FIXME - query from device properties
+    int block_xy = block.x*block.y;
+    if (block_xy % warpSize != 0) block_xy = ((block_xy / warpSize) + 1)*warpSize;
+    return block_xy*block.z*sharedBytesPerThread();
+  }
+
+  /** Helper function to set the 3-d grid size from the 3-d block size */
+  dim3 createGrid(const dim3 &block) const {
+    unsigned int gx = (in->X(0)*in->X(3) + block.x - 1) / block.x;
+    unsigned int gy = (in->X(1) + block.y - 1 ) / block.y;	
+    unsigned int gz = (in->X(2) + block.z - 1) / block.z;
+    return dim3(gx, gy, gz);
+  }
+
+  /** Advance the 3-d block size. */
+  bool advanceBlockDim(TuneParam &param) const {
+    if (dslashParam.kernel_type != INTERIOR_KERNEL) return DslashCuda::advanceBlockDim(param);
+    const unsigned int min_threads = 2;
+    const unsigned int max_threads = 512; // FIXME: use deviceProp.maxThreadsDim[0];
+    const unsigned int max_shared = 16384*3; // FIXME: use deviceProp.sharedMemPerBlock;
+
+    // set the x-block dimension equal to the entire x dimension
+    bool set = false;
+    dim3 blockInit = param.block;
+    blockInit.z++;
+    for (unsigned bx=blockInit.x; bx<=in->X(0); bx++) {
+      //unsigned int gx = (in->X(0)*in->x(3) + bx - 1) / bx;
+      for (unsigned by=blockInit.y; by<=in->X(1); by++) {
+	unsigned int gy = (in->X(1) + by - 1 ) / by;	
+
+	if (by > 1 && (by%2) != 0) continue; // can't handle odd blocks yet except by=1
+
+	for (unsigned bz=blockInit.z; bz<=in->X(2); bz++) {
+	  unsigned int gz = (in->X(2) + bz - 1) / bz;
+
+	  if (bz > 1 && (bz%2) != 0) continue; // can't handle odd blocks yet except bz=1
+	  if (bx*by*bz > max_threads) continue;
+	  if (bx*by*bz < min_threads) continue;
+	  // can't yet handle the last block properly in shared memory addressing
+	  if (by*gy != in->X(1)) continue;
+	  if (bz*gz != in->X(2)) continue;
+	  if (sharedBytes(dim3(bx, by, bz)) > max_shared) continue;
+
+	  param.block = dim3(bx, by, bz);	  
+	  set = true; break;
+	}
+	if (set) break;
+	blockInit.z = 1;
       }
+      if (set) break;
+      blockInit.y = 1;
+    }
 
-      /** Helper function to set the 3-d grid size from the 3-d block size */
-      dim3 createGrid(const dim3 &block) const {
-        unsigned int gx = (in->X(0)*in->X(3) + block.x - 1) / block.x;
-        unsigned int gy = (in->X(1) + block.y - 1 ) / block.y;	
-        unsigned int gz = (in->X(2) + block.z - 1) / block.z;
-        return dim3(gx, gy, gz);
-      }
+    if (param.block.x > in->X(0) && param.block.y > in->X(1) && param.block.z > in->X(2) || !set) {
+      //||sharedBytesPerThread()*param.block.x > max_shared) {
+      param.block = dim3(in->X(0), 1, 1);
+      return false;
+    } else { 
+      param.grid = createGrid(param.block);
+      param.shared_bytes = sharedBytes(param.block);
+      return true; 
+    }
+  }
 
-      /** Advance the 3-d block size. */
-      bool advanceBlockDim(TuneParam &param) const {
-        if (dslashParam.kernel_type != INTERIOR_KERNEL) return DslashCuda::advanceBlockDim(param);
-        const unsigned int min_threads = 2;
-        const unsigned int max_threads = 512; // FIXME: use deviceProp.maxThreadsDim[0];
-        const unsigned int max_shared = 16384*3; // FIXME: use deviceProp.sharedMemPerBlock;
+public:
+  SharedDslashCuda(cudaColorSpinorField *out, const cudaColorSpinorField *in,
+		   const cudaColorSpinorField *x, QudaReconstructType reconstruct, int dagger) 
+    : DslashCuda(out, in, x, reconstruct, dagger) { ; }
+  virtual ~SharedDslashCuda() { ; }
+  std::string paramString(const TuneParam &param) const // override and print out grid as well
+  {
+    std::stringstream ps;
+    ps << "block=(" << param.block.x << "," << param.block.y << "," << param.block.z << "), ";
+    ps << "grid=(" << param.grid.x << "," << param.grid.y << "," << param.grid.z << "), ";
+    ps << "shared=" << param.shared_bytes;
+    return ps.str();
+  }
 
-        // set the x-block dimension equal to the entire x dimension
-        bool set = false;
-        dim3 blockInit = param.block;
-        blockInit.z++;
-        for (unsigned bx=blockInit.x; bx<=in->X(0); bx++) {
-          //unsigned int gx = (in->X(0)*in->x(3) + bx - 1) / bx;
-          for (unsigned by=blockInit.y; by<=in->X(1); by++) {
-            unsigned int gy = (in->X(1) + by - 1 ) / by;	
+  virtual void initTuneParam(TuneParam &param) const
+  {
+    if (dslashParam.kernel_type != INTERIOR_KERNEL) return DslashCuda::initTuneParam(param);
 
-            if (by > 1 && (by%2) != 0) continue; // can't handle odd blocks yet except by=1
+    param.block = dim3(in->X(0), 1, 1);
+    param.grid = createGrid(param.block);
+    param.shared_bytes = sharedBytes(param.block);
+  }
 
-            for (unsigned bz=blockInit.z; bz<=in->X(2); bz++) {
-              unsigned int gz = (in->X(2) + bz - 1) / bz;
-
-              if (bz > 1 && (bz%2) != 0) continue; // can't handle odd blocks yet except bz=1
-              if (bx*by*bz > max_threads) continue;
-              if (bx*by*bz < min_threads) continue;
-              // can't yet handle the last block properly in shared memory addressing
-              if (by*gy != in->X(1)) continue;
-              if (bz*gz != in->X(2)) continue;
-              if (sharedBytes(dim3(bx, by, bz)) > max_shared) continue;
-
-              param.block = dim3(bx, by, bz);	  
-              set = true; break;
-            }
-            if (set) break;
-            blockInit.z = 1;
-          }
-          if (set) break;
-          blockInit.y = 1;
-        }
-
-        if (param.block.x > in->X(0) && param.block.y > in->X(1) && param.block.z > in->X(2) || !set) {
-          //||sharedBytesPerThread()*param.block.x > max_shared) {
-          param.block = dim3(in->X(0), 1, 1);
-          return false;
-        } else { 
-          param.grid = createGrid(param.block);
-          param.shared_bytes = sharedBytes(param.block);
-          return true; 
-        }
-      }
-
-  public:
-      SharedDslashCuda(cudaColorSpinorField *out, const cudaColorSpinorField *in,
-		       const cudaColorSpinorField *x, QudaReconstructType reconstruct, int dagger) 
-	: DslashCuda(out, in, x, reconstruct, dagger) { ; }
-      virtual ~SharedDslashCuda() { ; }
-      std::string paramString(const TuneParam &param) const // override and print out grid as well
-      {
-	std::stringstream ps;
-	ps << "block=(" << param.block.x << "," << param.block.y << "," << param.block.z << "), ";
-	ps << "grid=(" << param.grid.x << "," << param.grid.y << "," << param.grid.z << "), ";
-	ps << "shared=" << param.shared_bytes;
-	return ps.str();
-      }
-
-      virtual void initTuneParam(TuneParam &param) const
-      {
-	if (dslashParam.kernel_type != INTERIOR_KERNEL) return DslashCuda::initTuneParam(param);
-
-	param.block = dim3(in->X(0), 1, 1);
-	param.grid = createGrid(param.block);
-	param.shared_bytes = sharedBytes(param.block);
-      }
-
-      /** Sets default values for when tuning is disabled - this is guaranteed to work, but will be slow */
-      virtual void defaultTuneParam(TuneParam &param) const
-      {
-	if (dslashParam.kernel_type != INTERIOR_KERNEL) DslashCuda::defaultTuneParam(param);
-	else initTuneParam(param);
-      }
-    };
+  /** Sets default values for when tuning is disabled - this is guaranteed to work, but will be slow */
+  virtual void defaultTuneParam(TuneParam &param) const
+  {
+    if (dslashParam.kernel_type != INTERIOR_KERNEL) DslashCuda::defaultTuneParam(param);
+    else initTuneParam(param);
+  }
+};
 #else /** For pre-Fermi architectures */
-    class SharedDslashCuda : public DslashCuda {
-    public:
-      SharedDslashCuda(cudaColorSpinorField *out, const cudaColorSpinorField *in,
-		       const cudaColorSpinorField *x, QudaReconstructType reconstruct, int dagger) 
-	: DslashCuda(out, in, x, reconstruct, dagger) { }
-      virtual ~SharedDslashCuda() { }
-    };
+class SharedDslashCuda : public DslashCuda {
+public:
+  SharedDslashCuda(cudaColorSpinorField *out, const cudaColorSpinorField *in,
+		   const cudaColorSpinorField *x, QudaReconstructType reconstruct, int dagger) 
+    : DslashCuda(out, in, x, reconstruct, dagger) { }
+  virtual ~SharedDslashCuda() { }
+};
 #endif

--- a/lib/dslash_staggered.cu
+++ b/lib/dslash_staggered.cu
@@ -140,6 +140,10 @@ namespace quda {
 		gauge.Precision(), in->Precision());
     }
 
+    if (gauge.Reconstruct() == QUDA_RECONSTRUCT_9 || gauge.Reconstruct() == QUDA_RECONSTRUCT_13) {
+      errorQuda("Reconstruct %d not supported", gauge.Reconstruct());
+    }
+
     DslashCuda *dslash = 0;
     size_t regSize = sizeof(float);
 

--- a/lib/read_gauge.h
+++ b/lib/read_gauge.h
@@ -359,6 +359,16 @@
   (G##6).x *= max; (G##6).y *= max; (G##7).x *= max; (G##7).y *= max;	\
   (G##8).x *= max; (G##8).y *= max;			
 
+#define RESCALE4(G, max)						\
+  (G##0).x *= max; (G##0).y *= max; (G##0).z *= max; (G##0).w *= max;	\
+  (G##1).x *= max; (G##1).y *= max; (G##1).z *= max; (G##1).w *= max;	\
+  (G##2).x *= max; (G##2).y *= max; (G##2).z *= max; (G##2).w *= max;	\
+  (G##3).x *= max; (G##3).y *= max; (G##3).z *= max; (G##3).w *= max;	\
+  (G##4).x *= max; (G##4).y *= max;
+
+
+
+
 // FIXME: merge staggered and Wilson reconstruct macros
 
 #define RECONSTRUCT_MATRIX_18_DOUBLE(dir) 

--- a/lib/staggered_dslash_def.h
+++ b/lib/staggered_dslash_def.h
@@ -8,7 +8,8 @@
 #define DD_LOOP
 
 #define DD_AXPY 0
-#define DD_RECON 8
+#define DD_FAT_RECON 8
+#define DD_LONG_RECON 8
 #define DD_PREC 0
 #endif
 
@@ -35,11 +36,22 @@
 #define DD_PARAM_AXPY const short2 *x, const float *xNorm, const float a, const DslashParam param
 #endif
 
+#if (DD_FAT_RECON==8)
+#define DD_FAT_RECON_F 8
+#elif (DD_FAT_RECON==9)
+#define DD_FAT_RECON_F 9
+#elif (DD_FAT_RECON==12)
+#define DD_FAT_RECON_F 12
+#elif (DD_FAT_RECON==13)
+#define DD_FAT_RECON_F 13
+#else 
+#define DD_FAT_RECON_F 18
+#endif
 
 #define READ_LONG_PHASE(phase, dir, idx, stride) // May be a problem below with redefinitions
 
-#if (DD_RECON==8) // reconstruct from 8 reals
-#define DD_RECON_F 8
+#if (DD_LONG_RECON==8) // reconstruct from 8 reals
+#define DD_LONG_RECON_F 8
 
 #if (DD_PREC==0) // DOUBLE PRECISION
 
@@ -49,17 +61,38 @@
 #else
 #define DD_PARAM_GAUGE const double2 *fatGauge0, const double2 *fatGauge1, const double2* longGauge0, const double2* longGauge1
 #endif
-#else
+#else // !DD_IMPROVED
 #define DD_PARAM_GAUGE const double2 *fatGauge0, const double2 *fatGauge1
+#endif // DD_IMPROVED
+
+#define RECONSTRUCT_LONG_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_8_DOUBLE
+
+#if (DD_FAT_RECON==8)
+#define RECONSTRUCT_FAT_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_8_DOUBLE
+#elif (DD_FAT_RECON==12)
+#define RECONSTRUCT_FAT_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_12_DOUBLE
+#else
+#define RECONSTRUCT_FAT_GAUGE_MATRIX(dir, gauge, idx, sign)
 #endif
 
-#define RECONSTRUCT_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_8_DOUBLE
-
 #ifdef DIRECT_ACCESS_FAT_LINK
+#if (DD_FAT_RECON==8)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_8_DOUBLE2(FAT, gauge, dir, idx, stride)
+#elif (DD_FAT_RECON==12)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_12_DOUBLE2(FAT, gauge, dir, idx, stride)
+#else
 #define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_18_DOUBLE2(FAT, gauge, dir, idx, stride)
+#endif
+#else // texture access
+#if (DD_FAT_RECON==8)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_8_DOUBLE2_TEX(FAT, gauge, dir, idx, stride)
+#elif (DD_FAT_RECON==12)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_12_DOUBLE2_TEX(FAT, gauge, dir, idx, stride)
 #else
 #define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_18_DOUBLE2_TEX(FAT, gauge, dir, idx, stride)
+#endif // DD_FAT_RECON
 #endif // DIRECT_ACCESS_FAT_LINK
+
 #ifdef DIRECT_ACCESS_LONG_LINK
 #define READ_LONG_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_8_DOUBLE2(LONG, gauge, dir, idx, stride)
 #else
@@ -70,20 +103,40 @@
 #if (DD_IMPROVED==1)
 #if (__COMPUTE_CAPABILITY__ >= 200)
 #define DD_PARAM_GAUGE const float2 *fatGauge0, const float2 *fatGauge1, const float4* longGauge0, const float4* longGauge1, const float* longPhase0, const float* longPhase1
-#else
+#else 
 #define DD_PARAM_GAUGE const float2 *fatGauge0, const float2 *fatGauge1, const float4* longGauge0, const float4* longGauge1
 #endif
-#else
+#else // !DD_IMPROVED
 #define DD_PARAM_GAUGE const float2 *fatGauge0, const float2 *fatGauge1
 #endif
 
-#define RECONSTRUCT_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_8_SINGLE
+#define RECONSTRUCT_LONG_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_8_SINGLE
+#if (DD_FAT_RECON==8)
+#define RECONSTRUCT_FAT_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_8_SINGLE
+#elif (DD_FAT_RECON==12)
+#define RECONSTRUCT_FAT_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_12_SINGLE
+#else 
+#define RECONSTRUCT_FAT_GAUGE_MATRIX(dir, gauge, idx, sign)
+#endif // DD_FAT_RECON
 
 #ifdef DIRECT_ACCESS_FAT_LINK
+#if (DD_FAT_RECON==8)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_8_FLOAT4(FAT, gauge, dir, idx, stride)
+#elif (DD_FAT_RECON==12)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_12_FLOAT4(FAT, gauge, dir, idx, stride)
+#else
 #define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_18_FLOAT2(FAT, gauge, dir, idx, stride)
+#endif // DD_FAT_RECON
+#else
+#if (DD_FAT_RECON==8)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_8_FLOAT4_TEX(FAT, gauge, dir, idx, stride)
+#elif (DD_FAT_RECON==12)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_12_FLOAT4_TEX(FAT, gauge, dir, idx, stride)
 #else
 #define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_18_FLOAT2_TEX(FAT, gauge, dir, idx, stride)
+#endif // DD_FAT_RECON
 #endif // DIRECT_ACCESS_FAT_LINK
+
 #ifdef DIRECT_ACCESS_LONG_LINK
 #define READ_LONG_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_8_FLOAT4(LONG, gauge, dir, idx, stride)
 #else
@@ -100,12 +153,26 @@
 #else
 #define DD_PARAM_GAUGE const short2 *fatGauge0, const short2* fatGauge1
 #endif
-#define RECONSTRUCT_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_8_SINGLE
+
+#define RECONSTRUCT_LONG_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_8_SINGLE
+#if (DD_FAT_RECON==8)
+#define RECONSTRUCT_FAT_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_8_SINGLE
+#elif (DD_FAT_RECON==12)
+#define RECONSTRUCT_FAT_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_12_SINGLE
+#else 
+#define RECONSTRUCT_FAT_GAUGE_MATRIX(dir, gauge, idx, sign)
+#endif //DD_FAT_RECON
 
 /*#ifdef DIRECT_ACCESS_FAT_LINK
 #define READ_FAT_MATRIX(gauge, dir, idx) READ_GAUGE_MATRIX_18_SHORT2(FAT, gauge, dir, idx, fat_ga_stride); RESCALE2(FAT, fat_link_max);
 #else*/
+#if (DD_FAT_RECON==8)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_8_SHORT4_TEX(FAT, gauge, dir, idx, stride); RESCALE4(FAT, fat_link_max);
+#elif (DD_FAT_RECON==12)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_12_SHORT4_TEX(FAT, gauge, dir, idx, stride); RESCALE4(FAT, fat_link_max);
+#else
 #define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_18_SHORT2_TEX(FAT, gauge, dir, idx, stride); RESCALE2(FAT, fat_link_max);
+#endif
 /*#endif // DIRECT_ACCESS_FAT_LINK
 #ifdef DIRECT_ACCESS_LONG_LINK
 #define READ_LONG_MATRIX(gauge, dir, idx) READ_GAUGE_MATRIX_8_SHORT4(LONG, gauge, dir, idx, long_ga_stride)
@@ -115,9 +182,9 @@
 
 #endif // DD_PREC
 
-#elif (DD_RECON == 9) // reconstruct from 9 reals
+#elif (DD_LONG_RECON == 9) // reconstruct from 9 reals
 
-#define DD_RECON_F 9
+#define DD_LONG_RECON_F 9
 
 #if (DD_PREC==0) // DOUBLE PRECISION
 #if (DD_IMPROVED==1)
@@ -130,14 +197,34 @@
 #define DD_PARAM_GAUGE const double2 *fatGauge0, const double2 *fatGauge1
 #endif
 
-#define RECONSTRUCT_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_9_DOUBLE
+#define RECONSTRUCT_LONG_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_9_DOUBLE
+#if (DD_FAT_RECON==8)
+#define RECONSTRUCT_FAT_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_8_DOUBLE
+#elif (DD_FAT_RECON==12)
+#define RECONSTRUCT_FAT_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_12_DOUBLE
+#else 
+#define RECONSTRUCT_FAT_GAUGE_MATRIX(dir, gauge, idx, sign)
+#endif
 
 #ifdef DIRECT_ACCESS_FAT_LINK
+#if (DD_FAT_RECON==8)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_8_DOUBLE2(FAT, gauge, dir, idx, stride)
+#elif (DD_FAT_RECON==12)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_12_DOUBLE2(FAT, gauge, dir, idx, stride)
+#else
 #define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_18_DOUBLE2(FAT, gauge, dir, idx, stride)
+#endif
+#else // texture access
+#if (DD_FAT_RECON==8)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_8_DOUBLE2_TEX(FAT, gauge, dir, idx, stride)
+#elif (DD_FAT_RECON==12)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_12_DOUBLE2_TEX(FAT, gauge, dir, idx, stride)
 #else
 #define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_18_DOUBLE2_TEX(FAT, gauge, dir, idx, stride)
+#endif // DD_FAT_RECON
 #endif // DIRECT_ACCESS_FAT_LINK
-#undef READ_LONG_PHASE 
+#undef READ_LONG_PHASE
+
 #ifdef DIRECT_ACCESS_LONG_LINK
 #define READ_LONG_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_8_DOUBLE2(LONG, gauge, dir, idx, stride)
 #define READ_LONG_PHASE(phase, dir, idx, stride) READ_GAUGE_PHASE_DOUBLE(PHASE, phase, dir, idx, stride);
@@ -157,14 +244,34 @@
 #define DD_PARAM_GAUGE const float2 *fatGauge0, const float2 *fatGauge1
 #endif
 
-#define RECONSTRUCT_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_9_SINGLE
+#define RECONSTRUCT_LONG_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_9_SINGLE
+#if (DD_FAT_RECON==8)
+#define RECONSTRUCT_FAT_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_8_SINGLE
+#elif (DD_FAT_RECON==12)
+#define RECONSTRUCT_FAT_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_12_SINGLE
+#else
+#define RECONSTRUCT_FAT_GAUGE_MATRIX(dir, gauge, idx, sign)
+#endif
 
 #ifdef DIRECT_ACCESS_FAT_LINK
+#if (DD_FAT_RECON==8)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_8_FLOAT4(FAT, gauge, dir, idx, stride)
+#elif (DD_FAT_RECON==12)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_12_FLOAT4(FAT, gauge, dir, idx, stride)
+#else
 #define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_18_FLOAT2(FAT, gauge, dir, idx, stride)
+#endif
+#else
+#if (DD_FAT_RECON==8)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_8_FLOAT4_TEX(FAT, gauge, dir, idx, stride)
+#elif (DD_FAT_RECON==12)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_12_FLOAT4_TEX(FAT, gauge, dir, idx, stride)
 #else
 #define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_18_FLOAT2_TEX(FAT, gauge, dir, idx, stride)
+#endif
 #endif // DIRECT_ACCESS_FAT_LINK
-#undef READ_LONG_PHASE 
+#undef READ_LONG_PHASE
+
 #ifdef DIRECT_ACCESS_LONG_LINK
 #define READ_LONG_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_8_FLOAT4(LONG, gauge, dir, idx, stride)
 #define READ_LONG_PHASE(phase, dir, idx, stride) READ_GAUGE_PHASE_FLOAT(PHASE, phase, dir, idx, stride);
@@ -183,12 +290,26 @@
 #else
 #define DD_PARAM_GAUGE const short2 *fatGauge0, const short2* fatGauge1
 #endif
-#define RECONSTRUCT_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_9_SINGLE
+
+#define RECONSTRUCT_LONG_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_9_SINGLE
+#if (DD_FAT_RECON==8)
+#define RECONSTRUCT_FAT_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_8_SINGLE
+#elif (DD_FAT_RECON==12)
+#define RECONSTRUCT_FAT_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_12_SINGLE
+#else
+#define RECONSTRUCT_FAT_GAUGE_MATRIX(dir, gauge, idx, sign)
+#endif
 
 /*#ifdef DIRECT_ACCESS_FAT_LINK
 #define READ_FAT_MATRIX(gauge, dir, idx) READ_GAUGE_MATRIX_18_SHORT2(FAT, gauge, dir, idx, fat_ga_stride); RESCALE2(FAT, fat_link_max);
 #else*/
+#if (DD_FAT_RECON==8)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_8_SHORT4_TEX(FAT, gauge, dir, idx, stride); RESCALE4(FAT, fat_link_max);
+#elif (DD_FAT_RECON==12)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_12_SHORT4_TEX(FAT, gauge, dir, idx, stride); RESCALE4(FAT, fat_link_max);
+#else
 #define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_18_SHORT2_TEX(FAT, gauge, dir, idx, stride); RESCALE2(FAT, fat_link_max);
+#endif
 /*#endif // DIRECT_ACCESS_FAT_LINK
 #ifdef DIRECT_ACCESS_LONG_LINK
 #define READ_LONG_MATRIX(gauge, dir, idx) READ_GAUGE_MATRIX_8_SHORT4(LONG, gauge, dir, idx, long_ga_stride)
@@ -200,9 +321,9 @@
 
 #endif // DD_PREC
 
-#elif (DD_RECON == 12)// reconstruct from 12 reals
+#elif (DD_LONG_RECON == 12)// reconstruct from 12 reals
 
-#define DD_RECON_F 12
+#define DD_LONG_RECON_F 12
 
 #if (DD_PREC==0) // DOUBLE PRECISION
 #if (DD_IMPROVED==1)
@@ -214,13 +335,33 @@
 #else
 #define DD_PARAM_GAUGE const double2 *fatGauge0, const double2 *fatGauge1
 #endif
-#define RECONSTRUCT_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_12_DOUBLE
+#define RECONSTRUCT_LONG_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_12_DOUBLE
+#if (DD_FAT_RECON==8)
+#define RECONSTRUCT_FAT_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_8_DOUBLE
+#elif (DD_FAT_RECON==12)
+#define RECONSTRUCT_FAT_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_12_DOUBLE
+#else
+#define RECONSTRUCT_FAT_GAUGE_MATRIX(dir, gauge, idx, sign)
+#endif
 
 #ifdef DIRECT_ACCESS_FAT_LINK
+#if (DD_FAT_RECON==8)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_8_DOUBLE2(FAT, gauge, dir, idx, stride)
+#elif (DD_FAT_RECON==12)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_12_DOUBLE2(FAT, gauge, dir, idx, stride)
+#else
 #define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_18_DOUBLE2(FAT, gauge, dir, idx, stride)
+#endif
+#else // texture access
+#if (DD_FAT_RECON==8)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_8_DOUBLE2_TEX(FAT, gauge, dir, idx, stride)
+#elif (DD_FAT_RECON==12)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_12_DOUBLE2_TEX(FAT, gauge, dir, idx, stride)
 #else
 #define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_18_DOUBLE2_TEX(FAT, gauge, dir, idx, stride)
+#endif // DD_FAT_RECON
 #endif // DIRECT_ACCESS_FAT_LINK
+
 #ifdef DIRECT_ACCESS_LONG_LINK
 #define READ_LONG_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_12_DOUBLE2(LONG, gauge, dir, idx, stride)
 #else
@@ -237,13 +378,34 @@
 #else
 #define DD_PARAM_GAUGE const float2 *fatGauge0, const float2 *fatGauge1
 #endif
-#define RECONSTRUCT_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_12_SINGLE
+
+#define RECONSTRUCT_LONG_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_12_SINGLE
+#if (DD_FAT_RECON==8)
+#define RECONSTRUCT_FAT_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_8_SINGLE
+#elif (DD_FAT_RECON==12)
+#define RECONSTRUCT_FAT_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_12_SINGLE
+#else 
+#define RECONSTRUCT_FAT_GAUGE_MATRIX(dir, gauge, idx, sign)
+#endif
 
 #ifdef DIRECT_ACCESS_FAT_LINK
+#if (DD_FAT_RECON==8)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_8_FLOAT4(FAT, gauge, dir, idx, stride)
+#elif (DD_FAT_RECON==12)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_12_FLOAT4(FAT, gauge, dir, idx, stride)
+#else
 #define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_18_FLOAT2(FAT, gauge, dir, idx, stride)
+#endif
+#else
+#if (DD_FAT_RECON==8)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_8_FLOAT4_TEX(FAT, gauge, dir, idx, stride)
+#elif (DD_FAT_RECON==12)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_12_FLOAT4_TEX(FAT, gauge, dir, idx, stride)
 #else
 #define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_18_FLOAT2_TEX(FAT, gauge, dir, idx, stride)
+#endif
 #endif // DIRECT_ACCESS_FAT_LINK
+
 #ifdef DIRECT_ACCESS_LONG_LINK
 #define READ_LONG_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_12_FLOAT4(LONG, gauge, dir, idx, stride)
 #else
@@ -258,25 +420,36 @@
 #define DD_PARAM_GAUGE const short2 *fatGauge0, const short2 *fatGauge1, const short4* longGauge0, const short4* longGauge1
 #endif
 #else
-#define DD_PARAM_GAUGE const short2 *fatGauge0, const short2 *fatGauge1
+#define DD_PARAM_GAUGE const short2 *fatGauge0, const short2* fatGauge1
 #endif
-#define RECONSTRUCT_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_12_SINGLE
 
-/*#ifdef DIRECT_ACCESS_FAT_LINK
-#define READ_FAT_MATRIX(gauge, dir, idx) READ_GAUGE_MATRIX_18_SHORT2(FAT, gauge, dir, idx, fat_ga_stride); RESCALE2(FAT, fat_link_max);
-#else*/
+#define RECONSTRUCT_LONG_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_12_SINGLE
+#if (DD_FAT_RECON==8)
+#define RECONSTRUCT_FAT_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_8_SINGLE
+#elif (DD_FAT_RECON==12)
+#define RECONSTRUCT_FAT_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_12_SINGLE
+#else
+#define RECONSTRUCT_FAT_GAUGE_MATRIX(dir, gauge, idx, sign)
+#endif
+
+#if (DD_FAT_RECON==8)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_8_SHORT4_TEX(FAT, gauge, dir, idx, stride); RESCALE4(FAT, fat_link_max);
+#elif (DD_FAT_RECON==12)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_12_SHORT4_TEX(FAT, gauge, dir, idx, stride); RESCALE4(FAT, fat_link_max);
+#else
 #define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_18_SHORT2_TEX(FAT, gauge, dir, idx, stride); RESCALE2(FAT, fat_link_max);
-/*#endif // DIRECT_ACCCESS_FAT_LINK
-#ifdef DIRECT_ACCESS_LONG_LINK
+#endif
+
+/*#ifdef DIRECT_ACCESS_LONG_LINK
 #define READ_LONG_MATRIX(gauge, dir, idx) READ_GAUGE_MATRIX_12_SHORT4(LONG, gauge, dir, idx, long_ga_stride)
 #else*/
 #define READ_LONG_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_12_SHORT4_TEX(LONG, gauge, dir, idx, stride)
-									//#endif // DIRECT_ACCCESS_LONG_LINK
+//#endif // DIRECT_ACCCESS_LONG_LINK
 
 #endif // DD_PREC
 
-#elif (DD_RECON == 13)
-#define DD_RECON_F 13
+#elif (DD_LONG_RECON == 13)
+#define DD_LONG_RECON_F 13
 
 #if (DD_PREC==0) // DOUBLE PRECISION
 #if (DD_IMPROVED==1)
@@ -288,13 +461,33 @@
 #else
 #define DD_PARAM_GAUGE const double2 *fatGauge0, const double2 *fatGauge1
 #endif
-#define RECONSTRUCT_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_13_DOUBLE
+#define RECONSTRUCT_LONG_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_13_DOUBLE
+#if (DD_FAT_RECON==8)
+#define RECONSTRUCT_FAT_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_8_DOUBLE
+#elif (DD_FAT_RECON==12)
+#define RECONSTRUCT_FAT_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_12_DOUBLE
+#else 
+#define RECONSTRUCT_FAT_GAUGE_MATRIX(dir, gauge, idx, sign)
+#endif
 
 #ifdef DIRECT_ACCESS_FAT_LINK
+#if (DD_FAT_RECON==8)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_8_DOUBLE2(FAT, gauge, dir, idx, stride)
+#elif (DD_FAT_RECON==12)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_12_DOUBLE2(FAT, gauge, dir, idx, stride)
+#else
 #define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_18_DOUBLE2(FAT, gauge, dir, idx, stride)
+#endif
+#else // texture access
+#if (DD_FAT_RECON==8)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_8_DOUBLE2_TEX(FAT, gauge, dir, idx, stride)
+#elif (DD_FAT_RECON==12)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_12_DOUBLE2_TEX(FAT, gauge, dir, idx, stride)
 #else
 #define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_18_DOUBLE2_TEX(FAT, gauge, dir, idx, stride)
+#endif // DD_FAT_RECON
 #endif // DIRECT_ACCESS_FAT_LINK
+
 #undef READ_LONG_PHASE
 #ifdef DIRECT_ACCESS_LONG_LINK
 #define READ_LONG_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_12_DOUBLE2(LONG, gauge, dir, idx, stride)
@@ -314,13 +507,34 @@
 #else
 #define DD_PARAM_GAUGE const float2 *fatGauge0, const float2 *fatGauge1
 #endif
-#define RECONSTRUCT_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_13_SINGLE
+
+#define RECONSTRUCT_LONG_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_13_SINGLE
+#if (DD_FAT_RECON==8)
+#define RECONSTRUCT_FAT_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_8_SINGLE
+#elif (DD_FAT_RECON==12)
+#define RECONSTRUCT_FAT_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_12_SINGLE
+#else
+#define RECONSTRUCT_FAT_GAUGE_MATRIX(dir, gauge, idx, sign)
+#endif
 
 #ifdef DIRECT_ACCESS_FAT_LINK
+#if (DD_FAT_RECON==8)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_8_FLOAT4(FAT, gauge, dir, idx, stride)
+#elif (DD_FAT_RECON==12)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_12_FLOAT4(FAT, gauge, dir, idx, stride)
+#else
 #define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_18_FLOAT2(FAT, gauge, dir, idx, stride)
+#endif
+#else
+#if (DD_FAT_RECON==8)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_8_FLOAT4_TEX(FAT, gauge, dir, idx, stride)
+#elif (DD_FAT_RECON==12)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_12_FLOAT4_TEX(FAT, gauge, dir, idx, stride)
 #else
 #define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_18_FLOAT2_TEX(FAT, gauge, dir, idx, stride)
+#endif
 #endif // DIRECT_ACCESS_FAT_LINK
+
 #undef READ_LONG_PHASE 
 #ifdef DIRECT_ACCESS_LONG_LINK
 #define READ_LONG_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_12_FLOAT4(LONG, gauge, dir, idx, stride)
@@ -338,16 +552,26 @@
 #define DD_PARAM_GAUGE const short2 *fatGauge0, const short2 *fatGauge1, const short4* longGauge0, const short4* longGauge1
 #endif
 #else
-#define DD_PARAM_GAUGE const short2 *fatGauge0, const short2 *fatGauge1
+#define DD_PARAM_GAUGE const short2 *fatGauge0, const short2* fatGauge1
 #endif
-#define RECONSTRUCT_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_13_SINGLE
 
-/*#ifdef DIRECT_ACCESS_FAT_LINK
-#define READ_FAT_MATRIX(gauge, dir, idx) READ_GAUGE_MATRIX_18_SHORT2(FAT, gauge, dir, idx, fat_ga_stride); RESCALE2(FAT, fat_link_max);
-#else*/
+#define RECONSTRUCT_LONG_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_13_SINGLE
+#if (DD_FAT_RECON==8)
+#define RECONSTRUCT_FAT_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_8_SINGLE
+#elif (DD_FAT_RECON==12)
+#define RECONSTRUCT_FAT_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_12_SINGLE
+#else
+#define RECONSTRUCT_FAT_GAUGE_MATRIX(dir, gauge, idx, sign)
+#endif
+
+#if (DD_FAT_RECON==8)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_8_SHORT4_TEX(FAT, gauge, dir, idx, stride); RESCALE4(FAT, fat_link_max);
+#elif (DD_FAT_RECON==12)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_12_SHORT4_TEX(FAT, gauge, dir, idx, stride); RESCALE4(FAT, fat_link_max);
+#else
 #define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_18_SHORT2_TEX(FAT, gauge, dir, idx, stride); RESCALE2(FAT, fat_link_max);
-/*#endif // DIRECT_ACCCESS_FAT_LINK
-#ifdef DIRECT_ACCESS_LONG_LINK
+#endif
+ /*#ifdef DIRECT_ACCESS_LONG_LINK
 #define READ_LONG_MATRIX(gauge, dir, idx) READ_GAUGE_MATRIX_12_SHORT4(LONG, gauge, dir, idx, long_ga_stride)
 #else*/
 #undef READ_LONG_PHASE
@@ -358,8 +582,8 @@
 #endif // DD_PREC
 
 #else //18 reconstruct
-#define DD_RECON_F 18
-#define RECONSTRUCT_GAUGE_MATRIX(dir, gauge, idx, sign)
+#define DD_LONG_RECON_F 18
+#define RECONSTRUCT_LONG_GAUGE_MATRIX(dir, gauge, idx, sign)
 
 #if (DD_PREC==0) // DOUBLE PRECISION
 #if (DD_IMPROVED==1)
@@ -371,11 +595,32 @@
 #else
 #define DD_PARAM_GAUGE const double2 *fatGauge0, const double2 *fatGauge1
 #endif
+#if (DD_FAT_RECON==8)
+#define RECONSTRUCT_FAT_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_8_DOUBLE
+#elif (DD_FAT_RECON==12)
+#define RECONSTRUCT_FAT_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_12_DOUBLE
+#else
+#define RECONSTRUCT_FAT_GAUGE_MATRIX(dir, gauge, idx, sign)
+#endif
+
 #ifdef DIRECT_ACCESS_FAT_LINK
+#if (DD_FAT_RECON==8)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_8_DOUBLE2(FAT, gauge, dir, idx, stride)
+#elif (DD_FAT_RECON==12)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_12_DOUBLE2(FAT, gauge, dir, idx, stride)
+#else
 #define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_18_DOUBLE2(FAT, gauge, dir, idx, stride)
+#endif
+#else // texture access
+#if (DD_FAT_RECON==8)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_8_DOUBLE2_TEX(FAT, gauge, dir, idx, stride)
+#elif (DD_FAT_RECON==12)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_12_DOUBLE2_TEX(FAT, gauge, dir, idx, stride)
 #else
 #define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_18_DOUBLE2_TEX(FAT, gauge, dir, idx, stride)
-#endif // DIRECT_ACCCESS_FAT_LINK
+#endif // DD_FAT_RECON
+#endif // DIRECT_ACCESS_FAT_LINK
+
 #ifdef DIRECT_ACCESS_LONG_LINK
 #define READ_LONG_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_18_DOUBLE2(LONG, gauge, dir, idx, stride)
 #else
@@ -394,11 +639,32 @@
 #define DD_PARAM_GAUGE const float2 *fatGauge0, const float2 *fatGauge1
 #endif
 
+#if (DD_FAT_RECON==8)
+#define RECONSTRUCT_FAT_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_8_SINGLE
+#elif (DD_FAT_RECON==12)
+#define RECONSTRUCT_FAT_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_12_SINGLE
+#else
+#define RECONSTRUCT_FAT_GAUGE_MATRIX(dir, gauge, idx, sign)
+#endif
+
 #ifdef DIRECT_ACCESS_FAT_LINK
+#if (DD_FAT_RECON==8)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_8_FLOAT4(FAT, gauge, dir, idx, stride)
+#elif (DD_FAT_RECON==12)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_12_FLOAT4(FAT, gauge, dir, idx, stride)
+#else
 #define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_18_FLOAT2(FAT, gauge, dir, idx, stride)
+#endif
+#else
+#if (DD_FAT_RECON==8)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_8_FLOAT4_TEX(FAT, gauge, dir, idx, stride)
+#elif (DD_FAT_RECON==12)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_12_FLOAT4_TEX(FAT, gauge, dir, idx, stride)
 #else
 #define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_18_FLOAT2_TEX(FAT, gauge, dir, idx, stride)
-#endif // DIRECT_ACCCESS_FAT_LINK
+#endif
+#endif // DIRECT_ACCESS_FAT_LINK
+ 
 #ifdef DIRECT_ACCESS_LONG_LINK
 #define READ_LONG_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_18_FLOAT2(LONG, gauge, dir, idx, stride)
 #else
@@ -414,15 +680,26 @@
 #define DD_PARAM_GAUGE const short2 *fatGauge0, const short2 *fatGauge1, const short4* longGauge0, const short4* longGauge1
 #endif
 #else
-#define DD_PARAM_GAUGE const short2 *fatGauge0, const short2 *fatGauge1
+#define DD_PARAM_GAUGE const short2 *fatGauge0, const short2* fatGauge1
 #endif
 
-/*#ifdef DIRECT_ACCESS_FAT_LINK
-#define READ_FAT_MATRIX(gauge, dir, idx) READ_GAUGE_MATRIX_18_SHORT2(FAT, gauge, dir, idx, fat_ga_stride); RESCALE2(FAT, fat_link_max);
-#else*/
+#if (DD_FAT_RECON==8)
+#define RECONSTRUCT_FAT_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_8_SINGLE
+#elif (DD_FAT_RECON==12)
+#define RECONSTRUCT_FAT_GAUGE_MATRIX RECONSTRUCT_GAUGE_MATRIX_12_SINGLE
+#else
+#define RECONSTRUCT_FAT_GAUGE_MATRIX(dir, gauge, idx, sign)
+#endif
+
+#if (DD_FAT_RECON==8)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_8_SHORT4_TEX(FAT, gauge, dir, idx, stride); RESCALE4(FAT, fat_link_max);
+#elif (DD_FAT_RECON==12)
+#define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_12_SHORT4_TEX(FAT, gauge, dir, idx, stride); RESCALE4(FAT, fat_link_max);
+#else
 #define READ_FAT_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_18_SHORT2_TEX(FAT, gauge, dir, idx, stride); RESCALE2(FAT, fat_link_max);
-									 /*#endif // DIRECT_ACCESS_FAT_LINK
-#ifdef DIRECT_ACCESS_LONG_LINK
+#endif
+ 
+  /*#ifdef DIRECT_ACCESS_LONG_LINK
 #define READ_LONG_MATRIX(gauge, dir, idx) READ_GAUGE_MATRIX_18_SHORT2(LONG, gauge, dir, idx, long_ga_stride)
 #else*/
 #define READ_LONG_MATRIX(gauge, dir, idx, stride) READ_GAUGE_MATRIX_18_SHORT2_TEX(LONG, gauge, dir, idx, stride)
@@ -430,7 +707,7 @@
 
 #endif // DD_PREC
 
-#endif // DD_RECON
+#endif // DD_LONG_RECON
 
 #if (DD_PREC==0) // double-precision fields
 
@@ -539,7 +816,7 @@
 #define LONGPHASE0TEX param.longPhase0Tex
 #define LONGPHASE1TEX param.longPhase1Tex
 #else
-#if (DD_RECON ==18)
+#if (DD_LONG_RECON ==18)
 #define LONGLINK0TEX longGauge0TexSingle_norecon
 #define LONGLINK1TEX longGauge1TexSingle_norecon
 #else
@@ -615,7 +892,7 @@
 #else
 #define FATLINK0TEX fatGauge0TexHalf
 #define FATLINK1TEX fatGauge1TexHalf
-#if (DD_RECON ==18)
+#if (DD_LONG_RECON ==18)
 #define LONGLINK0TEX longGauge0TexHalf_norecon
 #define LONGLINK1TEX longGauge1TexHalf_norecon
 #else
@@ -663,28 +940,30 @@
 // only build double precision if supported
 #if !(__COMPUTE_CAPABILITY__ < 130 && DD_PREC == 0) 
 
-#define DD_CONCAT(n,r,x) n ## r ## x ## Kernel
-#define DD_FUNC(n,r,x) DD_CONCAT(n,r,x)
-
 // define the kernel
 
 #if (DD_IMPROVED==1)
 
+#define DD_CONCAT(n,r1,r2,x) n ## r1 ## r2 ## x ## Kernel
+#define DD_FUNC(n,r1,r2,x) DD_CONCAT(n,r1,r2,x)
+
 template <KernelType kernel_type>
-__global__ void	DD_FUNC(DD_FNAME, DD_RECON_F, DD_AXPY_F)
+__global__ void	DD_FUNC(DD_FNAME, DD_FAT_RECON_F, DD_LONG_RECON_F, DD_AXPY_F)
   (DD_PARAM_OUT, DD_PARAM_GAUGE, DD_PARAM_IN, DD_PARAM_AXPY) {
-#ifdef GPU_STAGGERED_DIRAC
+#if defined(GPU_STAGGERED_DIRAC) && DD_FAT_RECON == 18 // improved staggered only supports no reconstruct fat-links 
   #include "staggered_dslash_core.h"
 #endif
 }
 
+#ifdef MULTI_GPU
 template <>
-__global__ void	DD_FUNC(DD_FNAME, DD_RECON_F, DD_AXPY_F)<EXTERIOR_KERNEL_ALL>
+__global__ void	DD_FUNC(DD_FNAME, DD_FAT_RECON_F, DD_LONG_RECON_F, DD_AXPY_F)<EXTERIOR_KERNEL_ALL>
   (DD_PARAM_OUT, DD_PARAM_GAUGE, DD_PARAM_IN, DD_PARAM_AXPY) {
-#ifdef GPU_STAGGERED_DIRAC
+#if defined(GPU_STAGGERED_DIRAC) && DD_FAT_RECON == 18 // improved staggered only supports no reconstruct fat-links 
   #include "staggered_fused_exterior_dslash_core.h"
 #endif
 }
+#endif
 
 #else // naive staggered kernel
 
@@ -694,21 +973,30 @@ __global__ void	DD_FUNC(DD_FNAME, DD_RECON_F, DD_AXPY_F)<EXTERIOR_KERNEL_ALL>
 #undef READ_LONG_PHASE
 #define READ_LONG_PHASE(phase, dir, idx, stride)
 
+#define DD_CONCAT(n,r,x) n ## r ## x ## Kernel
+#define DD_FUNC(n,r,x) DD_CONCAT(n,r,x)
+
+#if (DD_LONG_RECON == 18) // avoid kernel aliasing over non-existant long-links
+
 template <KernelType kernel_type>
-__global__ void	DD_FUNC(DD_FNAME, DD_RECON_F, DD_AXPY_F)
+__global__ void	DD_FUNC(DD_FNAME, DD_FAT_RECON_F, DD_AXPY_F)
   (DD_PARAM_OUT, DD_PARAM_GAUGE, DD_PARAM_IN, DD_PARAM_AXPY) {
-#ifdef GPU_STAGGERED_DIRAC
+#if defined(GPU_STAGGERED_DIRAC) && DD_FAT_RECON != 9 && DD_FAT_RECON != 13
   #include "staggered_dslash_core.h"
 #endif
 }
 
+#ifdef MULTI_GPU
 template <>
-__global__ void	DD_FUNC(DD_FNAME, DD_RECON_F, DD_AXPY_F)<EXTERIOR_KERNEL_ALL>
+__global__ void	DD_FUNC(DD_FNAME, DD_FAT_RECON_F, DD_AXPY_F)<EXTERIOR_KERNEL_ALL>
   (DD_PARAM_OUT, DD_PARAM_GAUGE, DD_PARAM_IN, DD_PARAM_AXPY) {
-#ifdef GPU_STAGGERED_DIRAC
+#if defined(GPU_STAGGERED_DIRAC) && DD_FAT_RECON != 9 && DD_FAT_RECON != 13
   #include "staggered_fused_exterior_dslash_core.h"
 #endif
 }
+#endif // MULTI_GPU
+
+#endif
 
 #endif
 
@@ -719,7 +1007,8 @@ __global__ void	DD_FUNC(DD_FNAME, DD_RECON_F, DD_AXPY_F)<EXTERIOR_KERNEL_ALL>
 // clean up
 
 #undef DD_PREC_F
-#undef DD_RECON_F
+#undef DD_FAT_RECON_F
+#undef DD_LONG_RECON_F
 #undef DD_AXPY_F
 #undef DD_PARAM_OUT
 #undef DD_PARAM_GAUGE
@@ -731,7 +1020,8 @@ __global__ void	DD_FUNC(DD_FNAME, DD_RECON_F, DD_AXPY_F)<EXTERIOR_KERNEL_ALL>
 
 #undef DSLASH_AXPY
 #undef READ_GAUGE_MATRIX
-#undef RECONSTRUCT_GAUGE_MATRIX
+#undef RECONSTRUCT_FAT_GAUGE_MATRIX
+#undef RECONSTRUCT_LONG_GAUGE_MATRIX
 #undef FATLINK0TEX
 #undef FATLINK1TEX
 #undef LONGLINK0TEX
@@ -766,22 +1056,39 @@ __global__ void	DD_FUNC(DD_FNAME, DD_RECON_F, DD_AXPY_F)<EXTERIOR_KERNEL_ALL>
 #undef DD_AXPY
 #define DD_AXPY 0
 
-#if (DD_RECON==8)
-#undef DD_RECON
-#define DD_RECON 9
-#elif (DD_RECON==9)
-#undef DD_RECON
-#define DD_RECON 12
-#elif (DD_RECON==12)
-#undef DD_RECON
-#define DD_RECON 13
-#elif (DD_RECON==13)
-#undef DD_RECON
-#define DD_RECON 18
+#if (DD_LONG_RECON==8)
+#undef DD_LONG_RECON
+#define DD_LONG_RECON 9
+#elif (DD_LONG_RECON==9)
+#undef DD_LONG_RECON
+#define DD_LONG_RECON 12
+#elif (DD_LONG_RECON==12)
+#undef DD_LONG_RECON
+#define DD_LONG_RECON 13
+#elif (DD_LONG_RECON==13)
+#undef DD_LONG_RECON
+#define DD_LONG_RECON 18
 #else
-#undef DD_RECON
+#undef DD_LONG_RECON
 
-#define DD_RECON 8
+#define DD_LONG_RECON 8
+
+#if (DD_FAT_RECON==8)
+#undef DD_FAT_RECON
+#define DD_FAT_RECON 9 // dummy
+#elif (DD_FAT_RECON==9)
+#undef DD_FAT_RECON
+#define DD_FAT_RECON 12
+#elif (DD_FAT_RECON==12)
+#undef DD_FAT_RECON
+#define DD_FAT_RECON 13 //dummy
+#elif (DD_FAT_RECON==13)
+#undef DD_FAT_RECON
+#define DD_FAT_RECON 18
+#else
+#undef DD_FAT_RECON
+
+#define DD_FAT_RECON 8
 
 #if (DD_PREC==0)
 #undef DD_PREC
@@ -795,11 +1102,12 @@ __global__ void	DD_FUNC(DD_FNAME, DD_RECON_F, DD_AXPY_F)<EXTERIOR_KERNEL_ALL>
 
 #undef DD_LOOP
 #undef DD_AXPY
-#undef DD_RECON
+#undef DD_LONG_RECON
 #undef DD_PREC
 
 #endif // DD_PREC
-#endif // DD_RECON
+#endif // DD_FAT_RECON
+#endif // DD_LONG_RECON
 #endif // DD_AXPY
 
 #ifdef DD_LOOP

--- a/tests/staggered_dslash_test.cpp
+++ b/tests/staggered_dslash_test.cpp
@@ -102,9 +102,14 @@ void init()
   gaugeParam.reconstruct_sloppy = gaugeParam.reconstruct;
   gaugeParam.cuda_prec_sloppy = gaugeParam.cuda_prec;
 
+    // ensure that the default is improved staggered
+  if (inv_param.dslash_type != QUDA_STAGGERED_DSLASH &&
+      inv_param.dslash_type != QUDA_ASQTAD_DSLASH)
+    dslash_type = QUDA_ASQTAD_DSLASH;
+
   gaugeParam.anisotropy = 1.0;
   gaugeParam.tadpole_coeff = 0.8;
-  gaugeParam.scale = -1.0/(24.0*gaugeParam.tadpole_coeff*gaugeParam.tadpole_coeff);
+  gaugeParam.scale = (dslash_type == QUDA_ASQTAD_DSLASH) ? -1.0/(24.0*gaugeParam.tadpole_coeff*gaugeParam.tadpole_coeff) : 1.0;
   gaugeParam.gauge_order = QUDA_QDP_GAUGE_ORDER;
   gaugeParam.t_boundary = QUDA_ANTI_PERIODIC_T;
   gaugeParam.gauge_fix = QUDA_GAUGE_FIXED_NO;
@@ -117,11 +122,6 @@ void init()
   inv_param.dagger = dagger;
   inv_param.matpc_type = QUDA_MATPC_EVEN_EVEN;
   inv_param.dslash_type = dslash_type;
-
-  // ensure that the default is improved staggered
-  if (inv_param.dslash_type != QUDA_STAGGERED_DSLASH &&
-      inv_param.dslash_type != QUDA_ASQTAD_DSLASH)
-    inv_param.dslash_type = QUDA_ASQTAD_DSLASH;
 
   inv_param.input_location = QUDA_CPU_FIELD_LOCATION;
   inv_param.output_location = QUDA_CPU_FIELD_LOCATION;
@@ -179,30 +179,6 @@ void init()
   }
   construct_fat_long_gauge_field(fatlink, longlink, 1, gaugeParam.cpu_prec, &gaugeParam, dslash_type);
 
-  if(link_recon == QUDA_RECONSTRUCT_9 || link_recon == QUDA_RECONSTRUCT_13){ // incorporate non-trivial phase into long links
-    const double cos_pi_3 = 0.5; // Cos(pi/3)
-    const double sin_pi_3 = sqrt(0.75); // Sin(pi/3)
-    for(int dir=0; dir<4; ++dir){
-      for(int i=0; i<V; ++i){
-        for(int j=0; j<gaugeSiteSize; j+=2){
-          if(gaugeParam.cpu_prec == QUDA_DOUBLE_PRECISION){
-            const double real = ((double*)longlink[dir])[i*gaugeSiteSize + j];
-            const double imag = ((double*)longlink[dir])[i*gaugeSiteSize + j + 1];
-            ((double*)longlink[dir])[i*gaugeSiteSize + j] = real*cos_pi_3 - imag*sin_pi_3;
-            ((double*)longlink[dir])[i*gaugeSiteSize + j + 1] = real*sin_pi_3 + imag*cos_pi_3;
-          }else{
-            const float real = ((float*)longlink[dir])[i*gaugeSiteSize + j];
-            const float imag = ((float*)longlink[dir])[i*gaugeSiteSize + j + 1];
-            ((float*)longlink[dir])[i*gaugeSiteSize + j] = real*cos_pi_3 - imag*sin_pi_3;
-            ((float*)longlink[dir])[i*gaugeSiteSize + j + 1] = real*sin_pi_3 + imag*cos_pi_3;
-          }
-        } 
-      }
-    }
-  }
-
-
-
 #ifdef MULTI_GPU
   gaugeParam.type = QUDA_ASQTAD_FAT_LINKS;
   gaugeParam.reconstruct = QUDA_RECONSTRUCT_NO;
@@ -219,15 +195,19 @@ void init()
   int y_face_size = X[0]*X[2]*X[3]/2;
   int z_face_size = X[0]*X[1]*X[3]/2;
   int t_face_size = X[0]*X[1]*X[2]/2;
-  int pad_size =MAX(x_face_size, y_face_size);
+  int pad_size = MAX(x_face_size, y_face_size);
   pad_size = MAX(pad_size, z_face_size);
   pad_size = MAX(pad_size, t_face_size);
   gaugeParam.ga_pad = pad_size;    
 #endif
 
-  gaugeParam.type = QUDA_ASQTAD_FAT_LINKS;
-  gaugeParam.reconstruct = gaugeParam.reconstruct_sloppy = QUDA_RECONSTRUCT_NO;
-
+  gaugeParam.type = (dslash_type == QUDA_ASQTAD_DSLASH) ? QUDA_ASQTAD_FAT_LINKS : QUDA_SU3_LINKS;
+  if (dslash_type == QUDA_STAGGERED_DSLASH) {
+    gaugeParam.reconstruct = gaugeParam.reconstruct_sloppy = link_recon;
+  } else {
+    gaugeParam.reconstruct = gaugeParam.reconstruct_sloppy = QUDA_RECONSTRUCT_NO;
+  }
+  
   printfQuda("Fat links sending..."); 
   loadGaugeQuda(fatlink, &gaugeParam);
   printfQuda("Fat links sent\n"); 
@@ -238,10 +218,12 @@ void init()
   gaugeParam.ga_pad = 3*pad_size;
 #endif
 
-  gaugeParam.reconstruct = gaugeParam.reconstruct_sloppy = link_recon;
-  printfQuda("Long links sending..."); 
-  loadGaugeQuda(longlink, &gaugeParam);
-  printfQuda("Long links sent...\n"); 
+  if (dslash_type == QUDA_ASQTAD_DSLASH) {
+    gaugeParam.reconstruct = gaugeParam.reconstruct_sloppy = link_recon;
+    printfQuda("Long links sending..."); 
+    loadGaugeQuda(longlink, &gaugeParam);
+    printfQuda("Long links sent...\n");
+  }
 
   printfQuda("Sending fields to GPU..."); 
 


### PR DESCRIPTION
This is mainly a feature-add:
* Adds support for 8/12 reconstruction for naive staggered fermions.
* Fixes a bug for both naive and improved staggered fermions, whereby 8/12 reconstruction was broken for periodic boundary conditions or anti-periodic boundary conditions with temporal splitting over multiple GPUs.

While 9/13 reconstruction for naive staggered is not (yet) supported, this would be an easy addition if needed.  Similarly, for improved staggered, the fat-link field is only supported using no reconstruction but adding support for non-trivial reconstruction would be straightforward.  This would only be desirable when using stout smearing (or similar) for the fat-link.