### PR TITLE
Feature/complex cleanup

### DIFF
--- a/include/clover_field_order.h
+++ b/include/clover_field_order.h
@@ -131,8 +131,8 @@ namespace quda {
 
 	const int chirality = s_col / 2;
 
-	int row = s_row%2 * nColor + c_row;
-	int col = s_col%2 * nColor + c_col;
+	unsigned int row = s_row%2 * nColor + c_row;
+	unsigned int col = s_col%2 * nColor + c_col;
 
 	if (row == col) {
 	  complex<Float> tmp = a[parity][(x*2 + chirality)*N*N + row];

--- a/include/color_spinor.h
+++ b/include/color_spinor.h
@@ -27,7 +27,7 @@ namespace quda {
     struct ColorSpinor<Float, Nc, 4> {
     static const int Ns = 4;
     complex<Float> data[Nc*4];
-    
+
     __device__ __host__ ColorSpinor<Float, Nc, 4>() {
       for (int i=0; i<Nc*Ns; i++) {
 	data[i] = 0;
@@ -473,10 +473,9 @@ namespace quda {
      @return The spin traced matrix
   */
   template<typename Float, int Nc, int Ns> __device__ __host__
-    Matrix< typename ComplexTypeId<Float>::Type ,Nc> outerProdSpinTrace(const ColorSpinor<Float,Nc,Ns> &a, const ColorSpinor<Float,Nc,Ns> &b) {
+    Matrix<complex<Float>,Nc> outerProdSpinTrace(const ColorSpinor<Float,Nc,Ns> &a, const ColorSpinor<Float,Nc,Ns> &b) {
 
-    typedef typename ComplexTypeId<Float>::Type complex_type;
-    Matrix<complex_type,Nc> out;
+    Matrix<complex<Float>,Nc> out;
     for (int i=0; i<Nc; i++) {
       for(int j=0; j<Nc; j++) {
 	out(i,j) = make_double2(0.0, 0.0);
@@ -487,14 +486,13 @@ namespace quda {
     for (int s=0; s<Ns; s++) {
       // outer product over color
       for (int i=0; i<Nc; i++) {
-        for(int j=0; j<Nc; j++) {
+	for(int j=0; j<Nc; j++) {
 	  out(j,i) += a(s,j) * conj(b(s,i));
 	}
       }
     }
     return out;
   }
-
 
   
 } // namespace quda

--- a/include/complex_quda.h
+++ b/include/complex_quda.h
@@ -418,6 +418,14 @@ public:
       return *this;
     }
 
+  __host__ __device__
+    inline complex<ValueType>& operator*=(const ValueType z)
+    {
+      this->x *= z;
+      this->y *= z;
+      return *this;
+    }
+
   __host__ __device__ inline ValueType real() const volatile;
   __host__ __device__ inline ValueType imag() const volatile;
   __host__ __device__ inline ValueType real() const;
@@ -511,6 +519,14 @@ public:
       return *this;
     }
 
+  __host__ __device__
+    inline complex<float>& operator*=(const float z)
+    {
+      this->x *= z;
+      this->y *= z;
+      return *this;
+    }
+
   // Let the compiler synthesize the copy and assignment operators.
   __host__ __device__ inline complex<float>(const volatile complex<float> & z)
   {
@@ -591,6 +607,14 @@ public:
     }
 
   __host__ __device__
+    inline complex<double>& operator+=(const complex<float> z)
+    {
+      real(real()+z.real());
+      imag(imag()+z.imag());
+      return *this;
+    }
+
+  __host__ __device__
     inline complex<double>& operator-=(const complex<double> z)
     {
       real(real()-z.real());
@@ -609,6 +633,14 @@ public:
     inline complex<double>& operator/=(const complex<double> z)
     {
       *this = *this / z;
+      return *this;
+    }
+
+  __host__ __device__
+    inline complex<double>& operator*=(const double z)
+    {
+      this->x *= z;
+      this->y *= z;
       return *this;
     }
 

--- a/include/su3_project.cuh
+++ b/include/su3_project.cuh
@@ -67,11 +67,10 @@ namespace quda {
    * @param in The input matrix to which we're projecting
    * @param tol Tolerance to which this check is applied
    */
-  template <typename Float2,typename Float>
-  __host__ __device__ void polarSu3(Matrix<Float2,3> &in, Float tol)
+  template <typename Float>
+  __host__ __device__ void polarSu3(Matrix<complex<Float>,3> &in, Float tol)
   {
-    typedef typename ComplexTypeId<Float>::Type Cmplx;
-    Matrix<Cmplx,3> inv, out;
+    Matrix<complex<Float>,3> inv, out;
 
     out = in;
     computeMatrixInverse(out, &inv);
@@ -84,13 +83,13 @@ namespace quda {
 
 
     // now project onto special unitary group
-    Cmplx  det = getDeterminant(out);
+    complex<Float> det = getDeterminant(out);
     double mod = det.x*det.x + det.y*det.y;
     mod = pow(mod, (1./6.));
     double angle = atan2(det.y, det.x);
     angle /= -3.;
     
-    Cmplx cTemp;
+    complex<Float> cTemp;
 
     cTemp.x = cos(angle)/mod;
     cTemp.y = sin(angle)/mod;

--- a/lib/clover_deriv_quda.cu
+++ b/lib/clover_deriv_quda.cu
@@ -13,14 +13,14 @@ namespace quda {
   
 #ifdef GPU_CLOVER_DIRAC
   
-  template<class Cmplx, typename Force, typename Gauge, typename Oprod>
+  template<class Float, typename Force, typename Gauge, typename Oprod>
   struct CloverDerivArg
   {
     int X[4];
     int border[4];
     int mu;
     int nu;
-    typename RealTypeId<Cmplx>::Type coeff;
+    Float coeff;
     int parity;
     int volumeCB;
 
@@ -42,11 +42,12 @@ namespace quda {
   };
 
   
-  template<typename Cmplx, bool isConjugate, typename Arg>
+  template<typename real, bool isConjugate, typename Arg>
   __global__ void 
   cloverDerivativeKernel(Arg arg)
   {
-    typedef typename RealTypeId<Cmplx>::Type real;
+    typedef complex<real> Complex;
+    typedef Matrix<Complex,3> M;
 
     int index = threadIdx.x + blockIdx.x*blockDim.x;
 
@@ -69,42 +70,35 @@ namespace quda {
     const int& mu = arg.mu;
     const int& nu = arg.nu;
 
-    Matrix<Cmplx,3> thisForce;
-    Matrix<Cmplx,3> otherForce;
+    M thisForce, otherForce;
 
     // U[mu](x) U[nu](x+mu) U[*mu](x+nu) U[*nu](x) Oprod(x)
     {
       int d[4] = {0, 0, 0, 0};
+      M U1, U2, U3, U4, Oprod1, Oprod2;
 
       // load U(x)_(+mu)
-      Matrix<Cmplx,3> U1;
       arg.gauge.load((real*)(U1.data), linkIndexShift(x, d, X), mu, arg.parity);
 
       // load U(x+mu)_(+nu)
-      Matrix<Cmplx,3> U2;
       d[mu]++;
       arg.gauge.load((real*)(U2.data), linkIndexShift(x, d, X), nu, otherparity);
       d[mu]--;
 
-
       // load U(x+nu)_(+mu) 
-      Matrix<Cmplx,3> U3;
       d[nu]++;
       arg.gauge.load((real*)(U3.data), linkIndexShift(x, d, X), mu, otherparity);
       d[nu]--;
       
       // load U(x)_(+nu)
-      Matrix<Cmplx,3> U4;
       arg.gauge.load((real*)(U4.data), linkIndexShift(x, d, X), nu, arg.parity);
 
       // load Oprod
-      Matrix<Cmplx,3> Oprod1;
       arg.oprod.load((real*)(Oprod1.data), linkIndexShift(x, d, X), 0, arg.parity);
 
       if(isConjugate) Oprod1 -= conj(Oprod1);
       thisForce = U1*U2*conj(U3)*conj(U4)*Oprod1;
 
-      Matrix<Cmplx,3> Oprod2;
       d[mu]++; d[nu]++;
       arg.oprod.load((real*)(Oprod2.data), linkIndexShift(x, d, X), 0, arg.parity);
       d[mu]--; d[nu]--;
@@ -114,30 +108,27 @@ namespace quda {
       thisForce += U1*U2*Oprod2*conj(U3)*conj(U4);
     } 
  
-    { 
+    {
       int d[4] = {0, 0, 0, 0};
+      M U1, U2, U3, U4, Oprod3, Oprod4;
+
       // load U(x)_(+mu)
-      Matrix<Cmplx,3> U1;
       arg.gauge.load((real*)(U1.data), linkIndexShift(y, d, X), mu, otherparity);
 
       // load U(x+mu)_(+nu)
-      Matrix<Cmplx,3> U2;
       d[mu]++;
       arg.gauge.load((real*)(U2.data), linkIndexShift(y, d, X), nu, arg.parity);
       d[mu]--;
 
       // load U(x+nu)_(+mu) 
-      Matrix<Cmplx,3> U3;
       d[nu]++;
       arg.gauge.load((real*)(U3.data), linkIndexShift(y, d, X), mu, arg.parity);
       d[nu]--;
 
       // load U(x)_(+nu)
-      Matrix<Cmplx,3> U4;
       arg.gauge.load((real*)(U4.data), linkIndexShift(y, d, X), nu, otherparity);
 
       // load opposite parity Oprod
-      Matrix<Cmplx,3> Oprod3;
       d[nu]++;
       arg.oprod.load((real*)(Oprod3.data), linkIndexShift(y, d, X), 0, arg.parity);
       d[nu]--;
@@ -146,7 +137,6 @@ namespace quda {
       otherForce = U1*U2*conj(U3)*Oprod3*conj(U4);
 
       // load Oprod(x+mu)
-      Matrix<Cmplx, 3> Oprod4;
       d[mu]++;
       arg.oprod.load((real*)(Oprod4.data), linkIndexShift(y, d, X), 0, arg.parity);
       d[mu]--;
@@ -161,30 +151,27 @@ namespace quda {
     // U[nu*](x-nu) U[mu](x-nu) U[nu](x+mu-nu) Oprod(x+mu) U[*mu](x)
     {
       int d[4] = {0, 0, 0, 0};
+      M U1, U2, U3, U4, Oprod1, Oprod2;
+
       // load U(x-nu)(+nu)
-      Matrix<Cmplx,3> U1;
       d[nu]--;
       arg.gauge.load((real*)(U1.data), linkIndexShift(y, d, X), nu, arg.parity);
       d[nu]++;
 
       // load U(x-nu)(+mu) 
-      Matrix<Cmplx, 3> U2;
       d[nu]--;
       arg.gauge.load((real*)(U2.data), linkIndexShift(y, d, X), mu, arg.parity);
       d[nu]++;
 
       // load U(x+mu-nu)(nu)
-      Matrix<Cmplx, 3> U3;
       d[mu]++; d[nu]--;
       arg.gauge.load((real*)(U3.data), linkIndexShift(y, d, X), nu, otherparity);
       d[mu]--; d[nu]++;
 
       // load U(x)_(+mu)
-      Matrix<Cmplx,3> U4;
       arg.gauge.load((real*)(U4.data), linkIndexShift(y, d, X), mu, otherparity);
 
       // load Oprod(x+mu)
-      Matrix<Cmplx, 3> Oprod1;
       d[mu]++;
       arg.oprod.load((real*)(Oprod1.data), linkIndexShift(y, d, X), 0, arg.parity);
       d[mu]--;    
@@ -193,7 +180,6 @@ namespace quda {
 
       otherForce -= conj(U1)*U2*U3*Oprod1*conj(U4);
 
-      Matrix<Cmplx,3> Oprod2;
       d[nu]--;
       arg.oprod.load((real*)(Oprod2.data), linkIndexShift(y, d, X), 0, arg.parity);
       d[nu]++;
@@ -204,29 +190,26 @@ namespace quda {
 
     {
       int d[4] = {0, 0, 0, 0};
+      M U1, U2, U3, U4, Oprod1, Oprod4;
+
       // load U(x-nu)(+nu)
-      Matrix<Cmplx,3> U1;
       d[nu]--;
       arg.gauge.load((real*)(U1.data), linkIndexShift(x, d, X), nu, otherparity);
       d[nu]++;
 	
       // load U(x-nu)(+mu) 
-      Matrix<Cmplx, 3> U2;
       d[nu]--;
       arg.gauge.load((real*)(U2.data), linkIndexShift(x, d, X), mu, otherparity);
       d[nu]++;
 
       // load U(x+mu-nu)(nu)
-      Matrix<Cmplx, 3> U3;
       d[mu]++; d[nu]--;
       arg.gauge.load((real*)(U3.data), linkIndexShift(x, d, X), nu, arg.parity);
       d[mu]--; d[nu]++;
 
       // load U(x)_(+mu)
-      Matrix<Cmplx,3> U4;
       arg.gauge.load((real*)(U4.data), linkIndexShift(x, d, X), mu, arg.parity);
 
-      Matrix<Cmplx,3> Oprod1;
       d[mu]++; d[nu]--;
       arg.oprod.load((real*)(Oprod1.data), linkIndexShift(x, d, X), 0, arg.parity);
       d[mu]--; d[nu]++;
@@ -234,7 +217,6 @@ namespace quda {
       if(isConjugate) Oprod1 -= conj(Oprod1);
       thisForce -= conj(U1)*U2*Oprod1*U3*conj(U4);
 
-      Matrix<Cmplx, 3> Oprod4;
       arg.oprod.load((real*)(Oprod4.data), linkIndexShift(x, d, X), 0, arg.parity);
 
       if(isConjugate) Oprod4 -= conj(Oprod4);
@@ -246,14 +228,14 @@ namespace quda {
 
     // Write to array
     {
-      Matrix<Cmplx, 3> F;
+      M F;
       arg.force.load((real*)(F.data), index, mu, arg.parity);
       F += thisForce;
       arg.force.save((real*)(F.data), index, mu, arg.parity);
     }
       
     {
-      Matrix<Cmplx, 3> F;
+      M F;
       arg.force.load((real*)(F.data), index, mu, otherparity);
       F += otherForce;
       arg.force.save((real*)(F.data), index, mu, otherparity);
@@ -263,7 +245,7 @@ namespace quda {
   } // cloverDerivativeKernel
   
   
-  template<typename Complex, typename Arg>
+  template<typename Float, typename Arg>
   class CloverDerivative : public Tunable {
     
   private:
@@ -280,16 +262,16 @@ namespace quda {
     CloverDerivative(const Arg &arg, const GaugeField &meta)
       : arg(arg), meta(meta) {
       writeAuxString("threads=%d,prec=%lu,fstride=%d,gstride=%d,ostride=%d",
-		     arg.volumeCB,sizeof(Complex)/2,arg.force.stride,arg.gauge.stride,arg.oprod.stride);
+		     arg.volumeCB,sizeof(Float),arg.force.stride,arg.gauge.stride,arg.oprod.stride);
     }
     virtual ~CloverDerivative() {}
 
     void apply(const cudaStream_t &stream){
       TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
       if(arg.conjugate){
-	cloverDerivativeKernel<Complex,true><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+	cloverDerivativeKernel<Float,true><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
       }else{
-	cloverDerivativeKernel<Complex,false><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+	cloverDerivativeKernel<Float,false><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
       }
     } // apply
 
@@ -320,8 +302,6 @@ namespace quda {
     if (force.Reconstruct() != QUDA_RECONSTRUCT_NO) 
       errorQuda("Force field does not support reconstruction");
   
-    typedef typename ComplexTypeId<Float>::Type Complex;
-
     if (force.Order() == QUDA_FLOAT2_GAUGE_ORDER){
       typedef gauge::FloatNOrder<Float, 18, 2, 18> F;
       typedef gauge::FloatNOrder<Float, 18, 2, 18> O;
@@ -329,15 +309,15 @@ namespace quda {
       if (gauge.isNative()) {
 	if (gauge.Reconstruct() == QUDA_RECONSTRUCT_NO) {
 	  typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_NO>::type G;
-	  typedef CloverDerivArg<Complex,F,G,O> Arg;
+	  typedef CloverDerivArg<Float,F,G,O> Arg;
 	  Arg arg(F(force), G(gauge), O(oprod), force.X(), mu, nu, coeff, parity, conjugate);
-	  CloverDerivative<Complex, Arg> deriv(arg, gauge);
+	  CloverDerivative<Float, Arg> deriv(arg, gauge);
 	  deriv.apply(0);
 	} else if(gauge.Reconstruct() == QUDA_RECONSTRUCT_12) {
 	  typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_12>::type G;
-	  typedef CloverDerivArg<Complex,F,G,O> Arg;
+	  typedef CloverDerivArg<Float,F,G,O> Arg;
 	  Arg arg(F(force), G(gauge), O(oprod), force.X(), mu, nu, coeff, parity, conjugate);
-	  CloverDerivative<Complex, Arg> deriv(arg, gauge);
+	  CloverDerivative<Float, Arg> deriv(arg, gauge);
 	  deriv.apply(0);
 	}else{
 	  errorQuda("Reconstruction type %d not supported",gauge.Reconstruct());

--- a/lib/clover_outer_product.cu
+++ b/lib/clover_outer_product.cu
@@ -64,7 +64,7 @@ namespace quda {
 
   enum KernelType {OPROD_INTERIOR_KERNEL, OPROD_EXTERIOR_KERNEL};
 
-  template<typename Complex, typename Output, typename Gauge, typename InputA, typename InputB, typename InputC, typename InputD>
+  template<typename Float, typename Output, typename Gauge, typename InputA, typename InputB, typename InputC, typename InputD>
     struct CloverForceArg {
       unsigned int length;
       int X[4];
@@ -80,7 +80,7 @@ namespace quda {
       InputD inD_shift;
       Gauge  gauge;
       Output force;
-      typename RealTypeId<Complex>::Type coeff;
+      Float coeff;
       
     CloverForceArg(const unsigned int parity,
 		   const unsigned int dir,
@@ -275,9 +275,9 @@ namespace quda {
 
 
 
-  template<typename Complex, typename Output, typename Gauge, typename InputA, typename InputB, typename InputC, typename InputD>
-  __global__ void interiorOprodKernel(CloverForceArg<Complex, Output, Gauge, InputA, InputB, InputC, InputD> arg) {
-    typedef typename RealTypeId<Complex>::Type real;
+  template<typename real, typename Output, typename Gauge, typename InputA, typename InputB, typename InputC, typename InputD>
+  __global__ void interiorOprodKernel(CloverForceArg<real, Output, Gauge, InputA, InputB, InputC, InputD> arg) {
+    typedef complex<real> Complex;
     int idx = blockIdx.x*blockDim.x + threadIdx.x;
 
     ColorSpinor<real,3,4> A, B_shift, C, D_shift;
@@ -313,9 +313,9 @@ namespace quda {
     return;
   } // interiorOprodKernel
 
-  template<int dim, typename Complex, typename Output, typename Gauge, typename InputA, typename InputB, typename InputC, typename InputD> 
-  __global__ void exteriorOprodKernel(CloverForceArg<Complex, Output, Gauge, InputA, InputB, InputC, InputD> arg) {
-    typedef typename RealTypeId<Complex>::Type real;
+  template<int dim, typename real, typename Output, typename Gauge, typename InputA, typename InputB, typename InputC, typename InputD>
+  __global__ void exteriorOprodKernel(CloverForceArg<real, Output, Gauge, InputA, InputB, InputC, InputD> arg) {
+    typedef complex<real> Complex;
     int cb_idx = blockIdx.x*blockDim.x + threadIdx.x;
     
     ColorSpinor<real,3,4> A, B_shift, C, D_shift;
@@ -348,11 +348,11 @@ namespace quda {
     return;
   } // exteriorOprodKernel
   
-  template<typename Complex, typename Output, typename Gauge, typename InputA, typename InputB, typename InputC, typename InputD> 
+  template<typename Float, typename Output, typename Gauge, typename InputA, typename InputB, typename InputC, typename InputD>
   class CloverForce : public Tunable {
     
   private:
-    CloverForceArg<Complex,Output,Gauge,InputA,InputB,InputC,InputD> &arg;
+    CloverForceArg<Float,Output,Gauge,InputA,InputB,InputC,InputD> &arg;
     const GaugeField &meta;
     QudaFieldLocation location; // location of the lattice fields
     
@@ -363,10 +363,10 @@ namespace quda {
     bool tuneGridDim() const { return false; }
     
   public:
-    CloverForce(CloverForceArg<Complex,Output,Gauge,InputA,InputB,InputC,InputD> &arg,
+    CloverForce(CloverForceArg<Float,Output,Gauge,InputA,InputB,InputC,InputD> &arg,
 		const GaugeField &meta, QudaFieldLocation location)
       : arg(arg), meta(meta), location(location) {
-      writeAuxString("prec=%lu,stride=%d", sizeof(Complex)/2, arg.inA.Stride());
+      writeAuxString("prec=%lu,stride=%d", sizeof(Float), arg.inA.Stride());
       // this sets the communications pattern for the packing kernel
       int comms[QUDA_MAX_DIM] = { commDimPartitioned(0), commDimPartitioned(1), commDimPartitioned(2), commDimPartitioned(3) };
       setPackComms(comms);
@@ -470,7 +470,7 @@ namespace quda {
     setKernelPackT(pack_old); // restore packing state
   }
 
-  template<typename Complex, typename Output, typename Gauge, typename InputA, typename InputB, typename InputC, typename InputD>
+  template<typename Float, typename Output, typename Gauge, typename InputA, typename InputB, typename InputC, typename InputD>
   void computeCloverForceCuda(Output force, Gauge gauge, cudaGaugeField& out, 
 			      InputA& inA, InputB& inB, InputC &inC, InputD &inD,
 			      cudaColorSpinorField& src1, cudaColorSpinorField& src2,
@@ -479,8 +479,8 @@ namespace quda {
     {
       cudaEventRecord(oprodStart, streams[Nstream-1]);
       // Create the arguments for the interior kernel 
-      CloverForceArg<Complex,Output,Gauge,InputA,InputB,InputC,InputD> arg(parity, 0, ghostOffset, 1, OPROD_INTERIOR_KERNEL, coeff, inA, inB, inC, inD, gauge, force, out);
-      CloverForce<Complex,Output,Gauge,InputA,InputB,InputC,InputD> oprod(arg, out, QUDA_CUDA_FIELD_LOCATION);
+      CloverForceArg<Float,Output,Gauge,InputA,InputB,InputC,InputD> arg(parity, 0, ghostOffset, 1, OPROD_INTERIOR_KERNEL, coeff, inA, inB, inC, inD, gauge, force, out);
+      CloverForce<Float,Output,Gauge,InputA,InputB,InputC,InputD> oprod(arg, out, QUDA_CUDA_FIELD_LOCATION);
 
       int dag = 1;
       exchangeGhost(src1, parity, dag);
@@ -547,19 +547,19 @@ namespace quda {
 	Spinor<double2, double2, double2, 12, 0, 0> spinorC(inC);
 	Spinor<double2, double2, double2, 12, 0, 1> spinorD(inD);
 	if (U.Reconstruct() == QUDA_RECONSTRUCT_NO) {
-	  computeCloverForceCuda<double2>(gauge::FloatNOrder<double, 18, 2, 18>(force), 
-					  gauge::FloatNOrder<double,18, 2, 18>(U),
-					  force, spinorA, spinorB, spinorC, spinorD, 
-					  static_cast<cudaColorSpinorField&>(inB), 
-					  static_cast<cudaColorSpinorField&>(inD), 
-					  parity, inB.GhostFace(), ghostOffset, coeff);
+	  computeCloverForceCuda<double>(gauge::FloatNOrder<double, 18, 2, 18>(force),
+					 gauge::FloatNOrder<double,18, 2, 18>(U),
+					 force, spinorA, spinorB, spinorC, spinorD,
+					 static_cast<cudaColorSpinorField&>(inB),
+					 static_cast<cudaColorSpinorField&>(inD),
+					 parity, inB.GhostFace(), ghostOffset, coeff);
 	} else if (U.Reconstruct() == QUDA_RECONSTRUCT_12) {
-	  computeCloverForceCuda<double2>(gauge::FloatNOrder<double, 18, 2, 18>(force), 
-					  gauge::FloatNOrder<double,18, 2, 12>(U),
-					  force, spinorA, spinorB, spinorC, spinorD, 
-					  static_cast<cudaColorSpinorField&>(inB), 
-					  static_cast<cudaColorSpinorField&>(inD), 
-					  parity, inB.GhostFace(), ghostOffset, coeff);
+	  computeCloverForceCuda<double>(gauge::FloatNOrder<double, 18, 2, 18>(force),
+					 gauge::FloatNOrder<double,18, 2, 12>(U),
+					 force, spinorA, spinorB, spinorC, spinorD,
+					 static_cast<cudaColorSpinorField&>(inB),
+					 static_cast<cudaColorSpinorField&>(inD),
+					 parity, inB.GhostFace(), ghostOffset, coeff);
 	} else {
 	  errorQuda("Unsupported recontruction type");
 	}
@@ -568,19 +568,19 @@ namespace quda {
 	Spinor<float4, float4, float4, 6, 0, 0> spinorA(inA);
 	Spinor<float4, float4, float4, 6, 0, 1> spinorB(inB);
 	if (U.Reconstruct() == QUDA_RECONSTRUCT_NO) {
-	  computeCloverForceCuda<float2>(gauge::FloatNOrder<float, 18, 2, 18>(force), 
-					 gauge::FloatNOrder<float, 18, 2, 18>(U), 
-					 force, spinorA, spinorB, spinorC, spinorD, 
-					 static_cast<cudaColorSpinorField&>(inB), 
-					 static_cast<cudaColorSpinorField&>(inD), 
-					 parity, inB.GhostFace(), ghostOffset, coeff);
+	  computeCloverForceCuda<float>(gauge::FloatNOrder<float, 18, 2, 18>(force),
+					gauge::FloatNOrder<float, 18, 2, 18>(U),
+					force, spinorA, spinorB, spinorC, spinorD,
+					static_cast<cudaColorSpinorField&>(inB),
+					static_cast<cudaColorSpinorField&>(inD),
+					parity, inB.GhostFace(), ghostOffset, coeff);
 	} else if (U.Reconstruct() == QUDA_RECONSTRUCT_12) {
-	  computeCloverForceCuda<float2>(gauge::FloatNOrder<float, 18, 2, 18>(force), 
-					 gauge::FloatNOrder<float, 18, 4, 12>(U), 
-					 force, spinorA, spinorB, spinorC, spinorD, 
-					 static_cast<cudaColorSpinorField&>(inB), 
-					 static_cast<cudaColorSpinorField&>(inD), 
-					 parity, inB.GhostFace(), ghostOffset, coeff);
+	  computeCloverForceCuda<float>(gauge::FloatNOrder<float, 18, 2, 18>(force),
+					gauge::FloatNOrder<float, 18, 4, 12>(U),
+					force, spinorA, spinorB, spinorC, spinorD,
+					static_cast<cudaColorSpinorField&>(inB),
+					static_cast<cudaColorSpinorField&>(inD),
+					parity, inB.GhostFace(), ghostOffset, coeff);
 	}
 #endif
       } else {

--- a/lib/clover_quda.cu
+++ b/lib/clover_quda.cu
@@ -74,19 +74,18 @@ namespace quda {
         parity = 1;
         idx -= arg.threads/2;
       }
-      typedef typename ComplexTypeId<Float>::Type Cmplx;
-
+      typedef complex<Float> Complex;
 
       // Load the field-strength tensor from global memory
-      Matrix<Cmplx,3> F[6];
+      Matrix<Complex,3> F[6];
       for(int i=0; i<6; ++i){
 	arg.f.load((Float*)(F[i].data), idx, i, parity);
       }
 
-      Cmplx I; I.x = 0; I.y = 1.0;
-      Cmplx coeff; coeff.x = 0; coeff.y = arg.cloverCoeff;
-      Matrix<Cmplx,3> block1[2];
-      Matrix<Cmplx,3> block2[2];
+      Complex I; I.x = 0; I.y = 1.0;
+      Complex coeff; coeff.x = 0; coeff.y = arg.cloverCoeff;
+      Matrix<Complex,3> block1[2];
+      Matrix<Complex,3> block2[2];
       block1[0] =  coeff*(F[0]-F[5]); // (18 + 6*9=) 72 floating-point ops 
       block1[1] =  coeff*(F[0]+F[5]); // 72 floating-point ops 
       block2[0] =  arg.cloverCoeff*(F[1]+F[4] - I*(F[2]-F[3])); // 126 floating-point ops
@@ -95,7 +94,7 @@ namespace quda {
 
       const int idtab[15]={0,1,3,6,10,2,4,7,11,5,8,12,9,13,14};
       Float diag[6];
-      Cmplx triangle[15]; 
+      Complex triangle[15];
       Float A[72];
 
       // This uses lots of unnecessary memory

--- a/lib/clover_trace_quda.cu
+++ b/lib/clover_trace_quda.cu
@@ -28,9 +28,8 @@ namespace quda {
     {
 
       Float A[72];
-      typedef typename ComplexTypeId<Float>::Type Complex;
 
-      Matrix<Complex,3> mat;  
+      Matrix<complex<Float>,3> mat;
       setZero(&mat);
 
       // load the clover term into memory

--- a/lib/coarse_op.cuh
+++ b/lib/coarse_op.cuh
@@ -250,7 +250,7 @@ namespace quda {
     /* We proceed by chiral blocks */
 
     for (int ch = 0; ch < 2; ch++) {	/* Loop over chiral blocks */
-      Float d, diag[6], tmp[6];
+      Float diag[6], tmp[6];
       complex<Float> tri[15];	/* Off-diagonal components of the inverse clover term */
 
       /*	This macro avoid the infinitely long expansion of the tri products	*/

--- a/lib/covDev.cu
+++ b/lib/covDev.cu
@@ -109,7 +109,9 @@ namespace quda
         break;									\
       case EXTERIOR_KERNEL_T:						\
         MORE_GENERIC_COVDEV(FUNC, dir, DAG, EXTERIOR_KERNEL_T, gridDim, blockDim, shared, stream, param, __VA_ARGS__) \
-        break;									\
+	break;							        \
+      default:								\
+        errorQuda("Unsupported kernel_type %d", param.kernel_type);	\
     }
 
   #define COVDEV(FUNC, mu, gridDim, blockDim, shared, stream, param, ...)	\

--- a/lib/dslash_quda.cu
+++ b/lib/dslash_quda.cu
@@ -597,7 +597,7 @@ void twistCloverGamma5Cuda(cudaColorSpinorField *out, const cudaColorSpinorField
 #ifdef GPU_TWISTED_CLOVER_DIRAC
   Tunable *tmClovGamma5 = 0;
 
-  void *clover, *cNorm, *cloverInv, *cNorm2;
+  void *clover=0, *cNorm=0, *cloverInv=0, *cNorm2=0;
   QudaPrecision clover_prec = bindTwistedCloverTex(*clov, *clovInv, parity, &clover, &cNorm, &cloverInv, &cNorm2);
 
   if (in->Precision() != clover_prec)

--- a/lib/dslash_twisted_clover.cu
+++ b/lib/dslash_twisted_clover.cu
@@ -285,7 +285,7 @@ namespace quda {
     void *gauge0, *gauge1;
     bindGaugeTex(gauge, parity, &gauge0, &gauge1);
 
-    void *cloverP, *cloverNormP, *cloverInvP, *cloverInvNormP;
+    void *cloverP=0, *cloverNormP=0, *cloverInvP=0, *cloverInvNormP=0;
     QudaPrecision clover_prec = bindTwistedCloverTex(*clover, *cloverInv, parity, &cloverP, &cloverNormP, &cloverInvP, &cloverInvNormP);
 
     if (in->Precision() != clover_prec)

--- a/lib/gauge_fix_fft.cu
+++ b/lib/gauge_fix_fft.cu
@@ -57,69 +57,71 @@ namespace quda {
     return 0.0;
   }
   template <>
-  inline __device__ typename ComplexTypeId<float>::Type TEXTURE_GX<typename ComplexTypeId<float>::Type>(int id){
+  inline __device__ complex<float> TEXTURE_GX<complex<float> >(int id){
     return tex1Dfetch(GXTexSingle, id);
   }
   template <>
-  inline __device__ typename ComplexTypeId<double>::Type TEXTURE_GX<typename ComplexTypeId<double>::Type>(int id){
+  inline __device__ complex<double> TEXTURE_GX<complex<double> >(int id){
     int4 u = tex1Dfetch(GXTexDouble, id);
-    return makeComplex(__hiloint2double(u.y, u.x), __hiloint2double(u.w, u.z));
+    return complex<double>(__hiloint2double(u.y, u.x), __hiloint2double(u.w, u.z));
   }
   template <class T>
   inline __device__ T TEXTURE_DELTA(int id){
     return 0.0;
   }
   template <>
-  inline __device__ typename ComplexTypeId<float>::Type TEXTURE_DELTA<typename ComplexTypeId<float>::Type>(int id){
+  inline __device__ complex<float> TEXTURE_DELTA<complex<float> >(int id){
     return tex1Dfetch(DELTATexSingle, id);
   }
   template <>
-  inline __device__ typename ComplexTypeId<double>::Type TEXTURE_DELTA<typename ComplexTypeId<double>::Type>(int id){
+  inline __device__ complex<double> TEXTURE_DELTA<complex<double> >(int id){
     int4 u = tex1Dfetch(DELTATexDouble, id);
-    return makeComplex(__hiloint2double(u.y, u.x), __hiloint2double(u.w, u.z));
+    return complex<double>(__hiloint2double(u.y, u.x), __hiloint2double(u.w, u.z));
   }
 
-  static void BindTex(typename ComplexTypeId<float>::Type *delta, typename ComplexTypeId<float>::Type *gx, size_t bytes){
-        #ifdef GAUGEFIXING_SITE_MATRIX_LOAD_TEX
-                #ifndef GAUGEFIXING_DONT_USE_GX
+  static void BindTex(complex<float> *delta, complex<float> *gx, size_t bytes){
+#ifdef GAUGEFIXING_SITE_MATRIX_LOAD_TEX
+#ifndef GAUGEFIXING_DONT_USE_GX
     cudaBindTexture(0, GXTexSingle, gx, bytes);
-                #endif
+#endif
     cudaBindTexture(0, DELTATexSingle, delta, bytes);
-        #endif
+#endif
   }
-  static void BindTex(typename ComplexTypeId<double>::Type *delta, typename ComplexTypeId<double>::Type *gx, size_t bytes){
-        #ifdef GAUGEFIXING_SITE_MATRIX_LOAD_TEX
-                #ifndef GAUGEFIXING_DONT_USE_GX
+
+  static void BindTex(complex<double> *delta, complex<double> *gx, size_t bytes){
+#ifdef GAUGEFIXING_SITE_MATRIX_LOAD_TEX
+#ifndef GAUGEFIXING_DONT_USE_GX
     cudaBindTexture(0, GXTexDouble, gx, bytes);
-                #endif
+#endif
     cudaBindTexture(0, DELTATexDouble, delta, bytes);
-        #endif
+#endif
   }
 
-  static void UnBindTex(typename ComplexTypeId<float>::Type *delta, typename ComplexTypeId<float>::Type *gx){
-        #ifdef GAUGEFIXING_SITE_MATRIX_LOAD_TEX
-                #ifndef GAUGEFIXING_DONT_USE_GX
+  static void UnBindTex(complex<float> *delta, complex<float> *gx){
+#ifdef GAUGEFIXING_SITE_MATRIX_LOAD_TEX
+#ifndef GAUGEFIXING_DONT_USE_GX
     cudaUnbindTexture(GXTexSingle);
-                #endif
+#endif
     cudaUnbindTexture(DELTATexSingle);
-        #endif
+#endif
   }
-  static void UnBindTex(typename ComplexTypeId<double>::Type *delta, typename ComplexTypeId<double>::Type *gx){
-        #ifdef GAUGEFIXING_SITE_MATRIX_LOAD_TEX
-                #ifndef GAUGEFIXING_DONT_USE_GX
+
+  static void UnBindTex(complex<double> *delta, complex<double> *gx){
+#ifdef GAUGEFIXING_SITE_MATRIX_LOAD_TEX
+#ifndef GAUGEFIXING_DONT_USE_GX
     cudaUnbindTexture(GXTexDouble);
-                #endif
+#endif
     cudaUnbindTexture(DELTATexDouble);
-        #endif
+#endif
   }
 
 
-  template <typename Cmplx>
+  template <typename Float>
   struct GaugeFixFFTRotateArg {
     int threads;     // number of active threads required
     int X[4];     // grid dimensions
-    Cmplx *tmp0;
-    Cmplx *tmp1;
+    complex<Float> *tmp0;
+    complex<Float> *tmp1;
     GaugeFixFFTRotateArg(const cudaGaugeField &data){
       for ( int dir = 0; dir < 4; ++dir ) X[dir] = data.X()[dir];
       threads = X[0] * X[1] * X[2] * X[3];
@@ -130,8 +132,8 @@ namespace quda {
 
 
 
-  template <int direction, typename Cmplx>
-  __global__ void fft_rotate_kernel_2D2D(GaugeFixFFTRotateArg<Cmplx> arg){ //Cmplx *data_in, Cmplx *data_out){
+  template <int direction, typename Float>
+  __global__ void fft_rotate_kernel_2D2D(GaugeFixFFTRotateArg<Float> arg){ //Cmplx *data_in, Cmplx *data_out){
     int id = blockIdx.x * blockDim.x + threadIdx.x;
     if ( id >= arg.threads ) return;
     if ( direction == 0 ) {
@@ -152,8 +154,6 @@ namespace quda {
       int x3 = (id / arg.X[2]) % arg.X[3];
       int x2 = id % arg.X[2];
 
-
-
       int id  =  x2 + (x3 +  (x0 + x1 * arg.X[0]) * arg.X[3]) * arg.X[2];
       int id_out =  x0 + (x1 + (x2 + x3 * arg.X[2]) * arg.X[1]) * arg.X[0];
       arg.tmp1[id_out] = arg.tmp0[id];
@@ -166,9 +166,9 @@ namespace quda {
 
 
 
-  template<typename Cmplx>
+  template<typename Float>
   class GaugeFixFFTRotate : Tunable {
-    GaugeFixFFTRotateArg<Cmplx> arg;
+    GaugeFixFFTRotateArg<Float> arg;
     unsigned int direction;
     mutable char aux_string[128];     // used as a label in the autotuner
     private:
@@ -187,13 +187,12 @@ namespace quda {
     }
 
     public:
-    GaugeFixFFTRotate(GaugeFixFFTRotateArg<Cmplx> &arg)
-      : arg(arg) {
+    GaugeFixFFTRotate(GaugeFixFFTRotateArg<Float> &arg) : arg(arg) {
       direction = 0;
     }
     ~GaugeFixFFTRotate () {
     }
-    void setDirection(unsigned int dir, Cmplx *data_in, Cmplx *data_out){
+    void setDirection(unsigned int dir, complex<Float> *data_in, complex<Float> *data_out){
       direction = dir;
       arg.tmp0 = data_in;
       arg.tmp1 = data_out;
@@ -202,9 +201,9 @@ namespace quda {
     void apply(const cudaStream_t &stream){
       TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
       if ( direction == 0 )
-        fft_rotate_kernel_2D2D<0, Cmplx><< < tp.grid, tp.block, 0, stream >> > (arg);
+        fft_rotate_kernel_2D2D<0, Float ><< < tp.grid, tp.block, 0, stream >> > (arg);
       else if ( direction == 1 )
-        fft_rotate_kernel_2D2D<1, Cmplx><< < tp.grid, tp.block, 0, stream >> > (arg);
+        fft_rotate_kernel_2D2D<1, Float ><< < tp.grid, tp.block, 0, stream >> > (arg);
       else
         errorQuda("Error in GaugeFixFFTRotate option.\n");
     }
@@ -215,7 +214,7 @@ namespace quda {
       vol << arg.X[1] << "x";
       vol << arg.X[2] << "x";
       vol << arg.X[3];
-      sprintf(aux_string,"threads=%d,prec=%d",arg.threads, sizeof(Cmplx) / 2);
+      sprintf(aux_string,"threads=%d,prec=%lu", arg.threads, sizeof(Float));
       return TuneKey(vol.str().c_str(), typeid(*this).name(), aux_string);
 
     }
@@ -229,20 +228,20 @@ namespace quda {
       return 0;
     }
     long long bytes() const {
-      return 2LL * sizeof(Cmplx) * arg.threads;
+      return 4LL * sizeof(Float) * arg.threads;
     }
 
   };
 
 
-  template <typename Cmplx, typename Gauge>
+  template <typename Float, typename Gauge>
   struct GaugeFixQualityArg : public ReduceArg<double2> {
     int threads;     // number of active threads required
     int X[4];     // grid dimensions
     Gauge dataOr;
-    Cmplx *delta;
+    complex<Float> *delta;
 
-    GaugeFixQualityArg(const Gauge &dataOr, const cudaGaugeField &data, Cmplx * delta)
+    GaugeFixQualityArg(const Gauge &dataOr, const cudaGaugeField &data, complex<Float> * delta)
       : ReduceArg<double2>(), dataOr(dataOr), delta(delta) {
       for ( int dir = 0; dir < 4; ++dir ) X[dir] = data.X()[dir];
       threads = data.VolumeCB();
@@ -254,13 +253,13 @@ namespace quda {
 
 
   template<int blockSize, unsigned int Elems, typename Float, typename Gauge, int gauge_dir>
-  __global__ void computeFix_quality(GaugeFixQualityArg<typename ComplexTypeId<Float>::Type, Gauge> argQ){
+  __global__ void computeFix_quality(GaugeFixQualityArg<Float, Gauge> argQ){
     int idx = threadIdx.x + blockIdx.x * blockDim.x;
     int parity = threadIdx.y;
 
     double2 data = make_double2(0.0,0.0);
     if ( idx < argQ.threads ) {
-      typedef typename ComplexTypeId<Float>::Type Cmplx;
+      typedef complex<Float> Cmplx;
 
       int x[4];
       getCoords(x, idx, argQ.X, parity);
@@ -306,14 +305,14 @@ namespace quda {
 
   template<unsigned int Elems, typename Float, typename Gauge, int gauge_dir>
   class GaugeFixQuality : TunableLocalParity {
-    GaugeFixQualityArg<typename ComplexTypeId<Float>::Type, Gauge> argQ;
+    GaugeFixQualityArg<Float, Gauge> argQ;
     mutable char aux_string[128];     // used as a label in the autotuner
     private:
 
     unsigned int minThreads() const { return argQ.threads; }
 
     public:
-    GaugeFixQuality(GaugeFixQualityArg<typename ComplexTypeId<Float>::Type, Gauge> &argQ)
+    GaugeFixQuality(GaugeFixQualityArg<Float, Gauge> &argQ)
       : argQ(argQ) {
     }
     ~GaugeFixQuality () { }
@@ -330,7 +329,7 @@ namespace quda {
     TuneKey tuneKey() const {
       std::stringstream vol;
       vol << argQ.X[0] << "x" << argQ.X[1] << "x" << argQ.X[2] << "x" << argQ.X[3];
-      sprintf(aux_string,"threads=%d,prec=%d,gaugedir=%d",argQ.threads, sizeof(Float),gauge_dir);
+      sprintf(aux_string,"threads=%d,prec=%lu,gaugedir=%d", argQ.threads, sizeof(Float), gauge_dir);
       return TuneKey(vol.str().c_str(), typeid(*this).name(), aux_string);
     }
 
@@ -358,20 +357,20 @@ namespace quda {
     int X[4];     // grid dimensions
     cudaGaugeField &data;
     Float *invpsq;
-    typename ComplexTypeId<Float>::Type *delta;
-    typename ComplexTypeId<Float>::Type *gx;
+    complex<Float> *delta;
+    complex<Float> *gx;
 
     GaugeFixArg( cudaGaugeField & data, const unsigned int Elems) : data(data){
       for ( int dir = 0; dir < 4; ++dir ) X[dir] = data.X()[dir];
       threads = X[0] * X[1] * X[2] * X[3];
       invpsq = (Float*)device_malloc(sizeof(Float) * threads);
-      delta = (typename ComplexTypeId<Float>::Type *)device_malloc(sizeof(typename ComplexTypeId<Float>::Type) * threads * 6);
+      delta = (complex<Float>*)device_malloc(sizeof(complex<Float>) * threads * 6);
 #ifdef GAUGEFIXING_DONT_USE_GX
-      gx = (typename ComplexTypeId<Float>::Type *)device_malloc(sizeof(typename ComplexTypeId<Float>::Type) * threads);
+      gx = (complex<Float>*)device_malloc(sizeof(complex<Float>) * threads);
 #else
-      gx = (typename ComplexTypeId<Float>::Type *)device_malloc(sizeof(typename ComplexTypeId<Float>::Type) * threads * Elems);
+      gx = (complex<Float>*)device_malloc(sizeof(complex<Float>) * threads * Elems);
 #endif
-      BindTex(delta, gx, sizeof(typename ComplexTypeId<Float>::Type) * threads * Elems);
+      BindTex(delta, gx, sizeof(complex<Float>) * threads * Elems);
     }
     void free(){
       UnBindTex(delta, gx);
@@ -441,7 +440,7 @@ namespace quda {
       vol << arg.X[1] << "x";
       vol << arg.X[2] << "x";
       vol << arg.X[3];
-      sprintf(aux_string,"threads=%d,prec=%d",arg.threads, sizeof(Float));
+      sprintf(aux_string,"threads=%d,prec=%lu", arg.threads, sizeof(Float));
       return TuneKey(vol.str().c_str(), typeid(*this).name(), aux_string);
 
     }
@@ -506,7 +505,7 @@ namespace quda {
       vol << arg.X[1] << "x";
       vol << arg.X[2] << "x";
       vol << arg.X[3];
-      sprintf(aux_string,"threads=%d,prec=%d",arg.threads, sizeof(Float));
+      sprintf(aux_string,"threads=%d,prec=%lu", arg.threads, sizeof(Float));
       return TuneKey(vol.str().c_str(), typeid(*this).name(), aux_string);
 
     }
@@ -518,7 +517,7 @@ namespace quda {
     }
     void preTune(){
       //since delta contents are irrelevant at this point, we can swap gx with delta
-      typename ComplexTypeId<Float>::Type *tmp = arg.gx;
+      complex<Float> *tmp = arg.gx;
       arg.gx = arg.delta;
       arg.delta = tmp;
     }
@@ -536,28 +535,15 @@ namespace quda {
 
 
 
-
-
-
-
-  template<typename Cmplx>
-  __device__ __host__ inline typename RealTypeId<Cmplx>::Type Abs2(const Cmplx & a){
-    return a.x * a.x + a.y * a.y;
-  }
-
-
-
   template <typename Float>
-  __host__ __device__ inline void reunit_link( Matrix<typename ComplexTypeId<Float>::Type,3> &U ){
+  __host__ __device__ inline void reunit_link( Matrix<complex<Float>,3> &U ){
 
-    typedef typename ComplexTypeId<Float>::Type Cmplx;
-
-    Cmplx t2 = makeComplex((Float)0.0, (Float)0.0);
+    complex<Float> t2((Float)0.0, (Float)0.0);
     Float t1 = 0.0;
     //first normalize first row
     //sum of squares of row
 #pragma unroll
-    for ( int c = 0; c < 3; c++ ) t1 += Abs2(U(0, c));
+    for ( int c = 0; c < 3; c++ ) t1 += norm(U(0,c));
     t1 = (Float)1.0 / sqrt(t1);
     //14
     //used to normalize row
@@ -565,7 +551,7 @@ namespace quda {
     for ( int c = 0; c < 3; c++ ) U(0,c) *= t1;
     //6
 #pragma unroll
-    for ( int c = 0; c < 3; c++ ) t2 += Conj(U(0,c)) * U(1,c);
+    for ( int c = 0; c < 3; c++ ) t2 += conj(U(0,c)) * U(1,c);
     //24
 #pragma unroll
     for ( int c = 0; c < 3; c++ ) U(1,c) -= t2 * U(0,c);
@@ -574,7 +560,7 @@ namespace quda {
     //sum of squares of row
     t1 = 0.0;
 #pragma unroll
-    for ( int c = 0; c < 3; c++ ) t1 += Abs2(U(1,c));
+    for ( int c = 0; c < 3; c++ ) t1 += norm(U(1,c));
     t1 = (Float)1.0 / sqrt(t1);
     //14
     //used to normalize row
@@ -582,9 +568,9 @@ namespace quda {
     for ( int c = 0; c < 3; c++ ) U(1, c) *= t1;
     //6
     //Reconstruct lat row
-    U(2,0) = Conj(U(0,1) * U(1,2) - U(0,2) * U(1,1));
-    U(2,1) = Conj(U(0,2) * U(1,0) - U(0,0) * U(1,2));
-    U(2,2) = Conj(U(0,0) * U(1,1) - U(0,1) * U(1,0));
+    U(2,0) = conj(U(0,1) * U(1,2) - U(0,2) * U(1,1));
+    U(2,1) = conj(U(0,2) * U(1,0) - U(0,0) * U(1,2));
+    U(2,2) = conj(U(0,0) * U(1,1) - U(0,1) * U(1,0));
     //42
     //T=130
   }
@@ -598,7 +584,7 @@ namespace quda {
 
     if ( id >= arg.threads/2 ) return;
 
-    typedef typename ComplexTypeId<Float>::Type Cmplx;
+    typedef complex<Float> Cmplx;
 
     int x[4];
     getCoords(x, id, arg.X, parity);
@@ -620,9 +606,9 @@ namespace quda {
     de(1,2) = arg.delta[idx + 4 * arg.threads];
     de(2,2) = arg.delta[idx + 5 * arg.threads];
 #endif
-    de(1,0) = makeComplex(-de(0,1).x, de(0,1).y);
-    de(2,0) = makeComplex(-de(0,2).x, de(0,2).y);
-    de(2,1) = makeComplex(-de(1,2).x, de(1,2).y);
+    de(1,0) = Cmplx(-de(0,1).x, de(0,1).y);
+    de(2,0) = Cmplx(-de(0,2).x, de(0,2).y);
+    de(2,1) = Cmplx(-de(1,2).x, de(1,2).y);
     Matrix<Cmplx,3> g;
     setIdentity(&g);
     g += de * half_alpha;
@@ -654,9 +640,9 @@ namespace quda {
       de(1,2) = arg.delta[idx + 4 * arg.threads];
       de(2,2) = arg.delta[idx + 5 * arg.threads];
 #endif
-      de(1,0) = makeComplex(-de(0,1).x, de(0,1).y);
-      de(2,0) = makeComplex(-de(0,2).x, de(0,2).y);
-      de(2,1) = makeComplex(-de(1,2).x, de(1,2).y);
+      de(1,0) = Cmplx(-de(0,1).x, de(0,1).y);
+      de(2,0) = Cmplx(-de(0,2).x, de(0,2).y);
+      de(2,1) = Cmplx(-de(1,2).x, de(1,2).y);
 
       setIdentity(&g0);
       g0 += de * half_alpha;
@@ -702,7 +688,7 @@ namespace quda {
     TuneKey tuneKey() const {
       std::stringstream vol;
       vol << arg.X[0] << "x" << arg.X[1] << "x" << arg.X[2] << "x" << arg.X[3];
-      sprintf(aux_string,"threads=%d,prec=%d",arg.threads, sizeof(Float));
+      sprintf(aux_string,"threads=%d,prec=%lu", arg.threads, sizeof(Float));
       return TuneKey(vol.str().c_str(), typeid(*this).name(), aux_string);
 
     }
@@ -739,7 +725,7 @@ namespace quda {
 
     if ( id >= arg.threads ) return;
 
-    typedef typename ComplexTypeId<Float>::Type Cmplx;
+    typedef complex<Float> Cmplx;
 
     Matrix<Cmplx,3> de;
     //Read Delta
@@ -831,7 +817,7 @@ namespace quda {
       vol << arg.X[1] << "x";
       vol << arg.X[2] << "x";
       vol << arg.X[3];
-      sprintf(aux_string,"threads=%d,prec=%d",arg.threads, sizeof(Float));
+      sprintf(aux_string,"threads=%d,prec=%lu", arg.threads, sizeof(Float));
       return TuneKey(vol.str().c_str(), typeid(*this).name(), aux_string);
 
     }
@@ -864,7 +850,7 @@ namespace quda {
       parity = 1;
       id -= arg.threads / 2;
     }
-    typedef typename ComplexTypeId<Float>::Type Cmplx;
+    typedef complex<Float> Cmplx;
 
     Matrix<Cmplx,3> g;
     //for(int i = 0; i < Elems; i++) g.data[i] = arg.gx[idd + i * arg.threads];
@@ -876,9 +862,9 @@ namespace quda {
                 #endif
     }
     if ( Elems == 6 ) {
-      g(2,0) = Conj(g(0,1) * g(1,2) - g(0,2) * g(1,1));
-      g(2,1) = Conj(g(0,2) * g(1,0) - g(0,0) * g(1,2));
-      g(2,2) = Conj(g(0,0) * g(1,1) - g(0,1) * g(1,0));
+      g(2,0) = conj(g(0,1) * g(1,2) - g(0,2) * g(1,1));
+      g(2,1) = conj(g(0,2) * g(1,0) - g(0,0) * g(1,2));
+      g(2,2) = conj(g(0,0) * g(1,1) - g(0,1) * g(1,0));
       //42
     }
     int x[4];
@@ -900,9 +886,9 @@ namespace quda {
                         #endif
       }
       if ( Elems == 6 ) {
-        g0(2,0) = Conj(g0(0,1) * g0(1,2) - g0(0,2) * g0(1,1));
-        g0(2,1) = Conj(g0(0,2) * g0(1,0) - g0(0,0) * g0(1,2));
-        g0(2,2) = Conj(g0(0,0) * g0(1,1) - g0(0,1) * g0(1,0));
+        g0(2,0) = conj(g0(0,1) * g0(1,2) - g0(0,2) * g0(1,1));
+        g0(2,1) = conj(g0(0,2) * g0(1,0) - g0(0,0) * g0(1,2));
+        g0(2,2) = conj(g0(0,0) * g0(1,1) - g0(0,1) * g0(1,0));
         //42
       }
       U = U * conj(g0);
@@ -954,7 +940,7 @@ namespace quda {
       vol << arg.X[1] << "x";
       vol << arg.X[2] << "x";
       vol << arg.X[3];
-      sprintf(aux_string,"threads=%d,prec=%d",arg.threads, sizeof(Float));
+      sprintf(aux_string,"threads=%d,prec=%lu", arg.threads, sizeof(Float));
       return TuneKey(vol.str().c_str(), typeid(*this).name(), aux_string);
 
     }
@@ -1052,8 +1038,6 @@ namespace quda {
     std::cout << "\tPrint convergence results at every " << verbose_interval << " steps" << std::endl;
 
 
-    typedef typename ComplexTypeId<Float>::Type Cmplx;
-
     unsigned int delta_pad = data.X()[0] * data.X()[1] * data.X()[2] * data.X()[3];
     int4 size = make_int4( data.X()[0], data.X()[1], data.X()[2], data.X()[3] );
     cufftHandle plan_xy;
@@ -1064,8 +1048,8 @@ namespace quda {
     SetPlanFFT2DMany( plan_xy, size, 1, arg.delta);    //with space only XY
 
 
-    GaugeFixFFTRotateArg<Cmplx> arg_rotate(data);
-    GaugeFixFFTRotate<Cmplx> GFRotate(arg_rotate);
+    GaugeFixFFTRotateArg<Float> arg_rotate(data);
+    GaugeFixFFTRotate<Float> GFRotate(arg_rotate);
 
     GaugeFixSETINVPSP<Float> setinvpsp(arg);
     setinvpsp.apply(0);
@@ -1081,7 +1065,7 @@ namespace quda {
     GaugeFix<Elems, Float, Gauge> gfix(dataOr, arg);
         #endif
 
-    GaugeFixQualityArg<Cmplx, Gauge> argQ(dataOr, data, arg.delta);
+    GaugeFixQualityArg<Float, Gauge> argQ(dataOr, data, arg.delta);
     GaugeFixQuality<Elems, Float, Gauge, gauge_dir> gfixquality(argQ);
 
     gfixquality.apply(0);
@@ -1097,7 +1081,7 @@ namespace quda {
         // each element is stored with stride lattice volume
         // it uses gx as temporary array!!!!!!
         //------------------------------------------------------------------------
-        Cmplx *_array = arg.delta + k * delta_pad;
+        complex<Float> *_array = arg.delta + k * delta_pad;
         //////  2D FFT + 2D FFT
         //------------------------------------------------------------------------
         // Perform FFT on xy plane

--- a/lib/gauge_fix_ovr_hit_devf.cuh
+++ b/lib/gauge_fix_ovr_hit_devf.cuh
@@ -65,8 +65,8 @@ namespace quda {
    * Uses 8 treads per lattice site, the reduction is performed by shared memory without using atomicadd.
    * This implementation needs 8x more shared memory than the implementation using atomicadd 
    */
-  template<int blockSize, typename Float2, typename Float, int gauge_dir, int NCOLORS>
-  __forceinline__ __device__ void GaugeFixHit_AtomicAdd(Matrix<Float2,NCOLORS> &link, const Float relax_boost, const int tid){
+  template<int blockSize, typename Float, int gauge_dir, int NCOLORS>
+  __forceinline__ __device__ void GaugeFixHit_AtomicAdd(Matrix<complex<Float>,NCOLORS> &link, const Float relax_boost, const int tid){
 
     //Container for the four real parameters of SU(2) subgroup in shared memory
     //__shared__ Float elems[blockSize * 4];
@@ -115,27 +115,27 @@ namespace quda {
       __syncthreads();
       //_____________
       if ( threadIdx.x < blockSize * 4 ) {
-        Float2 m0;
+        complex<Float> m0;
         //Do SU(2) hit on all upward links
         //left multiply an su3_matrix by an su2 matrix
         //link <- u * link
         //#pragma unroll
         for ( int j = 0; j < NCOLORS; j++ ) {
           m0 = link(p,j);
-          link(p,j) = makeComplex( elems[tid], elems[tid + blockSize * 3] ) * m0 + makeComplex( elems[tid + blockSize * 2], elems[tid + blockSize] ) * link(q,j);
-          link(q,j) = makeComplex(-elems[tid + blockSize * 2], elems[tid + blockSize]) * m0 + makeComplex( elems[tid],-elems[tid + blockSize * 3] ) * link(q,j);
+          link(p,j) = complex<Float>( elems[tid], elems[tid + blockSize * 3] ) * m0 + complex<Float>( elems[tid + blockSize * 2], elems[tid + blockSize] ) * link(q,j);
+          link(q,j) = complex<Float>(-elems[tid + blockSize * 2], elems[tid + blockSize]) * m0 + complex<Float>( elems[tid],-elems[tid + blockSize * 3] ) * link(q,j);
         }
       }
       else{
-        Float2 m0;
+        complex<Float> m0;
         //Do SU(2) hit on all downward links
         //right multiply an su3_matrix by an su2 matrix
         //link <- link * u_adj
         //#pragma unroll
         for ( int j = 0; j < NCOLORS; j++ ) {
           m0 = link(j,p);
-          link(j,p) = makeComplex( elems[tid], -elems[tid + blockSize * 3] ) * m0 + makeComplex( elems[tid + blockSize * 2], -elems[tid + blockSize] ) * link(j,q);
-          link(j,q) = makeComplex(-elems[tid + blockSize * 2], -elems[tid + blockSize]) * m0 + makeComplex( elems[tid],elems[tid + blockSize * 3] ) * link(j,q);
+          link(j,p) = complex<Float>( elems[tid], -elems[tid + blockSize * 3] ) * m0 + complex<Float>( elems[tid + blockSize * 2], -elems[tid + blockSize] ) * link(j,q);
+          link(j,q) = complex<Float>(-elems[tid + blockSize * 2], -elems[tid + blockSize]) * m0 + complex<Float>( elems[tid],elems[tid + blockSize * 3] ) * link(j,q);
         }
       }
       //_____________ //FLOP per lattice site = 8 * NCOLORS * 2 * (2*6+2) = NCOLORS * 224
@@ -155,8 +155,8 @@ namespace quda {
    * Device function to perform gauge fixing with overrelxation.
    * Uses 4 treads per lattice site, the reduction is performed by shared memory using atomicadd.
    */
-  template<int blockSize, typename Float2, typename Float, int gauge_dir, int NCOLORS>
-  __forceinline__ __device__ void GaugeFixHit_NoAtomicAdd(Matrix<Float2,NCOLORS> &link, const Float relax_boost, const int tid){
+  template<int blockSize, typename Float, int gauge_dir, int NCOLORS>
+  __forceinline__ __device__ void GaugeFixHit_NoAtomicAdd(Matrix<complex<Float>,NCOLORS> &link, const Float relax_boost, const int tid){
 
     //Container for the four real parameters of SU(2) subgroup in shared memory
     //__shared__ Float elems[blockSize * 4 * 8];
@@ -214,27 +214,27 @@ namespace quda {
       __syncthreads();
       //_____________
       if ( threadIdx.x < blockSize * 4 ) {
-        Float2 m0;
+        complex<Float> m0;
         //Do SU(2) hit on all upward links
         //left multiply an su3_matrix by an su2 matrix
         //link <- u * link
         //#pragma unroll
         for ( int j = 0; j < NCOLORS; j++ ) {
           m0 = link(p,j);
-          link(p,j) = makeComplex( elems[tid], elems[tid + blockSize * 3] ) * m0 + makeComplex( elems[tid + blockSize * 2], elems[tid + blockSize] ) * link(q,j);
-          link(q,j) = makeComplex(-elems[tid + blockSize * 2], elems[tid + blockSize]) * m0 + makeComplex( elems[tid],-elems[tid + blockSize * 3] ) * link(q,j);
+          link(p,j) = complex<Float>( elems[tid], elems[tid + blockSize * 3] ) * m0 + complex<Float>( elems[tid + blockSize * 2], elems[tid + blockSize] ) * link(q,j);
+          link(q,j) = complex<Float>(-elems[tid + blockSize * 2], elems[tid + blockSize]) * m0 + complex<Float>( elems[tid],-elems[tid + blockSize * 3] ) * link(q,j);
         }
       }
       else{
-        Float2 m0;
+        complex<Float> m0;
         //Do SU(2) hit on all downward links
         //right multiply an su3_matrix by an su2 matrix
         //link <- link * u_adj
         //#pragma unroll
         for ( int j = 0; j < NCOLORS; j++ ) {
           m0 = link(j,p);
-          link(j,p) = makeComplex( elems[tid], -elems[tid + blockSize * 3] ) * m0 + makeComplex( elems[tid + blockSize * 2], -elems[tid + blockSize] ) * link(j,q);
-          link(j,q) = makeComplex(-elems[tid + blockSize * 2], -elems[tid + blockSize]) * m0 + makeComplex( elems[tid],elems[tid + blockSize * 3] ) * link(j,q);
+          link(j,p) = complex<Float>( elems[tid], -elems[tid + blockSize * 3] ) * m0 + complex<Float>( elems[tid + blockSize * 2], -elems[tid + blockSize] ) * link(j,q);
+          link(j,q) = complex<Float>(-elems[tid + blockSize * 2], -elems[tid + blockSize]) * m0 + complex<Float>(elems[tid],elems[tid + blockSize * 3] ) * link(j,q);
         }
       }
       //_____________ //FLOP per lattice site = 8 * NCOLORS * 2 * (2*6+2) = NCOLORS * 224
@@ -250,8 +250,8 @@ namespace quda {
    * Uses 8 treads per lattice site, the reduction is performed by shared memory without using atomicadd.
    * This implementation uses the same amount of shared memory as the atomicadd implementation with more thread block synchronization
    */
-  template<int blockSize, typename Float2, typename Float, int gauge_dir, int NCOLORS>
-  __forceinline__ __device__ void GaugeFixHit_NoAtomicAdd_LessSM(Matrix<Float2,NCOLORS> &link, const Float relax_boost, const int tid){
+  template<int blockSize, typename Float, int gauge_dir, int NCOLORS>
+  __forceinline__ __device__ void GaugeFixHit_NoAtomicAdd_LessSM(Matrix<complex<Float>,NCOLORS> &link, const Float relax_boost, const int tid){
 
     //Container for the four real parameters of SU(2) subgroup in shared memory
     //__shared__ Float elems[blockSize * 4 * 8];
@@ -340,27 +340,27 @@ namespace quda {
       __syncthreads();
       //_____________
       if ( threadIdx.x < blockSize * 4 ) {
-        Float2 m0;
+        complex<Float> m0;
         //Do SU(2) hit on all upward links
         //left multiply an su3_matrix by an su2 matrix
         //link <- u * link
         //#pragma unroll
         for ( int j = 0; j < NCOLORS; j++ ) {
           m0 = link(p,j);
-          link(p,j) = makeComplex( elems[tid], elems[tid + blockSize * 3] ) * m0 + makeComplex( elems[tid + blockSize * 2], elems[tid + blockSize] ) * link(q,j);
-          link(q,j) = makeComplex(-elems[tid + blockSize * 2], elems[tid + blockSize]) * m0 + makeComplex( elems[tid],-elems[tid + blockSize * 3] ) * link(q,j);
+          link(p,j) = complex<Float>( elems[tid], elems[tid + blockSize * 3] ) * m0 + complex<Float>( elems[tid + blockSize * 2], elems[tid + blockSize] ) * link(q,j);
+          link(q,j) = complex<Float>(-elems[tid + blockSize * 2], elems[tid + blockSize]) * m0 + complex<Float>( elems[tid],-elems[tid + blockSize * 3] ) * link(q,j);
         }
       }
       else{
-        Float2 m0;
+        complex<Float> m0;
         //Do SU(2) hit on all downward links
         //right multiply an su3_matrix by an su2 matrix
         //link <- link * u_adj
         //#pragma unroll
         for ( int j = 0; j < NCOLORS; j++ ) {
           m0 = link(j,p);
-          link(j,p) = makeComplex( elems[tid], -elems[tid + blockSize * 3] ) * m0 + makeComplex( elems[tid + blockSize * 2], -elems[tid + blockSize] ) * link(j,q);
-          link(j,q) = makeComplex(-elems[tid + blockSize * 2], -elems[tid + blockSize]) * m0 + makeComplex( elems[tid],elems[tid + blockSize * 3] ) * link(j,q);
+          link(j,p) = complex<Float>( elems[tid], -elems[tid + blockSize * 3] ) * m0 + complex<Float>( elems[tid + blockSize * 2], -elems[tid + blockSize] ) * link(j,q);
+          link(j,q) = complex<Float>(-elems[tid + blockSize * 2], -elems[tid + blockSize]) * m0 + complex<Float>( elems[tid],elems[tid + blockSize * 3] ) * link(j,q);
         }
       }
       //_____________ //FLOP per lattice site = 8 * NCOLORS * 2 * (2*6+2) = NCOLORS * 224
@@ -388,8 +388,9 @@ namespace quda {
    * Uses 8 treads per lattice site, the reduction is performed by shared memory without using atomicadd.
    * This implementation needs 8x more shared memory than the implementation using atomicadd 
    */
-  template<int blockSize, typename Float2, typename Float, int gauge_dir, int NCOLORS>
-  __forceinline__ __device__ void GaugeFixHit_AtomicAdd(Matrix<Float2,NCOLORS> &link, Matrix<Float2,NCOLORS> &link1, const Float relax_boost, const int tid){
+  template<int blockSize, typename Float, int gauge_dir, int NCOLORS>
+  __forceinline__ __device__ void GaugeFixHit_AtomicAdd(Matrix<complex<Float>,NCOLORS> &link, Matrix<complex<Float>,NCOLORS> &link1,
+							const Float relax_boost, const int tid){
 
     //Container for the four real parameters of SU(2) subgroup in shared memory
     //__shared__ Float elems[blockSize * 4];
@@ -431,17 +432,17 @@ namespace quda {
         elems[threadIdx.x + blockSize * 3] *= x * r;
       } //FLOP per lattice site = 22CUB: "Collective" Software Primitives for CUDA Kernel Development
       __syncthreads();
-      Float2 m0;
+      complex<Float> m0;
       //Do SU(2) hit on all upward links
       //left multiply an su3_matrix by an su2 matrix
       //link <- u * link
       //#pragma unroll
       for ( int j = 0; j < NCOLORS; j++ ) {
         m0 = link(p,j);
-        link(p,j) = makeComplex( elems[tid], elems[tid + blockSize * 3] ) * m0 + \
-                    makeComplex( elems[tid + blockSize * 2], elems[tid + blockSize] ) * link(q,j);
-        link(q,j) = makeComplex(-elems[tid + blockSize * 2], elems[tid + blockSize]) * m0 + \
-                    makeComplex( elems[tid],-elems[tid + blockSize * 3] ) * link(q,j);
+        link(p,j) = complex<Float>( elems[tid], elems[tid + blockSize * 3] ) * m0 +
+	  complex<Float>( elems[tid + blockSize * 2], elems[tid + blockSize] ) * link(q,j);
+        link(q,j) = complex<Float>(-elems[tid + blockSize * 2], elems[tid + blockSize]) * m0 +
+	  complex<Float>( elems[tid],-elems[tid + blockSize * 3] ) * link(q,j);
       }
       //Do SU(2) hit on all downward links
       //right multiply an su3_matrix by an su2 matrix
@@ -449,10 +450,10 @@ namespace quda {
       //#pragma unroll
       for ( int j = 0; j < NCOLORS; j++ ) {
         m0 = link1(j,p);
-        link1(j,p) = makeComplex( elems[tid], -elems[tid + blockSize * 3] ) * m0 + \
-                     makeComplex( elems[tid + blockSize * 2], -elems[tid + blockSize] ) * link1(j,q);
-        link1(j,q) = makeComplex(-elems[tid + blockSize * 2], -elems[tid + blockSize]) * m0 + \
-                     makeComplex( elems[tid],elems[tid + blockSize * 3] ) * link1(j,q);
+        link1(j,p) = complex<Float>( elems[tid], -elems[tid + blockSize * 3] ) * m0 +
+	  complex<Float>( elems[tid + blockSize * 2], -elems[tid + blockSize] ) * link1(j,q);
+        link1(j,q) = complex<Float>(-elems[tid + blockSize * 2], -elems[tid + blockSize]) * m0 +
+	  complex<Float>( elems[tid],elems[tid + blockSize * 3] ) * link1(j,q);
       }
       if ( block < (NCOLORS * (NCOLORS - 1) / 2) - 1 ) {
         __syncthreads();
@@ -481,8 +482,9 @@ namespace quda {
    * Device function to perform gauge fixing with overrelxation.
    * Uses 4 treads per lattice site, the reduction is performed by shared memory using atomicadd.
    */
-  template<int blockSize, typename Float2, typename Float, int gauge_dir, int NCOLORS>
-  __forceinline__ __device__ void GaugeFixHit_NoAtomicAdd(Matrix<Float2,NCOLORS> &link, Matrix<Float2,NCOLORS> &link1, const Float relax_boost, const int tid){
+  template<int blockSize, typename Float, int gauge_dir, int NCOLORS>
+  __forceinline__ __device__ void GaugeFixHit_NoAtomicAdd(Matrix<complex<Float>,NCOLORS> &link, Matrix<complex<Float>,NCOLORS> &link1,
+							  const Float relax_boost, const int tid){
 
     //Container for the four real parameters of SU(2) subgroup in shared memory
     //__shared__ Float elems[blockSize * 4 * 8];
@@ -521,17 +523,17 @@ namespace quda {
         elems[threadIdx.x + blockSize * 3] = a3 * x * r;
       } //FLOP per lattice site = 22 + 8 * 4
       __syncthreads();
-      Float2 m0;
+      complex<Float> m0;
       //Do SU(2) hit on all upward links
       //left multiply an su3_matrix by an su2 matrix
       //link <- u * link
       //#pragma unroll
       for ( int j = 0; j < NCOLORS; j++ ) {
         m0 = link(p,j);
-        link(p,j) = makeComplex( elems[tid], elems[tid + blockSize * 3] ) * m0 + \
-                    makeComplex( elems[tid + blockSize * 2], elems[tid + blockSize] ) * link(q,j);
-        link(q,j) = makeComplex(-elems[tid + blockSize * 2], elems[tid + blockSize]) * m0 + \
-                    makeComplex( elems[tid],-elems[tid + blockSize * 3] ) * link(q,j);
+        link(p,j) = complex<Float>( elems[tid], elems[tid + blockSize * 3] ) * m0 +
+	  complex<Float>( elems[tid + blockSize * 2], elems[tid + blockSize] ) * link(q,j);
+        link(q,j) = complex<Float>(-elems[tid + blockSize * 2], elems[tid + blockSize]) * m0 +
+	  complex<Float>( elems[tid],-elems[tid + blockSize * 3] ) * link(q,j);
       }
       //Do SU(2) hit on all downward links
       //right multiply an su3_matrix by an su2 matrix
@@ -539,10 +541,10 @@ namespace quda {
       //#pragma unroll
       for ( int j = 0; j < NCOLORS; j++ ) {
         m0 = link1(j,p);
-        link1(j,p) = makeComplex( elems[tid], -elems[tid + blockSize * 3] ) * m0 + \
-                     makeComplex( elems[tid + blockSize * 2], -elems[tid + blockSize] ) * link1(j,q);
-        link1(j,q) = makeComplex(-elems[tid + blockSize * 2], -elems[tid + blockSize]) * m0 + \
-                     makeComplex( elems[tid],elems[tid + blockSize * 3] ) * link1(j,q);
+        link1(j,p) = complex<Float>( elems[tid], -elems[tid + blockSize * 3] ) * m0 +
+	  complex<Float>( elems[tid + blockSize * 2], -elems[tid + blockSize] ) * link1(j,q);
+        link1(j,q) = complex<Float>(-elems[tid + blockSize * 2], -elems[tid + blockSize]) * m0 +
+	  complex<Float>( elems[tid],elems[tid + blockSize * 3] ) * link1(j,q);
       }
       if ( block < (NCOLORS * (NCOLORS - 1) / 2) - 1 ) { __syncthreads(); }
     }
@@ -557,8 +559,8 @@ namespace quda {
    * Uses 4 treads per lattice site, the reduction is performed by shared memory without using atomicadd.
    * This implementation uses the same amount of shared memory as the atomicadd implementation with more thread block synchronization
    */
-  template<int blockSize, typename Float2, typename Float, int gauge_dir, int NCOLORS>
-  __forceinline__ __device__ void GaugeFixHit_NoAtomicAdd_LessSM(Matrix<Float2,NCOLORS> &link, Matrix<Float2,NCOLORS> &link1, const Float relax_boost, const int tid){
+  template<int blockSize, typename Float, int gauge_dir, int NCOLORS>
+  __forceinline__ __device__ void GaugeFixHit_NoAtomicAdd_LessSM(Matrix<complex<Float>,NCOLORS> &link, Matrix<complex<Float>,NCOLORS> &link1, const Float relax_boost, const int tid){
 
     //Container for the four real parameters of SU(2) subgroup in shared memory
     //__shared__ Float elems[blockSize * 4 * 8];
@@ -613,17 +615,17 @@ namespace quda {
         elems[tid + blockSize * 3] *= x * r;
       }
       __syncthreads();
-      Float2 m0;
+      complex<Float> m0;
       //Do SU(2) hit on all upward links
       //left multiply an su3_matrix by an su2 matrix
       //link <- u * link
       //#pragma unroll
       for ( int j = 0; j < NCOLORS; j++ ) {
         m0 = link(p,j);
-        link(p,j) = makeComplex( elems[tid], elems[tid + blockSize * 3] ) * m0 + \
-                    makeComplex( elems[tid + blockSize * 2], elems[tid + blockSize] ) * link(q,j);
-        link(q,j) = makeComplex(-elems[tid + blockSize * 2], elems[tid + blockSize]) * m0 + \
-                    makeComplex( elems[tid],-elems[tid + blockSize * 3] ) * link(q,j);
+        link(p,j) = complex<Float>( elems[tid], elems[tid + blockSize * 3] ) * m0 +
+	  complex<Float>( elems[tid + blockSize * 2], elems[tid + blockSize] ) * link(q,j);
+        link(q,j) = complex<Float>(-elems[tid + blockSize * 2], elems[tid + blockSize]) * m0 +
+	  complex<Float>( elems[tid],-elems[tid + blockSize * 3] ) * link(q,j);
       }
       //Do SU(2) hit on all downward links
       //right multiply an su3_matrix by an su2 matrix
@@ -631,10 +633,10 @@ namespace quda {
       //#pragma unroll
       for ( int j = 0; j < NCOLORS; j++ ) {
         m0 = link1(j,p);
-        link1(j,p) = makeComplex( elems[tid], -elems[tid + blockSize * 3] ) * m0 + \
-                     makeComplex( elems[tid + blockSize * 2], -elems[tid + blockSize] ) * link1(j,q);
-        link1(j,q) = makeComplex(-elems[tid + blockSize * 2], -elems[tid + blockSize]) * m0 + \
-                     makeComplex( elems[tid],elems[tid + blockSize * 3] ) * link1(j,q);
+        link1(j,p) = complex<Float>( elems[tid], -elems[tid + blockSize * 3] ) * m0 +
+	  complex<Float>( elems[tid + blockSize * 2], -elems[tid + blockSize] ) * link1(j,q);
+        link1(j,q) = complex<Float>(-elems[tid + blockSize * 2], -elems[tid + blockSize]) * m0 +
+	  complex<Float>( elems[tid],elems[tid + blockSize * 3] ) * link1(j,q);
       }
       if ( block < (NCOLORS * (NCOLORS - 1) / 2) - 1 ) { __syncthreads(); }
     }

--- a/lib/gauge_stout.cu
+++ b/lib/gauge_stout.cu
@@ -44,7 +44,7 @@ namespace quda {
   template <typename Float, typename GaugeOr, typename GaugeDs, typename Float2>
   __host__ __device__ void computeStaple(GaugeSTOUTArg<Float,GaugeOr,GaugeDs>& arg, int idx, int parity, int dir, Matrix<Float2,3> &staple) {
 
-    typedef typename ComplexTypeId<Float>::Type Cmplx;
+    typedef Matrix<complex<Float>,3> M;
       // compute spacetime dimensions and parity
 
     int X[4]; 
@@ -70,20 +70,16 @@ namespace quda {
 
       {
         int dx[4] = {0, 0, 0, 0};
-        Matrix<Cmplx,3> U1;
+        M U1, U2, U3, U4, tmpS;
         arg.origin.load((Float*)(U1.data),linkIndexShift(x,dx,X), mu, parity); 
 
-        Matrix<Cmplx,3> U2;
         dx[mu]++;
         arg.origin.load((Float*)(U2.data),linkIndexShift(x,dx,X), nu, 1-parity); 
 
-        Matrix<Cmplx,3> U3;
         dx[mu]--;
         dx[nu]++;
         arg.origin.load((Float*)(U3.data),linkIndexShift(x,dx,X), mu, 1-parity); 
    
-        Matrix<Cmplx,3> tmpS;
-
         tmpS	= U1 * U2;
 	tmpS	= tmpS * conj(U3);
 
@@ -110,7 +106,8 @@ namespace quda {
     __global__ void computeSTOUTStep(GaugeSTOUTArg<Float,GaugeOr,GaugeDs> arg){
       int idx = threadIdx.x + blockIdx.x*blockDim.x;
       if(idx >= arg.threads) return;
-      typedef typename ComplexTypeId<Float>::Type Cmplx;
+      typedef complex<Float> Complex;
+      typedef Matrix<complex<Float>,3> M;
 
       int parity = 0;
       if(idx >= arg.threads/2) {
@@ -132,12 +129,12 @@ namespace quda {
 
       int dx[4] = {0, 0, 0, 0};
       for (int dir=0; dir < 3; dir++) {				//Only spatial dimensions are smeared
-        Matrix<Cmplx,3> U, UDag, Stap, Omega, OmegaDag, OmegaDiff, ODT, Q, exp_iQ, tmp1;
-	Cmplx OmegaDiffTr;
-	Cmplx i_2 = makeComplex<Cmplx>(0,0.5);
+        M U, UDag, Stap, Omega, OmegaDag, OmegaDiff, ODT, Q, exp_iQ, tmp1;
+	Complex OmegaDiffTr;
+	Complex i_2(0,0.5);
 
 	//This function gets stap = S_{mu,nu} i.e., the staple of length 3,
-        computeStaple<Float,GaugeOr,GaugeDs,Cmplx>(arg,idx,parity,dir,Stap);
+        computeStaple<Float,GaugeOr,GaugeDs,Complex>(arg,idx,parity,dir,Stap);
 	//
 	// |- > -|
 	// ^     v
@@ -179,8 +176,6 @@ namespace quda {
 	exponentiate_iQ(Q,&exp_iQ);
 	U = exp_iQ * U;
 
-	//No need to project back down to SU(3)
-        //polarSu3<Cmplx,Float>(&U, arg.tolerance);
         arg.dest.save((Float*)(U.data),linkIndexShift(x,dx,X), dir, parity); 
     }
   }

--- a/lib/gauge_update_quda.cu
+++ b/lib/gauge_update_quda.cu
@@ -13,89 +13,88 @@ namespace quda {
 
 #ifdef GPU_GAUGE_TOOLS
 
-  template <typename Complex, typename Gauge, typename Mom>
+  template <typename Float, typename Gauge, typename Mom>
   struct UpdateGaugeArg {
-    typedef typename RealTypeId<Complex>::Type real;
     Gauge out;
     Gauge in;
     Mom momentum;
-    real dt;
+    Float dt;
     int nDim;
     UpdateGaugeArg(const Gauge &out, const Gauge &in, 
-		   const Mom &momentum, real dt, int nDim)
+		   const Mom &momentum, Float dt, int nDim)
       : out(out), in(in), momentum(momentum), dt(dt), nDim(nDim) { }
   };
 
   /**
      Direct port of the TIFR expsu3 algorithm
   */
-  template <typename complex, typename Cmplx>
-  __device__ __host__ void expsu3(Matrix<Cmplx,3> &q, int x) {
-    typedef typename RealTypeId<Cmplx>::Type real;
+  template <typename Float>
+  __device__ __host__ void expsu3(Matrix<complex<Float>,3> &q, int x) {
+    typedef complex<Float> Complex;
 
-    complex a2 = (q(3)*q(1)+q(7)*q(5)+q(6)*q(2) - 
-		  (q(0)*q(4)+(q(0)+q(4))*q(8))) / (real)3.0 ;
-    complex a3 = q(0)*q(4)*q(8) + q(1)*q(5)*q(6) + q(2)*q(3)*q(7) - 
+    Complex a2 = (q(3)*q(1)+q(7)*q(5)+q(6)*q(2) -
+		  (q(0)*q(4)+(q(0)+q(4))*q(8))) / (Float)3.0 ;
+    Complex a3 = q(0)*q(4)*q(8) + q(1)*q(5)*q(6) + q(2)*q(3)*q(7) -
       q(6)*q(4)*q(2) - q(3)*q(1)*q(8) - q(0)*q(7)*q(5);
 
-    complex sg2h3 = sqrt(a3*a3-(real)4.*a2*a2*a2);
-    complex cp = exp( log((real)0.5*(a3+sg2h3)) / (real)3.0);
-    complex cm = a2/cp;
+    Complex sg2h3 = sqrt(a3*a3-(Float)4.*a2*a2*a2);
+    Complex cp = exp( log((Float)0.5*(a3+sg2h3)) / (Float)3.0);
+    Complex cm = a2/cp;
 
-    complex r1 = exp( complex(0.0,1.0)*(real)(2.0*M_PI/3.0));
-    complex r2 = exp(-complex(0.0,1.0)*(real)(2.0*M_PI/3.0));
+    Complex r1 = exp( Complex(0.0,1.0)*(Float)(2.0*M_PI/3.0));
+    Complex r2 = exp(-Complex(0.0,1.0)*(Float)(2.0*M_PI/3.0));
 
-    complex w1[3];
+    Complex w1[3];
       
     w1[0]=cm+cp;
     w1[1]=r1*cp+r2*cm;
     w1[2]=r2*cp+r1*cm;
-    complex z1=q(1)*q(6)-q(0)*q(7);
-    complex z2=q(3)*q(7)-q(4)*q(6);
+    Complex z1=q(1)*q(6)-q(0)*q(7);
+    Complex z2=q(3)*q(7)-q(4)*q(6);
 
-    complex al = w1[0];
-    complex wr21 = (z1+al*q(7)) / (z2+al*q(6));
-    complex wr31 = (al-q(0)-wr21*q(3))/q(6);
+    Complex al = w1[0];
+    Complex wr21 = (z1+al*q(7)) / (z2+al*q(6));
+    Complex wr31 = (al-q(0)-wr21*q(3))/q(6);
 
     al=w1[1];
-    complex wr22 = (z1+al*q(7))/(z2+al*q(6));
-    complex wr32 = (al-q(0)-wr22*q(3))/q(6);
+    Complex wr22 = (z1+al*q(7))/(z2+al*q(6));
+    Complex wr32 = (al-q(0)-wr22*q(3))/q(6);
 
     al=w1[2];
-    complex wr23 = (z1+al*q(7))/(z2+al*q(6));
-    complex wr33 = (al-q(0)-wr23*q(3))/q(6);
+    Complex wr23 = (z1+al*q(7))/(z2+al*q(6));
+    Complex wr33 = (al-q(0)-wr23*q(3))/q(6);
 
     z1=q(3)*q(2) - q(0)*q(5);
     z2=q(1)*q(5) - q(4)*q(2);
 
     al=w1[0];
-    complex wl21 = conj((z1+al*q(5))/(z2+al*q(2)));
-    complex wl31 = conj((al-q(0)-conj(wl21)*q(1))/q(2));
+    Complex wl21 = conj((z1+al*q(5))/(z2+al*q(2)));
+    Complex wl31 = conj((al-q(0)-conj(wl21)*q(1))/q(2));
 
     al=w1[1];
-    complex wl22 = conj((z1+al*q(5))/(z2+al*q(2)));
-    complex wl32 = conj((al-q(0)-conj(wl22)*q(1))/q(2));
+    Complex wl22 = conj((z1+al*q(5))/(z2+al*q(2)));
+    Complex wl32 = conj((al-q(0)-conj(wl22)*q(1))/q(2));
 
     al=w1[2];
-    complex wl23 = conj((z1+al*q(5))/(z2+al*q(2)));
-    complex wl33 = conj((al-q(0)-conj(wl23)*q(1))/q(2));
+    Complex wl23 = conj((z1+al*q(5))/(z2+al*q(2)));
+    Complex wl33 = conj((al-q(0)-conj(wl23)*q(1))/q(2));
 
-    complex xn1 = (real)1. + wr21*conj(wl21) + wr31*conj(wl31);
-    complex xn2 = (real)1. + wr22*conj(wl22) + wr32*conj(wl32);
-    complex xn3 = (real)1. + wr23*conj(wl23) + wr33*conj(wl33);
+    Complex xn1 = (Float)1. + wr21*conj(wl21) + wr31*conj(wl31);
+    Complex xn2 = (Float)1. + wr22*conj(wl22) + wr32*conj(wl32);
+    Complex xn3 = (Float)1. + wr23*conj(wl23) + wr33*conj(wl33);
 
-    complex d1 = exp(w1[0]);
-    complex d2 = exp(w1[1]);
-    complex d3 = exp(w1[2]);
-    complex y11 = d1/xn1;
-    complex y12 = d2/xn2;
-    complex y13 = d3/xn3;
-    complex y21 = wr21*d1/xn1;
-    complex y22 = wr22*d2/xn2;
-    complex y23 = wr23*d3/xn3;
-    complex y31 = wr31*d1/xn1;
-    complex y32 = wr32*d2/xn2;
-    complex y33 = wr33*d3/xn3;
+    Complex d1 = exp(w1[0]);
+    Complex d2 = exp(w1[1]);
+    Complex d3 = exp(w1[2]);
+    Complex y11 = d1/xn1;
+    Complex y12 = d2/xn2;
+    Complex y13 = d3/xn3;
+    Complex y21 = wr21*d1/xn1;
+    Complex y22 = wr22*d2/xn2;
+    Complex y23 = wr23*d3/xn3;
+    Complex y31 = wr31*d1/xn1;
+    Complex y32 = wr32*d2/xn2;
+    Complex y33 = wr33*d3/xn3;
     q(0) = y11 + y12 + y13;
     q(1) = y21 + y22 + y23;
     q(2) = y31 + y32 + y33;
@@ -107,21 +106,21 @@ namespace quda {
     q(8) = y31*conj(wl31) + y32*conj(wl32) + y33*conj(wl33);
   }
 
-  template<typename Cmplx, typename Gauge, typename Mom, int N, 
+  template<typename Float, typename Gauge, typename Mom, int N,
 	   bool conj_mom, bool exact>
   __device__ __host__  void updateGaugeFieldCompute
-  (UpdateGaugeArg<Cmplx,Gauge,Mom> &arg, int x, int parity) {
+  (UpdateGaugeArg<Float,Gauge,Mom> &arg, int x, int parity) {
+    typedef complex<Float> Complex;
 
-    typedef typename RealTypeId<Cmplx>::Type real;
-    Matrix<Cmplx,3> link, result, mom;
+    Matrix<Complex,3> link, result, mom;
     for(int dir=0; dir<arg.nDim; ++dir){
-      arg.in.load((real*)(link.data), x, dir, parity);
-      arg.momentum.load((real*)(mom.data), x, dir, parity);
+      arg.in.load((Float*)(link.data), x, dir, parity);
+      arg.momentum.load((Float*)(mom.data), x, dir, parity);
 
-      Cmplx trace = getTrace(mom);
-      mom(0,0) -= trace/3.0;
-      mom(1,1) -= trace/3.0;
-      mom(2,2) -= trace/3.0;
+      Complex trace = getTrace(mom);
+      mom(0,0) -= trace/static_cast<Float>(3.0);
+      mom(1,1) -= trace/static_cast<Float>(3.0);
+      mom(2,2) -= trace/static_cast<Float>(3.0);
 
       if (!exact) {
 	result = link;
@@ -136,7 +135,7 @@ namespace quda {
 	}
       } else {
 	mom = arg.dt * mom;
-	expsu3<complex<real> >(mom, x+dir+parity);
+	expsu3<Float>(mom, x+dir+parity);
 
 	if (!conj_mom) {
 	  link = mom * link;
@@ -147,40 +146,39 @@ namespace quda {
 	result = link;
       }
 
-      arg.out.save((real*)(result.data), x, dir, parity);
+      arg.out.save((Float*)(result.data), x, dir, parity);
     } // dir
 
   }
 
-  template<typename Cmplx, typename Gauge, typename Mom, int N, 
+  template<typename Float, typename Gauge, typename Mom, int N,
 	   bool conj_mom, bool exact>
-  void updateGaugeField(UpdateGaugeArg<Cmplx,Gauge,Mom> arg) {
+  void updateGaugeField(UpdateGaugeArg<Float,Gauge,Mom> arg) {
 
     for (unsigned int parity=0; parity<2; parity++) {
       for (unsigned int x=0; x<arg.out.volumeCB; x++) {
-	updateGaugeFieldCompute<Cmplx,Gauge,Mom,N,conj_mom,exact>
+	updateGaugeFieldCompute<Float,Gauge,Mom,N,conj_mom,exact>
 	  (arg, x, parity);
       }
     }
   }
 
-  template<typename Cmplx, typename Gauge, typename Mom, int N, 
+  template<typename Float, typename Gauge, typename Mom, int N,
 	   bool conj_mom, bool exact>
-  __global__ void updateGaugeFieldKernel(UpdateGaugeArg<Cmplx,Gauge,Mom> arg) { 
+  __global__ void updateGaugeFieldKernel(UpdateGaugeArg<Float,Gauge,Mom> arg) {
     int idx = blockIdx.x*blockDim.x + threadIdx.x;
     if (idx >= 2*arg.out.volumeCB) return;
     int parity = (idx >= arg.out.volumeCB) ? 1 : 0;
     idx -= parity*arg.out.volumeCB;
 
-    updateGaugeFieldCompute<Cmplx,Gauge,Mom,N,conj_mom,exact>
-      (arg, idx, parity);
+    updateGaugeFieldCompute<Float,Gauge,Mom,N,conj_mom,exact>(arg, idx, parity);
  }
    
-  template <typename Complex, typename Gauge, typename Mom, int N, 
+  template <typename Float, typename Gauge, typename Mom, int N,
 	    bool conj_mom, bool exact>
    class UpdateGaugeField : public Tunable {
   private:
-    UpdateGaugeArg<Complex,Gauge,Mom> arg;
+    UpdateGaugeArg<Float,Gauge,Mom> arg;
     const GaugeField &meta; // meta data
     const QudaFieldLocation location; // location of the lattice fields
 
@@ -191,21 +189,21 @@ namespace quda {
     bool tuneGridDim() const { return false; }
     
   public:
-    UpdateGaugeField(const UpdateGaugeArg<Complex,Gauge,Mom> &arg, 
+    UpdateGaugeField(const UpdateGaugeArg<Float,Gauge,Mom> &arg,
 		     const GaugeField &meta, QudaFieldLocation location)
       : arg(arg), meta(meta), location(location) {
       writeAuxString("threads=%d,prec=%lu,stride=%d", 
-		     2*arg.in.volumeCB, sizeof(Complex)/2, arg.in.stride);
+		     2*arg.in.volumeCB, sizeof(Float), arg.in.stride);
     }
     virtual ~UpdateGaugeField() { }
     
     void apply(const cudaStream_t &stream){
       if (location == QUDA_CUDA_FIELD_LOCATION) {
 	TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
-	updateGaugeFieldKernel<Complex,Gauge,Mom,N,conj_mom,exact>
+	updateGaugeFieldKernel<Float,Gauge,Mom,N,conj_mom,exact>
 	  <<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
       } else { // run the CPU code
-	updateGaugeField<Complex,Gauge,Mom,N,conj_mom,exact>(arg);
+	updateGaugeField<Float,Gauge,Mom,N,conj_mom,exact>(arg);
       }
     } // apply
     
@@ -231,25 +229,24 @@ namespace quda {
     // degree of exponential expansion
     const int N = 8;
 
-    typedef typename ComplexTypeId<Float>::Type Complex;
     if (conj_mom) {
       if (exact) {
-	UpdateGaugeArg<Complex, Gauge, Mom> arg(out, in, mom, dt, 4);
-	UpdateGaugeField<Complex,Gauge,Mom,N,true,true> updateGauge(arg, meta, location);
+	UpdateGaugeArg<Float, Gauge, Mom> arg(out, in, mom, dt, 4);
+	UpdateGaugeField<Float,Gauge,Mom,N,true,true> updateGauge(arg, meta, location);
 	updateGauge.apply(0); 
       } else {
-	UpdateGaugeArg<Complex, Gauge, Mom> arg(out, in, mom, dt, 4);
-	UpdateGaugeField<Complex,Gauge,Mom,N,true,false> updateGauge(arg, meta, location);
+	UpdateGaugeArg<Float, Gauge, Mom> arg(out, in, mom, dt, 4);
+	UpdateGaugeField<Float,Gauge,Mom,N,true,false> updateGauge(arg, meta, location);
 	updateGauge.apply(0); 
       }
     } else {
       if (exact) {
-	UpdateGaugeArg<Complex, Gauge, Mom> arg(out, in, mom, dt, 4);
-	UpdateGaugeField<Complex,Gauge,Mom,N,false,true> updateGauge(arg, meta, location);
+	UpdateGaugeArg<Float, Gauge, Mom> arg(out, in, mom, dt, 4);
+	UpdateGaugeField<Float,Gauge,Mom,N,false,true> updateGauge(arg, meta, location);
 	updateGauge.apply(0);
       } else {
-	UpdateGaugeArg<Complex, Gauge, Mom> arg(out, in, mom, dt, 4);
-	UpdateGaugeField<Complex,Gauge,Mom,N,false,false> updateGauge(arg, meta, location);
+	UpdateGaugeArg<Float, Gauge, Mom> arg(out, in, mom, dt, 4);
+	UpdateGaugeField<Float,Gauge,Mom,N,false,false> updateGauge(arg, meta, location);
 	updateGauge.apply(0); 
       }
     }

--- a/lib/hisq_paths_force_core.h
+++ b/lib/hisq_paths_force_core.h
@@ -1,3 +1,5 @@
+#include<type_traits>
+
 
 //macro KERNEL_ENABLED is used to control compile time, debug purpose only
 #if (PRECISION == 0 && RECON == 18)
@@ -90,7 +92,8 @@ template<class RealA, class RealB, int sig_positive, int mu_positive>
                      RealA* const newOprodEven, RealA* const newOprodOdd,
                      hisq_kernel_param_t kparam) 
 {
-
+  typedef typename std::remove_reference<decltype(RealA::x)>::type real;
+  typedef complex<real> Complex;
 
   int oddBit = threadIdx.y;
   int sid = blockIdx.x * blockDim.x + threadIdx.x;
@@ -100,9 +103,8 @@ template<class RealA, class RealB, int sig_positive, int mu_positive>
 
   getCoords(x, sid, kparam.D, oddBit);
 
-
-  Matrix<RealA,3> Uab, Ubc, Uad;
-  Matrix<RealA,3> Ow, Ox, Oy;
+  Matrix<Complex,3> Uab, Ubc, Uad;
+  Matrix<Complex,3> Ow, Ox, Oy;
 
 
   /*        A________B
@@ -255,16 +257,16 @@ HISQ_KERNEL_NAME(do_lepage_middle_link, EXT)(const RealA* const oprodEven, const
     RealA* const newOprodEven, RealA* const newOprodOdd,
     hisq_kernel_param_t kparam) 
 {
+  typedef typename std::remove_reference<decltype(RealA::x)>::type real;
+  typedef complex<real> Complex;
 
   int sid = blockIdx.x * blockDim.x + threadIdx.x;
   if(sid >= kparam.threads) return;
   int oddBit = threadIdx.y;
 
 
-  Matrix<RealA,3> Uab, Ubc, Uad;
-  Matrix<RealA,3> Ow, Ox, Oy;
-
-
+  Matrix<Complex,3> Uab, Ubc, Uad;
+  Matrix<Complex,3> Ow, Ox, Oy;
 
 
   /*        A________B
@@ -440,18 +442,16 @@ HISQ_KERNEL_NAME(do_side_link, EXT)(const RealA* const P3Even, const RealA* cons
     RealA* const newOprodEven, RealA* const newOprodOdd,
     hisq_kernel_param_t kparam)
 {
+  typedef typename std::remove_reference<decltype(RealA::x)>::type real;
+  typedef complex<real> Complex;
+
   int oddBit = threadIdx.y;
   int sid = blockIdx.x * blockDim.x + threadIdx.x;
   if(sid >= kparam.threads) return;
 
-
   int x[4];
   int dx[4] = {0,0,0,0};
   getCoords(x, sid, kparam.D, oddBit);
-
-
-
-
 
 #ifdef MULTI_GPU
   int E[4]= {kparam.X[0]+4, kparam.X[1]+4, kparam.X[2]+4, kparam.X[3]+4};
@@ -466,14 +466,8 @@ HISQ_KERNEL_NAME(do_side_link, EXT)(const RealA* const P3Even, const RealA* cons
   int new_sid = sid;
 #endif
 
-
-
-  Matrix<RealA,3> Uad;
-  Matrix<RealA,3> Ow, Ox, Oy;
-
-
-
-
+  Matrix<Complex,3> Uad;
+  Matrix<Complex,3> Ow, Ox, Oy;
 
   loadMatrixFromField(P3Even, P3Odd, new_sid, Oy.data, oddBit, kparam.color_matrix_stride);
 
@@ -491,14 +485,11 @@ HISQ_KERNEL_NAME(do_side_link, EXT)(const RealA* const P3Even, const RealA* cons
 
   int y[4] = {x[0], x[1], x[2], x[3]}; 
 
-  typename RealTypeId<RealA>::Type mycoeff;
   int point_d;
   int ad_link_nbr_idx;
   int mymu = posDir(mu);
   updateCoords(y, mymu, (mu_positive ? -1 : 1), kparam.X, kparam.ghostDim);
   point_d = linkIndexShift(y,dx,E);
-
-
 
   if (mu_positive){
     ad_link_nbr_idx = point_d;
@@ -515,10 +506,8 @@ HISQ_KERNEL_NAME(do_side_link, EXT)(const RealA* const P3Even, const RealA* cons
     Ow = conj(Uad)*Oy;
   }
 
-
-
   addMatrixToField(Ow.data, point_d, accumu_coeff, shortPEven, shortPOdd, 1-oddBit, kparam.color_matrix_stride);
-  mycoeff = CoeffSign(sig_positive, oddBit)*coeff;
+  real mycoeff = CoeffSign(sig_positive, oddBit)*coeff;
 
   loadMatrixFromField(QprodEven, QprodOdd, point_d, Ox.data, 1-oddBit, kparam.color_matrix_stride);
 
@@ -548,6 +537,9 @@ HISQ_KERNEL_NAME(do_side_link_short, EXT)(const RealA* const P3Even, const RealA
     RealA* const newOprodEven, RealA* const newOprodOdd,
     hisq_kernel_param_t kparam)
 {
+  typedef typename std::remove_reference<decltype(RealA::x)>::type real;
+  typedef complex<real> Complex;
+
   int oddBit = threadIdx.y;
   int sid = blockIdx.x * blockDim.x + threadIdx.x;
   if(sid >= kparam.threads) return;
@@ -581,12 +573,12 @@ HISQ_KERNEL_NAME(do_side_link_short, EXT)(const RealA* const P3Even, const RealA
    *
    */
 
-  Matrix<RealA,3> Ow, Oy;
+  Matrix<Complex,3> Ow, Oy;
 
 
   loadMatrixFromField(P3Even, P3Odd, new_sid, Oy.data, oddBit, kparam.color_matrix_stride);
 
-  typename RealTypeId<RealA>::Type mycoeff;
+  real mycoeff;
   int point_d;
   int mymu = posDir(mu);
   int y[4] = {x[0], x[1], x[2], x[3]};  
@@ -656,6 +648,9 @@ HISQ_KERNEL_NAME(do_all_link, EXT)(const RealA* const oprodEven, const RealA* co
     RealA* const newOprodEven, RealA* const newOprodOdd,
     hisq_kernel_param_t kparam)
 {
+  typedef typename std::remove_reference<decltype(RealA::x)>::type real;
+  typedef complex<real> Complex;
+
   int oddBit = threadIdx.y;
   int sid = blockIdx.x * blockDim.x + threadIdx.x;
   if(sid >= kparam.threads) return;
@@ -667,8 +662,8 @@ HISQ_KERNEL_NAME(do_all_link, EXT)(const RealA* const oprodEven, const RealA* co
 
 
 
-  Matrix<RealA,3> Uab, Ubc, Uad;
-  Matrix<RealA,3> Ow, Ox, Oy, Oz;
+  Matrix<Complex,3> Uab, Ubc, Uad;
+  Matrix<Complex,3> Ow, Ox, Oy, Oz;
 
 
   /*            sig
@@ -804,6 +799,9 @@ HISQ_KERNEL_NAME(do_longlink, EXT)(const RealB* const linkEven, const RealB* con
     RealA* const outputEven, RealA* const outputOdd,
     hisq_kernel_param_t kparam)
 {
+  typedef typename std::remove_reference<decltype(RealA::x)>::type real;
+  typedef complex<real> Complex;
+
   int sid = blockIdx.x * blockDim.x + threadIdx.x;
   if (sid >= kparam.threads) return;
   int oddBit = threadIdx.y;
@@ -839,8 +837,8 @@ HISQ_KERNEL_NAME(do_longlink, EXT)(const RealB* const linkEven, const RealB* con
    */
 
 
-  Matrix<RealA,3> Uab, Ubc, Ude, Uef;
-  Matrix<RealA,3> Ox, Oy, Oz;
+  Matrix<Complex,3> Uab, Ubc, Ude, Uef;
+  Matrix<Complex,3> Ox, Oy, Oz;
 
   // compute the force for forward long links
   for(int sig=0; sig<4; ++sig){
@@ -868,7 +866,7 @@ HISQ_KERNEL_NAME(do_longlink, EXT)(const RealB* const linkEven, const RealB* con
     loadMatrixFromField(naikOprodEven, naikOprodOdd, sig, point_b, Oy.data, 1-oddBit, kparam.color_matrix_stride);
     loadMatrixFromField(naikOprodEven, naikOprodOdd, sig, point_a, Ox.data, oddBit, kparam.color_matrix_stride);
 
-    Matrix<RealA,3> temp = Ude*Uef*Oz - Ude*Oy*Ubc + Ox*Uab*Ubc;
+    Matrix<Complex,3> temp = Ude*Uef*Oz - Ude*Oy*Ubc + Ox*Uab*Ubc;
 
     addMatrixToField(temp.data, sig, new_sid,  coeff, outputEven, outputOdd, oddBit, kparam.color_matrix_stride);
   } // loop over sig
@@ -885,6 +883,9 @@ HISQ_KERNEL_NAME(do_complete_force, EXT)(const RealB* const linkEven, const Real
     RealA* const forceEven, RealA* const forceOdd,
     hisq_kernel_param_t kparam)
 {
+  typedef typename std::remove_reference<decltype(RealA::x)>::type real;
+  typedef complex<real> Complex;
+
   int sid = blockIdx.x * blockDim.x + threadIdx.x;
   if (sid >= kparam.threads) return;
   int oddBit = threadIdx.y;
@@ -905,12 +906,12 @@ HISQ_KERNEL_NAME(do_complete_force, EXT)(const RealB* const linkEven, const Real
 
   for(int sig=0; sig<4; ++sig){
   
-    Matrix<RealA,3> Uw, Ow, Ox;
+    Matrix<Complex,3> Uw, Ow, Ox;
 
     loadLink<18>(linkEven, linkOdd, sig, new_sid, Uw.data, oddBit, kparam.thin_link_stride);  
 
     loadMatrixFromField(oprodEven, oprodOdd, sig, new_sid, Ox.data, oddBit, kparam.color_matrix_stride);
-    typename RealTypeId<RealA>::Type coeff = (oddBit==1) ? -1 : 1;
+    real coeff = (oddBit==1) ? -1 : 1;
     Ow = Uw*Ox;
 
     storeMatrixToMomentumField(Ow.data, sig, sid, coeff, forceEven, forceOdd, oddBit, kparam.momentum_stride); 

--- a/lib/hisq_paths_force_quda.cu
+++ b/lib/hisq_paths_force_quda.cu
@@ -164,29 +164,6 @@ namespace quda {
       return make_double2(a*b.x,a*b.y);
     }
 
-    inline __device__ const float2 & operator+=(float2 & a, const float2 & b)
-    {
-      a.x += b.x;
-      a.y += b.y;
-      return a;
-    }
-
-    inline __device__ const double2 & operator+=(double2 & a, const double2 & b)
-    {
-      a.x += b.x;
-      a.y += b.y;
-      return a;
-    }
-
-    inline __device__ const float4 & operator+=(float4 & a, const float4 & b)
-    {
-      a.x += b.x;
-      a.y += b.y;
-      a.z += b.z;
-      a.w += b.w;
-      return a;
-    }
-
     // Replication of code 
     // This structure is already defined in 
     // unitarize_utilities.h
@@ -232,10 +209,10 @@ namespace quda {
       }
 
 
-    template<int N, class T>
+    template<int N, class T, class U>
       inline __device__
       void loadMatrixFromField(const T* const field_even, const T* const field_odd,
-          int dir, int idx, T* const mat, int oddness, int stride)
+          int dir, int idx, U* const mat, int oddness, int stride)
       {
         const T* const field = (oddness)?field_odd:field_even;
         for(int i = 0;i < N ;i++){
@@ -244,20 +221,18 @@ namespace quda {
         return;
       }
 
-    template<class T>
+    template<class T, class U>
       inline __device__
       void loadMatrixFromField(const T* const field_even, const T* const field_odd,
-          int dir, int idx, T* const mat, int oddness, int stride)
+			       int dir, int idx, complex<U>* const mat, int oddness, int stride)
       {
         loadMatrixFromField<9> (field_even, field_odd, dir, idx, mat, oddness, stride);
         return;
       }
 
-
-
     inline __device__
       void loadMatrixFromField(const float4* const field_even, const float4* const field_odd, 
-          int dir, int idx, float2* const mat, int oddness, int stride)
+			       int dir, int idx, complex<float>* const mat, int oddness, int stride)
       {
         const float4* const field = oddness?field_odd: field_even;
         float4 tmp;
@@ -273,9 +248,9 @@ namespace quda {
         return;
       }
 
-    template<class T>
+    template<class T, class U>
       inline __device__
-      void loadMatrixFromField(const T* const field_even, const T* const field_odd, int idx, T* const mat, int oddness, int stride)
+      void loadMatrixFromField(const T* const field_even, const T* const field_odd, int idx, U* const mat, int oddness, int stride)
       {
         const T* const field = (oddness)?field_odd:field_even;
         mat[0] = field[idx];
@@ -292,11 +267,11 @@ namespace quda {
       }
 
     template<class U>
-      inline __device__
-      void  addMatrixToNewOprod(const double2* const mat,  int dir, int idx, U coeff, 
-          double2* const field_even, double2* const field_odd, int oddness, int stride){
-        double2* const field = (oddness)?field_odd: field_even;		
-        double2 value[9];			
+    inline __device__
+    void  addMatrixToNewOprod(const complex<double>* const mat,  int dir, int idx, U coeff,
+			      double2* const field_even, double2* const field_odd, int oddness, int stride){
+      double2* const field = (oddness)?field_odd: field_even;
+      double2 value[9];
 
 #if (HISQ_NEW_OPROD_LOAD_TEX == 1)
         value[0] = READ_DOUBLE2_TEXTURE( ((oddness)?newOprod1TexDouble:newOprod0TexDouble), field, idx+dir*stride*9); 
@@ -327,14 +302,14 @@ namespace quda {
 
 
     template<class U>
-      inline __device__
-      void  addMatrixToNewOprod(const float2* const mat,  int dir, int idx, U coeff, 
-          float2* const field_even, float2* const field_odd, int oddness, int stride){
-        float2* const field = (oddness)?field_odd: field_even;		
-        float2 value[9];			
+    inline __device__
+    void  addMatrixToNewOprod(const complex<float>* const mat,  int dir, int idx, U coeff,
+			      float2* const field_even, float2* const field_odd, int oddness, int stride){
+      float2* const field = (oddness)?field_odd: field_even;
+      float2 value[9];
 
 #if (HISQ_NEW_OPROD_LOAD_TEX == 1)
-        value[0] = tex1Dfetch( ((oddness)?newOprod1TexSingle:newOprod0TexSingle),  idx+dir*stride*9); 
+        value[0] = tex1Dfetch( ((oddness)?newOprod1TexSingle:newOprod0TexSingle),  idx+dir*stride*9);
         value[1] = tex1Dfetch( ((oddness)?newOprod1TexSingle:newOprod0TexSingle),  idx+dir*stride*9 + stride); 
         value[2] = tex1Dfetch( ((oddness)?newOprod1TexSingle:newOprod0TexSingle),  idx+dir*stride*9 + 2*stride); 
         value[3] = tex1Dfetch( ((oddness)?newOprod1TexSingle:newOprod0TexSingle),  idx+dir*stride*9 + 3*stride); 
@@ -362,12 +337,12 @@ namespace quda {
 
     // only works if Promote<T,U>::Type = T
 
-    template<class T, class U>   
+    template<class T, class U, class V>
       inline __device__
       void addMatrixToField(const T* const mat, int dir, int idx, U coeff, 
-          T* const field_even, T* const field_odd, int oddness, int stride)
+          V* const field_even, V* const field_odd, int oddness, int stride)
       {
-        T* const field = (oddness)?field_odd: field_even;
+        V* const field = (oddness)?field_odd: field_even;
         field[idx + dir*stride*9]          += coeff*mat[0];
         field[idx + dir*stride*9 + stride]     += coeff*mat[1];
         field[idx + dir*stride*9 + stride*2]   += coeff*mat[2];
@@ -382,14 +357,14 @@ namespace quda {
       }
 
 
-    template<class T, class U>
+    template<class T, class U, class V>
       inline __device__
-      void addMatrixToField(const T* const mat, int idx, U coeff, T* const field_even,
-          T* const field_odd, int oddness, int stride)
+      void addMatrixToField(const T* const mat, int idx, U coeff, V* const field_even,
+          V* const field_odd, int oddness, int stride)
       {
-        T* const field = (oddness)?field_odd: field_even;
-        field[idx ]         += coeff*mat[0];
-        field[idx + stride]     += coeff*mat[1];
+        V* const field = (oddness)?field_odd: field_even;
+        field[idx + stride*0]   += coeff*mat[0];
+        field[idx + stride*1]   += coeff*mat[1];
         field[idx + stride*2]   += coeff*mat[2];
         field[idx + stride*3]   += coeff*mat[3];
         field[idx + stride*4]   += coeff*mat[4];
@@ -422,9 +397,9 @@ namespace quda {
         return;
       }
 
-    template<class T>
+    template<class T, class U>
       inline __device__
-      void storeMatrixToField(const T* const mat, int dir, int idx, T* const field_even, T* const field_odd, int oddness, int stride)
+      void storeMatrixToField(const T* const mat, int dir, int idx, U* const field_even, U* const field_odd, int oddness, int stride)
       {
         T* const field = (oddness)?field_odd: field_even;
         field[idx + dir*stride*9]          = mat[0];
@@ -441,11 +416,11 @@ namespace quda {
       }
 
 
-    template<class T>
+    template<class T, class U>
       inline __device__
-      void storeMatrixToField(const T* const mat, int idx, T* const field_even, T* const field_odd, int oddness, int stride)
+      void storeMatrixToField(const T* const mat, int idx, U* const field_even, U* const field_odd, int oddness, int stride)
       {
-        T* const field = (oddness)?field_odd: field_even;
+        U* const field = (oddness)?field_odd: field_even;
         field[idx]          = mat[0];
         field[idx + stride]     = mat[1];
         field[idx + stride*2]   = mat[2];
@@ -460,12 +435,12 @@ namespace quda {
       }
 
 
-    template<class T, class U> 
+    template<class T, class U, class V>
       inline __device__
       void storeMatrixToMomentumField(const T* const mat, int dir, int idx, U coeff, 
-          T* const mom_even, T* const mom_odd, int oddness, int stride)
+          V* const mom_even, V* const mom_odd, int oddness, int stride)
       {
-        T* const mom_field = (oddness)?mom_odd:mom_even;
+        V* const mom_field = (oddness)?mom_odd:mom_even;
         T temp2;
         temp2.x = (mat[1].x - mat[3].x)*0.5*coeff;
         temp2.y = (mat[1].y + mat[3].y)*0.5*coeff;
@@ -479,7 +454,7 @@ namespace quda {
         temp2.y = (mat[5].y + mat[7].y)*0.5*coeff;
         mom_field[idx + dir*stride*5 + stride*2] = temp2;
 
-        const typename RealTypeId<T>::Type temp = (mat[0].y + mat[4].y + mat[8].y)*0.3333333333333333333333333;
+        const typename T::value_type temp = (mat[0].y + mat[4].y + mat[8].y)*0.3333333333333333333333333;
         temp2.x =  (mat[0].y-temp)*coeff; 
         temp2.y =  (mat[4].y-temp)*coeff;
         mom_field[idx + dir*stride*5 + stride*3] = temp2;
@@ -521,6 +496,9 @@ namespace quda {
           typename RealTypeId<RealA>::Type coeff,
           RealA* const outputEven, RealA* const outputOdd, hisq_kernel_param_t kparam)
       {
+	typedef typename std::remove_reference<decltype(RealA::x)>::type real;
+	typedef complex<real> Complex;
+
         int sid = blockIdx.x * blockDim.x + threadIdx.x;
         if (sid >= kparam.threads) return;
 	int oddBit = threadIdx.y;
@@ -535,7 +513,7 @@ namespace quda {
         int new_sid = sid;
 #endif
 	for(int sig=0; sig<4; ++sig){
-          RealA COLOR_MAT_W[ArrayLength<RealA>::result];
+          Complex COLOR_MAT_W[ArrayLength<RealA>::result];
           loadMatrixFromField(oprodEven, oprodOdd, sig, new_sid, COLOR_MAT_W, oddBit, kparam.color_matrix_stride);
           addMatrixToField(COLOR_MAT_W, sig, new_sid, coeff, outputEven, outputOdd, oddBit, kparam.color_matrix_stride);
 	}
@@ -1323,7 +1301,7 @@ namespace quda {
             return TuneKey(vol.str().c_str(), typeid(*this).name(), aux.str().c_str());
           }  
 
-#define CALL_ARGUMENTS(typeA, typeB)  <<<tp.grid, tp.block>>>		\
+#define CALL_ARGUMENTS(typeA, typeB)  <<<tp.grid, tp.block>>>	\
           ((typeB*)link.Even_p(), (typeB*)link.Odd_p(),			\
            (typeA*)oprod.Even_p(), (typeA*)oprod.Odd_p(),			\
            (typeA*)mom.Even_p(), (typeA*)mom.Odd_p(),			\

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -752,7 +752,10 @@ void loadCloverQuda(void *h_clover, void *h_clovinv, QudaInvertParam *inv_param)
   }
 
   CloverFieldParam clover_param;
-  CloverField *in=NULL, *inInv=NULL;
+  CloverField *in=NULL;
+#ifndef DYNAMIC_CLOVER
+  CloverField *inInv=NULL;
+#endif
 
   if(!device_calc){
     // create a param for the cpu clover field

--- a/lib/ks_force_quda.cu
+++ b/lib/ks_force_quda.cu
@@ -63,11 +63,9 @@ namespace quda {
 #endif
 #endif
 
-      typedef typename ComplexTypeId<Float>::Type Cmplx;
-
-      Matrix<Cmplx,3> O;
-      Matrix<Cmplx,3> G;
-      Matrix<Cmplx,3> M;
+      Matrix<complex<Float>,3> O;
+      Matrix<complex<Float>,3> G;
+      Matrix<complex<Float>,3> M;
 
 
       int dx[4] = {0,0,0,0};
@@ -277,7 +275,7 @@ X[dir] += 2*arg.border[dir];
 #endif
 #endif
 
-typedef typename ComplexTypeId<Float>::Type Cmplx;
+typedef complex<Float> Cmplx;
 
 Matrix<Cmplx,3> O;
 Matrix<Cmplx,3> G;

--- a/lib/momentum.cu
+++ b/lib/momentum.cu
@@ -155,10 +155,9 @@ using namespace gauge;
 
   template<typename Float, typename Mom, typename Force>
   __global__ void UpdateMom(UpdateMomArg<Float, Mom, Force> arg) {
-    typedef typename ComplexTypeId<Float>::Type Complex;
     int x = blockIdx.x*blockDim.x + threadIdx.x;
     int parity = blockIdx.y;
-    Matrix<Complex,3> m, f;
+    Matrix<complex<Float>,3> m, f;
     while(x<arg.volumeCB){
       for (int d=0; d<4; d++) {
 	arg.mom.load(reinterpret_cast<Float*>(m.data), x, d, parity); 

--- a/lib/pgauge_exchange.cu
+++ b/lib/pgauge_exchange.cu
@@ -8,15 +8,12 @@
 
 #include <device_functions.h>
 
-
 #include <comm_quda.h>
 
 
 namespace quda {
 
 #ifdef GPU_GAUGE_ALG
-
-  static int numParams = 18;
 
 #define LAUNCH_KERNEL_GAUGEFIX(kernel, tp, stream, arg, parity, ...)     \
   if ( tp.block.z == 0 ) { \
@@ -65,11 +62,6 @@ namespace quda {
   }
 
 
-
-
-
-
-
   template <typename Gauge>
   struct GaugeFixUnPackArg {
     int X[4]; // grid dimensions
@@ -86,7 +78,7 @@ namespace quda {
 
   template<int NElems, typename Float, typename Gauge, bool pack>
   __global__ void Kernel_UnPack(int size, GaugeFixUnPackArg<Gauge> arg, \
-                                typename ComplexTypeId<Float>::Type *array, int parity, int face, int dir, int borderid){
+                                complex<Float> *array, int parity, int face, int dir, int borderid){
     int idx = blockIdx.x * blockDim.x + threadIdx.x;
     if ( idx >= size ) return;
     int X[4];
@@ -128,17 +120,17 @@ namespace quda {
       break;
     }
     int id = (((x[3] * X[2] + x[2]) * X[1] + x[1]) * X[0] + x[0]) >> 1;
-    typedef typename ComplexTypeId<Float>::Type Cmplx;
+    typedef complex<Float> Complex;
     typedef typename mapper<Float>::type RegType;
     RegType tmp[NElems];
     RegType data[18];
     if ( pack ) {
       arg.dataOr.load(data, id, dir, parity);
       arg.dataOr.reconstruct.Pack(tmp, data, id);
-      for ( int i = 0; i < NElems / 2; ++i ) array[idx + size * i] = ((Cmplx*)tmp)[i];
+      for ( int i = 0; i < NElems / 2; ++i ) array[idx + size * i] = ((Complex*)tmp)[i];
     }
     else{
-      for ( int i = 0; i < NElems / 2; ++i ) ((Cmplx*)tmp)[i] = array[idx + size * i];
+      for ( int i = 0; i < NElems / 2; ++i ) ((Complex*)tmp)[i] = array[idx + size * i];
       arg.dataOr.reconstruct.Unpack(data, tmp, id, dir, 0);
       arg.dataOr.save(data, id, dir, parity);
     }
@@ -275,11 +267,11 @@ namespace quda {
       comm_start(mh_recv_fwd[d]);
 
       //extract top face
-      Kernel_UnPack<NElems, Float, Gauge, true><< < grid[d], block[d], 0, GFStream[0] >> > ( \
-        faceVolumeCB[d], dataexarg, reinterpret_cast<typename ComplexTypeId<Float>::Type*>(send_d[d]), parity, d, dir, X[d] -  data.R()[d] - 1);
+      Kernel_UnPack<NElems, Float, Gauge, true><< < grid[d], block[d], 0, GFStream[0] >> >
+	(faceVolumeCB[d], dataexarg, reinterpret_cast<complex<Float>*>(send_d[d]), parity, d, dir, X[d] -  data.R()[d] - 1);
       //extract bottom
-      Kernel_UnPack<NElems, Float, Gauge, true><< < grid[d], block[d], 0, GFStream[1] >> > ( \
-        faceVolumeCB[d], dataexarg, reinterpret_cast<typename ComplexTypeId<Float>::Type*>(sendg_d[d]), parity, d, dir, data.R()[d]);
+      Kernel_UnPack<NElems, Float, Gauge, true><< < grid[d], block[d], 0, GFStream[1] >> >
+	(faceVolumeCB[d], dataexarg, reinterpret_cast<complex<Float>*>(sendg_d[d]), parity, d, dir, data.R()[d]);
 
     #ifndef GPU_COMMS
       cudaMemcpyAsync(send[d], send_d[d], bytes[d], cudaMemcpyDeviceToHost, GFStream[0]);
@@ -298,8 +290,8 @@ namespace quda {
       #ifdef GPU_COMMS
       comm_wait(mh_recv_back[d]);
       #endif
-      Kernel_UnPack<NElems, Float, Gauge, false><< < grid[d], block[d], 0, GFStream[0] >> > ( \
-        faceVolumeCB[d], dataexarg, reinterpret_cast<typename ComplexTypeId<Float>::Type*>(recv_d[d]), parity, d, dir, data.R()[d] - 1);
+      Kernel_UnPack<NElems, Float, Gauge, false><< < grid[d], block[d], 0, GFStream[0] >> >
+	(faceVolumeCB[d], dataexarg, reinterpret_cast<complex<Float>*>(recv_d[d]), parity, d, dir, data.R()[d] - 1);
 
     #ifndef GPU_COMMS
       comm_wait(mh_recv_fwd[d]);
@@ -309,8 +301,8 @@ namespace quda {
       #ifdef GPU_COMMS
       comm_wait(mh_recv_fwd[d]);
       #endif
-      Kernel_UnPack<NElems, Float, Gauge, false><< < grid[d], block[d], 0, GFStream[1] >> > ( \
-        faceVolumeCB[d], dataexarg, reinterpret_cast<typename ComplexTypeId<Float>::Type*>(recvg_d[d]), parity, d, dir, X[d] - data.R()[d]);
+      Kernel_UnPack<NElems, Float, Gauge, false><< < grid[d], block[d], 0, GFStream[1] >> >
+	(faceVolumeCB[d], dataexarg, reinterpret_cast<complex<Float>*>(recvg_d[d]), parity, d, dir, X[d] - data.R()[d]);
 
       comm_wait(mh_send_back[d]);
       comm_wait(mh_send_fwd[d]);
@@ -332,22 +324,14 @@ namespace quda {
     // Need to fix this!!
     if ( data.isNative() ) {
       if ( data.Reconstruct() == QUDA_RECONSTRUCT_NO ) {
-        //printfQuda("QUDA_RECONSTRUCT_NO\n");
-        numParams = 18;
 	typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_NO>::type G;
 	PGaugeExchange<Float, 18>(G(data), data, dir, parity);
       } else if ( data.Reconstruct() == QUDA_RECONSTRUCT_12 ) {
-        //printfQuda("QUDA_RECONSTRUCT_12\n");
-        numParams = 12;
 	typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_12>::type G;
         PGaugeExchange<Float, 12>(G(data), data, dir, parity);
-
       } else if ( data.Reconstruct() == QUDA_RECONSTRUCT_8 ) {
-        //printfQuda("QUDA_RECONSTRUCT_8\n");
-        numParams = 8;
 	typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_8>::type G;
         PGaugeExchange<Float, 8>(G(data), data, dir, parity);
-
       } else {
         errorQuda("Reconstruction type %d of gauge field not supported", data.Reconstruct());
       }

--- a/lib/pgauge_heatbath.cu
+++ b/lib/pgauge_heatbath.cu
@@ -162,7 +162,7 @@ namespace quda {
     @return 4 real numbers
  */
   template < class T>
-  __host__ __device__ static inline Matrix<T,2> get_block_su2( Matrix<typename ComplexTypeId<T>::Type,3> tmp1, int block ){
+  __host__ __device__ static inline Matrix<T,2> get_block_su2( Matrix<complex<T>,3> tmp1, int block ){
     Matrix<T,2> r;
     switch ( block ) {
     case 0:
@@ -194,7 +194,7 @@ namespace quda {
     @return 4 real numbers
  */
   template <class T, int NCOLORS>
-  __host__ __device__ static inline Matrix<T,2> get_block_su2( Matrix<typename ComplexTypeId<T>::Type,NCOLORS> tmp1, int2 id ){
+  __host__ __device__ static inline Matrix<T,2> get_block_su2( Matrix<complex<T>,NCOLORS> tmp1, int2 id ){
     Matrix<T,2> r;
     r(0,0) = tmp1(id.x,id.x).x + tmp1(id.y,id.y).x;
     r(0,1) = tmp1(id.x,id.y).y + tmp1(id.y,id.x).y;
@@ -210,13 +210,13 @@ namespace quda {
     @return SU(Nc) matrix
  */
   template <class T, int NCOLORS>
-  __host__ __device__ static inline Matrix<typename ComplexTypeId<T>::Type,NCOLORS> block_su2_to_sun( Matrix<T,2> rr, int2 id ){
-    Matrix<typename ComplexTypeId<T>::Type,NCOLORS> tmp1;
+  __host__ __device__ static inline Matrix<complex<T>,NCOLORS> block_su2_to_sun( Matrix<T,2> rr, int2 id ){
+    Matrix<complex<T>,NCOLORS> tmp1;
     setIdentity(&tmp1);
-    tmp1(id.x,id.x) = makeComplex( rr(0,0), rr(1,1) );
-    tmp1(id.x,id.y) = makeComplex( rr(1,0), rr(0,1) );
-    tmp1(id.y,id.x) = makeComplex(-rr(1,0), rr(0,1) );
-    tmp1(id.y,id.y) = makeComplex( rr(0,0),-rr(1,1) );
+    tmp1(id.x,id.x) = complex<T>( rr(0,0), rr(1,1) );
+    tmp1(id.x,id.y) = complex<T>( rr(1,0), rr(0,1) );
+    tmp1(id.y,id.x) = complex<T>(-rr(1,0), rr(0,1) );
+    tmp1(id.y,id.y) = complex<T>( rr(0,0),-rr(1,1) );
     return tmp1;
   }
 /**
@@ -226,11 +226,10 @@ namespace quda {
     @param id indices
  */
   template <class T, int NCOLORS>
-  __host__ __device__ static inline void mul_block_sun( Matrix<T,2> u, Matrix<typename ComplexTypeId<T>::Type,NCOLORS> &link, int2 id ){
-    typename ComplexTypeId<T>::Type tmp;
+  __host__ __device__ static inline void mul_block_sun( Matrix<T,2> u, Matrix<complex<T>,NCOLORS> &link, int2 id ){
     for ( int j = 0; j < NCOLORS; j++ ) {
-      tmp = makeComplex( u(0,0), u(1,1) ) * link(id.x, j) + makeComplex( u(1,0), u(0,1) ) * link(id.y, j);
-      link(id.y, j) = makeComplex(-u(1,0), u(0,1) ) * link(id.x, j) + makeComplex( u(0,0),-u(1,1) ) * link(id.y, j);
+      complex<T> tmp = complex<T>( u(0,0), u(1,1) ) * link(id.x, j) + complex<T>( u(1,0), u(0,1) ) * link(id.y, j);
+      link(id.y, j) = complex<T>(-u(1,0), u(0,1) ) * link(id.x, j) + complex<T>( u(0,0),-u(1,1) ) * link(id.y, j);
       link(id.x, j) = tmp;
     }
   }
@@ -304,15 +303,14 @@ namespace quda {
     @param localstate CURAND rng state
  */
   template <class Float, int NCOLORS>
-  __device__ inline void heatBathSUN( Matrix<typename ComplexTypeId<Float>::Type,NCOLORS>& U, Matrix<typename ComplexTypeId<Float>::Type,NCOLORS> F, \
+  __device__ inline void heatBathSUN( Matrix<complex<Float>,NCOLORS>& U, Matrix<complex<Float>,NCOLORS> F,
                                       cuRNGState& localState, Float BetaOverNc ){
 
-    typedef typename ComplexTypeId<Float>::Type Cmplx;
     if ( NCOLORS == 3 ) {
       //////////////////////////////////////////////////////////////////
       /*
          for( int block = 0; block < NCOLORS; block++ ) {
-         Matrix<typename ComplexTypeId<T>::Type,3> tmp1 = U * F;
+         Matrix<complex<T>,3> tmp1 = U * F;
          Matrix<T,2> r = get_block_su2<T>(tmp1, block);
          T k = sqrt(r(0,0)*r(0,0)+r(0,1)*r(0,1)+r(1,0)*r(1,0)+r(1,1)*r(1,1));
          T ap = BetaOverNc * k;
@@ -330,10 +328,10 @@ namespace quda {
       for ( int block = 0; block < NCOLORS; block++ ) {
         int p,q;
         IndexBlock<NCOLORS>(block, p, q);
-        Cmplx a0 = makeComplex((Float)0.0, (Float)0.0);
-        Cmplx a1 = a0;
-        Cmplx a2 = a0;
-        Cmplx a3 = a0;
+        complex<Float> a0((Float)0.0, (Float)0.0);
+        complex<Float> a1 = a0;
+        complex<Float> a2 = a0;
+        complex<Float> a3 = a0;
 
         for ( int j = 0; j < NCOLORS; j++ ) {
           a0 += U(p,j) * F(j,p);
@@ -353,11 +351,11 @@ namespace quda {
         Matrix<Float,2> a = generate_su2_matrix_milc<Float>(ap, localState);
         r = mulsu2UVDagger<Float>( a, r);
         ///////////////////////////////////////
-        a0 = makeComplex( r(0,0), r(1,1) );
-        a1 = makeComplex( r(1,0), r(0,1) );
-        a2 = makeComplex(-r(1,0), r(0,1) );
-        a3 = makeComplex( r(0,0),-r(1,1) );
-        Cmplx tmp0;
+        a0 = complex<Float>( r(0,0), r(1,1) );
+        a1 = complex<Float>( r(1,0), r(0,1) );
+        a2 = complex<Float>(-r(1,0), r(0,1) );
+        a3 = complex<Float>( r(0,0),-r(1,1) );
+        complex<Float> tmp0;
 
         for ( int j = 0; j < NCOLORS; j++ ) {
           tmp0 = a0 * U(p,j) + a1 * U(q,j);
@@ -371,7 +369,7 @@ namespace quda {
     else if ( NCOLORS > 3 ) {
       //////////////////////////////////////////////////////////////////
       //TESTED IN SU(4) SP THIS IS WORST
-      Matrix<typename ComplexTypeId<Float>::Type,NCOLORS> M = U * F;
+      Matrix<complex<Float>,NCOLORS> M = U * F;
       for ( int block = 0; block < NCOLORS * ( NCOLORS - 1) / 2; block++ ) {
         int2 id = IndexBlock<NCOLORS>( block );
         Matrix<Float,2> r = get_block_su2<Float>(M, id);
@@ -438,14 +436,13 @@ namespace quda {
      @param F staple
    */
   template <class Float, int NCOLORS>
-  __device__ inline void overrelaxationSUN( Matrix<typename ComplexTypeId<Float>::Type,NCOLORS>& U, Matrix<typename ComplexTypeId<Float>::Type,NCOLORS> F ){
+  __device__ inline void overrelaxationSUN( Matrix<complex<Float>,NCOLORS>& U, Matrix<complex<Float>,NCOLORS> F ){
 
-    typedef typename ComplexTypeId<Float>::Type Cmplx;
     if ( NCOLORS == 3 ) {
       //////////////////////////////////////////////////////////////////
       /*
          for( int block = 0; block < 3; block++ ) {
-         Matrix<typename ComplexTypeId<T>::Type,3> tmp1 = U * F;
+         Matrix<complex<T>,3> tmp1 = U * F;
          Matrix<T,2> r = get_block_su2<T>(tmp1, block);
          //normalize and conjugate
          Float norm = 1.0 / sqrt(r(0,0)*r(0,0)+r(0,1)*r(0,1)+r(1,0)*r(1,0)+r(1,1)*r(1,1));;
@@ -470,10 +467,10 @@ namespace quda {
       for ( int block = 0; block < 3; block++ ) {
         int p,q;
         IndexBlock<NCOLORS>(block, p, q);
-        Cmplx a0 = makeComplex((Float)0., (Float)0.);
-        Cmplx a1 = a0;
-        Cmplx a2 = a0;
-        Cmplx a3 = a0;
+        complex<Float> a0((Float)0., (Float)0.);
+        complex<Float> a1 = a0;
+        complex<Float> a2 = a0;
+        complex<Float> a3 = a0;
 
         for ( int j = 0; j < NCOLORS; j++ ) {
           a0 += U(p,j) * F(j,p);
@@ -496,11 +493,11 @@ namespace quda {
 
 
         ///////////////////////////////////////
-        a0 = makeComplex( r(0,0), r(1,1) );
-        a1 = makeComplex( r(1,0), r(0,1) );
-        a2 = makeComplex(-r(1,0), r(0,1) );
-        a3 = makeComplex( r(0,0),-r(1,1) );
-        Cmplx tmp0, tmp1;
+        a0 = complex<Float>( r(0,0), r(1,1) );
+        a1 = complex<Float>( r(1,0), r(0,1) );
+        a2 = complex<Float>(-r(1,0), r(0,1) );
+        a3 = complex<Float>( r(0,0),-r(1,1) );
+        complex<Float> tmp0, tmp1;
 
         for ( int j = 0; j < NCOLORS; j++ ) {
           tmp0 = a0 * U(p,j) + a1 * U(q,j);
@@ -514,7 +511,7 @@ namespace quda {
     }
     else if ( NCOLORS > 3 ) {
       ///////////////////////////////////////////////////////////////////
-      Matrix<typename ComplexTypeId<Float>::Type,NCOLORS> M = U * F;
+      Matrix<complex<Float>,NCOLORS> M = U * F;
       for ( int block = 0; block < NCOLORS * ( NCOLORS - 1) / 2; block++ ) {
         int2 id = IndexBlock<NCOLORS>( block );
         Matrix<Float,2> r = get_block_su2<Float, NCOLORS>(M, id);
@@ -607,7 +604,6 @@ namespace quda {
   __global__ void compute_heatBath(MonteArg<Gauge, Float, NCOLORS> arg, int mu, int parity){
     int idx = threadIdx.x + blockIdx.x * blockDim.x;
     if ( idx >= arg.threads ) return;
-    typedef typename ComplexTypeId<Float>::Type Cmplx;
     int id = idx;
     int X[4];
     #pragma unroll
@@ -624,13 +620,13 @@ namespace quda {
     idx = linkIndex(x,X);
 #endif
 
-    Matrix<Cmplx,NCOLORS> staple;
+    Matrix<complex<Float>,NCOLORS> staple;
     setZero(&staple);
 
-    Matrix<Cmplx,NCOLORS> U;
+    Matrix<complex<Float>,NCOLORS> U;
     for ( int nu = 0; nu < 4; nu++ ) if ( mu != nu ) {
         int dx[4] = { 0, 0, 0, 0 };
-        Matrix<Cmplx,NCOLORS> link;
+        Matrix<complex<Float>,NCOLORS> link;
         arg.dataOr.load((Float*)(link.data), idx, nu, parity);
         dx[nu]++;
         arg.dataOr.load((Float*)(U.data), linkIndexShift(x,dx,X), mu, 1 - parity);
@@ -705,7 +701,7 @@ namespace quda {
       vol << arg.X[1] << "x";
       vol << arg.X[2] << "x";
       vol << arg.X[3];
-      sprintf(aux_string,"threads=%d,prec=%d",arg.threads, sizeof(Float));
+      sprintf(aux_string,"threads=%d,prec=%lu",arg.threads, sizeof(Float));
       return TuneKey(vol.str().c_str(), typeid(*this).name(), aux_string);
     }
     std::string paramString(const TuneParam &param) const {

--- a/lib/pgauge_init.cu
+++ b/lib/pgauge_init.cu
@@ -42,13 +42,12 @@ namespace quda {
   __global__ void compute_InitGauge_ColdStart(InitGaugeColdArg<Gauge> arg){
     int idx = threadIdx.x + blockIdx.x * blockDim.x;
     if ( idx >= arg.threads ) return;
-    typedef typename ComplexTypeId<Float>::Type Cmplx;
     int parity = 0;
     if ( idx >= arg.threads / 2 ) {
       parity = 1;
       idx -= arg.threads / 2;
     }
-    Matrix<Cmplx,NCOLORS> U;
+    Matrix<complex<Float>,NCOLORS> U;
     setIdentity(&U);
     for ( int d = 0; d < 4; d++ )
       arg.dataOr.save((Float*)(U.data),idx, d, parity);
@@ -93,7 +92,7 @@ namespace quda {
       vol << arg.X[1] << "x";
       vol << arg.X[2] << "x";
       vol << arg.X[3];
-      sprintf(aux_string,"threads=%d,prec=%d",arg.threads, sizeof(Float));
+      sprintf(aux_string,"threads=%d,prec=%lu", arg.threads, sizeof(Float));
       return TuneKey(vol.str().c_str(), typeid(*this).name(), aux_string);
 
     }
@@ -197,25 +196,15 @@ namespace quda {
   };
 
 
-
-  template<typename Cmplx>
-  __device__ __host__ static inline typename RealTypeId<Cmplx>::Type Abs2(const Cmplx & a){
-    return a.x * a.x + a.y * a.y;
-  }
-
-
-
   template <typename Float>
-  __host__ __device__ static inline void reunit_link( Matrix<typename ComplexTypeId<Float>::Type,3> &U ){
+  __host__ __device__ static inline void reunit_link( Matrix<complex<Float>,3> &U ){
 
-    typedef typename ComplexTypeId<Float>::Type Cmplx;
-
-    Cmplx t2 = makeComplex((Float)0.0, (Float)0.0);
+    complex<Float> t2((Float)0.0, (Float)0.0);
     Float t1 = 0.0;
     //first normalize first row
     //sum of squares of row
 #pragma unroll
-    for ( int c = 0; c < 3; c++ ) t1 += Abs2(U(0, c));
+    for ( int c = 0; c < 3; c++ ) t1 += norm(U(0,c));
     t1 = (Float)1.0 / sqrt(t1);
     //14
     //used to normalize row
@@ -223,7 +212,7 @@ namespace quda {
     for ( int c = 0; c < 3; c++ ) U(0,c) *= t1;
     //6
 #pragma unroll
-    for ( int c = 0; c < 3; c++ ) t2 += Conj(U(0,c)) * U(1,c);
+    for ( int c = 0; c < 3; c++ ) t2 += conj(U(0,c)) * U(1,c);
     //24
 #pragma unroll
     for ( int c = 0; c < 3; c++ ) U(1,c) -= t2 * U(0,c);
@@ -232,7 +221,7 @@ namespace quda {
     //sum of squares of row
     t1 = 0.0;
 #pragma unroll
-    for ( int c = 0; c < 3; c++ ) t1 += Abs2(U(1,c));
+    for ( int c = 0; c < 3; c++ ) t1 += norm(U(1,c));
     t1 = (Float)1.0 / sqrt(t1);
     //14
     //used to normalize row
@@ -240,9 +229,9 @@ namespace quda {
     for ( int c = 0; c < 3; c++ ) U(1, c) *= t1;
     //6
     //Reconstruct lat row
-    U(2,0) = Conj(U(0,1) * U(1,2) - U(0,2) * U(1,1));
-    U(2,1) = Conj(U(0,2) * U(1,0) - U(0,0) * U(1,2));
-    U(2,2) = Conj(U(0,0) * U(1,1) - U(0,1) * U(1,0));
+    U(2,0) = conj(U(0,1) * U(1,2) - U(0,2) * U(1,1));
+    U(2,1) = conj(U(0,2) * U(1,0) - U(0,0) * U(1,2));
+    U(2,2) = conj(U(0,0) * U(1,1) - U(0,1) * U(1,0));
     //42
     //T=130
   }
@@ -280,11 +269,10 @@ namespace quda {
     @param id indices
  */
   template <class T, int NCOLORS>
-  __host__ __device__ static inline void mul_block_sun( Matrix<T,2> u, Matrix<typename ComplexTypeId<T>::Type,NCOLORS> &link, int2 id ){
-    typename ComplexTypeId<T>::Type tmp;
+  __host__ __device__ static inline void mul_block_sun( Matrix<T,2> u, Matrix<complex<T>,NCOLORS> &link, int2 id ){
     for ( int j = 0; j < NCOLORS; j++ ) {
-      tmp = makeComplex( u(0,0), u(1,1) ) * link(id.x, j) + makeComplex( u(1,0), u(0,1) ) * link(id.y, j);
-      link(id.y, j) = makeComplex(-u(1,0), u(0,1) ) * link(id.x, j) + makeComplex( u(0,0),-u(1,1) ) * link(id.y, j);
+      complex<T> tmp = complex<T>( u(0,0), u(1,1) ) * link(id.x, j) + complex<T>( u(1,0), u(0,1) ) * link(id.y, j);
+      link(id.y, j) = complex<T>(-u(1,0), u(0,1) ) * link(id.x, j) + complex<T>( u(0,0),-u(1,1) ) * link(id.y, j);
       link(id.x, j) = tmp;
     }
   }
@@ -323,12 +311,12 @@ namespace quda {
     @return SU(Nc) matrix
  */
   template <class Float, int NCOLORS>
-  __device__ inline Matrix<typename ComplexTypeId<Float>::Type,NCOLORS> randomize( cuRNGState& localState ){
-    Matrix<typename ComplexTypeId<Float>::Type,NCOLORS> U;
+  __device__ inline Matrix<complex<Float>,NCOLORS> randomize( cuRNGState& localState ){
+    Matrix<complex<Float>,NCOLORS> U;
 
     for ( int i = 0; i < NCOLORS; i++ )
       for ( int j = 0; j < NCOLORS; j++ )
-        U(i,j) = makeComplex( (Float)(Random<Float>(localState) - 0.5), (Float)(Random<Float>(localState) - 0.5));
+        U(i,j) = complex<Float>( (Float)(Random<Float>(localState) - 0.5), (Float)(Random<Float>(localState) - 0.5) );
     reunit_link<Float>(U);
     return U;
 
@@ -346,7 +334,6 @@ namespace quda {
   __global__ void compute_InitGauge_HotStart(InitGaugeHotArg<Gauge> arg){
     int idx = threadIdx.x + blockIdx.x * blockDim.x;
     if ( idx >= arg.threads ) return;
-    typedef typename ComplexTypeId<Float>::Type Cmplx;
   #ifdef MULTI_GPU
     int X[4], x[4];
     for ( int dr = 0; dr < 4; ++dr ) X[dr] = arg.X[dr];
@@ -363,7 +350,7 @@ namespace quda {
       idx = linkIndex(x,X);
     #endif
       for ( int d = 0; d < 4; d++ ) {
-        Matrix<Cmplx,NCOLORS> U;
+        Matrix<complex<Float>,NCOLORS> U;
         U = randomize<Float, NCOLORS>(localState);
         arg.dataOr.save((Float*)(U.data),idx, d, parity);
       }
@@ -418,7 +405,7 @@ namespace quda {
       vol << arg.X[1] << "x";
       vol << arg.X[2] << "x";
       vol << arg.X[3];
-      sprintf(aux_string,"threads=%d,prec=%d",arg.threads, sizeof(Float));
+      sprintf(aux_string,"threads=%d,prec=%lud", arg.threads, sizeof(Float));
       return TuneKey(vol.str().c_str(), typeid(*this).name(), aux_string);
 
     }

--- a/lib/qcharge_quda.cu
+++ b/lib/qcharge_quda.cu
@@ -39,10 +39,9 @@ namespace quda {
           parity = 1;
           idx -= arg.threads/2;
         }
-        typedef typename ComplexTypeId<Float>::Type Cmplx;
 
         // Load the field-strength tensor from global memory
-        Matrix<Cmplx,3> F[6], temp1, temp2, temp3;
+        Matrix<complex<Float>,3> F[6], temp1, temp2, temp3;
         double tmpQ2, tmpQ3;
         for(int i=0; i<6; ++i){
           arg.data.load((Float*)(F[i].data), idx, i, parity);

--- a/lib/quda_matrix.h
+++ b/lib/quda_matrix.h
@@ -12,52 +12,7 @@
 
 #include <complex_quda.h>
 
-namespace quda{
-
-  // Given a real type T, returns the corresponding complex type
-  template<class T>
-    struct ComplexTypeId;
-
-  template<>
-    struct ComplexTypeId<float>
-    {
-      typedef float2 Type;
-    };
-
-  template<>
-    struct ComplexTypeId<double>
-    {
-      typedef double2 Type;
-    };
-
-  template<class T> 
-    struct RealTypeId; 
-
-  template<>
-    struct RealTypeId<float>
-    {
-      typedef float Type;
-    };
-
-  template<>
-    struct RealTypeId<double>
-    {
-      typedef double Type;
-    };
-
-
-  template<>
-    struct RealTypeId<float2>
-    {
-      typedef float Type;
-    };
-
-  template<>
-    struct RealTypeId<double2>
-    {
-      typedef double Type;
-    };
-
+namespace quda {
 
   template<class T, class U>
     struct PromoteTypeId
@@ -65,32 +20,28 @@ namespace quda{
       typedef T Type;
     };
 
-
   template<>
-    struct PromoteTypeId<float2, float>
+    struct PromoteTypeId<complex<float>, float>
     {
-      typedef float2 Type;
+      typedef complex<float> Type;
     };
 
-
   template<>
-    struct PromoteTypeId<float, float2>
+    struct PromoteTypeId<float, complex<float> >
     {
-      typedef float2 Type;
+      typedef complex<float> Type;
     };
 
-
   template<>
-    struct PromoteTypeId<double2, double>
+    struct PromoteTypeId<complex<double>, double>
     {
-      typedef double2 Type;
+      typedef complex<double> Type;
     };
 
-
   template<>
-    struct PromoteTypeId<double, double2>
+    struct PromoteTypeId<double, complex<double> >
     {
-      typedef double2 Type;
+      typedef complex<double> Type;
     };
 
   template<>
@@ -116,182 +67,6 @@ namespace quda{
     {
       typedef float Type;
     };
-
-
-
-
-  template<class Cmplx>
-    __device__ __host__ inline 
-    Cmplx makeComplex(const typename RealTypeId<Cmplx>::Type & a, const typename RealTypeId<Cmplx>::Type & b)
-    {
-      Cmplx z;
-      z.x = a; z.y = b;
-      return z;
-    }
-
-
-  __device__ __host__ inline
-    double2 makeComplex(const double & a, const double & b){
-      return make_double2(a,b);
-    }
-
-  __device__ __host__ inline
-    float2 makeComplex(const float & a, const float & b){
-      return make_float2(a,b);
-    } 
-
-  template<class Cmplx>
-    __device__ __host__ inline Cmplx operator-(const Cmplx &a){
-      return makeComplex(-a.x, -a.y);
-    }
-
-  template<class Cmplx> 
-    __device__ __host__ inline Cmplx & operator+=(Cmplx & a, const Cmplx & b){
-      a.x += b.x; 
-      a.y += b.y;
-      return a;
-    }
-
-  template<class Cmplx>
-    __device__ __host__ inline Cmplx & operator-=(Cmplx & a, const Cmplx & b){
-      a.x -= b.x;
-      a.y -= b.y; 
-      return a;
-    }
-
-
-  template<class Cmplx>
-    __device__ __host__ inline Cmplx operator+(const Cmplx & a, const Cmplx & b){
-      return makeComplex(a.x+b.x,a.y+b.y);
-    }
-
-  template<class Cmplx>
-    __device__ __host__ inline Cmplx operator-(const Cmplx & a, const Cmplx & b)
-    {
-      return makeComplex(a.x-b.x,a.y-b.y);
-    }
-
-#ifdef __GNU_C__
-  template<class Cmplx>
-    __device__ __host__ inline Cmplx operator*(const Cmplx & a, const typename RealTypeId<Cmplx>::Type & scalar)
-    {
-      return makeComplex(a.x*scalar,a.y*scalar);
-    }
-
-  template<class Cmplx>
-    __device__ __host__ inline Cmplx operator+(const Cmplx & a, const typename RealTypeId<Cmplx>::Type & scalar)
-    {
-      return makeComplex(a.x+scalar,a.y);
-    }
-
-  template<class Cmplx>
-    __device__ __host__ inline Cmplx operator*(const typename RealTypeId<Cmplx>::Type & scalar, const Cmplx & b)
-    {
-      return operator*(b,scalar);
-    }
-#else
-    __device__ __host__ inline double2 operator*(const double2 & a, const double & scalar)
-    {
-      return makeComplex(a.x*scalar,a.y*scalar);
-    }
-
-    __device__ __host__ inline float2 operator*(const float2 & a, const float & scalar)
-    {
-      return makeComplex(a.x*scalar,a.y*scalar);
-    }
-
-  template<class Cmplx, class Float>
-    __device__ __host__ inline Cmplx operator+(const Cmplx & a, const Float & scalar)
-    {
-      return makeComplex(a.x+scalar,a.y);
-    }
-
-  /*__device__ __host__ inline float2 operator*(const float & scalar, const float2 & b)
-  {
-    return makeComplex(b.x*scalar,b.y*scalar);
-  }
-  
-    __device__ __host__ inline double2 operator*(const double & scalar, const double2 & b)
-  {
-    return makeComplex(b.x*scalar,b.y*scalar);
-    }*/
-#endif
-
-  template<class Cmplx>
-    __device__ __host__ inline Cmplx operator/(const Cmplx & a, const typename RealTypeId<Cmplx>::Type & scalar)
-    {
-      return makeComplex(a.x/scalar,a.y/scalar);
-    }
-
-  template<class Cmplx>
-    __device__ __host__ inline Cmplx operator+(const typename RealTypeId<Cmplx>::Type & scalar, const Cmplx & a)
-    {
-      return makeComplex(a.x+scalar,a.y);
-    }
-
-  template<class Cmplx>
-    __device__ __host__ inline Cmplx operator-(const Cmplx & a, const typename RealTypeId<Cmplx>::Type & scalar)
-    {
-      return makeComplex(a.x-scalar,a.y);
-    }
-
-  template<class Cmplx>
-    __device__ __host__ inline Cmplx operator-(const typename RealTypeId<Cmplx>::Type & scalar, const Cmplx & a)
-    {
-      return makeComplex(scalar-a.x,-a.y);
-    }
-
-  template<class Cmplx>
-    __device__ __host__ inline Cmplx operator*(const Cmplx & a, const Cmplx & b)
-    {
-      return makeComplex(a.x*b.x - a.y*b.y, a.x*b.y + a.y*b.x);
-    }
-
-  template<class Cmplx>
-    __device__ __host__ inline Cmplx conj(const Cmplx & a)
-    {
-      return makeComplex(a.x,-a.y);
-    }
-
-  __device__ __host__ inline double conj(const double & a)
-  {
-    return a;
-  }
-
-  __device__ __host__ inline float conj(const float & a)
-  {
-    return a;
-  }
-
-  template<typename Cmplx>
-    __device__ __host__ inline Cmplx Conj(const Cmplx & a)
-    {
-      return makeComplex(a.x,-a.y);
-    }
-
-
-
-  template<class Cmplx>
-    __device__ __host__ inline
-    Cmplx getPreciseInverse(const Cmplx & z){
-      typename RealTypeId<Cmplx>::Type ratio, max, denom;
-      if( fabs(z.x) > fabs(z.y) ){ max = z.x; ratio = z.y/max; }else{ max=z.y; ratio = z.x/max; }
-      denom = max*max*(1 + ratio*ratio);
-      return makeComplex(z.x/denom, -z.y/denom);
-    }
-
-
-  // for printing
-  inline std::ostream & operator << (std::ostream & os, const float2 & z){
-    os << "(" << z.x << "," << z.y << ")";
-    return os;
-  }
-
-  inline std::ostream & operator << (std::ostream & os, const double2 & z){
-    os << "(" << z.x << "," << z.y << ")";
-    return os;
-  }
-
 
 
   template<class T>
@@ -360,18 +135,16 @@ namespace quda{
           return data[index<N>(i,j)];
         }
 
-        __device__ __host__ inline complex<typename RealTypeId<T>::Type> const & operator()(int i) const{
+        __device__ __host__ inline T const & operator()(int i) const{
           int j = i % N;
           int k = i / N;
-          return static_cast<complex<typename RealTypeId<T>::Type> >
-            (data[index<N>(j,k)]);
+          return data[index<N>(j,k)];
         }
 
-        __device__ __host__ inline complex<typename RealTypeId<T>::Type>& operator()(int i) {
+        __device__ __host__ inline T& operator()(int i) {
           int j = i % N;
           int k = i / N;
-          return static_cast<complex<typename RealTypeId<T>::Type>& >
-            (data[index<N>(j,k)]);
+          return data[index<N>(j,k)];
         }
 
     };
@@ -468,24 +241,34 @@ namespace quda{
     }
 
 
+  template<class T, int N>
+    __device__ __host__ inline
+    Matrix<T,N> operator*(const Matrix<T,N> &a, const Matrix<T,N> &b)
+    {
+      Matrix<T,N> result;
+      for (int i=0; i<N; i++) {
+	for (int k=0; k<N; k++) {
+	  result(i,k) = 0.0;
+	  for (int j=0; j<N; j++) {
+	    result(i,k) += a(i,j) * b(j,k);
+	  }
+	}
+      }
+      return result;
+    }
 
   template<class T>
     __device__ __host__ inline
-    Matrix<T,3> operator*(const Matrix<T,3> & a, const Matrix<T,3> & b)
+    Matrix<T,3> operator*(const Matrix<T,3> &a, const Matrix<T,3> &b)
     {
-      // The compiler has a hard time unrolling nested loops,
-      // so here I do it by hand. 
-      // I could do something more sophisticated in the future.
       Matrix<T,3> result;
-      result(0,0) = a(0,0)*b(0,0) + a(0,1)*b(1,0) + a(0,2)*b(2,0);
-      result(0,1) = a(0,0)*b(0,1) + a(0,1)*b(1,1) + a(0,2)*b(2,1);
-      result(0,2) = a(0,0)*b(0,2) + a(0,1)*b(1,2) + a(0,2)*b(2,2);
-      result(1,0) = a(1,0)*b(0,0) + a(1,1)*b(1,0) + a(1,2)*b(2,0);
-      result(1,1) = a(1,0)*b(0,1) + a(1,1)*b(1,1) + a(1,2)*b(2,1);
-      result(1,2) = a(1,0)*b(0,2) + a(1,1)*b(1,2) + a(1,2)*b(2,2);
-      result(2,0) = a(2,0)*b(0,0) + a(2,1)*b(1,0) + a(2,2)*b(2,0);
-      result(2,1) = a(2,0)*b(0,1) + a(2,1)*b(1,1) + a(2,2)*b(2,1);
-      result(2,2) = a(2,0)*b(0,2) + a(2,1)*b(1,2) + a(2,2)*b(2,2);
+#pragma unroll
+      for (int i=0; i<3; i++) {
+#pragma unroll
+	for (int k=0; k<3; k++) {
+	  result(i,k) = a(i,0) * b(0,k) + a(i,1) * b(1,k) + a(i,2) * b(2,k);
+	}
+      }
       return result;
     }
 
@@ -497,31 +280,39 @@ namespace quda{
     return a;
   }
 
-  
-  
 
-
-
-
-
-  // This is so that I can multiply real and complex matrices
-  template<class T, class U>
+  // This is so that I can multiply real and complex matrice
+  template<class T, class U, int N>
     __device__ __host__ inline
-    Matrix<typename PromoteTypeId<T,U>::Type,3> operator*(const Matrix<T,3> & a, const Matrix<U,3> & b)
+    Matrix<typename PromoteTypeId<T,U>::Type,N> operator*(const Matrix<T,N> &a, const Matrix<U,N> &b)
     {
-      Matrix<typename PromoteTypeId<T,U>::Type,3> result;
-      result(0,0) = a(0,0)*b(0,0) + a(0,1)*b(1,0) + a(0,2)*b(2,0);
-      result(0,1) = a(0,0)*b(0,1) + a(0,1)*b(1,1) + a(0,2)*b(2,1);
-      result(0,2) = a(0,0)*b(0,2) + a(0,1)*b(1,2) + a(0,2)*b(2,2);
-      result(1,0) = a(1,0)*b(0,0) + a(1,1)*b(1,0) + a(1,2)*b(2,0);
-      result(1,1) = a(1,0)*b(0,1) + a(1,1)*b(1,1) + a(1,2)*b(2,1);
-      result(1,2) = a(1,0)*b(0,2) + a(1,1)*b(1,2) + a(1,2)*b(2,2);
-      result(2,0) = a(2,0)*b(0,0) + a(2,1)*b(1,0) + a(2,2)*b(2,0);
-      result(2,1) = a(2,0)*b(0,1) + a(2,1)*b(1,1) + a(2,2)*b(2,1);
-      result(2,2) = a(2,0)*b(0,2) + a(2,1)*b(1,2) + a(2,2)*b(2,2);
+      Matrix<typename PromoteTypeId<T,U>::Type,N> result;
+      for (int i=0; i<N; i++) {
+	for (int k=0; k<N; k++) {
+	  result(i,k) = 0.0;
+	  for (int j=0; j<N; j++) {
+	    result(i,k) += a(i,j) * b(j,k);
+	  }
+	}
+      }
       return result;
     }
 
+
+  template<class T, class U>
+    __device__ __host__ inline
+    Matrix<typename PromoteTypeId<T,U>::Type,3> operator*(const Matrix<T,3> &a, const Matrix<U,3> &b)
+    {
+      Matrix<typename PromoteTypeId<T,U>::Type,3> result;
+#pragma unroll
+      for (int i=0; i<3; i++) {
+#pragma unroll
+	for (int k=0; k<3; k++) {
+	  result(i,k) = a(i,0) * b(0,k) + a(i,1) * b(1,k) + a(i,2) * b(2,k);
+	}
+      }
+      return result;
+    }
 
 
   template<class T>
@@ -543,9 +334,7 @@ namespace quda{
       Matrix<T,N> result;
       for(int i=0; i<N; ++i){
         for(int j=0; j<N; ++j){
-          result(i,j) = 
-            conj(static_cast<complex<typename RealTypeId<T>::Type> >
-                (other(j,i)));
+          result(i,j) = conj( other(j,i) );
         }
       }
       return result;
@@ -558,7 +347,7 @@ namespace quda{
     {
 
       const T & det = getDeterminant(u);
-      const T & det_inv = getPreciseInverse(det);
+      const T & det_inv = static_cast<typename T::value_type>(1.0)/det;
 
       T temp;
 
@@ -678,7 +467,7 @@ namespace quda{
 
   template<typename Complex,int N>
     __device__ __host__ inline void makeAntiHerm(Matrix<Complex,N> &m) {
-    typedef typename RealTypeId<Complex>::Type real;
+    typedef typename Complex::value_type real;
     // first make the matrix anti-hermitian
     Matrix<Complex,N> am = m - conj(m);
 
@@ -735,7 +524,7 @@ namespace quda{
     __device__ __host__ inline
     void outerProd(const Array<T,N>& a, const Array<T,N> & b, Matrix<T,N>* m){
       for(int i=0; i<N; ++i){
-        const T conjb_i = Conj(b[i]);
+        const T conjb_i = conj(b[i]);
         for(int j=0; j<N; ++j){
           (*m)(j,i) = a[j]*conjb_i; // we reverse the ordering of indices because it cuts down on the number of function calls
         }
@@ -747,7 +536,7 @@ namespace quda{
     __device__ __host__ inline 
     void outerProd(const T (&a)[N], const T (&b)[N], Matrix<T,N>* m){
       for(int i=0; i<N; ++i){
-        const T conjb_i = conj(static_cast<complex<typename RealTypeId<T>::Type> >(b[i]));
+        const T conjb_i = conj(b[i]);
         for(int j=0; j<N; ++j){
           (*m)(j,i) = a[j]*conjb_i; // we reverse the ordering of indices because it cuts down on the number of function calls
         }
@@ -778,9 +567,9 @@ namespace quda{
     }
 
 
-  template<class T>
+  template<class T, class U>
     __device__ inline
-    void loadLinkVariableFromArray(const T* const array, const int dir, const int idx, const int stride, Matrix<T,3> *link)
+    void loadLinkVariableFromArray(const T* const array, const int dir, const int idx, const int stride, Matrix<U,3> *link)
     {
       for(int i=0; i<9; ++i){
         link->data[i] = array[idx + (dir*9 + i)*stride];
@@ -789,9 +578,9 @@ namespace quda{
     }
 
 
-  template<class T, int N>
+  template<class T, class U, int N>
     __device__ inline 
-    void loadMatrixFromArray(const T* const array, const int idx, const int stride, Matrix<T,N> *mat)
+    void loadMatrixFromArray(const T* const array, const int idx, const int stride, Matrix<U,N> *mat)
     {
       for(int i=0; i<(N*N); ++i){
         mat->data[i] = array[idx + i*stride];
@@ -800,7 +589,7 @@ namespace quda{
 
 
   __device__ inline  
-    void loadLinkVariableFromArray(const float2* const array, const int dir, const int idx, const int stride, Matrix<double2,3> *link)
+    void loadLinkVariableFromArray(const float2* const array, const int dir, const int idx, const int stride, Matrix<complex<double>,3> *link)
     { 
       float2 single_temp; 
       for(int i=0; i<9; ++i){
@@ -813,9 +602,9 @@ namespace quda{
 
 
 
-  template<class T, int N>
+  template<class T, int N, class U>
     __device__ inline 
-    void writeMatrixToArray(const Matrix<T,N>& mat, const int idx, const int stride, T* const array)
+    void writeMatrixToArray(const Matrix<T,N>& mat, const int idx, const int stride, U* const array)
     {
       for(int i=0; i<(N*N); ++i){
         array[idx + i*stride] = mat.data[i];
@@ -823,7 +612,7 @@ namespace quda{
     }
 
   __device__ inline 
-    void appendMatrixToArray(const Matrix<double2,3>& mat, const int idx, const int stride, double2* const array)
+    void appendMatrixToArray(const Matrix<complex<double>,3>& mat, const int idx, const int stride, double2* const array)
     {
       for(int i=0; i<9; ++i){
         array[idx + i*stride].x += mat.data[i].x;
@@ -832,7 +621,7 @@ namespace quda{
     }
 
   __device__ inline 
-    void appendMatrixToArray(const Matrix<float2,3>& mat, const int idx, const int stride, float2* const array)
+    void appendMatrixToArray(const Matrix<complex<float>,3>& mat, const int idx, const int stride, float2* const array)
     {
       for(int i=0; i<9; ++i){
         array[idx + i*stride].x += mat.data[i].x;
@@ -841,9 +630,9 @@ namespace quda{
     }
 
 
-  template<class T>
+  template<class T, class U>
     __device__ inline
-    void writeLinkVariableToArray(const Matrix<T,3> & link, const int dir, const int idx, const int stride, T* const array)
+    void writeLinkVariableToArray(const Matrix<T,3> & link, const int dir, const int idx, const int stride, U* const array)
     {
       for(int i=0; i<9; ++i){ 
         array[idx + (dir*9 + i)*stride] = link.data[i];
@@ -855,7 +644,7 @@ namespace quda{
 
 
   __device__ inline 
-    void writeLinkVariableToArray(const Matrix<double2,3> & link, const int dir, const int idx, const int stride, float2* const array)
+    void writeLinkVariableToArray(const Matrix<complex<double>,3> & link, const int dir, const int idx, const int stride, float2* const array)
     {
       float2 single_temp;
 
@@ -908,6 +697,7 @@ namespace quda{
     __device__  inline 
     void writeMomentumToArray(const Matrix<T,3> & mom, const int dir, const int idx, const U coeff, const int stride, T* const array)
     {
+      typedef typename T::value_type real;
       T temp2;
       temp2.x = (mom.data[1].x - mom.data[3].x)*0.5*coeff;
       temp2.y = (mom.data[1].y + mom.data[3].y)*0.5*coeff;
@@ -921,7 +711,7 @@ namespace quda{
       temp2.y = (mom.data[5].y + mom.data[7].y)*0.5*coeff;
       array[idx + dir*stride*5 + stride*2] = temp2;
 
-      const typename RealTypeId<T>::Type temp = (mom.data[0].y + mom.data[4].y + mom.data[8].y)*0.3333333333333333333333333;
+      const real temp = (mom.data[0].y + mom.data[4].y + mom.data[8].y)*0.3333333333333333333333333;
       temp2.x =  (mom.data[0].y-temp)*coeff;
       temp2.y =  (mom.data[4].y-temp)*coeff;
       array[idx + dir*stride*5 + stride*3] = temp2;
@@ -941,7 +731,7 @@ namespace quda{
     {
 
       const Cmplx & det = getDeterminant(u);
-      const Cmplx & det_inv = getPreciseInverse(det);
+      const Cmplx & det_inv = static_cast<typename Cmplx::value_type>(1.0)/det;
 
       Cmplx temp;
 
@@ -1032,7 +822,7 @@ namespace quda{
 
   template<class T>
   __device__ __host__ inline void SubTraceUnit(Matrix<T,3>& a){
-    T tr = (a(0,0) + a(1,1) + a(2,2)) / 3.0;
+    T tr = (a(0,0) + a(1,1) + a(2,2)) / static_cast<T>(3.0);
     a(0,0) -= tr; a(1,1) -= tr; a(2,2) -= tr;
   }
 

--- a/lib/transfer_util.cu
+++ b/lib/transfer_util.cu
@@ -303,9 +303,9 @@ namespace quda {
 	
 	// Normalize the block
 	// nrm2 is pure real, but need to use Complex because of template.
-	complex<sumFloat> nrm2 = 0.0;
+        sumFloat nrm2 = 0.0;
 	for (int i=0; i<blockSize; i++) nrm2 += norm(v[(b*N+jc)*blockSize+i]);
-	sumFloat scale = nrm2.real() > 0.0 ? 1.0/sqrt(nrm2.real()) : 0.0;
+	sumFloat scale = nrm2 > 0.0 ? 1.0/sqrt(nrm2) : 0.0;
 	for (int i=0; i<blockSize; i++) v[(b*N+jc)*blockSize+i] *= scale;
       }
 

--- a/tests/gauge_force_test.cpp
+++ b/tests/gauge_force_test.cpp
@@ -381,8 +381,8 @@ gauge_force_test(void)
 
   size_t gSize = qudaGaugeParam.cpu_prec;
     
-  void* sitelink;  
-  void* sitelink_1d;
+  void* sitelink = nullptr;
+  void* sitelink_1d = nullptr;
   
 #ifdef GPU_DIRECT
   sitelink_1d = pinned_malloc(4*V*gaugeSiteSize*gSize);


### PR DESCRIPTION
This pull request is a significant clean up of the complex-number usage: we now use the complex-number class in complex_quda.h for supporting complex-valued matrices in quda_matrix.h.  This is a wide-ranging change, albeit a straightforward one, affecting all code that uses the matrix class (gauge fixing, force terms, plaquette, link smearing, etc.).

This pull request also fixes a bunch of compiler warnings.