### PR TITLE
fixed printf used in qudamilc_called 

### DIFF
--- a/lib/milc_interface.cpp
+++ b/lib/milc_interface.cpp
@@ -61,11 +61,11 @@ void  inline qudamilc_called(const char* func, QudaVerbosity verb){
 #ifdef QUDAMILC_VERBOSE
 if (verb >= QUDA_VERBOSE) {
      if(start){
-       printf("QUDA_MILC_INTERFACE: %s (called) \n",func);
+       printfQuda("QUDA_MILC_INTERFACE: %s (called) \n",func);
        PUSH_RANGE(func,1)
      }
      else {
-      printf("QUDA_MILC_INTERFACE: %s (return) \n",func);
+      printfQuda("QUDA_MILC_INTERFACE: %s (return) \n",func);
       POP_RANGE
      }
    }
@@ -774,7 +774,8 @@ void qudaMultishiftInvert(int external_precision,
 
     const int long_pad = 3*fat_pad;
     gaugeParam.type = QUDA_THREE_LINKS;
-    gaugeParam.ga_pad = long_pad; 
+    gaugeParam.ga_pad = long_pad;
+    gaugeParam.reconstruct = gaugeParam.reconstruct_sloppy = QUDA_RECONSTRUCT_NO;
     loadGaugeQuda(const_cast<void*>(longlink), &gaugeParam);
 
    // invalidate_quda_gauge = false;


### PR DESCRIPTION
* now uses printfQuda 
* added missing reconstruct option (still no reconstruction by default)