### PR TITLE
add nvtx markers to milc interface

### DIFF
--- a/configure
+++ b/configure
@@ -607,6 +607,7 @@ BUILD_QDPJIT_INTERFACE
 BUILD_CPS_INTERFACE
 BUILD_MILC_INTERFACE
 BUILD_QDP_INTERFACE
+MILC_NVTX
 MPI_NVTX
 GPU_COMMS
 GPU_DIRECT
@@ -727,6 +728,7 @@ enable_multi_gpu
 enable_gpu_direct
 enable_gpu_comms
 enable_mpi_nvtx
+enable_milc_nvtx
 enable_device_pack
 with_mpi
 enable_pthreads
@@ -1411,6 +1413,8 @@ Optional Features:
                           default: disabled)
   --enable-mpi-nvtx       Enable NVTX markup for profiling MPI API calls in
                           the visual profiler (default: disabled)
+  --enable-milc-nvtx      Enable NVTX markup for profiling MILC interface
+                          calls in the visual profiler (default: disabled)
   --enable-device-pack    Enable the packing / unpacking of fields on the
                           device (default: disabled)
   --enable-pthreads       Enable pthreads in the multi-GPU dslash build
@@ -2290,6 +2294,15 @@ if test "${enable_mpi_nvtx+set}" = set; then :
   enableval=$enable_mpi_nvtx;  mpi_nvtx=${enableval}
 else
    mpi_nvtx="no"
+
+fi
+
+
+# Check whether --enable-milc-nvtx was given.
+if test "${enable_milc_nvtx+set}" = set; then :
+  enableval=$enable_milc_nvtx;  milc_nvtx=${enableval}
+else
+   milc_nvtx="no"
 
 fi
 
@@ -4190,6 +4203,14 @@ yes|no);;
   ;;
 esac
 
+case ${milc_nvtx} in
+yes|no);;
+*)
+  as_fn_error $? " invalid value for --enable-milc-nvtx " "$LINENO" 5
+  ;;
+esac
+
+
 case ${build_qdpjit} in
 yes|no);;
 *)
@@ -4406,6 +4427,11 @@ GPU_COMMS=${gpu_comms}
 { $as_echo "$as_me:${as_lineno-$LINENO}: Setting MPI_NVTXS= ${mpi_nvtx}" >&5
 $as_echo "$as_me: Setting MPI_NVTXS= ${mpi_nvtx}" >&6;}
 MPI_NVTX=${mpi_nvtx}
+
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: Setting MILC_NVTXS= ${milc_nvtx}" >&5
+$as_echo "$as_me: Setting MILC_NVTXS= ${milc_nvtx}" >&6;}
+MILC_NVTX=${milc_nvtx}
 
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: Setting BUILD_QDP_INTERFACE= ${build_qdp_interface}" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -210,6 +210,13 @@ AC_ARG_ENABLE(mpi-nvtx,
   [ mpi_nvtx="no" ]
 )
 
+dnl enable NVTX mark up for the MILC interface in the visual profiler
+AC_ARG_ENABLE(milc-nvtx,
+  AC_HELP_STRING([--enable-milc-nvtx], [ Enable NVTX markup for profiling MILC interface calls in the visual profiler (default: disabled)]),
+  [ milc_nvtx=${enableval}],
+  [ milc_nvtx="no" ]
+)
+
 dnl enable packing and unpacking on the device
 AC_ARG_ENABLE(device-pack,
   AC_HELP_STRING([--enable-device-pack], [ Enable the packing / unpacking of fields on the device (default: disabled)]),
@@ -559,6 +566,15 @@ yes|no);;
   ;;
 esac
 
+dnl enable NVTX mark up for the MILC interface in the visual profiler
+case ${milc_nvtx} in
+yes|no);;
+*) 
+  AC_MSG_ERROR([ invalid value for --enable-milc-nvtx ])
+  ;;
+esac
+
+
 dnl QDP-JIT support
 case ${build_qdpjit} in
 yes|no);;
@@ -725,6 +741,9 @@ AC_SUBST( GPU_COMMS, [${gpu_comms}])
 
 AC_MSG_NOTICE([Setting MPI_NVTXS= ${mpi_nvtx}])
 AC_SUBST( MPI_NVTX, [${mpi_nvtx}])
+
+AC_MSG_NOTICE([Setting MILC_NVTXS= ${milc_nvtx}])
+AC_SUBST( MILC_NVTX, [${milc_nvtx}])
 
 AC_MSG_NOTICE([Setting BUILD_QDP_INTERFACE= ${build_qdp_interface}])
 AC_SUBST( BUILD_QDP_INTERFACE, [${build_qdp_interface}])

--- a/lib/milc_interface.cpp
+++ b/lib/milc_interface.cpp
@@ -14,6 +14,34 @@
 
 #ifdef BUILD_MILC_INTERFACE
 
+// code for NVTX taken from Jiri Kraus' blog post:
+// http://devblogs.nvidia.com/parallelforall/cuda-pro-tip-generate-custom-application-profile-timelines-nvtx/
+
+#ifdef MILC_NVTX
+#include "nvToolsExt.h"
+
+const uint32_t colors[] = { 0x0000ff00, 0x000000ff, 0x00ffff00, 0x00ff00ff, 0x0000ffff, 0x00ff0000, 0x00ffffff };
+const int num_colors = sizeof(colors)/sizeof(uint32_t);
+
+#define PUSH_RANGE(name,cid) { \
+  int color_id = cid; \
+  color_id = color_id%num_colors;\
+  nvtxEventAttributes_t eventAttrib = {0}; \
+  eventAttrib.version = NVTX_VERSION; \
+  eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE; \
+  eventAttrib.colorType = NVTX_COLOR_ARGB; \
+  eventAttrib.color = colors[color_id]; \
+  eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII; \
+  eventAttrib.message.ascii = name; \
+  nvtxRangePushEx(&eventAttrib); \
+}
+#define POP_RANGE nvtxRangePop();
+#else
+#define PUSH_RANGE(name,cid)
+#define POP_RANGE
+#endif
+
+
 static bool initialized = false;
 static int gridDim[4];
 static int localDim[4];
@@ -32,12 +60,17 @@ template <bool start>
 void  inline qudamilc_called(const char* func, QudaVerbosity verb){
 #ifdef QUDAMILC_VERBOSE
 if (verb >= QUDA_VERBOSE) {
-     if(start)
+     if(start){
        printf("QUDA_MILC_INTERFACE: %s (called) \n",func);
-     else
+       PUSH_RANGE(func,1)
+     }
+     else {
       printf("QUDA_MILC_INTERFACE: %s (return) \n",func);
+      POP_RANGE
+     }
    }
 #endif
+
 }
 
 template <bool start>

--- a/lib/milc_interface.cpp
+++ b/lib/milc_interface.cpp
@@ -885,7 +885,7 @@ static inline void* createExtendedGaugeField(void* gauge, int geometry, int prec
   QudaGaugeParam gaugeParam = newMILCGaugeParam(localDim, qudaPrecision,
       (geometry==1) ? QUDA_GENERAL_LINKS : QUDA_SU3_LINKS);
   gaugeParam.use_resident_gauge = resident ? 1 : 0;
-
+  qudamilc_called<false>(__func__);
   return createExtendedGaugeFieldQuda(gauge, geometry, &gaugeParam);
 }
 
@@ -906,7 +906,7 @@ void* qudaCreateGaugeField(void* gauge, int geometry, int precision)
   QudaPrecision qudaPrecision = (precision==2) ? QUDA_DOUBLE_PRECISION : QUDA_SINGLE_PRECISION;
   QudaGaugeParam gaugeParam = newMILCGaugeParam(localDim, qudaPrecision,
       (geometry==1) ? QUDA_GENERAL_LINKS : QUDA_SU3_LINKS);
-
+  qudamilc_called<false>(__func__);
   return createGaugeFieldQuda(gauge, geometry, &gaugeParam);
 }
 
@@ -933,7 +933,9 @@ void qudaDestroyGaugeField(void* gauge)
 
 void qudaCloverTrace(void* out, void* clover, int mu, int nu)
 {
+  qudamilc_called<true>(__func__);
   computeCloverTraceQuda(out, clover, mu, nu, const_cast<int*>(localDim));
+  qudamilc_called<false>(__func__);
   return;
 }
 
@@ -941,14 +943,14 @@ void qudaCloverTrace(void* out, void* clover, int mu, int nu)
 
 void qudaCloverDerivative(void* out, void* gauge, void* oprod, int mu, int nu, double coeff, int precision, int parity, int conjugate)
 {
-
+  qudamilc_called<true>(__func__);
   QudaParity qudaParity = (parity==2) ? QUDA_EVEN_PARITY : QUDA_ODD_PARITY;
   QudaGaugeParam gaugeParam = newMILCGaugeParam(localDim, 
       (precision==1) ? QUDA_SINGLE_PRECISION : QUDA_DOUBLE_PRECISION,
       QUDA_GENERAL_LINKS);
 
   computeCloverDerivativeQuda(out, gauge, oprod, mu, nu, coeff, qudaParity, &gaugeParam, conjugate);
-
+  qudamilc_called<false>(__func__);
   return;
 }
 
@@ -1078,7 +1080,7 @@ void qudaLoadCloverField(int external_precision,
     double clover_coeff,
     int compute_trlog,
     double *trlog) {
-
+  qudamilc_called<true>(__func__);
   QudaInvertParam invertParam = newQudaInvertParam();
   setInvertParam(invertParam, inv_args, external_precision, quda_precision, 0.0, 0.0);
   invertParam.solution_type = solution_type;
@@ -1100,17 +1102,20 @@ void qudaLoadCloverField(int external_precision,
     trlog[0] = invertParam.trlogA[0];
     trlog[1] = invertParam.trlogA[1];
   }
+  qudamilc_called<false>(__func__);
 } // qudaLoadCoverField
 
 
 
 void qudaFreeCloverField() {
+  qudamilc_called<true>(__func__);
   if (clover_alloc==1) {
     freeCloverQuda();
     clover_alloc = 0;
   } else {
     errorQuda("Trying to free non-allocated clover term");
   }
+  qudamilc_called<false>(__func__);
 } // qudaFreeCloverField
 
 
@@ -1131,7 +1136,7 @@ void qudaCloverInvert(int external_precision,
     double* const final_fermilab_residual,
     int* num_iters)
 {
-
+  qudamilc_called<true>(__func__);
   if(target_fermilab_residual == 0 && target_residual == 0){
     errorQuda("qudaCloverInvert: requesting zero residual\n");
     exit(1);
@@ -1167,7 +1172,7 @@ void qudaCloverInvert(int external_precision,
 
   qudaFreeGaugeField();
   qudaFreeCloverField();
-
+  qudamilc_called<false>(__func__);
   return;
 } // qudaCloverInvert
 
@@ -1226,7 +1231,7 @@ void qudaCloverMultishiftInvert(int external_precision,
   // return the number of iterations taken by the inverter
   *num_iters = invertParam.iter;
   for(int i=0; i<num_offsets; ++i) final_residual[i] = invertParam.true_res_offset[i];
-
+  qudamilc_called<false>(__func__, verbosity);
   return;
 } // qudaCloverMultishiftInvert
 
@@ -1291,7 +1296,7 @@ void qudaCloverMultishiftMDInvert(int external_precision,
   // return the number of iterations taken by the inverter
   *num_iters = invertParam.iter;
   for(int i=0; i<num_offsets; ++i) final_residual[i] = invertParam.true_res_offset[i];
-
+  qudamilc_called<false>(__func__, verbosity);
   return;
 } // qudaCloverMultishiftMDInvert
 

--- a/make.inc.in
+++ b/make.inc.in
@@ -51,6 +51,7 @@ GPU_COMMS = @GPU_COMMS@            # set to 'yes' to allow GPU and NIC to commun
 
 # Profiling options
 MPI_NVTX = @MPI_NVTX@              # set to 'yes' to add nvtx markup to MPI API calls for the visual profiler
+MILC_NVTX = @MILC_NVTX@            # set to 'yes' to add nvtx markup to MILC interface calls for the visual profiler
 
 # Interface options
 BUILD_QDP_INTERFACE = @BUILD_QDP_INTERFACE@                     # build qdp interface
@@ -161,6 +162,11 @@ endif
 ifeq ($(strip $(MPI_NVTX)), yes)
   COMM_OBJS += nvtx_pmpi.o
   LIB += -lnvToolsExt
+endif
+
+ifeq ($(strip $(MILC_NVTX)), yes)
+  NVCCOPT += -DMILC_NVTX
+  COPT += -DMILC_NVTX
 endif
 
 ifeq ($(strip $(BUILD_MAGMA)), yes)


### PR DESCRIPTION
This adds the option to have nvtx markers in the MILC interface.
This also required the consequent bracketing of all MILC interface functions with `qudamilc_called`.
Closes #262.