### PR TITLE
Feature/async dd

### DIFF
--- a/include/blas_quda.h
+++ b/include/blas_quda.h
@@ -69,7 +69,9 @@ namespace quda {
     double caxpyNorm(const Complex &a, ColorSpinorField &x, ColorSpinorField &y);
     void caxpyXmaz(const Complex &a, ColorSpinorField &x,
 		   ColorSpinorField &y, ColorSpinorField &z);
-    double caxpyXmazNormX(const Complex &a, ColorSpinorField &x, 
+    void caxpyXmazMR(const Complex &a, ColorSpinorField &x,
+		     ColorSpinorField &y, ColorSpinorField &z);
+    double caxpyXmazNormX(const Complex &a, ColorSpinorField &x,
 			  ColorSpinorField &y, ColorSpinorField &z);
     double cabxpyAxNorm(const double &a, const Complex &b, ColorSpinorField &x, ColorSpinorField &y);
 

--- a/include/cub_helper.cuh
+++ b/include/cub_helper.cuh
@@ -54,7 +54,10 @@ namespace quda {
       partial(static_cast<T*>(blas::getDeviceReduceBuffer())),
       result_d(static_cast<T*>(blas::getMappedHostReduceBuffer())),
       result_h(static_cast<T*>(blas::getHostReduceBuffer())) 
-    { }
+    {
+      //  write reduction to GPU memory if asynchronous
+      if (commAsyncReduction()) result_d = partial;
+    }
 
   };
 

--- a/include/face_quda.h
+++ b/include/face_quda.h
@@ -129,6 +129,9 @@ void commDimPartitionedSet(int dir);
 bool commGlobalReduction();
 void commGlobalReductionSet(bool global_reduce);
 
+bool commAsyncReduction();
+void commAsyncReductionSet(bool global_reduce);
+
 #ifdef __cplusplus
   extern "C" {
 #endif

--- a/lib/blas_core.h
+++ b/lib/blas_core.h
@@ -22,6 +22,9 @@ template <typename FloatN, int M, typename SpinorX, typename SpinorY,
   __global__ void blasKernel(BlasArg<SpinorX,SpinorY,SpinorZ,SpinorW,Functor> arg) {
   unsigned int i = blockIdx.x*(blockDim.x) + threadIdx.x;
   unsigned int gridSize = gridDim.x*blockDim.x;
+
+  arg.f.init();
+
   while (i < arg.length) {
     FloatN x[M], y[M], z[M], w[M];
     arg.X.load(x, i);

--- a/lib/blas_quda.cu
+++ b/lib/blas_quda.cu
@@ -501,8 +501,6 @@ namespace quda {
 	double3 result = __ldg(Ar3);
 	a.y = a.x * (real)(result.y) * ((real)1.0 / (real)result.z);
 	a.x = a.x * (real)(result.x) * ((real)1.0 / (real)result.z);
-#else
-	errorQuda("This kernel cannot be run on CPU fields");
 #endif
       }
 
@@ -517,6 +515,8 @@ namespace quda {
 		     ColorSpinorField &y, ColorSpinorField &z) {
       if (!commAsyncReduction())
 	errorQuda("This kernel requires asynchronous reductions to be set");
+      if (x.Location() == QUDA_CPU_FIELD_LOCATION)
+	errorQuda("This kernel cannot be run on CPU fields");
 
       blasCuda<caxpyxmazMR_,1,1,0,0>(make_double2(REAL(a), IMAG(a)), make_double2(0.0, 0.0),
 				     make_double2(0.0, 0.0), x, y, z, x);

--- a/lib/blas_quda.cu
+++ b/lib/blas_quda.cu
@@ -76,15 +76,25 @@ namespace quda {
 #include <blas_mixed_core.h>
 
 
+    template <typename Float2, typename FloatN>
+    struct BlasFunctor {
+
+      //! pre-computation routine before the main loop
+      virtual __device__ __host__ void init() { ; }
+
+      //! where the reduction is usually computed and any auxiliary operations
+      virtual __device__ __host__ void operator()(FloatN &x, FloatN &y, FloatN &z, FloatN &w) = 0;
+    };
+
     /**
        Functor to perform the operation y = a*x + b*y
     */
     template <typename Float2, typename FloatN>
-    struct axpby_ {
+    struct axpby_ : public BlasFunctor<Float2,FloatN> {
       const Float2 a;
       const Float2 b;
       axpby_(const Float2 &a, const Float2 &b, const Float2 &c) : a(a), b(b) { ; }
-      __device__ __host__ void operator()(const FloatN &x, FloatN &y, const FloatN &z, const FloatN &w) 
+      __device__ __host__ void operator()(FloatN &x, FloatN &y, FloatN &z, FloatN &w)
       { y = a.x*x + b.x*y; }
       static int streams() { return 3; } //! total number of input and output streams
       static int flops() { return 3; } //! flops per element
@@ -105,9 +115,9 @@ namespace quda {
        Functor to perform the operation y += x
     */
     template <typename Float2, typename FloatN>
-    struct xpy_ {
+    struct xpy_ : public BlasFunctor<Float2,FloatN> {
       xpy_(const Float2 &a, const Float2 &b, const Float2 &c) { ; }
-      __device__ __host__ void operator()(const FloatN &x, FloatN &y, const FloatN &z, const FloatN &w) { y += x ; }
+      __device__ __host__ void operator()(FloatN &x, FloatN &y, FloatN &z, FloatN &w) { y += x ; }
       static int streams() { return 3; } //! total number of input and output streams
       static int flops() { return 1; } //! flops per element
     };
@@ -121,10 +131,10 @@ namespace quda {
        Functor to perform the operation y += a*x
     */
     template <typename Float2, typename FloatN>
-    struct axpy_ {
+    struct axpy_ : public BlasFunctor<Float2,FloatN> {
       const Float2 a;
       axpy_(const Float2 &a, const Float2 &b, const Float2 &c) : a(a) { ; }
-      __device__ __host__ void operator()(const FloatN &x, FloatN &y, const FloatN &z, const FloatN &w) { y = a.x*x + y; }
+      __device__ __host__ void operator()(FloatN &x, FloatN &y, FloatN &z, FloatN &w) { y = a.x*x + y; }
       static int streams() { return 3; } //! total number of input and output streams
       static int flops() { return 2; } //! flops per element
     };
@@ -144,10 +154,10 @@ namespace quda {
        Functor to perform the operation y = x + a*y
     */
     template <typename Float2, typename FloatN>
-    struct xpay_ {
+    struct xpay_ : public BlasFunctor<Float2,FloatN> {
       const Float2 a;
       xpay_(const Float2 &a, const Float2 &b, const Float2 &c) : a(a) { ; }
-      __device__ __host__ void operator()(const FloatN &x, FloatN &y, const FloatN &z, const FloatN &w) { y = x + a.x*y; }
+      __device__ __host__ void operator()(FloatN &x, FloatN &y, FloatN &z, FloatN &w) { y = x + a.x*y; }
       static int streams() { return 3; } //! total number of input and output streams
       static int flops() { return 2; } //! flops per element
     };
@@ -161,9 +171,9 @@ namespace quda {
        Functor to perform the operation y -= x;
     */
     template <typename Float2, typename FloatN>
-    struct mxpy_ {
+    struct mxpy_ : public BlasFunctor<Float2,FloatN> {
       mxpy_(const Float2 &a, const Float2 &b, const Float2 &c) { ; }
-      __device__ __host__ void operator()(const FloatN &x, FloatN &y, const FloatN &z, const FloatN &w) { y -= x; }
+      __device__ __host__ void operator()(FloatN &x, FloatN &y, FloatN &z, FloatN &w) { y -= x; }
       static int streams() { return 3; } //! total number of input and output streams
       static int flops() { return 1; } //! flops per element
     };
@@ -177,10 +187,10 @@ namespace quda {
        Functor to perform the operation x *= a
     */
     template <typename Float2, typename FloatN>
-    struct ax_ {
+    struct ax_ : public BlasFunctor<Float2,FloatN> {
       const Float2 a;
       ax_(const Float2 &a, const Float2 &b, const Float2 &c) : a(a) { ; }
-      __device__ __host__ void operator()(FloatN &x, const FloatN &y, const FloatN &z, const FloatN &w) { x *= a.x; }
+      __device__ __host__ void operator()(FloatN &x, FloatN &y, FloatN &z, FloatN &w) { x *= a.x; }
       static int streams() { return 2; } //! total number of input and output streams
       static int flops() { return 1; } //! flops per element
     };
@@ -212,10 +222,10 @@ namespace quda {
     }
 
     template <typename Float2, typename FloatN>
-    struct caxpy_ {
+    struct caxpy_ : public BlasFunctor<Float2,FloatN> {
       const Float2 a;
       caxpy_(const Float2 &a, const Float2 &b, const Float2 &c) : a(a) { ; }
-      __device__ __host__ void operator()(const FloatN &x, FloatN &y, const FloatN &z, const FloatN &w) 
+      __device__ __host__ void operator()(FloatN &x, FloatN &y, FloatN &z, FloatN &w)
       { _caxpy(a, x, y); }
       static int streams() { return 3; } //! total number of input and output streams
       static int flops() { return 4; } //! flops per element
@@ -251,11 +261,11 @@ namespace quda {
       y = yy; }
 
     template <typename Float2, typename FloatN>
-    struct caxpby_ {
+    struct caxpby_ : public BlasFunctor<Float2,FloatN> {
       const Float2 a;
       const Float2 b;
       caxpby_(const Float2 &a, const Float2 &b, const Float2 &c) : a(a), b(b) { ; }
-      __device__ __host__ void operator()(const FloatN &x, FloatN &y, const FloatN &z, const FloatN &w) 
+      __device__ __host__ void operator()(FloatN &x, FloatN &y, FloatN &z, FloatN &w)
       { _caxpby(a, x, b, y); }
       static int streams() { return 3; } //! total number of input and output streams
       static int flops() { return 7; } //! flops per element
@@ -294,11 +304,11 @@ namespace quda {
     }
 
     template <typename Float2, typename FloatN>
-    struct cxpaypbz_ {
+    struct cxpaypbz_ : public BlasFunctor<Float2,FloatN> {
       const Float2 a;
       const Float2 b;
       cxpaypbz_(const Float2 &a, const Float2 &b, const Float2 &c) : a(a), b(b) { ; }
-      __device__ __host__ void operator()(const FloatN &x, const FloatN &y, FloatN &z, FloatN &w) 
+      __device__ __host__ void operator()(FloatN &x, FloatN &y, FloatN &z, FloatN &w)
       { _cxpaypbz(x, a, y, b, z); }
       static int streams() { return 4; } //! total number of input and output streams
       static int flops() { return 8; } //! flops per element
@@ -314,12 +324,12 @@ namespace quda {
        Functor performing the operations: y[i] = a*x[i] + y[i]; x[i] = b*z[i] + c*x[i]
     */
     template <typename Float2, typename FloatN>
-    struct axpyBzpcx_ {
+    struct axpyBzpcx_ : public BlasFunctor<Float2,FloatN> {
       const Float2 a;
       const Float2 b;
       const Float2 c;
       axpyBzpcx_(const Float2 &a, const Float2 &b, const Float2 &c) : a(a), b(b), c(c) { ; }
-      __device__ __host__ void operator()(FloatN &x, FloatN &y, const FloatN &z, const FloatN &w)
+      __device__ __host__ void operator()(FloatN &x, FloatN &y, FloatN &z, FloatN &w)
       { y += a.x*x; x = b.x*z + c.x*x; }
       static int streams() { return 5; } //! total number of input and output streams
       static int flops() { return 10; } //! flops per element
@@ -342,11 +352,11 @@ namespace quda {
        Functor performing the operations: y[i] = a*x[i] + y[i]; x[i] = z[i] + b*x[i]
     */
     template <typename Float2, typename FloatN>
-    struct axpyZpbx_ {
+    struct axpyZpbx_ : public BlasFunctor<Float2,FloatN> {
       const Float2 a;
       const Float2 b;
       axpyZpbx_(const Float2 &a, const Float2 &b, const Float2 &c) : a(a), b(b) { ; }
-      __device__ __host__ void operator()(FloatN &x, FloatN &y, const FloatN &z, const FloatN &w)
+      __device__ __host__ void operator()(FloatN &x, FloatN &y, FloatN &z, FloatN &w)
       { y += a.x*x; x = z + b.x*x; }
       static int streams() { return 5; } //! total number of input and output streams
       static int flops() { return 8; } //! flops per element
@@ -369,11 +379,11 @@ namespace quda {
        Functor performing the operations z[i] = a*x[i] + b*y[i] + z[i] and y[i] -= b*w[i]
     */
     template <typename Float2, typename FloatN>
-    struct caxpbypzYmbw_ {
+    struct caxpbypzYmbw_ : public BlasFunctor<Float2,FloatN> {
       const Float2 a;
       const Float2 b;
       caxpbypzYmbw_(const Float2 &a, const Float2 &b, const Float2 &c) : a(a), b(b) { ; }
-      __device__ __host__ void operator()(const FloatN &x, FloatN &y, FloatN &z, const FloatN &w)
+      __device__ __host__ void operator()(FloatN &x, FloatN &y, FloatN &z, FloatN &w)
       { _caxpy(a, x, z); _caxpy(b, y, z); _caxpy(-b, w, y); }
 
       static int streams() { return 6; } //! total number of input and output streams
@@ -390,11 +400,11 @@ namespace quda {
        Functor performing the operation y[i] += a*b*x[i], x[i] *= a
     */
     template <typename Float2, typename FloatN>
-    struct cabxpyAx_ {
+    struct cabxpyAx_ : public BlasFunctor<Float2,FloatN> {
       const Float2 a;
       const Float2 b;
       cabxpyAx_(const Float2 &a, const Float2 &b, const Float2 &c) : a(a), b(b) { ; }
-      __device__ __host__ void operator()(FloatN &x, FloatN &y, const FloatN &z, const FloatN &w) 
+      __device__ __host__ void operator()(FloatN &x, FloatN &y, FloatN &z, FloatN &w)
       { x *= a.x; _caxpy(b, x, y); }
       static int streams() { return 4; } //! total number of input and output streams
       static int flops() { return 5; } //! flops per element
@@ -411,11 +421,11 @@ namespace quda {
        Functor performing the operation z[i] = a*x[i] + b*y[i] + z[i]
     */
     template <typename Float2, typename FloatN>
-    struct caxpbypz_ {
+    struct caxpbypz_ : public BlasFunctor<Float2,FloatN> {
       const Float2 a;
       const Float2 b;
       caxpbypz_(const Float2 &a, const Float2 &b, const Float2 &c) : a(a), b(b) { ; }
-      __device__ __host__ void operator()(const FloatN &x, const FloatN &y, FloatN &z, const FloatN &w) 
+      __device__ __host__ void operator()(FloatN &x, FloatN &y, FloatN &z, FloatN &w)
       { _caxpy(a, x, z); _caxpy(b, y, z); }
       static int streams() { return 4; } //! total number of input and output streams
       static int flops() { return 5; } //! flops per element
@@ -431,12 +441,12 @@ namespace quda {
        Functor Performing the operation w[i] = a*x[i] + b*y[i] + c*z[i] + w[i]
     */
     template <typename Float2, typename FloatN>
-    struct caxpbypczpw_ {
+    struct caxpbypczpw_ : public BlasFunctor<Float2,FloatN> {
       const Float2 a;
       const Float2 b;
       const Float2 c;
       caxpbypczpw_(const Float2 &a, const Float2 &b, const Float2 &c) : a(a), b(b), c(c) { ; }
-      __device__ __host__ void operator()(const FloatN &x, const FloatN &y, const FloatN &z, FloatN &w) 
+      __device__ __host__ void operator()(FloatN &x, FloatN &y, FloatN &z, FloatN &w)
       { _caxpy(a, x, w); _caxpy(b, y, w); _caxpy(c, z, w); }
 
       static int streams() { return 4; } //! total number of input and output streams
@@ -457,10 +467,10 @@ namespace quda {
        Second performs the operator x[i] -= a*z[i]
     */
     template <typename Float2, typename FloatN>
-    struct caxpyxmaz_ {
+    struct caxpyxmaz_ : public BlasFunctor<Float2,FloatN> {
       Float2 a;
       caxpyxmaz_(const Float2 &a, const Float2 &b, const Float2 &c) : a(a) { ; }
-      __device__ __host__ void operator()(FloatN &x, FloatN &y, const FloatN &z, const FloatN &w) 
+      __device__ __host__ void operator()(FloatN &x, FloatN &y, FloatN &z, FloatN &w)
       { _caxpy(a, x, y); _caxpy(-a, z, x); }
       static int streams() { return 5; } //! total number of input and output streams
       static int flops() { return 8; } //! flops per element
@@ -473,6 +483,46 @@ namespace quda {
     }
 
     /**
+       double caxpyXmazMR(c a, V x, V y, V z){}
+
+       First performs the operation y[i] += a*x[i]
+       Second performs the operator x[i] -= a*z[i]
+    */
+    template <typename Float2, typename FloatN>
+    struct caxpyxmazMR_ : public BlasFunctor<Float2,FloatN> {
+      Float2 a;
+      double3 *Ar3;
+      caxpyxmazMR_(const Float2 &a, const Float2 &b, const Float2 &c)
+	: a(a), Ar3(static_cast<double3*>(blas::getDeviceReduceBuffer())) { ; }
+
+      inline __device__ __host__ void init() {
+#ifdef __CUDA_ARCH__
+	typedef decltype(a.x) real;
+	double3 result = __ldg(Ar3);
+	a.y = a.x * (real)(result.y) * ((real)1.0 / (real)result.z);
+	a.x = a.x * (real)(result.x) * ((real)1.0 / (real)result.z);
+#else
+	errorQuda("This kernel cannot be run on CPU fields");
+#endif
+      }
+
+      __device__ __host__ void operator()(FloatN &x, FloatN &y, FloatN &z, FloatN &w)
+      { _caxpy(a, x, y); _caxpy(-a, z, x); }
+
+      static int streams() { return 5; } //! total number of input and output streams
+      static int flops() { return 8; } //! flops per element
+    };
+
+    void caxpyXmazMR(const Complex &a, ColorSpinorField &x,
+		     ColorSpinorField &y, ColorSpinorField &z) {
+      if (!commAsyncReduction())
+	errorQuda("This kernel requires asynchronous reductions to be set");
+
+      blasCuda<caxpyxmazMR_,1,1,0,0>(make_double2(REAL(a), IMAG(a)), make_double2(0.0, 0.0),
+				     make_double2(0.0, 0.0), x, y, z, x);
+    }
+
+    /**
        double tripleCGUpdate(d a, d b, V x, V y, V z, V w){}
    
        First performs the operation y[i] = y[i] + a*w[i]
@@ -480,10 +530,10 @@ namespace quda {
        Third performs the operation w[i] = z[i] + b*w[i]
     */
     template <typename Float2, typename FloatN>
-    struct tripleCGUpdate_ {
+    struct tripleCGUpdate_ : public BlasFunctor<Float2,FloatN> {
       Float2 a, b;
       tripleCGUpdate_(const Float2 &a, const Float2 &b, const Float2 &c) : a(a), b(b) { ; }
-      __device__ __host__ void operator()(const FloatN &x, FloatN &y, FloatN &z, FloatN &w) 
+      __device__ __host__ void operator()(FloatN &x, FloatN &y, FloatN &z, FloatN &w)
       //{ y -= a.x*x; z += a.x*w; w = y + b.x*w; }
       { y += a.x*w; z -= a.x*x; w = z + b.x*w; }
       static int streams() { return 7; } //! total number of input and output streams

--- a/lib/cuda_color_spinor_field.cu
+++ b/lib/cuda_color_spinor_field.cu
@@ -589,20 +589,23 @@ namespace quda {
   void cudaColorSpinorField::allocateGhostBuffer(int nFace) {
     if (!ghostInit || nFace != nFaceComms) {
 
-      if (nFace != nFaceComms) {
+      size_t ghost_bytes_old = ghost_bytes;
+
+      createGhostZone(nFace);
+
+      if (ghost_bytes_old != ghost_bytes) {
 #ifdef USE_TEXTURE_OBJECTS
 	destroyGhostTexObject();
 #endif
 	if (ghostInit && ghost_bytes) device_free(ghost_field);
-      }
 
-      createGhostZone(nFace);
+	// all fields create their own unique ghost zone
+	if (ghost_bytes) ghost_field = device_malloc(ghost_bytes);
 
-      // all fields create their own unique ghost zone
-      if (ghost_bytes) ghost_field = device_malloc(ghost_bytes);
 #ifdef USE_TEXTURE_OBJECTS
-      createGhostTexObject();
+	createGhostTexObject();
 #endif
+      }
 
       // initialize the ghost pointers
       if (siteSubset == QUDA_PARITY_SITE_SUBSET) {

--- a/lib/face_buffer.cpp
+++ b/lib/face_buffer.cpp
@@ -402,6 +402,7 @@ void FaceBuffer::scatter(cudaColorSpinorField &out, int dagger, int dir){
 
 
 static bool globalReduce = true;
+static bool asyncReduce = false;
 
 void reduceMaxDouble(double &max) { comm_allreduce_max(&max); }
 
@@ -421,3 +422,7 @@ void commDimPartitionedSet(int dir) { comm_dim_partitioned_set(dir);}
 bool commGlobalReduction() { return globalReduce; }
 
 void commGlobalReductionSet(bool global_reduction) { globalReduce = global_reduction; }
+
+bool commAsyncReduction() { return asyncReduce; }
+
+void commAsyncReductionSet(bool async_reduction) { asyncReduce = async_reduction; }

--- a/lib/reduce_core.cuh
+++ b/lib/reduce_core.cuh
@@ -82,16 +82,16 @@ doubleN reduceLaunch(ReductionArg<ReduceType,SpinorX,SpinorY,SpinorZ,SpinorW,Spi
 
   LAUNCH_KERNEL(reduceKernel,tp,stream,arg,ReduceType,ReduceSimpleType,FloatN,M);
 
+  if (!commAsyncReduction()) {
 #if (defined(_MSC_VER) && defined(_WIN64)) || defined(__LP64__)
-  if(deviceProp.canMapHostMemory) {
-    cudaEventRecord(reduceEnd, stream);
-    while (cudaSuccess != cudaEventQuery(reduceEnd)) { ; }
-  } else
+    if(deviceProp.canMapHostMemory) {
+      cudaEventRecord(reduceEnd, stream);
+      while (cudaSuccess != cudaEventQuery(reduceEnd)) { ; }
+    } else
 #endif
-    { cudaMemcpy(h_reduce, hd_reduce, sizeof(ReduceType), cudaMemcpyDeviceToHost); }
-
+      { cudaMemcpy(h_reduce, hd_reduce, sizeof(ReduceType), cudaMemcpyDeviceToHost); }
+  }
   doubleN cpu_sum = set(((ReduceType*)h_reduce)[0]);
-
   return cpu_sum;
 }
 


### PR DESCRIPTION
This pull request is an improvement to the strong scaling of domain-decomposition:
* Added support for asynchronous reductions where the reduced values are written to GPU instead of host-mapped memory, and the control thread does not wait for the kernel to finish
* Added support for a custom blas routine, `caxpyXmazMR` that sources part of its `a` coefficient from GPU memory, hence must be used in conjunction with a prior asynchronous reduction
* Deployed both of the above to enable a fully asynchronous minimal residual solver for domain decomposition.  This improves strong scaling of the domain decomposition preconditioner.
* Also fixes a minor issue with the ghost zone, where the ghost zone was being unnecessarily freed and reallocated.