### PR TITLE
QUDA Auto Profiling

### DIFF
--- a/README
+++ b/README
@@ -129,6 +129,15 @@ between jobs running on different systems (e.g., two clusters
 with different GPUs installed).  Attempting to use parameters tuned
 for one card on a different card may lead to unexpected errors.
 
+This autotuning information can also be used to build up a first-order
+kernel profile: since the autotuner measures how long a kernel takes
+to run, if we simply keep track of the number of kernel calls, from
+the product of these two quantities we have a time profile of a given
+job run.  If QUDA_RESOURCE_PATH is set, then this profiling
+information is output to the file "profile.tsv" in this specified
+directory.  Optionally, the output filename can be specified using the
+QUDA_PROFILE_OUTPUT environment variable, to avoid overwriting
+previously generated profile outputs.
 
 Using the Library:
 

--- a/include/tune_quda.h
+++ b/include/tune_quda.h
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <iomanip>
 #include <cstring>
+#include <cfloat>
 #include <stdarg.h>
 #include <tune_key.h>
 
@@ -20,16 +21,22 @@ namespace quda {
     dim3 grid;
     int shared_bytes;
     std::string comment;
+    float time;
+    long long n_calls;
 
-  TuneParam() : block(32, 1, 1), grid(1, 1, 1), shared_bytes(0) { }
-  TuneParam(const TuneParam &param)
-    : block(param.block), grid(param.grid), shared_bytes(param.shared_bytes), comment(param.comment) { }
+    TuneParam() : block(32, 1, 1), grid(1, 1, 1), shared_bytes(0), time(FLT_MAX), n_calls(0) { }
+
+    TuneParam(const TuneParam &param)
+      : block(param.block), grid(param.grid), shared_bytes(param.shared_bytes), comment(param.comment), time(param.time), n_calls(param.n_calls) { }
+
     TuneParam& operator=(const TuneParam &param) {
       if (&param != this) {
 	block = param.block;
 	grid = param.grid;
 	shared_bytes = param.shared_bytes;
 	comment = param.comment;
+	time = param.time;
+	n_calls = param.n_calls;
       }
       return *this;
     }
@@ -282,6 +289,8 @@ namespace quda {
 
   void loadTuneCache(QudaVerbosity verbosity);
   void saveTuneCache(QudaVerbosity verbosity);
+  void saveProfile(QudaVerbosity verbosity);
+
   TuneParam& tuneLaunch(Tunable &tunable, QudaTune enabled, QudaVerbosity verbosity);
 
 } // namespace quda

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -1227,6 +1227,7 @@ void endQuda(void)
 #endif
 
   saveTuneCache(getVerbosity());
+  saveProfile(getVerbosity());
 
 #if (!defined(USE_QDPJIT) && !defined(GPU_COMMS))
   // end this CUDA context

--- a/lib/tune.cpp
+++ b/lib/tune.cpp
@@ -9,6 +9,10 @@
 #include <typeinfo>
 #include <map>
 #include <unistd.h>
+
+#include <deque>
+#include <queue>
+#include <functional>
 #ifdef PTHREADS
 #include <pthread.h>
 #endif
@@ -68,7 +72,7 @@ namespace quda {
       if (check < 0 || check >= key.name_n) errorQuda("Error writing name string");
       check = snprintf(key.aux, key.aux_n, "%s", a.c_str());
       if (check < 0 || check >= key.aux_n) errorQuda("Error writing aux string");
-      ls >> param.grid.x >> param.grid.y >> param.grid.z >> param.shared_bytes;
+      ls >> param.grid.x >> param.grid.y >> param.grid.z >> param.shared_bytes >> param.time;
       ls.ignore(1); // throw away tab before comment
       getline(ls, param.comment); // assume anything remaining on the line is a comment
       param.comment += "\n"; // our convention is to include the newline, since ctime() likes to do this
@@ -91,8 +95,53 @@ namespace quda {
       out << key.volume << "\t" << key.name << "\t" << key.aux << "\t";
       out << param.block.x << "\t" << param.block.y << "\t" << param.block.z << "\t";
       out << param.grid.x << "\t" << param.grid.y << "\t" << param.grid.z << "\t";
-      out << param.shared_bytes << "\t" << param.comment; // param.comment ends with a newline
+      out << param.shared_bytes << "\t" << param.time << "\t" << param.comment; // param.comment ends with a newline
     }
+  }
+
+
+  template <class T>
+  struct less_significant : std::binary_function<T,T,bool> {
+    inline bool operator()(const T &lhs, const T &rhs) {
+      return lhs.second.time * lhs.second.n_calls < rhs.second.time * rhs.second.n_calls;
+    }
+  };
+
+  /**
+   * Serialize tunecache to an ostream, useful for writing to a file or sending to other nodes.
+   */
+  static void serializeProfile(std::ostream &out)
+  {
+    map::iterator entry;
+    double total_time = 0.0;
+
+    // first let's sort the entries in decreasing order of significance
+    typedef std::pair<TuneKey, TuneParam> profile_t;
+    typedef std::priority_queue<profile_t, std::deque<profile_t>, less_significant<profile_t> > queue_t;
+    queue_t q(tunecache.begin(), tunecache.end());
+
+    // now compute total time spent in kernels so we can give each kernel a significance
+    for (entry = tunecache.begin(); entry != tunecache.end(); entry++) {
+      TuneParam param = entry->second;
+      if (param.n_calls > 0) total_time += param.n_calls * param.time;
+    }
+
+
+    while ( !q.empty() ) {
+      TuneKey key = q.top().first;
+      TuneParam param = q.top().second;
+
+      if (param.n_calls > 0) {
+	double time = param.n_calls * param.time;
+
+	out << std::setw(12) << param.n_calls * param.time << "\t" << std::setw(12) << (time / total_time) * 100 << "\t" << std::setw(12) << param.n_calls << "\t" << std::setw(12) << param.time << "\t" << std::setw(15) << key.volume << "\t" << key.name << "\t" << key.aux << "\t";
+	out << param.shared_bytes << "\t" << param.comment; // param.comment ends with a newline
+      }
+
+      q.pop();
+    }
+
+    out << std::endl << "# Total time spent in kernels = " << total_time << " seconds" << std::endl;
   }
 
 
@@ -170,12 +219,12 @@ namespace quda {
 	ls >> token;
 	if (token.compare(quda_version)) errorQuda("Cache file %s does not match current QUDA version. \nPlease delete this file or set the QUDA_RESOURCE_PATH environment variable to point to a new path.", cache_path.c_str());
 	ls >> token;
-  #ifdef GITVERSION
+#ifdef GITVERSION
 	if (token.compare(gitversion)) errorQuda("Cache file %s does not match current QUDA version. \nPlease delete this file or set the QUDA_RESOURCE_PATH environment variable to point to a new path.", cache_path.c_str());
-  #else
-  if (token.compare(quda_version)) errorQuda("Cache file %s does not match current QUDA version. \nPlease delete this file or set the QUDA_RESOURCE_PATH environment variable to point to a new path.", cache_path.c_str());
-  #endif
-  ls >> token;
+#else
+	if (token.compare(quda_version)) errorQuda("Cache file %s does not match current QUDA version. \nPlease delete this file or set the QUDA_RESOURCE_PATH environment variable to point to a new path.", cache_path.c_str());
+#endif
+	ls >> token;
 	if (token.compare(quda_hash)) errorQuda("Cache file %s does not match current QUDA build. \nPlease delete this file or set the QUDA_RESOURCE_PATH environment variable to point to a new path.", cache_path.c_str());
 
 
@@ -260,7 +309,7 @@ namespace quda {
        cache_file << "\t" << quda_version;
 #endif
       cache_file << "\t" << quda_hash << "\t# Last updated " << ctime(&now) << std::endl;
-      cache_file << "volume\tname\taux\tblock.x\tblock.y\tblock.z\tgrid.x\tgrid.y\tgrid.z\tshared_bytes\tcomment" << std::endl;
+      cache_file << "volume\tname\taux\tblock.x\tblock.y\tblock.z\tgrid.x\tgrid.y\tgrid.z\tshared_bytes\ttime\tcomment" << std::endl;
       serializeTuneCache(cache_file);
       cache_file.close();
 
@@ -274,6 +323,68 @@ namespace quda {
     }
 #endif
   }
+
+
+  /**
+   * Write profile to disk.
+   */
+  void saveProfile(QudaVerbosity verbosity)
+  {
+    time_t now;
+    int lock_handle;
+    std::string lock_path, profile_path;
+    std::ofstream profile_file;
+
+    if (resource_path.empty()) return;
+
+#ifdef MULTI_GPU
+    if (comm_rank() == 0) {
+#endif
+
+      // Acquire lock.  Note that this is only robust if the filesystem supports flock() semantics, which is true for
+      // NFS on recent versions of linux but not Lustre by default (unless the filesystem was mounted with "-o flock").
+      lock_path = resource_path + "/profile.lock";
+      lock_handle = open(lock_path.c_str(), O_WRONLY | O_CREAT | O_EXCL, 0666);
+      if (lock_handle == -1) {
+	warningQuda("Unable to lock profile file.  Profile will not be saved to disk.  "
+		    "If you are certain that no other instances of QUDA are accessing this filesystem, "
+		    "please manually remove %s", lock_path.c_str());
+	return;
+      }
+      char msg[] = "If no instances of applications using QUDA are running,\n"
+	"this lock file shouldn't be here and is safe to delete.";
+      int stat = write(lock_handle, msg, sizeof(msg)); // check status to avoid compiler warning
+      if (stat == -1) warningQuda("Unable to write to lock file for some bizarre reason");
+
+      profile_path = resource_path + "/profile.tsv";
+      profile_file.open(profile_path.c_str());
+
+      if (verbosity >= QUDA_SUMMARIZE) {
+	printfQuda("Saving %d sets of cached parameters to %s\n", static_cast<int>(tunecache.size()), profile_path.c_str());
+      }
+
+      time(&now);
+
+      profile_file << "profile\t" << quda_version;
+#ifdef GITVERSION
+       profile_file << "\t" << gitversion;
+#else
+       profile_file << "\t" << quda_version;
+#endif
+      profile_file << "\t" << quda_hash << "\t# Last updated " << ctime(&now) << std::endl;
+      profile_file << std::setw(12) << "total time" << "\t" << std::setw(12) << "percentage" << "\t" << std::setw(12) << "calls" << "\t" << std::setw(12) << "time / call" << "\t" << std::setw(15) << "volume" << "\tname\taux\tcomment" << std::endl;
+      serializeProfile(profile_file);
+      profile_file.close();
+
+      // Release lock.
+      close(lock_handle);
+      remove(lock_path.c_str());
+
+#ifdef MULTI_GPU
+    }
+#endif
+  }
+
 
   static TimeProfile launchTimer("tuneLaunch");
 
@@ -315,15 +426,14 @@ namespace quda {
       launchTimer.TPSTART(QUDA_PROFILE_COMPUTE);
 #endif
 
-      //param = tunecache[key];
-      TuneParam param = it->second;
+      TuneParam &param = it->second;
 
 #ifdef LAUNCH_TIMER
       launchTimer.TPSTOP(QUDA_PROFILE_COMPUTE);
       launchTimer.TPSTART(QUDA_PROFILE_EPILOGUE);
 #endif
 
-      tunable.checkLaunchParam(it->second);
+      tunable.checkLaunchParam(param);
 
 #ifdef LAUNCH_TIMER
       launchTimer.TPSTOP(QUDA_PROFILE_EPILOGUE);
@@ -335,7 +445,9 @@ namespace quda {
       //tally--;
       //printfQuda("pthread_mutex_unlock a complete %d\n",tally);
 #endif
-      return it->second;
+      param.n_calls++;
+
+      return param;
     }
 
 #ifdef LAUNCH_TIMER
@@ -383,9 +495,7 @@ namespace quda {
 	tunable.checkLaunchParam(param);
 	cudaEventRecord(start, 0);
 	for (int i=0; i<tunable.tuningIter(); i++) {
-    if (verbosity >= QUDA_DEBUG_VERBOSE) {
-          printfQuda("About to call tunable.apply\n");
-        }
+	  if (verbosity >= QUDA_DEBUG_VERBOSE) printfQuda("About to call tunable.apply\n");
 	  tunable.apply(0);  // calls tuneLaunch() again, which simply returns the currently active param
 	}
 	cudaEventRecord(end, 0);
@@ -426,6 +536,8 @@ namespace quda {
       best_param.comment = "# " + tunable.perfString(best_time) + ", tuned ";
       best_param.comment += ctime(&now); // includes a newline
 
+      best_param.time = best_time;
+
       cudaEventDestroy(start);
       cudaEventDestroy(end);
 
@@ -446,6 +558,9 @@ namespace quda {
 //    tally--;
 //    printfQuda("pthread_mutex_unlock b complete %d\n",tally);
 #endif
+
+    param.n_calls++;
+
     return param;
   }
 

--- a/lib/tune.cpp
+++ b/lib/tune.cpp
@@ -134,8 +134,9 @@ namespace quda {
       if (param.n_calls > 0) {
 	double time = param.n_calls * param.time;
 
-	out << std::setw(12) << param.n_calls * param.time << "\t" << std::setw(12) << (time / total_time) * 100 << "\t" << std::setw(12) << param.n_calls << "\t" << std::setw(12) << param.time << "\t" << std::setw(15) << key.volume << "\t" << key.name << "\t" << key.aux << "\t";
-	out << param.shared_bytes << "\t" << param.comment; // param.comment ends with a newline
+	out << std::setw(12) << param.n_calls * param.time << "\t" << std::setw(12) << (time / total_time) * 100 << "\t";
+	out << std::setw(12) << param.n_calls << "\t" << std::setw(12) << param.time << "\t" << std::setw(15) << key.volume << "\t";
+	out << key.name << "\t" << key.aux << "\t" << param.comment; // param.comment ends with a newline
       }
 
       q.pop();

--- a/lib/tune.cpp
+++ b/lib/tune.cpp
@@ -559,7 +559,7 @@ namespace quda {
 //    printfQuda("pthread_mutex_unlock b complete %d\n",tally);
 #endif
 
-    param.n_calls++;
+    param.n_calls=1;
 
     return param;
   }


### PR DESCRIPTION
This adds a simple profiler to QUDA that builds on top of the auto-tuning framework.  For every kernel that is called, we increment a counter in the tunecache std::map every time it is called.  Moreover, we additionally store how long the kernel took to run when it was being autotuned.  With this information, we can work out a simple kernel profile (`total kernel time = n_calls * kernel_time`) which has zero overhead.  Similarly to how the tunecache.tsv file is written out, the profile is then dumped to disk in the file `profile.tsv` when `endQuda` is called when the library is torn down if `QUDA_RESOURCE_PATH` is set.

For example, here is running a double-half BiCGtab solver would give:
```
profile	0.8.0	v0.7.2-1089-g7fdebf8-dirty	cpu_arch=x86_64,gpu_arch=sm_52,cuda_version=8000	# Last updated Thu Feb  4 22:24:27 2016

  total time	  percentage	       calls	 time / call	         volume	name	aux	comment
    0.875413	     30.7151	        1000	 0.000875413	    12x24x24x24	N4quda4blas31caxpbypzYmbwcDotProductUYNormY_I7double37double2S3_EE	vol=165888,stride=165888,precision=2,vol=165888,stride=165888,precision=8	3072	# 81.86 Gflop/s, 68.98 GB/s, tuned Thu Feb  4 22:01:14 2016
    0.628672	     22.0578	        2000	 0.000314336	    12x24x24x24	N4quda16WilsonDslashCudaI6short4S1_EE	type=interior,comm=0111,ghost=0111,reconstruct=18,Xpay	0	# 695.03 Gflop/s, 351.48 GB/s, tuned Thu Feb  4 18:01:53 2016
    0.581632	     20.4074	        2000	 0.000290816	    12x24x24x24	N4quda16WilsonDslashCudaI6short4S1_EE	type=interior,comm=0111,ghost=0111,reconstruct=18	7022	# 730.71 Gflop/s, 387.32 GB/s, tuned Thu Feb  4 18:01:53 2016
    0.184288	       6.466	        1000	 0.000184288	    12x24x24x24	N4quda4blas4CdotI7double26float26float4EE	vol=165888,stride=165888,precision=2	4096	# 86.42 Gflop/s, 93.62 GB/s, tuned Thu Feb  4 22:01:08 2016
    0.137899	     4.83837	        1000	 0.000137899	    12x24x24x24	N4quda4blas9cxpaypbz_I6float26float4EE	vol=165888,stride=165888,precision=2	0	# 230.97 Gflop/s, 250.22 GB/s, tuned Thu Feb  4 22:01:15 2016
    0.106795	     3.74705	        1000	 0.000106795	    12x24x24x24	N4quda4blas6caxpy_I6float26float4EE	vol=165888,stride=165888,precision=2	0	# 149.12 Gflop/s, 242.32 GB/s, tuned Thu Feb  4 22:01:09 2016
   0.0839253	     2.94463	        1000	 8.39253e-05	    12x24x24x24	N4quda4blas9CdotNormAI7double36float26float4EE	vol=165888,stride=165888,precision=2	9216	# 284.63 Gflop/s, 205.57 GB/s, tuned Thu Feb  4 22:01:10 2016
    0.034944	     1.22606	        4000	   8.736e-06	    12x24x24x24	N4quda14PackFaceWilsonI6short4fEE	vol=165888,stride=165888,precision=2,comm=0111,nFace=1	9831	# 37.98 Gflop/s, 253.19 GB/s, tuned Thu Feb  4 18:01:53 2016
    0.031104	     1.09133	        2000	  1.5552e-05	    12x24x24x24	N4quda16WilsonDslashCudaI6short4S1_EE	type=exterior_y,comm=0111,reconstruct=18,Xpay	0	# 181.33 Gflop/s, 149.33 GB/s, tuned Thu Feb  4 18:01:53 2016
    0.026944	    0.945367	        2000	  1.3472e-05	    12x24x24x24	N4quda16WilsonDslashCudaI6short4S1_EE	type=exterior_t,comm=0111,reconstruct=18,Xpay	8193	# 209.33 Gflop/s, 172.39 GB/s, tuned Thu Feb  4 18:01:53 2016
    0.024768	    0.869019	        2000	  1.2384e-05	    12x24x24x24	N4quda16WilsonDslashCudaI6short4S1_EE	type=exterior_z,comm=0111,reconstruct=18,Xpay	9831	# 227.72 Gflop/s, 187.53 GB/s, tuned Thu Feb  4 18:01:53 2016
     0.02368	    0.830845	        2000	   1.184e-05	    12x24x24x24	N4quda16WilsonDslashCudaI6short4S1_EE	type=exterior_y,comm=0111,reconstruct=18	0	# 182.14 Gflop/s, 135.44 GB/s, tuned Thu Feb  4 18:01:53 2016
     0.02368	    0.830845	        2000	   1.184e-05	    12x24x24x24	N4quda16WilsonDslashCudaI6short4S1_EE	type=exterior_z,comm=0111,reconstruct=18	6145	# 182.14 Gflop/s, 135.44 GB/s, tuned Thu Feb  4 18:01:53 2016
    0.023424	    0.821863	        2000	  1.1712e-05	    12x24x24x24	N4quda16WilsonDslashCudaI6short4S1_EE	type=exterior_t,comm=0111,reconstruct=18	0	# 184.13 Gflop/s, 136.92 GB/s, tuned Thu Feb  4 18:01:53 2016
    0.021545	    0.755934	          16	  0.00134656	    12x24x24x24	N4quda16WilsonDslashCudaI7double2S1_EE	type=interior,comm=0111,ghost=0111,reconstruct=18,Xpay	9831	# 162.25 Gflop/s, 311.93 GB/s, tuned Thu Feb  4 17:38:55 2016
   0.0206925	    0.726024	          16	  0.00129328	    12x24x24x24	N4quda16WilsonDslashCudaI7double2S1_EE	type=interior,comm=0111,ghost=0111,reconstruct=18	8193	# 164.31 Gflop/s, 330.93 GB/s, tuned Thu Feb  4 17:38:55 2016
  0.00593101	    0.208097	          16	 0.000370688	    12x24x24x24	N4quda4blas8xmyNorm2Id7double2S2_EE	vol=165888,stride=165888,precision=8	5120	# 32.22 Gflop/s, 257.77 GB/s, tuned Thu Feb  4 17:38:58 2016
  0.00578099	    0.202834	          16	 0.000361312	    12x24x24x24	N4quda4blas4xpy_I7double2S2_EE	vol=165888,stride=165888,precision=8	0	# 11.02 Gflop/s, 264.46 GB/s, tuned Thu Feb  4 17:39:14 2016
  0.00282916	   0.0992648	          17	 0.000166421	    12x24x24x24	copyKernel	dst=vol=165888,stride=165888,precision=2,src=vol=165888,stride=165888,precision=8	0	# 0.00 Gflop/s, 243.22 GB/s, tuned Thu Feb  4 18:01:53 2016
  0.00100753	   0.0353505	           8	 0.000125941	    12x24x24x24	N4quda4blas5Norm2Id7double2S2_EE	vol=165888,stride=165888,precision=8	4608	# 63.22 Gflop/s, 252.90 GB/s, tuned Thu Feb  4 17:38:54 2016
 0.000986794	    0.034623	          32	 3.08373e-05	    12x24x24x24	N4quda14PackFaceWilsonI7double2dEE	vol=165888,stride=165888,precision=8,comm=0111,nFace=1	0	# 10.76 Gflop/s, 258.21 GB/s, tuned Thu Feb  4 17:38:54 2016
 0.000825344	   0.0289583	          16	  5.1584e-05	    12x24x24x24	N4quda16WilsonDslashCudaI7double2S1_EE	type=exterior_y,comm=0111,reconstruct=18,Xpay	6145	# 54.67 Gflop/s, 167.23 GB/s, tuned Thu Feb  4 17:38:55 2016
 0.000691712	   0.0242697	          16	  4.3232e-05	    12x24x24x24	N4quda16WilsonDslashCudaI7double2S1_EE	type=exterior_z,comm=0111,reconstruct=18,Xpay	6145	# 65.23 Gflop/s, 199.53 GB/s, tuned Thu Feb  4 17:38:55 2016
 0.000664064	   0.0232996	          16	  4.1504e-05	    12x24x24x24	N4quda16WilsonDslashCudaI7double2S1_EE	type=exterior_t,comm=0111,reconstruct=18,Xpay	16385	# 67.95 Gflop/s, 207.84 GB/s, tuned Thu Feb  4 17:38:55 2016
  0.00064512	   0.0226349	          16	   4.032e-05	    12x24x24x24	N4quda16WilsonDslashCudaI7double2S1_EE	type=exterior_y,comm=0111,reconstruct=18	6145	# 53.49 Gflop/s, 148.11 GB/s, tuned Thu Feb  4 17:38:55 2016
 0.000561152	   0.0196888	          16	  3.5072e-05	    12x24x24x24	N4quda16WilsonDslashCudaI7double2S1_EE	type=exterior_z,comm=0111,reconstruct=18	6145	# 61.49 Gflop/s, 170.28 GB/s, tuned Thu Feb  4 17:38:55 2016
  0.00054016	   0.0189522	          16	   3.376e-05	    12x24x24x24	N4quda16WilsonDslashCudaI7double2S1_EE	type=exterior_t,comm=0111,reconstruct=18	9831	# 63.88 Gflop/s, 176.89 GB/s, tuned Thu Feb  4 17:38:55 2016
 0.000241493	  0.00847311	           1	 0.000241493	    12x24x24x24	N4quda4blas23HeavyQuarkResidualNorm_I7double37double2S3_EE	vol=165888,stride=165888,precision=8	6144	# 65.94 Gflop/s, 263.78 GB/s, tuned Thu Feb  4 17:39:20 2016

# Total time spent in kernels = 2.85011 seconds
```

We can see that the output is ordered in decreasing significance to allow for rapid identification of which kernels are most important.

In order for the profiler to work between multiple runs, where the first run would do all the autotuning, we now store the kernel time for each kernel in the tunecache, with this being restored when then the tunecache is loaded.  This avoids us ever having to retime a given kernel.