### PR TITLE
Feature/axpy re dot

### DIFF
--- a/include/blas_quda.h
+++ b/include/blas_quda.h
@@ -37,6 +37,8 @@ namespace quda {
     void copy(ColorSpinorField &dst, const ColorSpinorField &src);
 
     double axpyNorm(const double &a, ColorSpinorField &x, ColorSpinorField &y);
+    double axpyReDot(const double &a, ColorSpinorField &x, ColorSpinorField &y);
+
     double reDotProduct(ColorSpinorField &x, ColorSpinorField &y);
     double2 reDotProductNormA(ColorSpinorField &a, ColorSpinorField &b);
 

--- a/lib/inv_multi_cg_quda.cpp
+++ b/lib/inv_multi_cg_quda.cpp
@@ -311,10 +311,9 @@ namespace quda {
       // iteration so that all shifts are updated during the dslash
       shift_update.updateNshift(num_offset_now);
 
-      // FIXME - this should be curried into the Dirac operator
-      if (r->Nspin()==4) blas::axpy(offset[0], *p[0], *Ap); 
-
-      pAp = blas::reDotProduct(*p[0], *Ap);
+      // at some point we should curry these into the Dirac operator
+      if (r->Nspin()==4) pAp = blas::axpyReDot(offset[0], *p[0], *Ap);
+      else pAp = blas::reDotProduct(*p[0], *Ap);
 
       // compute zeta and alpha
       updateAlphaZeta(alpha, zeta, zeta_old, r2, beta, pAp, offset, num_offset_now, j_low);

--- a/lib/reduce_quda.cu
+++ b/lib/reduce_quda.cu
@@ -351,7 +351,7 @@ namespace quda {
 
 
     /**
-       First performs the operation y[i] = a*x[i]
+       First performs the operation y[i] += a*x[i]
        Return the norm of y
     */
     template <typename ReduceType, typename Float2, typename FloatN>
@@ -366,6 +366,26 @@ namespace quda {
 
     double axpyNorm(const double &a, ColorSpinorField &x, ColorSpinorField &y) {
       return reduce::reduceCuda<double,QudaSumFloat,QudaSumFloat,axpyNorm2,0,1,0,0,0,false>
+	(make_double2(a, 0.0), make_double2(0.0, 0.0), x, y, x, x, x);
+    }
+
+
+    /**
+       First performs the operation y[i] += a*x[i]
+       Return real dot product (x,y)
+    */
+    template <typename ReduceType, typename Float2, typename FloatN>
+    struct AxpyReDot : public ReduceFunctor<ReduceType, Float2, FloatN> {
+      Float2 a;
+      AxpyReDot(const Float2 &a, const Float2 &b) : a(a) { ; }
+      __device__ __host__ void operator()(ReduceType &sum, FloatN &x, FloatN &y, FloatN &z, FloatN &w, FloatN &v) {
+	y += a.x*x; sum += dot_<ReduceType>(x,y); }
+      static int streams() { return 3; } //! total number of input and output streams
+      static int flops() { return 4; } //! flops per element
+    };
+
+    double axpyReDot(const double &a, ColorSpinorField &x, ColorSpinorField &y) {
+      return reduce::reduceCuda<double,QudaSumFloat,QudaSumFloat,AxpyReDot,0,1,0,0,0,false>
 	(make_double2(a, 0.0), make_double2(0.0, 0.0), x, y, x, x, x);
     }
 

--- a/tests/multigrid_invert_test.cpp
+++ b/tests/multigrid_invert_test.cpp
@@ -326,7 +326,6 @@ void setInvertParam(QudaInvertParam &inv_param) {
 
   // do we want to use an even-odd preconditioned solve or not
   inv_param.solve_type = solve_type;
-  //inv_param.solve_type = QUDA_DIRECT_SOLVE;
   inv_param.matpc_type = matpc_type;
 
   inv_param.inv_type = QUDA_GCR_INVERTER;
@@ -475,7 +474,11 @@ int main(int argc, char **argv)
 
   // load the clover term, if desired
   //if (dslash_type == QUDA_CLOVER_WILSON_DSLASH || dslash_type == QUDA_TWISTED_CLOVER_DSLASH) loadCloverQuda(clover, clover_inv, &inv_param);
+
+  // this line ensure that if we need to construct the clover inverse (in either the smoother or the solver) we do so
+  if (mg_param.smoother_solve_type[0] == QUDA_DIRECT_PC_SOLVE || solve_type == QUDA_DIRECT_PC_SOLVE) inv_param.solve_type = QUDA_DIRECT_PC_SOLVE;
   if (dslash_type == QUDA_CLOVER_WILSON_DSLASH || dslash_type == QUDA_TWISTED_CLOVER_DSLASH) loadCloverQuda(NULL, NULL, &inv_param);
+  inv_param.solve_type = solve_type; // restore actual solve_type we want to do
 
   // setup the multigrid solver
   void *mg_preconditioner = newMultigridQuda(&mg_param);


### PR DESCRIPTION
Small pull request:
* Introduce new blas function `axpyReDot` that does an `axpy` and returns the real dot product of the input `x` with the output `y`.
* Use this kernel to fuse adjacent `axpy` and `reDotProduct` calls in multi-shift solver (only for `nSpin=4`), giving a small performance boost.
* Fix for #450 (ensure that the clover term inverse is computed if we need it either for the outer solver or for the smoother in multigrid) 

This is ready for merge.