### PR TITLE
Hotfix/compile time

### DIFF
--- a/include/clover_field.h
+++ b/include/clover_field.h
@@ -61,6 +61,12 @@ namespace quda {
     const void* V(bool inverse=false) const { return inverse ? cloverInv : clover; }
     const void* Norm(bool inverse=false) const { return inverse ? invNorm : norm; }
 
+    /**
+       This function returns true if the field is stored in an
+       internal field order for the given precision.
+    */
+    bool isNative() const;
+
     double* TrLog() const { return trlog; }
     
     QudaCloverFieldOrder Order() const { return order; }

--- a/include/clover_field_order.h
+++ b/include/clover_field_order.h
@@ -300,4 +300,17 @@ namespace quda {
     };
 
 
+  // Use traits to reduce the template explosion
+  template<typename Float,int N=72> struct clover_mapper { };
+
+  // double precision uses Float2
+  template<int N> struct clover_mapper<double,N> { typedef FloatNOrder<double, N, 2> type; };
+
+  // single precision uses Float4
+  template<int N> struct clover_mapper<float,N> { typedef FloatNOrder<float, N, 4> type; };
+
+  // half precision uses Float4
+  template<int N> struct clover_mapper<short,N> { typedef FloatNOrder<short, N, 4> type; };
+
+
 }

--- a/include/gauge_field_order.h
+++ b/include/gauge_field_order.h
@@ -945,4 +945,29 @@ namespace quda {
   };
 
 
-}
+  
+  // Use traits to reduce the template explosion
+  template<typename ,QudaReconstructType,int N=18> struct gauge_mapper { };
+
+  // double precision
+  template<int N> struct gauge_mapper<double,QUDA_RECONSTRUCT_NO,N> { typedef FloatNOrder<double, N, 2, N> type; };
+  template<int N> struct gauge_mapper<double,QUDA_RECONSTRUCT_13,N> { typedef FloatNOrder<double, N, 2, 13> type; };
+  template<int N> struct gauge_mapper<double,QUDA_RECONSTRUCT_12,N> { typedef FloatNOrder<double, N, 2, 12> type; };
+  template<int N> struct gauge_mapper<double,QUDA_RECONSTRUCT_9,N> { typedef FloatNOrder<double, N, 2, 9> type; };
+  template<int N> struct gauge_mapper<double,QUDA_RECONSTRUCT_8,N> { typedef FloatNOrder<double, N, 2, 8> type; };
+
+  // single precision
+  template<int N> struct gauge_mapper<float,QUDA_RECONSTRUCT_NO,N> { typedef FloatNOrder<float, N, 2, N> type; };
+  template<int N> struct gauge_mapper<float,QUDA_RECONSTRUCT_13,N> { typedef FloatNOrder<float, N, 4, 13> type; };
+  template<int N> struct gauge_mapper<float,QUDA_RECONSTRUCT_12,N> { typedef FloatNOrder<float, N, 4, 12> type; };
+  template<int N> struct gauge_mapper<float,QUDA_RECONSTRUCT_9,N> { typedef FloatNOrder<float, N, 4, 9> type; };
+  template<int N> struct gauge_mapper<float,QUDA_RECONSTRUCT_8,N> { typedef FloatNOrder<float, N, 4, 8> type; };
+
+  // half precision
+  template<int N> struct gauge_mapper<short,QUDA_RECONSTRUCT_NO,N> { typedef FloatNOrder<short, N, 2, N> type; };
+  template<int N> struct gauge_mapper<short,QUDA_RECONSTRUCT_13,N> { typedef FloatNOrder<short, N, 4, 13> type; };
+  template<int N> struct gauge_mapper<short,QUDA_RECONSTRUCT_12,N> { typedef FloatNOrder<short, N, 4, 12> type; };
+  template<int N> struct gauge_mapper<short,QUDA_RECONSTRUCT_9,N> { typedef FloatNOrder<short, N, 4, 9> type; };
+  template<int N> struct gauge_mapper<short,QUDA_RECONSTRUCT_8,N> { typedef FloatNOrder<short, N, 4, 8> type; };
+
+} // namespace quda

--- a/lib/clover_field.cpp
+++ b/lib/clover_field.cpp
@@ -38,6 +38,16 @@ namespace quda {
     host_free(trlog);
   }
 
+  bool CloverField::isNative() const {
+    if (precision == QUDA_DOUBLE_PRECISION) {
+      if (order  == QUDA_FLOAT2_CLOVER_ORDER) return true;
+    } else if (precision == QUDA_SINGLE_PRECISION || 
+	       precision == QUDA_HALF_PRECISION) {
+      if (order == QUDA_FLOAT4_GAUGE_ORDER) return true;
+    }
+    return false;
+  }
+
   cudaCloverField::cudaCloverField(const CloverFieldParam &param) : CloverField(param) {
     
     if (create != QUDA_NULL_FIELD_CREATE && create != QUDA_REFERENCE_FIELD_CREATE) 

--- a/lib/clover_field.cpp
+++ b/lib/clover_field.cpp
@@ -43,7 +43,7 @@ namespace quda {
       if (order  == QUDA_FLOAT2_CLOVER_ORDER) return true;
     } else if (precision == QUDA_SINGLE_PRECISION || 
 	       precision == QUDA_HALF_PRECISION) {
-      if (order == QUDA_FLOAT4_GAUGE_ORDER) return true;
+      if (order == QUDA_FLOAT4_CLOVER_ORDER) return true;
     }
     return false;
   }

--- a/lib/clover_invert.cu
+++ b/lib/clover_invert.cu
@@ -278,14 +278,11 @@ namespace quda {
 
   template <typename Float>
   void cloverInvert(const CloverField &clover, bool computeTraceLog, QudaFieldLocation location) {
-    if (clover.Order() == QUDA_FLOAT2_CLOVER_ORDER) {
-      cloverInvert<Float>(FloatNOrder<Float,72,2>(clover, 1), 
-			  FloatNOrder<Float,72,2>(clover, 0), 
-			  computeTraceLog, clover.TrLog(), clover, location);
-    } else if (clover.Order() == QUDA_FLOAT4_CLOVER_ORDER) {
-      cloverInvert<Float>(FloatNOrder<Float,72,4>(clover, 1), 
-			  FloatNOrder<Float,72,4>(clover, 0), 
-			  computeTraceLog, clover.TrLog(), clover, location);
+
+    if (clover.isNative()) {
+      typedef typename clover_mapper<Float>::type C;
+      cloverInvert<Float>(C(clover, 1), C(clover, 0), computeTraceLog,
+			  clover.TrLog(), clover, location);
     } else {
       errorQuda("Clover field %d order not supported", clover.Order());
     }

--- a/lib/copy_gauge_extended.cu
+++ b/lib/copy_gauge_extended.cu
@@ -154,51 +154,37 @@ namespace quda {
     int faceVolumeCB[QUDA_MAX_DIM];
     for (int i=0; i<4; i++) faceVolumeCB[i] = out.SurfaceCB(i) * out.Nface(); 
 
-    if (out.Order() == QUDA_FLOAT2_GAUGE_ORDER) {
+    if (out.isNative()) {
       if (out.Reconstruct() == QUDA_RECONSTRUCT_NO) {
 	if (typeid(FloatOut)==typeid(short) && out.LinkType() == QUDA_ASQTAD_FAT_LINKS) {
-	  copyGaugeEx<FloatOut,FloatIn,length>
-	    (FloatNOrder<FloatOut,length,2,19>(out, Out), inOrder, out.X(), X, faceVolumeCB, out, location);
+	  copyGaugeEx<short,FloatIn,length>
+	    (FloatNOrder<short,length,2,19>(out, (short*)Out), inOrder, out.X(), X, faceVolumeCB, out, location);
 	} else {
+	  typedef typename gauge_mapper<FloatOut,QUDA_RECONSTRUCT_NO>::type G;
 	  copyGaugeEx<FloatOut,FloatIn,length>
-	    (FloatNOrder<FloatOut,length,2,18>(out, Out), inOrder, out.X(), X, faceVolumeCB, out, location);
+	    (G(out, Out), inOrder, out.X(), X, faceVolumeCB, out, location);
 	}
       } else if (out.Reconstruct() == QUDA_RECONSTRUCT_12) {
+	typedef typename gauge_mapper<FloatOut,QUDA_RECONSTRUCT_12>::type G;
 	copyGaugeEx<FloatOut,FloatIn,length> 
-	  (FloatNOrder<FloatOut,length,2,12>(out, Out), inOrder, out.X(), X, faceVolumeCB, out, location);
+	  (G(out, Out), inOrder, out.X(), X, faceVolumeCB, out, location);
       } else if (out.Reconstruct() == QUDA_RECONSTRUCT_8) {
+	typedef typename gauge_mapper<FloatOut,QUDA_RECONSTRUCT_8>::type G;
 	copyGaugeEx<FloatOut,FloatIn,length> 
-	  (FloatNOrder<FloatOut,length,2,8>(out, Out), inOrder, out.X(), X, faceVolumeCB, out, location);
+	  (G(out, Out), inOrder, out.X(), X, faceVolumeCB, out, location);
 #ifdef GPU_STAGGERED_DIRAC
       } else if (out.Reconstruct() == QUDA_RECONSTRUCT_13) {
+	typedef typename gauge_mapper<FloatOut,QUDA_RECONSTRUCT_13>::type G;
         copyGaugeEx<FloatOut,FloatIn,length>
-	  (FloatNOrder<FloatOut,length,2,13>(out, Out), inOrder, out.X(), X, faceVolumeCB, out, location);
+	  (G(out, Out), inOrder, out.X(), X, faceVolumeCB, out, location);
       } else if (out.Reconstruct() == QUDA_RECONSTRUCT_9) {
+	typedef typename gauge_mapper<FloatOut,QUDA_RECONSTRUCT_9>::type G;
         copyGaugeEx<FloatOut,FloatIn,length>
-	  (FloatNOrder<FloatOut,length,2,9>(out, Out), inOrder, out.X(), X, faceVolumeCB, out, location);
+	  (G(out, Out), inOrder, out.X(), X, faceVolumeCB, out, location);
 #endif
       } else {
 	errorQuda("Reconstruction %d and order %d not supported", out.Reconstruct(), out.Order());
       }
-    } else if (out.Order() == QUDA_FLOAT4_GAUGE_ORDER) {
-      if (out.Reconstruct() == QUDA_RECONSTRUCT_12) {
-	copyGaugeEx<FloatOut,FloatIn,length> 
-	  (FloatNOrder<FloatOut,length,4,12>(out, Out), inOrder, out.X(), X, faceVolumeCB, out, location);
-      } else if (out.Reconstruct() == QUDA_RECONSTRUCT_8) {
-	copyGaugeEx<FloatOut,FloatIn,length> 
-	  (FloatNOrder<FloatOut,length,4,8>(out, Out), inOrder, out.X(), X, faceVolumeCB, out, location);
-#ifdef GPU_STAGGERED_DIRAC
-      } else if (out.Reconstruct() == QUDA_RECONSTRUCT_13) {
-	copyGaugeEx<FloatOut,FloatIn,length> 
-	  (FloatNOrder<FloatOut,length,4,13>(out, Out), inOrder, out.X(), X, faceVolumeCB, out, location);
-      } else if (out.Reconstruct() == QUDA_RECONSTRUCT_9) {
-	copyGaugeEx<FloatOut,FloatIn,length> 
-	  (FloatNOrder<FloatOut,length,4,9>(out, Out), inOrder, out.X(), X, faceVolumeCB, out, location);
-#endif
-      } else {
-	errorQuda("Reconstruction %d and order %d not supported", out.Reconstruct(), out.Order());
-      }
-
     } else if (out.Order() == QUDA_QDP_GAUGE_ORDER) {
 
 #ifdef BUILD_QDP_INTERFACE
@@ -236,51 +222,32 @@ namespace quda {
   void copyGaugeEx(GaugeField &out, const GaugeField &in, QudaFieldLocation location, 
 		   FloatOut *Out, FloatIn *In) {
 
-    if (in.Order() == QUDA_FLOAT2_GAUGE_ORDER) {
+    if (in.isNative()) {
       if (in.Reconstruct() == QUDA_RECONSTRUCT_NO) {
 	if (typeid(FloatIn)==typeid(short) && in.LinkType() == QUDA_ASQTAD_FAT_LINKS) {
-	  copyGaugeEx<FloatOut,FloatIn,length> (FloatNOrder<FloatIn,length,2,19>(in, In), 
+	  copyGaugeEx<FloatOut,short,length> (FloatNOrder<short,length,2,19>(in, (short*)In), 
 					      in.X(), out, location, Out);
 	} else {
-	  copyGaugeEx<FloatOut,FloatIn,length> (FloatNOrder<FloatIn,length,2,18>(in, In),
-					      in.X(), out, location, Out);
+	  typedef typename gauge_mapper<FloatIn,QUDA_RECONSTRUCT_NO>::type G;
+	  copyGaugeEx<FloatOut,FloatIn,length> (G(in, In), in.X(), out, location, Out);
 	}
       } else if (in.Reconstruct() == QUDA_RECONSTRUCT_12) {
-	copyGaugeEx<FloatOut,FloatIn,length> (FloatNOrder<FloatIn,length,2,12>(in, In),
-					    in.X(), out, location, Out);
+	typedef typename gauge_mapper<FloatIn,QUDA_RECONSTRUCT_12>::type G;
+	copyGaugeEx<FloatOut,FloatIn,length> (G(in, In), in.X(), out, location, Out);
       } else if (in.Reconstruct() == QUDA_RECONSTRUCT_8) {
-	copyGaugeEx<FloatOut,FloatIn,length> (FloatNOrder<FloatIn,length,2,8>(in, In), 
-					    in.X(), out, location, Out);
+	typedef typename gauge_mapper<FloatIn,QUDA_RECONSTRUCT_8>::type G;
+	copyGaugeEx<FloatOut,FloatIn,length> (G(in, In), in.X(), out, location, Out);
 #ifdef GPU_STAGGERED_DIRAC
       } else if (in.Reconstruct() == QUDA_RECONSTRUCT_13) {
-	copyGaugeEx<FloatOut,FloatIn,length> (FloatNOrder<FloatIn,length,2,13>(in, In), 
-					    in.X(), out, location, Out);
+	typedef typename gauge_mapper<FloatIn,QUDA_RECONSTRUCT_13>::type G;
+	copyGaugeEx<FloatOut,FloatIn,length> (G(in, In), in.X(), out, location, Out);
       } else if (in.Reconstruct() == QUDA_RECONSTRUCT_9) {
-	copyGaugeEx<FloatOut,FloatIn,length> (FloatNOrder<FloatIn,length,2,9>(in, In), 
-					    in.X(), out, location, Out);
+	typedef typename gauge_mapper<FloatIn,QUDA_RECONSTRUCT_9>::type G;
+	copyGaugeEx<FloatOut,FloatIn,length> (G(in, In), in.X(), out, location, Out);
 #endif
       } else {
 	errorQuda("Reconstruction %d and order %d not supported", in.Reconstruct(), in.Order());
       }
-    } else if (in.Order() == QUDA_FLOAT4_GAUGE_ORDER) {
-      if (in.Reconstruct() == QUDA_RECONSTRUCT_12) {
-	copyGaugeEx<FloatOut,FloatIn,length> (FloatNOrder<FloatIn,length,4,12>(in, In), 
-					    in.X(), out, location, Out);
-      } else if (in.Reconstruct() == QUDA_RECONSTRUCT_8) {
-	copyGaugeEx<FloatOut,FloatIn,length> (FloatNOrder<FloatIn,length,4,8>(in, In), 
-					    in.X(), out, location, Out);
-#ifdef GPU_STAGGERED_DIRAC
-      } else if (in.Reconstruct() == QUDA_RECONSTRUCT_13) {
-	copyGaugeEx<FloatOut,FloatIn,length> (FloatNOrder<FloatIn,length,4,13>(in, In), 
-					    in.X(), out, location, Out);
-      } else if (in.Reconstruct() == QUDA_RECONSTRUCT_9) {
-	copyGaugeEx<FloatOut,FloatIn,length> (FloatNOrder<FloatIn,length,4,9>(in, In), 
-					      in.X(), out, location, Out);
-#endif
-      } else {
-	errorQuda("Reconstruction %d and order %d not supported", in.Reconstruct(), in.Order());
-      }
-
     } else if (in.Order() == QUDA_QDP_GAUGE_ORDER) {
 
 #ifdef BUILD_QDP_INTERFACE

--- a/lib/copy_gauge_inc.cu
+++ b/lib/copy_gauge_inc.cu
@@ -225,56 +225,39 @@ namespace quda {
 		 FloatOut *Out, FloatOut **outGhost, int type) {
     int faceVolumeCB[QUDA_MAX_DIM];
     for (int i=0; i<4; i++) faceVolumeCB[i] = out.SurfaceCB(i) * out.Nface(); 
-    if (out.Order() == QUDA_FLOAT2_GAUGE_ORDER) {
+    if (out.isNative()) {
       if (out.Reconstruct() == QUDA_RECONSTRUCT_NO) {
 	if (typeid(FloatOut)==typeid(short) && out.LinkType() == QUDA_ASQTAD_FAT_LINKS) {
-	  copyGauge<FloatOut,FloatIn,length>
-	    (FloatNOrder<FloatOut,length,2,19>(out, Out, outGhost), inOrder, out.Volume(), 
-	     faceVolumeCB, out.Ndim(), out.Geometry(), out, location, type);
+	  copyGauge<short,FloatIn,length>
+	    (FloatNOrder<short,length,2,19>(out, (short*)Out, (short**)outGhost), inOrder,
+	     out.Volume(), faceVolumeCB, out.Ndim(), out.Geometry(), out, location, type);
 	} else {
+	  typedef typename gauge_mapper<FloatOut,QUDA_RECONSTRUCT_NO>::type G;
 	  copyGauge<FloatOut,FloatIn,length>
-	    (FloatNOrder<FloatOut,length,2,18>(out, Out, outGhost), inOrder, out.Volume(), 
-	     faceVolumeCB, out.Ndim(), out.Geometry(), out, location, type);
+	    (G(out,Out,outGhost), inOrder, out.Volume(), faceVolumeCB,
+	     out.Ndim(), out.Geometry(), out, location, type);
 	}
       } else if (out.Reconstruct() == QUDA_RECONSTRUCT_12) {
-	copyGauge<FloatOut,FloatIn,length> 
-	  (FloatNOrder<FloatOut,length,2,12>(out, Out, outGhost), inOrder, out.Volume(), 
-	   faceVolumeCB, out.Ndim(), out.Geometry(), out, location, type);
+	typedef typename gauge_mapper<FloatOut,QUDA_RECONSTRUCT_12>::type G;
+	copyGauge<FloatOut,FloatIn,length>
+	  (G(out,Out,outGhost), inOrder, out.Volume(), faceVolumeCB,
+	   out.Ndim(), out.Geometry(), out, location, type);
       } else if (out.Reconstruct() == QUDA_RECONSTRUCT_8) {
+	typedef typename gauge_mapper<FloatOut,QUDA_RECONSTRUCT_8>::type G;
 	copyGauge<FloatOut,FloatIn,length> 
-	  (FloatNOrder<FloatOut,length,2,8>(out, Out, outGhost), inOrder, out.Volume(), 
-	   faceVolumeCB, out.Ndim(), out.Geometry(), out, location, type);
+	  (G(out,Out,outGhost), inOrder, out.Volume(), faceVolumeCB,
+	   out.Ndim(), out.Geometry(), out, location, type);
 #if defined(GPU_STAGGERED_DIRAC) && __COMPUTE_CAPABILITY__ >= 200
       } else if (out.Reconstruct() == QUDA_RECONSTRUCT_13) {
+	typedef typename gauge_mapper<FloatOut,QUDA_RECONSTRUCT_13>::type G;
         copyGauge<FloatOut,FloatIn,length>
-	  (FloatNOrder<FloatOut,length,2,13>(out, Out, outGhost), inOrder, out.Volume(), 
-	   faceVolumeCB, out.Ndim(),  out.Geometry(), out, location, type);
+	  (G(out, Out, outGhost), inOrder, out.Volume(), faceVolumeCB,
+	   out.Ndim(),  out.Geometry(), out, location, type);
       } else if (out.Reconstruct() == QUDA_RECONSTRUCT_9) {
+	typedef typename gauge_mapper<FloatOut,QUDA_RECONSTRUCT_9>::type G;
         copyGauge<FloatOut,FloatIn,length>
-	  (FloatNOrder<FloatOut,length,2,9>(out, Out, outGhost), inOrder, out.Volume(), 
-	   faceVolumeCB, out.Ndim(), out.Geometry(), out, location, type);
-#endif
-      } else {
-	errorQuda("Reconstruction %d and order %d not supported", out.Reconstruct(), out.Order());
-      }
-    } else if (out.Order() == QUDA_FLOAT4_GAUGE_ORDER) {
-      if (out.Reconstruct() == QUDA_RECONSTRUCT_12) {
-	copyGauge<FloatOut,FloatIn,length> 
-	  (FloatNOrder<FloatOut,length,4,12>(out, Out, outGhost), inOrder, out.Volume(), 
-	   faceVolumeCB, out.Ndim(), out.Geometry(), out, location, type);
-      } else if (out.Reconstruct() == QUDA_RECONSTRUCT_8) {
-	copyGauge<FloatOut,FloatIn,length> 
-	  (FloatNOrder<FloatOut,length,4,8>(out, Out, outGhost), inOrder, out.Volume(), 
-	   faceVolumeCB, out.Ndim(), out.Geometry(), out, location, type);
-#if defined(GPU_STAGGERED_DIRAC) && __COMPUTE_CAPABILITY__ >= 200
-      } else if (out.Reconstruct() == QUDA_RECONSTRUCT_13) {
-	copyGauge<FloatOut,FloatIn,length> 
-	  (FloatNOrder<FloatOut,length,4,13>(out, Out, outGhost), inOrder, out.Volume(), 
-	   faceVolumeCB, out.Ndim(), out.Geometry(), out, location, type);
-      } else if (out.Reconstruct() == QUDA_RECONSTRUCT_9) {
-	copyGauge<FloatOut,FloatIn,length> 
-	  (FloatNOrder<FloatOut,length,4,9>(out, Out, outGhost), inOrder, out.Volume(), 
-	   faceVolumeCB, out.Ndim(), out.Geometry(), out, location, type);
+	  (G(out, Out, outGhost), inOrder, out.Volume(), faceVolumeCB,
+	   out.Ndim(), out.Geometry(), out, location, type);
 #endif
       } else {
 	errorQuda("Reconstruction %d and order %d not supported", out.Reconstruct(), out.Order());
@@ -350,46 +333,29 @@ namespace quda {
 		   FloatOut *Out, FloatIn *In, FloatOut **outGhost, FloatIn **inGhost, int type) {
 
     // reconstruction only supported on FloatN fields currently
-    if (in.Order() == QUDA_FLOAT2_GAUGE_ORDER) {
+    if (in.isNative()) {      
       if (in.Reconstruct() == QUDA_RECONSTRUCT_NO) {
 	if (typeid(FloatIn)==typeid(short) && in.LinkType() == QUDA_ASQTAD_FAT_LINKS) {
-	  copyGauge<FloatOut,FloatIn,length> (FloatNOrder<FloatIn,length,2,19>(in, In, inGhost), 
-					      out, location, Out, outGhost, type);
+	  copyGauge<FloatOut,short,length> (FloatNOrder<short,length,2,19>
+					    (in,(short*)In,(short**)inGhost),
+					    out, location, Out, outGhost, type);
 	} else {
-	  copyGauge<FloatOut,FloatIn,length> (FloatNOrder<FloatIn,length,2,18>(in, In, inGhost),
-					      out, location, Out, outGhost, type);
+	  typedef typename gauge_mapper<FloatIn,QUDA_RECONSTRUCT_NO>::type G;
+	  copyGauge<FloatOut,FloatIn,length> (G(in,In,inGhost), out, location, Out, outGhost, type);
 	}
       } else if (in.Reconstruct() == QUDA_RECONSTRUCT_12) {
-	copyGauge<FloatOut,FloatIn,length> (FloatNOrder<FloatIn,length,2,12>(in, In, inGhost),
-					    out, location, Out, outGhost, type);
+	typedef typename gauge_mapper<FloatIn,QUDA_RECONSTRUCT_12>::type G;
+	copyGauge<FloatOut,FloatIn,length> (G(in,In,inGhost), out, location, Out, outGhost, type);
       } else if (in.Reconstruct() == QUDA_RECONSTRUCT_8) {
-	copyGauge<FloatOut,FloatIn,length> (FloatNOrder<FloatIn,length,2,8>(in, In, inGhost), 
-					    out, location, Out, outGhost, type);
+	typedef typename gauge_mapper<FloatIn,QUDA_RECONSTRUCT_8>::type G;
+	copyGauge<FloatOut,FloatIn,length> (G(in,In,inGhost), out, location, Out, outGhost, type);
 #if defined(GPU_STAGGERED_DIRAC) && __COMPUTE_CAPABILITY__ >= 200
       } else if (in.Reconstruct() == QUDA_RECONSTRUCT_13) {
-	copyGauge<FloatOut,FloatIn,length> (FloatNOrder<FloatIn,length,2,13>(in, In, inGhost), 
-					    out, location, Out, outGhost, type);
+	typedef typename gauge_mapper<FloatIn,QUDA_RECONSTRUCT_13>::type G;
+	copyGauge<FloatOut,FloatIn,length> (G(in,In,inGhost), out, location, Out, outGhost, type);
       } else if (in.Reconstruct() == QUDA_RECONSTRUCT_9) {
-	copyGauge<FloatOut,FloatIn,length> (FloatNOrder<FloatIn,length,2,9>(in, In, inGhost), 
-					    out, location, Out, outGhost, type);
-#endif
-      } else {
-	errorQuda("Reconstruction %d and order %d not supported", in.Reconstruct(), in.Order());
-      }
-    } else if (in.Order() == QUDA_FLOAT4_GAUGE_ORDER) {
-      if (in.Reconstruct() == QUDA_RECONSTRUCT_12) {
-	copyGauge<FloatOut,FloatIn,length> (FloatNOrder<FloatIn,length,4,12>(in, In, inGhost), 
-					    out, location, Out, outGhost, type);
-      } else if (in.Reconstruct() == QUDA_RECONSTRUCT_8) {
-	copyGauge<FloatOut,FloatIn,length> (FloatNOrder<FloatIn,length,4,8>(in, In, inGhost), 
-					    out, location, Out, outGhost, type);
-#if defined(GPU_STAGGERED_DIRAC) && __COMPUTE_CAPABILITY__ >= 200
-      } else if (in.Reconstruct() == QUDA_RECONSTRUCT_13) {
-	copyGauge<FloatOut,FloatIn,length> (FloatNOrder<FloatIn,length,4,13>(in, In, inGhost), 
-					    out, location, Out, outGhost, type);
-      } else if (in.Reconstruct() == QUDA_RECONSTRUCT_9) {
-	copyGauge<FloatOut,FloatIn,length> (FloatNOrder<FloatIn,length,4,9>(in, In, inGhost), 
-					    out, location, Out, outGhost, type);
+	typedef typename gauge_mapper<FloatIn,QUDA_RECONSTRUCT_9>::type G;
+	copyGauge<FloatOut,FloatIn,length> (G(in,In,inGhost), out, location, Out, outGhost, type);
 #endif
       } else {
 	errorQuda("Reconstruction %d and order %d not supported", in.Reconstruct(), in.Order());

--- a/lib/extract_gauge_ghost.cu
+++ b/lib/extract_gauge_ghost.cu
@@ -218,37 +218,27 @@ namespace quda {
     QudaFieldLocation location = 
       (typeid(u)==typeid(cudaGaugeField)) ? QUDA_CUDA_FIELD_LOCATION : QUDA_CPU_FIELD_LOCATION;
 
-    if (u.Order() == QUDA_FLOAT2_GAUGE_ORDER) {
+    if (u.isNative()) {
       if (u.Reconstruct() == QUDA_RECONSTRUCT_NO) {
 	if (typeid(Float)==typeid(short) && u.LinkType() == QUDA_ASQTAD_FAT_LINKS) {
-	  extractGhost<Float,length>(FloatNOrder<Float,length,2,19>(u, 0, Ghost), u, location);
+	  extractGhost<short,length>(FloatNOrder<short,length,2,19>
+				     (u, 0, (short**)Ghost), u, location);
 	} else {
-	  extractGhost<Float,length>(FloatNOrder<Float,length,2,18>(u, 0, Ghost), u, location);
+	  typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_NO>::type G;
+	  extractGhost<Float,length>(G(u, 0, Ghost), u, location);
 	}
       } else if (u.Reconstruct() == QUDA_RECONSTRUCT_12) {
-	extractGhost<Float,length>(FloatNOrder<Float,length,2,12>(u, 0, Ghost), u, location);
+	typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_12>::type G;
+	extractGhost<Float,length>(G(u, 0, Ghost), u, location);
       } else if (u.Reconstruct() == QUDA_RECONSTRUCT_8) {
-	extractGhost<Float,length>(FloatNOrder<Float,length,2,8>(u, 0, Ghost), u, location);
+	typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_8>::type G;
+	extractGhost<Float,length>(G(u, 0, Ghost), u, location);
       } else if (u.Reconstruct() == QUDA_RECONSTRUCT_13) {
-	extractGhost<Float,length>(FloatNOrder<Float,length,2,13>(u, 0, Ghost), u, location);
+	typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_13>::type G;
+	extractGhost<Float,length>(G(u, 0, Ghost), u, location);
       } else if (u.Reconstruct() == QUDA_RECONSTRUCT_9) {
-	extractGhost<Float,length>(FloatNOrder<Float,length,2,9>(u, 0, Ghost), u, location);
-      }
-    } else if (u.Order() == QUDA_FLOAT4_GAUGE_ORDER) {
-      if (u.Reconstruct() == QUDA_RECONSTRUCT_NO) {
-	if (typeid(Float)==typeid(short) && u.LinkType() == QUDA_ASQTAD_FAT_LINKS) {
-	  extractGhost<Float,length>(FloatNOrder<Float,length,1,19>(u, 0, Ghost), u, location);
-	} else {
-	  extractGhost<Float,length>(FloatNOrder<Float,length,1,18>(u, 0, Ghost), u, location);
-	}
-      } else if (u.Reconstruct() == QUDA_RECONSTRUCT_12) {
-	extractGhost<Float,length>(FloatNOrder<Float,length,4,12>(u, 0, Ghost), u, location);
-      } else if (u.Reconstruct() == QUDA_RECONSTRUCT_8) { 
-	extractGhost<Float,length>(FloatNOrder<Float,length,4,8>(u, 0, Ghost), u, location);
-      } else if(u.Reconstruct() == QUDA_RECONSTRUCT_13){
-	extractGhost<Float,length>(FloatNOrder<Float,length,4,13>(u, 0, Ghost), u, location);
-      } else if(u.Reconstruct() == QUDA_RECONSTRUCT_9){
-	extractGhost<Float,length>(FloatNOrder<Float,length,4,9>(u, 0, Ghost), u, location);
+	typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_9>::type G;
+	extractGhost<Float,length>(G(u, 0, Ghost), u, location);
       }
     } else if (u.Order() == QUDA_QDP_GAUGE_ORDER) {
       

--- a/lib/extract_gauge_ghost_extended.cu
+++ b/lib/extract_gauge_ghost_extended.cu
@@ -333,48 +333,31 @@ namespace quda {
     QudaFieldLocation location = 
       (typeid(u)==typeid(cudaGaugeField)) ? QUDA_CUDA_FIELD_LOCATION : QUDA_CPU_FIELD_LOCATION;
 
-    if (u.Order() == QUDA_FLOAT2_GAUGE_ORDER) {
+    if (u.isNative()) {
       if (u.Reconstruct() == QUDA_RECONSTRUCT_NO) {
 	if (typeid(Float)==typeid(short) && u.LinkType() == QUDA_ASQTAD_FAT_LINKS) {
-	  extractGhostEx<Float,length>(FloatNOrder<Float,length,2,19>(u, 0, Ghost), 
+	  extractGhostEx<short,length>(FloatNOrder<short,length,2,19>(u, 0, (short**)Ghost), 
 				       dim, u.SurfaceCB(), u.X(), R, extract, u, location);
 	} else {
-	  extractGhostEx<Float,length>(FloatNOrder<Float,length,2,18>(u, 0, Ghost),
+	  typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_NO>::type G;
+	  extractGhostEx<Float,length>(G(u, 0, Ghost),
 				       dim, u.SurfaceCB(), u.X(), R, extract, u, location);
 	}
       } else if (u.Reconstruct() == QUDA_RECONSTRUCT_12) {
-	extractGhostEx<Float,length>(FloatNOrder<Float,length,2,12>(u, 0, Ghost),
+	typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_12>::type G;
+	extractGhostEx<Float,length>(G(u, 0, Ghost),
 				     dim, u.SurfaceCB(), u.X(), R, extract, u, location);
       } else if (u.Reconstruct() == QUDA_RECONSTRUCT_8) {
-	extractGhostEx<Float,length>(FloatNOrder<Float,length,2,8>(u, 0, Ghost), 
+	typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_8>::type G;
+	extractGhostEx<Float,length>(G(u, 0, Ghost), 
 				     dim, u.SurfaceCB(), u.X(), R, extract, u, location);
       } else if (u.Reconstruct() == QUDA_RECONSTRUCT_13) {
-	extractGhostEx<Float,length>(FloatNOrder<Float,length,2,13>(u, 0, Ghost),
+	typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_13>::type G;
+	extractGhostEx<Float,length>(G(u, 0, Ghost),
 				     dim, u.SurfaceCB(), u.X(), R, extract, u, location);
       } else if (u.Reconstruct() == QUDA_RECONSTRUCT_9) {
-	extractGhostEx<Float,length>(FloatNOrder<Float,length,2,9>(u, 0, Ghost),
-				     dim, u.SurfaceCB(), u.X(), R, extract, u, location);
-      }
-    } else if (u.Order() == QUDA_FLOAT4_GAUGE_ORDER) {
-      if (u.Reconstruct() == QUDA_RECONSTRUCT_NO) {
-	if (typeid(Float)==typeid(short) && u.LinkType() == QUDA_ASQTAD_FAT_LINKS) {
-	  extractGhostEx<Float,length>(FloatNOrder<Float,length,1,19>(u, 0, Ghost),
-				       dim, u.SurfaceCB(), u.X(), R, extract, u, location);
-	} else {
-	  extractGhostEx<Float,length>(FloatNOrder<Float,length,1,18>(u, 0, Ghost),
-				       dim, u.SurfaceCB(), u.X(), R, extract, u, location);
-	}
-      } else if (u.Reconstruct() == QUDA_RECONSTRUCT_12) {
-	extractGhostEx<Float,length>(FloatNOrder<Float,length,4,12>(u, 0, Ghost),
-				     dim, u.SurfaceCB(), u.X(), R, extract, u, location);
-      } else if (u.Reconstruct() == QUDA_RECONSTRUCT_8) { 
-	extractGhostEx<Float,length>(FloatNOrder<Float,length,4,8>(u, 0, Ghost),
-				     dim, u.SurfaceCB(), u.X(), R, extract, u, location);
-      } else if(u.Reconstruct() == QUDA_RECONSTRUCT_13){
-	extractGhostEx<Float,length>(FloatNOrder<Float,length,4,13>(u, 0, Ghost),
-				     dim, u.SurfaceCB(), u.X(), R, extract, u, location);
-      } else if(u.Reconstruct() == QUDA_RECONSTRUCT_9){
-	extractGhostEx<Float,length>(FloatNOrder<Float,length,4,9>(u, 0, Ghost),
+	typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_13>::type G;
+	extractGhostEx<Float,length>(G(u, 0, Ghost),
 				     dim, u.SurfaceCB(), u.X(), R, extract, u, location);
       }
     } else if (u.Order() == QUDA_QDP_GAUGE_ORDER) {

--- a/lib/gauge_ape.cu
+++ b/lib/gauge_ape.cu
@@ -341,156 +341,53 @@ namespace quda {
   template<typename Float>
     void APEStep(GaugeField &dataDs, const GaugeField& dataOr, Float alpha, QudaFieldLocation location) {
 
-      // Switching to FloatNOrder for the gauge field in order to support RECONSTRUCT_12
-      // Need to fix this!!
+    if(dataDs.Reconstruct() == QUDA_RECONSTRUCT_NO) {
+      typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_NO>::type GDs;
 
-      if(dataDs.Order() == QUDA_FLOAT2_GAUGE_ORDER) {
-        if(dataOr.Order() == QUDA_FLOAT2_GAUGE_ORDER) {
-          if(dataDs.Reconstruct() == QUDA_RECONSTRUCT_NO) {
-            if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_NO) {
-              APEStep(FloatNOrder<Float, 18, 2, 18>(dataOr), FloatNOrder<Float, 18, 2, 18>(dataDs), dataOr, alpha, location);
-            }else if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_12){
-              APEStep(FloatNOrder<Float, 18, 2, 12>(dataOr), FloatNOrder<Float, 18, 2, 18>(dataDs), dataOr, alpha, location);
-            }else if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_8){
-              APEStep(FloatNOrder<Float, 18, 2,  8>(dataOr), FloatNOrder<Float, 18, 2, 18>(dataDs), dataOr, alpha, location);
-            }else{
-              errorQuda("Reconstruction type %d of origin gauge field not supported", dataOr.Reconstruct());
-            }
-          } else if(dataDs.Reconstruct() == QUDA_RECONSTRUCT_12){
-            if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_NO){
-              APEStep(FloatNOrder<Float, 18, 2, 18>(dataOr), FloatNOrder<Float, 18, 2, 12>(dataDs), dataOr, alpha, location);
-            }else if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_12){
-              APEStep(FloatNOrder<Float, 18, 2, 12>(dataOr), FloatNOrder<Float, 18, 2, 12>(dataDs), dataOr, alpha, location);
-            }else if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_8){
-              APEStep(FloatNOrder<Float, 18, 2,  8>(dataOr), FloatNOrder<Float, 18, 2, 12>(dataDs), dataOr, alpha, location);
-            }else{
-              errorQuda("Reconstruction type %d of origin gauge field not supported", dataOr.Reconstruct());
-            }
-          } else if(dataDs.Reconstruct() == QUDA_RECONSTRUCT_8){
-            if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_NO){
-              APEStep(FloatNOrder<Float, 18, 2, 18>(dataOr), FloatNOrder<Float, 18, 2,  8>(dataDs), dataOr, alpha, location);
-            }else if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_12){
-              APEStep(FloatNOrder<Float, 18, 2, 12>(dataOr), FloatNOrder<Float, 18, 2,  8>(dataDs), dataOr, alpha, location);
-            }else if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_8){
-              APEStep(FloatNOrder<Float, 18, 2,  8>(dataOr), FloatNOrder<Float, 18, 2,  8>(dataDs), dataOr, alpha, location);
-            }else{
-              errorQuda("Reconstruction type %d of origin gauge field not supported", dataOr.Reconstruct());
-            }
-          } else {
-            errorQuda("Reconstruction type %d of destination gauge field not supported", dataDs.Reconstruct());
-          }
-        } else if(dataOr.Order() == QUDA_FLOAT4_GAUGE_ORDER) {
-          if(dataDs.Reconstruct() == QUDA_RECONSTRUCT_NO) {
-            if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_NO) {
-              APEStep(FloatNOrder<Float, 18, 4, 18>(dataOr), FloatNOrder<Float, 18, 2, 18>(dataDs), dataOr, alpha, location);
-            }else if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_12){
-              APEStep(FloatNOrder<Float, 18, 4, 12>(dataOr), FloatNOrder<Float, 18, 2, 18>(dataDs), dataOr, alpha, location);
-            }else if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_8){
-              APEStep(FloatNOrder<Float, 18, 4,  8>(dataOr), FloatNOrder<Float, 18, 2, 18>(dataDs), dataOr, alpha, location);
-            }else{
-              errorQuda("Reconstruction type %d of origin gauge field not supported", dataOr.Reconstruct());
-            }
-          } else if(dataDs.Reconstruct() == QUDA_RECONSTRUCT_12){
-            if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_NO){
-              APEStep(FloatNOrder<Float, 18, 4, 18>(dataOr), FloatNOrder<Float, 18, 2, 12>(dataDs), dataOr, alpha, location);
-            }else if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_12){
-              APEStep(FloatNOrder<Float, 18, 4, 12>(dataOr), FloatNOrder<Float, 18, 2, 12>(dataDs), dataOr, alpha, location);
-            }else if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_8){
-              APEStep(FloatNOrder<Float, 18, 4,  8>(dataOr), FloatNOrder<Float, 18, 2, 12>(dataDs), dataOr, alpha, location);
-            }else{
-              errorQuda("Reconstruction type %d of origin gauge field not supported", dataOr.Reconstruct());
-            }
-          } else if(dataDs.Reconstruct() == QUDA_RECONSTRUCT_8){
-            if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_NO){
-              APEStep(FloatNOrder<Float, 18, 4, 18>(dataOr), FloatNOrder<Float, 18, 2,  8>(dataDs), dataOr, alpha, location);
-            }else if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_12){
-              APEStep(FloatNOrder<Float, 18, 4, 12>(dataOr), FloatNOrder<Float, 18, 2,  8>(dataDs), dataOr, alpha, location);
-            }else if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_8){
-              APEStep(FloatNOrder<Float, 18, 4,  8>(dataOr), FloatNOrder<Float, 18, 2,  8>(dataDs), dataOr, alpha, location);
-            }else{
-              errorQuda("Reconstruction type %d of origin gauge field not supported", dataOr.Reconstruct());
-            }
-          } else {
-            errorQuda("Reconstruction type %d of destination gauge field not supported", dataDs.Reconstruct());
-          }
-        } else {
-	  errorQuda("Invalid Gauge Order origin field\n");
-        }
-      } else if(dataDs.Order() == QUDA_FLOAT4_GAUGE_ORDER) {
-        if(dataOr.Order() == QUDA_FLOAT2_GAUGE_ORDER) {
-          if(dataDs.Reconstruct() == QUDA_RECONSTRUCT_NO) {
-            if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_NO) {
-              APEStep(FloatNOrder<Float, 18, 2, 18>(dataOr), FloatNOrder<Float, 18, 4, 18>(dataDs), dataOr, alpha, location);
-            }else if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_12){
-              APEStep(FloatNOrder<Float, 18, 2, 12>(dataOr), FloatNOrder<Float, 18, 4, 18>(dataDs), dataOr, alpha, location);
-            }else if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_8){
-              APEStep(FloatNOrder<Float, 18, 2,  8>(dataOr), FloatNOrder<Float, 18, 4, 18>(dataDs), dataOr, alpha, location);
-            }else{
-              errorQuda("Reconstruction type %d of origin gauge field not supported", dataOr.Reconstruct());
-            }
-          } else if(dataDs.Reconstruct() == QUDA_RECONSTRUCT_12){
-            if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_NO){
-              APEStep(FloatNOrder<Float, 18, 2, 18>(dataOr), FloatNOrder<Float, 18, 4, 12>(dataDs), dataOr, alpha, location);
-            }else if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_12){
-              APEStep(FloatNOrder<Float, 18, 2, 12>(dataOr), FloatNOrder<Float, 18, 4, 12>(dataDs), dataOr, alpha, location);
-            }else if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_8){
-              APEStep(FloatNOrder<Float, 18, 2,  8>(dataOr), FloatNOrder<Float, 18, 4, 12>(dataDs), dataOr, alpha, location);
-            }else{
-              errorQuda("Reconstruction type %d of origin gauge field not supported", dataOr.Reconstruct());
-            }
-          } else if(dataDs.Reconstruct() == QUDA_RECONSTRUCT_8){
-            if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_NO){
-              APEStep(FloatNOrder<Float, 18, 2, 18>(dataOr), FloatNOrder<Float, 18, 4,  8>(dataDs), dataOr, alpha, location);
-            }else if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_12){
-              APEStep(FloatNOrder<Float, 18, 2, 12>(dataOr), FloatNOrder<Float, 18, 4,  8>(dataDs), dataOr, alpha, location);
-            }else if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_8){
-              APEStep(FloatNOrder<Float, 18, 2,  8>(dataOr), FloatNOrder<Float, 18, 4,  8>(dataDs), dataOr, alpha, location);
-            }else{
-              errorQuda("Reconstruction type %d of origin gauge field not supported", dataOr.Reconstruct());
-            }
-          } else {
-            errorQuda("Reconstruction type %d of destination gauge field not supported", dataDs.Reconstruct());
-          }
-        } else if(dataOr.Order() == QUDA_FLOAT4_GAUGE_ORDER) {
-          if(dataDs.Reconstruct() == QUDA_RECONSTRUCT_NO) {
-            if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_NO) {
-              APEStep(FloatNOrder<Float, 18, 4, 18>(dataOr), FloatNOrder<Float, 18, 4, 18>(dataDs), dataOr, alpha, location);
-            }else if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_12){
-              APEStep(FloatNOrder<Float, 18, 4, 12>(dataOr), FloatNOrder<Float, 18, 4, 18>(dataDs), dataOr, alpha, location);
-            }else if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_8){
-              APEStep(FloatNOrder<Float, 18, 4,  8>(dataOr), FloatNOrder<Float, 18, 4, 18>(dataDs), dataOr, alpha, location);
-            }else{
-              errorQuda("Reconstruction type %d of origin gauge field not supported", dataOr.Reconstruct());
-            }
-          } else if(dataDs.Reconstruct() == QUDA_RECONSTRUCT_12){
-            if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_NO){
-              APEStep(FloatNOrder<Float, 18, 4, 18>(dataOr), FloatNOrder<Float, 18, 4, 12>(dataDs), dataOr, alpha, location);
-            }else if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_12){
-              APEStep(FloatNOrder<Float, 18, 4, 12>(dataOr), FloatNOrder<Float, 18, 4, 12>(dataDs), dataOr, alpha, location);
-            }else if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_8){
-              APEStep(FloatNOrder<Float, 18, 4,  8>(dataOr), FloatNOrder<Float, 18, 4, 12>(dataDs), dataOr, alpha, location);
-            }else{
-              errorQuda("Reconstruction type %d of origin gauge field not supported", dataOr.Reconstruct());
-            }
-          } else if(dataDs.Reconstruct() == QUDA_RECONSTRUCT_8){
-            if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_NO){
-              APEStep(FloatNOrder<Float, 18, 4, 18>(dataOr), FloatNOrder<Float, 18, 4,  8>(dataDs), dataOr, alpha, location);
-            }else if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_12){
-              APEStep(FloatNOrder<Float, 18, 4, 12>(dataOr), FloatNOrder<Float, 18, 4,  8>(dataDs), dataOr, alpha, location);
-            }else if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_8){
-              APEStep(FloatNOrder<Float, 18, 4,  8>(dataOr), FloatNOrder<Float, 18, 4,  8>(dataDs), dataOr, alpha, location);
-            }else{
-              errorQuda("Reconstruction type %d of origin gauge field not supported", dataOr.Reconstruct());
-            }
-          } else {
-            errorQuda("Reconstruction type %d of destination gauge field not supported", dataDs.Reconstruct());
-          }
-        } else {
-	  errorQuda("Invalid Gauge Order origin field\n");
-        }
-      } else {
-        errorQuda("Invalid Gauge Order destination field\n");
+      if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_NO) {
+	typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_NO>::type GOr;
+	APEStep(GOr(dataOr), GDs(dataDs), dataOr, alpha, location);
+      }else if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_12){
+	typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_12>::type GOr;
+	APEStep(GOr(dataOr), GDs(dataDs), dataOr, alpha, location);
+      }else if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_8){
+	typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_8>::type GOr;
+	APEStep(GOr(dataOr), GDs(dataDs), dataOr, alpha, location);
+      }else{
+	errorQuda("Reconstruction type %d of origin gauge field not supported", dataOr.Reconstruct());
       }
+    } else if(dataDs.Reconstruct() == QUDA_RECONSTRUCT_12){
+      typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_12>::type GDs;
+      if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_NO){
+	typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_NO>::type GOr;
+	APEStep(GOr(dataOr), GDs(dataDs), dataOr, alpha, location);
+      }else if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_12){
+	typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_12>::type GOr;
+	APEStep(GOr(dataOr), GDs(dataDs), dataOr, alpha, location);
+      }else if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_8){
+	typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_8>::type GOr;
+	APEStep(GOr(dataOr), GDs(dataDs), dataOr, alpha, location);
+      }else{
+	errorQuda("Reconstruction type %d of origin gauge field not supported", dataOr.Reconstruct());
+      }
+    } else if(dataDs.Reconstruct() == QUDA_RECONSTRUCT_8){
+      typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_8>::type GDs;
+      if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_NO){
+	typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_NO>::type GOr;
+	APEStep(GOr(dataOr), GDs(dataDs), dataOr, alpha, location);
+      }else if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_12){
+	typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_12>::type GOr;
+	APEStep(GOr(dataOr), GDs(dataDs), dataOr, alpha, location);
+      }else if(dataOr.Reconstruct() == QUDA_RECONSTRUCT_8){
+	typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_8>::type GOr;
+	APEStep(GOr(dataOr), GDs(dataDs), dataOr, alpha, location);
+      }else{
+	errorQuda("Reconstruction type %d of origin gauge field not supported", dataOr.Reconstruct());
+            }
+    } else {
+      errorQuda("Reconstruction type %d of destination gauge field not supported", dataDs.Reconstruct());
+    }
+
   }
 #endif
 
@@ -505,6 +402,12 @@ namespace quda {
     if(dataDs.Precision() == QUDA_HALF_PRECISION){
       errorQuda("Half precision not supported\n");
     }
+
+    if (!dataOr.isNative())
+      errorQuda("Order %d with %d reconstruct not supported", dataOr.Order(), dataOr.Reconstruct());
+
+    if (!dataDs.isNative())
+      errorQuda("Order %d with %d reconstruct not supported", dataDs.Order(), dataDs.Reconstruct());
 
     if (dataDs.Precision() == QUDA_SINGLE_PRECISION){
       APEStep<float>(dataDs, dataOr, (float) alpha, location);

--- a/lib/gauge_plaq.cu
+++ b/lib/gauge_plaq.cu
@@ -242,18 +242,6 @@ namespace quda {
       plq.y = arg.plaq_h[0].y;
     }
 
-
-  // Use traits to reduce the template explosion
-  template<typename,QudaReconstructType> struct gauge_mapper { };
-  template<> struct gauge_mapper<double,QUDA_RECONSTRUCT_NO> { typedef FloatNOrder<double, 18, 2, 18> type; };
-  template<> struct gauge_mapper<double,QUDA_RECONSTRUCT_12> { typedef FloatNOrder<double, 18, 2, 12> type; };
-  template<> struct gauge_mapper<double,QUDA_RECONSTRUCT_8> { typedef FloatNOrder<double, 18, 2, 8> type; };
-
-  template<> struct gauge_mapper<float,QUDA_RECONSTRUCT_NO> { typedef FloatNOrder<float, 18, 2, 18> type; };
-  template<> struct gauge_mapper<float,QUDA_RECONSTRUCT_12> { typedef FloatNOrder<float, 18, 4, 12> type; };
-  template<> struct gauge_mapper<float,QUDA_RECONSTRUCT_8> { typedef FloatNOrder<float, 18, 4, 8> type; };
-
-
   template<typename Float>
     double2 plaquette(const GaugeField& data, QudaFieldLocation location) {
       double2 res;

--- a/lib/gauge_update_quda.cu
+++ b/lib/gauge_update_quda.cu
@@ -314,25 +314,15 @@ namespace quda {
       errorQuda("Input and output gauge field ordering and reconstruction must match");
     }
 
-    if (out.Order() == QUDA_FLOAT2_GAUGE_ORDER) {
+    if (out.isNative()) {
       if (out.Reconstruct() == QUDA_RECONSTRUCT_NO) {
-	updateGaugeField<Float>(FloatNOrder<Float, Nc*Nc*2, 2, 18>(out),
-				FloatNOrder<Float, Nc*Nc*2, 2, 18>(in), 
-				mom, dt, conj_mom, exact, location);
+	typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_NO>::type G;
+	updateGaugeField<Float>(G(out),G(in), mom, dt, conj_mom, exact, location);
       } else if (out.Reconstruct() == QUDA_RECONSTRUCT_12) {
-	updateGaugeField<Float>(FloatNOrder<Float, Nc*Nc*2, 2, 12>(out),
-				FloatNOrder<Float, Nc*Nc*2, 2, 12>(in), 
-				mom, dt, conj_mom, exact, location);
+	typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_12>::type G;
+	updateGaugeField<Float>(G(out), G(in), mom, dt, conj_mom, exact, location);
       } else {
 	errorQuda("Reconstruction type not supported");
-      }
-    } else if (out.Order() == QUDA_FLOAT4_GAUGE_ORDER) {
-      if (out.Reconstruct() == QUDA_RECONSTRUCT_12) {
-	updateGaugeField<Float>(FloatNOrder<Float, Nc*Nc*2, 4, 12>(out),
-				FloatNOrder<Float, Nc*Nc*2, 4, 12>(in), 
-				mom, dt, conj_mom, exact,  location);
-      } else {
-	errorQuda("Reconstruction type %d not supported", out.Order());
       }
     } else if (out.Order() == QUDA_MILC_GAUGE_ORDER) {
       updateGaugeField<Float>(MILCOrder<Float, Nc*Nc*2>(out),


### PR DESCRIPTION
This pull significantly reduces the compilation time of algorithms that use `gauge::FloatNOrder` and `clover::FloatNOrder`.  This is done through utilizing C++ traits and the structs `gauge_mapper` and `clover_mapper` to only instantiate the correct field order templates for a given precision / reconstruct type.

There's more that could be done here, but I've left out some files that I know have been changed in the develop branch so we can easily merge this back into develop.