### PR TITLE
Hotfix/blas_tuning_speedup

### DIFF
--- a/include/tune_quda.h
+++ b/include/tune_quda.h
@@ -57,7 +57,7 @@ namespace quda {
     virtual bool advanceGridDim(TuneParam &param) const
     {
       if (tuneGridDim()) {
-	const unsigned int max_blocks = 256; // FIXME: set a reasonable value for blas currently
+	const unsigned int max_blocks = 2*deviceProp.multiProcessorCount;
 	const int step = 1;
 	param.grid.x += step;
 	if (param.grid.x > max_blocks) {


### PR DESCRIPTION
When tuning the grid size of a kernel, set the maximum size grid size based on the streaming multiprocessor (SM) count instead of the arbitrary previous value of 256.  Here we use 2xSM count since it allows for two CTAs to be simultaneously resident in an SM, which may be desirable where we wish to allocate all resources of an SM, e.g. using all the shared memory on a GM200 requires 2 thread blocks per SM.

A comparison against the previous value (256) shows no performance degradation on GM200 (48 blocks), however the tuning time is cut by a factor of 5x.