### PR TITLE
Feature/async profile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -351,8 +351,6 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(SYSTEM ${CUDA_INCLUDE_DIRS})
 include_directories(include)
 include_directories(lib)
-get_directory_property(CUDA_NVCC_INCLUDE_DIRECTORIES INCLUDE_DIRECTORIES)
-MESSAGE(${CUDA_NVCC_INCLUDE_DIRECTORIES})
 
 # QUDA_HASH for tunecache
 file(STRINGS ${CUDA_TOOLKIT_INCLUDE}/cuda.h  CUDA_VERSIONLONG REGEX "\#define CUDA_VERSION" )

--- a/lib/tune.cpp
+++ b/lib/tune.cpp
@@ -117,10 +117,11 @@ namespace quda {
   /**
    * Serialize tunecache to an ostream, useful for writing to a file or sending to other nodes.
    */
-  static void serializeProfile(std::ostream &out)
+  static void serializeProfile(std::ostream &out, std::ostream &async_out)
   {
     map::iterator entry;
     double total_time = 0.0;
+    double async_total_time = 0.0;
 
     // first let's sort the entries in decreasing order of significance
     typedef std::pair<TuneKey, TuneParam> profile_t;
@@ -136,6 +137,7 @@ namespace quda {
       strncpy(tmp, key.aux, 6);
       bool is_policy = strcmp(tmp, "policy") == 0 ? true : false;
       if (param.n_calls > 0 && !is_policy) total_time += param.n_calls * param.time;
+      if (param.n_calls > 0 && is_policy) async_total_time += param.n_calls * param.time;
     }
 
 
@@ -146,6 +148,8 @@ namespace quda {
       char tmp[7];
       strncpy(tmp, key.aux,6);
       bool is_policy = strcmp(tmp, "policy") == 0 ? true : false;
+
+      // synchronous profile
       if (param.n_calls > 0 && !is_policy) {
 	double time = param.n_calls * param.time;
 
@@ -154,10 +158,20 @@ namespace quda {
 	out << key.name << "\t" << key.aux << "\t" << param.comment; // param.comment ends with a newline
       }
 
+      // async policy profile
+      if (param.n_calls > 0 && is_policy) {
+	double time = param.n_calls * param.time;
+
+	async_out << std::setw(12) << param.n_calls * param.time << "\t" << std::setw(12) << (time / async_total_time) * 100 << "\t";
+	async_out << std::setw(12) << param.n_calls << "\t" << std::setw(12) << param.time << "\t" << std::setw(16) << key.volume << "\t";
+	async_out << key.name << "\t" << key.aux << "\t" << param.comment; // param.comment ends with a newline
+      }
+
       q.pop();
     }
 
     out << std::endl << "# Total time spent in kernels = " << total_time << " seconds" << std::endl;
+    async_out << std::endl << "# Total time spent in asynchronous execution = " << async_total_time << " seconds" << std::endl;
   }
 
 
@@ -348,8 +362,8 @@ namespace quda {
   {
     time_t now;
     int lock_handle;
-    std::string lock_path, profile_path;
-    std::ofstream profile_file;
+    std::string lock_path, profile_path, async_profile_path;
+    std::ofstream profile_file, async_profile_file;
 
     if (resource_path.empty()) return;
 
@@ -373,6 +387,7 @@ namespace quda {
       if (stat == -1) warningQuda("Unable to write to lock file for some bizarre reason");
 
       char *profile_fname = getenv("QUDA_PROFILE_OUTPUT");
+      char *async_profile_fname = getenv("QUDA_ASYNC_PROFILE_OUTPUT");
 
       if (!profile_fname) {
 	warningQuda("Environment variable QUDA_PROFILE_OUTPUT is not set; writing to profile.tsv");
@@ -382,9 +397,18 @@ namespace quda {
       }
       profile_file.open(profile_path.c_str());
 
+      if (!async_profile_fname) {
+	warningQuda("Environment variable QUDA_ASYNC_PROFILE_OUTPUT is not set; writing to async_profile.tsv");
+	async_profile_path = resource_path + "/async_profile.tsv";
+      } else {
+	async_profile_path = resource_path + "/" + async_profile_fname;
+      }
+      async_profile_file.open(async_profile_path.c_str());
+
       if (verbosity >= QUDA_SUMMARIZE) {
 	// compute number of non-zero entries that will be output in the profile
 	int n_entry = 0;
+	int n_policy = 0;
 	for (map::iterator entry = tunecache.begin(); entry != tunecache.end(); entry++) {
 	  // if a policy entry, then we can ignore
 	  char tmp[6];
@@ -392,23 +416,37 @@ namespace quda {
 	  TuneParam param = entry->second;
 	  bool is_policy = strcmp(tmp, "policy") == 0 ? true : false;
 	  if (param.n_calls > 0 && !is_policy) n_entry++;
+	  if (param.n_calls > 0 && is_policy) n_policy++;
 	}
 
 	printfQuda("Saving %d sets of cached parameters to %s\n", n_entry, profile_path.c_str());
+	printfQuda("Saving %d sets of cached profiles to %s\n", n_policy, async_profile_path.c_str());
       }
 
       time(&now);
 
       profile_file << "profile\t" << quda_version;
 #ifdef GITVERSION
-       profile_file << "\t" << gitversion;
+      profile_file << "\t" << gitversion;
 #else
-       profile_file << "\t" << quda_version;
+      profile_file << "\t" << quda_version;
 #endif
       profile_file << "\t" << quda_hash << "\t# Last updated " << ctime(&now) << std::endl;
       profile_file << std::setw(12) << "total time" << "\t" << std::setw(12) << "percentage" << "\t" << std::setw(12) << "calls" << "\t" << std::setw(12) << "time / call" << "\t" << std::setw(16) << "volume" << "\tname\taux\tcomment" << std::endl;
-      serializeProfile(profile_file);
+
+      async_profile_file << "profile\t" << quda_version;
+#ifdef GITVERSION
+      async_profile_file << "\t" << gitversion;
+#else
+      async_profile_file << "\t" << quda_version;
+#endif
+      async_profile_file << "\t" << quda_hash << "\t# Last updated " << ctime(&now) << std::endl;
+      async_profile_file << std::setw(12) << "total time" << "\t" << std::setw(12) << "percentage" << "\t" << std::setw(12) << "calls" << "\t" << std::setw(12) << "time / call" << "\t" << std::setw(16) << "volume" << "\tname\taux\tcomment" << std::endl;
+
+      serializeProfile(profile_file, async_profile_file);
+
       profile_file.close();
+      async_profile_file.close();
 
       // Release lock.
       close(lock_handle);

--- a/lib/tune.cpp
+++ b/lib/tune.cpp
@@ -386,23 +386,17 @@ namespace quda {
       int stat = write(lock_handle, msg, sizeof(msg)); // check status to avoid compiler warning
       if (stat == -1) warningQuda("Unable to write to lock file for some bizarre reason");
 
-      char *profile_fname = getenv("QUDA_PROFILE_OUTPUT");
-      char *async_profile_fname = getenv("QUDA_ASYNC_PROFILE_OUTPUT");
+      char *profile_fname = getenv("QUDA_PROFILE_OUTPUT_BASE");
 
       if (!profile_fname) {
-	warningQuda("Environment variable QUDA_PROFILE_OUTPUT is not set; writing to profile.tsv");
+	warningQuda("Environment variable QUDA_PROFILE_OUTPUT_BASE is not set; writing to profile.tsv and profile_async.tsv");
 	profile_path = resource_path + "/profile.tsv";
+	async_profile_path = resource_path + "/profile_async.tsv";
       } else {
-	profile_path = resource_path + "/" + profile_fname;
+	profile_path = resource_path + "/" + profile_fname + ".tsv";
+	async_profile_path = resource_path + "/" + profile_fname + "_async.tsv";
       }
       profile_file.open(profile_path.c_str());
-
-      if (!async_profile_fname) {
-	warningQuda("Environment variable QUDA_ASYNC_PROFILE_OUTPUT is not set; writing to async_profile.tsv");
-	async_profile_path = resource_path + "/async_profile.tsv";
-      } else {
-	async_profile_path = resource_path + "/" + async_profile_fname;
-      }
       async_profile_file.open(async_profile_path.c_str());
 
       if (verbosity >= QUDA_SUMMARIZE) {


### PR DESCRIPTION
This pull adds asynchronous auto profiling to QUDA.  Similar to the regular (synchronous) profile that is created, this creates an ordered file that gives a breakdown of time spent in asynchronous policy execution.  At present, such policy reporting is only enabled for the various dslash kernels, where the time and performance for the entire dslash computation is reported, e.g., including all halo exchange and updates.  This thus complements the regular profile, since it reports sustained performance including communication, as opposed to GPU kernel performance.

As with the kernel profile, the filename for the asynchronous profile defaults to async_profile.tsv, but can be changed by setting the `QUDA_ASYNC_PROFILE_OUTPUT` environment variable.

E.g., example from BiCGstab mixed precision solver.  We can see the actual sustain dslash performance in the asynchronous profile is noticeably lower than the kernel performance.
```
  total time	  percentage	       calls	 time / call	          volume	name	aux	comment
    0.566682	     51.3247	        2000	 0.000283341	     12x24x24x24	N4quda16WilsonDslashCudaI6short4S1_EE	policy,comm=0011,reconstruct=8,Xpay	# 800.93 Gflop/s, 320.84 GB/s, tuned Wed Apr 27 23:03:53 2016
    0.507316	     45.9479	        2000	 0.000253658	     12x24x24x24	N4quda16WilsonDslashCudaI6short4S1_EE	policy,comm=0011,reconstruct=8	# 863.26 Gflop/s, 358.38 GB/s, tuned Wed Apr 27 23:03:53 2016
   0.0153385	     1.38922	          10	  0.00153385	     12x24x24x24	N4quda16WilsonDslashCudaI7double2S1_EE	policy,comm=0011,reconstruct=18,Xpay	# 147.95 Gflop/s, 290.71 GB/s, tuned Wed Apr 27 23:03:48 2016
   0.0147743	     1.33812	          10	  0.00147743	     12x24x24x24	N4quda16WilsonDslashCudaI7double2S1_EE	policy,comm=0011,reconstruct=18	# 148.21 Gflop/s, 301.81 GB/s, tuned Wed Apr 27 23:03:47 2016

# Total time spent in asynchronous execution = 1.10411 seconds
```

compared to the kernel execution profile

```
  total time	  percentage	       calls	 time / call	          volume	name	aux	comment
    0.847456	     33.9758	        1000	 0.000847456	     12x24x24x24	N4quda4blas31caxpbypzYmbwcDotProductUYNormY_I7double37double2S3_EE	vol=165888,stride=165888,precision=2,vol=165888,stride=165888,precision=8	# 84.56 Gflop/s, 71.25 GB/s, tun
ed Wed Apr 27 23:04:40 2016
    0.429312	     17.2118	        2000	 0.000214656	     12x24x24x24	N4quda16WilsonDslashCudaI6short4S1_EE	type=interior,comm=0011,ghost=0011,reconstruct=8,Xpay	# 1030.93 Gflop/s, 404.44 GB/s, tuned Wed Apr 27 23:03:53 2016
    0.373696	     14.9821	        2000	 0.000186848	     12x24x24x24	N4quda16WilsonDslashCudaI6short4S1_EE	type=interior,comm=0011,ghost=0011,reconstruct=8	# 1148.84 Gflop/s, 472.32 GB/s, tuned Wed Apr 27 23:03:53 2016
    0.231072	     9.26404	        1000	 0.000231072	     12x24x24x24	N4quda4blas9CdotNormAI7double36float26float4EE	vol=165888,stride=165888,precision=2	# 103.38 Gflop/s, 74.66 GB/s, tuned Wed Apr 27 23:04:36 2016
    0.183957	     7.37513	        1000	 0.000183957	     12x24x24x24	N4quda4blas4CdotI7double26float26float4EE	vol=165888,stride=165888,precision=2	# 86.57 Gflop/s, 93.78 GB/s, tuned Wed Apr 27 23:04:32 2016
    0.139936	     5.61025	        1000	 0.000139936	     12x24x24x24	N4quda4blas9cxpaypbz_I6float26float4EE	vol=165888,stride=165888,precision=2	# 227.61 Gflop/s, 246.57 GB/s, tuned Wed Apr 27 23:04:41 2016
    0.108715	     4.35856	        1000	 0.000108715	     12x24x24x24	N4quda4blas6caxpy_I6float26float4EE	vol=165888,stride=165888,precision=2	# 146.49 Gflop/s, 238.04 GB/s, tuned Wed Apr 27 23:04:33 2016
     0.05728	     2.29645	        2000	   2.864e-05	     12x24x24x24	N4quda16WilsonDslashCudaI6short4S1_EE	type=exterior_all,comm=0011,reconstruct=8,Xpay	# 196.93 Gflop/s, 142.87 GB/s, tuned Wed Apr 27 23:03:53 2016
    0.044928	     1.80123	        2000	  2.2464e-05	     12x24x24x24	N4quda16WilsonDslashCudaI6short4S1_EE	type=exterior_all,comm=0011,reconstruct=8	# 192.00 Gflop/s, 118.15 GB/s, tuned Wed Apr 27 23:03:53 2016
   0.0287147	     1.15122	        4000	 7.17867e-06	     12x24x24x24	N4quda14PackFaceWilsonI6short4fEE	vol=165888,stride=165888,precision=2,comm=0011,nFace=1	# 23.11 Gflop/s, 154.06 GB/s, tuned Wed Apr 27 23:03:53 2016
    0.013679	    0.548413	          10	   0.0013679	     12x24x24x24	N4quda16WilsonDslashCudaI7double2S1_EE	type=interior,comm=0011,ghost=0011,reconstruct=18,Xpay	# 161.78 Gflop/s, 313.37 GB/s, tuned Wed Apr 27 23:03:48 2016
   0.0130333	    0.522526	          10	  0.00130333	     12x24x24x24	N4quda16WilsonDslashCudaI7double2S1_EE	type=interior,comm=0011,ghost=0011,reconstruct=18	# 164.70 Gflop/s, 332.97 GB/s, tuned Wed Apr 27 23:03:47 2016
  0.00518256	    0.207777	           1	  0.00518256	  bytes=31850496	cudaMemcpyHostToDevice	loadSpinorField,/home/kate/github/quda-develop/lib/cuda_color_spinor_field.cu:521	# 0.00 Gflop/s, 6.15 GB/s, tuned Wed Apr 27 23:03:44 2016
  0.00485904	    0.194807	           1	  0.00485904	  bytes=31850496	cudaMemcpyDeviceToHost	saveSpinorField,/home/kate/github/quda-develop/lib/cuda_color_spinor_field.cu:557	# 0.00 Gflop/s, 6.55 GB/s, tuned Wed Apr 27 23:04:10 2016
  0.00371499	     0.14894	          10	 0.000371499	     12x24x24x24	N4quda4blas8xmyNorm2Id7double2S2_EE	vol=165888,stride=165888,precision=8	# 32.15 Gflop/s, 257.21 GB/s, tuned Wed Apr 27 23:03:51 2016
  0.00361579	    0.144963	          10	 0.000361579	     12x24x24x24	N4quda4blas4xpy_I7double2S2_EE	vol=165888,stride=165888,precision=8	# 11.01 Gflop/s, 264.26 GB/s, tuned Wed Apr 27 23:04:06 2016
  0.00177818	   0.0712902	          11	 0.000161653	     12x24x24x24	copyKernel	dst=vol=165888,stride=165888,precision=2,src=vol=165888,stride=165888,precision=8	# 0.00 Gflop/s, 250.39 GB/s, tuned Wed Apr 27 23:03:53 2016
  0.00101546	   0.0407115	           8	 0.000126933	     12x24x24x24	N4quda4blas5Norm2Id7double2S2_EE	vol=165888,stride=165888,precision=8	# 62.73 Gflop/s, 250.92 GB/s, tuned Wed Apr 27 23:03:46 2016
   0.0008128	   0.0325864	          10	   8.128e-05	     12x24x24x24	N4quda16WilsonDslashCudaI7double2S1_EE	type=exterior_all,comm=0011,reconstruct=18	# 53.06 Gflop/s, 146.95 GB/s, tuned Wed Apr 27 23:03:47 2016
    0.000464	   0.0186025	          10	    4.64e-05	     12x24x24x24	N4quda16WilsonDslashCudaI7double2S1_EE	type=exterior_z,comm=0011,reconstruct=18,Xpay	# 60.78 Gflop/s, 185.91 GB/s, tuned Wed Apr 27 23:03:48 2016
  0.00043936	   0.0176146	          10	  4.3936e-05	     12x24x24x24	N4quda16WilsonDslashCudaI7double2S1_EE	type=exterior_t,comm=0011,reconstruct=18,Xpay	# 64.19 Gflop/s, 196.34 GB/s, tuned Wed Apr 27 23:03:48 2016
 0.000286294	    0.011478	          20	 1.43147e-05	     12x24x24x24	N4quda14PackFaceWilsonI7double2dEE	vol=165888,stride=165888,precision=8,comm=0011,nFace=1	# 11.59 Gflop/s, 278.13 GB/s, tuned Wed Apr 27 23:03:46 2016
 0.000256032	   0.0102647	           1	 0.000256032	  bytes=31850496	cudaMemcpyDeviceToDevice	copy,/home/kate/github/quda-develop/lib/copy_quda.cu:127	# 0.00 Gflop/s, 248.80 GB/s, tuned Wed Apr 27 23:03:46 2016
  7.2224e-05	  0.00289557	           1	  7.2224e-05	   bytes=7962624	cudaMemcpyDeviceToDevice	copy,/home/kate/github/quda-develop/lib/copy_quda.cu:127	# 0.00 Gflop/s, 220.50 GB/s, tuned Wed Apr 27 23:03:53 2016
  1.3952e-05	 0.000559358	           1	  1.3952e-05	    bytes=663552	cudaMemcpyDeviceToDevice	copy,/home/kate/github/quda-develop/lib/copy_quda.cu:129	# 0.00 Gflop/s, 95.12 GB/s, tuned Wed Apr 27 23:03:53 2016

# Total time spent in kernels = 2.49429 seconds
```