### PR TITLE
Covdev wrongly assigns the neighbour

### DIFF
--- a/lib/covDev.cu
+++ b/lib/covDev.cu
@@ -394,8 +394,8 @@ namespace quda
           MsgHandle *mh_send;
           MsgHandle *mh_from;
 
-          mh_send = comm_declare_send_relative	(send, dir, rel,      ghostBytes);
-          mh_from = comm_declare_receive_relative	(recv, dir, rel*(-1), ghostBytes);
+          mh_send = comm_declare_send_relative(send, dir, rel*(-1), ghostBytes);
+          mh_from = comm_declare_receive_relative(recv, dir, rel, ghostBytes);
           comm_start (mh_send);
           comm_start (mh_from);
           comm_wait (mh_send);


### PR DESCRIPTION
If splitted in more than 2 gpus per direction, the covariant derivative assigns a wrong neighbour and multiGPU gives the wrong result. This was fixed for 0.8.x, but a fix should be applied to the release/0.7.x for those wishing to stick with this old version.