### PR TITLE
Hotfix/milc clover coeff

### DIFF
--- a/include/quda_constants.h
+++ b/include/quda_constants.h
@@ -1,5 +1,5 @@
 #define QUDA_VERSION_MAJOR     0
-#define QUDA_VERSION_MINOR     8
+#define QUDA_VERSION_MINOR     9
 #define QUDA_VERSION_SUBMINOR  0
 
 /**

--- a/lib/milc_interface.cpp
+++ b/lib/milc_interface.cpp
@@ -1424,6 +1424,7 @@ void qudaCloverInvert(int external_precision,
   invertParam.tol =  target_residual;
   invertParam.tol_hq = target_fermilab_residual;
   if (invertParam.residual_type == QUDA_HEAVY_QUARK_RESIDUAL) invertParam.heavy_quark_check = 1;
+  invertParam.clover_coeff = clover_coeff;
 
   // solution types
   invertParam.solution_type      = QUDA_MAT_SOLUTION;


### PR DESCRIPTION
This pull fixes #477 and also bumps the version number to 0.9.0, since the present develop branch corresponds to the future 0.9.0 release.