### PR TITLE
Hotfix/dev timerprofile

### DIFF
--- a/include/quda_internal.h
+++ b/include/quda_internal.h
@@ -298,8 +298,8 @@ namespace quda {
 
   };
 
-#define Start(idx) Start_(__func__, __FILE__, __LINE__, idx)
-#define Stop(idx) Stop_(__func__, __FILE__, __LINE__, idx)
+#define TPSTART(idx) Start_(__func__, __FILE__, __LINE__, idx)
+#define TPSTOP(idx) Stop_(__func__, __FILE__, __LINE__, idx)
 
 #undef PUSH_RANGE
 #undef POP_RANGE

--- a/include/quda_internal.h
+++ b/include/quda_internal.h
@@ -260,8 +260,6 @@ namespace quda {
     void Start(QudaProfileType idx) { 
       // if total timer isn't running, then start it running
       if (!profile[QUDA_PROFILE_TOTAL].running && idx != QUDA_PROFILE_TOTAL) {
-	profile[QUDA_PROFILE_TOTAL].Start(); 
-	switchOff = true;
         profile[QUDA_PROFILE_TOTAL].Start();
         switchOff = true;
       }

--- a/lib/contract.cu
+++ b/lib/contract.cu
@@ -192,8 +192,8 @@ namespace quda {
       return;
     }
 
-    profile.Start(QUDA_PROFILE_TOTAL);
-    profile.Start(QUDA_PROFILE_INIT);
+    profile.TPSTART(QUDA_PROFILE_TOTAL);
+    profile.TPSTART(QUDA_PROFILE_INIT);
 
     dslashParam.threads = x.Volume();
 
@@ -211,19 +211,19 @@ namespace quda {
     } else if	(x.Precision() == QUDA_HALF_PRECISION) {
       errorQuda("Half precision not supported for gamma5 kernel yet");
     }
-    profile.Stop(QUDA_PROFILE_INIT);
+    profile.TPSTOP(QUDA_PROFILE_INIT);
 
-    profile.Start(QUDA_PROFILE_COMPUTE);
+    profile.TPSTART(QUDA_PROFILE_COMPUTE);
     contract->apply(streams[Nstream-1]);
-    profile.Stop(QUDA_PROFILE_COMPUTE);
+    profile.TPSTOP(QUDA_PROFILE_COMPUTE);
 
-    profile.Start(QUDA_PROFILE_EPILOGUE);
+    profile.TPSTART(QUDA_PROFILE_EPILOGUE);
     checkCudaError();
 
     delete contract;
 
-    profile.Stop(QUDA_PROFILE_EPILOGUE);
-    profile.Stop(QUDA_PROFILE_TOTAL);
+    profile.TPSTOP(QUDA_PROFILE_EPILOGUE);
+    profile.TPSTOP(QUDA_PROFILE_TOTAL);
 #else
     errorQuda("Contraction code has not been built");
 #endif
@@ -245,8 +245,8 @@ namespace quda {
       return;
     }
 
-    profile.Start(QUDA_PROFILE_TOTAL);
-    profile.Start(QUDA_PROFILE_INIT);
+    profile.TPSTART(QUDA_PROFILE_TOTAL);
+    profile.TPSTART(QUDA_PROFILE_INIT);
 
     dslashParam.threads = x.X(0)*x.X(1)*x.X(2);
 
@@ -263,18 +263,18 @@ namespace quda {
     } else if (x.Precision() == QUDA_HALF_PRECISION) {
       errorQuda("Half precision not supported for gamma5 kernel yet");
     }
-    profile.Stop(QUDA_PROFILE_INIT);
+    profile.TPSTOP(QUDA_PROFILE_INIT);
 
-    profile.Start(QUDA_PROFILE_COMPUTE);
+    profile.TPSTART(QUDA_PROFILE_COMPUTE);
     contract->apply(streams[Nstream-1]);
-    profile.Stop(QUDA_PROFILE_COMPUTE);
+    profile.TPSTOP(QUDA_PROFILE_COMPUTE);
 
-    profile.Start(QUDA_PROFILE_EPILOGUE);
+    profile.TPSTART(QUDA_PROFILE_EPILOGUE);
     checkCudaError();
     delete contract;
 
-    profile.Stop(QUDA_PROFILE_EPILOGUE);
-    profile.Stop(QUDA_PROFILE_TOTAL);
+    profile.TPSTOP(QUDA_PROFILE_EPILOGUE);
+    profile.TPSTOP(QUDA_PROFILE_TOTAL);
 #else
     errorQuda("Contraction code has not been built");
 #endif

--- a/lib/covDev.cu
+++ b/lib/covDev.cu
@@ -577,8 +577,8 @@ namespace quda
         if(in->Precision() != gauge.Precision())
           errorQuda("Mixing gauge %d and spinor %d precision not supported", gauge.Precision(), in->Precision());
 
-        profile.Start(QUDA_PROFILE_TOTAL);
-        profile.Start(QUDA_PROFILE_INIT);
+        profile.TPSTART(QUDA_PROFILE_TOTAL);
+        profile.TPSTART(QUDA_PROFILE_INIT);
 
         if(in->Precision() == QUDA_SINGLE_PRECISION)
           covdev = new CovDevCuda<float, float4>(out, &gauge, in, parity, mu);
@@ -590,15 +590,15 @@ namespace quda
             errorQuda("Error: Double precision not supported by hardware");
           #endif
         }
-        profile.Stop(QUDA_PROFILE_INIT);
+        profile.TPSTOP(QUDA_PROFILE_INIT);
 
         covDevCuda(*covdev, regSize, mu, profile);
 
-        profile.Start(QUDA_PROFILE_EPILOGUE);
+        profile.TPSTART(QUDA_PROFILE_EPILOGUE);
         delete covdev;
         checkCudaError();
-        profile.Stop(QUDA_PROFILE_EPILOGUE);
-        profile.Stop(QUDA_PROFILE_TOTAL);
+        profile.TPSTOP(QUDA_PROFILE_EPILOGUE);
+        profile.TPSTOP(QUDA_PROFILE_TOTAL);
       #else
         errorQuda("Contraction kernels have not been built");
       #endif

--- a/lib/dslash_constants.h
+++ b/lib/dslash_constants.h
@@ -205,7 +205,7 @@ __constant__ fat_force_const_t hf; //hisq force
 
 void initLatticeConstants(const LatticeField &lat, TimeProfile &profile)
 {
-  profile.Start(QUDA_PROFILE_CONSTANT);
+  profile.TPSTART(QUDA_PROFILE_CONSTANT);
 
   checkCudaError();
 
@@ -377,13 +377,13 @@ void initLatticeConstants(const LatticeField &lat, TimeProfile &profile)
 
   checkCudaError();
 
-  profile.Stop(QUDA_PROFILE_CONSTANT);
+  profile.TPSTOP(QUDA_PROFILE_CONSTANT);
 }
 
 
 void initGaugeConstants(const cudaGaugeField &gauge, TimeProfile &profile) 
 {
-  profile.Start(QUDA_PROFILE_CONSTANT);
+  profile.TPSTART(QUDA_PROFILE_CONSTANT);
 
   int ga_stride_h = gauge.Stride();
   cudaMemcpyToSymbol(ga_stride, &ga_stride_h, sizeof(int));  
@@ -419,12 +419,12 @@ void initGaugeConstants(const cudaGaugeField &gauge, TimeProfile &profile)
 
   checkCudaError();
 
-  profile.Stop(QUDA_PROFILE_CONSTANT);
+  profile.TPSTOP(QUDA_PROFILE_CONSTANT);
 }
 
 void initDslashConstants(TimeProfile &profile)
 {
-  profile.Start(QUDA_PROFILE_CONSTANT);
+  profile.TPSTART(QUDA_PROFILE_CONSTANT);
 
   float pi_f_h = M_PI;
   cudaMemcpyToSymbol(pi_f, &pi_f_h, sizeof(float));
@@ -446,13 +446,13 @@ void initDslashConstants(TimeProfile &profile)
   
   checkCudaError();
 
-  profile.Stop(QUDA_PROFILE_CONSTANT);
+  profile.TPSTOP(QUDA_PROFILE_CONSTANT);
 }
 
 void initStaggeredConstants(const cudaGaugeField &fatgauge, const cudaGaugeField &longgauge,
 			    TimeProfile &profile)
 {
-  profile.Start(QUDA_PROFILE_CONSTANT);
+  profile.TPSTART(QUDA_PROFILE_CONSTANT);
 
   int fat_ga_stride_h = fatgauge.Stride();
   int long_ga_stride_h = longgauge.Stride();
@@ -470,7 +470,7 @@ void initStaggeredConstants(const cudaGaugeField &fatgauge, const cudaGaugeField
 
   checkCudaError();
 
-  profile.Stop(QUDA_PROFILE_CONSTANT);
+  profile.TPSTOP(QUDA_PROFILE_CONSTANT);
 }
 
 //For initializing the coefficients used in MDWF
@@ -482,7 +482,7 @@ __constant__ float mdwf_c5_f[QUDA_MAX_DWF_LS];
 
 void initMDWFConstants(const double *b_5, const double *c_5, int dim_s, const double m5h, TimeProfile &profile)
 {
-  profile.Start(QUDA_PROFILE_CONSTANT);
+  profile.TPSTART(QUDA_PROFILE_CONSTANT);
 
   static int last_Ls = -1;
   if (dim_s != last_Ls) {
@@ -510,7 +510,7 @@ void initMDWFConstants(const double *b_5, const double *c_5, int dim_s, const do
     last_m5 = m5h;
   }
 
-  profile.Stop(QUDA_PROFILE_CONSTANT);
+  profile.TPSTOP(QUDA_PROFILE_CONSTANT);
 }
 
 void setTwistParam(double &a, double &b, const double &kappa, const double &mu, 

--- a/lib/dslash_policy.cuh
+++ b/lib/dslash_policy.cuh
@@ -70,9 +70,9 @@ struct DslashCommsPattern {
 
 
 #define PROFILE(f, profile, idx)		\
-  profile.Start(idx);				\
+  profile.TPSTART(idx);				\
   f;						\
-  profile.Stop(idx); 
+  profile.TPSTOP(idx); 
 
 
 
@@ -80,7 +80,7 @@ struct DslashCommsPattern {
 void dslashCuda(DslashCuda &dslash, const size_t regSize, const int parity, const int dagger, 
 		const int volume, const int *faceVolumeCB, TimeProfile &profile) {
   using namespace dslash;
-  profile.Start(QUDA_PROFILE_TOTAL);
+  profile.TPSTART(QUDA_PROFILE_TOTAL);
 
   dslashParam.parity = parity;
   dslashParam.kernel_type = INTERIOR_KERNEL;
@@ -203,7 +203,7 @@ void dslashCuda(DslashCuda &dslash, const size_t regSize, const int parity, cons
   it = (it^1);
 #endif // MULTI_GPU
 
-  profile.Stop(QUDA_PROFILE_TOTAL);
+  profile.TPSTOP(QUDA_PROFILE_TOTAL);
 }
 
 #ifdef PTHREADS
@@ -269,7 +269,7 @@ struct DslashCuda2 : DslashPolicyImp {
 
     using namespace dslash;
 
-    profile.Start(QUDA_PROFILE_TOTAL);
+    profile.TPSTART(QUDA_PROFILE_TOTAL);
 
   
     dslashParam.parity = parity;
@@ -391,7 +391,7 @@ struct DslashCuda2 : DslashPolicyImp {
     }
     inputSpinor->bufferIndex = (1 - inputSpinor->bufferIndex);
 #endif // MULTI_GPU
-    profile.Stop(QUDA_PROFILE_TOTAL);
+    profile.TPSTOP(QUDA_PROFILE_TOTAL);
   }
 
 };
@@ -403,7 +403,7 @@ struct DslashPthreads : DslashPolicyImp {
 #ifdef PTHREADS
     using namespace dslash;
 
-    profile.Start(QUDA_PROFILE_TOTAL);
+    profile.TPSTART(QUDA_PROFILE_TOTAL);
 
   
     dslashParam.parity = parity;
@@ -554,7 +554,7 @@ struct DslashPthreads : DslashPolicyImp {
     }
     inputSpinor->bufferIndex = (1 - inputSpinor->bufferIndex);
 #endif // MULTI_GPU
-    profile.Stop(QUDA_PROFILE_TOTAL);
+    profile.TPSTOP(QUDA_PROFILE_TOTAL);
 #else // !PTHREADS
     errorQuda("Pthreads has not been built\n"); 
 #endif
@@ -568,7 +568,7 @@ struct DslashGPUComms : DslashPolicyImp {
 #ifdef GPU_COMMS
     using namespace dslash;
 
-    profile.Start(QUDA_PROFILE_TOTAL);
+    profile.TPSTART(QUDA_PROFILE_TOTAL);
 
   
     dslashParam.parity = parity;
@@ -670,7 +670,7 @@ struct DslashGPUComms : DslashPolicyImp {
     }
     inputSpinor->bufferIndex = (1 - inputSpinor->bufferIndex);
 #endif // MULTI_GPU
-    profile.Stop(QUDA_PROFILE_TOTAL);
+    profile.TPSTOP(QUDA_PROFILE_TOTAL);
 #else 
     errorQuda("GPU_COMMS has not been built\n");
 #endif // GPU_COMMS
@@ -685,7 +685,7 @@ struct DslashFusedGPUComms : DslashPolicyImp {
 #ifdef GPU_COMMS
     using namespace dslash;
 
-    profile.Start(QUDA_PROFILE_TOTAL);
+    profile.TPSTART(QUDA_PROFILE_TOTAL);
 
   
     dslashParam.parity = parity;
@@ -791,7 +791,7 @@ struct DslashFusedGPUComms : DslashPolicyImp {
 
     inputSpinor->bufferIndex = (1 - inputSpinor->bufferIndex);
 #endif // MULTI_GPU
-    profile.Stop(QUDA_PROFILE_TOTAL);
+    profile.TPSTOP(QUDA_PROFILE_TOTAL);
 #else 
     errorQuda("GPU_COMMS has not been built\n");
 #endif // GPU_COMMS
@@ -804,7 +804,7 @@ struct DslashFaceBuffer : DslashPolicyImp {
 		const int volume, const int *faceVolumeCB, TimeProfile &profile) {
   
     using namespace dslash;
-    profile.Start(QUDA_PROFILE_TOTAL);
+    profile.TPSTART(QUDA_PROFILE_TOTAL);
 
     dslashParam.parity = parity;
     dslashParam.kernel_type = INTERIOR_KERNEL;
@@ -926,7 +926,7 @@ struct DslashFaceBuffer : DslashPolicyImp {
     }
     it = (it^1);
 #endif // MULTI_GPU
-    profile.Stop(QUDA_PROFILE_TOTAL);
+    profile.TPSTOP(QUDA_PROFILE_TOTAL);
   }
 
 };
@@ -939,7 +939,7 @@ struct DslashFusedExterior : DslashPolicyImp {
 
     using namespace dslash;
 
-    profile.Start(QUDA_PROFILE_TOTAL);
+    profile.TPSTART(QUDA_PROFILE_TOTAL);
 
   
     dslashParam.parity = parity;
@@ -1072,7 +1072,7 @@ struct DslashFusedExterior : DslashPolicyImp {
 #endif // MULTI_GPU
 
 
-    profile.Stop(QUDA_PROFILE_TOTAL);
+    profile.TPSTOP(QUDA_PROFILE_TOTAL);
   }
 };
 
@@ -1081,7 +1081,7 @@ struct DslashNC : DslashPolicyImp {
   void operator()(DslashCuda &dslash, cudaColorSpinorField* inputSpinor, const size_t regSize, const int parity, const int dagger, 
 		    const int volume, const int *faceVolumeCB, TimeProfile &profile) {
 
-    profile.Start(QUDA_PROFILE_TOTAL);
+    profile.TPSTART(QUDA_PROFILE_TOTAL);
     
     dslashParam.parity = parity;
     dslashParam.kernel_type = INTERIOR_KERNEL;
@@ -1089,7 +1089,7 @@ struct DslashNC : DslashPolicyImp {
 
     PROFILE(dslash.apply(streams[Nstream-1]), profile, QUDA_PROFILE_DSLASH_KERNEL);
 
-    profile.Stop(QUDA_PROFILE_TOTAL);
+    profile.TPSTOP(QUDA_PROFILE_TOTAL);
   }
 
 };
@@ -1136,7 +1136,7 @@ void dslashCuda2(DslashCuda &dslash, const size_t regSize, const int parity, con
 
   using namespace dslash;
 
-  profile.Start(QUDA_PROFILE_TOTAL);
+  profile.TPSTART(QUDA_PROFILE_TOTAL);
 
   
   dslashParam.parity = parity;
@@ -1335,7 +1335,7 @@ void dslashCuda2(DslashCuda &dslash, const size_t regSize, const int parity, con
   inSpinor->bufferIndex = (1 - inSpinor->bufferIndex);
   //	inSpinor->switchBufferPinned(); // Use a different pinned memory buffer for the next application
 #endif // MULTI_GPU
-  profile.Stop(QUDA_PROFILE_TOTAL);
+  profile.TPSTOP(QUDA_PROFILE_TOTAL);
 }
 
 /**
@@ -1346,7 +1346,7 @@ void dslashZeroCopyCuda(DslashCuda &dslash, const size_t regSize, const int pari
 			const int volume, const int *faceVolumeCB, TimeProfile &profile) {
   using namespace dslash;
 
-  profile.Start(QUDA_PROFILE_TOTAL);
+  profile.TPSTART(QUDA_PROFILE_TOTAL);
 
   dslashParam.parity = parity;
   dslashParam.kernel_type = INTERIOR_KERNEL;
@@ -1451,12 +1451,12 @@ void dslashZeroCopyCuda(DslashCuda &dslash, const size_t regSize, const int pari
   it = (it^1);
 #endif // MULTI_GPU
 
-  profile.Stop(QUDA_PROFILE_TOTAL);
+  profile.TPSTOP(QUDA_PROFILE_TOTAL);
 }
 
 void dslashCudaNC(DslashCuda &dslash, const size_t regSize, const int parity, const int dagger, 
 		  const int volume, const int *faceVolumeCB, TimeProfile &profile) {
-  profile.Start(QUDA_PROFILE_TOTAL);
+  profile.TPSTART(QUDA_PROFILE_TOTAL);
 
   dslashParam.parity = parity;
   dslashParam.kernel_type = INTERIOR_KERNEL;
@@ -1464,5 +1464,5 @@ void dslashCudaNC(DslashCuda &dslash, const size_t regSize, const int parity, co
 
   PROFILE(dslash.apply(streams[Nstream-1]), profile, QUDA_PROFILE_DSLASH_KERNEL);
 
-  profile.Stop(QUDA_PROFILE_TOTAL);
+  profile.TPSTOP(QUDA_PROFILE_TOTAL);
 }

--- a/lib/eig_lanczos_quda.cpp
+++ b/lib/eig_lanczos_quda.cpp
@@ -30,12 +30,12 @@ namespace quda {
 
   void Lanczos::operator()(double *alpha, double *beta, cudaColorSpinorField **Eig_Vec, cudaColorSpinorField &r, cudaColorSpinorField &Apsi, int k0, int m) 
   {
-    profile.Start(QUDA_PROFILE_COMPUTE);
+    profile.TPSTART(QUDA_PROFILE_COMPUTE);
 
     // Check to see that we'reV not trying to invert on a zero-field source    
     const double b2 = norm2(r);
     if(b2 == 0){
-      profile.Stop(QUDA_PROFILE_COMPUTE);
+      profile.TPSTOP(QUDA_PROFILE_COMPUTE);
       printfQuda("Warning: initial residual is already zero\n");
       return;
     }
@@ -87,7 +87,7 @@ namespace quda {
         }
       }
     }
-    profile.Stop(QUDA_PROFILE_COMPUTE);
+    profile.TPSTOP(QUDA_PROFILE_COMPUTE);
     return;
   }
   

--- a/lib/gauge_fix_fft.cu
+++ b/lib/gauge_fix_fft.cu
@@ -1146,7 +1146,7 @@ namespace quda {
 
     TimeProfile profileInternalGaugeFixFFT("InternalGaugeFixQudaFFT");
 
-    profileInternalGaugeFixFFT.Start(QUDA_PROFILE_COMPUTE);
+    profileInternalGaugeFixFFT.TPSTART(QUDA_PROFILE_COMPUTE);
 
     Float alpha = alpha0;
     std::cout << "\tAlpha parameter of the Steepest Descent Method: " << alpha << std::endl;
@@ -1313,7 +1313,7 @@ namespace quda {
     CUFFT_SAFE_CALL(cufftDestroy(plan_xy));
     checkCudaError();
     cudaDeviceSynchronize();
-    profileInternalGaugeFixFFT.Stop(QUDA_PROFILE_COMPUTE);
+    profileInternalGaugeFixFFT.TPSTOP(QUDA_PROFILE_COMPUTE);
 
     if (getVerbosity() > QUDA_SUMMARIZE){
       double secs = profileInternalGaugeFixFFT.Last(QUDA_PROFILE_COMPUTE);

--- a/lib/gauge_fix_fft.cu
+++ b/lib/gauge_fix_fft.cu
@@ -210,9 +210,7 @@ namespace quda {
     unsigned int sharedBytesPerBlock(const TuneParam &param) const {
       return 0;
     }
-    bool tuneSharedBytes() const {
-      return false;
-    }                                                  // Don't tune shared memory
+    //bool tuneSharedBytes() const { return false; } // Don't tune shared memory
     bool tuneGridDim() const {
       return false;
     }                                              // Don't tune the grid dimensions.
@@ -373,9 +371,7 @@ namespace quda {
     unsigned int sharedBytesPerBlock(const TuneParam &param) const {
       return 0;
     }
-    bool tuneSharedBytes() const {
-      return false;
-    }                                                  // Don't tune shared memory
+    //bool tuneSharedBytes() const {return false;}  // Don't tune shared memory
     bool tuneGridDim() const {
       return false;
     }                                              // Don't tune the grid dimensions.
@@ -565,9 +561,7 @@ namespace quda {
     unsigned int sharedBytesPerBlock(const TuneParam &param) const {
       return 0;
     }
-    bool tuneSharedBytes() const {
-      return false;
-    }                                                  // Don't tune shared memory
+    //bool tuneSharedBytes() const { return false; } // Don't tune shared memory
     bool tuneGridDim() const {
       return false;
     }                                              // Don't tune the grid dimensions.
@@ -777,9 +771,7 @@ namespace quda {
     unsigned int sharedBytesPerBlock(const TuneParam &param) const {
       return 0;
     }
-    bool tuneSharedBytes() const {
-      return false;
-    }                                                  // Don't tune shared memory
+    //bool tuneSharedBytes() const { return false; } // Don't tune shared memory
     bool tuneGridDim() const {
       return false;
     }                                              // Don't tune the grid dimensions.
@@ -908,9 +900,7 @@ namespace quda {
     unsigned int sharedBytesPerBlock(const TuneParam &param) const {
       return 0;
     }
-    bool tuneSharedBytes() const {
-      return false;
-    }                                                  // Don't tune shared memory
+    //bool tuneSharedBytes() const { return false; } // Don't tune shared memory
     bool tuneGridDim() const {
       return false;
     }                                              // Don't tune the grid dimensions.
@@ -1043,9 +1033,7 @@ namespace quda {
     unsigned int sharedBytesPerBlock(const TuneParam &param) const {
       return 0;
     }
-    bool tuneSharedBytes() const {
-      return false;
-    }                                                  // Don't tune shared memory
+    //bool tuneSharedBytes() const { return false; } // Don't tune shared memory
     bool tuneGridDim() const {
       return false;
     }                                              // Don't tune the grid dimensions.
@@ -1156,9 +1144,9 @@ namespace quda {
                        const Float alpha0, const unsigned int autotune, const double tolerance, \
                        const unsigned int stopWtheta) {
 
-    TimeProfile profileGaugeFix("GaugeFixCuda");
+    TimeProfile profileInternalGaugeFixFFT("InternalGaugeFixQudaFFT");
 
-    profileGaugeFix.Start(QUDA_PROFILE_COMPUTE);
+    profileInternalGaugeFixFFT.Start(QUDA_PROFILE_COMPUTE);
 
     Float alpha = alpha0;
     std::cout << "\tAlpha parameter of the Steepest Descent Method: " << alpha << std::endl;
@@ -1325,10 +1313,10 @@ namespace quda {
     CUFFT_SAFE_CALL(cufftDestroy(plan_xy));
     checkCudaError();
     cudaDeviceSynchronize();
-    profileGaugeFix.Stop(QUDA_PROFILE_COMPUTE);
+    profileInternalGaugeFixFFT.Stop(QUDA_PROFILE_COMPUTE);
 
     if (getVerbosity() > QUDA_SUMMARIZE){
-      double secs = profileGaugeFix.Last(QUDA_PROFILE_COMPUTE);
+      double secs = profileInternalGaugeFixFFT.Last(QUDA_PROFILE_COMPUTE);
       double fftflop = 5.0 * (log2((double)( data.X()[0] * data.X()[1]) ) + log2( (double)(data.X()[2] * data.X()[3] )));
       fftflop *= (double)( data.X()[0] * data.X()[1] * data.X()[2] * data.X()[3] );
       double gflops = setinvpsp.flops() + gfixquality.flops();
@@ -1385,15 +1373,15 @@ namespace quda {
     //9 and 6 means the number of complex elements used to store g(x) and Delta(x)
     if ( data.isNative() ) {
       if ( data.Reconstruct() == QUDA_RECONSTRUCT_NO ) {
-        printfQuda("QUDA_RECONSTRUCT_NO\n");
+        //printfQuda("QUDA_RECONSTRUCT_NO\n");
 	typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_NO>::type Gauge;
         gaugefixingFFT<9, Float>(Gauge(data), data, gauge_dir, Nsteps, verbose_interval, alpha, autotune, tolerance, stopWtheta);
       } else if ( data.Reconstruct() == QUDA_RECONSTRUCT_12 ) {
-        printfQuda("QUDA_RECONSTRUCT_12\n");
+        //printfQuda("QUDA_RECONSTRUCT_12\n");
 	typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_12>::type Gauge;
         gaugefixingFFT<6, Float>(Gauge(data), data, gauge_dir, Nsteps, verbose_interval, alpha, autotune, tolerance, stopWtheta);
       } else if ( data.Reconstruct() == QUDA_RECONSTRUCT_8 ) {
-        printfQuda("QUDA_RECONSTRUCT_8\n");
+        //printfQuda("QUDA_RECONSTRUCT_8\n");
 	typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_8>::type Gauge;
         gaugefixingFFT<6, Float>(Gauge(data), data, gauge_dir, Nsteps, verbose_interval, alpha, autotune, tolerance, stopWtheta);
 

--- a/lib/gauge_fix_ovr.cu
+++ b/lib/gauge_fix_ovr.cu
@@ -357,9 +357,7 @@ static bool checkDimsPartitioned(){
     unsigned int sharedBytesPerBlock(const TuneParam &param) const {
       return 0;
     }
-    bool tuneSharedBytes() const {
-      return false;
-    }                                            // Don't tune shared memory
+    //bool tuneSharedBytes() const { return false; } // Don't tune shared memory
     bool tuneGridDim() const {
       return false;
     }                                        // Don't tune the grid dimensions.
@@ -1471,9 +1469,9 @@ static bool checkDimsPartitioned(){
                        const unsigned int stopWtheta) {
 
 
-    TimeProfile profileGaugeFix("GaugeFixCuda");
+    TimeProfile profileInternalGaugeFixOVR("InternalGaugeFixQudaOVR");
 
-    profileGaugeFix.Start(QUDA_PROFILE_COMPUTE);
+    profileInternalGaugeFixOVR.Start(QUDA_PROFILE_COMPUTE);
     double flop = 0;
     double byte = 0;
 
@@ -1832,9 +1830,9 @@ static bool checkDimsPartitioned(){
   #endif
     checkCudaError();
     cudaDeviceSynchronize();
-    profileGaugeFix.Stop(QUDA_PROFILE_COMPUTE);
+    profileInternalGaugeFixOVR.Stop(QUDA_PROFILE_COMPUTE);
     if (getVerbosity() > QUDA_SUMMARIZE){
-      double secs = profileGaugeFix.Last(QUDA_PROFILE_COMPUTE);
+      double secs = profileInternalGaugeFixOVR.Last(QUDA_PROFILE_COMPUTE);
 	  double gflops = (flop * 1e-9) / (secs);
 	  double gbytes = byte / (secs * 1e9);
 	  #ifdef MULTI_GPU
@@ -1869,17 +1867,17 @@ static bool checkDimsPartitioned(){
     // Switching to FloatNOrder for the gauge field in order to support RECONSTRUCT_12
     if ( data.isNative() ) {
       if ( data.Reconstruct() == QUDA_RECONSTRUCT_NO ) {
-        printfQuda("QUDA_RECONSTRUCT_NO\n");
+        //printfQuda("QUDA_RECONSTRUCT_NO\n");
         numParams = 18;
 	typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_NO>::type Gauge;
         gaugefixingOVR<Float, 18>(Gauge(data), data, gauge_dir, Nsteps, verbose_interval, relax_boost, tolerance, reunit_interval, stopWtheta);
       } else if ( data.Reconstruct() == QUDA_RECONSTRUCT_12 ) {
-        printfQuda("QUDA_RECONSTRUCT_12\n");
+        //printfQuda("QUDA_RECONSTRUCT_12\n");
         numParams = 12;
 	typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_12>::type Gauge;
         gaugefixingOVR<Float, 12>(Gauge(data), data, gauge_dir, Nsteps, verbose_interval, relax_boost, tolerance, reunit_interval, stopWtheta);
       } else if ( data.Reconstruct() == QUDA_RECONSTRUCT_8 ) {
-        printfQuda("QUDA_RECONSTRUCT_8\n");
+        //printfQuda("QUDA_RECONSTRUCT_8\n");
         numParams = 8;
 	typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_8>::type Gauge;
         gaugefixingOVR<Float, 8>(Gauge(data), data, gauge_dir, Nsteps, verbose_interval, relax_boost, tolerance, reunit_interval, stopWtheta);

--- a/lib/gauge_fix_ovr.cu
+++ b/lib/gauge_fix_ovr.cu
@@ -1471,7 +1471,7 @@ static bool checkDimsPartitioned(){
 
     TimeProfile profileInternalGaugeFixOVR("InternalGaugeFixQudaOVR");
 
-    profileInternalGaugeFixOVR.Start(QUDA_PROFILE_COMPUTE);
+    profileInternalGaugeFixOVR.TPSTART(QUDA_PROFILE_COMPUTE);
     double flop = 0;
     double byte = 0;
 
@@ -1830,7 +1830,7 @@ static bool checkDimsPartitioned(){
   #endif
     checkCudaError();
     cudaDeviceSynchronize();
-    profileInternalGaugeFixOVR.Stop(QUDA_PROFILE_COMPUTE);
+    profileInternalGaugeFixOVR.TPSTOP(QUDA_PROFILE_COMPUTE);
     if (getVerbosity() > QUDA_SUMMARIZE){
       double secs = profileInternalGaugeFixOVR.Last(QUDA_PROFILE_COMPUTE);
 	  double gflops = (flop * 1e-9) / (secs);

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -215,8 +215,8 @@ static TimeProfile profileCovDev("covDevQuda");
 static TimeProfile profileEnd("endQuda");
 
 //!< Profiler for GaugeFixing
-static TimeProfile GaugeFixFFTQuda("GaugeFixFFTQuda",false);
-static TimeProfile GaugeFixOVRQuda("GaugeFixOVRQuda",false);
+static TimeProfile GaugeFixFFTQuda("GaugeFixFFTQuda");
+static TimeProfile GaugeFixOVRQuda("GaugeFixOVRQuda");
 
 
 

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -445,8 +445,8 @@ extern char* gitversion;
 
 void initQuda(int dev)
 {
-  profileInit2End.Start(QUDA_PROFILE_TOTAL);
-  profileInit.Start(QUDA_PROFILE_TOTAL);
+  profileInit2End.TPSTART(QUDA_PROFILE_TOTAL);
+  profileInit.TPSTART(QUDA_PROFILE_TOTAL);
 
 
   if (getVerbosity() >= QUDA_SUMMARIZE) {
@@ -473,7 +473,7 @@ void initQuda(int dev)
   pthread_mutex_init(&pthread_mutex, &mutex_attr);
 #endif
 
-  profileInit.Stop(QUDA_PROFILE_TOTAL);
+  profileInit.TPSTOP(QUDA_PROFILE_TOTAL);
 }
 
 
@@ -482,14 +482,14 @@ void loadGaugeQuda(void *h_gauge, QudaGaugeParam *param)
   //printfQuda("loadGaugeQuda use_resident_gauge = %d phase=%d\n", 
   //param->use_resident_gauge, param->staggered_phase_applied);
 
-  profileGauge.Start(QUDA_PROFILE_TOTAL);
+  profileGauge.TPSTART(QUDA_PROFILE_TOTAL);
 
   if (!initialized) errorQuda("QUDA not initialized");
   if (getVerbosity() == QUDA_DEBUG_VERBOSE) printQudaGaugeParam(param);
 
   checkGaugeParam(param);
 
-  profileGauge.Start(QUDA_PROFILE_INIT);  
+  profileGauge.TPSTART(QUDA_PROFILE_INIT);  
   // Set the specific input parameters and create the cpu gauge field
   GaugeFieldParam gauge_param(h_gauge, *param);
 
@@ -527,18 +527,18 @@ void loadGaugeQuda(void *h_gauge, QudaGaugeParam *param)
     precise->exchangeGhost();
     delete gaugePrecise;
     gaugePrecise = NULL;
-    profileGauge.Stop(QUDA_PROFILE_INIT);  
+    profileGauge.TPSTOP(QUDA_PROFILE_INIT);  
   } else {
-    profileGauge.Stop(QUDA_PROFILE_INIT);  
-    profileGauge.Start(QUDA_PROFILE_H2D);  
+    profileGauge.TPSTOP(QUDA_PROFILE_INIT);  
+    profileGauge.TPSTART(QUDA_PROFILE_H2D);  
     precise->copy(*in);
-    profileGauge.Stop(QUDA_PROFILE_H2D);  
+    profileGauge.TPSTOP(QUDA_PROFILE_H2D);  
   }
 
   param->gaugeGiB += precise->GBytes();
 
   // creating sloppy fields isn't really compute, but it is work done on the gpu
-  profileGauge.Start(QUDA_PROFILE_COMPUTE); 
+  profileGauge.TPSTART(QUDA_PROFILE_COMPUTE); 
 
   // switch the parameters for creating the mirror sloppy cuda gauge field
   gauge_param.precision = param->cuda_prec_sloppy;
@@ -598,7 +598,7 @@ void loadGaugeQuda(void *h_gauge, QudaGaugeParam *param)
     extended->exchangeExtendedGhost(R);
   }
 
-  profileGauge.Stop(QUDA_PROFILE_COMPUTE); 
+  profileGauge.TPSTOP(QUDA_PROFILE_COMPUTE); 
 
   switch (param->type) {
     case QUDA_WILSON_LINKS:
@@ -641,16 +641,16 @@ void loadGaugeQuda(void *h_gauge, QudaGaugeParam *param)
   }
 
 
-  profileGauge.Start(QUDA_PROFILE_FREE);  
+  profileGauge.TPSTART(QUDA_PROFILE_FREE);  
   delete in;
-  profileGauge.Stop(QUDA_PROFILE_FREE);  
+  profileGauge.TPSTOP(QUDA_PROFILE_FREE);  
 
-  profileGauge.Stop(QUDA_PROFILE_TOTAL);
+  profileGauge.TPSTOP(QUDA_PROFILE_TOTAL);
 }
 
 void saveGaugeQuda(void *h_gauge, QudaGaugeParam *param)
 {
-  profileGauge.Start(QUDA_PROFILE_TOTAL);
+  profileGauge.TPSTART(QUDA_PROFILE_TOTAL);
 
   if (param->location != QUDA_CPU_FIELD_LOCATION) 
     errorQuda("Non-cpu output location not yet supported");
@@ -676,17 +676,17 @@ void saveGaugeQuda(void *h_gauge, QudaGaugeParam *param)
       errorQuda("Invalid gauge type");   
   }
 
-  profileGauge.Start(QUDA_PROFILE_D2H);  
+  profileGauge.TPSTART(QUDA_PROFILE_D2H);  
   cudaGauge->saveCPUField(cpuGauge, QUDA_CPU_FIELD_LOCATION);
-  profileGauge.Stop(QUDA_PROFILE_D2H);  
+  profileGauge.TPSTOP(QUDA_PROFILE_D2H);  
 
-  profileGauge.Stop(QUDA_PROFILE_TOTAL);
+  profileGauge.TPSTOP(QUDA_PROFILE_TOTAL);
 }
 
 
 void loadCloverQuda(void *h_clover, void *h_clovinv, QudaInvertParam *inv_param)
 {
-  profileClover.Start(QUDA_PROFILE_TOTAL);
+  profileClover.TPSTART(QUDA_PROFILE_TOTAL);
   bool device_calc = false; // calculate clover and inverse on the device?
 
   pushVerbosity(inv_param->verbosity);
@@ -742,7 +742,7 @@ void loadCloverQuda(void *h_clover, void *h_clovinv, QudaInvertParam *inv_param)
 
   if(!device_calc){
     // create a param for the cpu clover field
-    profileClover.Start(QUDA_PROFILE_INIT);
+    profileClover.TPSTART(QUDA_PROFILE_INIT);
     CloverFieldParam cpuParam;
     cpuParam.nDim = 4;
     for (int i=0; i<4; i++) cpuParam.x[i] = gaugePrecise->X()[i];
@@ -812,9 +812,9 @@ void loadCloverQuda(void *h_clover, void *h_clovinv, QudaInvertParam *inv_param)
       cloverPrecise = new cudaCloverField(clover_param);
     }
 
-    profileClover.Stop(QUDA_PROFILE_INIT);
+    profileClover.TPSTOP(QUDA_PROFILE_INIT);
 
-    profileClover.Start(QUDA_PROFILE_H2D);
+    profileClover.TPSTART(QUDA_PROFILE_H2D);
     if (inv_param->dslash_type == QUDA_TWISTED_CLOVER_DSLASH) {
       cloverPrecise->copy(*in, false);
 #ifndef DYNAMIC_CLOVER
@@ -825,9 +825,9 @@ void loadCloverQuda(void *h_clover, void *h_clovinv, QudaInvertParam *inv_param)
       cloverPrecise->copy(*in, h_clovinv ? true : false);
     }
 
-    profileClover.Stop(QUDA_PROFILE_H2D);
+    profileClover.TPSTOP(QUDA_PROFILE_H2D);
   } else {
-    profileClover.Start(QUDA_PROFILE_COMPUTE);
+    profileClover.TPSTART(QUDA_PROFILE_COMPUTE);
 
     createCloverQuda(inv_param);
 
@@ -840,14 +840,14 @@ void loadCloverQuda(void *h_clover, void *h_clovinv, QudaInvertParam *inv_param)
       }
     }
 #endif
-    profileClover.Stop(QUDA_PROFILE_COMPUTE);
+    profileClover.TPSTOP(QUDA_PROFILE_COMPUTE);
   }
 
   // inverted clover term is required when applying preconditioned operator
   if ((!h_clovinv && pc_solve) && inv_param->dslash_type != QUDA_TWISTED_CLOVER_DSLASH) {
-    profileClover.Start(QUDA_PROFILE_COMPUTE);
+    profileClover.TPSTART(QUDA_PROFILE_COMPUTE);
     cloverInvert(*cloverPrecise, inv_param->compute_clover_trlog, QUDA_CUDA_FIELD_LOCATION);
-    profileClover.Stop(QUDA_PROFILE_COMPUTE);
+    profileClover.TPSTOP(QUDA_PROFILE_COMPUTE);
     if (inv_param->compute_clover_trlog) {
       inv_param->trlogA[0] = cloverPrecise->TrLog()[0];
       inv_param->trlogA[1] = cloverPrecise->TrLog()[1];
@@ -876,7 +876,7 @@ void loadCloverQuda(void *h_clover, void *h_clovinv, QudaInvertParam *inv_param)
 
   // create the mirror sloppy clover field
   if (inv_param->clover_cuda_prec != inv_param->clover_cuda_prec_sloppy) {
-    profileClover.Start(QUDA_PROFILE_INIT);
+    profileClover.TPSTART(QUDA_PROFILE_INIT);
     clover_param.setPrecision(inv_param->clover_cuda_prec_sloppy);
 
     if (inv_param->dslash_type == QUDA_TWISTED_CLOVER_DSLASH) {
@@ -899,7 +899,7 @@ void loadCloverQuda(void *h_clover, void *h_clovinv, QudaInvertParam *inv_param)
       cloverSloppy->copy(*cloverPrecise);
       inv_param->cloverGiB += cloverSloppy->GBytes();
     }
-    profileClover.Stop(QUDA_PROFILE_INIT);
+    profileClover.TPSTOP(QUDA_PROFILE_INIT);
   } else {
     cloverSloppy = cloverPrecise;
 #ifndef DYNAMIC_CLOVER
@@ -911,7 +911,7 @@ void loadCloverQuda(void *h_clover, void *h_clovinv, QudaInvertParam *inv_param)
   // create the mirror preconditioner clover field
   if (inv_param->clover_cuda_prec_sloppy != inv_param->clover_cuda_prec_precondition &&
       inv_param->clover_cuda_prec_precondition != QUDA_INVALID_PRECISION) {
-    profileClover.Start(QUDA_PROFILE_INIT);
+    profileClover.TPSTART(QUDA_PROFILE_INIT);
     clover_param.setPrecision(inv_param->clover_cuda_prec_precondition);
     if (inv_param->dslash_type == QUDA_TWISTED_CLOVER_DSLASH) {
       clover_param.direct = true;
@@ -932,7 +932,7 @@ void loadCloverQuda(void *h_clover, void *h_clovinv, QudaInvertParam *inv_param)
       cloverPrecondition->copy(*cloverSloppy);
       inv_param->cloverGiB += cloverPrecondition->GBytes();
     }
-    profileClover.Stop(QUDA_PROFILE_INIT);
+    profileClover.TPSTOP(QUDA_PROFILE_INIT);
   } else {
     cloverPrecondition = cloverSloppy;
 #ifndef DYNAMIC_CLOVER
@@ -950,16 +950,16 @@ void loadCloverQuda(void *h_clover, void *h_clovinv, QudaInvertParam *inv_param)
     clover_param.order = inv_param->clover_order;
 
     // this isn't really "epilogue" but this label suffices
-    profileClover.Start(QUDA_PROFILE_EPILOGUE);
+    profileClover.TPSTART(QUDA_PROFILE_EPILOGUE);
     cudaCloverField hack(clover_param);
     hack.copy(*cloverPrecise);
-    profileClover.Stop(QUDA_PROFILE_EPILOGUE);
+    profileClover.TPSTOP(QUDA_PROFILE_EPILOGUE);
 
     // copy the odd components into the host application's clover field
-    profileClover.Start(QUDA_PROFILE_D2H);
+    profileClover.TPSTART(QUDA_PROFILE_D2H);
     cudaMemcpy((char*)(in->V(false))+in->Bytes()/2, (char*)(hack.V(true))+hack.Bytes()/2, 
         in->Bytes()/2, cudaMemcpyDeviceToHost);
-    profileClover.Stop(QUDA_PROFILE_D2H);
+    profileClover.TPSTOP(QUDA_PROFILE_D2H);
 
     checkCudaError();
   }
@@ -974,7 +974,7 @@ void loadCloverQuda(void *h_clover, void *h_clovinv, QudaInvertParam *inv_param)
 
   popVerbosity();
 
-  profileClover.Stop(QUDA_PROFILE_TOTAL);
+  profileClover.TPSTOP(QUDA_PROFILE_TOTAL);
 }
 
 void freeGaugeQuda(void) 
@@ -1068,7 +1068,7 @@ void freeCloverQuda(void)
 
 void endQuda(void)
 {
-  profileEnd.Start(QUDA_PROFILE_TOTAL);
+  profileEnd.TPSTART(QUDA_PROFILE_TOTAL);
 
   if (!initialized) return;
 
@@ -1116,8 +1116,8 @@ void endQuda(void)
   comm_finalize();
   comms_initialized = false;
 
-  profileEnd.Stop(QUDA_PROFILE_TOTAL);
-  profileInit2End.Stop(QUDA_PROFILE_TOTAL);
+  profileEnd.TPSTOP(QUDA_PROFILE_TOTAL);
+  profileInit2End.TPSTOP(QUDA_PROFILE_TOTAL);
   // print out the profile information of the lifetime of the library
   if (getVerbosity() >= QUDA_SUMMARIZE) {
     profileInit.Print();
@@ -1893,7 +1893,7 @@ void lanczosQuda(int k0, int m, void *hp_Apsi, void *hp_r, void *hp_V,
       param->dslash_type == QUDA_MOBIUS_DWF_DSLASH) setKernelPackT(true);
   if (gaugePrecise == NULL) errorQuda("Gauge field not allocated");
 
-  profileInvert.Start(QUDA_PROFILE_TOTAL);
+  profileInvert.TPSTART(QUDA_PROFILE_TOTAL);
 
   if (!initialized) errorQuda("QUDA not initialized");
 
@@ -1916,7 +1916,7 @@ void lanczosQuda(int k0, int m, void *hp_Apsi, void *hp_r, void *hp_V,
   
   Dirac &dirac = *d;
 
-  profileInvert.Start(QUDA_PROFILE_H2D);
+  profileInvert.TPSTART(QUDA_PROFILE_H2D);
 
   cudaColorSpinorField *r = NULL;
   cudaColorSpinorField *Apsi = NULL;
@@ -1973,7 +1973,7 @@ void lanczosQuda(int k0, int m, void *hp_Apsi, void *hp_r, void *hp_V,
       printfQuda("Eig_Vec[%d] CPU %1.14e CUDA %1.14e\n", k, cpu, gpu);
     }
   }
-  profileInvert.Stop(QUDA_PROFILE_H2D);
+  profileInvert.TPSTOP(QUDA_PROFILE_H2D);
 
   if(eig_param->RitzMat_lanczos == QUDA_MATPC_DAG_SOLUTION)
   {
@@ -2006,14 +2006,14 @@ void lanczosQuda(int k0, int m, void *hp_Apsi, void *hp_r, void *hp_V,
   }
 
   //Write back calculated eigen vector
-  profileInvert.Start(QUDA_PROFILE_D2H);
+  profileInvert.TPSTART(QUDA_PROFILE_D2H);
   for( int k = 0 ; k < m ; k++)
   {
     *h_Eig_Vec[k] = *Eig_Vec[k];
   }
   *h_r = *r;
   *h_Apsi = *Apsi;
-  profileInvert.Stop(QUDA_PROFILE_D2H);
+  profileInvert.TPSTOP(QUDA_PROFILE_D2H);
 
 
   delete h_r;
@@ -2031,7 +2031,7 @@ void lanczosQuda(int k0, int m, void *hp_Apsi, void *hp_r, void *hp_V,
   popVerbosity();
 
   saveTuneCache(getVerbosity());
-  profileInvert.Stop(QUDA_PROFILE_TOTAL);
+  profileInvert.TPSTOP(QUDA_PROFILE_TOTAL);
 }
 
 void invertQuda(void *hp_x, void *hp_b, QudaInvertParam *param)
@@ -2042,7 +2042,7 @@ void invertQuda(void *hp_x, void *hp_b, QudaInvertParam *param)
       param->dslash_type == QUDA_DOMAIN_WALL_4D_DSLASH ||
       param->dslash_type == QUDA_MOBIUS_DWF_DSLASH) setKernelPackT(true);
 
-  profileInvert.Start(QUDA_PROFILE_TOTAL);
+  profileInvert.TPSTART(QUDA_PROFILE_TOTAL);
 
   if (!initialized) errorQuda("QUDA not initialized");
 
@@ -2093,7 +2093,7 @@ void invertQuda(void *hp_x, void *hp_b, QudaInvertParam *param)
   Dirac &diracSloppy = *dSloppy;
   Dirac &diracPre = *dPre;
 
-  profileInvert.Start(QUDA_PROFILE_H2D);
+  profileInvert.TPSTART(QUDA_PROFILE_H2D);
 
   cudaColorSpinorField *b = NULL;
   cudaColorSpinorField *x = NULL;
@@ -2131,7 +2131,7 @@ void invertQuda(void *hp_x, void *hp_b, QudaInvertParam *param)
     x = new cudaColorSpinorField(cudaParam); // solution
   }
 
-  profileInvert.Stop(QUDA_PROFILE_H2D);
+  profileInvert.TPSTOP(QUDA_PROFILE_H2D);
 
   double nb = norm2(*b);
   if (nb==0.0) errorQuda("Source has zero norm");
@@ -2247,9 +2247,9 @@ void invertQuda(void *hp_x, void *hp_b, QudaInvertParam *param)
     axCuda(sqrt(nb), *x);
   }
 
-  profileInvert.Start(QUDA_PROFILE_D2H);
+  profileInvert.TPSTART(QUDA_PROFILE_D2H);
   *h_x = *x;
-  profileInvert.Stop(QUDA_PROFILE_D2H);
+  profileInvert.TPSTOP(QUDA_PROFILE_D2H);
 
   if (getVerbosity() >= QUDA_VERBOSE){
     double nx = norm2(*x);
@@ -2271,7 +2271,7 @@ void invertQuda(void *hp_x, void *hp_b, QudaInvertParam *param)
   // FIXME: added temporarily so that the cache is written out even if a long benchmarking job gets interrupted
   saveTuneCache(getVerbosity());
 
-  profileInvert.Stop(QUDA_PROFILE_TOTAL);
+  profileInvert.TPSTOP(QUDA_PROFILE_TOTAL);
 }
 
 void invertMDQuda(void *hp_x, void *hp_b, QudaInvertParam *param)
@@ -2280,7 +2280,7 @@ void invertMDQuda(void *hp_x, void *hp_b, QudaInvertParam *param)
 
   if (param->dslash_type == QUDA_DOMAIN_WALL_DSLASH) setKernelPackT(true);
 
-  profileInvert.Start(QUDA_PROFILE_TOTAL);
+  profileInvert.TPSTART(QUDA_PROFILE_TOTAL);
 
   if (!initialized) errorQuda("QUDA not initialized");
 
@@ -2331,7 +2331,7 @@ void invertMDQuda(void *hp_x, void *hp_b, QudaInvertParam *param)
   Dirac &diracSloppy = *dSloppy;
   Dirac &diracPre = *dPre;
 
-  profileInvert.Start(QUDA_PROFILE_H2D);
+  profileInvert.TPSTART(QUDA_PROFILE_H2D);
 
   cudaColorSpinorField *b = NULL;
   cudaColorSpinorField *x = NULL;
@@ -2369,7 +2369,7 @@ void invertMDQuda(void *hp_x, void *hp_b, QudaInvertParam *param)
     x = new cudaColorSpinorField(cudaParam); // solution
   }
 
-  profileInvert.Stop(QUDA_PROFILE_H2D);
+  profileInvert.TPSTOP(QUDA_PROFILE_H2D);
 
   double nb = norm2(*b);
   if (nb==0.0) errorQuda("Source has zero norm");
@@ -2497,9 +2497,9 @@ void invertMDQuda(void *hp_x, void *hp_b, QudaInvertParam *param)
 
   dirac.Dslash(solutionResident[0]->Odd(), solutionResident[0]->Even(), QUDA_ODD_PARITY);
 
-  profileInvert.Start(QUDA_PROFILE_D2H);
+  profileInvert.TPSTART(QUDA_PROFILE_D2H);
   *h_x = *x;
-  profileInvert.Stop(QUDA_PROFILE_D2H);
+  profileInvert.TPSTOP(QUDA_PROFILE_D2H);
 
   if (getVerbosity() >= QUDA_VERBOSE){
     double nx = norm2(*x);
@@ -2521,7 +2521,7 @@ void invertMDQuda(void *hp_x, void *hp_b, QudaInvertParam *param)
   // FIXME: added temporarily so that the cache is written out even if a long benchmarking job gets interrupted
   saveTuneCache(getVerbosity());
 
-  profileInvert.Stop(QUDA_PROFILE_TOTAL);
+  profileInvert.TPSTOP(QUDA_PROFILE_TOTAL);
 }
 
 
@@ -2537,7 +2537,7 @@ void invertMultiShiftQuda(void **_hp_x, void *_hp_b, QudaInvertParam *param)
 {
   setTuning(param->tune);
 
-  profileMulti.Start(QUDA_PROFILE_TOTAL);
+  profileMulti.TPSTART(QUDA_PROFILE_TOTAL);
 
   if (param->dslash_type == QUDA_DOMAIN_WALL_DSLASH ||
       param->dslash_type == QUDA_DOMAIN_WALL_4D_DSLASH ||
@@ -2654,13 +2654,13 @@ void invertMultiShiftQuda(void **_hp_x, void *_hp_b, QudaInvertParam *param)
       static_cast<ColorSpinorField*>(new cudaColorSpinorField(cpuParam));
   }
 
-  profileMulti.Start(QUDA_PROFILE_H2D);
+  profileMulti.TPSTART(QUDA_PROFILE_H2D);
   // Now I need a colorSpinorParam for the device
   ColorSpinorParam cudaParam(cpuParam, *param);
   // This setting will download a host vector
   cudaParam.create = QUDA_COPY_FIELD_CREATE;
   b = new cudaColorSpinorField(*h_b, cudaParam); // Creates b and downloads h_b to it
-  profileMulti.Stop(QUDA_PROFILE_H2D);
+  profileMulti.TPSTOP(QUDA_PROFILE_H2D);
 
   // Create the solution fields filled with zero
   x = new cudaColorSpinorField* [ param->num_offset ];
@@ -2782,7 +2782,7 @@ void invertMultiShiftQuda(void **_hp_x, void *_hp_b, QudaInvertParam *param)
     param->offset[i] = unscaled_shifts[i];
   }
 
-  profileMulti.Start(QUDA_PROFILE_D2H);
+  profileMulti.TPSTART(QUDA_PROFILE_D2H);
   for(int i=0; i < param->num_offset; i++) { 
     if (param->solver_normalization == QUDA_SOURCE_NORMALIZATION) { // rescale the solution 
       axCuda(sqrt(nb), *x[i]);
@@ -2795,7 +2795,7 @@ void invertMultiShiftQuda(void **_hp_x, void *_hp_b, QudaInvertParam *param)
 
     if (!param->make_resident_solution) *h_x[i] = *x[i];
   }
-  profileMulti.Stop(QUDA_PROFILE_D2H);
+  profileMulti.TPSTOP(QUDA_PROFILE_D2H);
 
   if (param->make_resident_solution) {
     for (unsigned int i=0; i<solutionResident.size(); i++) {
@@ -2830,7 +2830,7 @@ void invertMultiShiftQuda(void **_hp_x, void *_hp_b, QudaInvertParam *param)
   // FIXME: added temporarily so that the cache is written out even if a long benchmarking job gets interrupted
   saveTuneCache(getVerbosity());
 
-  profileMulti.Stop(QUDA_PROFILE_TOTAL);
+  profileMulti.TPSTOP(QUDA_PROFILE_TOTAL);
 }
 
 
@@ -2842,7 +2842,7 @@ void incrementalEigQuda(void *_h_x, void *_h_b, QudaInvertParam *param, void *_h
 
   if (param->dslash_type == QUDA_DOMAIN_WALL_DSLASH) setKernelPackT(true);
 
-  profileInvert.Start(QUDA_PROFILE_TOTAL);
+  profileInvert.TPSTART(QUDA_PROFILE_TOTAL);
 
   if (!initialized) errorQuda("QUDA not initialized");
 
@@ -2921,7 +2921,7 @@ void incrementalEigQuda(void *_h_x, void *_h_b, QudaInvertParam *param, void *_h
   Dirac &diracHalf     = *dHalfPrec;  
   Dirac &diracDeflate  = (param->cuda_prec_ritz == param->cuda_prec) ? *d : *dSloppy;
 
-  profileInvert.Start(QUDA_PROFILE_H2D);
+  profileInvert.TPSTART(QUDA_PROFILE_H2D);
 
   cudaColorSpinorField *b = NULL;
   cudaColorSpinorField *x = NULL;
@@ -2959,7 +2959,7 @@ void incrementalEigQuda(void *_h_x, void *_h_b, QudaInvertParam *param, void *_h
     x = new cudaColorSpinorField(cudaParam); // solution
   }
 
-  profileInvert.Stop(QUDA_PROFILE_H2D);
+  profileInvert.TPSTOP(QUDA_PROFILE_H2D);
 
   double nb = norm2(*b);
   if (nb==0.0) errorQuda("Source has zero norm");
@@ -3049,9 +3049,9 @@ void incrementalEigQuda(void *_h_x, void *_h_b, QudaInvertParam *param, void *_h
     axCuda(sqrt(nb), *x);
   }
 
-  profileInvert.Start(QUDA_PROFILE_D2H);
+  profileInvert.TPSTART(QUDA_PROFILE_D2H);
   *h_x = *x;
-  profileInvert.Stop(QUDA_PROFILE_D2H);
+  profileInvert.TPSTOP(QUDA_PROFILE_D2H);
 
   if (getVerbosity() >= QUDA_VERBOSE){
     double nx = norm2(*x);
@@ -3074,7 +3074,7 @@ void incrementalEigQuda(void *_h_x, void *_h_b, QudaInvertParam *param, void *_h
   // FIXME: added temporarily so that the cache is written out even if a long benchmarking job gets interrupted
   saveTuneCache(getVerbosity());
 
-  profileInvert.Stop(QUDA_PROFILE_TOTAL);
+  profileInvert.TPSTOP(QUDA_PROFILE_TOTAL);
 }
 
 
@@ -3141,7 +3141,7 @@ namespace quda {
 			  TimeProfile &profile)
   {
 
-    profile.Start(QUDA_PROFILE_INIT);
+    profile.TPSTART(QUDA_PROFILE_INIT);
     const int flag = qudaGaugeParam->preserve_gauge;
     GaugeFieldParam gParam(0,*qudaGaugeParam);
 
@@ -3165,22 +3165,22 @@ namespace quda {
       cudaStapleField  = new cudaGaugeField(gParam);
       cudaStapleField1 = new cudaGaugeField(gParam);
     }
-    profile.Stop(QUDA_PROFILE_INIT);
+    profile.TPSTOP(QUDA_PROFILE_INIT);
 
-    profile.Start(QUDA_PROFILE_COMPUTE);
+    profile.TPSTART(QUDA_PROFILE_COMPUTE);
     if (method == QUDA_COMPUTE_FAT_STANDARD) {
       llfat_cuda(cudaFatLink, cudaLongLink, *cudaSiteLink, *cudaStapleField, *cudaStapleField1, qudaGaugeParam, act_path_coeff);
     } else { //method == QUDA_COMPUTE_FAT_EXTENDED_VOLUME
       llfat_cuda_ex(cudaFatLink, cudaLongLink, *cudaSiteLink, *cudaStapleField, *cudaStapleField1, qudaGaugeParam, act_path_coeff);
     }
-    profile.Stop(QUDA_PROFILE_COMPUTE);
+    profile.TPSTOP(QUDA_PROFILE_COMPUTE);
 
-    profile.Start(QUDA_PROFILE_FREE);
+    profile.TPSTART(QUDA_PROFILE_FREE);
     if (!(flag & QUDA_FAT_PRESERVE_GPU_GAUGE) ){
       delete cudaStapleField; cudaStapleField = NULL;
       delete cudaStapleField1; cudaStapleField1 = NULL;
     }
-    profile.Stop(QUDA_PROFILE_FREE);
+    profile.TPSTOP(QUDA_PROFILE_FREE);
 
     return;
   }
@@ -3195,8 +3195,8 @@ namespace quda {
 
 void computeKSLinkQuda(void* fatlink, void* longlink, void* ulink, void* inlink, double *path_coeff, QudaGaugeParam *param, QudaComputeFatMethod method)
 {
-  profileFatLink.Start(QUDA_PROFILE_TOTAL);
-  profileFatLink.Start(QUDA_PROFILE_INIT);
+  profileFatLink.TPSTART(QUDA_PROFILE_TOTAL);
+  profileFatLink.TPSTART(QUDA_PROFILE_INIT);
   // Initialize unitarization parameters
   if(ulink){
     const double unitarize_eps = 1e-14;
@@ -3272,9 +3272,9 @@ void computeKSLinkQuda(void* fatlink, void* longlink, void* ulink, void* inlink,
     cudaInLinkEx = new cudaGaugeField(gParam);
   }
 
-  profileFatLink.Stop(QUDA_PROFILE_INIT);
+  profileFatLink.TPSTOP(QUDA_PROFILE_INIT);
   fatlink::initLatticeConstants(*cudaFatLink, profileFatLink);
-  profileFatLink.Start(QUDA_PROFILE_INIT);
+  profileFatLink.TPSTART(QUDA_PROFILE_INIT);
 
   cudaGaugeField* inlinkPtr;
   if(method == QUDA_COMPUTE_FAT_STANDARD){
@@ -3285,63 +3285,63 @@ void computeKSLinkQuda(void* fatlink, void* longlink, void* ulink, void* inlink,
     llfat_init_cuda_ex(qudaGaugeParam_ex);
     inlinkPtr = cudaInLinkEx;
   }
-  profileFatLink.Stop(QUDA_PROFILE_INIT);
+  profileFatLink.TPSTOP(QUDA_PROFILE_INIT);
 
-  profileFatLink.Start(QUDA_PROFILE_H2D);
+  profileFatLink.TPSTART(QUDA_PROFILE_H2D);
   cudaInLink->loadCPUField(cpuInLink, QUDA_CPU_FIELD_LOCATION);
-  profileFatLink.Stop(QUDA_PROFILE_H2D);
+  profileFatLink.TPSTOP(QUDA_PROFILE_H2D);
 
   if(method != QUDA_COMPUTE_FAT_STANDARD){
-    profileFatLink.Start(QUDA_PROFILE_COMMS);
+    profileFatLink.TPSTART(QUDA_PROFILE_COMMS);
     copyExtendedGauge(*cudaInLinkEx, *cudaInLink, QUDA_CUDA_FIELD_LOCATION);
 #ifdef MULTI_GPU
     int R[4] = {2, 2, 2, 2}; 
     cudaInLinkEx->exchangeExtendedGhost(R,true); // instead of exchange_cpu_sitelink_ex 
 #endif
-    profileFatLink.Stop(QUDA_PROFILE_COMMS);
+    profileFatLink.TPSTOP(QUDA_PROFILE_COMMS);
   } // Initialise and load siteLinks
 
   quda::computeFatLinkCore(inlinkPtr, const_cast<double*>(path_coeff), param, method, cudaFatLink, cudaLongLink, profileFatLink);
 
   if(ulink){
-    profileFatLink.Start(QUDA_PROFILE_INIT);
+    profileFatLink.TPSTART(QUDA_PROFILE_INIT);
     int num_failures=0;
     int* num_failures_dev = (int*)device_malloc(sizeof(int));
     cudaMemset(num_failures_dev, 0, sizeof(int));
-    profileFatLink.Stop(QUDA_PROFILE_INIT);
+    profileFatLink.TPSTOP(QUDA_PROFILE_INIT);
 
-    profileFatLink.Start(QUDA_PROFILE_COMPUTE);
+    profileFatLink.TPSTART(QUDA_PROFILE_COMPUTE);
     //quda::unitarizeLinksCuda(*param, *cudaFatLink, cudaUnitarizedLink, num_failures_dev); // unitarize on the gpu
     quda::unitarizeLinksQuda(*cudaUnitarizedLink, *cudaFatLink, num_failures_dev); // unitarize on the gpu
-    profileFatLink.Stop(QUDA_PROFILE_COMPUTE);
+    profileFatLink.TPSTOP(QUDA_PROFILE_COMPUTE);
 
 
-    profileFatLink.Start(QUDA_PROFILE_D2H); 
+    profileFatLink.TPSTART(QUDA_PROFILE_D2H); 
     cudaMemcpy(&num_failures, num_failures_dev, sizeof(int), cudaMemcpyDeviceToHost);
-    profileFatLink.Stop(QUDA_PROFILE_D2H); 
+    profileFatLink.TPSTOP(QUDA_PROFILE_D2H); 
     device_free(num_failures_dev); 
     if(num_failures>0){
       errorQuda("Error in the unitarization component of the hisq fattening\n"); 
     }
-    profileFatLink.Start(QUDA_PROFILE_D2H);
+    profileFatLink.TPSTART(QUDA_PROFILE_D2H);
     cudaUnitarizedLink->saveCPUField(cpuUnitarizedLink, QUDA_CPU_FIELD_LOCATION);
-    profileFatLink.Stop(QUDA_PROFILE_D2H);
+    profileFatLink.TPSTOP(QUDA_PROFILE_D2H);
   }
 
-  profileFatLink.Start(QUDA_PROFILE_D2H);
+  profileFatLink.TPSTART(QUDA_PROFILE_D2H);
   if(fatlink) cudaFatLink->saveCPUField(cpuFatLink, QUDA_CPU_FIELD_LOCATION);
   if(longlink) cudaLongLink->saveCPUField(cpuLongLink, QUDA_CPU_FIELD_LOCATION);
-  profileFatLink.Stop(QUDA_PROFILE_D2H);
+  profileFatLink.TPSTOP(QUDA_PROFILE_D2H);
 
-  profileFatLink.Start(QUDA_PROFILE_FREE);
+  profileFatLink.TPSTART(QUDA_PROFILE_FREE);
   if(longlink) delete cudaLongLink;
   delete cudaFatLink; 
   delete cudaInLink; 
   delete cudaUnitarizedLink; 
   if(cudaInLinkEx) delete cudaInLinkEx; 
-  profileFatLink.Stop(QUDA_PROFILE_FREE);
+  profileFatLink.TPSTOP(QUDA_PROFILE_FREE);
 
-  profileFatLink.Stop(QUDA_PROFILE_TOTAL);
+  profileFatLink.TPSTOP(QUDA_PROFILE_TOTAL);
 
   return;
 }
@@ -3379,8 +3379,8 @@ int computeGaugeForceQuda(void* mom, void* siteLink,  int*** input_path_buf, int
     qudaGaugeParam->use_resident_mom, qudaGaugeParam->make_resident_mom);*/
 
 #ifdef GPU_GAUGE_FORCE
-  profileGaugeForce.Start(QUDA_PROFILE_TOTAL);
-  profileGaugeForce.Start(QUDA_PROFILE_INIT); 
+  profileGaugeForce.TPSTART(QUDA_PROFILE_TOTAL);
+  profileGaugeForce.TPSTART(QUDA_PROFILE_INIT); 
 
   checkGaugeParam(qudaGaugeParam);
 
@@ -3402,7 +3402,7 @@ int computeGaugeForceQuda(void* mom, void* siteLink,  int*** input_path_buf, int
   if (qudaGaugeParam->use_resident_gauge) {
     if (!gaugePrecise) errorQuda("No resident gauge field to use");
     cudaSiteLink = gaugePrecise;
-    profileGaugeForce.Stop(QUDA_PROFILE_INIT); 
+    profileGaugeForce.TPSTOP(QUDA_PROFILE_INIT); 
     printfQuda("GaugeForce: Using resident gauge field\n");
   } else {
     gParam.create = QUDA_NULL_FIELD_CREATE;
@@ -3412,14 +3412,14 @@ int computeGaugeForceQuda(void* mom, void* siteLink,  int*** input_path_buf, int
       QUDA_FLOAT2_GAUGE_ORDER : QUDA_FLOAT4_GAUGE_ORDER;
 
     cudaSiteLink = new cudaGaugeField(gParam);  
-    profileGaugeForce.Stop(QUDA_PROFILE_INIT); 
+    profileGaugeForce.TPSTOP(QUDA_PROFILE_INIT); 
 
-    profileGaugeForce.Start(QUDA_PROFILE_H2D);
+    profileGaugeForce.TPSTART(QUDA_PROFILE_H2D);
     cudaSiteLink->loadCPUField(*cpuSiteLink, QUDA_CPU_FIELD_LOCATION);    
-    profileGaugeForce.Stop(QUDA_PROFILE_H2D);
+    profileGaugeForce.TPSTOP(QUDA_PROFILE_H2D);
   }
 
-  profileGaugeForce.Start(QUDA_PROFILE_INIT); 
+  profileGaugeForce.TPSTART(QUDA_PROFILE_INIT); 
 
 #ifndef MULTI_GPU
   cudaGaugeField *cudaGauge = cudaSiteLink;
@@ -3438,14 +3438,14 @@ int computeGaugeForceQuda(void* mom, void* siteLink,  int*** input_path_buf, int
   copyExtendedGauge(*cudaGauge, *cudaSiteLink, QUDA_CUDA_FIELD_LOCATION);
   int R[4] = {2, 2, 2, 2}; // radius of the extended region in each dimension / direction
 
-  profileGaugeForce.Stop(QUDA_PROFILE_INIT); 
+  profileGaugeForce.TPSTOP(QUDA_PROFILE_INIT); 
 
-  profileGaugeForce.Start(QUDA_PROFILE_COMMS);
+  profileGaugeForce.TPSTART(QUDA_PROFILE_COMMS);
   // do extended fill so we can reuse this extended gauge field
   bool no_comms_fill =  (qudaGaugeParam->make_resident_gauge) ? true : false;
   cudaGauge->exchangeExtendedGhost(R, no_comms_fill); 
-  profileGaugeForce.Stop(QUDA_PROFILE_COMMS);
-  profileGaugeForce.Start(QUDA_PROFILE_INIT); 
+  profileGaugeForce.TPSTOP(QUDA_PROFILE_COMMS);
+  profileGaugeForce.TPSTART(QUDA_PROFILE_INIT); 
 #endif
 
   GaugeFieldParam &gParamMom = gParam;
@@ -3466,7 +3466,7 @@ int computeGaugeForceQuda(void* mom, void* siteLink,  int*** input_path_buf, int
     if (!gaugePrecise) errorQuda("No resident momentum field to use");
     cudaMom = momResident;
     printfQuda("GaugeForce: Using resident mom field\n");
-    profileGaugeForce.Stop(QUDA_PROFILE_INIT);
+    profileGaugeForce.TPSTOP(QUDA_PROFILE_INIT);
   } else {
     gParamMom.create = QUDA_ZERO_FIELD_CREATE;  
     gParamMom.order = QUDA_FLOAT2_GAUGE_ORDER;
@@ -3474,32 +3474,32 @@ int computeGaugeForceQuda(void* mom, void* siteLink,  int*** input_path_buf, int
     gParamMom.link_type = QUDA_ASQTAD_MOM_LINKS;
     gParamMom.precision = qudaGaugeParam->cuda_prec;
     cudaMom = new cudaGaugeField(gParamMom);
-    profileGaugeForce.Stop(QUDA_PROFILE_INIT);
+    profileGaugeForce.TPSTOP(QUDA_PROFILE_INIT);
 
-    profileGaugeForce.Start(QUDA_PROFILE_H2D);
+    profileGaugeForce.TPSTART(QUDA_PROFILE_H2D);
     cudaMom->loadCPUField(*cpuMom, QUDA_CPU_FIELD_LOCATION);
-    profileGaugeForce.Stop(QUDA_PROFILE_H2D);
+    profileGaugeForce.TPSTOP(QUDA_PROFILE_H2D);
   }
 
   gaugeforce::initLatticeConstants(*cudaMom, profileGaugeForce);
 
-  profileGaugeForce.Start(QUDA_PROFILE_CONSTANT);
+  profileGaugeForce.TPSTART(QUDA_PROFILE_CONSTANT);
   qudaGaugeParam->mom_ga_pad = gParamMom.pad; //need to set this (until we use order classes)
   gauge_force_init_cuda(qudaGaugeParam, max_length); 
-  profileGaugeForce.Stop(QUDA_PROFILE_CONSTANT);
+  profileGaugeForce.TPSTOP(QUDA_PROFILE_CONSTANT);
 
   // actually do the computation
-  profileGaugeForce.Start(QUDA_PROFILE_COMPUTE);
+  profileGaugeForce.TPSTART(QUDA_PROFILE_COMPUTE);
   gauge_force_cuda(*cudaMom, eb3, *cudaGauge, qudaGaugeParam, input_path_buf, 
       path_length, loop_coeff, num_paths, max_length);
-  profileGaugeForce.Stop(QUDA_PROFILE_COMPUTE);
+  profileGaugeForce.TPSTOP(QUDA_PROFILE_COMPUTE);
 
   // still need to copy this back even when preserving
-  profileGaugeForce.Start(QUDA_PROFILE_D2H);
+  profileGaugeForce.TPSTART(QUDA_PROFILE_D2H);
   cudaMom->saveCPUField(*cpuMom, QUDA_CPU_FIELD_LOCATION);
-  profileGaugeForce.Stop(QUDA_PROFILE_D2H);
+  profileGaugeForce.TPSTOP(QUDA_PROFILE_D2H);
 
-  profileGaugeForce.Start(QUDA_PROFILE_FREE);
+  profileGaugeForce.TPSTART(QUDA_PROFILE_FREE);
   if (qudaGaugeParam->make_resident_gauge) {
     if (gaugePrecise && gaugePrecise != cudaSiteLink) delete gaugePrecise;
     gaugePrecise = cudaSiteLink;
@@ -3525,9 +3525,9 @@ int computeGaugeForceQuda(void* mom, void* siteLink,  int*** input_path_buf, int
     delete cudaGauge;
   }
 #endif
-  profileGaugeForce.Stop(QUDA_PROFILE_FREE);
+  profileGaugeForce.TPSTOP(QUDA_PROFILE_FREE);
 
-  profileGaugeForce.Stop(QUDA_PROFILE_TOTAL);
+  profileGaugeForce.TPSTOP(QUDA_PROFILE_TOTAL);
 
   if(timeinfo){
     timeinfo[0] = profileGaugeForce.Last(QUDA_PROFILE_H2D);
@@ -3545,8 +3545,8 @@ int computeGaugeForceQuda(void* mom, void* siteLink,  int*** input_path_buf, int
 
 void createCloverQuda(QudaInvertParam* invertParam)
 {
-  profileCloverCreate.Start(QUDA_PROFILE_TOTAL);
-  profileCloverCreate.Start(QUDA_PROFILE_INIT);
+  profileCloverCreate.TPSTART(QUDA_PROFILE_TOTAL);
+  profileCloverCreate.TPSTART(QUDA_PROFILE_INIT);
   if(!cloverPrecise){
     CloverFieldParam cloverParam;
     cloverParam.nDim = 4;
@@ -3598,17 +3598,17 @@ void createCloverQuda(QudaInvertParam* invertParam)
   cudaGaugeField *cudaGaugeExtended = NULL;
   if (extendedGaugeResident) {
     cudaGaugeExtended = extendedGaugeResident;
-    profileCloverCreate.Stop(QUDA_PROFILE_INIT);
+    profileCloverCreate.TPSTOP(QUDA_PROFILE_INIT);
   } else {
     cudaGaugeExtended = new cudaGaugeField(gParamEx);
 
     // copy gaugePrecise into the extended device gauge field
     copyExtendedGauge(*cudaGaugeExtended, *gaugePrecise, QUDA_CUDA_FIELD_LOCATION);
 #if 1
-    profileCloverCreate.Stop(QUDA_PROFILE_INIT);
-    profileCloverCreate.Start(QUDA_PROFILE_COMMS);
+    profileCloverCreate.TPSTOP(QUDA_PROFILE_INIT);
+    profileCloverCreate.TPSTART(QUDA_PROFILE_COMMS);
     cudaGaugeExtended->exchangeExtendedGhost(R,true);
-    profileCloverCreate.Stop(QUDA_PROFILE_COMMS);
+    profileCloverCreate.TPSTOP(QUDA_PROFILE_COMMS);
 #else
 
     GaugeFieldParam gParam(gaugePrecise->X(), gaugePrecise->Precision(), QUDA_RECONSTRUCT_NO,
@@ -3624,15 +3624,15 @@ void createCloverQuda(QudaInvertParam* invertParam)
     cpuGaugeField cpuGaugeExtended(gParam);
     cudaGaugeExtended->saveCPUField(cpuGaugeExtended, QUDA_CPU_FIELD_LOCATION);
 
-    profileCloverCreate.Stop(QUDA_PROFILE_INIT);
+    profileCloverCreate.TPSTOP(QUDA_PROFILE_INIT);
     // communicate data
-    profileCloverCreate.Start(QUDA_PROFILE_COMMS);
+    profileCloverCreate.TPSTART(QUDA_PROFILE_COMMS);
     //exchange_cpu_sitelink_ex(const_cast<int*>(gaugePrecise->X()), R, (void**)cpuGaugeExtended.Gauge_p(),
     //			   cpuGaugeExtended.Order(),cpuGaugeExtended.Precision(), 0, 4);
     cpuGaugeExtended.exchangeExtendedGhost(R,true);
 
     cudaGaugeExtended->loadCPUField(cpuGaugeExtended, QUDA_CPU_FIELD_LOCATION);
-    profileCloverCreate.Stop(QUDA_PROFILE_COMMS);
+    profileCloverCreate.TPSTOP(QUDA_PROFILE_COMMS);
 #endif
   }
 
@@ -3643,16 +3643,16 @@ void createCloverQuda(QudaInvertParam* invertParam)
 #endif
 
 
-  profileCloverCreate.Start(QUDA_PROFILE_INIT);
+  profileCloverCreate.TPSTART(QUDA_PROFILE_INIT);
   // create the Fmunu field
   GaugeFieldParam tensorParam(gaugePrecise->X(), gauge->Precision(), QUDA_RECONSTRUCT_NO, pad, QUDA_TENSOR_GEOMETRY);
   tensorParam.siteSubset = QUDA_FULL_SITE_SUBSET;
   tensorParam.order = QUDA_FLOAT2_GAUGE_ORDER;
   tensorParam.ghostExchange = QUDA_GHOST_EXCHANGE_NO;
   cudaGaugeField Fmunu(tensorParam);
-  profileCloverCreate.Stop(QUDA_PROFILE_INIT);
+  profileCloverCreate.TPSTOP(QUDA_PROFILE_INIT);
 
-  profileCloverCreate.Start(QUDA_PROFILE_COMPUTE);
+  profileCloverCreate.TPSTART(QUDA_PROFILE_COMPUTE);
 
   computeFmunu(Fmunu, *gauge, QUDA_CUDA_FIELD_LOCATION);
   computeClover(*cloverPrecise, Fmunu, invertParam->clover_coeff, QUDA_CUDA_FIELD_LOCATION);
@@ -3663,9 +3663,9 @@ void createCloverQuda(QudaInvertParam* invertParam)
   }
 #endif
 
-  profileCloverCreate.Stop(QUDA_PROFILE_COMPUTE);
+  profileCloverCreate.TPSTOP(QUDA_PROFILE_COMPUTE);
 
-  profileCloverCreate.Stop(QUDA_PROFILE_TOTAL);
+  profileCloverCreate.TPSTOP(QUDA_PROFILE_TOTAL);
 
   // FIXME always preserve the extended gauge
   extendedGaugeResident = cudaGaugeExtended;
@@ -3723,14 +3723,14 @@ void saveGaugeFieldQuda(void* gauge, void* inGauge, QudaGaugeParam* param){
 
 void* createExtendedGaugeFieldQuda(void* gauge, int geometry, QudaGaugeParam* param)
 {
-  profileExtendedGauge.Start(QUDA_PROFILE_TOTAL);
+  profileExtendedGauge.TPSTART(QUDA_PROFILE_TOTAL);
 
   if (param->use_resident_gauge && extendedGaugeResident && geometry == 4) {
-    profileExtendedGauge.Stop(QUDA_PROFILE_TOTAL);
+    profileExtendedGauge.TPSTOP(QUDA_PROFILE_TOTAL);
     return extendedGaugeResident;
   }
 
-  profileExtendedGauge.Start(QUDA_PROFILE_INIT);
+  profileExtendedGauge.TPSTART(QUDA_PROFILE_INIT);
 
   QudaFieldGeometry geom = QUDA_INVALID_GEOMETRY;
   if (geometry == 1) {
@@ -3761,14 +3761,14 @@ void* createExtendedGaugeFieldQuda(void* gauge, int geometry, QudaGaugeParam* pa
     gParam.order  = QUDA_FLOAT2_GAUGE_ORDER;
     gParam.create = QUDA_NULL_FIELD_CREATE;
     cudaGauge     = new cudaGaugeField(gParam);
-    profileExtendedGauge.Stop(QUDA_PROFILE_INIT);
+    profileExtendedGauge.TPSTOP(QUDA_PROFILE_INIT);
 
     // load the data into the unextended device field 
-    profileExtendedGauge.Start(QUDA_PROFILE_H2D);
+    profileExtendedGauge.TPSTART(QUDA_PROFILE_H2D);
     cudaGauge->loadCPUField(*cpuGauge, QUDA_CPU_FIELD_LOCATION);
-    profileExtendedGauge.Stop(QUDA_PROFILE_H2D);
+    profileExtendedGauge.TPSTOP(QUDA_PROFILE_H2D);
 
-    profileExtendedGauge.Start(QUDA_PROFILE_INIT);
+    profileExtendedGauge.TPSTART(QUDA_PROFILE_INIT);
   }
 
   QudaGaugeParam param_ex;
@@ -3787,17 +3787,17 @@ void* createExtendedGaugeFieldQuda(void* gauge, int geometry, QudaGaugeParam* pa
   // copy data from the interior into the border region
   if(gauge) copyExtendedGauge(*cudaGaugeEx, *cudaGauge, QUDA_CUDA_FIELD_LOCATION);
 
-  profileExtendedGauge.Stop(QUDA_PROFILE_INIT);
+  profileExtendedGauge.TPSTOP(QUDA_PROFILE_INIT);
   if(gauge){
     int R[4] = {2,2,2,2};
     // communicate 
-    profileExtendedGauge.Start(QUDA_PROFILE_COMMS);
+    profileExtendedGauge.TPSTART(QUDA_PROFILE_COMMS);
     cudaGaugeEx->exchangeExtendedGhost(R, true);
-    profileExtendedGauge.Stop(QUDA_PROFILE_COMMS);
+    profileExtendedGauge.TPSTOP(QUDA_PROFILE_COMMS);
     if (cpuGauge) delete cpuGauge;
     if (cudaGauge) delete cudaGauge;
   }
-  profileExtendedGauge.Stop(QUDA_PROFILE_TOTAL);
+  profileExtendedGauge.TPSTOP(QUDA_PROFILE_TOTAL);
 
   return cudaGaugeEx;
 }
@@ -3830,7 +3830,7 @@ void computeCloverTraceQuda(void *out,
     int dim[4])
 {
 
-  profileCloverTrace.Start(QUDA_PROFILE_TOTAL);
+  profileCloverTrace.TPSTART(QUDA_PROFILE_TOTAL);
 
 
   cudaGaugeField* cudaGauge = reinterpret_cast<cudaGaugeField*>(out);
@@ -3841,7 +3841,7 @@ void computeCloverTraceQuda(void *out,
   }else{
     errorQuda("cloverPrecise not set\n");
   }
-  profileCloverTrace.Stop(QUDA_PROFILE_TOTAL);
+  profileCloverTrace.TPSTOP(QUDA_PROFILE_TOTAL);
   return;
 }
 
@@ -3855,11 +3855,11 @@ void computeCloverDerivativeQuda(void* out,
     QudaGaugeParam* param,
     int conjugate)
 {
-  profileCloverDerivative.Start(QUDA_PROFILE_TOTAL);
+  profileCloverDerivative.TPSTART(QUDA_PROFILE_TOTAL);
 
   checkGaugeParam(param);
 
-  profileCloverDerivative.Start(QUDA_PROFILE_INIT);
+  profileCloverDerivative.TPSTART(QUDA_PROFILE_INIT);
 
   // create host fields
   GaugeFieldParam gParam(0, *param);
@@ -3871,24 +3871,24 @@ void computeCloverDerivativeQuda(void* out,
   //  gParam.gauge = out;
   //  cpuGaugeField cpuOut(gParam);
 
-  profileCloverDerivative.Stop(QUDA_PROFILE_INIT);
+  profileCloverDerivative.TPSTOP(QUDA_PROFILE_INIT);
 
   cudaGaugeField* cudaOut = reinterpret_cast<cudaGaugeField*>(out);
   cudaGaugeField* gPointer = reinterpret_cast<cudaGaugeField*>(gauge);
   cudaGaugeField* oPointer = reinterpret_cast<cudaGaugeField*>(oprod);
 
-  profileCloverDerivative.Start(QUDA_PROFILE_COMPUTE);
+  profileCloverDerivative.TPSTART(QUDA_PROFILE_COMPUTE);
   cloverDerivative(*cudaOut, *gPointer, *oPointer, mu, nu, coeff, parity, conjugate);
-  profileCloverDerivative.Stop(QUDA_PROFILE_COMPUTE);
+  profileCloverDerivative.TPSTOP(QUDA_PROFILE_COMPUTE);
 
 
-  profileCloverDerivative.Start(QUDA_PROFILE_D2H);
+  profileCloverDerivative.TPSTART(QUDA_PROFILE_D2H);
 
-  profileCloverDerivative.Stop(QUDA_PROFILE_D2H);
+  profileCloverDerivative.TPSTOP(QUDA_PROFILE_D2H);
   checkCudaError();
 
 
-  profileCloverDerivative.Stop(QUDA_PROFILE_TOTAL);
+  profileCloverDerivative.TPSTOP(QUDA_PROFILE_TOTAL);
 
   return;
 }
@@ -3991,8 +3991,8 @@ void computeAsqtadForceQuda(void* const milc_momentum,
 #ifdef GPU_HISQ_FORCE
   long long partialFlops;
   using namespace quda::fermion_force;
-  profileAsqtadForce.Start(QUDA_PROFILE_TOTAL);
-  profileAsqtadForce.Start(QUDA_PROFILE_INIT);
+  profileAsqtadForce.TPSTART(QUDA_PROFILE_TOTAL);
+  profileAsqtadForce.TPSTART(QUDA_PROFILE_INIT);
 
   cudaGaugeField *cudaGauge = NULL;
   cpuGaugeField *cpuGauge = NULL;
@@ -4062,24 +4062,24 @@ void computeAsqtadForceQuda(void* const milc_momentum,
   cudaInForce_ex  = new cudaGaugeField(param);
   cudaOutForce_ex = new cudaGaugeField(param);
 #endif
-  profileAsqtadForce.Stop(QUDA_PROFILE_INIT);
+  profileAsqtadForce.TPSTOP(QUDA_PROFILE_INIT);
 
 #ifdef MULTI_GPU
   int R[4] = {2, 2, 2, 2};
 #endif
 
-  profileAsqtadForce.Start(QUDA_PROFILE_H2D);
+  profileAsqtadForce.TPSTART(QUDA_PROFILE_H2D);
   cudaGauge->loadCPUField(*cpuGauge, QUDA_CPU_FIELD_LOCATION);
-  profileAsqtadForce.Stop(QUDA_PROFILE_H2D);
+  profileAsqtadForce.TPSTOP(QUDA_PROFILE_H2D);
 #ifdef MULTI_GPU
   cudaMemset((void**)(cudaInForce_ex->Gauge_p()), 0, cudaInForce_ex->Bytes());
   copyExtendedGauge(*cudaGauge_ex, *cudaGauge, QUDA_CUDA_FIELD_LOCATION);
   cudaGauge_ex->exchangeExtendedGhost(R,true);
 #endif
 
-  profileAsqtadForce.Start(QUDA_PROFILE_H2D);
+  profileAsqtadForce.TPSTART(QUDA_PROFILE_H2D);
   cudaInForce->loadCPUField(*cpuOneLinkInForce, QUDA_CPU_FIELD_LOCATION);
-  profileAsqtadForce.Stop(QUDA_PROFILE_H2D);
+  profileAsqtadForce.TPSTOP(QUDA_PROFILE_H2D);
 #ifdef MULTI_GPU
   cudaMemset((void**)(cudaInForce_ex->Gauge_p()), 0, cudaInForce_ex->Bytes());
   copyExtendedGauge(*cudaInForce_ex, *cudaInForce, QUDA_CUDA_FIELD_LOCATION);
@@ -4087,7 +4087,7 @@ void computeAsqtadForceQuda(void* const milc_momentum,
 #endif
 
   cudaMemset((void**)(cudaOutForce->Gauge_p()), 0, cudaOutForce->Bytes());
-  profileAsqtadForce.Start(QUDA_PROFILE_COMPUTE);
+  profileAsqtadForce.TPSTART(QUDA_PROFILE_COMPUTE);
 #ifdef MULTI_GPU
   cudaMemset((void**)(cudaOutForce_ex->Gauge_p()), 0, cudaOutForce_ex->Bytes());
   hisqStaplesForceCuda(act_path_coeff, *gParam, *cudaInForce_ex, *cudaGauge_ex, cudaOutForce_ex, &partialFlops);
@@ -4096,17 +4096,17 @@ void computeAsqtadForceQuda(void* const milc_momentum,
   hisqStaplesForceCuda(act_path_coeff, *gParam, *cudaInForce, *cudaGauge, cudaOutForce, &partialFlops);
   *flops += partialFlops;
 #endif
-  profileAsqtadForce.Stop(QUDA_PROFILE_COMPUTE);
+  profileAsqtadForce.TPSTOP(QUDA_PROFILE_COMPUTE);
 
-  profileAsqtadForce.Start(QUDA_PROFILE_H2D);
+  profileAsqtadForce.TPSTART(QUDA_PROFILE_H2D);
   cudaInForce->loadCPUField(*cpuNaikInForce, QUDA_CPU_FIELD_LOCATION); 
 #ifdef MULTI_GPU
   copyExtendedGauge(*cudaInForce_ex, *cudaInForce, QUDA_CUDA_FIELD_LOCATION);
   cudaInForce_ex->exchangeExtendedGhost(R,true);
 #endif
-  profileAsqtadForce.Stop(QUDA_PROFILE_H2D);
+  profileAsqtadForce.TPSTOP(QUDA_PROFILE_H2D);
 
-  profileAsqtadForce.Start(QUDA_PROFILE_COMPUTE);
+  profileAsqtadForce.TPSTART(QUDA_PROFILE_COMPUTE);
 #ifdef MULTI_GPU
   hisqLongLinkForceCuda(act_path_coeff[1], *gParam, *cudaInForce_ex, *cudaGauge_ex, cudaOutForce_ex, &partialFlops);
   *flops += partialFlops;
@@ -4118,13 +4118,13 @@ void computeAsqtadForceQuda(void* const milc_momentum,
   hisqCompleteForceCuda(*gParam, *cudaOutForce, *cudaGauge, cudaMom, &partialFlops);
   *flops += partialFlops;
 #endif
-  profileAsqtadForce.Stop(QUDA_PROFILE_COMPUTE);
+  profileAsqtadForce.TPSTOP(QUDA_PROFILE_COMPUTE);
 
-  profileAsqtadForce.Start(QUDA_PROFILE_D2H);
+  profileAsqtadForce.TPSTART(QUDA_PROFILE_D2H);
   cudaMom->saveCPUField(*cpuMom, QUDA_CPU_FIELD_LOCATION);
-  profileAsqtadForce.Stop(QUDA_PROFILE_D2H);
+  profileAsqtadForce.TPSTOP(QUDA_PROFILE_D2H);
 
-  profileAsqtadForce.Start(QUDA_PROFILE_FREE);
+  profileAsqtadForce.TPSTART(QUDA_PROFILE_FREE);
   delete cudaInForce;
   delete cudaOutForce;
   delete cudaGauge;
@@ -4140,9 +4140,9 @@ void computeAsqtadForceQuda(void* const milc_momentum,
   delete cpuNaikInForce;
   delete cpuMom;
 
-  profileAsqtadForce.Stop(QUDA_PROFILE_FREE);
+  profileAsqtadForce.TPSTOP(QUDA_PROFILE_FREE);
 
-  profileAsqtadForce.Stop(QUDA_PROFILE_TOTAL);
+  profileAsqtadForce.TPSTOP(QUDA_PROFILE_TOTAL);
   return;
 
 #else
@@ -4209,8 +4209,8 @@ computeHISQForceQuda(void* const milc_momentum,
   long long partialFlops;
 	
   using namespace quda::fermion_force;
-  profileHISQForce.Start(QUDA_PROFILE_TOTAL);
-  profileHISQForce.Start(QUDA_PROFILE_INIT); 
+  profileHISQForce.TPSTART(QUDA_PROFILE_TOTAL);
+  profileHISQForce.TPSTART(QUDA_PROFILE_INIT); 
 
   double act_path_coeff[6] = {0,1,level2_coeff[2],level2_coeff[3],level2_coeff[4],level2_coeff[5]};
   // You have to look at the MILC routine to understand the following
@@ -4301,92 +4301,92 @@ computeHISQForceQuda(void* const milc_momentum,
         svd_rel_err, 
         svd_abs_err);
   }
-  profileHISQForce.Stop(QUDA_PROFILE_INIT); 
+  profileHISQForce.TPSTOP(QUDA_PROFILE_INIT); 
 
 
-  profileHISQForce.Start(QUDA_PROFILE_H2D);
+  profileHISQForce.TPSTART(QUDA_PROFILE_H2D);
   cudaGauge->loadCPUField(cpuWLink, QUDA_CPU_FIELD_LOCATION);
-  profileHISQForce.Stop(QUDA_PROFILE_H2D);
+  profileHISQForce.TPSTOP(QUDA_PROFILE_H2D);
 #ifdef MULTI_GPU
   int R[4] = {2, 2, 2, 2};
-  profileHISQForce.Start(QUDA_PROFILE_COMMS);
+  profileHISQForce.TPSTART(QUDA_PROFILE_COMMS);
   copyExtendedGauge(*cudaGaugeEx, *cudaGauge, QUDA_CUDA_FIELD_LOCATION);
   cudaGaugeEx->exchangeExtendedGhost(R,true);
-  profileHISQForce.Stop(QUDA_PROFILE_COMMS);
+  profileHISQForce.TPSTOP(QUDA_PROFILE_COMMS);
 #endif
 
-  profileHISQForce.Start(QUDA_PROFILE_H2D);
+  profileHISQForce.TPSTART(QUDA_PROFILE_H2D);
   cudaInForce->loadCPUField(*cpuStapleForce, QUDA_CPU_FIELD_LOCATION);
-  profileHISQForce.Stop(QUDA_PROFILE_H2D);
+  profileHISQForce.TPSTOP(QUDA_PROFILE_H2D);
 #ifdef MULTI_GPU
-  profileHISQForce.Start(QUDA_PROFILE_COMMS);
+  profileHISQForce.TPSTART(QUDA_PROFILE_COMMS);
   copyExtendedGauge(*cudaInForceEx, *cudaInForce, QUDA_CUDA_FIELD_LOCATION);
   cudaInForceEx->exchangeExtendedGhost(R,true);
-  profileHISQForce.Stop(QUDA_PROFILE_COMMS);
-  profileHISQForce.Start(QUDA_PROFILE_H2D);
+  profileHISQForce.TPSTOP(QUDA_PROFILE_COMMS);
+  profileHISQForce.TPSTART(QUDA_PROFILE_H2D);
   cudaInForce->loadCPUField(*cpuOneLinkForce, QUDA_CPU_FIELD_LOCATION);
-  profileHISQForce.Stop(QUDA_PROFILE_H2D);
-  profileHISQForce.Start(QUDA_PROFILE_COMMS);
+  profileHISQForce.TPSTOP(QUDA_PROFILE_H2D);
+  profileHISQForce.TPSTART(QUDA_PROFILE_COMMS);
   copyExtendedGauge(*cudaOutForceEx, *cudaInForce, QUDA_CUDA_FIELD_LOCATION);
   cudaOutForceEx->exchangeExtendedGhost(R,true);
-  profileHISQForce.Stop(QUDA_PROFILE_COMMS);
+  profileHISQForce.TPSTOP(QUDA_PROFILE_COMMS);
 #else 
-  profileHISQForce.Start(QUDA_PROFILE_H2D);
+  profileHISQForce.TPSTART(QUDA_PROFILE_H2D);
   cudaOutForce->loadCPUField(*cpuOneLinkForce, QUDA_CPU_FIELD_LOCATION);
-  profileHISQForce.Stop(QUDA_PROFILE_H2D);
+  profileHISQForce.TPSTOP(QUDA_PROFILE_H2D);
 #endif
 
-  profileHISQForce.Start(QUDA_PROFILE_COMPUTE);
+  profileHISQForce.TPSTART(QUDA_PROFILE_COMPUTE);
   hisqStaplesForceCuda(act_path_coeff, *gParam, *inForcePtr, *gaugePtr, outForcePtr, &partialFlops);
   *flops += partialFlops;
-  profileHISQForce.Stop(QUDA_PROFILE_COMPUTE);
+  profileHISQForce.TPSTOP(QUDA_PROFILE_COMPUTE);
 
   // Load naik outer product
-  profileHISQForce.Start(QUDA_PROFILE_H2D);
+  profileHISQForce.TPSTART(QUDA_PROFILE_H2D);
   cudaInForce->loadCPUField(*cpuNaikForce, QUDA_CPU_FIELD_LOCATION);
-  profileHISQForce.Stop(QUDA_PROFILE_H2D);
+  profileHISQForce.TPSTOP(QUDA_PROFILE_H2D);
 #ifdef MULTI_GPU
-  profileHISQForce.Start(QUDA_PROFILE_COMMS);
+  profileHISQForce.TPSTART(QUDA_PROFILE_COMMS);
   copyExtendedGauge(*cudaInForceEx, *cudaInForce, QUDA_CUDA_FIELD_LOCATION);
   cudaInForceEx->exchangeExtendedGhost(R,true);
-  profileHISQForce.Stop(QUDA_PROFILE_COMMS);
+  profileHISQForce.TPSTOP(QUDA_PROFILE_COMMS);
 #endif
 
   // Compute Naik three-link term
-  profileHISQForce.Start(QUDA_PROFILE_COMPUTE);
+  profileHISQForce.TPSTART(QUDA_PROFILE_COMPUTE);
   hisqLongLinkForceCuda(act_path_coeff[1], *gParam, *inForcePtr, *gaugePtr, outForcePtr, &partialFlops);
   *flops += partialFlops;
-  profileHISQForce.Stop(QUDA_PROFILE_COMPUTE);
+  profileHISQForce.TPSTOP(QUDA_PROFILE_COMPUTE);
 #ifdef MULTI_GPU
-  profileHISQForce.Start(QUDA_PROFILE_COMMS);
+  profileHISQForce.TPSTART(QUDA_PROFILE_COMMS);
   cudaOutForceEx->exchangeExtendedGhost(R,true);
-  profileHISQForce.Stop(QUDA_PROFILE_COMMS);
+  profileHISQForce.TPSTOP(QUDA_PROFILE_COMMS);
 #endif
   // load v-link
-  profileHISQForce.Start(QUDA_PROFILE_H2D);
+  profileHISQForce.TPSTART(QUDA_PROFILE_H2D);
   cudaGauge->loadCPUField(cpuVLink, QUDA_CPU_FIELD_LOCATION);
-  profileHISQForce.Stop(QUDA_PROFILE_H2D);
+  profileHISQForce.TPSTOP(QUDA_PROFILE_H2D);
 #ifdef MULTI_GPU
-  profileHISQForce.Start(QUDA_PROFILE_COMMS);
+  profileHISQForce.TPSTART(QUDA_PROFILE_COMMS);
   copyExtendedGauge(*cudaGaugeEx, *cudaGauge, QUDA_CUDA_FIELD_LOCATION);
   cudaGaugeEx->exchangeExtendedGhost(R,true);
-  profileHISQForce.Stop(QUDA_PROFILE_COMMS);
+  profileHISQForce.TPSTOP(QUDA_PROFILE_COMMS);
 #endif
   // Done with cudaInForce. It becomes the output force. Oops!
-  profileHISQForce.Start(QUDA_PROFILE_INIT);
+  profileHISQForce.TPSTART(QUDA_PROFILE_INIT);
   int numFailures = 0;
   int* numFailuresDev = (int*)device_malloc(sizeof(int));
   cudaMemset(numFailuresDev, 0, sizeof(int));
-  profileHISQForce.Stop(QUDA_PROFILE_INIT);
+  profileHISQForce.TPSTOP(QUDA_PROFILE_INIT);
 
 
-  profileHISQForce.Start(QUDA_PROFILE_COMPUTE);
+  profileHISQForce.TPSTART(QUDA_PROFILE_COMPUTE);
   unitarizeForceCuda(*outForcePtr, *gaugePtr, inForcePtr, numFailuresDev, &partialFlops);
   *flops += partialFlops;
-  profileHISQForce.Stop(QUDA_PROFILE_COMPUTE);
-  profileHISQForce.Start(QUDA_PROFILE_D2H);
+  profileHISQForce.TPSTOP(QUDA_PROFILE_COMPUTE);
+  profileHISQForce.TPSTART(QUDA_PROFILE_D2H);
   cudaMemcpy(&numFailures, numFailuresDev, sizeof(int), cudaMemcpyDeviceToHost);
-  profileHISQForce.Stop(QUDA_PROFILE_D2H);
+  profileHISQForce.TPSTOP(QUDA_PROFILE_D2H);
   device_free(numFailuresDev); 
 
   if(numFailures>0){
@@ -4395,31 +4395,31 @@ computeHISQForceQuda(void* const milc_momentum,
   } 
   cudaMemset((void**)(outForcePtr->Gauge_p()), 0, outForcePtr->Bytes());
   // read in u-link
-  profileHISQForce.Start(QUDA_PROFILE_COMPUTE);
+  profileHISQForce.TPSTART(QUDA_PROFILE_COMPUTE);
   cudaGauge->loadCPUField(cpuULink, QUDA_CPU_FIELD_LOCATION);
-  profileHISQForce.Stop(QUDA_PROFILE_COMPUTE);
+  profileHISQForce.TPSTOP(QUDA_PROFILE_COMPUTE);
 #ifdef MULTI_GPU
-  profileHISQForce.Start(QUDA_PROFILE_COMMS);
+  profileHISQForce.TPSTART(QUDA_PROFILE_COMMS);
   copyExtendedGauge(*cudaGaugeEx, *cudaGauge, QUDA_CUDA_FIELD_LOCATION);
   cudaGaugeEx->exchangeExtendedGhost(R,true);
-  profileHISQForce.Stop(QUDA_PROFILE_COMMS);
+  profileHISQForce.TPSTOP(QUDA_PROFILE_COMMS);
 #endif
   // Compute Fat7-staple term 
-  profileHISQForce.Start(QUDA_PROFILE_COMPUTE);
+  profileHISQForce.TPSTART(QUDA_PROFILE_COMPUTE);
   hisqStaplesForceCuda(fat7_coeff, *gParam, *inForcePtr, *gaugePtr, outForcePtr, &partialFlops);
   *flops += partialFlops;
   hisqCompleteForceCuda(*gParam, *outForcePtr, *gaugePtr, cudaMom, &partialFlops);
   *flops += partialFlops;
-  profileHISQForce.Stop(QUDA_PROFILE_COMPUTE);
+  profileHISQForce.TPSTOP(QUDA_PROFILE_COMPUTE);
 
-  profileHISQForce.Start(QUDA_PROFILE_D2H);
+  profileHISQForce.TPSTART(QUDA_PROFILE_D2H);
   // Close the paths, make anti-hermitian, and store in compressed format
   cudaMom->saveCPUField(*cpuMom, QUDA_CPU_FIELD_LOCATION);
-  profileHISQForce.Stop(QUDA_PROFILE_D2H);
+  profileHISQForce.TPSTOP(QUDA_PROFILE_D2H);
 
 
 
-  profileHISQForce.Start(QUDA_PROFILE_FREE);
+  profileHISQForce.TPSTART(QUDA_PROFILE_FREE);
 
   delete cpuStapleForce;
   delete cpuOneLinkForce;
@@ -4437,8 +4437,8 @@ computeHISQForceQuda(void* const milc_momentum,
 #else
   delete cudaOutForce;
 #endif
-  profileHISQForce.Stop(QUDA_PROFILE_FREE);
-  profileHISQForce.Stop(QUDA_PROFILE_TOTAL);
+  profileHISQForce.TPSTOP(QUDA_PROFILE_FREE);
+  profileHISQForce.TPSTOP(QUDA_PROFILE_TOTAL);
   return;
 #else 
   errorQuda("HISQ force has not been built");
@@ -4457,11 +4457,11 @@ void computeStaggeredOprodQuda(void** oprod,
 #error "Staggerd oprod requires BUILD_QDP_INTERFACE";
 #endif
   using namespace quda;
-  profileStaggeredOprod.Start(QUDA_PROFILE_TOTAL);
+  profileStaggeredOprod.TPSTART(QUDA_PROFILE_TOTAL);
 
   checkGaugeParam(param);
 
-  profileStaggeredOprod.Start(QUDA_PROFILE_INIT);
+  profileStaggeredOprod.TPSTART(QUDA_PROFILE_INIT);
   GaugeFieldParam oParam(0, *param);
 
   oParam.nDim = 4;
@@ -4485,17 +4485,17 @@ void computeStaggeredOprodQuda(void** oprod,
   oParam.order = QUDA_FLOAT2_GAUGE_ORDER;
   cudaGaugeField cudaOprod0(oParam);
   cudaGaugeField cudaOprod1(oParam);
-  profileStaggeredOprod.Stop(QUDA_PROFILE_INIT); 
+  profileStaggeredOprod.TPSTOP(QUDA_PROFILE_INIT); 
 
   //initLatticeConstants(cudaOprod0, profileStaggeredOprod);
 
-  profileStaggeredOprod.Start(QUDA_PROFILE_H2D);
+  profileStaggeredOprod.TPSTART(QUDA_PROFILE_H2D);
   cudaOprod0.loadCPUField(cpuOprod0,QUDA_CPU_FIELD_LOCATION);
   cudaOprod1.loadCPUField(cpuOprod1,QUDA_CPU_FIELD_LOCATION);
-  profileStaggeredOprod.Stop(QUDA_PROFILE_H2D);
+  profileStaggeredOprod.TPSTOP(QUDA_PROFILE_H2D);
 
 
-  profileStaggeredOprod.Start(QUDA_PROFILE_INIT);
+  profileStaggeredOprod.TPSTART(QUDA_PROFILE_INIT);
 
 
 
@@ -4525,43 +4525,43 @@ void computeStaggeredOprodQuda(void** oprod,
   const int Ninternal = 6;
   FaceBuffer faceBuffer1(cudaOprod0.X(), 4, Ninternal, 3, cudaOprod0.Precision(), Ls);
   FaceBuffer faceBuffer2(cudaOprod0.X(), 4, Ninternal, 3, cudaOprod0.Precision(), Ls);
-  profileStaggeredOprod.Stop(QUDA_PROFILE_INIT);
+  profileStaggeredOprod.TPSTOP(QUDA_PROFILE_INIT);
 
   // loop over different quark fields
   for(int i=0; i<num_terms; ++i){
 
     // Wrap the even-parity MILC quark field 
-    profileStaggeredOprod.Start(QUDA_PROFILE_INIT);
+    profileStaggeredOprod.TPSTART(QUDA_PROFILE_INIT);
     qParam.v = fermion[i];
     cpuColorSpinorField cpuQuarkEven(qParam); // create host quark field
     qParam.v = (char*)fermion[i] + cpuQuarkEven.RealLength()*cpuQuarkEven.Precision();
     cpuColorSpinorField cpuQuarkOdd(qParam); // create host field
-    profileStaggeredOprod.Stop(QUDA_PROFILE_INIT);
+    profileStaggeredOprod.TPSTOP(QUDA_PROFILE_INIT);
 
-    profileStaggeredOprod.Start(QUDA_PROFILE_H2D);
+    profileStaggeredOprod.TPSTART(QUDA_PROFILE_H2D);
     cudaQuarkEven = cpuQuarkEven;
     cudaQuarkOdd = cpuQuarkOdd;
-    profileStaggeredOprod.Stop(QUDA_PROFILE_H2D); 
+    profileStaggeredOprod.TPSTOP(QUDA_PROFILE_H2D); 
 
 
-    profileStaggeredOprod.Start(QUDA_PROFILE_COMPUTE);
+    profileStaggeredOprod.TPSTART(QUDA_PROFILE_COMPUTE);
     // Operate on even-parity sites
     computeStaggeredOprod(cudaOprod0, cudaOprod1, cudaQuarkEven, cudaQuarkOdd, faceBuffer1, 0, coeff[i]);
 
     // Operate on odd-parity sites
     computeStaggeredOprod(cudaOprod0, cudaOprod1, cudaQuarkEven, cudaQuarkOdd, faceBuffer2, 1, coeff[i]);
-    profileStaggeredOprod.Stop(QUDA_PROFILE_COMPUTE);
+    profileStaggeredOprod.TPSTOP(QUDA_PROFILE_COMPUTE);
   }
 
 
   // copy the outer product field back to the host
-  profileStaggeredOprod.Start(QUDA_PROFILE_D2H);
+  profileStaggeredOprod.TPSTART(QUDA_PROFILE_D2H);
   cudaOprod0.saveCPUField(cpuOprod0,QUDA_CPU_FIELD_LOCATION);
   cudaOprod1.saveCPUField(cpuOprod1,QUDA_CPU_FIELD_LOCATION);
-  profileStaggeredOprod.Stop(QUDA_PROFILE_D2H); 
+  profileStaggeredOprod.TPSTOP(QUDA_PROFILE_D2H); 
 
 
-  profileStaggeredOprod.Stop(QUDA_PROFILE_TOTAL);
+  profileStaggeredOprod.TPSTOP(QUDA_PROFILE_TOTAL);
 
   checkCudaError();
   return;
@@ -4579,11 +4579,11 @@ void computeStaggeredOprodQuda(void** oprod,
    QudaGaugeParam* param)
    {
    using namespace quda;
-   profileStaggeredOprod.Start(QUDA_PROFILE_TOTAL);
+   profileStaggeredOprod.TPSTART(QUDA_PROFILE_TOTAL);
 
    checkGaugeParam(param);
 
-   profileStaggeredOprod.Start(QUDA_PROFILE_INIT);
+   profileStaggeredOprod.TPSTART(QUDA_PROFILE_INIT);
    GaugeFieldParam oParam(0, *param);
 
    oParam.nDim = 4;
@@ -4607,13 +4607,13 @@ cudaGaugeField cudaOprod0(oParam);
 cudaGaugeField cudaOprod1(oParam);
 initLatticeConstants(cudaOprod0, profileStaggeredOprod);
 
-profileStaggeredOprod.Stop(QUDA_PROFILE_INIT); 
+profileStaggeredOprod.TPSTOP(QUDA_PROFILE_INIT); 
 
 
-profileStaggeredOprod.Start(QUDA_PROFILE_H2D);
+profileStaggeredOprod.TPSTART(QUDA_PROFILE_H2D);
 cudaOprod0.loadCPUField(cpuOprod0,QUDA_CPU_FIELD_LOCATION);
 cudaOprod1.loadCPUField(cpuOprod1,QUDA_CPU_FIELD_LOCATION);
-profileStaggeredOprod.Stop(QUDA_PROFILE_H2D);
+profileStaggeredOprod.TPSTOP(QUDA_PROFILE_H2D);
 
 
 
@@ -4661,10 +4661,10 @@ for(int i=0; i<num_terms; ++i){
 
 
 // copy the outer product field back to the host
-profileStaggeredOprod.Start(QUDA_PROFILE_D2H);
+profileStaggeredOprod.TPSTART(QUDA_PROFILE_D2H);
 cudaOprod0.saveCPUField(cpuOprod0,QUDA_CPU_FIELD_LOCATION);
 cudaOprod1.saveCPUField(cpuOprod1,QUDA_CPU_FIELD_LOCATION);
-profileStaggeredOprod.Stop(QUDA_PROFILE_D2H); 
+profileStaggeredOprod.TPSTOP(QUDA_PROFILE_D2H); 
 
 
 for(int i=0; i<num_terms; ++i){
@@ -4673,7 +4673,7 @@ for(int i=0; i<num_terms; ++i){
 delete[] dQuark;
 delete[] new_coeff;
 
-profileStaggeredOprod.Stop(QUDA_PROFILE_TOTAL);
+profileStaggeredOprod.TPSTOP(QUDA_PROFILE_TOTAL);
 
 checkCudaError();
 return;
@@ -4688,13 +4688,13 @@ void computeCloverForceQuda(void *h_mom, double dt, void **h_x, void **h_p,
 
 
   using namespace quda;
-  profileCloverForce.Start(QUDA_PROFILE_TOTAL);
+  profileCloverForce.TPSTART(QUDA_PROFILE_TOTAL);
 
   checkGaugeParam(gauge_param);
 
   if (!gaugePrecise) errorQuda("No resident gauge field");
 
-  profileCloverForce.Start(QUDA_PROFILE_INIT);
+  profileCloverForce.TPSTART(QUDA_PROFILE_INIT);
   GaugeFieldParam fParam(0, *gauge_param);
   // create the host momentum field
   fParam.create = QUDA_REFERENCE_FIELD_CREATE;
@@ -4717,9 +4717,9 @@ void computeCloverForceQuda(void *h_mom, double dt, void **h_x, void **h_p,
   fParam.reconstruct = QUDA_RECONSTRUCT_NO;
   cudaGaugeField cudaForce(fParam);
 
-  profileCloverForce.Stop(QUDA_PROFILE_INIT); 
+  profileCloverForce.TPSTOP(QUDA_PROFILE_INIT); 
 
-  profileCloverForce.Start(QUDA_PROFILE_INIT);
+  profileCloverForce.TPSTART(QUDA_PROFILE_INIT);
 
   ColorSpinorParam qParam;
   qParam.nColor = 3;
@@ -4748,7 +4748,7 @@ void computeCloverForceQuda(void *h_mom, double dt, void **h_x, void **h_p,
   qParam.fieldOrder = QUDA_SPACE_SPIN_COLOR_FIELD_ORDER;
   qParam.gammaBasis = QUDA_DEGRAND_ROSSI_GAMMA_BASIS; // need expose this to interface
 
-  profileCloverForce.Stop(QUDA_PROFILE_INIT);
+  profileCloverForce.TPSTOP(QUDA_PROFILE_INIT);
 
   bool pc_solve = (inv_param->solve_type == QUDA_DIRECT_PC_SOLVE) || 
     (inv_param->solve_type == QUDA_NORMOP_PC_SOLVE);
@@ -4773,21 +4773,21 @@ void computeCloverForceQuda(void *h_mom, double dt, void **h_x, void **h_p,
 
     if (!inv_param->use_resident_solution) {
       // Wrap the even-parity MILC quark field 
-      profileCloverForce.Start(QUDA_PROFILE_INIT);
+      profileCloverForce.TPSTART(QUDA_PROFILE_INIT);
       qParam.v = h_x[i];
       cpuColorSpinorField cpuQuarkX(qParam); // create host quark field
-      profileCloverForce.Stop(QUDA_PROFILE_INIT);
+      profileCloverForce.TPSTOP(QUDA_PROFILE_INIT);
 
-      profileCloverForce.Start(QUDA_PROFILE_H2D);
+      profileCloverForce.TPSTART(QUDA_PROFILE_H2D);
       x.Even() = cpuQuarkX;
-      profileCloverForce.Stop(QUDA_PROFILE_H2D);
+      profileCloverForce.TPSTOP(QUDA_PROFILE_H2D);
 
       gamma5Cuda(&(x.Even()), &(x.Even()));
     } else {
       x.Even() = *(solutionResident[i]);
       delete solutionResident[i];
     }
-    profileCloverForce.Start(QUDA_PROFILE_COMPUTE);
+    profileCloverForce.TPSTART(QUDA_PROFILE_COMPUTE);
     dirac->Dslash(x.Odd(), x.Even(), QUDA_ODD_PARITY);
     dirac->M(p.Even(), x.Even());
     dirac->Dagger(QUDA_DAG_YES);
@@ -4799,13 +4799,13 @@ void computeCloverForceQuda(void *h_mom, double dt, void **h_x, void **h_p,
     gamma5Cuda(&(p.Even()), &(p.Even()));
     gamma5Cuda(&(p.Odd()), &(p.Odd()));
 
-    profileCloverForce.Stop(QUDA_PROFILE_COMPUTE);
+    profileCloverForce.TPSTOP(QUDA_PROFILE_COMPUTE);
     
     checkCudaError();
 
-    profileCloverForce.Start(QUDA_PROFILE_COMPUTE);
+    profileCloverForce.TPSTART(QUDA_PROFILE_COMPUTE);
     computeCloverForce(cudaForce, *gaugePrecise, x, p, 2.0*dt*coeff[i]*kappa2);
-    profileCloverForce.Stop(QUDA_PROFILE_COMPUTE);
+    profileCloverForce.TPSTOP(QUDA_PROFILE_COMPUTE);
   }
 
   if (inv_param->use_resident_solution) solutionResident.clear();
@@ -4826,7 +4826,7 @@ void computeCloverForceQuda(void *h_mom, double dt, void **h_x, void **h_p,
   cudaGaugeField oprodEx(fParam);
   cudaGaugeField &traceEx = oprodEx;
 
-  profileCloverForce.Start(QUDA_PROFILE_COMPUTE);
+  profileCloverForce.TPSTART(QUDA_PROFILE_COMPUTE);
 
   for(int mu=0; mu<4; mu++) {
     for(int nu=0;nu<4;nu++) 
@@ -4835,13 +4835,13 @@ void computeCloverForceQuda(void *h_mom, double dt, void **h_x, void **h_p,
 
 	copyExtendedGauge(traceEx, trace, QUDA_CUDA_FIELD_LOCATION); // FIXME this is unnecessary if we write directly to traceEx
 
-	profileCloverForce.Stop(QUDA_PROFILE_COMPUTE);
-	profileCloverForce.Start(QUDA_PROFILE_COMMS);
+	profileCloverForce.TPSTOP(QUDA_PROFILE_COMPUTE);
+	profileCloverForce.TPSTART(QUDA_PROFILE_COMMS);
 
 	traceEx.exchangeExtendedGhost(R,true);
 
-	profileCloverForce.Stop(QUDA_PROFILE_COMMS);
-	profileCloverForce.Start(QUDA_PROFILE_COMPUTE);
+	profileCloverForce.TPSTOP(QUDA_PROFILE_COMMS);
+	profileCloverForce.TPSTART(QUDA_PROFILE_COMPUTE);
 
 	cloverDerivative(cudaForce, gaugeEx, traceEx, mu, nu, 2.0*ck*multiplicity*dt, QUDA_ODD_PARITY, 0);
       }
@@ -4856,13 +4856,13 @@ void computeCloverForceQuda(void *h_mom, double dt, void **h_x, void **h_p,
 
 	copyExtendedGauge(oprodEx, oprod, QUDA_CUDA_FIELD_LOCATION); // FIXME this is unnecessary if we write directly to oprod
 
-	profileCloverForce.Stop(QUDA_PROFILE_COMPUTE);
-	profileCloverForce.Start(QUDA_PROFILE_COMMS);
+	profileCloverForce.TPSTOP(QUDA_PROFILE_COMPUTE);
+	profileCloverForce.TPSTART(QUDA_PROFILE_COMMS);
 
 	oprodEx.exchangeExtendedGhost(R,true); 
 
-	profileCloverForce.Stop(QUDA_PROFILE_COMMS);
-	profileCloverForce.Start(QUDA_PROFILE_COMPUTE);
+	profileCloverForce.TPSTOP(QUDA_PROFILE_COMMS);
+	profileCloverForce.TPSTART(QUDA_PROFILE_COMPUTE);
 
 	cloverDerivative(cudaForce, gaugeEx, oprodEx, mu, nu, -kappa2*ck, QUDA_ODD_PARITY, 1);
 	cloverDerivative(cudaForce, gaugeEx, oprodEx, mu, nu, ck, QUDA_EVEN_PARITY, 1);
@@ -4871,14 +4871,14 @@ void computeCloverForceQuda(void *h_mom, double dt, void **h_x, void **h_p,
   } // end loop over mu
 
   updateMomentum(cudaMom, cudaForce);
-  profileCloverForce.Stop(QUDA_PROFILE_COMPUTE);
+  profileCloverForce.TPSTOP(QUDA_PROFILE_COMPUTE);
 
   // copy the outer product field back to the host
-  profileCloverForce.Start(QUDA_PROFILE_D2H);
+  profileCloverForce.TPSTART(QUDA_PROFILE_D2H);
   cudaMom.saveCPUField(cpuMom,QUDA_CPU_FIELD_LOCATION);
-  profileCloverForce.Stop(QUDA_PROFILE_D2H); 
+  profileCloverForce.TPSTOP(QUDA_PROFILE_D2H); 
 
-  profileCloverForce.Stop(QUDA_PROFILE_TOTAL);
+  profileCloverForce.TPSTOP(QUDA_PROFILE_TOTAL);
 
   for (int i=0; i<nvector; i++) {
     delete cudaQuarkX[i];
@@ -4900,11 +4900,11 @@ void updateGaugeFieldQuda(void* gauge,
     int exact,
     QudaGaugeParam* param)
 {
-  profileGaugeUpdate.Start(QUDA_PROFILE_TOTAL);
+  profileGaugeUpdate.TPSTART(QUDA_PROFILE_TOTAL);
 
   checkGaugeParam(param);
 
-  profileGaugeUpdate.Start(QUDA_PROFILE_INIT);  
+  profileGaugeUpdate.TPSTART(QUDA_PROFILE_INIT);  
   GaugeFieldParam gParam(0, *param);
 
   // create the host fields
@@ -4942,9 +4942,9 @@ void updateGaugeFieldQuda(void* gauge,
   cudaGaugeField *cudaInGauge = !param->use_resident_gauge ? new cudaGaugeField(gParam) : NULL;
   cudaGaugeField *cudaOutGauge = new cudaGaugeField(gParam);
 
-  profileGaugeUpdate.Stop(QUDA_PROFILE_INIT);  
+  profileGaugeUpdate.TPSTOP(QUDA_PROFILE_INIT);  
 
-  profileGaugeUpdate.Start(QUDA_PROFILE_H2D);
+  profileGaugeUpdate.TPSTART(QUDA_PROFILE_H2D);
 
   /*printfQuda("UpdateGaugeFieldQuda use_resident_gauge = %d, make_resident_gauge = %d\n", 
     param->use_resident_gauge, param->make_resident_gauge);
@@ -4967,20 +4967,20 @@ void updateGaugeFieldQuda(void* gauge,
     momResident = NULL;
   }
 
-  profileGaugeUpdate.Stop(QUDA_PROFILE_H2D);
+  profileGaugeUpdate.TPSTOP(QUDA_PROFILE_H2D);
   
   // perform the update
-  profileGaugeUpdate.Start(QUDA_PROFILE_COMPUTE);
+  profileGaugeUpdate.TPSTART(QUDA_PROFILE_COMPUTE);
   updateGaugeField(*cudaOutGauge, dt, *cudaInGauge, *cudaMom, 
       (bool)conj_mom, (bool)exact);
-  profileGaugeUpdate.Stop(QUDA_PROFILE_COMPUTE);
+  profileGaugeUpdate.TPSTOP(QUDA_PROFILE_COMPUTE);
 
   // copy the gauge field back to the host
-  profileGaugeUpdate.Start(QUDA_PROFILE_D2H);
+  profileGaugeUpdate.TPSTART(QUDA_PROFILE_D2H);
   cudaOutGauge->saveCPUField(*cpuGauge, QUDA_CPU_FIELD_LOCATION);
-  profileGaugeUpdate.Stop(QUDA_PROFILE_D2H);
+  profileGaugeUpdate.TPSTOP(QUDA_PROFILE_D2H);
 
-  profileGaugeUpdate.Stop(QUDA_PROFILE_TOTAL);
+  profileGaugeUpdate.TPSTOP(QUDA_PROFILE_TOTAL);
 
   if (param->make_resident_gauge) {
     if (gaugePrecise != NULL) delete gaugePrecise;
@@ -5143,9 +5143,9 @@ void plaq_quda_(double plaq[3]) {
 
 void plaqQuda (double plq[3])
 {
-  profilePlaq.Start(QUDA_PROFILE_TOTAL);
+  profilePlaq.TPSTART(QUDA_PROFILE_TOTAL);
 
-  profilePlaq.Start(QUDA_PROFILE_INIT);
+  profilePlaq.TPSTART(QUDA_PROFILE_INIT);
   if (!gaugePrecise) 
     errorQuda("Cannot compute plaquette as there is no resident gauge field");
 
@@ -5171,33 +5171,33 @@ void plaqQuda (double plq[3])
     
     copyExtendedGauge(*data, *gaugePrecise, QUDA_CUDA_FIELD_LOCATION);
     int R[4] = {2,2,2,2}; // radius of the extended region in each dimension / direction
-    profilePlaq.Stop(QUDA_PROFILE_INIT);  
+    profilePlaq.TPSTOP(QUDA_PROFILE_INIT);  
 
-    profilePlaq.Start(QUDA_PROFILE_COMMS);
+    profilePlaq.TPSTART(QUDA_PROFILE_COMMS);
     data->exchangeExtendedGhost(R,true);
-    profilePlaq.Stop(QUDA_PROFILE_COMMS);
+    profilePlaq.TPSTOP(QUDA_PROFILE_COMMS);
 
-    profilePlaq.Start(QUDA_PROFILE_INIT);  
+    profilePlaq.TPSTART(QUDA_PROFILE_INIT);  
     extendedGaugeResident = data;
   }
 #endif
 
-  profilePlaq.Stop(QUDA_PROFILE_INIT);  
+  profilePlaq.TPSTOP(QUDA_PROFILE_INIT);  
 
-  profilePlaq.Start(QUDA_PROFILE_COMPUTE);  
+  profilePlaq.TPSTART(QUDA_PROFILE_COMPUTE);  
   double3 plaq = quda::plaquette(*data, QUDA_CUDA_FIELD_LOCATION);
   plq[0] = plaq.x;
   plq[1] = plaq.y;
   plq[2] = plaq.z;
-  profilePlaq.Stop(QUDA_PROFILE_COMPUTE);  
+  profilePlaq.TPSTOP(QUDA_PROFILE_COMPUTE);  
   
-  profilePlaq.Stop(QUDA_PROFILE_TOTAL);
+  profilePlaq.TPSTOP(QUDA_PROFILE_TOTAL);
   return;
 }
 
 void performAPEnStep(unsigned int nSteps, double alpha)
 {
-  profileAPE.Start(QUDA_PROFILE_TOTAL);
+  profileAPE.TPSTART(QUDA_PROFILE_TOTAL);
 
   if (gaugePrecise == NULL) {
     errorQuda("Gauge field must be loaded");
@@ -5287,7 +5287,7 @@ void performAPEnStep(unsigned int nSteps, double alpha)
     printfQuda("Plaquette after %d APE steps: %le\n", nSteps, plq.x);
   }
 
-  profileAPE.Stop(QUDA_PROFILE_TOTAL);
+  profileAPE.TPSTOP(QUDA_PROFILE_TOTAL);
 }
 
 
@@ -5296,11 +5296,11 @@ int computeGaugeFixingOVRQuda(void* gauge, const unsigned int gauge_dir,  const 
   const unsigned int  stopWtheta, QudaGaugeParam* param , double* timeinfo)
 {
 
-  GaugeFixOVRQuda.Start(QUDA_PROFILE_TOTAL);
+  GaugeFixOVRQuda.TPSTART(QUDA_PROFILE_TOTAL);
 
   checkGaugeParam(param);
 
-  GaugeFixOVRQuda.Start(QUDA_PROFILE_INIT);  
+  GaugeFixOVRQuda.TPSTART(QUDA_PROFILE_INIT);  
   GaugeFieldParam gParam(gauge, *param);
   cpuGaugeField *cpuGauge = new cpuGaugeField(gParam);
 
@@ -5313,9 +5313,9 @@ int computeGaugeFixingOVRQuda(void* gauge, const unsigned int gauge_dir,  const 
     QUDA_FLOAT2_GAUGE_ORDER : QUDA_FLOAT4_GAUGE_ORDER;
   cudaGaugeField *cudaInGauge = new cudaGaugeField(gParam);
 
-  GaugeFixOVRQuda.Stop(QUDA_PROFILE_INIT);  
+  GaugeFixOVRQuda.TPSTOP(QUDA_PROFILE_INIT);  
 
-  GaugeFixOVRQuda.Start(QUDA_PROFILE_H2D);
+  GaugeFixOVRQuda.TPSTART(QUDA_PROFILE_H2D);
 
 
   ///if (!param->use_resident_gauge) {   // load fields onto the device
@@ -5326,20 +5326,20 @@ int computeGaugeFixingOVRQuda(void* gauge, const unsigned int gauge_dir,  const 
     gaugePrecise = NULL;
   } */
 
-  GaugeFixOVRQuda.Stop(QUDA_PROFILE_H2D);
+  GaugeFixOVRQuda.TPSTOP(QUDA_PROFILE_H2D);
   
   checkCudaError();
 
 #ifdef MULTI_GPU
   if(comm_size() == 1){
     // perform the update
-    GaugeFixOVRQuda.Start(QUDA_PROFILE_COMPUTE);
+    GaugeFixOVRQuda.TPSTART(QUDA_PROFILE_COMPUTE);
     gaugefixingOVR(*cudaInGauge, gauge_dir, Nsteps, verbose_interval, relax_boost, tolerance, \
       reunit_interval, stopWtheta);
-    GaugeFixOVRQuda.Stop(QUDA_PROFILE_COMPUTE);
+    GaugeFixOVRQuda.TPSTOP(QUDA_PROFILE_COMPUTE);
     checkCudaError();
     // copy the gauge field back to the host
-    GaugeFixOVRQuda.Start(QUDA_PROFILE_D2H);
+    GaugeFixOVRQuda.TPSTART(QUDA_PROFILE_D2H);
   }
   else{
 
@@ -5361,32 +5361,32 @@ int computeGaugeFixingOVRQuda(void* gauge, const unsigned int gauge_dir,  const 
     copyExtendedGauge(*cudaInGaugeEx, *cudaInGauge, QUDA_CUDA_FIELD_LOCATION);
     cudaInGaugeEx->exchangeExtendedGhost(R,false);
     // perform the update
-    GaugeFixOVRQuda.Start(QUDA_PROFILE_COMPUTE);
+    GaugeFixOVRQuda.TPSTART(QUDA_PROFILE_COMPUTE);
     gaugefixingOVR(*cudaInGaugeEx, gauge_dir, Nsteps, verbose_interval, relax_boost, tolerance, \
       reunit_interval, stopWtheta);
-    GaugeFixOVRQuda.Stop(QUDA_PROFILE_COMPUTE);
+    GaugeFixOVRQuda.TPSTOP(QUDA_PROFILE_COMPUTE);
 
     checkCudaError();
     // copy the gauge field back to the host
-    GaugeFixOVRQuda.Start(QUDA_PROFILE_D2H);
+    GaugeFixOVRQuda.TPSTART(QUDA_PROFILE_D2H);
     //HOW TO COPY BACK TO CPU: cudaInGaugeEx->cpuGauge
     copyExtendedGauge(*cudaInGauge, *cudaInGaugeEx, QUDA_CUDA_FIELD_LOCATION);
   }
 #else
   // perform the update
-  GaugeFixOVRQuda.Start(QUDA_PROFILE_COMPUTE);
+  GaugeFixOVRQuda.TPSTART(QUDA_PROFILE_COMPUTE);
   gaugefixingOVR(*cudaInGauge, gauge_dir, Nsteps, verbose_interval, relax_boost, tolerance, \
     reunit_interval, stopWtheta);
-  GaugeFixOVRQuda.Stop(QUDA_PROFILE_COMPUTE);
+  GaugeFixOVRQuda.TPSTOP(QUDA_PROFILE_COMPUTE);
   // copy the gauge field back to the host
-  GaugeFixOVRQuda.Start(QUDA_PROFILE_D2H);
+  GaugeFixOVRQuda.TPSTART(QUDA_PROFILE_D2H);
 #endif
 
   checkCudaError();
   cudaInGauge->saveCPUField(*cpuGauge, QUDA_CPU_FIELD_LOCATION);
-  GaugeFixOVRQuda.Stop(QUDA_PROFILE_D2H);
+  GaugeFixOVRQuda.TPSTOP(QUDA_PROFILE_D2H);
 
-  GaugeFixOVRQuda.Stop(QUDA_PROFILE_TOTAL);
+  GaugeFixOVRQuda.TPSTOP(QUDA_PROFILE_TOTAL);
 
   if (param->make_resident_gauge) {
     if (gaugePrecise != NULL) delete gaugePrecise;
@@ -5413,11 +5413,11 @@ int computeGaugeFixingFFTQuda(void* gauge, const unsigned int gauge_dir,  const 
   const unsigned int  stopWtheta, QudaGaugeParam* param , double* timeinfo)
 {
 
-  GaugeFixFFTQuda.Start(QUDA_PROFILE_TOTAL);
+  GaugeFixFFTQuda.TPSTART(QUDA_PROFILE_TOTAL);
 
   checkGaugeParam(param);
 
-  GaugeFixFFTQuda.Start(QUDA_PROFILE_INIT);  
+  GaugeFixFFTQuda.TPSTART(QUDA_PROFILE_INIT);  
 
   GaugeFieldParam gParam(gauge, *param);
   cpuGaugeField *cpuGauge = new cpuGaugeField(gParam);
@@ -5433,9 +5433,9 @@ int computeGaugeFixingFFTQuda(void* gauge, const unsigned int gauge_dir,  const 
   cudaGaugeField *cudaInGauge = new cudaGaugeField(gParam);
 
 
-  GaugeFixFFTQuda.Stop(QUDA_PROFILE_INIT);  
+  GaugeFixFFTQuda.TPSTOP(QUDA_PROFILE_INIT);  
 
-  GaugeFixFFTQuda.Start(QUDA_PROFILE_H2D);
+  GaugeFixFFTQuda.TPSTART(QUDA_PROFILE_H2D);
 
   //if (!param->use_resident_gauge) {   // load fields onto the device
     cudaInGauge->loadCPUField(*cpuGauge, QUDA_CPU_FIELD_LOCATION);
@@ -5446,25 +5446,25 @@ int computeGaugeFixingFFTQuda(void* gauge, const unsigned int gauge_dir,  const 
   } */
 
 
-  GaugeFixFFTQuda.Stop(QUDA_PROFILE_H2D);
+  GaugeFixFFTQuda.TPSTOP(QUDA_PROFILE_H2D);
   
   // perform the update
-  GaugeFixFFTQuda.Start(QUDA_PROFILE_COMPUTE);
+  GaugeFixFFTQuda.TPSTART(QUDA_PROFILE_COMPUTE);
   checkCudaError();
 
   gaugefixingFFT(*cudaInGauge, gauge_dir, Nsteps, verbose_interval, alpha, autotune, tolerance, stopWtheta);
 
-  GaugeFixFFTQuda.Stop(QUDA_PROFILE_COMPUTE);
+  GaugeFixFFTQuda.TPSTOP(QUDA_PROFILE_COMPUTE);
 
   checkCudaError();
   // copy the gauge field back to the host
-  GaugeFixFFTQuda.Start(QUDA_PROFILE_D2H);
+  GaugeFixFFTQuda.TPSTART(QUDA_PROFILE_D2H);
   checkCudaError();
   cudaInGauge->saveCPUField(*cpuGauge, QUDA_CPU_FIELD_LOCATION);
-  GaugeFixFFTQuda.Stop(QUDA_PROFILE_D2H);
+  GaugeFixFFTQuda.TPSTOP(QUDA_PROFILE_D2H);
   checkCudaError();
 
-  GaugeFixFFTQuda.Stop(QUDA_PROFILE_TOTAL);
+  GaugeFixFFTQuda.TPSTOP(QUDA_PROFILE_TOTAL);
 
   if (param->make_resident_gauge) {
     if (gaugePrecise != NULL) delete gaugePrecise;

--- a/lib/inv_bicgstab_quda.cpp
+++ b/lib/inv_bicgstab_quda.cpp
@@ -30,7 +30,7 @@ namespace quda {
   }
 
   BiCGstab::~BiCGstab() {
-    profile.Start(QUDA_PROFILE_FREE);
+    profile.TPSTART(QUDA_PROFILE_FREE);
 
     if(init) {
       delete yp;
@@ -41,7 +41,7 @@ namespace quda {
       delete tp;
     }
 
-    profile.Stop(QUDA_PROFILE_FREE);
+    profile.TPSTOP(QUDA_PROFILE_FREE);
   }
 
   int reliable(double &rNorm, double &maxrx, double &maxrr, const double &r2, const double &delta) {
@@ -60,7 +60,7 @@ namespace quda {
 
   void BiCGstab::operator()(cudaColorSpinorField &x, cudaColorSpinorField &b) 
   {
-    profile.Start(QUDA_PROFILE_PREAMBLE);
+    profile.TPSTART(QUDA_PROFILE_PREAMBLE);
 
     if (!init) {
       ColorSpinorParam csParam(x);
@@ -101,7 +101,7 @@ namespace quda {
 
     // Check to see that we're not trying to invert on a zero-field source
     if (b2 == 0) {
-      profile.Stop(QUDA_PROFILE_INIT);
+      profile.TPSTOP(QUDA_PROFILE_INIT);
       warningQuda("inverting on zero-field source\n");
       x = b;
       param.true_res = 0.0;
@@ -173,8 +173,8 @@ namespace quda {
       quda::blas_flops = 0;    
     }
 
-    profile.Stop(QUDA_PROFILE_PREAMBLE);
-    profile.Start(QUDA_PROFILE_COMPUTE);
+    profile.TPSTOP(QUDA_PROFILE_PREAMBLE);
+    profile.TPSTART(QUDA_PROFILE_COMPUTE);
     
     rho = r2; // cDotProductCuda(r0, r_sloppy); // BiCRstab
     copyCuda(p, rSloppy);
@@ -286,8 +286,8 @@ namespace quda {
     if (x.Precision() != xSloppy.Precision()) copyCuda(x, xSloppy);
     xpyCuda(y, x);
 
-    profile.Stop(QUDA_PROFILE_COMPUTE);
-    profile.Start(QUDA_PROFILE_EPILOGUE);
+    profile.TPSTOP(QUDA_PROFILE_COMPUTE);
+    profile.TPSTART(QUDA_PROFILE_EPILOGUE);
 
     param.secs += profile.Last(QUDA_PROFILE_COMPUTE);
     double gflops = (quda::blas_flops + mat.flops() + matSloppy.flops() + matPrecon.flops())*1e-9;
@@ -319,9 +319,9 @@ namespace quda {
     matSloppy.flops();
     matPrecon.flops();
 
-    profile.Stop(QUDA_PROFILE_EPILOGUE);
+    profile.TPSTOP(QUDA_PROFILE_EPILOGUE);
 
-    profile.Start(QUDA_PROFILE_FREE);
+    profile.TPSTART(QUDA_PROFILE_FREE);
     if (param.precision_sloppy != x.Precision()) {
       delete r_0;
       delete r_sloppy;
@@ -329,7 +329,7 @@ namespace quda {
 
     if (&x != &xSloppy) delete x_sloppy;
 
-    profile.Stop(QUDA_PROFILE_FREE);
+    profile.TPSTOP(QUDA_PROFILE_FREE);
     
     return;
   }

--- a/lib/inv_cg3_quda.cpp
+++ b/lib/inv_cg3_quda.cpp
@@ -30,7 +30,7 @@ namespace quda {
     // Check to see that we're not trying to invert on a zero-field source    
     const double b2 = norm2(b);
     if(b2 == 0){
-      profile.Stop(QUDA_PROFILE_INIT);
+      profile.TPSTOP(QUDA_PROFILE_INIT);
       printfQuda("Warning: inverting on zero-field source\n");
       x=b;
       param.true_res = 0.0;

--- a/lib/inv_cg_quda.cpp
+++ b/lib/inv_cg_quda.cpp
@@ -28,12 +28,12 @@ namespace quda {
 
   void CG::operator()(cudaColorSpinorField &x, cudaColorSpinorField &b) 
   {
-    profile.Start(QUDA_PROFILE_INIT);
+    profile.TPSTART(QUDA_PROFILE_INIT);
 
     // Check to see that we're not trying to invert on a zero-field source    
     const double b2 = norm2(b);
     if(b2 == 0){
-      profile.Stop(QUDA_PROFILE_INIT);
+      profile.TPSTOP(QUDA_PROFILE_INIT);
       printfQuda("Warning: inverting on zero-field source\n");
       x=b;
       param.true_res = 0.0;
@@ -100,8 +100,8 @@ namespace quda {
       (param.residual_type & QUDA_HEAVY_QUARK_RESIDUAL) ? true : false;
     bool heavy_quark_restart = false;
     
-    profile.Stop(QUDA_PROFILE_INIT);
-    profile.Start(QUDA_PROFILE_PREAMBLE);
+    profile.TPSTOP(QUDA_PROFILE_INIT);
+    profile.TPSTART(QUDA_PROFILE_PREAMBLE);
 
     double r2_old;
 
@@ -143,8 +143,8 @@ namespace quda {
     // only used if we use the heavy_quark_res
     bool L2breakdown =false;
 
-    profile.Stop(QUDA_PROFILE_PREAMBLE);
-    profile.Start(QUDA_PROFILE_COMPUTE);
+    profile.TPSTOP(QUDA_PROFILE_PREAMBLE);
+    profile.TPSTART(QUDA_PROFILE_COMPUTE);
     blas_flops = 0;
 
     int k=0;
@@ -307,8 +307,8 @@ namespace quda {
     copyCuda(x, xSloppy); // nop when these pointers alias
     xpyCuda(y, x);
 
-    profile.Stop(QUDA_PROFILE_COMPUTE);
-    profile.Start(QUDA_PROFILE_EPILOGUE);
+    profile.TPSTOP(QUDA_PROFILE_COMPUTE);
+    profile.TPSTART(QUDA_PROFILE_EPILOGUE);
 
     param.secs = profile.Last(QUDA_PROFILE_COMPUTE);
     double gflops = (quda::blas_flops + mat.flops() + matSloppy.flops())*1e-9;
@@ -338,8 +338,8 @@ namespace quda {
     mat.flops();
     matSloppy.flops();
 
-    profile.Stop(QUDA_PROFILE_EPILOGUE);
-    profile.Start(QUDA_PROFILE_FREE);
+    profile.TPSTOP(QUDA_PROFILE_EPILOGUE);
+    profile.TPSTART(QUDA_PROFILE_FREE);
 
     if (&tmp3 != &tmp) delete tmp3_p;
     if (&tmp2 != &tmp) delete tmp2_p;
@@ -347,7 +347,7 @@ namespace quda {
     if (rSloppy.Precision() != r.Precision()) delete r_sloppy;
     if (xSloppy.Precision() != x.Precision()) delete x_sloppy;
 
-    profile.Stop(QUDA_PROFILE_FREE);
+    profile.TPSTOP(QUDA_PROFILE_FREE);
 
     return;
   }

--- a/lib/inv_eigcg_quda.cpp
+++ b/lib/inv_eigcg_quda.cpp
@@ -450,13 +450,13 @@ namespace quda {
 
     if (eigcg_precision != x.Precision()) errorQuda("\nInput/output field precision is incorrect (solver precision: %u spinor precision: %u).\n", eigcg_precision, x.Precision());
 
-    profile.Start(QUDA_PROFILE_INIT);
+    profile.TPSTART(QUDA_PROFILE_INIT);
 
     // Check to see that we're not trying to invert on a zero-field source    
     const double b2 = norm2(b);
 
     if(b2 == 0){
-      profile.Stop(QUDA_PROFILE_INIT);
+      profile.TPSTOP(QUDA_PROFILE_INIT);
       printfQuda("Warning: inverting on zero-field source\n");
       x=b;
       param.true_res = 0.0;
@@ -495,8 +495,8 @@ namespace quda {
     const bool use_heavy_quark_res = 
       (param.residual_type & QUDA_HEAVY_QUARK_RESIDUAL) ? true : false;
     
-    profile.Stop(QUDA_PROFILE_INIT);
-    profile.Start(QUDA_PROFILE_PREAMBLE);
+    profile.TPSTOP(QUDA_PROFILE_INIT);
+    profile.TPSTART(QUDA_PROFILE_PREAMBLE);
 
     double r2_old;
     double stop = b2*param.tol*param.tol; // stopping condition of solver
@@ -511,8 +511,8 @@ namespace quda {
 
     int eigvRestart = 0;
 
-    profile.Stop(QUDA_PROFILE_PREAMBLE);
-    profile.Start(QUDA_PROFILE_COMPUTE);
+    profile.TPSTOP(QUDA_PROFILE_PREAMBLE);
+    profile.TPSTART(QUDA_PROFILE_COMPUTE);
     blas_flops = 0;
 
 //eigCG specific code:
@@ -650,8 +650,8 @@ namespace quda {
 //Free eigcg resources:
     delete eigcg_args;
 
-    profile.Stop(QUDA_PROFILE_COMPUTE);
-    profile.Start(QUDA_PROFILE_EPILOGUE);
+    profile.TPSTOP(QUDA_PROFILE_COMPUTE);
+    profile.TPSTART(QUDA_PROFILE_EPILOGUE);
 
     param.secs = profile.Last(QUDA_PROFILE_COMPUTE);
     double gflops = (quda::blas_flops + mat.flops())*1e-9;
@@ -682,15 +682,15 @@ namespace quda {
     quda::blas_flops = 0;
     mat.flops();
 
-    profile.Stop(QUDA_PROFILE_EPILOGUE);
-    profile.Start(QUDA_PROFILE_FREE);
+    profile.TPSTOP(QUDA_PROFILE_EPILOGUE);
+    profile.TPSTART(QUDA_PROFILE_FREE);
 
     if (&tmp2 != &tmp) delete tmp2_p;
 
 //Clean EigCG resources:
     if(search_space_prec != param.precision_sloppy)  delete v0;
 
-    profile.Stop(QUDA_PROFILE_FREE);
+    profile.TPSTOP(QUDA_PROFILE_FREE);
 
     return eigvRestart;
   }

--- a/lib/inv_gcr_quda.cpp
+++ b/lib/inv_gcr_quda.cpp
@@ -156,16 +156,16 @@ namespace quda {
   */
 
   GCR::~GCR() {
-    profile.Start(QUDA_PROFILE_FREE);
+    profile.TPSTART(QUDA_PROFILE_FREE);
 
     if (K) delete K;
 
-    profile.Stop(QUDA_PROFILE_FREE);
+    profile.TPSTOP(QUDA_PROFILE_FREE);
   }
 
   void GCR::operator()(cudaColorSpinorField &x, cudaColorSpinorField &b)
   {
-    profile.Start(QUDA_PROFILE_INIT);
+    profile.TPSTART(QUDA_PROFILE_INIT);
 
     int Nkrylov = param.Nkrylov; // size of Krylov space
 
@@ -241,7 +241,7 @@ namespace quda {
 
     // Check to see that we're not trying to invert on a zero-field source
     if (b2 == 0) {
-      profile.Stop(QUDA_PROFILE_INIT);
+      profile.TPSTOP(QUDA_PROFILE_INIT);
       warningQuda("inverting on zero-field source\n");
       x = b;
       param.true_res = 0.0;
@@ -266,8 +266,8 @@ namespace quda {
     int resIncrease = 0;
     int resIncreaseTotal = 0;
 
-    profile.Stop(QUDA_PROFILE_INIT);
-    profile.Start(QUDA_PROFILE_PREAMBLE);
+    profile.TPSTOP(QUDA_PROFILE_INIT);
+    profile.TPSTART(QUDA_PROFILE_PREAMBLE);
 
     blas_flops = 0;
 
@@ -278,8 +278,8 @@ namespace quda {
     double r2_old = r2;
     bool l2_converge = false;
 
-    profile.Stop(QUDA_PROFILE_PREAMBLE);
-    profile.Start(QUDA_PROFILE_COMPUTE);
+    profile.TPSTOP(QUDA_PROFILE_PREAMBLE);
+    profile.TPSTART(QUDA_PROFILE_COMPUTE);
 
     int k = 0;
     PrintStats("GCR", total_iter+k, r2, b2, heavy_quark_res);
@@ -389,8 +389,8 @@ namespace quda {
 
     if (total_iter > 0) copyCuda(x, y);
 
-    profile.Stop(QUDA_PROFILE_COMPUTE);
-    profile.Start(QUDA_PROFILE_EPILOGUE);
+    profile.TPSTOP(QUDA_PROFILE_COMPUTE);
+    profile.TPSTART(QUDA_PROFILE_EPILOGUE);
 
     param.secs += profile.Last(QUDA_PROFILE_COMPUTE);
   
@@ -421,8 +421,8 @@ namespace quda {
     matSloppy.flops();
     matPrecon.flops();
 
-    profile.Stop(QUDA_PROFILE_EPILOGUE);
-    profile.Start(QUDA_PROFILE_FREE);
+    profile.TPSTOP(QUDA_PROFILE_EPILOGUE);
+    profile.TPSTART(QUDA_PROFILE_FREE);
 
     PrintSummary("GCR", total_iter, r2, b2);
 
@@ -450,7 +450,7 @@ namespace quda {
     delete []beta;
     delete []gamma;
 
-    profile.Stop(QUDA_PROFILE_FREE);
+    profile.TPSTOP(QUDA_PROFILE_FREE);
 
     return;
   }

--- a/lib/inv_mpbicgstab_quda.cpp
+++ b/lib/inv_mpbicgstab_quda.cpp
@@ -139,7 +139,7 @@ namespace quda {
     // Check to see that we're not trying to invert on a zero-field source    
     const double b2 = norm2(b);
     if(b2 == 0){
-      profile.Stop(QUDA_PROFILE_INIT);
+      profile.TPSTOP(QUDA_PROFILE_INIT);
       printfQuda("Warning: inverting on zero-field source\n");
       x=b;
       param.true_res = 0.0;

--- a/lib/inv_mpcg_quda.cpp
+++ b/lib/inv_mpcg_quda.cpp
@@ -211,7 +211,7 @@ namespace quda {
     // Check to see that we're not trying to invert on a zero-field source    
     const double b2 = norm2(b);
     if(b2 == 0){
-      profile.Stop(QUDA_PROFILE_INIT);
+      profile.TPSTOP(QUDA_PROFILE_INIT);
       printfQuda("Warning: inverting on zero-field source\n");
       x=b;
       param.true_res = 0.0;

--- a/lib/inv_mr_quda.cpp
+++ b/lib/inv_mr_quda.cpp
@@ -23,13 +23,13 @@ namespace quda {
   }
 
   MR::~MR() {
-    if (param.inv_type_precondition != QUDA_GCR_INVERTER) profile.Start(QUDA_PROFILE_FREE);
+    if (param.inv_type_precondition != QUDA_GCR_INVERTER) profile.TPSTART(QUDA_PROFILE_FREE);
     if (init) {
       if (allocate_r) delete rp;
       delete Arp;
       delete tmpp;
     }
-    if (param.inv_type_precondition != QUDA_GCR_INVERTER) profile.Stop(QUDA_PROFILE_FREE);
+    if (param.inv_type_precondition != QUDA_GCR_INVERTER) profile.TPSTOP(QUDA_PROFILE_FREE);
   }
 
   void MR::operator()(cudaColorSpinorField &x, cudaColorSpinorField &b)
@@ -68,7 +68,7 @@ namespace quda {
 
     if (param.inv_type_precondition != QUDA_GCR_INVERTER) {
       quda::blas_flops = 0;
-      profile.Start(QUDA_PROFILE_COMPUTE);
+      profile.TPSTART(QUDA_PROFILE_COMPUTE);
     }
 
     double omega = 1.0;
@@ -114,8 +114,8 @@ namespace quda {
     if (b2 > 0.0) axCuda(sqrt(b2), x);
 
     if (param.inv_type_precondition != QUDA_GCR_INVERTER) {
-        profile.Stop(QUDA_PROFILE_COMPUTE);
-        profile.Start(QUDA_PROFILE_EPILOGUE);
+        profile.TPSTOP(QUDA_PROFILE_COMPUTE);
+        profile.TPSTART(QUDA_PROFILE_EPILOGUE);
 	param.secs += profile.Last(QUDA_PROFILE_COMPUTE);
   
 	double gflops = (quda::blas_flops + mat.flops())*1e-9;
@@ -138,7 +138,7 @@ namespace quda {
 	// reset the flops counters
 	quda::blas_flops = 0;
 	mat.flops();
-        profile.Stop(QUDA_PROFILE_EPILOGUE);
+        profile.TPSTOP(QUDA_PROFILE_EPILOGUE);
     }
 
     globalReduce = true; // renable global reductions for outer solver

--- a/lib/inv_multi_cg_quda.cpp
+++ b/lib/inv_multi_cg_quda.cpp
@@ -66,7 +66,7 @@ namespace quda {
 
   void MultiShiftCG::operator()(cudaColorSpinorField **x, cudaColorSpinorField &b)
   {
-    profile.Start(QUDA_PROFILE_INIT);
+    profile.TPSTART(QUDA_PROFILE_INIT);
 
     int num_offset = param.num_offset;
     double *offset = param.offset;
@@ -76,7 +76,7 @@ namespace quda {
     const double b2 = normCuda(b);
     // Check to see that we're not trying to invert on a zero-field source
     if(b2 == 0){
-      profile.Stop(QUDA_PROFILE_INIT);
+      profile.TPSTOP(QUDA_PROFILE_INIT);
       printfQuda("Warning: inverting on zero-field source\n");
       for(int i=0; i<num_offset; ++i){
         *(x[i]) = b;
@@ -155,8 +155,8 @@ namespace quda {
       new cudaColorSpinorField(*r, csParam) : &tmp1;
     cudaColorSpinorField &tmp3 = *tmp3_p;
 
-    profile.Stop(QUDA_PROFILE_INIT);
-    profile.Start(QUDA_PROFILE_PREAMBLE);
+    profile.TPSTOP(QUDA_PROFILE_INIT);
+    profile.TPSTART(QUDA_PROFILE_PREAMBLE);
 
     // stopping condition of each shift
     double stop[QUDA_MAX_MULTI_SHIFT];
@@ -197,8 +197,8 @@ namespace quda {
     int rUpdate = 0;
     quda::blas_flops = 0;
 
-    profile.Stop(QUDA_PROFILE_PREAMBLE);
-    profile.Start(QUDA_PROFILE_COMPUTE);
+    profile.TPSTOP(QUDA_PROFILE_PREAMBLE);
+    profile.TPSTART(QUDA_PROFILE_COMPUTE);
 
     if (getVerbosity() >= QUDA_VERBOSE) 
       printfQuda("MultiShift CG: %d iterations, <r,r> = %e, |r|/|b| = %e\n", k, r2[0], sqrt(r2[0]/b2));
@@ -325,8 +325,8 @@ namespace quda {
       if (reliable) xpyCuda(*y[i], *x[i]);
     }
 
-    profile.Stop(QUDA_PROFILE_COMPUTE);
-    profile.Start(QUDA_PROFILE_EPILOGUE);
+    profile.TPSTOP(QUDA_PROFILE_COMPUTE);
+    profile.TPSTART(QUDA_PROFILE_EPILOGUE);
 
     if (getVerbosity() >= QUDA_VERBOSE)
       printfQuda("MultiShift CG: Reliable updates = %d\n", rUpdate);
@@ -368,8 +368,8 @@ namespace quda {
     mat.flops();
     matSloppy.flops();
 
-    profile.Stop(QUDA_PROFILE_EPILOGUE);
-    profile.Start(QUDA_PROFILE_FREE);
+    profile.TPSTOP(QUDA_PROFILE_EPILOGUE);
+    profile.TPSTART(QUDA_PROFILE_FREE);
 
     if (&tmp3 != &tmp1) delete tmp3_p;
     if (&tmp2 != &tmp1) delete tmp2_p;
@@ -395,7 +395,7 @@ namespace quda {
     delete []alpha;
     delete []beta;
 
-    profile.Stop(QUDA_PROFILE_FREE);
+    profile.TPSTOP(QUDA_PROFILE_FREE);
 
     return;
   }

--- a/lib/inv_pcg_quda.cpp
+++ b/lib/inv_pcg_quda.cpp
@@ -55,22 +55,22 @@ namespace quda {
   }
 
   PreconCG::~PreconCG(){
-    profile.Start(QUDA_PROFILE_FREE);
+    profile.TPSTART(QUDA_PROFILE_FREE);
 
     if(K) delete K;
 
-    profile.Stop(QUDA_PROFILE_FREE);
+    profile.TPSTOP(QUDA_PROFILE_FREE);
   }
 
 
   void PreconCG::operator()(cudaColorSpinorField &x, cudaColorSpinorField &b)
   {
 
-    profile.Start(QUDA_PROFILE_INIT);
+    profile.TPSTART(QUDA_PROFILE_INIT);
     // Check to see that we're not trying to invert on a zero-field source
     const double b2 = norm2(b);
     if(b2 == 0){
-      profile.Stop(QUDA_PROFILE_INIT);
+      profile.TPSTOP(QUDA_PROFILE_INIT);
       printfQuda("Warning: inverting on zero-field source\n");
       x=b;
       param.true_res = 0.0;
@@ -151,10 +151,10 @@ namespace quda {
     }
 
   
-    profile.Stop(QUDA_PROFILE_INIT);
+    profile.TPSTOP(QUDA_PROFILE_INIT);
 
 
-    profile.Start(QUDA_PROFILE_PREAMBLE);
+    profile.TPSTART(QUDA_PROFILE_PREAMBLE);
 
 
 
@@ -179,8 +179,8 @@ namespace quda {
 
     if(K) rMinvr = reDotProductCuda(rSloppy,*minvrSloppy);
 
-    profile.Stop(QUDA_PROFILE_PREAMBLE);
-    profile.Start(QUDA_PROFILE_COMPUTE);
+    profile.TPSTOP(QUDA_PROFILE_PREAMBLE);
+    profile.TPSTART(QUDA_PROFILE_COMPUTE);
 
 
     quda::blas_flops = 0;
@@ -299,9 +299,9 @@ namespace quda {
     }
 
 
-    profile.Stop(QUDA_PROFILE_COMPUTE);
+    profile.TPSTOP(QUDA_PROFILE_COMPUTE);
 
-    profile.Start(QUDA_PROFILE_EPILOGUE);
+    profile.TPSTART(QUDA_PROFILE_EPILOGUE);
 
     if(x.Precision() != param.precision_sloppy) copyCuda(x, xSloppy);
     xpyCuda(y, x); // x += y
@@ -334,8 +334,8 @@ namespace quda {
     matSloppy.flops();
     matPrecon.flops();
 
-    profile.Stop(QUDA_PROFILE_EPILOGUE);
-    profile.Start(QUDA_PROFILE_FREE);
+    profile.TPSTOP(QUDA_PROFILE_EPILOGUE);
+    profile.TPSTART(QUDA_PROFILE_FREE);
 
     if(K){ // These are only needed if preconditioning is used
       delete minvrPre;
@@ -350,7 +350,7 @@ namespace quda {
       delete r_sloppy;
     }
 
-    profile.Stop(QUDA_PROFILE_FREE);
+    profile.TPSTOP(QUDA_PROFILE_FREE);
     return;
   }
 

--- a/lib/inv_sbicgstab_quda.cpp
+++ b/lib/inv_sbicgstab_quda.cpp
@@ -30,7 +30,7 @@ namespace quda {
     // Check to see that we're not trying to invert on a zero-field source    
     const double b2 = norm2(b);
     if(b2 == 0){
-      profile.Stop(QUDA_PROFILE_INIT);
+      profile.TPSTOP(QUDA_PROFILE_INIT);
       printfQuda("Warning: inverting on zero-field source\n");
       x=b;
       param.true_res = 0.0;

--- a/lib/inv_sd_quda.cpp
+++ b/lib/inv_sd_quda.cpp
@@ -23,13 +23,13 @@ namespace quda {
   }
 
   SD::~SD(){
-    if(param.inv_type_precondition != QUDA_PCG_INVERTER && param.inv_type_precondition != QUDA_GCR_INVERTER) profile.Start(QUDA_PROFILE_FREE);
+    if(param.inv_type_precondition != QUDA_PCG_INVERTER && param.inv_type_precondition != QUDA_GCR_INVERTER) profile.TPSTART(QUDA_PROFILE_FREE);
     if(init){
       delete r;
       delete Ar; 
       delete y;
     }
-    if(param.inv_type_precondition != QUDA_PCG_INVERTER && param.inv_type_precondition != QUDA_GCR_INVERTER) profile.Stop(QUDA_PROFILE_FREE);
+    if(param.inv_type_precondition != QUDA_PCG_INVERTER && param.inv_type_precondition != QUDA_GCR_INVERTER) profile.TPSTOP(QUDA_PROFILE_FREE);
   }
 
 

--- a/lib/inv_xsd_quda.cpp
+++ b/lib/inv_xsd_quda.cpp
@@ -25,13 +25,13 @@ namespace quda {
   }
 
   XSD::~XSD(){
-    if(param.inv_type_precondition != QUDA_GCR_INVERTER) profile.Start(QUDA_PROFILE_FREE);
+    if(param.inv_type_precondition != QUDA_GCR_INVERTER) profile.TPSTART(QUDA_PROFILE_FREE);
     if(init){
       delete xx;
       delete bx;
     }
     delete sd;
-    if(param.inv_type_precondition != QUDA_GCR_INVERTER) profile.Stop(QUDA_PROFILE_FREE);
+    if(param.inv_type_precondition != QUDA_GCR_INVERTER) profile.TPSTOP(QUDA_PROFILE_FREE);
   }
 
 

--- a/lib/pgauge_det_trace.cu
+++ b/lib/pgauge_det_trace.cu
@@ -157,7 +157,7 @@ class CalcFunc : Tunable {
 template<typename Float, int NCOLORS, int functiontype, typename Gauge>
 double2 computeValue( Gauge dataOr,  cudaGaugeField& data) {
   TimeProfile profileGenericFunc("GenericFunc");
-  if (getVerbosity() >= QUDA_SUMMARIZE) profileGenericFunc.Start(QUDA_PROFILE_COMPUTE);
+  if (getVerbosity() >= QUDA_SUMMARIZE) profileGenericFunc.TPSTART(QUDA_PROFILE_COMPUTE);
   KernelArg<Gauge> arg(dataOr, data);
   CalcFunc<Float, Gauge, NCOLORS, functiontype> func(arg);
   func.apply(0);
@@ -166,7 +166,7 @@ double2 computeValue( Gauge dataOr,  cudaGaugeField& data) {
   checkCudaError();
   cudaDeviceSynchronize();
   if (getVerbosity() >= QUDA_SUMMARIZE){
-    profileGenericFunc.Stop(QUDA_PROFILE_COMPUTE);
+    profileGenericFunc.TPSTOP(QUDA_PROFILE_COMPUTE);
     double secs = profileGenericFunc.Last(QUDA_PROFILE_COMPUTE);
     double gflops = (func.flops()*1e-9)/(secs);
     double gbytes = func.bytes()/(secs*1e9);

--- a/lib/pgauge_det_trace.cu
+++ b/lib/pgauge_det_trace.cu
@@ -101,7 +101,7 @@ class CalcFunc : Tunable {
   private:
   unsigned int sharedBytesPerThread() const { return 0; }
   unsigned int sharedBytesPerBlock(const TuneParam &param) const { return 0; }
-  bool tuneSharedBytes() const { return false; } // Don't tune shared memory
+  //bool tuneSharedBytes() const { return false; } // Don't tune shared memory
   bool tuneGridDim() const { return false; } // Don't tune the grid dimensions.
   unsigned int minThreads() const { return arg.threads; }
 

--- a/lib/pgauge_det_trace.cu
+++ b/lib/pgauge_det_trace.cu
@@ -156,7 +156,7 @@ class CalcFunc : Tunable {
 
 template<typename Float, int NCOLORS, int functiontype, typename Gauge>
 double2 computeValue( Gauge dataOr,  cudaGaugeField& data) {
-  TimeProfile profileGenericFunc("GenericFunc");
+  TimeProfile profileGenericFunc("GenericFunc", false);
   if (getVerbosity() >= QUDA_SUMMARIZE) profileGenericFunc.TPSTART(QUDA_PROFILE_COMPUTE);
   KernelArg<Gauge> arg(dataOr, data);
   CalcFunc<Float, Gauge, NCOLORS, functiontype> func(arg);

--- a/lib/pgauge_heatbath.cu
+++ b/lib/pgauge_heatbath.cu
@@ -780,7 +780,7 @@ namespace quda {
   template<typename Float, int NElems, int NCOLORS, typename Gauge>
   void Monte( Gauge dataOr,  cudaGaugeField& data, cuRNGState *rngstate, Float Beta, unsigned int nhb, unsigned int nover) {
 
-    TimeProfile profileHBOVR("HeatBath_OR_Relax");
+    TimeProfile profileHBOVR("HeatBath_OR_Relax", false);
     MonteArg<Gauge, Float, NCOLORS> montearg(dataOr, data, Beta, rngstate);
     if ( getVerbosity() >= QUDA_SUMMARIZE ) profileHBOVR.TPSTART(QUDA_PROFILE_COMPUTE);
     GaugeHB<Float, Gauge, NCOLORS, NElems, true> hb(montearg);

--- a/lib/pgauge_heatbath.cu
+++ b/lib/pgauge_heatbath.cu
@@ -677,9 +677,7 @@ namespace quda {
     unsigned int sharedBytesPerBlock(const TuneParam &param) const {
       return 0;
     }
-    bool tuneSharedBytes() const {
-      return false;
-    }                                            // Don't tune shared memory
+    //bool tuneSharedBytes() const { return false;  } // Don't tune shared memory
     bool tuneGridDim() const {
       return false;
     }                                        // Don't tune the grid dimensions.

--- a/lib/pgauge_heatbath.cu
+++ b/lib/pgauge_heatbath.cu
@@ -782,7 +782,7 @@ namespace quda {
 
     TimeProfile profileHBOVR("HeatBath_OR_Relax");
     MonteArg<Gauge, Float, NCOLORS> montearg(dataOr, data, Beta, rngstate);
-    if ( getVerbosity() >= QUDA_SUMMARIZE ) profileHBOVR.Start(QUDA_PROFILE_COMPUTE);
+    if ( getVerbosity() >= QUDA_SUMMARIZE ) profileHBOVR.TPSTART(QUDA_PROFILE_COMPUTE);
     GaugeHB<Float, Gauge, NCOLORS, NElems, true> hb(montearg);
     for ( int step = 0; step < nhb; ++step ) {
       for ( int parity = 0; parity < 2; ++parity ) {
@@ -797,7 +797,7 @@ namespace quda {
     }
     if ( getVerbosity() >= QUDA_SUMMARIZE ) {
       cudaDeviceSynchronize();
-      profileHBOVR.Stop(QUDA_PROFILE_COMPUTE);
+      profileHBOVR.TPSTOP(QUDA_PROFILE_COMPUTE);
       double secs = profileHBOVR.Last(QUDA_PROFILE_COMPUTE);
       double gflops = (hb.flops() * 8 * nhb * 1e-9) / (secs);
       double gbytes = hb.bytes() * 8 * nhb / (secs * 1e9);
@@ -808,7 +808,7 @@ namespace quda {
     #endif
     }
 
-    if ( getVerbosity() >= QUDA_SUMMARIZE ) profileHBOVR.Start(QUDA_PROFILE_COMPUTE);
+    if ( getVerbosity() >= QUDA_SUMMARIZE ) profileHBOVR.TPSTART(QUDA_PROFILE_COMPUTE);
     GaugeHB<Float, Gauge, NCOLORS, NElems, false> relax(montearg);
     for ( int step = 0; step < nover; ++step ) {
       for ( int parity = 0; parity < 2; ++parity ) {
@@ -823,7 +823,7 @@ namespace quda {
     }
     if ( getVerbosity() >= QUDA_SUMMARIZE ) {
       cudaDeviceSynchronize();
-      profileHBOVR.Stop(QUDA_PROFILE_COMPUTE);
+      profileHBOVR.TPSTOP(QUDA_PROFILE_COMPUTE);
       double secs = profileHBOVR.Last(QUDA_PROFILE_COMPUTE);
       double gflops = (relax.flops() * 8 * nover * 1e-9) / (secs);
       double gbytes = relax.bytes() * 8 * nover / (secs * 1e9);

--- a/lib/pgauge_init.cu
+++ b/lib/pgauge_init.cu
@@ -66,9 +66,7 @@ namespace quda {
     unsigned int sharedBytesPerBlock(const TuneParam &param) const {
       return 0;
     }
-    bool tuneSharedBytes() const {
-      return false;
-    }                                            // Don't tune shared memory
+    //bool tuneSharedBytes() const { return false; }  // Don't tune shared memory
     bool tuneGridDim() const {
       return false;
     }                                        // Don't tune the grid dimensions.

--- a/lib/tune.cpp
+++ b/lib/tune.cpp
@@ -276,8 +276,8 @@ namespace quda {
 #endif
 
 #ifdef LAUNCH_TIMER
-    launchTimer.Start(QUDA_PROFILE_TOTAL);
-    launchTimer.Start(QUDA_PROFILE_INIT);
+    launchTimer.TPSTART(QUDA_PROFILE_TOTAL);
+    launchTimer.TPSTART(QUDA_PROFILE_INIT);
 #endif
 
     const TuneKey key = tunable.tuneKey();
@@ -285,8 +285,8 @@ namespace quda {
     static TuneParam param;
 
 #ifdef LAUNCH_TIMER
-    launchTimer.Stop(QUDA_PROFILE_INIT);
-    launchTimer.Start(QUDA_PROFILE_PREAMBLE);
+    launchTimer.TPSTOP(QUDA_PROFILE_INIT);
+    launchTimer.TPSTART(QUDA_PROFILE_PREAMBLE);
 #endif
 
     // first check if we have the tuned value and return if we have it
@@ -296,23 +296,23 @@ namespace quda {
     if (enabled == QUDA_TUNE_YES && it != tunecache.end()) {
 
 #ifdef LAUNCH_TIMER
-      launchTimer.Stop(QUDA_PROFILE_PREAMBLE);
-      launchTimer.Start(QUDA_PROFILE_COMPUTE);
+      launchTimer.TPSTOP(QUDA_PROFILE_PREAMBLE);
+      launchTimer.TPSTART(QUDA_PROFILE_COMPUTE);
 #endif
 
       //param = tunecache[key];
       TuneParam param = it->second;
 
 #ifdef LAUNCH_TIMER
-      launchTimer.Stop(QUDA_PROFILE_COMPUTE);
-      launchTimer.Start(QUDA_PROFILE_EPILOGUE);
+      launchTimer.TPSTOP(QUDA_PROFILE_COMPUTE);
+      launchTimer.TPSTART(QUDA_PROFILE_EPILOGUE);
 #endif
 
       tunable.checkLaunchParam(it->second);
 
 #ifdef LAUNCH_TIMER
-      launchTimer.Stop(QUDA_PROFILE_EPILOGUE);
-      launchTimer.Stop(QUDA_PROFILE_TOTAL);
+      launchTimer.TPSTOP(QUDA_PROFILE_EPILOGUE);
+      launchTimer.TPSTOP(QUDA_PROFILE_TOTAL);
 #endif
 
 #ifdef PTHREADS
@@ -324,8 +324,8 @@ namespace quda {
     }
 
 #ifdef LAUNCH_TIMER
-    launchTimer.Stop(QUDA_PROFILE_PREAMBLE);
-    launchTimer.Stop(QUDA_PROFILE_TOTAL);
+    launchTimer.TPSTOP(QUDA_PROFILE_PREAMBLE);
+    launchTimer.TPSTOP(QUDA_PROFILE_TOTAL);
 #endif
 
 

--- a/tests/gauge_alg_test.cpp
+++ b/tests/gauge_alg_test.cpp
@@ -19,6 +19,9 @@
 
 using   namespace quda;
 
+#undef Start
+#undef Stop
+
 
 extern int device;
 extern int xdim;
@@ -162,8 +165,8 @@ class GaugeAlgTest : public ::testing::Test {
 
 
 
-    a0.Start();
-    a1.Start();
+    a0.Start(__func__, __FILE__, __LINE__);
+    a1.Start(__func__, __FILE__, __LINE__);
 
     cudaMalloc((void**)&num_failures_dev, sizeof(int));
     cudaMemset(num_failures_dev, 0, sizeof(int));
@@ -183,7 +186,7 @@ class GaugeAlgTest : public ::testing::Test {
       CallUnitarizeLinks(cudaInGauge);
       plaquette( *cudaInGauge, QUDA_CUDA_FIELD_LOCATION) ;
     }
-    a1.Stop();
+    a1.Stop(__func__, __FILE__, __LINE__);
 
     printfQuda("Time Monte -> %.6f s\n", a1.Last());
     plaq = plaquette( *cudaInGauge, QUDA_CUDA_FIELD_LOCATION) ;
@@ -203,7 +206,7 @@ class GaugeAlgTest : public ::testing::Test {
     //Release all temporary memory used for data exchange between GPUs in multi-GPU mode
     PGaugeExchangeFree();
 
-    a0.Stop();
+    a0.Stop(__func__, __FILE__, __LINE__);
     printfQuda("Time -> %.6f s\n", a0.Last());
     randstates->Release();
     delete randstates;

--- a/tests/gauge_alg_test.cpp
+++ b/tests/gauge_alg_test.cpp
@@ -19,10 +19,6 @@
 
 using   namespace quda;
 
-#undef Start
-#undef Stop
-
-
 extern int device;
 extern int xdim;
 extern int ydim;


### PR DESCRIPTION
This pull request fixes some issues with the TimeProfile class that came up in the gauge-fixing routines after the global timer was added.
* Disable global timer in algorithms, only enable this in interface timing to prevent double starting the global timer
* Add trace information for TimeProfile Start / Stop routines.  Now `TimeProfile::TPSTART` and `TimeProfile::TPSTOP` must be called instead of calling Start / Stop directly
*Fixed a bug in quda_internal.h that resulted in double starting a timer

This closes #344.