### PR TITLE
Removed default parameters from destroyDeflationQuda 

### DIFF
--- a/include/quda.h
+++ b/include/quda.h
@@ -946,7 +946,7 @@ extern "C" {
   * Clean deflation solver resources.
   *
   **/
-  void destroyDeflationQuda(QudaInvertParam *param, const int *X = NULL, void *_h_u = NULL, double *inv_eigenvals = NULL);
+  void destroyDeflationQuda(QudaInvertParam *param, const int *X, void *_h_u, double *inv_eigenvals);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The `destroyDeflationQuda` interface used default parameters which broke the C compatibility of the interface.  This removes these restoring the C-compatible interface.