### PR TITLE
compile time error if staggered outer product is compiled w/o QDP interface

### DIFF
--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -4716,6 +4716,11 @@ void computeStaggeredOprodQuda(void** oprod,
     double** coeff,
     QudaGaugeParam* param)
 {
+
+#ifdef  GPU_STAGGERED_OPROD
+#ifndef BUILD_QDP_INTERFACE
+#error "Staggerd oprod requires BUILD_QDP_INTERFACE";
+#endif
   using namespace quda;
   profileStaggeredOprod.Start(QUDA_PROFILE_TOTAL);
 
@@ -4825,6 +4830,9 @@ void computeStaggeredOprodQuda(void** oprod,
 
   checkCudaError();
   return;
+#else
+  errorQuda("Staggered oprod has not been built");
+#endif
 }
 
 


### PR DESCRIPTION
This pull request adds a compile time error if the staggered outer product is compiled without QDP interface. This is required until we remove the QDP dependence in the staggered outer product code (#160)