### PR TITLE
Iterate until breakdown with mixed precision multi shift

### DIFF
--- a/include/invert_quda.h
+++ b/include/invert_quda.h
@@ -112,6 +112,9 @@ namespace quda {
     /** Actual L2 residual norm achieved in solver for each offset */
     double true_res_offset[QUDA_MAX_MULTI_SHIFT]; 
 
+    /** Actual L2 residual norm achieved in solver for each offset */
+    double iter_res_offset[QUDA_MAX_MULTI_SHIFT];
+
     /** Actual heavy quark residual norm achieved in solver for each offset */
     double true_res_hq_offset[QUDA_MAX_MULTI_SHIFT]; 
 
@@ -203,10 +206,12 @@ namespace quda {
       param.secs += secs;
       if (offset >= 0) {
 	param.true_res_offset[offset] = true_res_offset[offset];
+	param.iter_res_offset[offset] = iter_res_offset[offset];
 	param.true_res_hq_offset[offset] = true_res_hq_offset[offset];
       } else {
 	for (int i=0; i<num_offset; i++) {
 	  param.true_res_offset[i] = true_res_offset[i];
+	  param.iter_res_offset[offset] = iter_res_offset[offset];
 	  param.true_res_hq_offset[i] = true_res_hq_offset[i];
 	}
       }

--- a/include/invert_quda.h
+++ b/include/invert_quda.h
@@ -112,7 +112,7 @@ namespace quda {
     /** Actual L2 residual norm achieved in solver for each offset */
     double true_res_offset[QUDA_MAX_MULTI_SHIFT]; 
 
-    /** Actual L2 residual norm achieved in solver for each offset */
+    /** Iterated L2 residual norm achieved in multi shift solver for each offset */
     double iter_res_offset[QUDA_MAX_MULTI_SHIFT];
 
     /** Actual heavy quark residual norm achieved in solver for each offset */
@@ -211,7 +211,7 @@ namespace quda {
       } else {
 	for (int i=0; i<num_offset; i++) {
 	  param.true_res_offset[i] = true_res_offset[i];
-	  param.iter_res_offset[offset] = iter_res_offset[offset];
+	  param.iter_res_offset[i] = iter_res_offset[i];
 	  param.true_res_hq_offset[i] = true_res_hq_offset[i];
 	}
       }

--- a/include/quda.h
+++ b/include/quda.h
@@ -139,6 +139,8 @@ extern "C" {
     /** Actual L2 residual norm achieved in solver for each offset */
     double true_res_offset[QUDA_MAX_MULTI_SHIFT]; 
 
+    double iter_res_offset[QUDA_MAX_MULTI_SHIFT];
+
     /** Actual heavy quark residual norm achieved in solver for each offset */
     double true_res_hq_offset[QUDA_MAX_MULTI_SHIFT]; 
 

--- a/include/quda.h
+++ b/include/quda.h
@@ -139,6 +139,7 @@ extern "C" {
     /** Actual L2 residual norm achieved in solver for each offset */
     double true_res_offset[QUDA_MAX_MULTI_SHIFT]; 
 
+    /** Iterated L2 residual norm achieved in multi shift solver for each offset */
     double iter_res_offset[QUDA_MAX_MULTI_SHIFT];
 
     /** Actual heavy quark residual norm achieved in solver for each offset */

--- a/lib/check_params.h
+++ b/lib/check_params.h
@@ -236,6 +236,7 @@ void printQudaInvertParam(QudaInvertParam *param) {
 	P(tol_hq_offset[i], INVALID_DOUBLE);
 #ifndef CHECK_PARAM
       P(true_res_offset[i], INVALID_DOUBLE); 
+      P(iter_res_offset[i], INVALID_DOUBLE);
 #endif
     }
   }

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -2734,8 +2734,10 @@ void invertMultiShiftQuda(void **_hp_x, void *_hp_b, QudaInvertParam *param)
     double tol_hq = param->residual_type & QUDA_HEAVY_QUARK_RESIDUAL ?
       param->tol_hq_offset[i] : 0;
 
+    const double prec_tol = pow(10.,(-2*(int)param->cuda_prec+1));
+    const double refine_tol = (param->tol_offset[i] ==0 ? prec_tol : param->tol_offset[i]);
     // refine if either L2 or heavy quark residual tolerances have not been met, only if desired residual is > 0    
-    if ((param->true_res_offset[i] > param->tol_offset[i] || rsd_hq > tol_hq)) {
+    if ((param->true_res_offset[i] > refine_tol || rsd_hq > tol_hq)) {
       if (getVerbosity() >= QUDA_VERBOSE) 
         printfQuda("Refining shift %d: L2 residual %e / %e, heavy quark %e / %e (actual / requested)\n",
             i, param->true_res_offset[i], param->tol_offset[i], rsd_hq, tol_hq);
@@ -2759,7 +2761,8 @@ void invertMultiShiftQuda(void **_hp_x, void *_hp_b, QudaInvertParam *param)
       SolverParam solverParam(*param);
       solverParam.iter = 0;
       solverParam.use_init_guess = QUDA_USE_INIT_GUESS_YES;
-      solverParam.tol = (param->tol_offset[i] >0 ?  param->tol_offset[i] : param->iter_res_offset[i]); // set L2 tolerance
+      const double itertol = (param->iter_res_offset[i] < prec_tol ? prec_tol : param->iter_res_offset[i] );
+      solverParam.tol = (param->tol_offset[i] >0 ?  param->tol_offset[i] : itertol); // set L2 tolerance
       solverParam.tol_hq = param->tol_hq_offset[i]; // set heavy quark tolerance
 
       CG cg(m, mSloppy, solverParam, profileMulti);

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -2735,7 +2735,7 @@ void invertMultiShiftQuda(void **_hp_x, void *_hp_b, QudaInvertParam *param)
       param->tol_hq_offset[i] : 0;
 
     // refine if either L2 or heavy quark residual tolerances have not been met, only if desired residual is > 0    
-    if (param->tol_offset[i] > 0 && (param->true_res_offset[i] > param->tol_offset[i] || rsd_hq > tol_hq)) {
+    if ((param->true_res_offset[i] > param->tol_offset[i] || rsd_hq > tol_hq)) {
       if (getVerbosity() >= QUDA_VERBOSE) 
         printfQuda("Refining shift %d: L2 residual %e / %e, heavy quark %e / %e (actual / requested)\n",
             i, param->true_res_offset[i], param->tol_offset[i], rsd_hq, tol_hq);
@@ -2759,7 +2759,7 @@ void invertMultiShiftQuda(void **_hp_x, void *_hp_b, QudaInvertParam *param)
       SolverParam solverParam(*param);
       solverParam.iter = 0;
       solverParam.use_init_guess = QUDA_USE_INIT_GUESS_YES;
-      solverParam.tol = param->tol_offset[i]; // set L2 tolerance
+      solverParam.tol = (param->tol_offset[i] >0 ?  param->tol_offset[i] : param->iter_res_offset[i]); // set L2 tolerance
       solverParam.tol_hq = param->tol_hq_offset[i]; // set heavy quark tolerance
 
       CG cg(m, mSloppy, solverParam, profileMulti);

--- a/lib/inv_multi_cg_quda.cpp
+++ b/lib/inv_multi_cg_quda.cpp
@@ -362,7 +362,7 @@ namespace quda {
       printfQuda("MultiShift CG: Converged after %d iterations\n", k);
       for(int i=0; i < num_offset; i++) { 
 	printfQuda(" shift=%d, relative residual: iterated = %e, true = %e\n", 
-		   i, sqrt(r2[i]/b2), param.true_res_offset[i]);
+		   i, param.iter_res_offset[i], param.true_res_offset[i]);
       }
     }
 

--- a/lib/inv_multi_cg_quda.cpp
+++ b/lib/inv_multi_cg_quda.cpp
@@ -350,6 +350,7 @@ namespace quda {
       }
       double true_res = xmyNormCuda(b, *r);
       param.true_res_offset[i] = sqrt(true_res/b2);
+      param.iter_res_offset[i] = sqrt(r2[i]/b2);
 #if (__COMPUTE_CAPABILITY__ >= 200)
       param.true_res_hq_offset[i] = sqrt(HeavyQuarkResidualNormCuda(*x[i], *r).z);
 #else
@@ -363,7 +364,8 @@ namespace quda {
 	printfQuda(" shift=%d, relative residual: iterated = %e, true = %e\n", 
 		   i, sqrt(r2[i]/b2), param.true_res_offset[i]);
       }
-    }      
+    }
+
   
     // reset the flops counters
     quda::blas_flops = 0;


### PR DESCRIPTION
MILC does not stop higher shifts in the multi shift CG solver. They are iterated until zeta becomes zero or the 0th shift converges.
This increases the precision of the higher shifts beyond the specified tolerance.

This could not be mimicked with the mixed precision multi shift solver (with a pure double precision solver quda accepted 0 as residual for the higher shifts and did not use internal refinement for these shifts).
Quda now accepts 0 as tolerance for higher shifts when using mixed precision. The higher shifts are then refined to the iterated residual from the multi shift solve or until the precision is maxed out (10^(-2*cuda_prec+1), e.g.. 1e-15 for double precision.