### PR TITLE
copy include directory to cmake build directory

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -61,6 +61,8 @@ cuda_add_library(quda STATIC ${QUDA_OBJS})
 if(GITVERSION)
   ADD_DEPENDENCIES(quda git_version)
 endif()
+ADD_CUSTOM_COMMAND(TARGET quda POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/include ${CMAKE_BINARY_DIR}/include)
+
 
 add_custom_target(gen ${PYTHON_EXECUTABLE} generate/gen.py
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}


### PR DESCRIPTION
Application like MILC expect to find

`QUDA_HOME/lib/libquda.a`
`QUDA_HOME/include/`

For out of source builds with cmake the include dir was missing as QUDA_HOME now points to a build dir.
In the end this should probably be fixed by using make install but as a quick solution we can just copy the include directory from the source to the build dir.