### PR TITLE
Fixed timer nomenclature

### DIFF
--- a/lib/covDev.cu
+++ b/lib/covDev.cu
@@ -121,9 +121,9 @@ namespace quda
     }
 
   #define PROFILE(f, profile, idx)		\
-    profile.Start(idx);				\
+    profile.TPSTART(idx);			\
     f;						\
-    profile.Stop(idx); 
+    profile.TPSTOP(idx); 
 
   /**
      This is a simpler version of the dslashCuda function to call the right kernels


### PR DESCRIPTION
Compilation was broken due to the inclusion of different timer functions. We should fuse this part of the code with dslash_policy.cuh at some point...