### PR TITLE
Fixed critical memory leak in MPI communications

### DIFF
--- a/lib/comm_mpi.cpp
+++ b/lib/comm_mpi.cpp
@@ -19,8 +19,22 @@
 
 
 struct MsgHandle_s {
+  /**
+     The persistant MPI communicator handle that is created with
+     MPI_Send_init / MPI_Recv_init.
+   */
   MPI_Request request;
+
+  /**
+     To create a strided communicator, a MPI_Vector datatype has to be
+     created.  This is where it is stored.
+   */
   MPI_Datatype datatype;
+
+  /**
+     Whether a custom datatype has been created or not.  Used to
+     determine whether we need to free the datatype or not.
+   */
   bool custom;
 };
 


### PR DESCRIPTION
This is a critical fix for two memory leaks
* Message handles not freed with MPI communication
* Custom datatypes not freed with MPI communication