### PR TITLE
Warn about deprecation of configure / autoconf

### DIFF
--- a/configure
+++ b/configure
@@ -743,6 +743,7 @@ enable_magma
 enable_blas_tex
 enable_fermi_double_tex
 enable_numa_affinity
+enable_force_ac
 '
       ac_precious_vars='build_alias
 host_alias
@@ -1436,6 +1437,8 @@ Optional Features:
                           (default: enabled)
   --enable-numa-affinity  Enable NUMA affinity support (default: enabled,
                           always disabled on osx target)
+  --enable-force-ac       Force using deprecated autoconf based build system.
+                          (default: disabled)
 
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
@@ -4010,6 +4013,16 @@ else
 fi
 
 
+# Check whether --enable-force-ac was given.
+if test "${enable_force_ac+set}" = set; then :
+  enableval=$enable_force_ac;  force_ac=${enableval}
+else
+   force_ac="no"
+
+fi
+
+
+
 case ${cpu_arch} in
 x86 | x86_64 ) ;;
 *)
@@ -4585,6 +4598,38 @@ QDP_INSTALL_PATH=${qdp_home}
 { $as_echo "$as_me:${as_lineno-$LINENO}: Setting BUILD_MAGMA = ${build_magma}" >&5
 $as_echo "$as_me: Setting BUILD_MAGMA = ${build_magma}" >&6;}
 BUILD_MAGMA=${build_magma}
+
+
+if test "X${force_ac}X" = "XnoX";
+  then
+    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING:
+    Note that of QUDA 0.8.0 configure (autoconf) is deprecated.
+    Please consider switching to the new cmake based build system.
+    See https://github.com/lattice/quda/wiki/Building-QUDA-with-cmake
+
+    This warning will be turned into an error soon (use --enable-force-ac to turn it off).
+    At some point configure (autoconf) will no longer be maintained and removed from QUDA.
+    " >&5
+$as_echo "$as_me: WARNING:
+    Note that of QUDA 0.8.0 configure (autoconf) is deprecated.
+    Please consider switching to the new cmake based build system.
+    See https://github.com/lattice/quda/wiki/Building-QUDA-with-cmake
+
+    This warning will be turned into an error soon (use --enable-force-ac to turn it off).
+    At some point configure (autoconf) will no longer be maintained and removed from QUDA.
+    " >&2;}
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING:
+  If you require --enable-force-ac please file a bug on https://github.com/lattice/quda
+  This will allow us to make sure you can build quda with cmake (required in the future).
+
+  " >&5
+$as_echo "$as_me: WARNING:
+  If you require --enable-force-ac please file a bug on https://github.com/lattice/quda
+  This will allow us to make sure you can build quda with cmake (required in the future).
+
+  " >&2;}
+fi
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -327,6 +327,13 @@ AC_ARG_ENABLE(numa-affinity,
  [ numa_affinity=${enableval}],
  [ numa_affinity="yes" ]
 )
+
+AC_ARG_ENABLE(force-ac,
+  AC_HELP_STRING([--enable-force-ac], [ Force using deprecated autoconf based build system. (default: disabled)]),
+  [ force_ac=${enableval} ],
+  [ force_ac="no" ]
+)
+
 dnl Input validation
 
 dnl CPU Arch
@@ -841,6 +848,25 @@ AC_SUBST( QDP_INSTALL_PATH, [${qdp_home} ])
 
 AC_MSG_NOTICE([Setting BUILD_MAGMA = ${build_magma}])
 AC_SUBST( BUILD_MAGMA, [${build_magma}])
+
+if test "X${force_ac}X" = "XnoX";
+  then
+    AC_MSG_WARN([
+    Note that of QUDA 0.8.0 configure (autoconf) is deprecated.
+    Please consider switching to the new cmake based build system.
+    See https://github.com/lattice/quda/wiki/Building-QUDA-with-cmake
+
+    This warning will be turned into an error soon (use --enable-force-ac to turn it off).
+    At some point configure (autoconf) will no longer be maintained and removed from QUDA.
+    ])
+else
+  AC_MSG_WARN([
+  If you require --enable-force-ac please file a bug on https://github.com/lattice/quda
+  This will allow us to make sure you can build quda with cmake (required in the future).
+  ]
+  )
+fi
+
 
 
 AC_CONFIG_FILES(make.inc)


### PR DESCRIPTION
This introduces a warning message at the end of the `configure` run.
```
configure: WARNING:
    Note that of QUDA 0.8.0 configure (autoconf) is deprecated.
    Please consider switching to the new cmake based build system.
    See https://github.com/lattice/quda/wiki/Building-QUDA-with-cmake

    This warning will be turned into an error soon (use --enable-force-ac to turn it off).
    At some point configure (autoconf) will no longer be maintained and removed from QUDA.
```
This message should be later turned into a hard error.

A new flag `--enable-force-ac` is introduced to turn off the warning / error but prints a request to file a bug so we can make sure cmake can be used in the future.

```
configure: WARNING:
  If you require --enable-force-ac please file a bug on https://github.com/lattice/quda
  This will allow us to make sure you can build quda with cmake (required in the future).
```