### PR TITLE
When calling comm_abort() in (HOST)DEBUG builds raise SIGINT

### DIFF
--- a/include/util_quda.h
+++ b/include/util_quda.h
@@ -27,6 +27,7 @@ void popVerbosity();
 
 char *getPrintBuffer();
 
+
 // Note that __func__ is part of C++11 and has long been supported by GCC.
 
 #define zeroThread (threadIdx.x + blockDim.x*blockIdx.x==0)
@@ -86,7 +87,7 @@ char *getPrintBuffer();
   fprintf(getOutputFile(), "%s       last kernel called was (name=%s,volume=%s,aux=%s)\n", \
 	  getOutputPrefix(), getLastTuneKey().name,			     \
 	  getLastTuneKey().volume, getLastTuneKey().aux);		     \
-  exit(1);								     \
+  comm_abort(1);								     \
 } while (0)
 
 #define warningQuda(...) do {                                 \

--- a/lib/comm_qmp.cpp
+++ b/lib/comm_qmp.cpp
@@ -1,5 +1,5 @@
 #include <qmp.h>
-
+#include <csignal>
 #include <quda_internal.h>
 #include <comm_quda.h>
 
@@ -289,11 +289,11 @@ void comm_start(MsgHandle *mh)
 
 void comm_wait(MsgHandle *mh)
 {
-  QMP_CHECK( QMP_wait(mh->handle) ); 
+  QMP_CHECK( QMP_wait(mh->handle) );
 }
 
 
-int comm_query(MsgHandle *mh) 
+int comm_query(MsgHandle *mh)
 {
   return (QMP_is_complete(mh->handle) == QMP_TRUE);
 }
@@ -302,13 +302,13 @@ int comm_query(MsgHandle *mh)
 void comm_allreduce(double* data)
 {
   QMP_CHECK( QMP_sum_double(data) );
-} 
+}
 
 
 void comm_allreduce_max(double* data)
 {
   QMP_CHECK( QMP_max_double(data) );
-} 
+}
 
 
 void comm_allreduce_array(double* data, size_t size)
@@ -331,11 +331,14 @@ void comm_broadcast(void *data, size_t nbytes)
 
 void comm_barrier(void)
 {
-  QMP_CHECK( QMP_barrier() );  
+  QMP_CHECK( QMP_barrier() );
 }
 
 
 void comm_abort(int status)
 {
+  #ifdef HOST_DEBUG
+  raise(SIGINT);
+  #endif
   QMP_abort(status);
 }

--- a/lib/comm_single.cpp
+++ b/lib/comm_single.cpp
@@ -3,6 +3,7 @@
  */
 
 #include <stdlib.h>
+#include <csignal>
 #include <comm_quda.h>
 
 void comm_init(int ndim, const int *dims, QudaCommsMap rank_from_coords, void *map_data)
@@ -21,18 +22,18 @@ int comm_size(void) { return 1; }
 
 int comm_gpuid(void) { return 0; }
 
-MsgHandle *comm_declare_send_displaced(void *buffer, const int displacement[], size_t nbytes) 
+MsgHandle *comm_declare_send_displaced(void *buffer, const int displacement[], size_t nbytes)
 { return NULL; }
 
-MsgHandle *comm_declare_receive_displaced(void *buffer, const int displacement[], size_t nbytes) 
+MsgHandle *comm_declare_receive_displaced(void *buffer, const int displacement[], size_t nbytes)
 { return NULL; }
 
-MsgHandle *comm_declare_strided_send_displaced(void *buffer, const int displacement[], 
-					       size_t blksize, int nblocks, size_t stride) 
+MsgHandle *comm_declare_strided_send_displaced(void *buffer, const int displacement[],
+					       size_t blksize, int nblocks, size_t stride)
 { return NULL; }
 
-MsgHandle *comm_declare_strided_receive_displaced(void *buffer, const int displacement[], 
-						  size_t blksize, int nblocks, size_t stride) 
+MsgHandle *comm_declare_strided_receive_displaced(void *buffer, const int displacement[],
+						  size_t blksize, int nblocks, size_t stride)
 { return NULL; }
 
 void comm_free(MsgHandle *mh) {}
@@ -55,4 +56,9 @@ void comm_broadcast(void *data, size_t nbytes) {}
 
 void comm_barrier(void) {}
 
-void comm_abort(int status) { exit(status); }
+void comm_abort(int status) {
+  #ifdef HOST_DEBUG
+  raise(SIGINT);
+  #endif
+  exit(status);
+}


### PR DESCRIPTION
This allows to attach gdb to the process to e.g. get a backtrace where the error was caused, e.g. like

```
ERROR: wrong here (rank 0, host nvsocal2, /home/mathias/quda/tests/invert_test.cpp:126 in main())
       last kernel called was (name=,volume=,aux=)
Program received signal SIGINT, Interrupt.
0x00007ffff7bcc20b in raise (sig=2) at ../nptl/sysdeps/unix/sysv/linux/pt-raise.c:37
37      ../nptl/sysdeps/unix/sysv/linux/pt-raise.c: No such file or directory.
(gdb) bt
#0  0x00007ffff7bcc20b in raise (sig=2) at ../nptl/sysdeps/unix/sysv/linux/pt-raise.c:37
#1  0x000000000194dd6d in comm_abort (status=1) at /home/mathias/quda/lib/comm_mpi.cpp:339
#2  0x00000000018bf0f1 in main (argc=1, argv=0x7fffffffe558) at /home/mathias/quda/tests/invert_test.cpp:126

```

I did not do a lot of testing whether this somehow interferes with MPI but I believe it should be find and is anyway only enabled for (HOST)DEBUG builds.