### PR TITLE
Feature/fgmresdr2

### DIFF
--- a/include/enum_quda.h
+++ b/include/enum_quda.h
@@ -97,6 +97,7 @@ extern "C" {
   typedef enum QudaInverterType_s {
     QUDA_CG_INVERTER,
     QUDA_BICGSTAB_INVERTER,
+    QUDA_GMRES_INVERTER,      // My modification
     QUDA_GCR_INVERTER,
     QUDA_MR_INVERTER,
     QUDA_MPBICGSTAB_INVERTER,

--- a/include/gmres_utilities.h
+++ b/include/gmres_utilities.h
@@ -1,0 +1,61 @@
+#ifndef _GMRES_UTILITIES
+#define _GMRES_UTILITIES
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <string>
+#include <complex>
+#include <cuComplex.h>
+#include <stdio.h>
+
+#include <stdio.h>
+#include <color_spinor_field.h>     // cudaColorSpinorField, ColorSpinorParam
+#include <invert_quda.h>            // SolverParam, 
+#include <util_quda.h>
+
+
+
+// This file contains some utilities and auxiliary functions needed for
+// F-GMRES-DR which is implemented in "/lib/inv_gmres_quda.cpp".
+//-----------------------------------------------------------------------------
+namespace utilGMRES {
+
+// Creates neccessary parameters for the inner and outer solver
+void fillInnerSolveParam(quda::SolverParam &inner, const quda::SolverParam &outer);
+
+// Solve a general linear system A.x = b. Size of the problem is order.ldA,
+// whereas ldA is the leading dimension of A (A(ij) = A[i+j*ldA])
+void linearSolve(quda::Complex *x, quda::Complex *b, quda::Complex *A, int order, int ldA);
+
+// Get the eigenvectors (sorted) of a quadratic matrix A. On entry A is the
+// problems matrix, on exit its columns are the eigenvectors.
+void getRitzVectors(quda::Complex *A, int dim);
+
+// QR factorize the matrix A. On exit A is Q.
+// "columns" is also ldA.
+void qrFactorize(quda::Complex *A, int rows, int columns);
+
+// Perform deflation of the Arnoldi vectors V and Z. Update all variables.
+void deflate(quda::Complex *H, quda::cudaColorSpinorField **V, quda::cudaColorSpinorField **Z,
+             quda::Complex *c, quda::Complex *rho, int dim, int ldH, int kAug,
+             quda::ColorSpinorParam csParam);
+              
+// Check if augmented subspace is in bad shape and if clean restart is required.
+// If so, return 1 otherwise 0.
+// NOTE: For a explanation of the underlying algorithm see Masters Thesis
+int checkRestartCriterion(int currentIter, int *deflCount, int *badSubspCount, int maxDefl,
+                          int maxBadSubsp, int kAug, double *detGref, quda::cudaColorSpinorField **V);
+
+// Contract a spinor-matrix with an ordinary c-type matrix: spinorOut <-- spinorIn.cMatrixIn
+// *in  has rows(cIn) columns, out has columns(cIn) columns
+void contractSpinorAndCMatrix(quda::cudaColorSpinorField **out, quda::cudaColorSpinorField **in,
+                              quda::Complex *cIn, int rowsCin, int columnsCin, int ldCin);
+
+// Solve the least squares problem min||c - H.y||. Input values are c and H,
+// while y is returned. dim(H) = (row, col) with ldH. dim(c) = row, dim(y) = col
+void solveLeastSquares(quda::Complex *H, quda::Complex *c, quda::Complex *y,
+		       int row, int col, int ldH);
+                              
+}  // end of namespace utilGMRES            
+//-----------------------------------------------------------------------------
+#endif

--- a/include/invert_quda.h
+++ b/include/invert_quda.h
@@ -368,6 +368,28 @@ namespace quda {
     void operator()(cudaColorSpinorField &out, cudaColorSpinorField &in);
   };
   
+  
+  // My modification: Additional GMRES solver class
+  class GMRES : public Solver {
+
+  private:
+    const DiracMatrix &mat;
+    const DiracMatrix &matSloppy;
+    const DiracMatrix &matPrecon;
+
+    Solver *K;
+    SolverParam Kparam; // Parameters for preconditioner solve
+
+  public:
+    GMRES(DiracMatrix &mat, DiracMatrix &matSloppy, DiracMatrix &matPrecon,
+	SolverParam &param, TimeProfile &profile);
+    virtual ~GMRES();
+
+    void operator()(cudaColorSpinorField &out, cudaColorSpinorField &in);
+  };
+  
+  
+  
   class MPBiCGstab : public Solver {
 
   private:

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -33,7 +33,8 @@ QUDA_OBJS = gauge_phase.o timer.o malloc.o solver.o			\
 	unitarize_links_quda.o milc_interface.o				\
 	extended_color_spinor_utilities.o eig_lanczos_quda.o		\
 	ritz_quda.o eig_solver.o blas_magma.o misc_helpers.o		\
-	inv_mpcg_quda.o inv_mpbicgstab_quda.o
+	inv_mpcg_quda.o inv_mpbicgstab_quda.o                           \
+	gmres_utilities.o inv_gmres_quda.o
 
 
 # header files, found in include/
@@ -45,7 +46,8 @@ QUDA_HDRS = blas_quda.h clover_field.h color_spinor_field.h convert.h	\
 	texture.h eig_variables.h numa_affinity.h misc_helpers.h	\
 	fermion_force_quda.h malloc_quda.h gauge_field_order.h		\
 	clover_field_order.h color_spinor_field_order.h			\
-	staggered_oprod.h lanczos_quda.h ritz_quda.h blas_magma.h
+	staggered_oprod.h lanczos_quda.h ritz_quda.h blas_magma.h       \
+	gmres_utilities.h
 
 
 # These are only inlined into blas_quda.cu
@@ -245,6 +247,8 @@ copy_gauge_single.o: copy_gauge_single.cu copy_gauge_inc.cu $(HDRS)
 copy_gauge_half.o: copy_gauge_half.cu copy_gauge_inc.cu $(HDRS)
 	$(NVCC) $(NVCCFLAGS) $< -c -o $@
 
+gmres_utilities.o: gmres_utilities.cpp $(HDRS)
+	$(CXX) $(MAGMA_INCLUDE) $(CXXFLAGS) $(MAGMA_FLAGS) $< -c -o $@	
 
 %.o: %.cpp $(HDRS)
 	$(CXX) $(CXXFLAGS) $< -c -o $@

--- a/lib/gmres_utilities.cpp
+++ b/lib/gmres_utilities.cpp
@@ -1,0 +1,484 @@
+#include <gmres_utilities.h>
+
+#include <stdio.h>               // standard C++ includes
+#include <stdlib.h>
+#include <math.h>
+#include <iostream>
+#include <algorithm>             // std::swap() and std::max()
+
+#include <quda_internal.h>       // quda includes
+#include <color_spinor_field.h>
+#include <blas_quda.h>
+#include <dslash_quda.h>
+#include <invert_quda.h>
+#include <util_quda.h>
+
+#include <face_quda.h>
+
+#ifdef MAGMA_LIB
+#include <magma.h>
+#include <magma_operators.h>     // manipulating complex magma numbers
+#endif
+
+
+// This file implements some utilities and auxiliary functions needed for
+// F-GMRES-DR which is implemented in "/lib/inv_gmres_quda.cpp".
+//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
+namespace utilGMRES {
+
+   // Creates necessary parameters for the inner and outer solver
+   //--------------------------------------------------------------------------
+   void fillInnerSolveParam(quda::SolverParam &inner, const quda::SolverParam &outer) {
+
+      // Define inner solvers precision
+      inner.tol      = outer.tol_precondition;
+      inner.maxiter  = outer.maxiter_precondition;
+      inner.delta    = 1e-20;    // no reliable updates within the inner solver
+
+      // Preconditioners are uni-precision solvers
+      inner.precision        = outer.precision_precondition;
+      inner.precision_sloppy = outer.precision_precondition;
+            
+      // Set the inner flops counter
+      inner.iter = 0;
+      inner.gflops = 0;
+      inner.secs = 0;
+      
+      // Tell the inner solver it is an inner solver (see e.g., line 26 of "inv_mr_quda.ccp")
+      inner.inv_type_precondition = QUDA_GCR_INVERTER;
+            
+      // Preserve the source depending on precision
+      if (outer.precision_sloppy != outer.precision_precondition)
+         inner.preserve_source = QUDA_PRESERVE_SOURCE_NO;
+      else
+         inner.preserve_source = QUDA_PRESERVE_SOURCE_YES;
+   }
+   //--------------------------------------------------------------------------
+
+
+   // Solve a general linear system A.x = b. Size of the problem is order.ldA,
+   // whereas ldA is the leading dimension of A (A(ij) = A[i+j*ldA])
+   //--------------------------------------------------------------------------
+   void linearSolve(quda::Complex *x, quda::Complex *b, quda::Complex *A, int order, int ldA) {
+#ifdef MAGMA_LIB
+      // define variables required by the magma solver
+      magmaDoubleComplex *tmpA, *tmpB;
+      magma_int_t *ipiv;
+      magma_int_t err, info = 0;
+      
+      // allocate pinned memory for magma
+      magma_zmalloc_pinned( &tmpA, order*ldA );
+      magma_zmalloc_pinned( &tmpB, order );
+      magma_imalloc_pinned( &ipiv, order );
+      
+      // duplicate the data (this is necessary, since A and b get destroyed during solve)
+      memcpy( tmpA, A, order*ldA*sizeof(magmaDoubleComplex) );
+      memcpy( tmpB, b, order*sizeof(magmaDoubleComplex) );
+                
+      // perform the actual solve, catch possibly occuring error
+      err = magma_zgesv(order, 1, tmpA, ldA, ipiv, tmpB, order, &info);
+      if (err != 0) {
+         printf("\nError in linearSolveGMRES, with INFO(magma_zgesv) = %d, exit ...\n", info);
+         exit(-1);   
+      }
+                      
+      // copy back solution (b is now the solution vector x)
+      memcpy( x, tmpB, order*sizeof(magmaDoubleComplex) );
+               
+      // delete all temporary data
+      magma_free_pinned(tmpA);
+      magma_free_pinned(tmpB);
+      magma_free_pinned(ipiv);
+#endif
+      return;
+   }
+   //--------------------------------------------------------------------------
+
+
+   // Get the eigenvectors (sorted) of a quadratic matrix A. On entry A is the
+   // problems matrix, on exit its columns are the eigenvectors.
+   //--------------------------------------------------------------------------
+   void getRitzVectors(quda::Complex *A, int dim) {
+#ifdef MAGMA_LIB
+      // define variables required by the magma solver
+      magmaDoubleComplex *leftVecs, *rightVecs;    // for the eigenvectors
+      magmaDoubleComplex *lambda;                  // for the eigenvalues
+      magmaDoubleComplex *work;                    // workspace
+      double *rwork;                               // workspace
+      magma_int_t nb, lwork, err, info = 0;
+      
+      magma_vec_t jobvl, jobvr;                    // calculate left or right eigenpairs
+      jobvl = MagmaNoVec;
+      jobvr = MagmaVec;
+   
+      nb = magma_get_zgehrd_nb(dim);               // get ideal workspace blocksize
+      lwork = (1+2*nb)*dim;
+      
+      // allocate memory
+      magma_zmalloc_pinned( &rightVecs, dim*dim );
+      magma_zmalloc_pinned( &lambda, dim );
+      magma_zmalloc_pinned( &work, lwork );
+      magma_dmalloc_pinned( &rwork, 2*dim );
+      
+      // perform the actual solve, catch possibly occurring error
+      err = magma_zgeev(jobvl, jobvr, dim, (magmaDoubleComplex*)A, dim, lambda, leftVecs,
+                        dim, rightVecs, dim, work, lwork, rwork, &info);
+      if (err != 0) {
+         printf("\nError in getRitzVectorsGMRES, with INFO(magma_zgeev) = %d, exit ...\n", info);
+         exit(-1);   
+      }
+                      
+      // now sort the eigenvalues/vectors in ascending order (by magnitude)
+      // this uses insertion-sort with an permutation matrix to avoid repeated copying
+      magmaDoubleComplex tmp;
+      int i, tmp2;
+      int *permTable = new int[dim];
+      for (int i=0; i<dim; i++)
+	 permTable[i] = i;
+      
+      for (int j=1; j<dim; j++) {
+	 tmp  = lambda[j];
+	 tmp2 = permTable[j];
+	 i = j;
+	 while ( i>0 && fabs(lambda[i-1]) > fabs(tmp) ) {
+	    lambda[i] = lambda[i-1];
+	    permTable[i] = permTable[i-1];
+	    i--;
+	 }
+	 lambda[i] = tmp;
+	 permTable[i] = tmp2;
+      }
+                      
+      // rearrange the eigenvectors in A according to the permutation matrix
+      for (int i=0; i<dim; i++)
+	 memcpy( &A[i*dim], &rightVecs[permTable[i]*dim], dim*sizeof(magmaDoubleComplex) );
+                      
+      // delete all temporary data
+      magma_free_pinned(rightVecs);
+      magma_free_pinned(lambda);
+      magma_free_pinned(work);
+      magma_free_pinned(rwork);
+      delete[] permTable;
+#endif
+      return;
+   }
+   //--------------------------------------------------------------------------
+
+
+   // QR factorize the matrix A. On exit A is Q.
+   // "columns" is also ldA.
+   //--------------------------------------------------------------------------
+   void qrFactorize(quda::Complex *A, int rows, int columns) {
+#ifdef MAGMA_LIB
+      // define variables required by the magma solver
+      magmaDoubleComplex *tau, *work;
+      magma_int_t nb, lwork, err, info = 0;
+      
+      nb = magma_get_zgeqrf_nb( std::max(rows, columns) );  // get ideal workspace blocksize
+      lwork = std::max( columns*nb, 2*nb*nb );
+      
+      // allocate memory
+      magma_zmalloc_pinned( &tau, std::min(rows, columns) );
+      magma_zmalloc_pinned( &work, lwork );
+      
+      // generate the raw data for A = QR
+      err = magma_zgeqrf( rows, columns, (magmaDoubleComplex*)A,
+                          rows, tau, work, lwork, &info );
+      if (err != 0) {
+         printf("\nError in qrFactorizeGMRES, with INFO(magma_zgeqrf) = %d, exit ...\n", info);
+         exit(-1);   
+      }
+                      
+      // extract the Q-matrix out of this data
+      err = magma_zungqr2( rows, columns, std::min(rows, columns),
+                           (magmaDoubleComplex*)A, rows, tau, &info );
+      if (err != 0) {
+         printf("\nError in qrFactorizeGMRES, with INFO(magma_zungqr2) = %d, exit ...\n", info);
+         exit(-1);   
+      }
+      
+      // delete all temporary data
+      magma_free_pinned(tau);
+      magma_free_pinned(work);
+#endif      
+      return;
+   }
+   //--------------------------------------------------------------------------
+
+
+   // Perform deflation of the Arnoldi vectors V and Z. Update all variables.
+   //--------------------------------------------------------------------------
+   void deflate(quda::Complex *H, quda::cudaColorSpinorField **V, quda::cudaColorSpinorField **Z,
+                quda::Complex *c, quda::Complex *rho, int dim, int ldH, int kAug,
+                quda::ColorSpinorParam csParam) {
+            
+      // step a): calculate Hm + fm.adj(hm), where Hm !def= Haux
+      //-----------------------------------------------------------------------
+      // get some space for auxiliary matrices
+      quda::Complex *Haux = new quda::Complex[dim*dim];
+      quda::Complex *hm   = new quda::Complex[dim];
+      quda::Complex *fm   = new quda::Complex[dim];
+               
+      // build Haux = adj(Hm)
+      for (int i=0; i<dim; i++) {
+         for (int j=0; j<dim; j++) {
+            Haux[i+j*dim] = conj(H[j+i*ldH]);
+         }
+         hm[i] = conj(H[(ldH-1)+i*ldH]);
+      }
+               
+      // calculate the vector fm
+      linearSolve(fm, hm, Haux, dim, dim);
+               
+      // compute Hm + fm.adj(hm) -- Haux above cant be used, cause its adjoint,
+      // but it can be recycled however
+      for (int i=0; i<dim; i++)
+         for (int j=0; j<dim; j++) {
+            Haux[i+j*dim] = H[i+j*ldH] + fm[i]*conj(hm[j]);
+         }
+      //---------------------------------------------------------------------
+            
+      // step b) and c) together:
+      // get the kAug smallest eigenpairs (lambdaI, gI) of Hm + fm.adj(hm)
+      // and calculate the matrix Gk1
+      //---------------------------------------------------------------------
+      // get space for another matrix
+      quda::Complex *Gk1 = new quda::Complex[ldH*(kAug+1)]();
+            
+      // get ALL Ritz vectors
+      getRitzVectors(Haux, dim);
+               
+      // fill the matrix Gk1 with numbers -- first part
+      for (int i=0; i<dim; i++)
+         for (int j=0; j<kAug; j++) {
+            Gk1[i+j*ldH] = Haux[i+j*dim];
+         }
+               
+      // and now the last column of Gk1
+      for (int i=0; i<ldH; i++) {
+         Gk1[i+kAug*ldH] = c[i];
+         for (int j=0; j<dim; j++) {
+            Gk1[i+kAug*ldH] -= H[i+j*ldH]*rho[j];
+         }
+      }
+      //-----------------------------------------------------------------------
+            
+      // step d) and e):
+      // QR-factorize Gk1 and update H, V and Z
+      //-----------------------------------------------------------------------
+      // QR-factorization: dim(Gk1) = (ldH, kAug+1)   
+      qrFactorize(Gk1, ldH, (kAug+1)); // ATTENTION: Gk1 is now Qk1
+               
+      // calculate Hk = adj(Qk1).Hm.Qk
+      // first step: Haux2 = Hm.Qk
+      quda::Complex *Haux2 = new quda::Complex[ldH*kAug]();
+      for (int i=0; i<ldH; i++)  // Haux = Hm.Qk
+         for (int j=0; j<kAug; j++) {
+            for (int m=0; m<dim; m++) {
+               Haux2[i+j*ldH] += H[i+m*ldH] * Gk1[m+j*ldH];
+            }
+         }
+      
+      // second step: Hk = adj(Qk1).Haux2, i.e., Hk = adj(Qk1).Hm.Qk
+      std::memset( H, 0.0, dim*ldH*sizeof(quda::Complex) );
+      for (int i=0; i<(kAug+1); i++)   // Hk = adj(Qk1).Haux2
+         for (int j=0; j<kAug; j++) {
+            for (int m=0; m<ldH; m++) {
+               H[i+j*ldH] += conj(Gk1[m+i*ldH]) * Haux2[m+j*ldH];
+            }
+         }
+               
+      // calculate Vk1 = Vm1.Qk1 and Zk = Zm.Qk
+      //-----------------------------------------------------------------------
+      // allocate space for the auxiliary fields
+      csParam.create = QUDA_ZERO_FIELD_CREATE;  // defensive measure
+      quda::cudaColorSpinorField **tmpField = new quda::cudaColorSpinorField*[kAug+1];
+      for (int i=0; i<(kAug+1); i++)
+         tmpField[i] = new quda::cudaColorSpinorField(*V[0], csParam);
+                  
+      // calculate the matrix product tmpField = Vm1.Qk1
+      contractSpinorAndCMatrix(tmpField, V, Gk1, ldH, (kAug+1), ldH);
+               
+      // copy Vk1 = tmpField
+      for (int i=0; i<(kAug+1); i++)
+         quda::copyCuda( *V[i], *tmpField[i] );
+         
+      // calculate the matrix product tmpField = Zm.Qk
+      contractSpinorAndCMatrix(tmpField, Z, Gk1, (ldH-1), kAug, ldH);
+               
+      // copy Zm = tmpField
+      for (int i=0; i<(kAug+1); i++)
+         quda::copyCuda( *Z[i], *tmpField[i] );
+                  
+      // delete temporary data
+      for (int i=0; i<(kAug+1); i++)
+         delete tmpField[i];
+      delete[] tmpField;
+      //-----------------------------------------------------------------------
+                  
+      // clear all memory that is not needed anymore
+      //-----------------------------------------------------------------------
+      delete[] Haux;
+      delete[] Haux2;
+      delete[] hm;
+      delete[] fm;
+      delete[] Gk1;
+      //-----------------------------------------------------------------------
+      return;
+   }
+   //--------------------------------------------------------------------------
+
+
+   // Check if augmented subspace is in bad shape and if clean restart is required.
+   // If so, return 1 otherwise 0.
+   //--------------------------------------------------------------------------
+   int checkRestartCriterion(int currentIter, int *deflCount, int *badSubspCount, int maxDefl,
+                             int maxBadSubsp, int kAug, double *detGref, quda::cudaColorSpinorField **V) {
+#ifdef MAGMA_LIB
+      // check if we have a condition where restart-checking is mandatory
+      //-----------------------------------------------------------------------
+      if (currentIter == 1 || *deflCount >= maxDefl) {
+	 *badSubspCount = 0;
+	 *deflCount     = 0;
+	 return 1;
+      }
+      
+      // allocate memory and calculate the Gram-Matrix of the first
+      // kAug+1 vectors of V[i]
+      //-----------------------------------------------------------------------
+      int ldG = (kAug+1);
+      quda::Complex *G = new quda::Complex[ldG*ldG];
+      magma_int_t err, *ipiv, info = 0;
+      magma_imalloc_pinned( &ipiv, ldG );
+      
+      // Gram-Matrix is symmetric, so we just have to get the upper triangle
+      // the rest can be copied
+      for (int j=0; j<ldG; j++)
+         for (int i=0; i<=j; i++) {
+            G[i+j*ldG] = quda::cDotProductCuda(*V[i], *V[j]);
+            if (i != j)
+               G[j+i*ldG] = conj(G[i+j*ldG]);
+         }
+            
+      // calculate |det(G)| which is a criterion for the linear dependence
+      // of the vectors V[i]
+      // MAGMA LU-factorization will be used to achieve this, det(G) is then
+      // proportional to the product of all diagonal coefficients
+      //-----------------------------------------------------------------------
+      err = magma_zgetrf( ldG, ldG, (magmaDoubleComplex*)G, ldG, ipiv, &info );
+      if (err != 0) {
+         printf("\nError in checkRestartCriterionGMRES, with INFO(magma_zgetrf) = %d, exit ...\n", info);
+         exit(-1);   
+      }
+                      
+      quda::Complex detGram = 1.0;
+      for (int i=0; i<ldG; i++) {
+         detGram *= G[i+i*ldG];
+      }
+                      
+      // clean memory which is not used anymore
+      //-----------------------------------------------------------------------
+      delete [] G;
+      magma_free_pinned(ipiv);
+      
+      // if we have done the 2nd iteration, |det(G)| will be stored and used as
+      // a reference for future restart checks
+      //-----------------------------------------------------------------------
+      if (currentIter == 2)
+	 *detGref = abs(detGram);   // we are only interested in the absolute value
+      
+      // check if linear independence of subspace vectors has become worse and
+      // count how often this happened
+      // if in between one subspace should be ok, reset the counter
+      //-----------------------------------------------------------------------
+      if (abs(detGram) < *detGref)
+	 *badSubspCount += 1;
+      else
+	 *badSubspCount = 0;
+                   
+      // finally check if one of our restart criteria got violated
+      //-----------------------------------------------------------------------
+      if (*badSubspCount >= maxBadSubsp) {
+	 *badSubspCount = 0;   // reset all counters
+	 *deflCount     = 0;
+	 return 1;
+      }
+      else {
+	 *deflCount += 1;      // increment deflation counter
+	 return 0;
+      }
+#endif
+      return 1;   // in case MAGMA isnt available         
+   }
+   //--------------------------------------------------------------------------
+   
+   
+   // Contract a spinor-matrix with an ordinary c-type matrix
+   // spinorOut <-- spinorIn.cMatrixIn
+   // *in  has rows(cIn) columns 
+   // *out has columns(cIn) columns
+   //--------------------------------------------------------------------------
+   void contractSpinorAndCMatrix(quda::cudaColorSpinorField **out, quda::cudaColorSpinorField **in,
+                                 quda::Complex *cIn, int rowsCin, int columnsCin, int ldCin) {
+                                 
+      // calculate the matrix product
+      for (int i=0; i<columnsCin; i++) {
+      
+         // as a defensive measure zero all rows of *out, before doing the contraction
+         quda::zeroCuda(*out[i]);
+         
+         // do the contraction
+         for (int j=0; j<rowsCin; j++)
+            quda::caxpyCuda( cIn[j+i*ldCin], *in[j], *out[i] );
+      }                          
+   }
+   //--------------------------------------------------------------------------
+   
+   
+   // Solve the least squares problem min||c - H.y||. Input values are c and H,
+   // while y is returned. dim(H) = (row, col) with ldH. dim(c) = row, dim(y) = col
+   //--------------------------------------------------------------------------
+   void solveLeastSquares(quda::Complex *H, quda::Complex *c, quda::Complex *y,
+		          int row, int col, int ldH) {
+#ifdef MAGMA_LIB
+      // define the required variables
+      magmaDoubleComplex *tmpA, *tmpB, *hwork;
+      magma_int_t lwork, err, nb, info;
+      
+      // get ideal workspace blocksize
+      nb = magma_get_zgeqrf_nb( row );
+      lwork = std::max( col*nb, 2*nb*nb );
+      
+      // allocate GPU and CPU memory for the hybrid algorithm
+      magma_zmalloc( &tmpA, row*col );
+      magma_zmalloc( &tmpB, row );
+      magma_zmalloc_cpu( &hwork, std::max(1, lwork) );
+      
+      // copy H and c onto the device
+      magma_zsetmatrix( row, col, (magmaDoubleComplex*)H, ldH,  tmpA, ldH);
+      magma_zsetmatrix( row, 1, (magmaDoubleComplex*)c, ldH, tmpB, ldH );
+      
+      // solve the problem
+      // NOTE: Newer versions of Magma support magma_zgels_cpu, which might be more handy
+      err = magma_zgels_gpu( MagmaNoTrans, row, col, 1, tmpA, ldH, tmpB,
+			     ldH, hwork, lwork, &info );
+      if (err != 0) {
+	 printf("\nError in solveLeastSquaresGMRES, with INFO(magma_zgels) = %d, exit ...\n", info);
+	 exit(-1);   
+      }
+      
+      // get back the solution
+      magma_zgetmatrix( col, 1, tmpB, ldH, (magmaDoubleComplex*)y, ldH );
+      
+      // free the memory
+      magma_free(tmpA);
+      magma_free(tmpB);
+      magma_free_cpu(hwork);
+#endif
+   }
+   //--------------------------------------------------------------------------
+
+}  // end of namespace utilGMRES
+//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------

--- a/lib/inv_gmres_quda.cpp
+++ b/lib/inv_gmres_quda.cpp
@@ -1,0 +1,411 @@
+// define the necessary includes
+//-----------------------------------------------------------------------------
+#include <stdio.h>               // standard C++ includes
+#include <stdlib.h>
+#include <math.h>
+#include <iostream>
+#include <algorithm>             // std::swap() and std::max()
+
+#include <quda_internal.h>       // quda includes
+#include <color_spinor_field.h>
+#include <blas_quda.h>
+#include <dslash_quda.h>
+#include <invert_quda.h>
+#include <util_quda.h>
+
+#include <face_quda.h>
+
+#include <gmres_utilities.h>
+//-----------------------------------------------------------------------------
+
+
+// envelope everything in the corresponding namespace
+//-----------------------------------------------------------------------------
+namespace quda {
+   
+   
+   // define the solver factories call
+   //--------------------------------------------------------------------------
+   GMRES::GMRES( DiracMatrix &mat, DiracMatrix &matSloppy, DiracMatrix &matPrecon,
+                 SolverParam &param, TimeProfile &profile ) :
+      Solver(param, profile), mat(mat), matSloppy(matSloppy), matPrecon(matPrecon), K(0), Kparam(param) {
+         
+   // derive parameters for inner solver
+   utilGMRES::fillInnerSolveParam(Kparam, param);
+
+   if (param.inv_type_precondition == QUDA_CG_INVERTER)                    // inner CG preconditioner
+      K = new CG(matPrecon, matPrecon, Kparam, profile);
+   else if (param.inv_type_precondition == QUDA_BICGSTAB_INVERTER)         // inner BiCGstab preconditioner
+      K = new BiCGstab(matPrecon, matPrecon, matPrecon, Kparam, profile);
+   else if (param.inv_type_precondition == QUDA_MR_INVERTER)               // inner MR preconditioner
+      K = new MR(matPrecon, Kparam, profile);
+   else if (param.inv_type_precondition == QUDA_SD_INVERTER)               // inner SD preconditioner
+      K = new SD(matPrecon, Kparam, profile);
+   else if (param.inv_type_precondition != QUDA_INVALID_INVERTER)          // unknown preconditioner
+      errorQuda("Unknown inner solver %d", param.inv_type_precondition);
+   }
+
+   GMRES::~GMRES() {
+      profile.Start(QUDA_PROFILE_FREE);   // time profiling
+      // delete inner solver structure, if it should already exist
+      if (K) delete K;
+      profile.Stop(QUDA_PROFILE_FREE); // stop profiling
+   }
+   //--------------------------------------------------------------------------
+   
+
+   //--------------------------------------------------------------------------
+   //--------------------------------------------------------------------------
+   // implement the solver
+   //--------------------------------------------------------------------------
+   //--------------------------------------------------------------------------
+   void GMRES::operator()(cudaColorSpinorField &x, cudaColorSpinorField &b) {
+      
+      // start the time-profiler --> FOR INITIALIZATION
+      //-----------------------------------------------------------------------
+      profile.Start(QUDA_PROFILE_INIT);
+      //-----------------------------------------------------------------------
+   
+      // Check to see that we're not trying to invert on a zero-field source
+      //-----------------------------------------------------------------------
+      const double b2 = normCuda(b);   // norm sq of source vector
+      if (b2==0) {
+         profile.Stop(QUDA_PROFILE_INIT);
+         printfQuda("Warning: inverting on zero-field source\n");
+         x=b;
+         param.true_res = 0.0;
+         param.true_res_hq = 0.0;
+         return;
+      }
+      //-----------------------------------------------------------------------
+           
+      // set up usage of heavy quark residual
+      //-----------------------------------------------------------------------
+      const bool use_heavy_quark_res = 
+         (param.residual_type & QUDA_HEAVY_QUARK_RESIDUAL) ? true : false;
+      double heavy_quark_res = 0.0; // true value calculated later
+      //-----------------------------------------------------------------------
+              
+      // get the spinors properties
+      //-----------------------------------------------------------------------
+      ColorSpinorParam csParam(x);
+      csParam.create = QUDA_ZERO_FIELD_CREATE;
+      //-----------------------------------------------------------------------
+               
+      // get the vital parameters of the solver
+      //-----------------------------------------------------------------------
+      double stop = stopping(param.tol, b2, param.residual_type);
+      int maxIter = param.maxiter;
+      int maxInnerIter = param.Nkrylov;
+      int kAug    = param.deflation_grid; // dim. of augmented subspace
+      int startArnoldi = 0;               // begin of arnoldi loop
+           
+      double detGref;                     // measure for quality of augmented subspace
+      int deflCount     = 0;              // counts the number of consecutive deflations
+      int badSubspCount = 0;              // counts the number of rejected subspaces
+      int subspaceShape  = 1;             // 1 -> GMRES-R, 0 -> GMRES-DR
+      //-----------------------------------------------------------------------
+           
+      // allocate memory for the required matrices and spinor-matrices
+      //-----------------------------------------------------------------------
+      // for the arnoldi spinors
+      csParam.setPrecision(param.precision_sloppy);         // change precision
+      cudaColorSpinorField **V = new cudaColorSpinorField*[maxInnerIter+1];
+      for (int i=0; i<(maxInnerIter+1); i++)
+         V[i] = new cudaColorSpinorField(b, csParam);
+           
+      // auxiliary spinor for arnoldi process
+      cudaColorSpinorField *w;
+      w = new cudaColorSpinorField(b, csParam);
+           
+      // preconditioned spinors in main solver precision
+      cudaColorSpinorField **Z = new cudaColorSpinorField*[maxInnerIter];
+      for (int i=0; i<maxInnerIter; i++)
+         Z[i] = new cudaColorSpinorField(b, csParam);
+      csParam.setPrecision(param.precision);                // change back precision
+           
+      // auxiliary precon. spinors in preconditioner-precision
+      // allocate memory only if necessary (might throw a compiler warning, but this is ok)
+      cudaColorSpinorField *Z_precon, *V_precon;
+      if ( param.precision_precondition!=param.precision_sloppy ) {
+         csParam.setPrecision(param.precision_precondition);   // change precision
+         Z_precon = new cudaColorSpinorField(b, csParam);
+         V_precon = new cudaColorSpinorField(b, csParam);
+         csParam.setPrecision(param.precision);                // change back precision
+      }
+           
+      // temporary spinors for the dirac operators in both precisions
+      csParam.setPrecision(param.precision);
+      cudaColorSpinorField temp(b, csParam);
+      csParam.setPrecision(param.precision_sloppy);            // change precision
+      cudaColorSpinorField temp_sloppy(b, csParam);
+      csParam.setPrecision(param.precision);                   // change back precision
+           
+      // residual spinors
+      cudaColorSpinorField r(b);
+      cudaColorSpinorField *r_sloppy;
+      if ( param.precision_sloppy!=param.precision ) {
+         csParam.setPrecision(param.precision_sloppy);         // change precision
+         r_sloppy = new cudaColorSpinorField(b, csParam);
+         csParam.setPrecision(param.precision);                // change back precision
+      }
+      else
+         r_sloppy = &r;
+            
+      // for the arnoldi H-matrix (initialize to zero)
+      int ldH = maxInnerIter+1;
+      Complex *H = new Complex[maxInnerIter*ldH]();
+           
+      // vectors for the approximate solve (the paper calls y = rho)
+      Complex *c = new Complex[maxInnerIter+1]();
+      Complex *y = new Complex[maxInnerIter]();
+            
+      // value stored in H[k+1]
+      double normV;
+      //-----------------------------------------------------------------------   
+           
+      // compute parity of the node (needed for the Schwarz solver)
+      //-----------------------------------------------------------------------
+      int parity = 0;
+      for (int i=0; i<4; i++)
+         parity += commCoords(i);
+      parity = parity % 2;
+      //-----------------------------------------------------------------------
+           
+      // switch time-profilers --> FROM INITIALIZATION TO PREAMBLE
+      //-----------------------------------------------------------------------
+      profile.Stop(QUDA_PROFILE_INIT);
+      profile.Start(QUDA_PROFILE_PREAMBLE);
+      //-----------------------------------------------------------------------
+           
+      // calculate values of the 0th iteration
+      //-----------------------------------------------------------------------
+      // reset blas flop-counter
+      blas_flops = 0;
+           
+      // exact initial residual depending on the values for x and b
+      mat(r, x, temp);              // r = Ax
+      axpbyCuda(1.0, b, -1.0, r);   // r = b - r = b - Ax
+      double r2 = normCuda(r);      // r2 = |r|^2
+           
+      // first arnoldi vector (low precision)
+      Complex beta = 1.0/sqrt(r2);        // caxpy needs compl. constants
+      copyCuda(*r_sloppy, r);             // get r also in low precision
+      caxpyCuda(beta, *r_sloppy, *V[0]);  // V[0] = beta*r_sloppy + V[0]
+      
+      // calculate heavy quark residual                                       FIX ME: is this line necessary
+      if ( use_heavy_quark_res )
+         heavy_quark_res = sqrt(HeavyQuarkResidualNormCuda(x,r).z);
+            
+      // print stats of the current iteration
+      PrintStats("GMRES", 0, r2, b2, heavy_quark_res);
+      //-----------------------------------------------------------------------
+           
+      // switch time-profilers --> FROM PREAMBLE TO CALCULATION
+      //-----------------------------------------------------------------------
+      profile.Stop(QUDA_PROFILE_PREAMBLE);
+      profile.Start(QUDA_PROFILE_COMPUTE);
+      //-----------------------------------------------------------------------
+           
+      // start the outer iteration
+      //-----------------------------------------------------------------------
+      int k=0;         
+      while( !convergence(r2, heavy_quark_res, stop, param.tol_hq) && k<maxIter ) {
+      
+	 // run the deflation subroutine, with check if deflation makes sense or not
+	 //--------------------------------------------------------------------
+	 // check shape of last subspace and modify matrices for the next iteration,
+	 // i.e., deflate or zero them
+	 if (kAug != 0) {
+	    // we accept one bad subspace, but if the next one should also be
+	    // corrupted we force a clean restart
+	    subspaceShape = utilGMRES::checkRestartCriterion(k+1, &deflCount,
+				            &badSubspCount, 20, 1, kAug, &detGref, V);
+	 }
+	 
+	 if ( subspaceShape == 1 || kAug == 0 ) {
+	    // perform clean restart and print warning message
+	    printfQuda("GMRES: performing clean restart after iteration %d\n", k);
+	    std::memset( H, 0.0, maxInnerIter*ldH*sizeof(Complex) );
+	 
+	    beta = 1.0/sqrt(r2);                                     // sqrt() since r2 = res^2
+	    zeroCuda(*V[0]);                                         // V[0] = 0 so that next line works
+	    if ( param.precision_sloppy!=param.precision ) {
+	       copyCuda(*r_sloppy, r);                               // convert precision of r
+	       caxpyCuda(beta, *r_sloppy, *V[0]);                    // V[0] = beta*r + V[0]
+	    }
+	    else
+	       caxpyCuda(beta, r, *V[0]);                            // V[0] = beta*r + V[0]
+	    
+	    // in the next iteration perform clean arnoldi procedure
+	    startArnoldi = 0;
+	 }
+	 else {   // deflate the system
+	    csParam.setPrecision(param.precision_sloppy);
+	    utilGMRES::deflate( H, V, Z, c, y, maxInnerIter, ldH, kAug, csParam);
+	    csParam.setPrecision(param.precision);
+	 
+	    // start Arnoldi procedure at a later stage
+	    startArnoldi = kAug;
+	 }
+         //--------------------------------------------------------------------
+
+         // start the inner iteration, i.e., flexible Arnoldi and Gram Schmidt
+         //--------------------------------------------------------------------
+         for (int l=startArnoldi; l<maxInnerIter; l++) {
+               
+            // preconditioning for m consecutive steps (compare with inv_gcr_quda.cpp)
+            //-----------------------------------------------------------------
+            for (int m=0; m<param.precondition_cycle; m++) {
+               // if a valid inverter was set, do the following
+               if (param.inv_type_precondition != QUDA_INVALID_INVERTER) {
+                  // perform one approximate iteration
+                  if ((parity+m)%2 == 0 || param.schwarz_type == QUDA_ADDITIVE_SCHWARZ) {
+                     if ( param.precision_precondition!=param.precision_sloppy ) {
+                        copyCuda(*V_precon, *V[l]);   // V_precon = V[l]
+                        (*K)(*Z_precon, *V_precon);   // Z_precon = inv(A)*V_precon
+                        copyCuda(*Z[l], *Z_precon);   // Z[l] = Z_precon
+                     }
+                     else
+                        (*K)(*Z[l], *V[l]);           // Z_precon = inv(A)*V_precon
+                  }
+               }
+               else  // no preconditioner was set --> copy V into Z
+                  copyCuda(*Z[l], *V[l]);             // Z[l] = V[l]
+            }
+            //-----------------------------------------------------------------
+               
+            // do flexible arnoldi iteration (in low precision)
+            if ( param.precision_sloppy!=param.precision )
+               matSloppy(*w, *Z[l], temp_sloppy);     // w = A*Z[l]
+            else
+               mat(*w, *Z[l], temp);                  // copy w <-- Z[l]
+               
+            for (int j=0; j<=l; j++) {
+               H[j+ldH*l] = cDotProductCuda(*w, *V[j]);
+               caxpyCuda(-H[j+ldH*l], *V[j], *w);     // w = w - H[j][l]*V[j]
+            }
+            
+            // fill in the missing elements of H and V
+            normV          = sqrt( normCuda(*w) );    // normCuda(x) returns |x|^2
+            H[(l+1)+ldH*l] = normV;
+            axCuda(1.0/normV, *w);                    // V[l+1] = V[l+1]/H[l+1][l]
+            copyCuda(*V[l+1], *w);  
+         }
+         //--------------------------------------------------------------------
+         
+         // form the approximate solution
+         if ( k==0 || subspaceShape == 1 || kAug == 0 ) {            // in case of clean (re-) start
+            std::memset( c, 0.0, (maxInnerIter+1)*sizeof(Complex) ); // defensive measure
+            c[0] = sqrt(r2);                                         // sqrt() since r2 = res^2
+         }
+         else {                                                      // in case of deflated restart
+            std::memset( c, 0.0, (maxInnerIter+1)*sizeof(Complex) ); // defensive measure
+            copyCuda(*r_sloppy, r);                                  // convert r into low prec. (just to be shure)
+            for (int i=0; i<(kAug+1); i++) {
+               c[i] = cDotProductCuda(*V[i], *r_sloppy);             // update the c-vector
+            }
+         }
+         utilGMRES::solveLeastSquares(H, c, y, ldH, maxInnerIter, ldH); // y = argmin||c-H.y||
+         
+         // calculate the new solution by x = x + Z.y
+         if ( param.precision_sloppy!=param.precision ) {
+            for (int i=0; i<maxInnerIter; i++) {      
+               copyCuda(temp, *Z[i]);                                // convert Z[i] into high precision
+               caxpyCuda(y[i], temp, x);                             // x = x + Z.y
+            }
+         }
+         else {
+            for (int i=0; i<maxInnerIter; i++)  
+               caxpyCuda(y[i], *Z[i], x);                            // x = x + Z.y
+         }
+            
+         //...and mathematically correct resNorm (in high precision)
+         mat(r, x, temp);                                            // r = A.x
+         axpbyCuda(1.0, b, -1.0, r);                                 // r = b - r = b - A.x
+         r2 = normCuda(r);
+            
+         // calculate heavy quark residual
+         if ( use_heavy_quark_res )
+               heavy_quark_res = sqrt(HeavyQuarkResidualNormCuda(x,r).z);
+            
+         // print stats of the current iteration
+         PrintStats("GMRES", (k+1), r2, b2, heavy_quark_res);
+                  
+         // increment k
+         k++;
+      }
+      //-----------------------------------------------------------------------
+            
+      // switch time-profilers --> FROM CALCULATION TO EPILOGUE
+      //-----------------------------------------------------------------------
+      profile.Stop(QUDA_PROFILE_COMPUTE);
+      profile.Start(QUDA_PROFILE_EPILOGUE);
+      //-----------------------------------------------------------------------
+           
+      // calculate some additional informations to finish the solve
+      //-----------------------------------------------------------------------
+      param.secs += profile.Last(QUDA_PROFILE_COMPUTE);
+           
+      // calculate the flops number (same as for GCR solver)
+      double gflops;
+      gflops = (blas_flops + mat.flops() + matSloppy.flops() + matPrecon.flops())*1e-9;
+      reduceDouble(gflops);
+         
+      // set the flop-counters
+      param.gflops += gflops;
+      param.iter   += k;      // No. of total outer iterations
+      blas_flops    = 0;
+      mat.flops();
+      matSloppy.flops();
+      matPrecon.flops();
+         
+      // tell calling function the true residual
+      param.true_res = sqrt( r2/b2 );     // sqrt() since r2 = res^2
+#if (__COMPUTE_CAPABILITY__ >= 200)
+      param.true_res_hq = heavy_quark_res;
+#else
+      param.true_res_hq = 0.0;
+#endif   
+      //-----------------------------------------------------------------------
+           
+      // switch time-profilers --> FROM EPILOGUE TO FREE
+      //-----------------------------------------------------------------------
+      profile.Stop(QUDA_PROFILE_EPILOGUE);
+      profile.Start(QUDA_PROFILE_FREE);
+      //-----------------------------------------------------------------------
+                 
+      // free allocated memory
+      //-----------------------------------------------------------------------
+      for (int i=0; i<(maxInnerIter+1); i++)
+         delete V[i];
+           
+      for (int i=0; i<maxInnerIter; i++)
+         delete Z[i];
+           
+      delete[] V;
+      delete[] Z;
+      delete w;
+              
+      if ( param.precision_sloppy!=param.precision )
+         delete r_sloppy;
+
+      if ( param.precision_precondition!=param.precision_sloppy ) {
+         delete V_precon;
+         delete Z_precon;
+      }
+      delete[] H;
+      delete[] y;
+      delete[] c;
+      //-----------------------------------------------------------------------
+           
+      // kill the last time-profiler
+      //-----------------------------------------------------------------------
+      profile.Stop(QUDA_PROFILE_FREE);
+      //-----------------------------------------------------------------------
+           
+   }
+   //--------------------------------------------------------------------------
+   //--------------------------------------------------------------------------
+}
+//-----------------------------------------------------------------------------

--- a/lib/solver.cpp
+++ b/lib/solver.cpp
@@ -15,6 +15,10 @@ namespace quda {
     Solver *solver=0;
 
     switch (param.inv_type) {
+    case QUDA_GMRES_INVERTER: // This is my modification
+      report("GMRES");
+      solver = new GMRES(mat, matSloppy, matPrecon, param, profile);
+      break;
     case QUDA_CG_INVERTER:
       report("CG");
       solver = new CG(mat, matSloppy, param, profile);

--- a/make.inc.uniRgb
+++ b/make.inc.uniRgb
@@ -1,0 +1,372 @@
+###### Local configuration:
+
+CUDA_INSTALL_PATH = /usr/local/cuda
+QDP_INSTALL_PATH = 
+QDPXX_CXXFLAGS = 
+QDPXX_LDFLAGS = 
+QDPXX_LIBS = 
+
+CPU_ARCH = x86_64  	  # x86 or x86_64
+GPU_ARCH = sm_20	  # sm_13, sm_20, sm_21, sm_30, or sm_35
+OS       = linux	  # linux or osx
+
+PYTHON = python	  # python 2.5 or later required for 'make gen'
+
+# compilation options
+HOST_DEBUG = no			# compile host debug code
+DEVICE_DEBUG = no		# compile device debug code for cuda-gdb 
+VERBOSE = no			# display kernel register useage
+BLAS_TEX = yes			# enable texture reads in BLAS?
+FERMI_DBLE_TEX = yes		# enable double-precision texture reads on Fermi?
+
+BUILD_WILSON_DIRAC = yes			# build Wilson Dirac operators?
+BUILD_CLOVER_DIRAC = yes			# build clover Dirac operators?
+BUILD_DOMAIN_WALL_DIRAC = yes			# build domain wall Dirac operators?
+BUILD_STAGGERED_DIRAC = yes			# build staggered Dirac operators?
+BUILD_TWISTED_MASS_DIRAC = yes			# build twisted mass Dirac operators?
+BUILD_TWISTED_CLOVER_DIRAC = no			# build twisted clover Dirac operators?
+BUILD_NDEG_TWISTED_MASS_DIRAC = no		# build non-degenerate twisted mass Dirac operators?
+BUILD_FATLINK = no				# build code for computing asqtad fat links?
+BUILD_HISQLINK = no				# build code for computing hisq fat links?
+BUILD_GAUGE_FORCE = no				# build code for (1-loop Symanzik) gauge force?
+BUILD_FERMION_FORCE = no			# build code for asqtad fermion force?
+BUILD_HISQ_FORCE = no				# build code for hisq fermion force?
+BUILD_GAUGE_TOOLS = no				# build auxilary gauge-field tools?
+BUILD_SSTEP = no                                # build s-step linear solvers?
+
+# Multi-GPU options
+BUILD_MULTI_GPU = no  	    # set to 'yes' to build the multi-GPU code
+BUILD_QMP = no              # set to 'yes' to build the QMP multi-GPU code
+BUILD_MPI = no              # set to 'yes' to build the MPI multi-GPU code
+POSIX_THREADS = no          # set to 'yes' to build pthread-enabled dslash
+
+
+#BLAS library
+BUILD_MAGMA = yes 	  # build magma interface
+
+# GPUdirect options
+GPU_DIRECT = yes          # set to 'yes' to allow GPU and NIC to shared pinned buffers
+GPU_COMMS = no            # set to 'yes' to allow GPU and NIC to communicate using RDMA
+
+# Interface options
+BUILD_QDP_INTERFACE = yes                 # build qdp interface
+BUILD_MILC_INTERFACE = yes                # build milc interface
+BUILD_CPS_INTERFACE = no                  # build cps interface
+BUILD_QDPJIT_INTERFACE = no               # build qdpjit interface
+BUILD_BQCD_INTERFACE = no                 # build bqcd interface
+BUILD_TIFR_INTERFACE = no                 # build tifr interface
+
+# Packing option
+DEVICE_PACK = yes	     # set to 'yes' to enable packing and unpacking on the device
+
+# GPU contractions of spinors
+BUILD_CONTRACT = yes    	     # build code for bilinear contraction?
+
+BUILD_QIO = no               # set to 'yes' to build QIO code for binary I/O
+
+USE_QDPJIT = no              # build QDP-JIT support?
+
+FECC = gcc			# front-end CC
+FECXX = g++			# front-end CXX
+FEF90 = gfortran		# front-end F90
+
+MPI_HOME=
+QMP_HOME=
+QIO_HOME=
+
+MAGMA_HOME=/home/bam53693/MAGMAinstall
+ATLAS_HOME=/home/bam53693/atlasInstall
+LAPACK_HOME=/home/bam53693/atlasInstall
+
+
+NUMA_AFFINITY=yes   # enable NUMA affinity?
+
+###################################################################################################
+
+INC = -I$(CUDA_INSTALL_PATH)/include
+
+ifeq ($(strip $(CPU_ARCH)), x86_64)
+  ifeq ($(strip $(OS)), osx)
+    LIB = -L$(CUDA_INSTALL_PATH)/lib -lcudart
+    NVCCOPT = -m64
+  else
+    LIB = -L$(CUDA_INSTALL_PATH)/lib64 -lcudart
+  endif
+else
+  LIB = -L$(CUDA_INSTALL_PATH)/lib -lcudart -m32
+  COPT = -malign-double -m32
+  NVCCOPT = -m32
+endif
+
+COMP_CAP = $(GPU_ARCH:sm_%=%0)
+
+COPT += -D__COMPUTE_CAPABILITY__=$(COMP_CAP)
+NVCCOPT += -D__COMPUTE_CAPABILITY__=$(COMP_CAP)
+
+TESLA_ARCH = $(shell [ $(COMP_CAP) -lt 200 ] && echo true)
+ifneq ($(TESLA_ARCH),true)
+  NVCCOPT += -ftz=true -prec-div=false -prec-sqrt=false -w
+else
+  NVCCOPT += -w
+endif
+
+ifeq ($(strip $(BUILD_MULTI_GPU)), yes)
+  COPT += -DMULTI_GPU
+  NVCCOPT += -DMULTI_GPU
+else
+  COMM_OBJS = comm_single.o
+endif
+
+CC  = $(FECC)
+CXX = $(FECXX)
+F90 = $(FEF90)
+
+ifeq ($(strip $(BUILD_MPI)), yes)
+  MPI_CFLAGS =
+  MPI_LDFLAGS =
+  MPI_LIBS =
+  INC += -DMPI_COMMS $(MPI_CFLAGS) -I$(MPI_HOME)/include
+  LIB += $(MPI_LDFLAGS) $(MPI_LIBS)
+  COMM_OBJS = comm_mpi.o
+endif
+
+ifeq ($(strip $(BUILD_QIO)), yes)
+  INC += -DHAVE_QIO -I$(QIO_HOME)/include
+  LIB += -L$(QIO_HOME)/lib -lqio -llime
+  QIO_UTIL = qio_util.o layout_hyper.o gauge_qio.o
+endif
+
+ifeq ($(strip $(BUILD_QMP)), yes)
+  QMP_CFLAGS = $(shell $(QMP_HOME)/bin/qmp-config --cflags )
+  QMP_LDFLAGS = $(shell $(QMP_HOME)/bin/qmp-config --ldflags )
+  QMP_LIBS = $(shell $(QMP_HOME)/bin/qmp-config --libs )
+  INC += -DQMP_COMMS $(QMP_CFLAGS)
+  LIB += $(QMP_LDFLAGS) $(QMP_LIBS)
+  COMM_OBJS = comm_qmp.o
+endif 
+
+ifeq ($(strip $(BUILD_MAGMA)), yes)
+  MAGMA_INCLUDE = -I$(CUDA_INSTALL_PATH)/include -I../include -I${MAGMA_HOME}/include
+  MAGMA_FLAGS   = -DMAGMA_LIB -DADD_ -DMAGMA_SETAFFINITY -DGPUSHMEM=300 -DHAVE_CUBLAS
+  COPT += -fopenmp  -DMAGMA_LIB
+  
+  LIB += -fopenmp -L$(MAGMA_HOME)/lib -lmagma 
+  LIB += -L$(LAPACK_HOME) -llapack -lf77blas -lgfortran 
+  LIB += -L$(ATLAS_HOME)/lib -lcblas -latlas
+  LIB += -L$(CUDA_INSTALL_PATH)/lib64 -lcublas
+
+else
+  MAGMA_INCLUDE = 
+  MAGMA_FLAGS   = 
+endif
+
+ifeq ($(strip $(BUILD_SSTEP)), yes)
+  NVCCOPT += -DSSTEP
+  COPT += -DSSTEP
+endif
+
+ifeq ($(strip $(POSIX_THREADS)), yes)
+  NVCCOPT += -DPTHREADS
+  COPT += -DPTHREADS
+endif
+
+ifeq ($(strip $(POSIX_THREADS)), yes)
+  LIB += -lpthread
+endif
+
+
+ifeq ($(strip $(BUILD_WILSON_DIRAC)), yes)
+  NVCCOPT += -DGPU_WILSON_DIRAC
+  COPT += -DGPU_WILSON_DIRAC
+  DIRAC_TEST = dslash_test invert_test
+endif
+
+ifeq ($(strip $(BUILD_DOMAIN_WALL_DIRAC)), yes)
+  NVCCOPT += -DGPU_DOMAIN_WALL_DIRAC
+  COPT += -DGPU_DOMAIN_WALL_DIRAC
+  DIRAC_TEST = dslash_test invert_test
+endif
+
+ifeq ($(strip $(BUILD_STAGGERED_DIRAC)), yes)
+  NVCCOPT += -DGPU_STAGGERED_DIRAC
+  COPT += -DGPU_STAGGERED_DIRAC
+  STAGGERED_DIRAC_TEST=staggered_dslash_test staggered_invert_test
+endif
+
+ifeq ($(strip $(BUILD_CLOVER_DIRAC)), yes)
+  NVCCOPT += -DGPU_CLOVER_DIRAC -DGPU_WILSON_DIRAC -DGPU_GAUGE_TOOLS
+  COPT += -DGPU_CLOVER_DIRAC -DGPU_WILSON_DIRAC -DGPU_GAUGE_TOOLS
+endif
+
+ifeq ($(strip $(BUILD_TWISTED_MASS_DIRAC)), yes)
+  NVCCOPT += -DGPU_TWISTED_MASS_DIRAC -DGPU_WILSON_DIRAC
+  COPT += -DGPU_TWISTED_MASS_DIRAC -DGPU_WILSON_DIRAC
+endif
+
+ifeq ($(strip $(BUILD_TWISTED_CLOVER_DIRAC)), yes)
+  NVCCOPT += -DGPU_TWISTED_CLOVER_DIRAC -DGPU_CLOVER_DIRAC -DGPU_TWISTED_MASS_DIRAC -DGPU_WILSON_DIRAC -DGPU_GAUGE_TOOLS
+  COPT += -DGPU_TWISTED_CLOVER_DIRAC -DGPU_CLOVER_DIRAC -DGPU_TWISTED_MASS_DIRAC -DGPU_WILSON_DIRAC -DGPU_GAUGE_TOOLS
+endif
+
+ifeq ($(strip $(BUILD_NDEG_TWISTED_MASS_DIRAC)), yes)
+  NVCCOPT += -DGPU_NDEG_TWISTED_MASS_DIRAC -DGPU_TWISTED_MASS_DIRAC -DGPU_WILSON_DIRAC
+  COPT += -DGPU_NDEG_TWISTED_MASS_DIRAC -DGPU_TWISTED_MASS_DIRAC -DGPU_WILSON_DIRAC
+endif
+
+ifeq ($(strip $(BUILD_FATLINK)), yes)
+  NVCCOPT += -DGPU_FATLINK -DGPU_GAUGE_TOOLS
+  COPT += -DGPU_FATLINK -DGPU_GAUGE_TOOLS
+  FATLINK_TEST=llfat_test
+endif
+
+ifeq ($(strip $(BUILD_HISQLINK)), yes)
+  ifneq ($(strip $(BUILD_FATLINK)), yes) 
+    NVCCOPT += -DGPU_FATLINK 
+    COPT    += -DGPU_FATLINK
+    FATLINK_TEST=llfat_test
+  endif
+  UNITARIZE_LINK_TEST=unitarize_link_test
+  NVCCOPT += -DGPU_UNITARIZE -DGPU_GAUGE_TOOLS
+  COPT    += -DGPU_UNITARIZE -DGPU_GAUGE_TOOLS
+endif
+
+ifeq ($(strip $(BUILD_GAUGE_FORCE)), yes)
+  NVCCOPT += -DGPU_GAUGE_FORCE -DGPU_GAUGE_TOOLS
+  COPT += -DGPU_GAUGE_FORCE -DGPU_GAUGE_TOOLS
+  GAUGE_FORCE_TEST=gauge_force_test
+endif
+
+ifeq ($(strip $(BUILD_FERMION_FORCE)), yes)
+  NVCCOPT += -DGPU_FERMION_FORCE -DGPU_GAUGE_TOOLS
+  COPT += -DGPU_FERMION_FORCE -DGPU_GAUGE_TOOLS
+  FERMION_FORCE_TEST=fermion_force_test
+endif
+
+ifeq ($(strip $(BUILD_HISQ_FORCE)), yes)
+  NVCCOPT += -DGPU_HISQ_FORCE -DGPU_STAGGERED_OPROD -DGPU_GAUGE_TOOLS
+  COPT += -DGPU_HISQ_FORCE -DGPU_STAGGERED_OPROD -DGPU_GAUGE_TOOLS
+  HISQ_PATHS_FORCE_TEST=hisq_paths_force_test
+  HISQ_UNITARIZE_FORCE_TEST=hisq_unitarize_force_test
+endif
+
+ifeq ($(strip $(BUILD_GAUGE_TOOLS)), yes)
+  NVCCOPT += -DGPU_GAUGE_TOOLS
+  COPT += -DGPU_GAUGE_TOOLS
+endif
+
+ifeq ($(strip $(HOST_DEBUG)), yes)
+  NVCCOPT += -g -DHOST_DEBUG
+  COPT += -g -fno-inline -DHOST_DEBUG
+endif
+
+ifeq ($(strip $(DEVICE_DEBUG)), yes)
+  NVCCOPT += -G
+endif
+
+ifeq ($(strip $(VERBOSE)), yes)
+  NVCCOPT += --ptxas-options=-v
+endif
+
+ifeq ($(strip $(BLAS_TEX)), no)
+  NVCCOPT += -DDIRECT_ACCESS_BLAS
+  COPT += -DDIRECT_ACCESS_BLAS
+endif
+
+ifeq ($(strip $(FERMI_DBLE_TEX)), no)
+  NVCCOPT += -DFERMI_NO_DBLE_TEX
+  COPT += -DFERMI_NO_DBLE_TEX
+endif
+
+ifeq ($(strip $(GPU_DIRECT)), yes)
+  NVCCOPT += -DGPU_DIRECT
+  COPT += -DGPU_DIRECT
+endif
+
+ifeq ($(strip $(GPU_COMMS)), yes)
+  NVCCOPT += -DGPU_COMMS
+  COPT += -DGPU_COMMS
+endif
+
+ifeq ($(strip $(BUILD_QDP_INTERFACE)), yes)
+  NVCCOPT += -DBUILD_QDP_INTERFACE
+  COPT += -DBUILD_QDP_INTERFACE
+endif
+
+ifeq ($(strip $(BUILD_MILC_INTERFACE)), yes)
+  NVCCOPT += -DBUILD_MILC_INTERFACE
+  COPT += -DBUILD_MILC_INTERFACE
+endif
+
+ifeq ($(strip $(BUILD_CPS_INTERFACE)), yes)
+  NVCCOPT += -DBUILD_CPS_INTERFACE
+  COPT += -DBUILD_CPS_INTERFACE
+endif
+
+ifeq ($(strip $(BUILD_QDPJIT_INTERFACE)), yes)
+  NVCCOPT += -DBUILD_QDPJIT_INTERFACE
+  COPT += -DBUILD_QDPJIT_INTERFACE
+endif
+
+ifeq ($(strip $(BUILD_BQCD_INTERFACE)), yes)
+  NVCCOPT += -DBUILD_BQCD_INTERFACE
+  COPT += -DBUILD_BQCD_INTERFACE
+endif
+
+ifeq ($(strip $(BUILD_TIFR_INTERFACE)), yes)
+  NVCCOPT += -DBUILD_TIFR_INTERFACE
+  COPT += -DBUILD_TIFR_INTERFACE
+endif
+
+ifeq ($(strip $(DEVICE_PACK)), yes)
+  NVCCOPT += -DDEVICE_PACK
+  COPT += -DDEVICE_PACK
+endif
+
+ifeq ($(strip $(OS)), osx)
+  NUMA_AFFINITY = no
+endif
+
+ifeq ($(strip $(NUMA_AFFINITY)), yes)
+  NVCCOPT += -DNUMA_AFFINITY
+  COPT += -DNUMA_AFFINITY
+  NUMA_AFFINITY_OBJS=numa_affinity.o
+endif
+
+ifeq ($(strip $(BUILD_CONTRACT)), yes)
+  LOOPVV_TEST=vvTrickLoops
+  LOOPVV_TUNE=tuneOneEndTrick
+  LOOPTD_TEST=tDilutionLoops
+  LPTDHP_TEST=tDilHPELoops
+  LOOPCV_TEST=loopsPlain
+  LOOPHP_TEST=loopsHPE
+  NVCCOPT += -DGPU_CONTRACT
+  COPT += -DGPU_CONTRACT
+endif
+
+### Next conditional is necessary.
+### QDPXX_CXXFLAGS contains "-O3".
+### We must make sure its not given
+### twice to nvcc. It would complain.
+
+ifeq ($(strip $(USE_QDPJIT)), yes)
+  NVCCOPT += -DUSE_QDPJIT
+  COPT += -DUSE_QDPJIT
+  LIB += $(QDPXX_LDFLAGS) $(QDPXX_LIBS)
+  INC += -I$(QDP_INSTALL_PATH)/include
+
+  CFLAGS = -Wall -std=c99 $(COPT) $(INC)
+  CXXFLAGS = -Wall $(COPT) $(INC) $(QDPXX_CXXFLAGS)
+  NVCC = $(CUDA_INSTALL_PATH)/bin/nvcc 
+  NVCCFLAGS = $(NVCCOPT) -arch=$(GPU_ARCH) $(INC)
+  LDFLAGS = -fPIC $(LIB)
+else
+  CFLAGS = -Wall -O3 -std=c99 $(COPT) $(INC)
+  CXXFLAGS = -Wall -O3 $(COPT) $(INC)
+  NVCC = $(CUDA_INSTALL_PATH)/bin/nvcc 
+  NVCCFLAGS = -O3 $(NVCCOPT) -arch=$(GPU_ARCH) $(INC)
+  LDFLAGS = -fPIC $(LIB)
+endif
+
+
+### Add any other user options like keep to NVCCOPT
+NVCCFLAGS += 


### PR DESCRIPTION
Implemented the F-GMRES-DR solver presented in **http://arxiv.org/abs/1204.5463** with slight modifications in order to make it more robust against floating point errors accumulating in a mixed precision environment.
The solver assumes that Quda was linked against Magma (everything was tested with Magma 1.6.2).

Analogously to all other QUDA solvers, F-GMRES-DRs vital parameters are defined
within QudaInvertParam. Among all possible settings only two parameters are distinct
from all other available solvers, namely the total size of the used Krylov space, and the
number of Ritz vectors used for deflation. These two parameters were assigned to
**QudaInvertParam.gcrNkrylov  // size of Krylov space
QudaInvertParam.deflation_grid // # of Ritz vectors for deflation**
since their names are the most adequate for the intended purpose.
The following code snippet set up GMRES in a default way:
**QudaInvertParam inv_param = newQudaInvertParam();
inv_param.inv_type = QUDA_GMRES_INVERTER;
inv_param.gcrNkrylov = 8; // 8 Krylov vectors
inv_param.deflation_grid = 1; // 1 Ritz vector for deflation**
For a short example of the overall interface see the appended file “invert_test.cpp”,
which belongs into the “tests” directory.
