### PR TITLE
Hotfix/multinode spinor compare

### DIFF
--- a/lib/color_spinor_util.cu
+++ b/lib/color_spinor_util.cu
@@ -177,6 +177,10 @@ namespace quda {
       }
     }
 
+    // reduce over all processes
+    for (int i=0; i<N; i++) comm_allreduce_int(&iter[i]);
+    for (int f=0; f<fail_check; f++) comm_allreduce_int(&fail[f]);
+
     for (int i=0; i<N; i++) printfQuda("%d fails = %d\n", i, iter[i]);
 
     int accuracy_level =0;
@@ -184,9 +188,10 @@ namespace quda {
       if (fail[f] == 0) accuracy_level = f+1;
     }
 
+    size_t total = u.Nparity()*u.VolumeCB()*N*comm_size();
     for (int f=0; f<fail_check; f++) {
-      printfQuda("%e Failures: %d / %d  = %e\n", pow(10.0,-(f+1)/(double)tol), 
-		 fail[f], u.Nparity()*u.VolumeCB()*N, fail[f] / (double)(u.Nparity()*u.VolumeCB()*N));
+      printfQuda("%e Failures: %d / %lu  = %e\n", pow(10.0,-(f+1)/(double)tol),
+		 fail[f], total, fail[f] / (double)total);
     }
 
     delete []iter;

--- a/lib/tune.cpp
+++ b/lib/tune.cpp
@@ -133,7 +133,7 @@ namespace quda {
       TuneKey key = entry->first;
       TuneParam param = entry->second;
 
-      char tmp[7];
+      char tmp[7] = { };
       strncpy(tmp, key.aux, 6);
       bool is_policy = strcmp(tmp, "policy") == 0 ? true : false;
       if (param.n_calls > 0 && !is_policy) total_time += param.n_calls * param.time;
@@ -145,8 +145,8 @@ namespace quda {
       TuneKey key = q.top().first;
       TuneParam param = q.top().second;
 
-      char tmp[7];
-      strncpy(tmp, key.aux,6);
+      char tmp[7] = { };
+      strncpy(tmp, key.aux, 6);
       bool is_policy = strcmp(tmp, "policy") == 0 ? true : false;
 
       // synchronous profile
@@ -405,7 +405,7 @@ namespace quda {
 	int n_policy = 0;
 	for (map::iterator entry = tunecache.begin(); entry != tunecache.end(); entry++) {
 	  // if a policy entry, then we can ignore
-	  char tmp[6];
+	  char tmp[7] = { };
 	  strncpy(tmp, entry->first.aux, 6);
 	  TuneParam param = entry->second;
 	  bool is_policy = strcmp(tmp, "policy") == 0 ? true : false;


### PR DESCRIPTION
This minor fix ensures that the results `ColorSpinorField::Compare` is consistent across all processes, thus ensuring that failures are correctly reported in dslash_test if they do not occur in process 0.

Also fixes a valgrind initialization warning.