### PR TITLE
Hotfix/qmp gpuid

### DIFF
--- a/lib/comm_qmp.cpp
+++ b/lib/comm_qmp.cpp
@@ -37,7 +37,7 @@ void comm_init(int ndim, const int *dims, QudaCommsMap rank_from_coords, void *m
 
   // determine which GPU this rank will use
   char *hostname = comm_hostname();
-  char *hostname_recv_buf = (char *)safe_malloc(128*size);
+  char *hostname_recv_buf = (char *)safe_malloc(128*comm_size());
 
   // Abuse reductions to emulate all-gather.  We need to copy the
   // local hostname to all other nodes
@@ -56,7 +56,7 @@ void comm_init(int ndim, const int *dims, QudaCommsMap rank_from_coords, void *m
   }
 
   gpuid = 0;
-  for (int i = 0; i < rank; i++) {
+  for (int i = 0; i < comm_rank(); i++) {
     if (!strncmp(hostname, &hostname_recv_buf[128*i], 128)) {
       gpuid++;
     }

--- a/lib/comm_qmp.cpp
+++ b/lib/comm_qmp.cpp
@@ -35,7 +35,33 @@ void comm_init(int ndim, const int *dims, QudaCommsMap rank_from_coords, void *m
   Topology *topo = comm_create_topology(ndim, dims, rank_from_coords, map_data);
   comm_set_default_topology(topo);
 
-  // determine which GPU this process will use (FIXME: adopt the scheme in comm_mpi.cpp)
+  // determine which GPU this rank will use
+  char *hostname = comm_hostname();
+  char *hostname_recv_buf = (char *)safe_malloc(128*size);
+
+  // Abuse reductions to emulate all-gather.  We need to copy the
+  // local hostname to all other nodes
+  for (int i=0; i<comm_size(); i++) {
+    int data[128];
+    for (int j=0; j<128; j++) {
+      data[j] = (i == comm_rank()) ? hostname[j] : 0;
+    }
+    // check nasty int to float hack is valid
+    if (sizeof(float) != sizeof(int)) errorQuda("Broken");
+    QMP_sum_float_array(reinterpret_cast<float*>(&data), 128);
+
+    for (int j=0; j<128; j++) {
+      hostname_recv_buf[i*128 + j] = data[j];
+    }
+  }
+
+  gpuid = 0;
+  for (int i = 0; i < rank; i++) {
+    if (!strncmp(hostname, &hostname_recv_buf[128*i], 128)) {
+      gpuid++;
+    }
+  }
+  host_free(hostname_recv_buf);
 
   int device_count;
   cudaGetDeviceCount(&device_count);

--- a/lib/comm_qmp.cpp
+++ b/lib/comm_qmp.cpp
@@ -16,6 +16,15 @@ struct MsgHandle_s {
 
 static int gpuid = -1;
 
+// this is a work around (in the absence of C++11) to do a compile
+// time check that the size of float and int are the same.  Since we
+// are reinterpretting a float as an int, this property is required.
+template <typename A, typename B>
+inline void static_assert_equal_size()
+{
+  typedef char sizeof_float_must_equal_sizeof_int[sizeof(A) == sizeof(B) ? 1 : -1];
+  (void) sizeof(sizeof_float_must_equal_sizeof_int);
+}
 
 void comm_init(int ndim, const int *dims, QudaCommsMap rank_from_coords, void *map_data)
 {
@@ -47,7 +56,7 @@ void comm_init(int ndim, const int *dims, QudaCommsMap rank_from_coords, void *m
       data[j] = (i == comm_rank()) ? hostname[j] : 0;
     }
     // check nasty int to float hack is valid
-    if (sizeof(float) != sizeof(int)) errorQuda("Broken");
+    static_assert_equal_size<float,int>();
     QMP_sum_float_array(reinterpret_cast<float*>(&data), 128);
 
     for (int j=0; j<128; j++) {


### PR DESCRIPTION
This pull fixes an issue when using the QMP backend on multiple nodes with multiple GPUs: the GPU ID assignment would result in multiple MPI processes sharing the same GPU if the process mapping is done round-robin between the nodes.

This fixes the issue by using the same mechanism adopted by the MPI backend, where we make a local array holding all the hostnames of all processes.  Locally, we iterate`i` from 0 to `comm_rank()`, and every time my hostname matches an entry in the array up to rank we increment the variable `gpuid`.  This ensures that each process will have a unique `gpuid`.

In QMP this is a bit of a hack since there is no all-gather algorithm, so we mimic this using reductions.  Furthermore, since there is no integer array reductions in QMP, and we wish to avoid having to do a reduction for every element of the hostname array, we use the `QMP_sum_float_array` to achieve this.
