### PR TITLE
Hotfix/solve verbosity

### DIFF
--- a/lib/inv_cg_quda.cpp
+++ b/lib/inv_cg_quda.cpp
@@ -242,8 +242,12 @@ namespace quda {
 	  warningQuda("CG: new reliable residual norm %e is greater than previous reliable residual norm %e (total #inc %i)",
 		      sqrt(r2), r0Norm, resIncreaseTotal);
 	  if ( resIncrease > maxResIncrease or resIncreaseTotal > maxResIncreaseTotal) {
-            if (use_heavy_quark_res) L2breakdown = true;
-            else break;
+            if (use_heavy_quark_res) {
+	      L2breakdown = true;
+            } else {
+	      warningQuda("CG: solver exiting due to too many true residual norm increases");
+	      break;
+	    }
 	  }
 	} else {
 	  resIncrease = 0;
@@ -257,7 +261,10 @@ namespace quda {
 	    hqresIncrease++;
 	    warningQuda("CG: new reliable HQ residual norm %e is greater than previous reliable residual norm %e", heavy_quark_res, heavy_quark_res_old);
 	    // break out if we do not improve here anymore
-	    if (hqresIncrease > hqmaxresIncrease) break;
+	    if (hqresIncrease > hqmaxresIncrease) {
+	      warningQuda("CG: solver exiting due to too many heavy quark residual norm increases");
+	      break;
+	    }
 	  }
 	}
 

--- a/lib/inv_gcr_quda.cpp
+++ b/lib/inv_gcr_quda.cpp
@@ -361,7 +361,10 @@ namespace quda {
 	  resIncreaseTotal++;
 	  warningQuda("GCR: new reliable residual norm %e is greater than previous reliable residual norm %e (total #inc %i)",
 		      sqrt(r2), sqrt(r2_old), resIncreaseTotal);
-	  if (resIncrease > maxResIncrease or resIncreaseTotal > maxResIncreaseTotal) break;
+	  if (resIncrease > maxResIncrease or resIncreaseTotal > maxResIncreaseTotal) {
+	    warningQuda("GCR: solver exiting due to too many true residual norm increases");
+	    break;
+	  }
 	} else {
 	  resIncrease = 0;
 	}

--- a/lib/inv_multi_cg_quda.cpp
+++ b/lib/inv_multi_cg_quda.cpp
@@ -357,8 +357,10 @@ namespace quda {
 	  warningQuda("MultiShiftCG: Shift %d, updated residual %e is greater than previous residual %e (total #inc %i)", 
 		      reliable_shift, sqrt(r2[reliable_shift]), r0Norm[reliable_shift], resIncreaseTotal[reliable_shift]);
 
-
-	  if (resIncrease > maxResIncrease or resIncreaseTotal[reliable_shift] > maxResIncreaseTotal) break; // check if we reached the limit of our tolerancebreak;
+	  if (resIncrease > maxResIncrease or resIncreaseTotal[reliable_shift] > maxResIncreaseTotal) {
+	    warningQuda("MultiShiftCG: solver exiting due to too many true residual norm increases");
+	    break;
+	  }
 	} else {
 	  resIncrease = 0;
 	}

--- a/tests/deflation_test.cpp
+++ b/tests/deflation_test.cpp
@@ -461,7 +461,7 @@ int main(int argc, char **argv)
   time0 += clock();
   time0 /= CLOCKS_PER_SEC;
 
-  destroyDeflationQuda(&inv_param);
+  destroyDeflationQuda(&inv_param, NULL, NULL, NULL);
 
   closeMagma();
     


### PR DESCRIPTION
* When solvers exit owing to too many residual norm increases then issue a warning to this effect
* Fixes bug in deflation_test that assumed C++ default parameters