### PR TITLE
moved typedef for Complex in blas_magma into class scope 

### DIFF
--- a/include/blas_magma.h
+++ b/include/blas_magma.h
@@ -11,9 +11,12 @@
 //MAGMA library interface 
 //required for (incremental) EigCG solver
 
-   typedef std::complex<double> Complex; //same notations
+
 
    class BlasMagmaArgs{
+
+     typedef std::complex<double> Complex; //same notations
+
     private:
 
       //problem sizes:


### PR DESCRIPTION
to avoid compilation issues because of additional typedef

```
../include/blas_magma.h:111: error: reference to ‘Complex’ is ambiguous
../include/blas_magma.h:14: error: candidates are: typedef struct std::complex<double> Complex
../include/eig_variables.h:13: error:                 typedef struct std::complex<double> quda::Complex
```

Might be that only the oooooooooold gcc on the local GPU development machine in Bloomington is picky about that but it might be safer to have that in the class scope anyway. 