### PR TITLE
Hotfix/dslash cleanup

### DIFF
--- a/lib/dslash_domain_wall_4d.cu
+++ b/lib/dslash_domain_wall_4d.cu
@@ -215,6 +215,28 @@ namespace quda {
       }
       return flops;
     }
+
+    long long bytes() const {
+      bool isHalf = in->Precision() == sizeof(short) ? true : false;
+      int spinor_bytes = 2 * in->Ncolor() * in->Nspin() * in->Precision() + (isHalf ? sizeof(float) : 0);
+      long long Ls = in->X(4);
+      long long bytes;
+
+      switch(DS_type){
+      case 0:
+	bytes = DslashCuda::bytes();
+	break;
+      case 1:
+	bytes = (x ? 5ll : 4ll ) * spinor_bytes * in->VolumeCB();
+	break;
+      case 2:
+	bytes = (x ? Ls + 2 : Ls + 1) * spinor_bytes * in->VolumeCB();
+	break;
+      default:
+	errorQuda("invalid Dslash type");
+      }
+      return bytes;
+    }
   };
 #endif // GPU_DOMAIN_WALL_DIRAC
 

--- a/lib/dslash_mobius.cu
+++ b/lib/dslash_mobius.cu
@@ -228,6 +228,29 @@ namespace quda {
       }
       return flops;
     }
+
+    long long bytes() const {
+      bool isHalf = in->Precision() == sizeof(short) ? true : false;
+      int spinor_bytes = 2 * in->Ncolor() * in->Nspin() * in->Precision() + (isHalf ? sizeof(float) : 0);
+      long long Ls = in->X(4);
+      long long bytes;
+
+      switch(DS_type){
+      case 0:
+	bytes = DslashCuda::bytes();
+	break;
+      case 1:
+      case 2:
+	bytes = (x ? 5ll : 4ll) * spinor_bytes * in->VolumeCB();
+	break;
+      case 3:
+	bytes = (x ? Ls + 2 : Ls + 1) * spinor_bytes * in->VolumeCB();
+	break;
+      default:
+	errorQuda("invalid Dslash type");
+      }
+      return bytes;
+    }
   };
 #endif // GPU_DOMAIN_WALL_DIRAC
 

--- a/lib/dw_dslash4_def.h
+++ b/lib/dw_dslash4_def.h
@@ -385,7 +385,7 @@ __global__ void	DD_FUNC(DD_NAME_F, DD_RECON_F, DD_DAG_F, DD_XPAY_F)
 
 }
 
-
+#ifdef MULTI_GPU
 template <>
 __global__ void DD_FUNC(DD_NAME_F, DD_RECON_F, DD_DAG_F, DD_XPAY_F)<EXTERIOR_KERNEL_ALL>
      (DD_PARAM1, DD_PARAM2, DD_PARAM3, DD_PARAM4) {
@@ -399,6 +399,7 @@ __global__ void DD_FUNC(DD_NAME_F, DD_RECON_F, DD_DAG_F, DD_XPAY_F)<EXTERIOR_KER
 #endif
 
 }
+#endif // MULTI_GPU
 
 
 #endif

--- a/lib/dw_dslash_def.h
+++ b/lib/dw_dslash_def.h
@@ -385,6 +385,7 @@ __global__ void	DD_FUNC(DD_NAME_F, DD_RECON_F, DD_DAG_F, DD_XPAY_F)
 
 }
 
+#ifdef MULTI_GPU
 template <>
 __global__ void	DD_FUNC(DD_NAME_F, DD_RECON_F, DD_DAG_F, DD_XPAY_F)<EXTERIOR_KERNEL_ALL>
      (DD_PARAM1, DD_PARAM2, DD_PARAM3, DD_PARAM4) {
@@ -397,6 +398,7 @@ __global__ void	DD_FUNC(DD_NAME_F, DD_RECON_F, DD_DAG_F, DD_XPAY_F)<EXTERIOR_KER
 #endif
 #endif
 }
+#endif // MULTI_GPU
 
 #endif
 

--- a/lib/mdw_dslash4_def.h
+++ b/lib/mdw_dslash4_def.h
@@ -387,6 +387,7 @@ __global__ void	DD_FUNC(DD_NAME_F, DD_RECON_F, DD_DAG_F, DD_XPAY_F)
 
 }
 
+#ifdef MULTI_GPU
 template <>
 __global__ void DD_FUNC(DD_NAME_F, DD_RECON_F, DD_DAG_F, DD_XPAY_F)<EXTERIOR_KERNEL_ALL>
      (DD_PARAM1, DD_PARAM2, DD_PARAM3, DD_PARAM4) {
@@ -402,7 +403,7 @@ __global__ void DD_FUNC(DD_NAME_F, DD_RECON_F, DD_DAG_F, DD_XPAY_F)<EXTERIOR_KER
 #endif
 
 }
-
+#endif // MULTI_GPU
 
 #endif
 

--- a/lib/staggered_dslash_def.h
+++ b/lib/staggered_dslash_def.h
@@ -678,6 +678,7 @@ __global__ void	DD_FUNC(DD_FNAME, DD_RECON_F, DD_AXPY_F)
 #endif
 }
 
+#ifdef MULTI_GPU
 template <>
 __global__ void	DD_FUNC(DD_FNAME, DD_RECON_F, DD_AXPY_F)<EXTERIOR_KERNEL_ALL>
   (DD_PARAM_OUT, DD_PARAM_GAUGE, DD_PARAM_IN, DD_PARAM_AXPY) {
@@ -685,6 +686,7 @@ __global__ void	DD_FUNC(DD_FNAME, DD_RECON_F, DD_AXPY_F)<EXTERIOR_KERNEL_ALL>
   #include "staggered_fused_exterior_dslash_core.h"
 #endif
 }
+#endif // MULTI_GPU
 
 #else // naive staggered kernel
 
@@ -702,6 +704,7 @@ __global__ void	DD_FUNC(DD_FNAME, DD_RECON_F, DD_AXPY_F)
 #endif
 }
 
+#ifdef MULTI_GPU
 template <>
 __global__ void	DD_FUNC(DD_FNAME, DD_RECON_F, DD_AXPY_F)<EXTERIOR_KERNEL_ALL>
   (DD_PARAM_OUT, DD_PARAM_GAUGE, DD_PARAM_IN, DD_PARAM_AXPY) {
@@ -709,6 +712,7 @@ __global__ void	DD_FUNC(DD_FNAME, DD_RECON_F, DD_AXPY_F)<EXTERIOR_KERNEL_ALL>
   #include "staggered_fused_exterior_dslash_core.h"
 #endif
 }
+#endif // MULTI_GPU
 
 #endif
 

--- a/lib/tm_dslash_def.h
+++ b/lib/tm_dslash_def.h
@@ -419,6 +419,7 @@ __global__ void	DD_FUNC(DD_NAME_F, DD_RECON_F, DD_DAG_F, DD_XPAY_F)
 
 }
 
+#ifdef MULTI_GPU
 template <>
 __global__ void	DD_FUNC(DD_NAME_F, DD_RECON_F, DD_DAG_F, DD_XPAY_F)<EXTERIOR_KERNEL_ALL>
      (DD_PARAM1, DD_PARAM2, DD_PARAM3, DD_PARAM4) {
@@ -454,6 +455,7 @@ __global__ void	DD_FUNC(DD_NAME_F, DD_RECON_F, DD_DAG_F, DD_XPAY_F)<EXTERIOR_KER
 #endif
 
 }
+#endif // MULTI_GPU
 
 
 //NEW

--- a/lib/tm_ndeg_dslash_def.h
+++ b/lib/tm_ndeg_dslash_def.h
@@ -413,7 +413,7 @@ __global__ void	DD_FUNC(DD_NAME_F, DD_RECON_F, DD_DAG_F, DD_TWIST_F, DD_XPAY_F)
 
 }
 
-
+#ifdef MULTI_GPU
 template <>
 __global__ void DD_FUNC(DD_NAME_F, DD_RECON_F, DD_DAG_F, DD_TWIST_F, DD_XPAY_F)<EXTERIOR_KERNEL_ALL>
      (DD_PARAM1, DD_PARAM2, DD_PARAM3, DD_PARAM4) {
@@ -427,7 +427,7 @@ __global__ void DD_FUNC(DD_NAME_F, DD_RECON_F, DD_DAG_F, DD_TWIST_F, DD_XPAY_F)<
 #endif
 
 }
-
+#endif // MULTI_GPU
 
 #endif
 

--- a/lib/tmc_dslash_def.h
+++ b/lib/tmc_dslash_def.h
@@ -482,6 +482,7 @@ __global__ void	DD_FUNC(DD_NAME_F, DD_RECON_F, DD_DAG_F, DD_XPAY_F)
 
 }
 
+#ifdef MULTI_GPU
 template <>
 __global__ void DD_FUNC(DD_NAME_F, DD_RECON_F, DD_DAG_F, DD_XPAY_F)<EXTERIOR_KERNEL_ALL>
      (DD_PARAM1, DD_PARAM2, DD_PARAMCLOVER, DD_PARAM3, DD_PARAM4) {
@@ -517,6 +518,7 @@ __global__ void DD_FUNC(DD_NAME_F, DD_RECON_F, DD_DAG_F, DD_XPAY_F)<EXTERIOR_KER
 #endif
 
 }
+#endif // MULTI_GPU
 
 
 //NEW
@@ -563,6 +565,7 @@ __global__ void	DD_FUNC(DD_NAME_F, DD_RECON_F, DD_DAG_F, DD_XPAY_F)
 
 }
 
+#ifdef MULTI_GPU
 template <>
 __global__ void DD_FUNC(DD_NAME_F, DD_RECON_F, DD_DAG_F, DD_XPAY_F)<EXTERIOR_KERNEL_ALL>
      (DD_PARAM1, DD_PARAM2, DD_PARAMCLOVER, DD_PARAM3, DD_PARAM4) {
@@ -598,6 +601,7 @@ __global__ void DD_FUNC(DD_NAME_F, DD_RECON_F, DD_DAG_F, DD_XPAY_F)<EXTERIOR_KER
 #endif
 
 }
+#endif // MULTI_GPU
 
 #undef CLOVER_TWIST_XPAY
 #endif //(DD_XPAY==0) && (DD_TWIST==1)

--- a/lib/wilson_dslash_def.h
+++ b/lib/wilson_dslash_def.h
@@ -518,7 +518,7 @@ __global__ void	DD_FUNC(DD_NAME_F, DD_RECON_F, DD_DAG_F, DD_XPAY_F)
 
 }
 
-
+#ifdef MULTI_GPU
 template <>
 __global__ void	DD_FUNC(DD_NAME_F, DD_RECON_F, DD_DAG_F, DD_XPAY_F)<EXTERIOR_KERNEL_ALL>
   (DD_PARAM_OUT DD_PARAM_GAUGE DD_PARAM_CLOVER DD_PARAM_IN DD_PARAM_XPAY const DslashParam param) {
@@ -593,6 +593,7 @@ __global__ void	DD_FUNC(DD_NAME_F, DD_RECON_F, DD_DAG_F, DD_XPAY_F)<EXTERIOR_KER
 #endif // DD_CLOVER
 
 }
+#endif // MULTI_GPU
 #endif
 
 // clean up


### PR DESCRIPTION
This pull request:
* Only compile fused dslash kernels when `MULTI_GPU` is set
* Fixes the memory bandwidth numbers for the 4-d domain-wall kernels (closes #315)