### PR TITLE
Hotfix/mr solver

### DIFF
--- a/lib/blas_quda.cu
+++ b/lib/blas_quda.cu
@@ -436,7 +436,7 @@ namespace quda {
   /**
      double caxpyXmazCuda(c a, V x, V y, V z){}
    
-     First performs the operation y[i] = a*x[i] + y[i]
+     First performs the operation y[i] += a*x[i]
      Second performs the operator x[i] -= a*z[i]
   */
   template <typename Float2, typename FloatN>
@@ -444,7 +444,7 @@ namespace quda {
     Float2 a;
     caxpyxmaz(const Float2 &a, const Float2 &b, const Float2 &c) : a(a) { ; }
     __device__ void operator()(FloatN &x, FloatN &y, const FloatN &z, const FloatN &w) 
-    { caxpy_(a, x, y); x-= a.x*z; }
+    { caxpy_(a, x, y); caxpy_(-a, z, x); }
     static int streams() { return 5; } //! total number of input and output streams
     static int flops() { return 8; } //! flops per element
   };
@@ -459,7 +459,7 @@ namespace quda {
      double tripleCGUpdate(d a, d b, V x, V y, V z, V w){}
    
      First performs the operation y[i] = y[i] - a*x[i] 
-     Second performs the operatio z[i] = z[i] + a*w[i]
+     Second performs the operation z[i] = z[i] + a*w[i]
      Third performs the operation w[i] = y[i] + b*w[i]
 
      First performs the operatio y[i] = y[i] + a*w[i]

--- a/lib/inv_mr_quda.cpp
+++ b/lib/inv_mr_quda.cpp
@@ -124,15 +124,22 @@ namespace quda {
 	param.gflops += gflops;
 	param.iter += k;
 	
-	// Calculate the true residual
+	// this is the relative residual since it has been scaled by b2
 	r2 = norm2(r);
-	mat(r, x);
-	double true_res = xmyNormCuda(b, r);
-	param.true_res = sqrt(true_res / b2);
 
-	if (getVerbosity() >= QUDA_SUMMARIZE) {
-	  printfQuda("MR: Converged after %d iterations, relative residua: iterated = %e, true = %e\n", 
-		     k, sqrt(r2/b2), param.true_res);    
+	if (param.preserve_source == QUDA_PRESERVE_SOURCE_YES) {
+	  // Calculate the true residual
+	  mat(r, x);
+	  double true_res = xmyNormCuda(b, r);
+	  param.true_res = sqrt(true_res / b2);
+	  if (getVerbosity() >= QUDA_SUMMARIZE) {
+	    printfQuda("MR: Converged after %d iterations, relative residua: iterated = %e, true = %e\n",
+		       k, sqrt(r2), param.true_res);
+	  }
+	} else {
+	  if (getVerbosity() >= QUDA_SUMMARIZE) {
+	    printfQuda("MR: Converged after %d iterations, relative residua: iterated = %e\n", k, sqrt(r2));
+	  }
 	}
 
 	// reset the flops counters

--- a/lib/reduce_quda.cu
+++ b/lib/reduce_quda.cu
@@ -393,7 +393,7 @@ namespace quda {
   /**
      double caxpyXmayNormCuda(float a, float *x, float *y, n){}
    
-     First performs the operation y[i] = a*x[i] + y[i]
+     First performs the operation y[i] += a*x[i]
      Second performs the operator x[i] -= a*z[i]
      Third returns the norm of x
   */
@@ -405,7 +405,7 @@ namespace quda {
 #endif
     Float2 a;
     caxpyxmaznormx(const Float2 &a, const Float2 &b) : a(a) { ; }
-    __device__ void operator()(ReduceType &sum, FloatN &x, FloatN &y, FloatN &z, FloatN &w, FloatN &v) { Caxpy_(a, x, y); x-= a.x*z; sum += norm2_(x); }
+    __device__ void operator()(ReduceType &sum, FloatN &x, FloatN &y, FloatN &z, FloatN &w, FloatN &v) { Caxpy_(a, x, y); Caxpy_(-a, z, x); sum += norm2_(x); }
     static int streams() { return 5; } //! total number of input and output streams
     static int flops() { return 10; } //! flops per element
   };

--- a/tests/invert_test.cpp
+++ b/tests/invert_test.cpp
@@ -54,6 +54,7 @@ extern double tol_hq; // heavy-quark tolerance for inverter
 extern QudaMassNormalization normalization; // mass normalization of Dirac operators
 extern QudaMatPCType matpc_type; // preconditioning type
 
+extern int niter; // max solver iterations
 extern char latfile[];
 
 extern void usage(char** );
@@ -180,8 +181,8 @@ int main(int argc, char **argv)
   }
 
   // offsets used only by multi-shift solver
-  inv_param.num_offset = 4;
-  double offset[4] = {0.01, 0.02, 0.03, 0.04};
+  inv_param.num_offset = 12;
+  double offset[12] = {0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09, 0.1, 0.11, 0.12};
   for (int i=0; i<inv_param.num_offset; i++) inv_param.offset[i] = offset[i];
 
   inv_param.inv_type = inv_type;
@@ -237,7 +238,7 @@ int main(int argc, char **argv)
     inv_param.tol_offset[i] = inv_param.tol;
     inv_param.tol_hq_offset[i] = inv_param.tol_hq;
   }
-  inv_param.maxiter = 10000;
+  inv_param.maxiter = niter;
   inv_param.reliable_delta = 1e-1;
   inv_param.use_sloppy_partial_accumulator = 0;
   inv_param.max_res_increase = 1;
@@ -256,7 +257,7 @@ int main(int argc, char **argv)
   inv_param.cpu_prec = cpu_prec;
   inv_param.cuda_prec = cuda_prec;
   inv_param.cuda_prec_sloppy = cuda_prec_sloppy;
-  inv_param.preserve_source = QUDA_PRESERVE_SOURCE_NO;
+  inv_param.preserve_source = QUDA_PRESERVE_SOURCE_YES;
   inv_param.gamma_basis = QUDA_DEGRAND_ROSSI_GAMMA_BASIS;
   inv_param.dirac_order = QUDA_DIRAC_ORDER;
 

--- a/tests/test_util.cpp
+++ b/tests/test_util.cpp
@@ -1566,7 +1566,7 @@ int gridsize_from_cmdline[4] = {1,1,1,1};
 QudaDslashType dslash_type = QUDA_WILSON_DSLASH;
 char latfile[256] = "";
 bool tune = true;
-int niter = 10;
+int niter = 100;
 int test_type = 0;
 QudaInverterType inv_type;
 QudaInverterType precon_type = QUDA_INVALID_INVERTER;


### PR DESCRIPTION
This fixes a long-standing bug in the MR solver, which led to incorrect convergence in the solver.  Also some minor clean up of tests/invert_test adding support for the `--niter` flag to set the maximum number of solver iterations.