### PR TITLE
Minor fixes for llfat and link unitarization test

### DIFF
--- a/lib/llfat_quda_itf.cpp
+++ b/lib/llfat_quda_itf.cpp
@@ -44,7 +44,7 @@ namespace quda {
 
       }
 
-      if (cudaLongLink->Reconstruct() != QUDA_RECONSTRUCT_NO) {
+      if (cudaLongLink && cudaLongLink->Reconstruct() != QUDA_RECONSTRUCT_NO) {
 	errorQuda("Long-link must have no reconstruction set");
       }
 

--- a/tests/unitarize_link_test.cpp
+++ b/tests/unitarize_link_test.cpp
@@ -47,7 +47,7 @@ extern int gridsize_from_cmdline[];
 extern QudaReconstructType link_recon;
 extern QudaPrecision prec;
 static QudaPrecision cpu_prec = QUDA_DOUBLE_PRECISION;
-static QudaGaugeFieldOrder gauge_order = QUDA_QDP_GAUGE_ORDER;
+static QudaGaugeFieldOrder gauge_order = QUDA_MILC_GAUGE_ORDER;
 
 static size_t gSize;
 
@@ -99,6 +99,10 @@ unitarize_link_test()
 
   qudaGaugeParam.cpu_prec = cpu_prec;
   qudaGaugeParam.cuda_prec = prec;
+
+  if (gauge_order != QUDA_MILC_GAUGE_ORDER)
+    errorQuda("Unsupported gauge order %d", gauge_order);
+
   qudaGaugeParam.gauge_order = gauge_order;
   qudaGaugeParam.type=QUDA_WILSON_LINKS;
   qudaGaugeParam.reconstruct = link_recon;
@@ -181,14 +185,8 @@ unitarize_link_test()
 		    QUDA_COMPUTE_FAT_STANDARD);
 
 
-  void* fatlink_2d[4];
-  for(int dir=0; dir<4; ++dir){
-    fatlink_2d[dir] = (char*)fatlink + dir*V*gaugeSiteSize*gSize;
-  }
-
-
   gParam.create = QUDA_REFERENCE_FIELD_CREATE;
-  gParam.gauge  = fatlink_2d;
+  gParam.gauge  = fatlink;
   cpuGaugeField *cpuOutLink  = new cpuGaugeField(gParam);
 
   


### PR DESCRIPTION
Minor clean up of llfat routine and unitarize_link_test to avoid bad memory access when running this test.