### PR TITLE
Feature/unitarization cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,7 +163,7 @@ endif()
 if(${QUDA_MPI})
   add_definitions(-DMPI_COMMS)
   set(COMM_OBJS comm_mpi.cpp)
-  include_directories(${MPI_CXX_INCLUDE_PATH})
+  include_directories(SYSTEM ${MPI_CXX_INCLUDE_PATH})
 endif()
 
 if (${QUDA_QMP})
@@ -172,7 +172,7 @@ if (${QUDA_QMP})
   execute_process(COMMAND ${QUDA_QMPHOME}/bin/qmp-config --ldflags OUTPUT_VARIABLE QMP_LDFLAGS OUTPUT_STRIP_TRAILING_WHITESPACE)
   execute_process(COMMAND ${QUDA_QMPHOME}/bin/qmp-config --libs OUTPUT_VARIABLE QMP_LIBS OUTPUT_STRIP_TRAILING_WHITESPACE)
   FIND_LIBRARY(QMP_LIB qmp ${QUDA_QMPHOME}/lib)
-  include_directories(${QUDA_QMPHOME}/include)
+  include_directories(SYSTEM ${QUDA_QMPHOME}/include)
   set(COMM_OBJS comm_qmp.cpp)
 endif()
 
@@ -181,14 +181,14 @@ if (${QUDA_QIO})
   set(QIO_UTIL qio_util.cpp qio_field.cpp layout_hyper.c)
   FIND_LIBRARY(QIO_LIB qio ${QUDA_QIOHOME}/lib/)
   FIND_LIBRARY(LIME_LIB lime ${QUDA_QIOHOME}/lib/)
-  include_directories(${QUDA_QIOHOME}/include)
+  include_directories(SYSTEM ${QUDA_QIOHOME}/include)
 endif()
 
 if(QUDA_MAGMA)
   add_definitions(-DMAGMA_LIB -DADD_ -DMAGMA_SETAFFINITY -DGPUSHMEM=300 -DHAVE_CUBLAS -DMAGMA_LIB)
   find_package(PkgConfig REQUIRED)
   pkg_check_modules(MAGMA  magma)
-  include_directories(${MAGMA_INCLUDEDIR})
+  include_directories(SYSTEM ${MAGMA_INCLUDEDIR})
   message(${MAGMA_INCLUDEDIR})
   find_package(OpenMP)
 endif(QUDA_MAGMA)
@@ -351,6 +351,8 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(SYSTEM ${CUDA_INCLUDE_DIRS})
 include_directories(include)
 include_directories(lib)
+get_directory_property(CUDA_NVCC_INCLUDE_DIRECTORIES INCLUDE_DIRECTORIES)
+MESSAGE(${CUDA_NVCC_INCLUDE_DIRECTORIES})
 
 # QUDA_HASH for tunecache
 file(STRINGS ${CUDA_TOOLKIT_INCLUDE}/cuda.h  CUDA_VERSIONLONG REGEX "\#define CUDA_VERSION" )
@@ -390,7 +392,7 @@ endif(QUDA_VERBOSE_BUILD)
 
 
 
-set(CUDA_NVCC_FLAGS_DEVEL ${QUDA_NVCC_FLAGS} -Xcompiler -Wno-unknown-pragmas -O3 -lineinfo CACHE STRING
+set(CUDA_NVCC_FLAGS_DEVEL ${QUDA_NVCC_FLAGS} -Xcompiler -Wno-unknown-pragmas,-Wno-unused-function,-Wno-unused-local-typedef -O3 -lineinfo CACHE STRING
     "Flags used by the CUDA compiler during regular development builds."
     FORCE )
 set(CUDA_NVCC_FLAGS_RELEASE ${QUDA_NVCC_FLAGS} -O3 -w CACHE STRING

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,10 @@
 # basic setup for cmake
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_INCLUDE_DIRECTORIES_PROJECT_BEFORE ON)
 set(CMAKE_COLOR_MAKEFILE ON)
-
+set(CMAKE_CXX_STANDARD_REQUIRED 11)
+set(CMAKE_CXX_STANDARD 11)
 # disable in source builds
 # this is only a temporary fix, but for now we need it as cmake will
 # otherwise overwrite the existing makefiles
@@ -145,6 +146,7 @@ set(CPU_ARCH x86_64)
 # we need to check for some packages
 find_package(PythonInterp)
 
+set(CUDA_HOST_COMPILER "${CMAKE_CXX_COMPILER}" CACHE FILEPATH "Host side compiler used by NVCC")
 find_package(CUDA REQUIRED)
 find_package(Threads REQUIRED)
 
@@ -380,7 +382,7 @@ add_definitions(-D__COMPUTE_CAPABILITY__=${COMP_CAP})
 
 
 # NVCC FLAGS independet off build type
-set(QUDA_NVCC_FLAGS -std=c++11 -arch=${QUDA_GPU_ARCH} -ftz=true -prec-div=false -prec-sqrt=false)
+set(QUDA_NVCC_FLAGS -std c++11 -arch=${QUDA_GPU_ARCH} -ftz=true -prec-div=false -prec-sqrt=false)
 
 if(QUDA_VERBOSE_BUILD)
   LIST(APPEND QUDA_NVCC_FLAGS --ptxas-options=-v)
@@ -413,15 +415,15 @@ mark_as_advanced(CUDA_NVCC_FLAGS_DEVICEDEBUG)
 # we might use:
 # set_property(TARGET tgt PROPERTY CXX_STANDARD 11) in the future but need to check support in older cmake version
 
-set(CMAKE_CXX_FLAGS_DEVEL  "${OpenMP_CXX_FLAGS} -std=c++11 -O3 -Wall" CACHE STRING
+set(CMAKE_CXX_FLAGS_DEVEL  "${OpenMP_CXX_FLAGS} -O3 -Wall" CACHE STRING
     "Flags used by the CUDA compiler during regular development builds.")
-set(CMAKE_CXX_FLAGS_RELEASE "${OpenMP_CXX_FLAGS} -std=c++11 -O3 -w" CACHE STRING
+set(CMAKE_CXX_FLAGS_RELEASE "${OpenMP_CXX_FLAGS} -O3 -w" CACHE STRING
     "Flags used by the C++ compiler during release builds.")
-set(CMAKE_CXX_FLAGS_HOSTDEBUG "${OpenMP_CXX_FLAGS} -std=c++11 -Wall -Wno-unknown-pragmas -g -fno-inline -DHOST_DEBUG" CACHE STRING
+set(CMAKE_CXX_FLAGS_HOSTDEBUG "${OpenMP_CXX_FLAGS} -Wall -Wno-unknown-pragmas -g -fno-inline -DHOST_DEBUG" CACHE STRING
     "Flags used by the C++ compiler during host-debug builds.")
-set(CMAKE_CXX_FLAGS_DEVICEDEBUG "${OpenMP_CXX_FLAGS} -std=c++11 -Wall -Wno-unknown-pragmas" CACHE STRING
+set(CMAKE_CXX_FLAGS_DEVICEDEBUG "${OpenMP_CXX_FLAGS} -Wall -Wno-unknown-pragmas" CACHE STRING
     "Flags used by the C++ compiler during device-debug builds.")
-set(CMAKE_CXX_FLAGS_DEBUG "${OpenMP_CXX_FLAGS} -std=c++11 -Wall -Wno-unknown-pragmas -g -fno-inline -DHOST_DEBUG" CACHE STRING
+set(CMAKE_CXX_FLAGS_DEBUG "${OpenMP_CXX_FLAGS} -Wall -Wno-unknown-pragmas -g -fno-inline -DHOST_DEBUG" CACHE STRING
     "Flags used by the C++ compiler during full (host+device) debug builds.")
 
 set(CMAKE_F_FLAGS -std=c99 CACHE STRING "Fortran Flags")

--- a/include/comm_quda.h
+++ b/include/comm_quda.h
@@ -114,6 +114,11 @@ extern "C" {
   void comm_dim_partitioned_set(int dim);
   int comm_dim_partitioned(int dim);
 
+  /**
+     @brief Loop over comm_dim_partitioned(dim) for all comms dimensions
+     @return Whether any communications dimensions are partitioned
+   */
+  int comm_partitioned();
 
   /* implemented in comm_single.cpp, comm_qmp.cpp, and comm_mpi.cpp */
 

--- a/include/float_vector.h
+++ b/include/float_vector.h
@@ -191,13 +191,13 @@ namespace quda {
   };
 
   __forceinline__ __host__ __device__ double max_fabs(const double4 &c) {
-    double a = fmaxf(fabsf(c.x), fabsf(c.y));
-    double b = fmaxf(fabsf(c.z), fabsf(c.w));
-    return fmaxf(a, b);
+    double a = fmax(fabs(c.x), fabs(c.y));
+    double b = fmax(fabs(c.z), fabs(c.w));
+    return fmax(a, b);
   };
 
   __forceinline__ __host__ __device__ double max_fabs(const double2 &b) {
-    return fmaxf(fabsf(b.x), fabsf(b.y));
+    return fmax(fabs(b.x), fabs(b.y));
   };
 
   /*

--- a/include/invert_quda.h
+++ b/include/invert_quda.h
@@ -466,10 +466,6 @@ namespace quda {
 
   private:
     DiracMatrix &mat;
-
-    // pointers to fields to avoid multiple creation overhead
-    cudaColorSpinorField *yp, *rp, *pp, *vp, *tmpp, *tp;
-    bool init;
     void computeMatrixPowers(std::vector<cudaColorSpinorField>& pr, cudaColorSpinorField& p, cudaColorSpinorField& r, int nsteps);
 
   public:

--- a/include/ks_improved_force.h
+++ b/include/ks_improved_force.h
@@ -37,16 +37,15 @@ namespace quda {
 				     double svd_rel_error,
 				     double svd_abs_error);
 
-  void unitarizeForceCuda(cudaGaugeField &cudaOldForce,
-                          cudaGaugeField &cudaGauge,
-                          cudaGaugeField *cudaNewForce,
-			  int* unitarization_failed, 
-			  long long* flops = NULL);
+  void unitarizeForce(cudaGaugeField &newForce,
+		      const cudaGaugeField &oldForce,
+		      const cudaGaugeField &gauge,
+		      int* unitarization_failed,
+		      long long* flops = NULL);
 
-  void unitarizeForceCPU( cpuGaugeField &cpuOldForce,
-                          cpuGaugeField &cpuGauge,
-                          cpuGaugeField *cpuNewForce);
-
+  void unitarizeForceCPU( cpuGaugeField &newForce,
+			  const cpuGaugeField &oldForce,
+                          const cpuGaugeField &gauge);
 
  } // namespace fermion_force
 }  // namespace quda

--- a/include/lanczos_quda.h
+++ b/include/lanczos_quda.h
@@ -70,8 +70,9 @@ namespace quda {
                     cudaColorSpinorField &r, cudaColorSpinorField &Apsi, int k0, int m);
   };
     
+#if 0
   /**
-  Not implemented yet!!!, Implicitely restarted Lanczos algoritm can rapidly approach the solution than normal Lanczos, Chebychev acceleration and implicite restart processes are needed. At this moment external program call can do this.
+     Not implemented yet!!!, Implicitely restarted Lanczos algoritm can rapidly approach the solution than normal Lanczos, Chebychev acceleration and implicite restart processes are needed. At this moment external program call can do this.
   */
 
   class ImpRstLanczos : public Eig_Solver {
@@ -86,7 +87,7 @@ namespace quda {
     void operator()(double *alpha, double *beta, cudaColorSpinorField **Eig_Vec, 
                     cudaColorSpinorField &r, cudaColorSpinorField &Apsi, int k0, int m);
   };
-
+#endif
 
 } // namespace quda
 

--- a/include/qio_field.h
+++ b/include/qio_field.h
@@ -9,17 +9,17 @@ void read_spinor_field(const char *filename, void *V[], QudaPrecision precision,
 void write_spinor_field(const char *filename, void *V[], QudaPrecision precision, const int *X,
 			int nColor, int nSpin, int Nvec, int argc, char *argv[]);
 #else
-static void read_gauge_field(const char *filename, void *gauge[], QudaPrecision prec,
+inline void read_gauge_field(const char *filename, void *gauge[], QudaPrecision prec,
 		      const int *X, int argc, char *argv[]) {
   printf("QIO support has not been enabled\n");
   exit(-1);
 }
-static void read_spinor_field(const char *filename, void *V[], QudaPrecision precision, const int *X,
+inline void read_spinor_field(const char *filename, void *V[], QudaPrecision precision, const int *X,
 			int nColor, int nSpin, int Nvec, int argc, char *argv[]) {
   printf("QIO support has not been enabled\n");
   exit(-1);
 }
-static void write_spinor_field(const char *filename, void *V[], QudaPrecision precision, const int *X,
+inline void write_spinor_field(const char *filename, void *V[], QudaPrecision precision, const int *X,
 			       int nColor, int nSpin, int Nvec, int argc, char *argv[]) {
   printf("QIO support has not been enabled\n");
   exit(-1);

--- a/include/transfer.h
+++ b/include/transfer.h
@@ -92,12 +92,6 @@ namespace quda {
     /** The parity of any single-parity fine-grid fields that are passed into the transfer operator */
     QudaParity parity;
 
-    /** The length of the fine lattice */
-    int fine_length;
-
-    /** The length of the coarse lattice */
-    int coarse_length;
-
     /** Whether to enable transfer operator on the GPU */
     bool enable_gpu;
 

--- a/include/unitarization_links.h
+++ b/include/unitarization_links.h
@@ -31,13 +31,12 @@ namespace quda {
 
   void setUnitarizeLinksConstants(double unitarize_eps, double max_error, 
 				  bool allow_svd, bool svd_only,
-				  double svd_rel_error, double svd_abs_error,
-				  bool check_unitarization=true);
+				  double svd_rel_error, double svd_abs_error);
 
   void unitarizeLinksCPU(cpuGaugeField& outfield, const cpuGaugeField &infield);
 
-  void unitarizeLinksQuda(cudaGaugeField& outfield, const cudaGaugeField &infield, int *fails);
-  void unitarizeLinksQuda(cudaGaugeField& outfield, int *fails);
+  void unitarizeLinks(cudaGaugeField& outfield, const cudaGaugeField &infield, int *fails);
+  void unitarizeLinks(cudaGaugeField& outfield, int *fails);
   
   bool isUnitary(const cpuGaugeField& field, double max_error);
 

--- a/lib/blas_core.h
+++ b/lib/blas_core.h
@@ -272,7 +272,9 @@ template <template <typename Float, typename FloatN> class Functor,
     errorQuda("blas has not been built for Nspin=%d fields", x.Nspin());
 #endif
   } else if (x.Precision() == QUDA_SINGLE_PRECISION) {
+#if defined(GPU_WILSON_DIRAC) || defined(GPU_DOMAIN_WALL_DIRAC)
       const int M = 1;
+#endif
       if (x.Nspin() == 4) {
 #if defined(GPU_WILSON_DIRAC) || defined(GPU_DOMAIN_WALL_DIRAC)
 	Spinor<float4,float4,float4,M,writeX,0> X(x);

--- a/lib/clover_deriv_quda.cu
+++ b/lib/clover_deriv_quda.cu
@@ -47,7 +47,7 @@ namespace quda {
   cloverDerivativeKernel(Arg arg)
   {
     typedef complex<real> Complex;
-    typedef Matrix<Complex,3> M;
+    typedef Matrix<Complex,3> Link;
 
     int index = threadIdx.x + blockIdx.x*blockDim.x;
 
@@ -70,12 +70,12 @@ namespace quda {
     const int& mu = arg.mu;
     const int& nu = arg.nu;
 
-    M thisForce, otherForce;
+    Link thisForce, otherForce;
 
     // U[mu](x) U[nu](x+mu) U[*mu](x+nu) U[*nu](x) Oprod(x)
     {
       int d[4] = {0, 0, 0, 0};
-      M U1, U2, U3, U4, Oprod1, Oprod2;
+      Link U1, U2, U3, U4, Oprod1, Oprod2;
 
       // load U(x)_(+mu)
       arg.gauge.load((real*)(U1.data), linkIndexShift(x, d, X), mu, arg.parity);
@@ -110,7 +110,7 @@ namespace quda {
  
     {
       int d[4] = {0, 0, 0, 0};
-      M U1, U2, U3, U4, Oprod3, Oprod4;
+      Link U1, U2, U3, U4, Oprod3, Oprod4;
 
       // load U(x)_(+mu)
       arg.gauge.load((real*)(U1.data), linkIndexShift(y, d, X), mu, otherparity);
@@ -151,7 +151,7 @@ namespace quda {
     // U[nu*](x-nu) U[mu](x-nu) U[nu](x+mu-nu) Oprod(x+mu) U[*mu](x)
     {
       int d[4] = {0, 0, 0, 0};
-      M U1, U2, U3, U4, Oprod1, Oprod2;
+      Link U1, U2, U3, U4, Oprod1, Oprod2;
 
       // load U(x-nu)(+nu)
       d[nu]--;
@@ -190,7 +190,7 @@ namespace quda {
 
     {
       int d[4] = {0, 0, 0, 0};
-      M U1, U2, U3, U4, Oprod1, Oprod4;
+      Link U1, U2, U3, U4, Oprod1, Oprod4;
 
       // load U(x-nu)(+nu)
       d[nu]--;
@@ -228,14 +228,14 @@ namespace quda {
 
     // Write to array
     {
-      M F;
+      Link F;
       arg.force.load((real*)(F.data), index, mu, arg.parity);
       F += thisForce;
       arg.force.save((real*)(F.data), index, mu, arg.parity);
     }
       
     {
-      M F;
+      Link F;
       arg.force.load((real*)(F.data), index, mu, otherparity);
       F += otherForce;
       arg.force.save((real*)(F.data), index, mu, otherparity);

--- a/lib/clover_outer_product.cu
+++ b/lib/clover_outer_product.cu
@@ -32,9 +32,11 @@ namespace quda {
   }
   
   
+#ifdef MULTI_GPU
   static cudaEvent_t packEnd;
   static cudaEvent_t gatherEnd[4];
   static cudaEvent_t scatterEnd[4];
+#endif
   static cudaEvent_t oprodStart;
   static cudaEvent_t oprodEnd;
 

--- a/lib/coarse_op.cuh
+++ b/lib/coarse_op.cuh
@@ -1011,7 +1011,7 @@ namespace quda {
 
   public:
     CalculateY(Arg &arg, QudaDiracType dirac, const ColorSpinorField &meta)
-      : TunableVectorY(2), arg(arg), type(type),
+      : TunableVectorY(2), arg(arg), type(COMPUTE_INVALID),
 	bidirectional(dirac==QUDA_CLOVERPC_DIRAC || dirac==QUDA_COARSEPC_DIRAC || dirac==QUDA_TWISTED_MASSPC_DIRAC || dirac==QUDA_TWISTED_CLOVERPC_DIRAC ||  bidirectional_debug),
 	meta(meta), dim(0), dir(QUDA_BACKWARDS)
     {

--- a/lib/comm_common.cpp
+++ b/lib/comm_common.cpp
@@ -429,3 +429,12 @@ int comm_dim_partitioned(int dim)
 {
   return (manual_set_partition[dim] || (comm_dim(dim) > 1));
 }
+
+int comm_partitioned()
+{
+  int partitioned = 0;
+  for (int i=0; i<4; i++) {
+    partitioned = partitioned || comm_dim_partitioned(i);
+  }
+  return partitioned;
+}

--- a/lib/cuda_color_spinor_field.cu
+++ b/lib/cuda_color_spinor_field.cu
@@ -12,9 +12,9 @@
 #include <dslash_quda.h>
 
 #ifdef DEVICE_PACK
-#define REORDER_LOCATION QUDA_CUDA_FIELD_LOCATION
+static const QudaFieldLocation reorder_location = QUDA_CUDA_FIELD_LOCATION;
 #else
-#define REORDER_LOCATION QUDA_CPU_FIELD_LOCATION
+static const QudaFieldLocation reorder_location = QUDA_CPU_FIELD_LOCATION;
 #endif
 
 int zeroCopy = 0;
@@ -509,7 +509,7 @@ namespace quda {
 
   void cudaColorSpinorField::loadSpinorField(const ColorSpinorField &src) {
 
-    if (REORDER_LOCATION == QUDA_CPU_FIELD_LOCATION && 
+    if (reorder_location == QUDA_CPU_FIELD_LOCATION &&
 	typeid(src) == typeid(cpuColorSpinorField)) {
       for (int b=0; b<2; ++b) {
         resizeBufferPinned(bytes + norm_bytes, b);
@@ -551,7 +551,7 @@ namespace quda {
 
   void cudaColorSpinorField::saveSpinorField(ColorSpinorField &dest) const {
 
-    if (REORDER_LOCATION == QUDA_CPU_FIELD_LOCATION && 
+    if (reorder_location == QUDA_CPU_FIELD_LOCATION &&
 	typeid(dest) == typeid(cpuColorSpinorField)) {
       for (int b=0; b<2; ++b) resizeBufferPinned(bytes+norm_bytes,b);
       qudaMemcpy(bufferPinned[bufferIndex], v, bytes, cudaMemcpyDeviceToHost);

--- a/lib/dslash_constants.h
+++ b/lib/dslash_constants.h
@@ -518,6 +518,12 @@ void initMDWFConstants(const double *b_5, const double *c_5, int dim_s, const do
   profile.TPSTOP(QUDA_PROFILE_CONSTANT);
 }
 
+void initConstants(cudaGaugeField &gauge, TimeProfile &profile) {
+  initLatticeConstants(gauge, profile);
+  initGaugeConstants(gauge, profile);
+  initDslashConstants(profile);
+}
+
 void setTwistParam(double &a, double &b, const double &kappa, const double &mu, 
 		   const int dagger, const QudaTwistGamma5Type twist) {
   if (twist == QUDA_TWIST_GAMMA5_DIRECT) {

--- a/lib/dslash_init.cuh
+++ b/lib/dslash_init.cuh
@@ -9,10 +9,6 @@ void initMDWFConstants(const double *b_5, const double *c_5, int dim_s,
 		       const double m5h, TimeProfile &profile);
 
 // this needs to be called for each dslash that has its own namespace
-static void initConstants(cudaGaugeField &gauge, TimeProfile &profile) {
-  initLatticeConstants(gauge, profile);
-  initGaugeConstants(gauge, profile);
-  initDslashConstants(profile);
-}
+void initConstants(cudaGaugeField &gauge, TimeProfile &profile);
 
 void setFace(const FaceBuffer &Face1, const FaceBuffer &Face2);

--- a/lib/eig_lanczos_quda.cpp
+++ b/lib/eig_lanczos_quda.cpp
@@ -93,16 +93,17 @@ namespace quda {
     return;
   }
   
+#if 0
   ImpRstLanczos::ImpRstLanczos(RitzMat &ritz_mat, QudaEigParam &eigParam, TimeProfile &profile) :
     Eig_Solver(eigParam, profile), ritz_mat(ritz_mat)
-  {
-  }
+  { }
 
-  ImpRstLanczos::~ImpRstLanczos() 
-  {
-  }
+  ImpRstLanczos::~ImpRstLanczos()
+  { }
 
-  void ImpRstLanczos::operator()(double *alpha, double *beta, cudaColorSpinorField **Eig_Vec, cudaColorSpinorField &r, cudaColorSpinorField &Apsi, int k0, int m) 
-  {
-  }
+  void ImpRstLanczos::operator()(double *alpha, double *beta, cudaColorSpinorField **Eig_Vec,
+				 cudaColorSpinorField &r, cudaColorSpinorField &Apsi, int k0, int m)
+  { }
+#endif
+
 } // namespace quda

--- a/lib/eig_solver.cpp
+++ b/lib/eig_solver.cpp
@@ -18,10 +18,12 @@ namespace quda {
       report("Lanczos solver");
       eig_solver = new Lanczos(ritz_mat, param, profile);
       break;
+#if 0
     case QUDA_IMP_RST_LANCZOS:
-      report("BiCGstab");
+      report("Implicitly restarted Lanczos");
       eig_solver = new ImpRstLanczos(ritz_mat, param, profile);
       break;
+#endif
     default:
       errorQuda("Invalid eig solver type");
     }

--- a/lib/field_strength_tensor.cu
+++ b/lib/field_strength_tensor.cu
@@ -34,7 +34,7 @@ namespace quda {
   template <typename Float, typename Fmunu, typename GaugeOrder>
     __host__ __device__ void computeFmunuCore(FmunuArg<Float,Fmunu,GaugeOrder>& arg, int idx) {
 
-      typedef Matrix<complex<Float>,3> M;
+      typedef Matrix<complex<Float>,3> Link;
 
       // compute spacetime dimensions and parity
       int parity = 0;
@@ -57,10 +57,10 @@ namespace quda {
 
       for (int mu=0; mu<4; mu++) {
         for (int nu=0; nu<mu; nu++) {
-          M F;
+          Link F;
           setZero(&F);
           { // U(x,mu) U(x+mu,nu) U[dagger](x+nu,mu) U[dagger](x,nu)
-            M U1, U2, U3, U4;
+            Link U1, U2, U3, U4;
 
             // load U(x)_(+mu)
             int dx[4] = {0, 0, 0, 0};
@@ -70,7 +70,7 @@ namespace quda {
             arg.gauge.load((Float*)(U2.data),linkIndexShift(x,dx,X), nu, 1-parity);
             dx[mu]--;
 
-            M Ftmp = U1 * U2;
+            Link Ftmp = U1 * U2;
 
             // load U(x+nu)_(+mu)
             dx[nu]++;
@@ -88,7 +88,7 @@ namespace quda {
 
 
           { // U(x,nu) U[dagger](x+nu-mu,mu) U[dagger](x-mu,nu) U(x-mu, mu)
-            M U1, U2, U3, U4;
+            Link U1, U2, U3, U4;
 
             // load U(x)_(+nu)
             int dx[4] = {0, 0, 0, 0};
@@ -101,7 +101,7 @@ namespace quda {
             dx[mu]++;
             dx[nu]--;
 
-            M Ftmp =  U1 * conj(U2);
+            Link Ftmp =  U1 * conj(U2);
 
             // load U(x-mu)_nu
             dx[mu]--;
@@ -123,7 +123,7 @@ namespace quda {
           }
 
           { // U[dagger](x-nu,nu) U(x-nu,mu) U(x+mu-nu,nu) U[dagger](x,mu)
-            M U1, U2, U3, U4;
+            Link U1, U2, U3, U4;
 
             // load U(x)_(-nu)
             int dx[4] = {0, 0, 0, 0};
@@ -136,7 +136,7 @@ namespace quda {
             arg.gauge.load((Float*)(U2.data), linkIndexShift(x,dx,X), mu, 1-parity);
             dx[nu]++;
 
-            M Ftmp = conj(U1) * U2;
+            Link Ftmp = conj(U1) * U2;
 
             // load U(x+mu-nu)_(+nu)
             dx[mu]++;
@@ -157,7 +157,7 @@ namespace quda {
           }
 
           { // U[dagger](x-mu,mu) U[dagger](x-mu-nu,nu) U(x-mu-nu,mu) U(x-nu,nu)
-            M U1, U2, U3, U4;
+            Link U1, U2, U3, U4;
 
             // load U(x)_(-mu)
             int dx[4] = {0, 0, 0, 0};
@@ -172,7 +172,7 @@ namespace quda {
             dx[nu]++;
             dx[mu]++;
 
-            M Ftmp = conj(U1) * conj(U2);
+            Link Ftmp = conj(U1) * conj(U2);
 
             // load U(x-nu)_mu
             dx[mu]--;

--- a/lib/gauge_fix_fft.cu
+++ b/lib/gauge_fix_fft.cu
@@ -1174,7 +1174,7 @@ namespace quda {
     cudaMalloc((void**)&num_failures_dev, sizeof(int));
     cudaMemset(num_failures_dev, 0, sizeof(int));
     if ( num_failures_dev == NULL ) errorQuda("cudaMalloc failed for dev_pointer\n");
-    unitarizeLinksQuda(data, data, num_failures_dev);
+    unitarizeLinks(data, data, num_failures_dev);
     qudaMemcpy(&num_failures, num_failures_dev, sizeof(int), cudaMemcpyDeviceToHost);
     if ( num_failures > 0 ) {
       cudaFree(num_failures_dev);

--- a/lib/gauge_fix_ovr.cu
+++ b/lib/gauge_fix_ovr.cu
@@ -203,12 +203,6 @@ namespace quda {
   }
 
 
-
-  static bool checkDimsPartitioned(){
-    if(comm_dim_partitioned(0) || comm_dim_partitioned(1) || comm_dim_partitioned(2) || comm_dim_partitioned(3)) return true;
-    return false;
-  }
-
   /**
    * @brief container to pass parameters for the gauge fixing quality kernel
    */
@@ -956,7 +950,7 @@ namespace quda {
         faceVolume[dir] = faceVolume_[dir];
         faceVolumeCB[dir] = faceVolumeCB_[dir];
       }
-      if ( checkDimsPartitioned() ) PreCalculateLatticeIndices(faceVolume, faceVolumeCB, X, border, threads, borderpoints);
+      if ( comm_partitioned() ) PreCalculateLatticeIndices(faceVolume, faceVolumeCB, X, border, threads, borderpoints);
     }
   };
 
@@ -1142,7 +1136,7 @@ namespace quda {
     }
     GaugeFixBorderPoints(GaugeFixBorderPointsArg<Float, Gauge> &arg) : arg(arg), parity(0) { }
     ~GaugeFixBorderPoints () {
-      if ( checkDimsPartitioned() ) for ( int i = 0; i < 2; i++ ) cudaFree(arg.borderpoints[i]);
+      if ( comm_partitioned() ) for ( int i = 0; i < 2; i++ ) cudaFree(arg.borderpoints[i]);
     }
     void setParity(const int par){
       parity = par;
@@ -1452,7 +1446,7 @@ namespace quda {
     dim3 block[4];
     dim3 grid[4];
 
-    if ( checkDimsPartitioned() ) {
+    if ( comm_partitioned() ) {
 
       for ( int dir = 0; dir < 4; ++dir ) {
         X[dir] = data.X()[dir] - data.R()[dir] * 2;
@@ -1535,7 +1529,7 @@ namespace quda {
         flop += (double)gaugeFix.flops();
         byte += (double)gaugeFix.bytes();
       #else
-        if ( !checkDimsPartitioned() ) {
+        if ( !comm_partitioned() ) {
           gaugeFix.setParity(p);
           gaugeFix.apply(0);
           flop += (double)gaugeFix.flops();
@@ -1632,7 +1626,7 @@ namespace quda {
            flop += (double)gaugeFix.flops();
            byte += (double)gaugeFix.bytes();
            #ifdef MULTI_GPU
-           if(checkDimsPartitioned()){//exchange updated top face links in current parity
+           if(comm_partitioned()){//exchange updated top face links in current parity
            for (int d=0; d<4; d++) {
             if (!commDimPartitioned(d)) continue;
             comm_start(mh_recv_back[d]);
@@ -1722,7 +1716,7 @@ namespace quda {
     }
     cudaFree(num_failures_dev);
   #ifdef MULTI_GPU
-    if ( checkDimsPartitioned() ) {
+    if ( comm_partitioned() ) {
       data.exchangeExtendedGhost(data.R(),false);
       for ( int d = 0; d < 4; d++ ) {
         if ( commDimPartitioned(d)) {

--- a/lib/gauge_fix_ovr.cu
+++ b/lib/gauge_fix_ovr.cu
@@ -1517,7 +1517,7 @@ namespace quda {
     printfQuda("Step: %d\tAction: %.16e\ttheta: %.16e\n", 0, argQ.getAction(), argQ.getTheta());
 
 
-    unitarizeLinksQuda(data, data, num_failures_dev);
+    unitarizeLinks(data, data, num_failures_dev);
     qudaMemcpy(&num_failures, num_failures_dev, sizeof(int), cudaMemcpyDeviceToHost);
     if ( num_failures > 0 ) {
       cudaFree(num_failures_dev);
@@ -1674,7 +1674,7 @@ namespace quda {
          #endif*/
       }
       if ((iter % reunit_interval) == (reunit_interval - 1)) {
-        unitarizeLinksQuda(data, data, num_failures_dev);
+        unitarizeLinks(data, data, num_failures_dev);
         qudaMemcpy(&num_failures, num_failures_dev, sizeof(int), cudaMemcpyDeviceToHost);
         if ( num_failures > 0 ) {
           cudaFree(num_failures_dev);
@@ -1701,7 +1701,7 @@ namespace quda {
       action0 = action;
     }
     if ((iter % reunit_interval) != 0 )  {
-      unitarizeLinksQuda(data, data, num_failures_dev);
+      unitarizeLinks(data, data, num_failures_dev);
       qudaMemcpy(&num_failures, num_failures_dev, sizeof(int), cudaMemcpyDeviceToHost);
       if ( num_failures > 0 ) {
         cudaFree(num_failures_dev);

--- a/lib/gauge_stout.cu
+++ b/lib/gauge_stout.cu
@@ -44,7 +44,7 @@ namespace quda {
   template <typename Float, typename GaugeOr, typename GaugeDs, typename Float2>
   __host__ __device__ void computeStaple(GaugeSTOUTArg<Float,GaugeOr,GaugeDs>& arg, int idx, int parity, int dir, Matrix<Float2,3> &staple) {
 
-    typedef Matrix<complex<Float>,3> M;
+    typedef Matrix<complex<Float>,3> Link;
       // compute spacetime dimensions and parity
 
     int X[4]; 
@@ -70,7 +70,7 @@ namespace quda {
 
       {
         int dx[4] = {0, 0, 0, 0};
-        M U1, U2, U3, U4, tmpS;
+        Link U1, U2, U3, U4, tmpS;
         arg.origin.load((Float*)(U1.data),linkIndexShift(x,dx,X), mu, parity); 
 
         dx[mu]++;
@@ -107,7 +107,7 @@ namespace quda {
       int idx = threadIdx.x + blockIdx.x*blockDim.x;
       if(idx >= arg.threads) return;
       typedef complex<Float> Complex;
-      typedef Matrix<complex<Float>,3> M;
+      typedef Matrix<complex<Float>,3> Link;
 
       int parity = 0;
       if(idx >= arg.threads/2) {
@@ -129,7 +129,7 @@ namespace quda {
 
       int dx[4] = {0, 0, 0, 0};
       for (int dir=0; dir < 3; dir++) {				//Only spatial dimensions are smeared
-        M U, UDag, Stap, Omega, OmegaDag, OmegaDiff, ODT, Q, exp_iQ, tmp1;
+        Link U, UDag, Stap, Omega, OmegaDag, OmegaDiff, ODT, Q, exp_iQ, tmp1;
 	Complex OmegaDiffTr;
 	Complex i_2(0,0.5);
 

--- a/lib/hisq_paths_force_core.h
+++ b/lib/hisq_paths_force_core.h
@@ -891,11 +891,11 @@ HISQ_KERNEL_NAME(do_complete_force, EXT)(const RealB* const linkEven, const Real
   int oddBit = threadIdx.y;
 
   int x[4];
-  int dx[4] = {0,0,0,0};
   getCoords(x, sid, kparam.X, oddBit);
 
   int new_sid=sid;
 #ifdef MULTI_GPU
+  int dx[4] = {0,0,0,0};
   x[0] = x[0]+2;
   x[1] = x[1]+2;
   x[2] = x[2]+2;

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -4366,7 +4366,7 @@ computeHISQForceQuda(void* const milc_momentum,
 
   profileHISQForce.TPSTART(QUDA_PROFILE_COMPUTE);
   *num_failures_h = 0;
-  unitarizeForceCuda(*outForcePtr, *gaugePtr, inForcePtr, num_failures_d, &partialFlops);
+  unitarizeForce(*inForcePtr, *outForcePtr, *gaugePtr, num_failures_d, &partialFlops);
   *flops += partialFlops;
   profileHISQForce.TPSTOP(QUDA_PROFILE_COMPUTE);
 

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -3231,7 +3231,7 @@ void computeKSLinkQuda(void* fatlink, void* longlink, void* ulink, void* inlink,
 {
   profileFatLink.TPSTART(QUDA_PROFILE_TOTAL);
   profileFatLink.TPSTART(QUDA_PROFILE_INIT);
-  // Initialize unitarization parameters
+
   if(ulink){
     const double unitarize_eps = 1e-14;
     const double max_error = 1e-10;
@@ -3337,7 +3337,7 @@ void computeKSLinkQuda(void* fatlink, void* longlink, void* ulink, void* inlink,
     profileFatLink.TPSTOP(QUDA_PROFILE_INIT);
 
     profileFatLink.TPSTART(QUDA_PROFILE_COMPUTE);
-    quda::unitarizeLinksQuda(*cudaUnitarizedLink, *cudaFatLink, num_failures_d); // unitarize on the gpu
+    quda::unitarizeLinks(*cudaUnitarizedLink, *cudaFatLink, num_failures_d); // unitarize on the gpu
     profileFatLink.TPSTOP(QUDA_PROFILE_COMPUTE);
 
     if(*num_failures_h>0){

--- a/lib/inv_xsd_quda.cpp
+++ b/lib/inv_xsd_quda.cpp
@@ -16,7 +16,6 @@
 
 namespace quda {
 
-#ifdef MULTI_GPU
   XSD::XSD(DiracMatrix &mat, SolverParam &param, TimeProfile &profile) :
     Solver(param,profile), mat(mat)
   {
@@ -33,7 +32,6 @@ namespace quda {
     delete sd;
     if(!param.is_preconditioner) profile.TPSTOP(QUDA_PROFILE_FREE);
   }
-
 
   void XSD::operator()(ColorSpinorField &x, ColorSpinorField &b)
   {
@@ -56,5 +54,4 @@ namespace quda {
     return;
   }
 
-#endif // MULTI_GPU
 } // namespace quda

--- a/lib/llfat_core.h
+++ b/lib/llfat_core.h
@@ -25,8 +25,7 @@
 #endif
 #else //RECONSTRUCT == 12
 #define DECLARE_VAR_SIGN short sign=1
-#define DECLARE_NEW_X short new_x1=x1; short new_x2=x2; \
-  short new_x3=x3; short new_x4=x4; 
+#define DECLARE_NEW_X short new_x1=x1; short new_x2=x2; short new_x4=x4;
 #define DECLARE_X_ARRAY int x[4] = {x1,x2,x3, x4};
 
 #endif
@@ -345,7 +344,7 @@
 #undef COMPUTE_RECONSTRUCT_SIGN
 #if (RECONSTRUCT  != 18)
 #define UPDATE_COOR_PLUS(mydir, n, idx) do {				\
-    new_x1 = x1; new_x2 = x2; new_x3=x3; new_x4 = x4;			\
+    new_x1 = x1; new_x2 = x2; new_x4 = x4;				\
     switch(mydir){                                                      \
     case 0:                                                             \
       new_x1 = x1+n;							\
@@ -354,7 +353,6 @@
       new_x2 = x2+n;							\
       break;                                                            \
     case 2:                                                             \
-      new_x3 = x3+n;                                                     \
       break;                                                            \
     case 3:								\
       new_x4 = x4+n;							\
@@ -516,7 +514,7 @@
 #define UPDATE_COOR_MINUS(mydir, idx)
 #define UPDATE_COOR_LOWER_STAPLE(mydir1, mydir2)
 #define UPDATE_COOR_LOWER_STAPLE_DIAG(nu, mu, dir1, dir2)
-#define COMPUTE_RECONSTRUCT_SIGN(sign, dir, i1,i2,i3,i4) 
+#define COMPUTE_RECONSTRUCT_SIGN(sign, dir, i1,i2,i3,i4)
 #define UPDATE_COOR_LOWER_STAPLE_EX(mydir1, mydir2)
 #endif
 
@@ -865,7 +863,7 @@ template<int mu, int nu, int odd_bit>
     /* load matrix B*/  
     LLFAT_COMPUTE_NEW_IDX_PLUS(nu, 1, X);    
     LOAD_ODD_SITE_MATRIX(mu, new_mem_idx, B);
-    COMPUTE_RECONSTRUCT_SIGN(sign, mu, new_x1, new_x2, new_x3, new_x4);    
+    COMPUTE_RECONSTRUCT_SIGN(sign, mu, new_x1, new_x2, 0, new_x4);
     RECONSTRUCT_SITE_LINK(sign, b);
     
 
@@ -875,7 +873,7 @@ template<int mu, int nu, int odd_bit>
         
     LLFAT_COMPUTE_NEW_IDX_PLUS(mu, 1, X);    
     LOAD_ODD_SITE_MATRIX(nu, new_mem_idx, C);
-    COMPUTE_RECONSTRUCT_SIGN(sign, nu, new_x1, new_x2, new_x3, new_x4);    
+    COMPUTE_RECONSTRUCT_SIGN(sign, nu, new_x1, new_x2, 0, new_x4);
     RECONSTRUCT_SITE_LINK(sign, c);
 
     MULT_SU3_NA(tempa, c, staple);		
@@ -895,12 +893,12 @@ template<int mu, int nu, int odd_bit>
     LLFAT_COMPUTE_NEW_IDX_MINUS(nu,X);    
     
     LOAD_ODD_SITE_MATRIX(nu, (new_mem_idx), A);
-    COMPUTE_RECONSTRUCT_SIGN(sign, nu, new_x1, new_x2, new_x3, new_x4);        
+    COMPUTE_RECONSTRUCT_SIGN(sign, nu, new_x1, new_x2, 0, new_x4);
     RECONSTRUCT_SITE_LINK(sign, a);
     
     /* load matrix B*/				
     LOAD_ODD_SITE_MATRIX(mu, (new_mem_idx), B);
-    COMPUTE_RECONSTRUCT_SIGN(sign, mu, new_x1, new_x2, new_x3, new_x4);    
+    COMPUTE_RECONSTRUCT_SIGN(sign, mu, new_x1, new_x2, 0, new_x4);
     RECONSTRUCT_SITE_LINK(sign, b);
     
     MULT_SU3_AN(a, b, tempa);
@@ -920,7 +918,7 @@ template<int mu, int nu, int odd_bit>
 
     LOAD_EVEN_SITE_MATRIX(nu, new_mem_idx, C);
    
-    COMPUTE_RECONSTRUCT_SIGN(sign, nu, new_x1, new_x2, new_x3, new_x4);        
+    COMPUTE_RECONSTRUCT_SIGN(sign, nu, new_x1, new_x2, 0, new_x4);
     RECONSTRUCT_SITE_LINK(sign, c);
     
     
@@ -1012,7 +1010,7 @@ template<int mu, int nu, int odd_bit, int save_staple>
     /* load matrix C*/
     LLFAT_COMPUTE_NEW_IDX_PLUS(mu, 1, X);    
     LOAD_ODD_SITE_MATRIX(nu, new_mem_idx, C);
-    COMPUTE_RECONSTRUCT_SIGN(sign, nu, new_x1, new_x2, new_x3, new_x4);
+    COMPUTE_RECONSTRUCT_SIGN(sign, nu, new_x1, new_x2, 0, new_x4);
     RECONSTRUCT_SITE_LINK(sign, c);
     if (save_staple){
       MULT_SU3_NA(tempa, c, staple);
@@ -1037,7 +1035,7 @@ template<int mu, int nu, int odd_bit, int save_staple>
     LLFAT_COMPUTE_NEW_IDX_MINUS(nu, X);
     
     LOAD_ODD_SITE_MATRIX(nu, new_mem_idx, A);
-    COMPUTE_RECONSTRUCT_SIGN(sign, nu, new_x1, new_x2, new_x3, new_x4);
+    COMPUTE_RECONSTRUCT_SIGN(sign, nu, new_x1, new_x2, 0, new_x4);
     RECONSTRUCT_SITE_LINK(sign, a);
     
     /* load matrix B*/
@@ -1060,7 +1058,7 @@ template<int mu, int nu, int odd_bit, int save_staple>
 #endif
 
     LOAD_EVEN_SITE_MATRIX(nu, new_mem_idx, C);
-    COMPUTE_RECONSTRUCT_SIGN(sign, nu, new_x1, new_x2, new_x3, new_x4);
+    COMPUTE_RECONSTRUCT_SIGN(sign, nu, new_x1, new_x2, 0, new_x4);
     RECONSTRUCT_SITE_LINK(sign, c);				
     
     MULT_SU3_NN(tempa, c, a);	
@@ -1210,7 +1208,7 @@ template<int mu, int nu, int odd_bit>
     /* load matrix B*/  
     LLFAT_COMPUTE_NEW_IDX_PLUS_EX(nu, 1, X);    
     LOAD_ODD_SITE_MATRIX(mu, new_mem_idx, B);
-    COMPUTE_RECONSTRUCT_SIGN(sign, mu, (new_x1-2), (new_x2-2), (new_x3-2), (new_x4-2));    
+    COMPUTE_RECONSTRUCT_SIGN(sign, mu, (new_x1-2), (new_x2-2), 0, (new_x4-2));
     RECONSTRUCT_SITE_LINK(sign, b);
     
 
@@ -1220,7 +1218,7 @@ template<int mu, int nu, int odd_bit>
         
     LLFAT_COMPUTE_NEW_IDX_PLUS_EX(mu, 1, X);    
     LOAD_ODD_SITE_MATRIX(nu, new_mem_idx, C);
-    COMPUTE_RECONSTRUCT_SIGN(sign, nu, (new_x1-2), (new_x2-2), (new_x3-2), (new_x4-2));    
+    COMPUTE_RECONSTRUCT_SIGN(sign, nu, (new_x1-2), (new_x2-2), 0, (new_x4-2));
     RECONSTRUCT_SITE_LINK(sign, c);
 
     MULT_SU3_NA(tempa, c, staple);		   
@@ -1241,12 +1239,12 @@ template<int mu, int nu, int odd_bit>
     LLFAT_COMPUTE_NEW_IDX_MINUS_EX(nu,X);    
     
     LOAD_ODD_SITE_MATRIX(nu, (new_mem_idx), A);
-    COMPUTE_RECONSTRUCT_SIGN(sign, nu, (new_x1-2), (new_x2-2), (new_x3-2), (new_x4-2));        
+    COMPUTE_RECONSTRUCT_SIGN(sign, nu, (new_x1-2), (new_x2-2), 0, (new_x4-2));
     RECONSTRUCT_SITE_LINK(sign, a);
     
     /* load matrix B*/				
     LOAD_ODD_SITE_MATRIX(mu, (new_mem_idx), B);
-    COMPUTE_RECONSTRUCT_SIGN(sign, mu, (new_x1-2), (new_x2-2), (new_x3-2), (new_x4-2));    
+    COMPUTE_RECONSTRUCT_SIGN(sign, mu, (new_x1-2), (new_x2-2), 0, (new_x4-2));
     RECONSTRUCT_SITE_LINK(sign, b);
     
     MULT_SU3_AN(a, b, tempa);
@@ -1257,7 +1255,7 @@ template<int mu, int nu, int odd_bit>
     LLFAT_COMPUTE_NEW_IDX_LOWER_STAPLE_EX(nu, mu);
     LOAD_EVEN_SITE_MATRIX(nu, new_mem_idx, C);
    
-    COMPUTE_RECONSTRUCT_SIGN(sign, nu, (new_x1-2), (new_x2-2), (new_x3-2), (new_x4-2));        
+    COMPUTE_RECONSTRUCT_SIGN(sign, nu, (new_x1-2), (new_x2-2), 0, (new_x4-2));
     RECONSTRUCT_SITE_LINK(sign, c);
     
     
@@ -1344,7 +1342,7 @@ template<int mu, int nu, int odd_bit, int save_staple>
     /* load matrix C*/
     LLFAT_COMPUTE_NEW_IDX_PLUS_EX(mu, 1, X);    
     LOAD_ODD_SITE_MATRIX(nu, new_mem_idx, C);
-    COMPUTE_RECONSTRUCT_SIGN(sign, nu, (new_x1-2), (new_x2-2), (new_x3-2), (new_x4-2));
+    COMPUTE_RECONSTRUCT_SIGN(sign, nu, (new_x1-2), (new_x2-2), 0, (new_x4-2));
     RECONSTRUCT_SITE_LINK(sign, c);
     
     MULT_SU3_NA(tempa, c, staple);
@@ -1365,7 +1363,7 @@ template<int mu, int nu, int odd_bit, int save_staple>
     LLFAT_COMPUTE_NEW_IDX_MINUS_EX(nu, X);
     
     LOAD_ODD_SITE_MATRIX(nu, new_mem_idx, A);
-    COMPUTE_RECONSTRUCT_SIGN(sign, nu, (new_x1-2), (new_x2-2), (new_x3-2), (new_x4-2));
+    COMPUTE_RECONSTRUCT_SIGN(sign, nu, (new_x1-2), (new_x2-2), 0, (new_x4-2));
     RECONSTRUCT_SITE_LINK(sign, a);
     
     /* load matrix B*/
@@ -1379,7 +1377,7 @@ template<int mu, int nu, int odd_bit, int save_staple>
     LLFAT_COMPUTE_NEW_IDX_LOWER_STAPLE_EX(nu, mu);
     
     LOAD_EVEN_SITE_MATRIX(nu, new_mem_idx, C);
-    COMPUTE_RECONSTRUCT_SIGN(sign, nu, (new_x1-2), (new_x2-2), (new_x3-2), (new_x4-2));
+    COMPUTE_RECONSTRUCT_SIGN(sign, nu, (new_x1-2), (new_x2-2), 0, (new_x4-2));
     RECONSTRUCT_SITE_LINK(sign, c);				
     
     MULT_SU3_NN(tempa, c, a);	
@@ -1514,22 +1512,22 @@ __global__ void LLFAT_KERNEL(computeLongLinkParity,RECONSTRUCT)
 #ifdef MULTI_GPU
     LLFAT_COMPUTE_NEW_IDX_PLUS_EX(dir, 1, X);
     LOAD_ODD_SITE_MATRIX(dir, new_mem_idx, B);
-    COMPUTE_RECONSTRUCT_SIGN(sign, dir, new_x1-2, new_x2-2, new_x3-2, new_x4-2);
+    COMPUTE_RECONSTRUCT_SIGN(sign, dir, new_x1-2, new_x2-2, 0, new_x4-2);
 #else
     LLFAT_COMPUTE_NEW_IDX_PLUS(dir, 1, X);
     LOAD_ODD_SITE_MATRIX(dir, new_mem_idx, B);
-    COMPUTE_RECONSTRUCT_SIGN(sign, dir, new_x1, new_x2, new_x3, new_x4);
+    COMPUTE_RECONSTRUCT_SIGN(sign, dir, new_x1, new_x2, 0, new_x4);
 #endif
     RECONSTRUCT_SITE_LINK(sign, b);
 
 #ifdef MULTI_GPU
     LLFAT_COMPUTE_NEW_IDX_PLUS_EX(dir, 2, X);
     LOAD_EVEN_SITE_MATRIX(dir, new_mem_idx, C);
-    COMPUTE_RECONSTRUCT_SIGN(sign, dir, new_x1-2, new_x2-2, new_x3-2, new_x4-2);
+    COMPUTE_RECONSTRUCT_SIGN(sign, dir, new_x1-2, new_x2-2, 0, new_x4-2);
 #else
     LLFAT_COMPUTE_NEW_IDX_PLUS(dir, 2, X);
     LOAD_EVEN_SITE_MATRIX(dir, new_mem_idx, C);
-    COMPUTE_RECONSTRUCT_SIGN(sign, dir, new_x1, new_x2, new_x3, new_x4);
+    COMPUTE_RECONSTRUCT_SIGN(sign, dir, new_x1, new_x2, 0, new_x4);
 #endif
     RECONSTRUCT_SITE_LINK(sign, c);
 

--- a/lib/milc_interface.cpp
+++ b/lib/milc_interface.cpp
@@ -212,13 +212,10 @@ static QudaGaugeParam newMILCGaugeParam(const int* dim, QudaPrecision prec, Quda
   return gParam;
 }
 
-
 static  void invalidateGaugeQuda() {
   freeGaugeQuda();
   invalidate_quda_gauge = true;
 }
-
-#ifdef GPU_FATLINK
 
 void qudaLoadKSLink(int prec, QudaFatLinkArgs_t fatlink_args,
     const double act_path_coeff[6], void* inlink, void* fatlink, void* longlink)
@@ -273,10 +270,6 @@ void qudaLoadUnitarizedLink(int prec, QudaFatLinkArgs_t fatlink_args,
   qudamilc_called<false>(__func__);
 }
 
-#endif
-
-
-#ifdef GPU_HISQ_FORCE
 
 void qudaHisqForce(int prec, const double level2_coeff[6], const double fat7_coeff[6],
     const void* const staple_src[4], const void* const one_link_src[4], const void* const naik_src[4],
@@ -341,9 +334,7 @@ void qudaComputeOprod(int prec, int num_terms, double** coeff,
   return;
 }
 
-#endif // GPU_HISQ_FORCE
 
-#ifdef GPU_GAUGE_FORCE
 void  qudaUpdateU(int prec, double eps, void* momentum, void* link)
 {
   qudamilc_called<true>(__func__);
@@ -571,9 +562,7 @@ void qudaGaugeForce( int precision,
   return;
 }
 
-#endif // GPU_GAUGE_FORCE
 
-#if defined(GPU_STAGGERED_DIRAC) || defined(GPU_CLOVER_DIRAC)
 static int getFatLinkPadding(const int dim[4])
 {
   int padding = MAX(dim[1]*dim[2]*dim[3]/2, dim[0]*dim[2]*dim[3]/2);
@@ -581,9 +570,8 @@ static int getFatLinkPadding(const int dim[4])
   padding = MAX(padding, dim[0]*dim[1]*dim[2]/2);
   return padding;
 }
-#endif
 
-#ifdef GPU_STAGGERED_DIRAC
+
 // set the params for the single mass solver
 static void setInvertParams(const int dim[4],
     QudaPrecision cpu_prec,
@@ -1118,9 +1106,6 @@ void qudaEigCGInvert(int external_precision,
   return;
 } // qudaEigCGInvert
 
-#endif
-
-#ifdef GPU_CLOVER_DIRAC
 
 static int clover_alloc = 0;
 
@@ -1640,9 +1625,6 @@ void qudaCloverMultishiftInvert(int external_precision,
   return;
 } // qudaCloverMultishiftInvert
 
-#endif
-
-#ifdef GPU_GAUGE_ALG
 
 void qudaGaugeFixingOVR( int precision,
     unsigned int gauge_dir,
@@ -1707,7 +1689,5 @@ void qudaGaugeFixingFFT( int precision,
 
   return;
 }
-#endif // BUILD_GAUGE_ALG
-
 
 #endif // BUILD_MILC_INTERFACE

--- a/lib/milc_interface.cpp
+++ b/lib/milc_interface.cpp
@@ -573,6 +573,7 @@ void qudaGaugeForce( int precision,
 
 #endif // GPU_GAUGE_FORCE
 
+#if defined(GPU_STAGGERED_DIRAC) || defined(GPU_CLOVER_DIRAC)
 static int getFatLinkPadding(const int dim[4])
 {
   int padding = MAX(dim[1]*dim[2]*dim[3]/2, dim[0]*dim[2]*dim[3]/2);
@@ -580,7 +581,7 @@ static int getFatLinkPadding(const int dim[4])
   padding = MAX(padding, dim[0]*dim[1]*dim[2]/2);
   return padding;
 }
-
+#endif
 
 #ifdef GPU_STAGGERED_DIRAC
 // set the params for the single mass solver

--- a/lib/milc_interface.cpp
+++ b/lib/milc_interface.cpp
@@ -99,7 +99,7 @@ void qudaFinalize()
   endQuda();
   qudamilc_called<false>(__func__);
 }
-
+#ifdef MULTI_GPU
 /**
  *  Implements a lexicographical mapping of node coordinates to ranks,
  *  with t varying fastest.
@@ -114,7 +114,7 @@ static int rankFromCoords(const int *coords, void *fdata)
   }
   return rank;
 }
-
+#endif
 
 void qudaSetLayout(QudaLayout_t input)
 {

--- a/lib/milc_interface.cpp
+++ b/lib/milc_interface.cpp
@@ -905,8 +905,8 @@ void qudaInvert(int external_precision,
     exit(1);
   }
 
-  const bool use_mixed_precision = (((quda_precision==2) && inv_args.mixed_precision) ||
-                                     ((quda_precision==1) && (inv_args.mixed_precision==2) ) ) ? true : false;
+  //  const bool use_mixed_precision = (((quda_precision==2) && inv_args.mixed_precision) ||
+  //                                 ((quda_precision==1) && (inv_args.mixed_precision==2) ) ) ? true : false;
 
   // static const QudaVerbosity verbosity = getVerbosity();
   QudaPrecision host_precision = (external_precision == 2) ? QUDA_DOUBLE_PRECISION : QUDA_SINGLE_PRECISION;
@@ -1023,8 +1023,8 @@ void qudaEigCGInvert(int external_precision,
     exit(1);
   }
 
-  const bool use_mixed_precision = (((quda_precision==2) && inv_args.mixed_precision) ||
-                                     ((quda_precision==1) && (inv_args.mixed_precision==2) ) ) ? true : false;
+  // const bool use_mixed_precision = (((quda_precision==2) && inv_args.mixed_precision) ||
+  // ((quda_precision==1) && (inv_args.mixed_precision==2) ) ) ? true : false;
 
   // static const QudaVerbosity verbosity = getVerbosity();
   QudaPrecision host_precision = (external_precision == 2) ? QUDA_DOUBLE_PRECISION : QUDA_SINGLE_PRECISION;
@@ -1076,7 +1076,6 @@ void qudaEigCGInvert(int external_precision,
 
 
   QudaParity local_parity = inv_args.evenodd;
-  //double& target_res = (invertParam.residual_type == QUDA_L2_RELATIVE_RESIDUAL) ? target_residual : target_fermilab_residual;
   double& target_res = target_residual;
   double& target_res_hq = target_fermilab_residual;
   const double reliable_delta = 1e-1;
@@ -1511,6 +1510,7 @@ void qudaEigCGCloverInvert(int external_precision,
 
   invertParam.residual_type = (target_residual != 0) ? QUDA_L2_RELATIVE_RESIDUAL : QUDA_HEAVY_QUARK_RESIDUAL;
   invertParam.tol = (target_residual != 0) ? target_residual : target_fermilab_residual;
+  invertParam.reliable_delta = reliable_delta;
 
   //eigcg specific stuff:
   invertParam.rhs_idx = rhs_idx;

--- a/lib/pgauge_exchange.cu
+++ b/lib/pgauge_exchange.cu
@@ -136,6 +136,7 @@ namespace quda {
     }
   }
 
+#ifdef MULTI_GPU
   static void *send[4];
   static void *recv[4];
   static void *sendg[4];
@@ -159,8 +160,7 @@ namespace quda {
   static dim3 block[4];
   static dim3 grid[4];
   static bool notinitialized = true;
-
-
+#endif // MULTI_GPU
 
   /**
    * @brief Release all allocated memory used to exchange data between nodes

--- a/lib/quda_matrix.h
+++ b/lib/quda_matrix.h
@@ -147,6 +147,11 @@ namespace quda {
           return data[index<N>(j,k)];
         }
 
+	template<class U>
+	  __device__ __host__ inline void operator=(const Matrix<U,N> & b) {
+	  for(int i=0; i<N*N; i++) data[i] = b.data[i];
+	}
+
     };
 
   template<class T>

--- a/lib/reduce_quda.cu
+++ b/lib/reduce_quda.cu
@@ -732,7 +732,7 @@ namespace quda {
       Float2 a;
       Float2 b;
       ReduceType aux;
-      HeavyQuarkResidualNorm_(const Float2 &a, const Float2 &b) : a(a), b(b) { ; }
+      HeavyQuarkResidualNorm_(const Float2 &a, const Float2 &b) : a(a), b(b), aux{ } { ; }
 
       __device__ __host__ void pre() { aux.x = 0; aux.y = 0; }
 
@@ -771,7 +771,7 @@ namespace quda {
       Float2 a;
       Float2 b;
       ReduceType aux;
-      xpyHeavyQuarkResidualNorm_(const Float2 &a, const Float2 &b) : a(a), b(b) { ; }
+      xpyHeavyQuarkResidualNorm_(const Float2 &a, const Float2 &b) : a(a), b(b), aux{ } { ; }
 
       __device__ __host__ void pre() { aux.x = 0; aux.y = 0; }
 

--- a/lib/staggered_oprod.cu
+++ b/lib/staggered_oprod.cu
@@ -31,9 +31,11 @@ namespace quda {
     }
 
 
+#ifdef MULTI_GPU
   static cudaEvent_t packEnd;
   static cudaEvent_t gatherEnd[4];
   static cudaEvent_t scatterEnd[4];
+#endif
   static cudaEvent_t oprodStart;
   static cudaEvent_t oprodEnd;
 

--- a/lib/unitarize_links_quda.cu
+++ b/lib/unitarize_links_quda.cu
@@ -68,6 +68,17 @@ namespace{
     }
   };
 
+  void setUnitarizeLinksConstants(double unitarize_eps_, double max_error_,
+				  bool reunit_allow_svd_, bool reunit_svd_only_,
+				  double svd_rel_error_, double svd_abs_error_) {
+    unitarize_eps = unitarize_eps_;
+    max_error = max_error_;
+    reunit_allow_svd = reunit_allow_svd_;
+    reunit_svd_only = reunit_svd_only_;
+    svd_rel_error = svd_rel_error_;
+    svd_abs_error = svd_abs_error_;
+  }
+
 
   template<class Cmplx>
   __device__ __host__
@@ -500,17 +511,6 @@ void unitarizeLinks(cudaGaugeField& output, const cudaGaugeField &input, int* fa
 
   void unitarizeLinks(cudaGaugeField &links, int* fails) {
     unitarizeLinks(links, links, fails);
-  }
-
-  void setUnitarizeLinksConstants(double unitarize_eps_, double max_error_,
-				  bool reunit_allow_svd_, bool reunit_svd_only_,
-				  double svd_rel_error_, double svd_abs_error_) {
-    unitarize_eps = unitarize_eps_;
-    max_error = max_error_;
-    reunit_allow_svd = reunit_allow_svd_;
-    reunit_svd_only = reunit_svd_only_;
-    svd_rel_error = svd_rel_error_;
-    svd_abs_error = svd_abs_error_;
   }
 
 

--- a/lib/unitarize_links_quda.cu
+++ b/lib/unitarize_links_quda.cu
@@ -28,25 +28,46 @@ namespace{
 #define FL_UNITARIZE_PI23 FL_UNITARIZE_PI*0.66666666666666666666
 #endif 
  
-  __constant__ int DEV_MAX_ITER = 20;
+  static const int max_iter_newton = 20;
+  static const int max_iter = 20;
 
-  static int HOST_MAX_ITER = 20;
+  static double unitarize_eps = 1e-14;
+  static double max_error = 1e-10;
+  static int reunit_allow_svd = 1;
+  static int reunit_svd_only  = 0;
+  static double svd_rel_error = 1e-6;
+  static double svd_abs_error = 1e-6;
 
-  __constant__ double DEV_FL_MAX_ERROR;
-  __constant__ double DEV_FL_UNITARIZE_EPS;
-  __constant__ bool   DEV_FL_REUNIT_ALLOW_SVD;
-  __constant__ bool   DEV_FL_REUNIT_SVD_ONLY;
-  __constant__ double DEV_FL_REUNIT_SVD_REL_ERROR;
-  __constant__ double DEV_FL_REUNIT_SVD_ABS_ERROR;
-  __constant__ bool   DEV_FL_CHECK_UNITARIZATION;
+  template <typename Out, typename In>
+  struct UnitarizeLinksArg {
+    int threads; // number of active threads required
+    int X[4]; // grid dimensions
+    Out output;
+    const In input;
+    int *fails;
+    const int max_iter;
+    const double unitarize_eps;
+    const double max_error;
+    const int reunit_allow_svd;
+    const int reunit_svd_only;
+    const double svd_rel_error;
+    const double svd_abs_error;
+    const static bool check_unitarization = true;
 
-  static double HOST_FL_MAX_ERROR;
-  static double HOST_FL_UNITARIZE_EPS;
-  static bool   HOST_FL_REUNIT_ALLOW_SVD;
-  static bool   HOST_FL_REUNIT_SVD_ONLY;
-  static double HOST_FL_REUNIT_SVD_REL_ERROR;
-  static double HOST_FL_REUNIT_SVD_ABS_ERROR;
-  static bool   HOST_FL_CHECK_UNITARIZATION;
+    UnitarizeLinksArg(Out &output, const In &input, const GaugeField &data, int* fails,
+		      int max_iter, double unitarize_eps, double max_error,
+		      int reunit_allow_svd, int reunit_svd_only, double svd_rel_error,
+		      double svd_abs_error)
+      : output(output), input(input), fails(fails), unitarize_eps(unitarize_eps),
+	max_iter(max_iter), max_error(max_error), reunit_allow_svd(reunit_allow_svd),
+	reunit_svd_only(reunit_svd_only), svd_rel_error(svd_rel_error),
+	svd_abs_error(svd_abs_error)
+    {
+      for(int dir=0; dir<4; ++dir) X[dir] = data.X()[dir];
+      threads = X[0]*X[1]*X[2]*X[3];
+    }
+  };
+
 
   template<class Cmplx>
   __device__ __host__
@@ -102,9 +123,9 @@ namespace{
 
   // Compute the reciprocal square root of the matrix q
   // Also modify q if the eigenvalues are dangerously small.
-  template<class Float>
+  template<class Float, typename Arg>
   __device__  __host__ 
-  bool reciprocalRoot(const Matrix<complex<Float>,3>& q, Matrix<complex<Float>,3>* res){
+  bool reciprocalRoot(const Matrix<complex<Float>,3>& q, Matrix<complex<Float>,3>* res, Arg &arg){
 
     Matrix<complex<Float>,3> qsq, tempq;
 
@@ -126,24 +147,8 @@ namespace{
     Float r,s,theta;
     s = c[1]*one_third - c[0]*c[0]*one_eighteenth;
 
-#ifdef __CUDA_ARCH__
-#define FL_UNITARIZE_EPS DEV_FL_UNITARIZE_EPS
-#else
-#define FL_UNITARIZE_EPS HOST_FL_UNITARIZE_EPS
-#endif
-
-
-#ifdef __CUDA_ARCH__
-#define FL_REUNIT_SVD_REL_ERROR DEV_FL_REUNIT_SVD_REL_ERROR
-#define FL_REUNIT_SVD_ABS_ERROR DEV_FL_REUNIT_SVD_ABS_ERROR
-#else // cpu
-#define FL_REUNIT_SVD_REL_ERROR HOST_FL_REUNIT_SVD_REL_ERROR
-#define FL_REUNIT_SVD_ABS_ERROR HOST_FL_REUNIT_SVD_ABS_ERROR
-#endif
-
-
     Float cosTheta;
-    if(fabs(s) >= FL_UNITARIZE_EPS){ // faster when this conditional is removed?
+    if(fabs(s) >= arg.unitarize_eps){ // faster when this conditional is removed?
       const Float rsqrt_s = rsqrt(s);
       r = c[2]*0.5 - (c[0]*one_third)*(c[1] - c[0]*c[0]*one_ninth);
       cosTheta = r*rsqrt_s*rsqrt_s*rsqrt_s;
@@ -174,8 +179,8 @@ namespace{
     // Check the eigenvalues, if the determinant does not match the product of the eigenvalues
     // return false. Then call SVD instead.
     Float det = getDeterminant(q).x;
-    if( fabs(det) < FL_REUNIT_SVD_ABS_ERROR ) return false;
-    if( checkRelativeError(g[0]*g[1]*g[2],det,FL_REUNIT_SVD_REL_ERROR) == false ) return false;
+    if( fabs(det) < arg.svd_abs_error) return false;
+    if( checkRelativeError(g[0]*g[1]*g[2],det,arg.svd_rel_error) == false ) return false;
 
 
     // At this point we have finished with the c's 
@@ -206,20 +211,13 @@ namespace{
 
 
 
-  template<class Float>
+  template<class Float, typename Arg>
   __host__ __device__
-  bool unitarizeLinkMILC(const Matrix<complex<Float>,3>& in, Matrix<complex<Float>,3>* const result)
+  bool unitarizeLinkMILC(const Matrix<complex<Float>,3>& in, Matrix<complex<Float>,3>* const result, Arg &arg)
   {
     Matrix<complex<Float>,3> u;
-#ifdef __CUDA_ARCH__
-#define FL_REUNIT_SVD_ONLY  DEV_FL_REUNIT_SVD_ONLY
-#define FL_REUNIT_ALLOW_SVD DEV_FL_REUNIT_ALLOW_SVD
-#else
-#define FL_REUNIT_SVD_ONLY  HOST_FL_REUNIT_SVD_ONLY
-#define FL_REUNIT_ALLOW_SVD HOST_FL_REUNIT_ALLOW_SVD
-#endif
-    if( !FL_REUNIT_SVD_ONLY ){
-      if( reciprocalRoot<Float>(conj(in)*in,&u) ){
+    if( !arg.reunit_svd_only ){
+      if( reciprocalRoot<Float>(conj(in)*in,&u,arg) ){
 	*result = in*u;
 	return true;
       }
@@ -227,7 +225,7 @@ namespace{
 
     // If we've got this far, then the Caley-Hamilton unitarization 
     // has failed. If SVD is not allowed, the unitarization has failed.
-    if( !FL_REUNIT_ALLOW_SVD ) return false;
+    if( !arg.reunit_allow_svd ) return false;
 
     Matrix<complex<Float>,3> v;
     Float singular_values[3];
@@ -239,7 +237,8 @@ namespace{
 
   template<class Float>
   __host__ __device__
-  bool unitarizeLinkSVD(const Matrix<complex<Float>,3>& in, Matrix<complex<Float>,3>* const result)
+  bool unitarizeLinkSVD(const Matrix<complex<Float>,3>& in, Matrix<complex<Float>,3>* const result,
+			const double max_error)
   {
     Matrix<complex<Float>,3> u, v;
     Float singular_values[3];
@@ -247,40 +246,28 @@ namespace{
 
     *result = u*conj(v);
 
-#ifdef __CUDA_ARCH__ 
-#define FL_MAX_ERROR  DEV_FL_MAX_ERROR
-#else 
-#define FL_MAX_ERROR  HOST_FL_MAX_ERROR
-#endif
-    if(isUnitary(*result,FL_MAX_ERROR)==false)
+    if (isUnitary(*result,max_error)==false)
       {
 	printf("ERROR: Link unitarity test failed\n");
-	printf("TOLERANCE: %g\n", FL_MAX_ERROR);
+	printf("TOLERANCE: %g\n", max_error);
 	return false;
       }
     return true;
   }
-#undef FL_MAX_ERROR
 
 
   template<class Float>
   __host__ __device__
-  bool unitarizeLinkNewton(const Matrix<complex<Float>,3>& in, Matrix<complex<Float>,3>* const result)
+  bool unitarizeLinkNewton(const Matrix<complex<Float>,3>& in, Matrix<complex<Float>,3>* const result, int max_iter)
   {
     Matrix<complex<Float>,3> u, uinv;
     u = in;
 
-#ifdef __CUDA_ARCH__
-#define MAX_ITER DEV_MAX_ITER
-#else
-#define MAX_ITER HOST_MAX_ITER
-#endif
-    for(int i=0; i<MAX_ITER; ++i){
+    for(int i=0; i<max_iter; ++i){
       computeMatrixInverse(u, &uinv);
       u = 0.5*(u + conj(uinv));
     }
 
-#undef MAX_ITER	
     if(isUnitarizedLinkConsistent(in,u,0.0000001)==false)
       {
         printf("ERROR: Unitarized link is not consistent with incoming link\n");
@@ -303,11 +290,11 @@ namespace{
       for (int dir=0; dir<4; ++dir){
 	if (infield.Precision() == QUDA_SINGLE_PRECISION){
 	  copyArrayToLink(&inlink, ((float*)(infield.Gauge_p()) + (i*4 + dir)*18)); // order of arguments?
-	  if( unitarizeLinkNewton<double>(inlink, &outlink) == false ) num_failures++;
+	  if( unitarizeLinkNewton<double>(inlink, &outlink, max_iter_newton) == false ) num_failures++;
 	  copyLinkToArray(((float*)(outfield.Gauge_p()) + (i*4 + dir)*18), outlink); 
 	} else if (infield.Precision() == QUDA_DOUBLE_PRECISION){
 	  copyArrayToLink(&inlink, ((double*)(infield.Gauge_p()) + (i*4 + dir)*18)); // order of arguments?
-	  if( unitarizeLinkNewton<double>(inlink, &outlink) == false ) num_failures++;
+	  if( unitarizeLinkNewton<double>(inlink, &outlink, max_iter_newton) == false ) num_failures++;
 	  copyLinkToArray(((double*)(outfield.Gauge_p()) + (i*4 + dir)*18), outlink); 
 	} // precision?
       } // dir
@@ -342,23 +329,9 @@ namespace{
     return true;
   } // is unitary
 
-  template <typename Out, typename In>
-  struct UnitarizeLinksQudaArg {
-    int threads; // number of active threads required
-    int X[4]; // grid dimensions
-    Out output;
-    const In input;
-    int *fails;
-    UnitarizeLinksQudaArg(Out &output, const In &input, const GaugeField &data,  int* fails) 
-      : output(output), input(input), fails(fails) {
-      for(int dir=0; dir<4; ++dir) X[dir] = data.X()[dir];
-      threads = X[0]*X[1]*X[2]*X[3];
-    }
-  };
-
 
   template<typename Float, typename Out, typename In>
-  __global__ void DoUnitarizedLink(UnitarizeLinksQudaArg<Out,In> arg){
+  __global__ void DoUnitarizedLink(UnitarizeLinksArg<Out,In> arg){
     int idx = threadIdx.x + blockIdx.x*blockDim.x;
     if(idx >= arg.threads) return;
     int parity = 0;
@@ -377,34 +350,15 @@ namespace{
     Matrix<complex<Float>,3> tmp;
     for (int mu = 0; mu < 4; mu++) { 
       arg.input.load((Float*)(tmp.data),idx, mu, parity);
-      for(int i = 0; i < 9;i++) {
-        v.data[i].x = (double)tmp.data[i].x;
-        v.data[i].y = (double)tmp.data[i].y;
-      }
-      unitarizeLinkMILC(v, &result);
-#ifdef __CUDA_ARCH__
-#define FL_MAX_ERROR DEV_FL_MAX_ERROR
-#define FL_CHECK_UNITARIZATION DEV_FL_CHECK_UNITARIZATION
-#else
-#define FL_MAX_ERROR HOST_FL_MAX_ERROR
-#define FL_CHECK_UNITARIZATION HOST_FL_CHECK_UNITARIZATION
-#endif
-      if(FL_CHECK_UNITARIZATION){
-        if(isUnitary(result,FL_MAX_ERROR) == false)
-	  {
 
-#ifdef __CUDA_ARCH__
-	    atomicAdd(arg.fails, 1);
-#else 
-	    (*arg.fails)++;
-#endif
-	  }
+      v = tmp;
+      unitarizeLinkMILC(v, &result, arg);
+      if (arg.check_unitarization) {
+        if (isUnitary(result,arg.max_error) == false) atomicAdd(arg.fails, 1);
       }
       //WRITE BACK IF FAIL??????????
-      for(int i = 0; i < 9;i++) {
-	tmp.data[i].x = (Float)result.data[i].x;
-	tmp.data[i].y = (Float)result.data[i].y;
-      }
+      tmp = result;
+
       arg.output.save((Float*)(tmp.data),idx, mu, parity); 
     }
   }
@@ -412,8 +366,8 @@ namespace{
 
 
   template<typename Float, typename Out, typename In>
-  class UnitarizeLinksQuda : Tunable {    
-    UnitarizeLinksQudaArg<Out,In> arg;
+  class UnitarizeLinks : Tunable {
+    UnitarizeLinksArg<Out,In> arg;
     
     unsigned int sharedBytesPerThread() const { return 0; }
     unsigned int sharedBytesPerBlock(const TuneParam &) const { return 0; }
@@ -423,7 +377,7 @@ namespace{
     unsigned int minThreads() const { return arg.threads; }
     
   public:
-    UnitarizeLinksQuda(UnitarizeLinksQudaArg<Out,In> &arg) : arg(arg) { }
+    UnitarizeLinks(UnitarizeLinksArg<Out,In> &arg) : arg(arg) { }
     
     
     void apply(const cudaStream_t &stream){
@@ -437,7 +391,7 @@ namespace{
     }
     
     long long flops() const { 
-	  // Accounted only the minimum flops for the case FL_REUNIT_SVD_ONLY=0
+      // Accounted only the minimum flops for the case reunitarize_svd_only=0
       return 4588LL*arg.threads; 
     }
     long long bytes() const { return 4ll * arg.threads * (arg.input.Bytes() + arg.output.Bytes()); }
@@ -455,15 +409,16 @@ namespace{
   
   
   template<typename Float, typename Out, typename In>
-  void unitarizeLinksQuda(Out output,  const In input, const cudaGaugeField& meta, int* fails) {
-    UnitarizeLinksQudaArg<Out,In> arg(output, input, meta, fails);
-    UnitarizeLinksQuda<Float, Out, In> unitlinks(arg) ;
+  void unitarizeLinks(Out output,  const In input, const cudaGaugeField& meta, int* fails) {
+    UnitarizeLinksArg<Out,In> arg(output, input, meta, fails, max_iter, unitarize_eps, max_error,
+				      reunit_allow_svd, reunit_svd_only, svd_rel_error, svd_abs_error);
+    UnitarizeLinks<Float, Out, In> unitlinks(arg) ;
     unitlinks.apply(0);
     cudaDeviceSynchronize(); // need to synchronize to ensure failure write has completed
   }
   
 template<typename Float>
-void unitarizeLinksQuda(cudaGaugeField& output, const cudaGaugeField &input, int* fails) {
+void unitarizeLinks(cudaGaugeField& output, const cudaGaugeField &input, int* fails) {
 
   if( output.isNative() && input.isNative() ) {
     if(output.Reconstruct() == QUDA_RECONSTRUCT_NO) {
@@ -471,13 +426,13 @@ void unitarizeLinksQuda(cudaGaugeField& output, const cudaGaugeField &input, int
 
       if(input.Reconstruct() == QUDA_RECONSTRUCT_NO) {
 	typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_NO>::type In;
-	unitarizeLinksQuda<Float>(Out(output), In(input), input, fails) ;
+	unitarizeLinks<Float>(Out(output), In(input), input, fails) ;
       } else if(input.Reconstruct() == QUDA_RECONSTRUCT_12) {
 	typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_12>::type In;
-	unitarizeLinksQuda<Float>(Out(output), In(input), input, fails) ;
+	unitarizeLinks<Float>(Out(output), In(input), input, fails) ;
       } else if(input.Reconstruct() == QUDA_RECONSTRUCT_8) {
 	typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_8>::type In;
-	unitarizeLinksQuda<Float>(Out(output), In(input), input, fails) ;
+	unitarizeLinks<Float>(Out(output), In(input), input, fails) ;
       } else {
 	errorQuda("Reconstruction type %d of gauge field not supported", input.Reconstruct());
       }
@@ -487,13 +442,13 @@ void unitarizeLinksQuda(cudaGaugeField& output, const cudaGaugeField &input, int
 
       if(input.Reconstruct() == QUDA_RECONSTRUCT_NO) {
 	typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_NO>::type In;
-	unitarizeLinksQuda<Float>(Out(output), In(input), input, fails) ;
+	unitarizeLinks<Float>(Out(output), In(input), input, fails) ;
       } else if(input.Reconstruct() == QUDA_RECONSTRUCT_12) {
 	typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_12>::type In;
-	unitarizeLinksQuda<Float>(Out(output), In(input), input, fails) ;
+	unitarizeLinks<Float>(Out(output), In(input), input, fails) ;
       } else if(input.Reconstruct() == QUDA_RECONSTRUCT_8) {
 	typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_8>::type In;
-	unitarizeLinksQuda<Float>(Out(output), In(input), input, fails) ;
+	unitarizeLinks<Float>(Out(output), In(input), input, fails) ;
       } else {
 	errorQuda("Reconstruction type %d of gauge field not supported", input.Reconstruct());
       }
@@ -504,13 +459,13 @@ void unitarizeLinksQuda(cudaGaugeField& output, const cudaGaugeField &input, int
 
       if(input.Reconstruct() == QUDA_RECONSTRUCT_NO) {
 	typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_NO>::type In;
-	unitarizeLinksQuda<Float>(Out(output), In(input), input, fails) ;
+	unitarizeLinks<Float>(Out(output), In(input), input, fails) ;
       } else if(input.Reconstruct() == QUDA_RECONSTRUCT_12) {
 	typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_12>::type In;
-	unitarizeLinksQuda<Float>(Out(output), In(input), input, fails) ;
+	unitarizeLinks<Float>(Out(output), In(input), input, fails) ;
       } else if(input.Reconstruct() == QUDA_RECONSTRUCT_8) {
 	typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_8>::type In;
-	unitarizeLinksQuda<Float>(Out(output), In(input), input, fails) ;
+	unitarizeLinks<Float>(Out(output), In(input), input, fails) ;
       } else {
 	errorQuda("Reconstruction type %d of gauge field not supported", input.Reconstruct());
       }
@@ -526,15 +481,15 @@ void unitarizeLinksQuda(cudaGaugeField& output, const cudaGaugeField &input, int
   
 #endif
   
-  void unitarizeLinksQuda(cudaGaugeField& output, const cudaGaugeField &input, int* fails) {
+  void unitarizeLinks(cudaGaugeField& output, const cudaGaugeField &input, int* fails) {
 #ifdef GPU_UNITARIZE
     if (input.Precision() != output.Precision()) 
       errorQuda("input (%d) and output (%d) precisions must match", output.Precision(), input.Precision());
 
     if (input.Precision() == QUDA_SINGLE_PRECISION) {
-      unitarizeLinksQuda<float>(output, input, fails);
+      unitarizeLinks<float>(output, input, fails);
     } else if(input.Precision() == QUDA_DOUBLE_PRECISION) {
-      unitarizeLinksQuda<double>(output, input, fails);
+      unitarizeLinks<double>(output, input, fails);
     } else {
       errorQuda("Precision %d not supported", input.Precision());
     }
@@ -543,44 +498,19 @@ void unitarizeLinksQuda(cudaGaugeField& output, const cudaGaugeField &input, int
 #endif
   }
 
-  void unitarizeLinksQuda(cudaGaugeField &links, int* fails) {
-    unitarizeLinksQuda(links, links, fails);
+  void unitarizeLinks(cudaGaugeField &links, int* fails) {
+    unitarizeLinks(links, links, fails);
   }
 
-  void setUnitarizeLinksConstants(double unitarize_eps_h, double max_error_h, 
-				  bool allow_svd_h, bool svd_only_h,
-				  double svd_rel_error_h, double svd_abs_error_h, 
-				  bool check_unitarization_h)
-  {
-#ifdef GPU_UNITARIZE
-    // not_set is only initialised once
-    static bool not_set=true;
-		
-    if(not_set){
-      cudaMemcpyToSymbol(DEV_FL_UNITARIZE_EPS, &unitarize_eps_h, sizeof(double));
-      cudaMemcpyToSymbol(DEV_FL_REUNIT_ALLOW_SVD, &allow_svd_h, sizeof(bool));
-      cudaMemcpyToSymbol(DEV_FL_REUNIT_SVD_ONLY, &svd_only_h, sizeof(bool));
-      cudaMemcpyToSymbol(DEV_FL_REUNIT_SVD_REL_ERROR, &svd_rel_error_h, sizeof(double));
-      cudaMemcpyToSymbol(DEV_FL_REUNIT_SVD_ABS_ERROR, &svd_abs_error_h, sizeof(double));
-      cudaMemcpyToSymbol(DEV_FL_MAX_ERROR, &max_error_h, sizeof(double));
-      cudaMemcpyToSymbol(DEV_FL_CHECK_UNITARIZATION, &check_unitarization_h, sizeof(bool));
-	  
-
-      HOST_FL_UNITARIZE_EPS = unitarize_eps_h;
-      HOST_FL_REUNIT_ALLOW_SVD = allow_svd_h;
-      HOST_FL_REUNIT_SVD_ONLY = svd_only_h;
-      HOST_FL_REUNIT_SVD_REL_ERROR = svd_rel_error_h;
-      HOST_FL_REUNIT_SVD_ABS_ERROR = svd_abs_error_h;
-      HOST_FL_MAX_ERROR = max_error_h;     
-      HOST_FL_CHECK_UNITARIZATION = check_unitarization_h;
-
-      not_set = false;
-    }
-    checkCudaError();
-#else
-    errorQuda("Unitarization has not been built");
-#endif
-    return;
+  void setUnitarizeLinksConstants(double unitarize_eps_, double max_error_,
+				  bool reunit_allow_svd_, bool reunit_svd_only_,
+				  double svd_rel_error_, double svd_abs_error_) {
+    unitarize_eps = unitarize_eps_;
+    max_error = max_error_;
+    reunit_allow_svd = reunit_allow_svd_;
+    reunit_svd_only = reunit_svd_only_;
+    svd_rel_error = svd_rel_error_;
+    svd_abs_error = svd_abs_error_;
   }
 
 

--- a/tests/gauge_alg_test.cpp
+++ b/tests/gauge_alg_test.cpp
@@ -79,7 +79,7 @@ class GaugeAlgTest : public ::testing::Test {
 
 
   void CallUnitarizeLinks(cudaGaugeField *cudaInGauge){
-    unitarizeLinksQuda(*cudaInGauge, num_failures_dev);
+    unitarizeLinks(*cudaInGauge, num_failures_dev);
     cudaMemcpy(&num_failures, num_failures_dev, sizeof(int), cudaMemcpyDeviceToHost);
     if(num_failures>0){
       cudaFree(num_failures_dev);

--- a/tests/hisq_force_reference2.cpp
+++ b/tests/hisq_force_reference2.cpp
@@ -339,7 +339,6 @@ int LoadStore<Real>::half_idx_conversion_ex2normal(int half_lattice_index_ex, co
   int X2=dim[1];
   int X3=dim[2];
   //int X4=dim[3];
-  int X1h=X1/2;
   
   int E1=dim[0]+4;
   int E2=dim[1]+4;

--- a/tests/hisq_unitarize_force_test.cpp
+++ b/tests/hisq_unitarize_force_test.cpp
@@ -37,6 +37,8 @@ extern int device;
 extern int xdim, ydim, zdim, tdim;
 extern int gridsize_from_cmdline[];
 
+extern bool tune;
+
 extern QudaReconstructType link_recon;
 extern QudaPrecision prec;
 QudaPrecision link_prec = QUDA_SINGLE_PRECISION;
@@ -81,6 +83,7 @@ static void
 hisq_force_init()
 {
   initQuda(device);
+  setTuning(tune ? QUDA_TUNE_YES : QUDA_TUNE_NO);
 
   gaugeParam.X[0] = xdim;
   gaugeParam.X[1] = ydim;
@@ -168,12 +171,12 @@ hisq_force_test()
   cudaMemset(num_failures_dev, 0, sizeof(int));
 
   printfQuda("Calling unitarizeForceCuda\n");
-  fermion_force::unitarizeForceCuda(*cudaOprod, *cudaFatLink, cudaResult, num_failures_dev);
+  fermion_force::unitarizeForce(*cudaResult, *cudaOprod, *cudaFatLink, num_failures_dev);
 
 
   if(verify_results){
     printfQuda("Calling unitarizeForceCPU\n");
-    fermion_force::unitarizeForceCPU(*cpuOprod, *cpuFatLink, cpuResult);
+    fermion_force::unitarizeForceCPU(*cpuResult, *cpuOprod, *cpuFatLink);
   }
 
   cudaResult->saveCPUField(*cpuReference, QUDA_CPU_FIELD_LOCATION);

--- a/tests/multigrid_invert_test.cpp
+++ b/tests/multigrid_invert_test.cpp
@@ -416,7 +416,7 @@ int main(int argc, char **argv)
   size_t gSize = (gauge_param.cpu_prec == QUDA_DOUBLE_PRECISION) ? sizeof(double) : sizeof(float);
   size_t sSize = (inv_param.cpu_prec == QUDA_DOUBLE_PRECISION) ? sizeof(double) : sizeof(float);
 
-  void *gauge[4], *clover_inv=0, *clover=0;
+  void *gauge[4], *clover_inv=0;//, *clover=0;
 
   for (int dir = 0; dir < 4; dir++) {
     gauge[dir] = malloc(V*gaugeSiteSize*gSize);
@@ -449,12 +449,12 @@ int main(int argc, char **argv)
                          (inv_param.matpc_type == QUDA_MATPC_EVEN_EVEN_ASYMMETRIC ||
                           inv_param.matpc_type == QUDA_MATPC_ODD_ODD_ASYMMETRIC);
     if (!preconditioned) {
-      clover = clover_inv;
+      //clover = clover_inv;
       clover_inv = NULL;
     } else if (asymmetric) { // fake it by using the same random matrix
-      clover = clover_inv;   // for both clover and clover_inv
+      //clover = clover_inv;   // for both clover and clover_inv
     } else {
-      clover = NULL;
+      //clover = NULL;
     }
   }
 

--- a/tests/unitarize_link_test.cpp
+++ b/tests/unitarize_link_test.cpp
@@ -211,7 +211,7 @@ unitarize_link_test()
   struct timeval t0, t1;
 
   gettimeofday(&t0,NULL);
-  unitarizeLinksQuda(*cudaULink, *cudaFatLink, num_failures_dev);
+  unitarizeLinks(*cudaULink, *cudaFatLink, num_failures_dev);
   cudaDeviceSynchronize();
   gettimeofday(&t1,NULL);
 


### PR DESCRIPTION
This pull request is primary a clean up, and does the following:
* Fixes virtually all compiler warnings when compiling QUDA with cmake
* Force unitarization computation rewritten to use gauge-field accessors
* Force and link unitarization parameters are now set when running, rather than frozen at first instance.