### PR TITLE
Hotfix/clover half

### DIFF
--- a/include/clover_field.h
+++ b/include/clover_field.h
@@ -43,7 +43,7 @@ namespace quda {
     void *norm;
     void *cloverInv;
     void *invNorm;
-//new!
+
     bool twisted; 
     double mu2;
 

--- a/include/clover_field_order.h
+++ b/include/clover_field_order.h
@@ -60,23 +60,19 @@ namespace quda {
       const int volumeCB;
       const int stride;
 
-      /*	NEW FOR CLOVER + TWISTED MASS (ALEX)	*/
-
       const bool twisted;
       const Float mu2;
 
       FloatNOrder(const CloverField &clover, bool inverse, Float *clover_=0, float *norm_=0) : volumeCB(clover.VolumeCB()), stride(clover.Stride()),
-      twisted(clover.Twisted()), mu2(clover.Mu2()) {
+	twisted(clover.Twisted()), mu2(clover.Mu2()) {
 	this->clover[0] = clover_ ? clover_ : (Float*)(clover.V(inverse));
 	this->clover[1] = (Float*)((char*)this->clover[0] + clover.Bytes()/2);
 	this->norm[0] = norm_ ? norm_ : (float*)(clover.Norm(inverse));
 	this->norm[1] = (float*)((char*)this->norm[0] + clover.NormBytes()/2);
       }
       
-      bool  Twisted()	const	{return twisted;}
-      Float Mu2()	const	{return mu2;}
-
-      /*	END OF MODIFICATIONS	*/
+      bool  Twisted()	const	{ return twisted; }
+      Float Mu2()	const	{ return mu2; }
 
       __device__ __host__ inline void load(RegType v[length], int x, int parity) const {
 	const int M=length/(N*2);
@@ -86,7 +82,7 @@ namespace quda {
 	      int intIdx = (chirality*M + i)*N + j; // internal dof index
 	      int padIdx = intIdx / N;
 	      copy(v[(chirality*M+i)*N+j], clover[parity][(padIdx*stride + x)*N + intIdx%N]);
-	      if (sizeof(Float)==sizeof(short)) v[(chirality*M+i)*N+j] *= norm[parity][chirality*volumeCB + x];
+	      if (sizeof(Float)==sizeof(short)) v[(chirality*M+i)*N+j] *= norm[parity][chirality*stride + x];
 	    }
 	  }
 	}
@@ -101,7 +97,7 @@ namespace quda {
 	    scale[chi] = 0.0;
 	    for (int i=0; i<M; i++) 
 	      scale[chi] = fabs(v[chi*M+i]) > scale[chi] ? fabs(v[chi*M+i]) : scale[chi];
-	    norm[parity][chi*volumeCB + x] = scale[chi];
+	    norm[parity][chi*stride + x] = scale[chi];
 	  }
 	}
 

--- a/lib/clover_field.cpp
+++ b/lib/clover_field.cpp
@@ -24,10 +24,10 @@ namespace quda {
     length = 2*stride*nColor*nColor*nSpin*nSpin/2;
 
     bytes = length*precision;
-    bytes = ALIGNMENT_ADJUST(bytes);
+    bytes = 2*ALIGNMENT_ADJUST(bytes/2);
     if (precision == QUDA_HALF_PRECISION) {
       norm_bytes = sizeof(float)*2*stride*2; // 2 chirality
-      norm_bytes = ALIGNMENT_ADJUST(norm_bytes);
+      norm_bytes = 2*ALIGNMENT_ADJUST(norm_bytes/2);
     }
 //for twisted mass only:
     twisted = false;//param.twisted;
@@ -63,10 +63,10 @@ namespace quda {
       }
 
       even = clover;
-      odd = (char*)clover + bytes/2;
+      odd = static_cast<char*>(clover) + bytes/2;
     
       evenNorm = norm;
-      oddNorm = (char*)norm + norm_bytes/2;
+      oddNorm = static_cast<char*>(norm) + norm_bytes/2;
 
       total_bytes += bytes + norm_bytes;
 
@@ -91,10 +91,10 @@ namespace quda {
       }
 
       evenInv = cloverInv;
-      oddInv = (char*)cloverInv + bytes/2;
+      oddInv = static_cast<char*>(cloverInv) + bytes/2;
     
       evenInvNorm = invNorm;
-      oddInvNorm = (char*)invNorm + norm_bytes/2;
+      oddInvNorm = static_cast<char*>(invNorm) + norm_bytes/2;
 
       total_bytes += bytes + norm_bytes;
 
@@ -223,7 +223,7 @@ namespace quda {
     } else if (typeid(src) == typeid(cpuCloverField)) {
       resizeBufferPinned(bytes + norm_bytes);
       void *packClover = bufferPinned[0];
-      void *packCloverNorm = (precision == QUDA_HALF_PRECISION) ? (char*)bufferPinned[0] + bytes : 0;
+      void *packCloverNorm = (precision == QUDA_HALF_PRECISION) ? static_cast<char*>(bufferPinned[0]) + bytes : 0;
       
       if (src.V(false)) {
 	copyGenericClover(*this, src, false, QUDA_CPU_FIELD_LOCATION, packClover, 0, packCloverNorm, 0);
@@ -268,6 +268,8 @@ namespace quda {
       cloverInv = param.cloverInv;
       invNorm = param.invNorm;
     }
+
+    if (param.pad != 0) errorQuda("%s pad must be zero", __func__);
   }
 
   cpuCloverField::~cpuCloverField() { 

--- a/lib/inv_cg_quda.cpp
+++ b/lib/inv_cg_quda.cpp
@@ -322,7 +322,7 @@ namespace quda {
       printfQuda("CG: Reliable updates = %d\n", rUpdate);
 
     // compute the true residuals
-    mat(r, x, y);
+    mat(r, x, y, tmp3);
     param.true_res = sqrt(xmyNormCuda(b, r) / b2);
     param.true_res_hq = sqrt(HeavyQuarkResidualNormCuda(x,r).z);
 

--- a/lib/inv_cg_quda.cpp
+++ b/lib/inv_cg_quda.cpp
@@ -271,8 +271,7 @@ namespace quda {
 	  // perform a restart
 	  copyCuda(p, rSloppy);
 	  heavy_quark_restart = false;
-	}
-	else {
+	} else {
 	  // explicitly restore the orthogonality of the gradient vector
 	  double rp = reDotProductCuda(rSloppy, p) / (r2);
 	  axpyCuda(-rp, rSloppy, p);
@@ -293,11 +292,11 @@ namespace quda {
       // check convergence, if convergence is satisfied we only need to check that we had a reliable update for the heavy quarks recently
       converged = convergence(r2, heavy_quark_res, stop, param.tol_hq);
       
-      // check for recent enough relibale updates of the HQ residual if we use it
+      // check for recent enough reliable updates of the HQ residual if we use it
       if (use_heavy_quark_res) {
         // L2 is concverged or precision maxed out for L2
         bool L2done = L2breakdown or convergenceL2(r2, heavy_quark_res, stop, param.tol_hq);
-        // HQ is converged and if we do reliable update the HQ residual has been caclculated using a reliable update
+        // HQ is converged and if we do reliable update the HQ residual has been calculated using a reliable update
         bool HQdone = (steps_since_reliable == 0 and param.delta > 0) and convergenceHQ(r2, heavy_quark_res, stop, param.tol_hq);
         converged = L2done and HQdone;
       }

--- a/lib/solver.cpp
+++ b/lib/solver.cpp
@@ -137,7 +137,8 @@ namespace quda {
   void Solver::PrintSummary(const char *name, int k, const double &r2, const double &b2) {
     if (getVerbosity() >= QUDA_SUMMARIZE) {
       if (param.residual_type & QUDA_HEAVY_QUARK_RESIDUAL) {
-	printfQuda("%s: Convergence at %d iterations, L2 relative residual: iterated = %e, true = %e, heavy-quark residual = %e\n", name, k, sqrt(r2/b2), param.true_res, param.true_res_hq);    
+	printfQuda("%s: Convergence at %d iterations, L2 relative residual: iterated = %e, true = %e, heavy-quark residual = %e\n",
+		   name, k, sqrt(r2/b2), param.true_res, param.true_res_hq);
       } else {
 	printfQuda("%s: Convergence at %d iterations, L2 relative residual: iterated = %e, true = %e\n", 
 		   name, k, sqrt(r2/b2), param.true_res);


### PR DESCRIPTION
Does the following:
* Fixes a bug in `clover::FloatNOrder` whereby the norm should be using stride not volumeCB, as the stride between chiralities
* Fixes an alignment bug in clover allocation (align over each parity, not the entire field)
* Minor performance and memory fix in CG: use the already allocated temporary in CG for the final residual computation