### PR TITLE
Feature/stag multi src

### DIFF
--- a/include/color_spinor_field.h
+++ b/include/color_spinor_field.h
@@ -136,11 +136,13 @@ namespace quda {
 	    inv_param.dslash_type == QUDA_MOBIUS_DWF_DSLASH) {
 	  nDim++;
 	  x[4] = inv_param.Ls;
-	}
-	else if(inv_param.dslash_type == QUDA_TWISTED_MASS_DSLASH && (twistFlavor == QUDA_TWIST_NONDEG_DOUBLET)){
+	} else if (inv_param.dslash_type == QUDA_TWISTED_MASS_DSLASH && (twistFlavor == QUDA_TWIST_NONDEG_DOUBLET)) {
 	  nDim++;
 	  x[4] = 2;//for two flavors
-    	}
+	} else if (inv_param.dslash_type == QUDA_STAGGERED_DSLASH || inv_param.dslash_type == QUDA_ASQTAD_DSLASH) {
+	  nDim++;
+	  x[4] = inv_param.Ls;
+	}
 
 	if (inv_param.dirac_order == QUDA_INTERNAL_DIRAC_ORDER) {
 	  fieldOrder = (precision == QUDA_DOUBLE_PRECISION || nSpin == 1) ? 

--- a/include/color_spinor_field_order.h
+++ b/include/color_spinor_field_order.h
@@ -123,11 +123,12 @@ namespace quda {
 	accessor(field), ghostAccessor(field)
       { 
 	for (int d=0; d<4; d++) {
-	  x[d]=field.X(d); 
 	  void * const *_ghost = ghost_ ? ghost_ : field.Ghost();
 	  ghost[2*d+0] = static_cast<complex<Float>*>(_ghost[2*d+0]);
 	  ghost[2*d+1] = static_cast<complex<Float>*>(_ghost[2*d+1]);
 	}
+
+	for (int d=0; d<QUDA_MAX_DIM; d++) x[d]=field.X(d);
       }
 
       /**

--- a/lib/dirac_improved_staggered.cpp
+++ b/lib/dirac_improved_staggered.cpp
@@ -53,8 +53,8 @@ namespace quda {
 		in.SiteSubset(), out.SiteSubset());
     }
 
-    if ((out.Volume() != 2*fatGauge.VolumeCB() && out.SiteSubset() == QUDA_FULL_SITE_SUBSET) ||
-	(out.Volume() != fatGauge.VolumeCB() && out.SiteSubset() == QUDA_PARITY_SITE_SUBSET) ) {
+    if ((out.Volume()/out.X(4) != 2*fatGauge.VolumeCB() && out.SiteSubset() == QUDA_FULL_SITE_SUBSET) ||
+	(out.Volume()/out.X(4) != fatGauge.VolumeCB() && out.SiteSubset() == QUDA_PARITY_SITE_SUBSET) ) {
       errorQuda("Spinor volume %d doesn't match gauge volume %d", out.Volume(), fatGauge.VolumeCB());
     }
   }

--- a/lib/dirac_improved_staggered.cpp
+++ b/lib/dirac_improved_staggered.cpp
@@ -40,6 +40,10 @@ namespace quda {
 
   void DiracImprovedStaggered::checkParitySpinor(const ColorSpinorField &in, const ColorSpinorField &out) const
   {
+    if (in.Ndim() != 5 || out.Ndim() != 5) {
+      errorQuda("Staggered dslash requires 5-d fermion fields");
+    }
+
     if (in.Precision() != out.Precision()) {
       errorQuda("Input and output spinor precisions don't match in dslash_quda");
     }

--- a/lib/dirac_staggered.cpp
+++ b/lib/dirac_staggered.cpp
@@ -34,6 +34,10 @@ namespace quda {
 
   void DiracStaggered::checkParitySpinor(const ColorSpinorField &in, const ColorSpinorField &out) const
   {
+    if (in.Ndim() != 5 || out.Ndim() != 5) {
+      errorQuda("Staggered dslash requires 5-d fermion fields");
+    }
+
     if (in.Precision() != out.Precision()) {
       errorQuda("Input and output spinor precisions don't match in dslash_quda");
     }
@@ -45,6 +49,11 @@ namespace quda {
     if (in.SiteSubset() != QUDA_PARITY_SITE_SUBSET || out.SiteSubset() != QUDA_PARITY_SITE_SUBSET) {
       errorQuda("ColorSpinorFields are not single parity, in = %d, out = %d", 
 		in.SiteSubset(), out.SiteSubset());
+    }
+
+    if ((out.Volume()/out.X(4) != 2*gauge->VolumeCB() && out.SiteSubset() == QUDA_FULL_SITE_SUBSET) ||
+	(out.Volume()/out.X(4) != gauge->VolumeCB() && out.SiteSubset() == QUDA_PARITY_SITE_SUBSET) ) {
+      errorQuda("Spinor volume %d doesn't match gauge volume %d", out.Volume(), gauge->VolumeCB());
     }
   }
 
@@ -61,7 +70,7 @@ namespace quda {
 			  dagger, 0, 0, commDim, profile);
     } else {
       errorQuda("Not supported");
-    }  
+    }
 
     flops += 570ll*in.Volume();
   }

--- a/lib/dslash_constants.h
+++ b/lib/dslash_constants.h
@@ -13,9 +13,7 @@ enum KernelType {
     int threads; // the desired number of active threads
     int parity;  // Even-Odd or Odd-Even
     int X[4];
-#ifdef GPU_DOMAIN_WALL_DIRAC 
     int Ls;
-#endif
     KernelType kernel_type; //is it INTERIOR_KERNEL, EXTERIOR_KERNEL_X/Y/Z/T
     int commDim[QUDA_MAX_DIM]; // Whether to do comms or not
     int ghostDim[QUDA_MAX_DIM]; // Whether a ghost zone has been allocated for a given dimension

--- a/lib/dslash_core/staggered_dslash_core.h
+++ b/lib/dslash_core/staggered_dslash_core.h
@@ -436,11 +436,11 @@ if (threadId.z & 1)
 #ifdef MULTI_GPU
     if ( (kernel_type == EXTERIOR_KERNEL_X)){
       int space_con = ((y[3]*X[2]+y[2])*X[1]+y[1])/2;	
-      nbr_idx1 = param.ghostOffset[0][1] +(y[0]-(X[0]-1))*ghostFace[0]+ space_con;
-      stride1 = NFACE*ghostFace[0];
+      nbr_idx1 = param.ghostOffset[0][1] + src_idx*NFACE*ghostFace[0] + (y[0]-(X[0]-1))*ghostFace[0]+ space_con;
+      stride1 = NFACE*ghostFace[0]*param.Ls;
 #if (DD_PREC == 2) //half precision
-      norm_idx1 = param.ghostNormOffset[0][1] + (y[0]-(X[0]-1))*ghostFace[0]+ space_con;
-#endif		    
+      norm_idx1 = param.ghostNormOffset[0][1] + src_idx*NFACE*ghostFace[0] + (y[0]-(X[0]-1))*ghostFace[0]+ space_con;
+#endif
       READ_1ST_NBR_SPINOR(GHOSTSPINORTEX, nbr_idx1, stride1);
       RECONSTRUCT_FAT_GAUGE_MATRIX(0, fat, sp_idx_1st_nbr, fat_sign);
       MAT_MUL_V(A, fat, i);    
@@ -482,10 +482,10 @@ if (threadId.z & 1)
 #ifdef MULTI_GPU
     if ( (kernel_type == EXTERIOR_KERNEL_X)){
       int space_con = ((y[3]*X[2]+y[2])*X[1] + y[1])/2;		
-      nbr_idx3 = param.ghostOffset[0][1] + (y[0]-(X[0]-3))*ghostFace[0]+ space_con;
-      stride3 = NFACE*ghostFace[0];
+      nbr_idx3 = param.ghostOffset[0][1] + src_idx*NFACE*ghostFace[0] + (y[0]-(X[0]-3))*ghostFace[0]+ space_con;
+      stride3 = NFACE*ghostFace[0]*param.Ls;
 #if (DD_PREC == 2) //half precision
-      norm_idx3 = param.ghostNormOffset[0][1] + (y[0]-(X[0]-3))*ghostFace[0]+ space_con;
+      norm_idx3 = param.ghostNormOffset[0][1] + src_idx*NFACE*ghostFace[0] + (y[0]-(X[0]-3))*ghostFace[0]+ space_con;
 #endif	
       READ_3RD_NBR_SPINOR(T, GHOSTSPINORTEX, nbr_idx3, stride3);
     } else
@@ -541,10 +541,10 @@ if (!(threadIdx.z & 1))
 #endif	 
 #ifdef MULTI_GPU
     if (kernel_type == EXTERIOR_KERNEL_X){
-      nbr_idx1 = param.ghostOffset[0][0] + (y[0]+NFACE-1)*ghostFace[0]+ space_con;
-      stride1 = NFACE*ghostFace[0];
+      nbr_idx1 = param.ghostOffset[0][0] +  src_idx*NFACE*ghostFace[0] + (y[0]+NFACE-1)*ghostFace[0]+ space_con;
+      stride1 = NFACE*ghostFace[0]*param.Ls;
 #if (DD_PREC == 2) //half precision
-      norm_idx1 = param.ghostNormOffset[0][0]  + (y[0]+NFACE-1)*ghostFace[0]+ space_con;
+      norm_idx1 = param.ghostNormOffset[0][0] + src_idx*NFACE*ghostFace[0] + (y[0]+NFACE-1)*ghostFace[0]+ space_con;
 #endif	
       READ_1ST_NBR_SPINOR(GHOSTSPINORTEX, nbr_idx1, stride1);
       RECONSTRUCT_FAT_GAUGE_MATRIX(1, fat, sp_idx_1st_nbr, fat_sign);
@@ -593,10 +593,10 @@ if (!(threadIdx.z & 1))
     spinorFloat2 T0, T1, T2;
 #ifdef MULTI_GPU
     if (kernel_type == EXTERIOR_KERNEL_X){
-      nbr_idx3 = param.ghostOffset[0][0] + y[0]*ghostFace[0]+ space_con;
-      stride3 = NFACE*ghostFace[0];
+      nbr_idx3 = param.ghostOffset[0][0] + src_idx*NFACE*ghostFace[0] + y[0]*ghostFace[0]+ space_con;
+      stride3 = NFACE*ghostFace[0]*param.Ls;
 #if (DD_PREC == 2) //half precision
-      norm_idx3 = param.ghostNormOffset[0][0]  + y[0]*ghostFace[0]+ space_con;
+      norm_idx3 = param.ghostNormOffset[0][0] + src_idx*NFACE*ghostFace[0] + y[0]*ghostFace[0]+ space_con;
 #endif
       READ_3RD_NBR_SPINOR(T, GHOSTSPINORTEX, nbr_idx3, stride3);  
     } else
@@ -647,10 +647,10 @@ if (threadIdx.z & 1)
 #endif	 
 #ifdef MULTI_GPU
     if (kernel_type == EXTERIOR_KERNEL_Y){	    
-      nbr_idx1 = param.ghostOffset[1][1] + (y[1]-(X[1]-1))*ghostFace[1]+ space_con;
-      stride1 = NFACE*ghostFace[1];
+      nbr_idx1 = param.ghostOffset[1][1] +  src_idx*NFACE*ghostFace[1] + (y[1]-(X[1]-1))*ghostFace[1]+ space_con;
+      stride1 = NFACE*ghostFace[1]*param.Ls;
 #if (DD_PREC == 2) //half precision
-      norm_idx1 = param.ghostNormOffset[1][1] + (y[1]-(X[1]-1))*ghostFace[1]+ space_con;
+      norm_idx1 = param.ghostNormOffset[1][1] + src_idx*NFACE*ghostFace[1] + (y[1]-(X[1]-1))*ghostFace[1]+ space_con;
 #endif		    
       READ_1ST_NBR_SPINOR(GHOSTSPINORTEX, nbr_idx1, stride1);
       RECONSTRUCT_FAT_GAUGE_MATRIX(2, fat, sp_idx_1st_nbr, fat_sign);
@@ -693,10 +693,10 @@ if (threadIdx.z & 1)
     spinorFloat2 T0, T1, T2;
 #ifdef MULTI_GPU
     if (kernel_type == EXTERIOR_KERNEL_Y){
-      nbr_idx3 = param.ghostOffset[1][1] + (y[1]-(X[1]-3))*ghostFace[1]+ space_con;
-      stride3 = NFACE*ghostFace[1];
+      nbr_idx3 = param.ghostOffset[1][1] + src_idx*NFACE*ghostFace[1] + (y[1]-(X[1]-3))*ghostFace[1]+ space_con;
+      stride3 = NFACE*ghostFace[1]*param.Ls;
 #if (DD_PREC == 2) //half precision
-      norm_idx3 = param.ghostNormOffset[1][1] + (y[1]-(X[1]-3))*ghostFace[1]+ space_con;
+      norm_idx3 = param.ghostNormOffset[1][1] + src_idx*NFACE*ghostFace[1] + (y[1]-(X[1]-3))*ghostFace[1]+ space_con;
 #endif		    
       READ_3RD_NBR_SPINOR(T, GHOSTSPINORTEX, nbr_idx3, stride3);
     } else
@@ -751,10 +751,10 @@ if (!(threadIdx.z & 1))
 #endif	 
 #ifdef MULTI_GPU
     if (kernel_type == EXTERIOR_KERNEL_Y){
-      nbr_idx1 = param.ghostOffset[1][0] + (y[1]+NFACE-1)*ghostFace[1]+ space_con;
-      stride1 = NFACE*ghostFace[1];
+      nbr_idx1 = param.ghostOffset[1][0] + src_idx*NFACE*ghostFace[1] + (y[1]+NFACE-1)*ghostFace[1]+ space_con;
+      stride1 = NFACE*ghostFace[1]*param.Ls;
 #if (DD_PREC == 2) //half precision
-      norm_idx1 = param.ghostNormOffset[1][0]  + (y[1]+NFACE-1)*ghostFace[1]+ space_con;
+      norm_idx1 = param.ghostNormOffset[1][0] + src_idx*NFACE*ghostFace[1] + (y[1]+NFACE-1)*ghostFace[1]+ space_con;
 #endif	
       READ_1ST_NBR_SPINOR(GHOSTSPINORTEX, nbr_idx1, stride1);
       RECONSTRUCT_FAT_GAUGE_MATRIX(3, fat, sp_idx_1st_nbr, fat_sign);
@@ -803,10 +803,10 @@ if (!(threadIdx.z & 1))
     spinorFloat2 T0, T1, T2;
 #ifdef MULTI_GPU
     if (kernel_type == EXTERIOR_KERNEL_Y){
-      nbr_idx3 = param.ghostOffset[1][0] + y[1]*ghostFace[1]+ space_con;
-      stride3 = NFACE*ghostFace[1];
+      nbr_idx3 = param.ghostOffset[1][0] + src_idx*NFACE*ghostFace[1] + y[1]*ghostFace[1]+ space_con;
+      stride3 = NFACE*ghostFace[1]*param.Ls;
 #if (DD_PREC == 2) //half precision
-      norm_idx3 = param.ghostNormOffset[1][0]  + y[1]*ghostFace[1]+ space_con;
+      norm_idx3 = param.ghostNormOffset[1][0] + src_idx*NFACE*ghostFace[1] + y[1]*ghostFace[1]+ space_con;
 #endif
       READ_3RD_NBR_SPINOR(T, GHOSTSPINORTEX, nbr_idx3, stride3);
     } else
@@ -855,10 +855,10 @@ if (threadIdx.z&1)
 #endif	 
 #ifdef MULTI_GPU
     if (kernel_type == EXTERIOR_KERNEL_Z){	
-      nbr_idx1 = param.ghostOffset[2][1] + (y[2]-(X[2]-1))*ghostFace[2]+ space_con;
-      stride1 = NFACE*ghostFace[2];	    
+      nbr_idx1 = param.ghostOffset[2][1]  + src_idx*NFACE*ghostFace[2] + (y[2]-(X[2]-1))*ghostFace[2]+ space_con;
+      stride1 = NFACE*ghostFace[2]*param.Ls;
 #if (DD_PREC == 2) //half precision
-      norm_idx1 = param.ghostNormOffset[2][1] + (y[2]-(X[2]-1))*ghostFace[2]+ space_con;
+      norm_idx1 = param.ghostNormOffset[2][1] + src_idx*NFACE*ghostFace[2] + (y[2]-(X[2]-1))*ghostFace[2]+ space_con;
 #endif		
       READ_1ST_NBR_SPINOR(GHOSTSPINORTEX, nbr_idx1, stride1);
       RECONSTRUCT_FAT_GAUGE_MATRIX(4, fat, sp_idx_1st_nbr, fat_sign);
@@ -901,10 +901,10 @@ if (threadIdx.z&1)
     spinorFloat2 T0, T1, T2;
 #ifdef MULTI_GPU
     if (kernel_type == EXTERIOR_KERNEL_Z){
-      nbr_idx3 = param.ghostOffset[2][1] + (y[2]-(X[2]-3))*ghostFace[2]+ space_con;
-      stride3 = NFACE*ghostFace[2];
+      nbr_idx3 = param.ghostOffset[2][1] + src_idx*NFACE*ghostFace[2] + (y[2]-(X[2]-3))*ghostFace[2]+ space_con;
+      stride3 = NFACE*ghostFace[2]*param.Ls;
 #if (DD_PREC == 2) //half precision
-      norm_idx3 = param.ghostNormOffset[2][1] + (y[2]-(X[2]-3))*ghostFace[2]+ space_con;
+      norm_idx3 = param.ghostNormOffset[2][1] + src_idx*NFACE*ghostFace[2] + (y[2]-(X[2]-3))*ghostFace[2]+ space_con;
 #endif
       READ_3RD_NBR_SPINOR(T, GHOSTSPINORTEX, nbr_idx3, stride3);
     } else
@@ -961,10 +961,10 @@ if (!(threadIdx.z & 1))
 #endif	 
 #ifdef MULTI_GPU
     if (kernel_type == EXTERIOR_KERNEL_Z){
-      nbr_idx1 = param.ghostOffset[2][0] + (y[2]+NFACE-1)*ghostFace[2]+ space_con;
-      stride1 = NFACE*ghostFace[2];
+      nbr_idx1 = param.ghostOffset[2][0] + src_idx*NFACE*ghostFace[2] + (y[2]+NFACE-1)*ghostFace[2]+ space_con;
+      stride1 = NFACE*ghostFace[2]*param.Ls;
 #if (DD_PREC == 2) //half precision
-      norm_idx1 = param.ghostNormOffset[2][0]  + (y[2]+NFACE-1)*ghostFace[2]+ space_con;
+      norm_idx1 = param.ghostNormOffset[2][0] + src_idx*NFACE*ghostFace[2] + (y[2]+NFACE-1)*ghostFace[2]+ space_con;
 #endif			    
       READ_1ST_NBR_SPINOR(GHOSTSPINORTEX, nbr_idx1, stride1);
       RECONSTRUCT_FAT_GAUGE_MATRIX(5, fat, sp_idx_1st_nbr, fat_sign);
@@ -1013,10 +1013,10 @@ if (!(threadIdx.z & 1))
     spinorFloat2 T0, T1, T2;
 #ifdef MULTI_GPU
     if (kernel_type == EXTERIOR_KERNEL_Z){
-      nbr_idx3 = param.ghostOffset[2][0] + y[2]*ghostFace[2]+ space_con;
-      stride3 = NFACE*ghostFace[2];
+      nbr_idx3 = param.ghostOffset[2][0] + src_idx*NFACE*ghostFace[2] + y[2]*ghostFace[2]+ space_con;
+      stride3 = NFACE*ghostFace[2]*param.Ls;
 #if (DD_PREC == 2) //half precision
-      norm_idx3 = param.ghostNormOffset[2][0]  + y[2]*ghostFace[2]+ space_con;
+      norm_idx3 = param.ghostNormOffset[2][0] + src_idx*NFACE*ghostFace[2] + y[2]*ghostFace[2]+ space_con;
 #endif			    
       READ_3RD_NBR_SPINOR(T, GHOSTSPINORTEX, nbr_idx3, stride3);
     } else
@@ -1065,10 +1065,10 @@ if (threadIdx.z & 1)
 #endif
 #ifdef MULTI_GPU
     if (kernel_type == EXTERIOR_KERNEL_T){      
-      nbr_idx1 = param.ghostOffset[3][1] + (y[3]-(X[3]-1))*ghostFace[3]+ space_con;
-      stride1 = NFACE*ghostFace[3];
+      nbr_idx1 = param.ghostOffset[3][1] + src_idx*NFACE*ghostFace[3] + (y[3]-(X[3]-1))*ghostFace[3]+ space_con;
+      stride1 = NFACE*ghostFace[3]*param.Ls;
 #if (DD_PREC == 2) //half precision
-      norm_idx1 = param.ghostNormOffset[3][1] + (y[3]-(X[3]-1))*ghostFace[3]+ space_con;
+      norm_idx1 = param.ghostNormOffset[3][1] + src_idx*NFACE*ghostFace[3] + (y[3]-(X[3]-1))*ghostFace[3]+ space_con;
 #endif
       READ_1ST_NBR_SPINOR( GHOSTSPINORTEX, nbr_idx1, stride1);    
       RECONSTRUCT_FAT_GAUGE_MATRIX(6, fat, sp_idx_1st_nbr, fat_sign);
@@ -1112,10 +1112,10 @@ if (threadIdx.z & 1)
     spinorFloat2 T0, T1, T2;
 #ifdef MULTI_GPU
     if (kernel_type == EXTERIOR_KERNEL_T){
-      nbr_idx3 = param.ghostOffset[3][1] + (y[3]-(X[3]-3))*ghostFace[3]+ space_con;
-      stride3 = NFACE*ghostFace[3];
+      nbr_idx3 = param.ghostOffset[3][1] + src_idx*NFACE*ghostFace[3] + (y[3]-(X[3]-3))*ghostFace[3]+ space_con;
+      stride3 = NFACE*ghostFace[3]*param.Ls;
 #if (DD_PREC == 2) //half precision
-      norm_idx3 = param.ghostNormOffset[3][1] + (y[3]-(X[3]-3))*ghostFace[3]+ space_con;
+      norm_idx3 = param.ghostNormOffset[3][1] + src_idx*NFACE*ghostFace[3] + (y[3]-(X[3]-3))*ghostFace[3]+ space_con;
 #endif
       READ_3RD_NBR_SPINOR(T, GHOSTSPINORTEX, nbr_idx3, stride3); 
     } else
@@ -1167,10 +1167,10 @@ if (!(threadIdx.z & 1))
         fat_idx = half_volume + space_con;
       }
 
-      nbr_idx1 = param.ghostOffset[3][0] + (y[3]+NFACE-1)*ghostFace[3]+ space_con;
-      stride1 = NFACE*ghostFace[3];
+      nbr_idx1 = param.ghostOffset[3][0] + src_idx*NFACE*ghostFace[3] + (y[3]+NFACE-1)*ghostFace[3]+ space_con;
+      stride1 = NFACE*ghostFace[3]*param.Ls;
 #if (DD_PREC == 2) //half precision
-      norm_idx1 = param.ghostNormOffset[3][0]  + (y[3]+NFACE-1)*ghostFace[3]+ space_con;
+      norm_idx1 = param.ghostNormOffset[3][0] + src_idx*NFACE*ghostFace[3] + (y[3]+NFACE-1)*ghostFace[3]+ space_con;
 #endif		    
       READ_1ST_NBR_SPINOR(GHOSTSPINORTEX, nbr_idx1, stride1);
       READ_FAT_MATRIX(FATLINK1TEX, dir, fat_idx, fat_stride);
@@ -1217,10 +1217,10 @@ if (!(threadIdx.z & 1))
       if ( (y[3] - 3) < 0){
         long_idx = half_volume + y[3]*ghostFace[3]+ space_con;
       }	
-      nbr_idx3 = param.ghostOffset[3][0] + y[3]*ghostFace[3]+ space_con;
-      stride3 = NFACE*ghostFace[3];
+      nbr_idx3 = param.ghostOffset[3][0] + src_idx*NFACE*ghostFace[3] + y[3]*ghostFace[3]+ space_con;
+      stride3 = NFACE*ghostFace[3]*param.Ls;
 #if (DD_PREC == 2) //half precision
-      norm_idx3 = param.ghostNormOffset[3][0]  + y[3]*ghostFace[3]+ space_con;
+      norm_idx3 = param.ghostNormOffset[3][0] + src_idx*NFACE*ghostFace[3] + y[3]*ghostFace[3]+ space_con;
 #endif		    
       READ_3RD_NBR_SPINOR(T, GHOSTSPINORTEX, nbr_idx3, stride3);       
     } else

--- a/lib/dslash_core/staggered_fused_exterior_dslash_core.h
+++ b/lib/dslash_core/staggered_fused_exterior_dslash_core.h
@@ -434,10 +434,10 @@ if (threadId.z & 1)
 #ifdef MULTI_GPU
     active = true;
     int space_con = ((y[3]*X[2]+y[2])*X[1]+y[1])/2;	
-    nbr_idx1 = param.ghostOffset[0][1] + (y[0]-(X[0]-1))*ghostFace[0]+ space_con;
-    stride1 = NFACE*ghostFace[0];
+    nbr_idx1 = param.ghostOffset[0][1] + src_idx*NFACE*ghostFace[0] + (y[0]-(X[0]-1))*ghostFace[0] + space_con;
+    stride1 = NFACE*ghostFace[0]*param.Ls;
 #if (DD_PREC == 2) //half precision
-    norm_idx1 = param.ghostNormOffset[0][1] + (y[0]-(X[0]-1))*ghostFace[0]+ space_con;
+    norm_idx1 = param.ghostNormOffset[0][1] + src_idx*NFACE*ghostFace[0] + (y[0]-(X[0]-1))*ghostFace[0] + space_con;
 #endif		    
 #endif
     READ_1ST_NBR_SPINOR( GHOSTSPINORTEX, nbr_idx1, stride1);
@@ -467,10 +467,10 @@ if (threadId.z & 1)
 #ifdef MULTI_GPU
     active = true;
     int space_con = ((y[3]*X[2]+y[2])*X[1] + y[1])/2;		
-    nbr_idx3 = param.ghostOffset[0][1] + (y[0]-(X[0]-3))*ghostFace[0]+ space_con;
-    stride3 = NFACE*ghostFace[0];
+    nbr_idx3 = param.ghostOffset[0][1] + src_idx*NFACE*ghostFace[0] + (y[0]-(X[0]-3))*ghostFace[0] + space_con;
+    stride3 = NFACE*ghostFace[0]*param.Ls;
 #if (DD_PREC == 2) //half precision
-    norm_idx3 = param.ghostNormOffset[0][1] + (y[0]-(X[0]-3))*ghostFace[0]+ space_con;
+    norm_idx3 = param.ghostNormOffset[0][1] + src_idx*NFACE*ghostFace[0] + (y[0]-(X[0]-3))*ghostFace[0] + space_con;
 #endif	
 #endif
     spinorFloat2 T0, T1, T2;
@@ -524,10 +524,10 @@ if (!(threadIdx.z & 1))
 #endif	 
 #ifdef MULTI_GPU
     active = true;
-    nbr_idx1 = param.ghostOffset[0][0] + (y[0]+NFACE-1)*ghostFace[0]+ space_con;
-    stride1 = NFACE*ghostFace[0];
+    nbr_idx1 = param.ghostOffset[0][0] + src_idx*NFACE*ghostFace[0] + (y[0]+NFACE-1)*ghostFace[0] + space_con;
+    stride1 = NFACE*ghostFace[0]*param.Ls;
 #if (DD_PREC == 2) //half precision
-    norm_idx1 = param.ghostNormOffset[0][0]  + (y[0]+NFACE-1)*ghostFace[0]+ space_con;
+    norm_idx1 = param.ghostNormOffset[0][0] + src_idx*NFACE*ghostFace[0] + (y[0]+NFACE-1)*ghostFace[0] + space_con;
 #endif	
 #endif
     READ_1ST_NBR_SPINOR( GHOSTSPINORTEX, nbr_idx1, stride1);
@@ -563,10 +563,10 @@ if (!(threadIdx.z & 1))
 #endif	     
 #ifdef MULTI_GPU
     active = true;
-    nbr_idx3 = param.ghostOffset[0][0] + y[0]*ghostFace[0]+ space_con;
-    stride3 = NFACE*ghostFace[0];
+    nbr_idx3 = param.ghostOffset[0][0] + src_idx*NFACE*ghostFace[0] + y[0]*ghostFace[0] + space_con;
+    stride3 = NFACE*ghostFace[0]*param.Ls;
 #if (DD_PREC == 2) //half precision
-    norm_idx3 = param.ghostNormOffset[0][0]  + y[0]*ghostFace[0]+ space_con;
+    norm_idx3 = param.ghostNormOffset[0][0] + src_idx*NFACE*ghostFace[0] + y[0]*ghostFace[0] + space_con;
 #endif
 #endif
 
@@ -614,10 +614,10 @@ if (threadId.z & 1)
 #endif	 
 #ifdef MULTI_GPU
     active = true;
-    nbr_idx1 = param.ghostOffset[1][1] + (y[1]-(X[1]-1))*ghostFace[1]+ space_con;
-    stride1 = NFACE*ghostFace[1];
+    nbr_idx1 = param.ghostOffset[1][1] + src_idx*NFACE*ghostFace[1] + (y[1]-(X[1]-1))*ghostFace[1] + space_con;
+    stride1 = NFACE*ghostFace[1]*param.Ls;
 #if (DD_PREC == 2) //half precision
-    norm_idx1 = param.ghostNormOffset[1][1] + (y[1]-(X[1]-1))*ghostFace[1]+ space_con;
+    norm_idx1 = param.ghostNormOffset[1][1] + src_idx*NFACE*ghostFace[1] + (y[1]-(X[1]-1))*ghostFace[1] + space_con;
 #endif		    
 #endif 
     READ_1ST_NBR_SPINOR( GHOSTSPINORTEX, nbr_idx1, stride1);
@@ -647,10 +647,10 @@ if (threadId.z & 1)
 #endif	 
 #ifdef MULTI_GPU
     active = true;
-    nbr_idx3 = param.ghostOffset[1][1] + (y[1]-(X[1]-3))*ghostFace[1]+ space_con;
-    stride3 = NFACE*ghostFace[1];
+    nbr_idx3 = param.ghostOffset[1][1] + src_idx*NFACE*ghostFace[1] + (y[1]-(X[1]-3))*ghostFace[1] + space_con;
+    stride3 = NFACE*ghostFace[1]*param.Ls;
 #if (DD_PREC == 2) //half precision
-    norm_idx3 = param.ghostNormOffset[1][1] + (y[1]-(X[1]-3))*ghostFace[1]+ space_con;
+    norm_idx3 = param.ghostNormOffset[1][1] + src_idx*NFACE*ghostFace[1] + (y[1]-(X[1]-3))*ghostFace[1] + space_con;
 #endif		    
 #endif    
     spinorFloat2 T0, T1, T2;
@@ -703,10 +703,10 @@ if (!(threadIdx.z & 1))
 #endif	 
 #ifdef MULTI_GPU
     active = true;
-    nbr_idx1 = param.ghostOffset[1][0] + (y[1]+NFACE-1)*ghostFace[1]+ space_con;
-    stride1 = NFACE*ghostFace[1];
+    nbr_idx1 = param.ghostOffset[1][0] + src_idx*NFACE*ghostFace[1] + (y[1]+NFACE-1)*ghostFace[1] + space_con;
+    stride1 = NFACE*ghostFace[1]*param.Ls;
 #if (DD_PREC == 2) //half precision
-    norm_idx1 = param.ghostNormOffset[1][0]  + (y[1]+NFACE-1)*ghostFace[1]+ space_con;
+    norm_idx1 = param.ghostNormOffset[1][0] + src_idx*NFACE*ghostFace[1] + (y[1]+NFACE-1)*ghostFace[1] + space_con;
 #endif	
 #endif
     READ_1ST_NBR_SPINOR( GHOSTSPINORTEX, nbr_idx1, stride1);
@@ -742,10 +742,10 @@ if (!(threadIdx.z & 1))
 #endif	 
 #ifdef MULTI_GPU
     active = true;
-    nbr_idx3 = param.ghostOffset[1][0] + y[1]*ghostFace[1]+ space_con;
-    stride3 = NFACE*ghostFace[1];
+    nbr_idx3 = param.ghostOffset[1][0] + src_idx*NFACE*ghostFace[1] + y[1]*ghostFace[1] + space_con;
+    stride3 = NFACE*ghostFace[1]*param.Ls;
 #if (DD_PREC == 2) //half precision
-    norm_idx3 = param.ghostNormOffset[1][0]  + y[1]*ghostFace[1]+ space_con;
+    norm_idx3 = param.ghostNormOffset[1][0] + src_idx*NFACE*ghostFace[1] + y[1]*ghostFace[1] + space_con;
 #endif
 #endif
     spinorFloat2 T0, T1, T2;
@@ -794,10 +794,10 @@ if (threadId.z & 1)
 #endif	 
 #ifdef MULTI_GPU
     active = true;
-    nbr_idx1 = param.ghostOffset[2][1] + (y[2]-(X[2]-1))*ghostFace[2]+ space_con;
-    stride1 = NFACE*ghostFace[2];	    
+    nbr_idx1 = param.ghostOffset[2][1] + src_idx*NFACE*ghostFace[2] + (y[2]-(X[2]-1))*ghostFace[2] + space_con;
+    stride1 = NFACE*ghostFace[2]*param.Ls;
 #if (DD_PREC == 2) //half precision
-    norm_idx1 = param.ghostNormOffset[2][1] + (y[2]-(X[2]-1))*ghostFace[2]+ space_con;
+    norm_idx1 = param.ghostNormOffset[2][1] + src_idx*NFACE*ghostFace[2] + (y[2]-(X[2]-1))*ghostFace[2] + space_con;
 #endif		
 #endif
     READ_1ST_NBR_SPINOR( GHOSTSPINORTEX, nbr_idx1, stride1);
@@ -827,10 +827,10 @@ if (threadId.z & 1)
 #endif	 
 #ifdef MULTI_GPU
     active = true;
-    nbr_idx3 = param.ghostOffset[2][1] + (y[2]-(X[2]-3))*ghostFace[2]+ space_con;
-    stride3 = NFACE*ghostFace[2];
+    nbr_idx3 = param.ghostOffset[2][1] + src_idx*NFACE*ghostFace[2] + (y[2]-(X[2]-3))*ghostFace[2] + space_con;
+    stride3 = NFACE*ghostFace[2]*param.Ls;
 #if (DD_PREC == 2) //half precision
-    norm_idx3 = param.ghostNormOffset[2][1] + (y[2]-(X[2]-3))*ghostFace[2]+ space_con;
+    norm_idx3 = param.ghostNormOffset[2][1] + src_idx*NFACE*ghostFace[2] + (y[2]-(X[2]-3))*ghostFace[2] + space_con;
 #endif
 #endif
     spinorFloat2 T0, T1, T2;
@@ -885,10 +885,10 @@ if (!(threadIdx.z & 1))
 #endif	 
 #ifdef MULTI_GPU
     active = true;
-    nbr_idx1 = param.ghostOffset[2][0] + (y[2]+NFACE-1)*ghostFace[2]+ space_con;
-    stride1 = NFACE*ghostFace[2];
+    nbr_idx1 = param.ghostOffset[2][0] + src_idx*NFACE*ghostFace[2] + (y[2]+NFACE-1)*ghostFace[2] + space_con;
+    stride1 = NFACE*ghostFace[2]*param.Ls;
 #if (DD_PREC == 2) //half precision
-    norm_idx1 = param.ghostNormOffset[2][0]  + (y[2]+NFACE-1)*ghostFace[2]+ space_con;
+    norm_idx1 = param.ghostNormOffset[2][0] + src_idx*NFACE*ghostFace[2] + (y[2]+NFACE-1)*ghostFace[2] + space_con;
 #endif			    
 #endif
     READ_1ST_NBR_SPINOR( GHOSTSPINORTEX, nbr_idx1, stride1);
@@ -924,10 +924,10 @@ if (!(threadIdx.z & 1))
 #endif	 
 #ifdef MULTI_GPU
     active = true;
-    nbr_idx3 = param.ghostOffset[2][0] + y[2]*ghostFace[2]+ space_con;
-    stride3 = NFACE*ghostFace[2];
+    nbr_idx3 = param.ghostOffset[2][0] + src_idx*NFACE*ghostFace[2] + y[2]*ghostFace[2] + space_con;
+    stride3 = NFACE*ghostFace[2]*param.Ls;
 #if (DD_PREC == 2) //half precision
-    norm_idx3 = param.ghostNormOffset[2][0]  + y[2]*ghostFace[2]+ space_con;
+    norm_idx3 = param.ghostNormOffset[2][0] + src_idx*NFACE*ghostFace[2] + y[2]*ghostFace[2] + space_con;
 #endif			    
 #endif
     spinorFloat2 T0, T1, T2;
@@ -975,10 +975,10 @@ if (threadId.z & 1)
 #endif
 #ifdef MULTI_GPU
     active = true;
-    nbr_idx1 = param.ghostOffset[3][1] + (y[3]-(X[3]-1))*ghostFace[3]+ space_con;
-    stride1 = NFACE*ghostFace[3];
+    nbr_idx1 = param.ghostOffset[3][1] + src_idx*NFACE*ghostFace[3] + (y[3]-(X[3]-1))*ghostFace[3] + space_con;
+    stride1 = NFACE*ghostFace[3]*param.Ls;
 #if (DD_PREC == 2) //half precision
-    norm_idx1 = param.ghostNormOffset[3][1] + (y[3]-(X[3]-1))*ghostFace[3]+ space_con;
+    norm_idx1 = param.ghostNormOffset[3][1] + src_idx*NFACE*ghostFace[3] + (y[3]-(X[3]-1))*ghostFace[3] + space_con;
 #endif
 #endif
     READ_1ST_NBR_SPINOR( GHOSTSPINORTEX, nbr_idx1, stride1);    
@@ -1009,10 +1009,10 @@ if (threadId.z & 1)
 #endif
 #ifdef MULTI_GPU
     active = true;
-    nbr_idx3 = param.ghostOffset[3][1] + (y[3]-(X[3]-3))*ghostFace[3]+ space_con;
-    stride3 = NFACE*ghostFace[3];
+    nbr_idx3 = param.ghostOffset[3][1] + src_idx*NFACE*ghostFace[3] + (y[3]-(X[3]-3))*ghostFace[3] + space_con;
+    stride3 = NFACE*ghostFace[3]*param.Ls;
 #if (DD_PREC == 2) //half precision
-    norm_idx3 = param.ghostNormOffset[3][1] + (y[3]-(X[3]-3))*ghostFace[3]+ space_con;
+    norm_idx3 = param.ghostNormOffset[3][1] + src_idx*NFACE*ghostFace[3] + (y[3]-(X[3]-3))*ghostFace[3] + space_con;
 #endif
 #endif
 
@@ -1062,10 +1062,10 @@ if (!(threadIdx.z & 1))
     active = true;
     fat_idx = half_volume + space_con;
 
-    nbr_idx1 = param.ghostOffset[3][0] + (y[3]+NFACE-1)*ghostFace[3]+ space_con;
-    stride1 = NFACE*ghostFace[3];
+    nbr_idx1 = param.ghostOffset[3][0] + src_idx*NFACE*ghostFace[3] + (y[3]+NFACE-1)*ghostFace[3] + space_con;
+    stride1 = NFACE*ghostFace[3]*param.Ls;
 #if (DD_PREC == 2) //half precision
-    norm_idx1 = param.ghostNormOffset[3][0]  + (y[3]+NFACE-1)*ghostFace[3]+ space_con;
+    norm_idx1 = param.ghostNormOffset[3][0] + src_idx*NFACE*ghostFace[3] + (y[3]+NFACE-1)*ghostFace[3] + space_con;
 #endif		    
 #endif
     READ_FAT_MATRIX(FATLINK1TEX, dir, fat_idx, fat_stride);
@@ -1096,10 +1096,10 @@ if (!(threadIdx.z & 1))
 #ifdef MULTI_GPU
     active = true;
     long_idx = half_volume + y[3]*ghostFace[3]+ space_con;
-    nbr_idx3 = param.ghostOffset[3][0] + y[3]*ghostFace[3]+ space_con;
-    stride3 = NFACE*ghostFace[3];
+    nbr_idx3 = param.ghostOffset[3][0] + src_idx*NFACE*ghostFace[3] + y[3]*ghostFace[3] + space_con;
+    stride3 = NFACE*ghostFace[3]*param.Ls;
 #if (DD_PREC == 2) //half precision
-    norm_idx3 = param.ghostNormOffset[3][0]  + y[3]*ghostFace[3]+ space_con;
+    norm_idx3 = param.ghostNormOffset[3][0] + src_idx*NFACE*ghostFace[3] + y[3]*ghostFace[3] + space_con;
 #endif		    
 #endif	    
     READ_LONG_MATRIX(LONGLINK1TEX, dir, long_idx, long_stride);

--- a/lib/dslash_improved_staggered.cu
+++ b/lib/dslash_improved_staggered.cu
@@ -105,9 +105,8 @@ namespace quda {
 
     void apply(const cudaStream_t &stream)
     {
-      TuneParam tp = tuneLaunch(*this, getTuning(), QUDA_DEBUG_VERBOSE);
-      dim3 gridDim( (dslashParam.threads+tp.block.x-1) / tp.block.x, 1, 1);
-      IMPROVED_STAGGERED_DSLASH(gridDim, tp.block, tp.shared_bytes, stream, dslashParam,
+      TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
+      IMPROVED_STAGGERED_DSLASH(tp.grid, tp.block, tp.shared_bytes, stream, dslashParam,
 				(sFloat*)out->V(), (float*)out->Norm(), 
 				fat0, fat1, long0, long1, phase0, phase1, 
 				(sFloat*)in->V(), (float*)in->Norm(), 

--- a/lib/dslash_improved_staggered.cu
+++ b/lib/dslash_improved_staggered.cu
@@ -71,12 +71,17 @@ namespace quda {
     const longGFloat *long0, *long1;
     const phaseFloat *phase0, *phase1;
     const double a;
+    const int nSrc;
 
   protected:
     unsigned int sharedBytesPerThread() const
     {
+#ifdef PARALLEL_DIR
       int reg_size = (typeid(sFloat)==typeid(double2) ? sizeof(double) : sizeof(float));
       return 6 * reg_size;
+#else
+      return 0;
+#endif
     }
 
   public:
@@ -86,16 +91,21 @@ namespace quda {
 			const QudaReconstructType reconstruct, const cudaColorSpinorField *in,
 			const cudaColorSpinorField *x, const double a, const int dagger)
       : DslashCuda(out, in, x, reconstruct, dagger), fat0(fat0), fat1(fat1), long0(long0), 
-	long1(long1), phase0(phase0), phase1(phase1), a(a)
+	long1(long1), phase0(phase0), phase1(phase1), a(a), nSrc(in->X(4))
     { 
       bindSpinorTex<sFloat>(in, out, x);
     }
 
     virtual ~StaggeredDslashCuda() { unbindSpinorTex<sFloat>(in, out, x); }
 
+    virtual bool advanceTuneParam(TuneParam &param) const
+    {
+      return advanceBlockDim(param) || advanceGridDim(param) || advanceAux(param);
+    }
+
     void apply(const cudaStream_t &stream)
     {
-      TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
+      TuneParam tp = tuneLaunch(*this, getTuning(), QUDA_DEBUG_VERBOSE);
       dim3 gridDim( (dslashParam.threads+tp.block.x-1) / tp.block.x, 1, 1);
       IMPROVED_STAGGERED_DSLASH(gridDim, tp.block, tp.shared_bytes, stream, dslashParam,
 				(sFloat*)out->V(), (float*)out->Norm(), 
@@ -103,6 +113,35 @@ namespace quda {
 				(sFloat*)in->V(), (float*)in->Norm(), 
 				(sFloat*)(x ? x->V() : 0), (float*)(x ? x->Norm() : 0), a); 
     }
+
+    bool advanceBlockDim(TuneParam &param) const
+    {
+      const unsigned int max_shared = deviceProp.sharedMemPerBlock;
+      // first try to advance block.y (number of right-hand sides per block)
+      if (param.block.y < nSrc && param.block.y < deviceProp.maxThreadsDim[1] &&
+	  sharedBytesPerThread()*param.block.x*param.block.y < max_shared &&
+	  (param.block.x*(param.block.y+1)) <= deviceProp.maxThreadsPerBlock) {
+	param.block.y++;
+	param.grid.y = (nSrc + param.block.y - 1) / param.block.y;
+	return true;
+      } else {
+	param.block.y = 1;
+	param.grid.y = nSrc;
+	bool rtn = DslashCuda::advanceBlockDim(param);
+	param.block.y = 1;
+	param.grid.y = nSrc;
+	return rtn;
+      }
+    }
+
+    void initTuneParam(TuneParam &param) const
+    {
+      DslashCuda::initTuneParam(param);
+      param.block.y = 1;
+      param.grid.y = nSrc;
+    }
+
+    void defaultTuneParam(TuneParam &param) const { initTuneParam(param); }
 
     int Nface() { return 6; } 
 
@@ -215,6 +254,8 @@ namespace quda {
 
 #ifdef GPU_STAGGERED_DIRAC
 
+    dslashParam.Ls = out->X(4); // use Ls as the number of sources
+
 #ifdef MULTI_GPU
     for(int i=0;i < 4; i++){
       if(commDimPartitioned(i) && (fatGauge.X()[i] < 6)){
@@ -276,12 +317,17 @@ namespace quda {
 	 longGauge.Reconstruct(), in, x, k, dagger);
     }
 
+    // the parameters passed to dslashCuda must be 4-d volume and 3-d
+    // faces because Ls is added as the y-dimension in thread space
+    int ghostFace[QUDA_MAX_DIM];
+    for (int i=0; i<4; i++) ghostFace[i] = in->GhostFace()[i] / in->X(4);
+
 #ifndef GPU_COMMS
-    DslashPolicyTune dslash_policy(*dslash, const_cast<cudaColorSpinorField*>(in), regSize, parity, dagger, in->Volume(),  in->GhostFace(), profile);
+    DslashPolicyTune dslash_policy(*dslash, const_cast<cudaColorSpinorField*>(in), regSize, parity, dagger, in->Volume()/in->X(4), ghostFace, profile);
     dslash_policy.apply(0);
 #else
     DslashPolicyImp* dslashImp = DslashFactory::create(QUDA_GPU_COMMS_DSLASH);
-    (*dslashImp)(*dslash, const_cast<cudaColorSpinorField*>(in), regSize, parity, dagger, in->Volume(), in->GhostFace(), profile);
+    (*dslashImp)(*dslash, const_cast<cudaColorSpinorField*>(in), regSize, parity, dagger, in->Volume()/in->X(4), ghostFace, profile);
     delete dslashImp;
 #endif
 

--- a/lib/dslash_improved_staggered.cu
+++ b/lib/dslash_improved_staggered.cu
@@ -98,11 +98,6 @@ namespace quda {
 
     virtual ~StaggeredDslashCuda() { unbindSpinorTex<sFloat>(in, out, x); }
 
-    virtual bool advanceTuneParam(TuneParam &param) const
-    {
-      return advanceBlockDim(param) || advanceGridDim(param) || advanceAux(param);
-    }
-
     void apply(const cudaStream_t &stream)
     {
       TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());

--- a/lib/dslash_pack.cu
+++ b/lib/dslash_pack.cu
@@ -1040,6 +1040,8 @@ namespace quda {
     int face_idx = blockIdx.x*blockDim.x + threadIdx.x;
     if (face_idx >= param.threads) return;
 
+    const int Ls = param.X[4];
+
     // determine which dimension we are packing
     const int dim = dimFromFaceIndex(face_idx, param);
 
@@ -1048,52 +1050,52 @@ namespace quda {
     // read spinor and write to face
     if (dim == 0) {
       // face_num determines which end of the lattice we are packing: 0 = start, 1 = end
-      const int face_num = (param.face_num==2) ? ((face_idx >= nFace*param.ghostFace[0]) ? 1 : 0) : param.face_num;
-      if(param.face_num==2) face_idx -= face_num*nFace*param.ghostFace[0];
+      const int face_num = (param.face_num==2) ? ((face_idx >= Ls*nFace*param.ghostFace[0]) ? 1 : 0) : param.face_num;
+      if(param.face_num==2) face_idx -= face_num*Ls*nFace*param.ghostFace[0];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndexStaggered<0,nFace,0>(face_idx,param.ghostFace[0],param.parity,param.X);
+	const int idx = indexFromFaceIndexStaggered<0,nFace,0>(face_idx,Ls*param.ghostFace[0],param.parity,param.X);
 	packFaceStaggeredCore(param.out[0], param.outNorm[0], face_idx, 
-			      nFace*param.ghostFace[0], param.in, param.inNorm, idx, param);
+			      Ls*nFace*param.ghostFace[0], param.in, param.inNorm, idx, param);
       } else {
-	const int idx = indexFromFaceIndexStaggered<0,nFace,1>(face_idx,param.ghostFace[0],param.parity,param.X);
+	const int idx = indexFromFaceIndexStaggered<0,nFace,1>(face_idx,Ls*param.ghostFace[0],param.parity,param.X);
 	packFaceStaggeredCore(param.out[1], param.outNorm[1], face_idx,
-			      nFace*param.ghostFace[0], param.in, param.inNorm, idx, param);
+			      Ls*nFace*param.ghostFace[0], param.in, param.inNorm, idx, param);
       }
     } else if (dim == 1) {
-      const int face_num = (param.face_num==2) ? ((face_idx >= nFace*param.ghostFace[1]) ? 1 : 0) : param.face_num;
-      if(param.face_num==2) face_idx -= face_num*nFace*param.ghostFace[1];
+      const int face_num = (param.face_num==2) ? ((face_idx >= Ls*nFace*param.ghostFace[1]) ? 1 : 0) : param.face_num;
+      if(param.face_num==2) face_idx -= face_num*Ls*nFace*param.ghostFace[1];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndexStaggered<1,nFace,0>(face_idx,param.ghostFace[1],param.parity,param.X);
+	const int idx = indexFromFaceIndexStaggered<1,nFace,0>(face_idx,Ls*param.ghostFace[1],param.parity,param.X);
 	packFaceStaggeredCore(param.out[2], param.outNorm[2], face_idx, 
-			      nFace*param.ghostFace[1], param.in, param.inNorm, idx, param);
+			      Ls*nFace*param.ghostFace[1], param.in, param.inNorm, idx, param);
       } else {
-	const int idx = indexFromFaceIndexStaggered<1,nFace,1>(face_idx,param.ghostFace[1],param.parity,param.X);
+	const int idx = indexFromFaceIndexStaggered<1,nFace,1>(face_idx,Ls*param.ghostFace[1],param.parity,param.X);
 	packFaceStaggeredCore(param.out[3], param.outNorm[3], face_idx, 
-			      nFace*param.ghostFace[1], param.in, param.inNorm, idx, param);
+			      Ls*nFace*param.ghostFace[1], param.in, param.inNorm, idx, param);
       }
     } else if (dim == 2) {
-      const int face_num = (param.face_num==2) ? ((face_idx >= nFace*param.ghostFace[2]) ? 1 : 0) : param.face_num;
-      if(param.face_num==2) face_idx -= face_num*nFace*param.ghostFace[2];
+      const int face_num = (param.face_num==2) ? ((face_idx >= Ls*nFace*param.ghostFace[2]) ? 1 : 0) : param.face_num;
+      if(param.face_num==2) face_idx -= face_num*Ls*nFace*param.ghostFace[2];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndexStaggered<2,nFace,0>(face_idx,param.ghostFace[2],param.parity,param.X);
+	const int idx = indexFromFaceIndexStaggered<2,nFace,0>(face_idx,Ls*param.ghostFace[2],param.parity,param.X);
 	packFaceStaggeredCore(param.out[4], param.outNorm[4], face_idx,
-			      nFace*param.ghostFace[2], param.in, param.inNorm, idx, param);
+			      Ls*nFace*param.ghostFace[2], param.in, param.inNorm, idx, param);
       } else {
-	const int idx = indexFromFaceIndexStaggered<2,nFace,1>(face_idx,param.ghostFace[2],param.parity,param.X);
+	const int idx = indexFromFaceIndexStaggered<2,nFace,1>(face_idx,Ls*param.ghostFace[2],param.parity,param.X);
 	packFaceStaggeredCore(param.out[5], param.outNorm[5], face_idx,
-			      nFace*param.ghostFace[2], param.in, param.inNorm, idx, param);
+			      Ls*nFace*param.ghostFace[2], param.in, param.inNorm, idx, param);
       }
     } else {
-      const int face_num = (param.face_num==2) ? ((face_idx >= nFace*param.ghostFace[3]) ? 1 : 0) : param.face_num;
-      if(param.face_num==2) face_idx -= face_num*nFace*param.ghostFace[3];
+      const int face_num = (param.face_num==2) ? ((face_idx >= Ls*nFace*param.ghostFace[3]) ? 1 : 0) : param.face_num;
+      if(param.face_num==2) face_idx -= face_num*Ls*nFace*param.ghostFace[3];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndexStaggered<3,nFace,0>(face_idx,param.ghostFace[3],param.parity,param.X);
+	const int idx = indexFromFaceIndexStaggered<3,nFace,0>(face_idx,Ls*param.ghostFace[3],param.parity,param.X);
 	packFaceStaggeredCore(param.out[6], param.outNorm[6], face_idx,
-			      nFace*param.ghostFace[3], param.in, param.inNorm,idx, param);
+			      Ls*nFace*param.ghostFace[3], param.in, param.inNorm,idx, param);
       } else {
-	const int idx = indexFromFaceIndexStaggered<3,nFace,1>(face_idx,param.ghostFace[3],param.parity,param.X);
+	const int idx = indexFromFaceIndexStaggered<3,nFace,1>(face_idx,Ls*param.ghostFace[3],param.parity,param.X);
 	packFaceStaggeredCore(param.out[7], param.outNorm[7], face_idx, 
-			      nFace*param.ghostFace[3], param.in, param.inNorm, idx, param);
+			      Ls*nFace*param.ghostFace[3], param.in, param.inNorm, idx, param);
       }
     }
 

--- a/lib/dslash_staggered.cu
+++ b/lib/dslash_staggered.cu
@@ -69,19 +69,24 @@ namespace quda {
   private:
     const gFloat *gauge0, *gauge1;
     const double a;
+    const int nSrc;
 
   protected:
     unsigned int sharedBytesPerThread() const
     {
+#ifdef PARALLEL_DIR
       int reg_size = (typeid(sFloat)==typeid(double2) ? sizeof(double) : sizeof(float));
       return 6 * reg_size;
+#else
+      return 0;
+#endif
     }
 
   public:
     StaggeredDslashCuda(cudaColorSpinorField *out, const gFloat *gauge0, const gFloat *gauge1,
 			const QudaReconstructType reconstruct, const cudaColorSpinorField *in,
 			const cudaColorSpinorField *x, const double a, const int dagger)
-      : DslashCuda(out, in, x, reconstruct, dagger), gauge0(gauge0), gauge1(gauge1), a(a)
+      : DslashCuda(out, in, x, reconstruct, dagger), gauge0(gauge0), gauge1(gauge1), a(a), nSrc(in->X(4))
     { 
       bindSpinorTex<sFloat>(in, out, x);
     }
@@ -91,12 +96,40 @@ namespace quda {
     void apply(const cudaStream_t &stream)
     {
       TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
-      dim3 gridDim( (dslashParam.threads+tp.block.x-1) / tp.block.x, 1, 1);
-      STAGGERED_DSLASH(gridDim, tp.block, tp.shared_bytes, stream, dslashParam,
+      STAGGERED_DSLASH(tp.grid, tp.block, tp.shared_bytes, stream, dslashParam,
 		       (sFloat*)out->V(), (float*)out->Norm(), gauge0, gauge1, 
 		       (sFloat*)in->V(), (float*)in->Norm(), 
 		       (sFloat*)(x ? x->V() : 0), (float*)(x ? x->Norm() : 0), a); 
     }
+
+    bool advanceBlockDim(TuneParam &param) const
+    {
+      const unsigned int max_shared = deviceProp.sharedMemPerBlock;
+      // first try to advance block.y (number of right-hand sides per block)
+      if (param.block.y < nSrc && param.block.y < deviceProp.maxThreadsDim[1] &&
+	  sharedBytesPerThread()*param.block.x*param.block.y < max_shared &&
+	  (param.block.x*(param.block.y+1)) <= deviceProp.maxThreadsPerBlock) {
+	param.block.y++;
+	param.grid.y = (nSrc + param.block.y - 1) / param.block.y;
+	return true;
+      } else {
+	param.block.y = 1;
+	param.grid.y = nSrc;
+	bool rtn = DslashCuda::advanceBlockDim(param);
+	param.block.y = 1;
+	param.grid.y = nSrc;
+	return rtn;
+      }
+    }
+
+    void initTuneParam(TuneParam &param) const
+    {
+      DslashCuda::initTuneParam(param);
+      param.block.y = 1;
+      param.grid.y = nSrc;
+    }
+
+    void defaultTuneParam(TuneParam &param) const { initTuneParam(param); }
 
     int Nface() { return 2; } 
   };
@@ -113,6 +146,8 @@ namespace quda {
     inSpinor->allocateGhostBuffer(1);
 
 #ifdef GPU_STAGGERED_DIRAC
+
+    dslashParam.Ls = out->X(4);
 
     dslashParam.parity = parity;
     dslashParam.gauge_stride = gauge.Stride();
@@ -154,12 +189,17 @@ namespace quda {
 	(out, (short2*)gauge0, (short2*)gauge1, gauge.Reconstruct(), in, x, k, dagger);
     }
 
+    // the parameters passed to dslashCuda must be 4-d volume and 3-d
+    // faces because Ls is added as the y-dimension in thread space
+    int ghostFace[QUDA_MAX_DIM];
+    for (int i=0; i<4; i++) ghostFace[i] = in->GhostFace()[i] / in->X(4);
+
 #ifndef GPU_COMMS
-    DslashPolicyTune dslash_policy(*dslash, const_cast<cudaColorSpinorField*>(in), regSize, parity, dagger,  in->Volume(), in->GhostFace(), profile);
+    DslashPolicyTune dslash_policy(*dslash, const_cast<cudaColorSpinorField*>(in), regSize, parity, dagger,  in->Volume()/in->X(4), ghostFace, profile);
     dslash_policy.apply(0);
 #else
     DslashPolicyImp* dslashImp = DslashFactory::create(QUDA_GPU_COMMS_DSLASH);
-    (*dslashImp)(*dslash, const_cast<cudaColorSpinorField*>(in), regSize, parity, dagger, in->Volume(), in->GhostFace(), profile);
+    (*dslashImp)(*dslash, const_cast<cudaColorSpinorField*>(in), regSize, parity, dagger, in->Volume()/in->X(4), ghostFace, profile);
     delete dslashImp;
 #endif
 

--- a/lib/io_spinor.h
+++ b/lib/io_spinor.h
@@ -643,7 +643,7 @@
   out[1*mystride+sid] = make_float2(o01_re, o01_im);	\
   out[2*mystride+sid] = make_float2(o02_re, o02_im);
 
-#define WRITE_ST_SPINOR_SHORT2(out, sid, mystride)					\
+#define WRITE_ST_SPINOR_SHORT2(out, sid, mystride)			\
   float c0 = fmaxf(fabsf(o00_re), fabsf(o00_im));			\
   float c1 = fmaxf(fabsf(o01_re), fabsf(o01_im));			\
   float c2 = fmaxf(fabsf(o02_re), fabsf(o02_im));			\

--- a/tests/domain_wall_dslash_reference.cpp
+++ b/tests/domain_wall_dslash_reference.cpp
@@ -48,77 +48,6 @@ int neighborIndex_4d(int i, int oddBit, int dx4, int dx3, int dx2, int dx1) {
 }
 
 
-// i represents a "half index" into an even or odd "half lattice".
-// when oddBit={0,1} the half lattice is {even,odd}.
-//
-// the displacements, such as dx, refer to the full lattice coordinates.
-//
-// neighborIndex() takes a "half index", displaces it, and returns the
-// new "half index", which can be an index into either the even or odd lattices.
-// displacements of magnitude one always interchange odd and even lattices.
-//
-//
-template<QudaDWFPCType type>
-int neighborIndex_5d(int i, int oddBit, int dxs, int dx4, int dx3, int dx2, int dx1) {
-  // fullLatticeIndex was modified for fullLatticeIndex_4d.  It is in util_quda.cpp.
-  // This code bit may not properly perform 5dPC.
-  int X = type == QUDA_5D_PC ? fullLatticeIndex_5d(i, oddBit) : fullLatticeIndex_5d_4dpc(i, oddBit);
-  // Checked that this matches code in dslash_core_ante.h.
-  int xs = X/(Z[3]*Z[2]*Z[1]*Z[0]);
-  int x4 = (X/(Z[2]*Z[1]*Z[0])) % Z[3];
-  int x3 = (X/(Z[1]*Z[0])) % Z[2];
-  int x2 = (X/Z[0]) % Z[1];
-  int x1 = X % Z[0];
-  // Displace and project back into domain 0,...,Ls-1.
-  // Note that we add Ls to avoid the negative problem
-  // of the C % operator.
-  xs = (xs+dxs+Ls) % Ls;
-  // Etc.
-  x4 = (x4+dx4+Z[3]) % Z[3];
-  x3 = (x3+dx3+Z[2]) % Z[2];
-  x2 = (x2+dx2+Z[1]) % Z[1];
-  x1 = (x1+dx1+Z[0]) % Z[0];
-  // Return linear half index.  Remember that integer division
-  // rounds down.
-  return (xs*(Z[3]*Z[2]*Z[1]*Z[0]) + x4*(Z[2]*Z[1]*Z[0]) + x3*(Z[1]*Z[0]) + x2*(Z[0]) + x1) / 2;
-}
-
-template<QudaDWFPCType type>
-int neighborIndex_5d_mgpu(int i, int oddBit, int dxs, int dx4, int dx3, int dx2, int dx1)
-{
-  int ret;
-  
-  int Y = (type == QUDA_5D_PC) ? fullLatticeIndex_5d(i, oddBit) : fullLatticeIndex_5d_4dpc(i, oddBit);
-  
-  int xs = Y/(Z[3]*Z[2]*Z[1]*Z[0]);
-  int x4 = (Y/(Z[2]*Z[1]*Z[0])) % Z[3];
-  int x3 = (Y/(Z[1]*Z[0])) % Z[2];
-  int x2 = (Y/Z[0]) % Z[1];
-  int x1 = Y % Z[0];
-  
-  int ghost_x4 = x4+ dx4;
-  
-  xs = (xs+dxs+Ls) % Ls;
-  x4 = (x4+dx4+Z[3]) % Z[3];
-  x3 = (x3+dx3+Z[2]) % Z[2];
-  x2 = (x2+dx2+Z[1]) % Z[1];
-  x1 = (x1+dx1+Z[0]) % Z[0];
-  
-  if ( (ghost_x4 >= 0 && ghost_x4) < Z[3] || !comm_dim_partitioned(3)){
-    ret = (xs*Z[3]*Z[2]*Z[1]*Z[0] + x4*Z[2]*Z[1]*Z[0] + x3*Z[1]*Z[0] + x2*Z[0] + x1) >> 1;
-  }else{
-    ret = (xs*Z[2]*Z[1]*Z[0] + x3*Z[1]*Z[0] + x2*Z[0] + x1) >> 1;    
-  }
-
-  return ret;
-}
-
-template <QudaDWFPCType type>
-int x4_5d_mgpu(int i, int oddBit)
-{
-  int Y = (type == QUDA_5D_PC) ? fullLatticeIndex_5d(i, oddBit) : fullLatticeIndex_5d_4dpc(i, oddBit);
-  return (Y/(Z[2]*Z[1]*Z[0])) % Z[3];
-}
 
 //#ifndef MULTI_GPU
 // This is just a copy of gaugeLink() from the quda code, except
@@ -232,133 +161,6 @@ Float *gaugeLink_mgpu(int i, int dir, int oddBit, Float **gaugeEven, Float **gau
   }
 
   return &gaugeField[dir/2][j*(3*3*2)];
-}
-
-template <QudaDWFPCType type, typename Float>
-Float *spinorNeighbor_5d_mgpu(int i, int dir, int oddBit, Float *spinorField, Float** fwd_nbr_spinor, Float** back_nbr_spinor, int neighbor_distance, int nFace)
-{
-  int j;
-  int nb = neighbor_distance;
-  int Y = (type == QUDA_5D_PC) ? fullLatticeIndex_5d(i, oddBit) : fullLatticeIndex_5d_4dpc(i, oddBit);
- 
-  int mySpinorSiteSize = 24;
- 
-  int xs = Y/(Z[3]*Z[2]*Z[1]*Z[0]);
-  int x4 = (Y/(Z[2]*Z[1]*Z[0])) % Z[3];
-  int x3 = (Y/(Z[1]*Z[0])) % Z[2];
-  int x2 = (Y/Z[0]) % Z[1];
-  int x1 = Y % Z[0];
-  
-  int X1= Z[0];
-  int X2= Z[1];
-  int X3= Z[2];
-  int X4= Z[3];
-  switch (dir) {
-  case 0://+X
-    {
-      int new_x1 = (x1 + nb)% X1;
-      if(x1+nb >=X1 && comm_dim_partitioned(0)) {
-        int offset = ((x1 + nb -X1)*Ls*X4*X3*X2+xs*X4*X3*X2+x4*X3*X2 + x3*X2+x2) >> 1;
-        return fwd_nbr_spinor[0] + offset*mySpinorSiteSize;
-      }
-      j = (xs*X4*X3*X2*X1 + x4*X3*X2*X1 + x3*X2*X1 + x2*X1 + new_x1) >> 1;
-      break;
-
-    }
-  case 1://-X
-    {
-      int new_x1 = (x1 - nb + X1)% X1;
-      if(x1 - nb < 0 && comm_dim_partitioned(0)) {
-        int offset = (( x1+nFace- nb)*Ls*X4*X3*X2 + xs*X4*X3*X2 + x4*X3*X2 + x3*X2 + x2) >> 1;
-        return back_nbr_spinor[0] + offset*mySpinorSiteSize;
-      } 
-      j = (xs*X4*X3*X2*X1 + x4*X3*X2*X1 + x3*X2*X1 + x2*X1 + new_x1) >> 1;
-      break;
-    }
-  case 2://+Y
-    {
-      int new_x2 = (x2 + nb)% X2;
-      if(x2+nb >=X2 && comm_dim_partitioned(1)) {
-        int offset = (( x2 + nb -X2)*Ls*X4*X3*X1+xs*X4*X3*X1+x4*X3*X1 + x3*X1+x1) >> 1;
-        return fwd_nbr_spinor[1] + offset*mySpinorSiteSize;
-      } 
-      j = (xs*X4*X3*X2*X1 + x4*X3*X2*X1 + x3*X2*X1 + new_x2*X1 + x1) >> 1;
-      break;
-    }
-  case 3:// -Y
-    {
-      int new_x2 = (x2 - nb + X2)% X2;
-      if(x2 - nb < 0 && comm_dim_partitioned(1)) {
-        int offset = (( x2 + nFace -nb)*Ls*X4*X3*X1+xs*X4*X3*X1+ x4*X3*X1 + x3*X1+x1) >> 1;
-        return back_nbr_spinor[1] + offset*mySpinorSiteSize;
-      } 
-      j = (xs*X4*X3*X2*X1 + x4*X3*X2*X1 + x3*X2*X1 + new_x2*X1 + x1) >> 1;
-      break;
-    }
-  case 4://+Z
-    {
-      int new_x3 = (x3 + nb)% X3;
-      if(x3+nb >=X3 && comm_dim_partitioned(2)) {
-        int offset = (( x3 + nb -X3)*Ls*X4*X2*X1+xs*X4*X2*X1+x4*X2*X1 + x2*X1+x1) >> 1;
-        return fwd_nbr_spinor[2] + offset*mySpinorSiteSize;
-      } 
-      j = (xs*X4*X3*X2*X1 + x4*X3*X2*X1 + new_x3*X2*X1 + x2*X1 + x1) >> 1;
-      break;
-    }
-  case 5://-Z
-    {
-      int new_x3 = (x3 - nb + X3)% X3;
-      if(x3 - nb < 0 && comm_dim_partitioned(2)){
-        int offset = (( x3 + nFace -nb)*Ls*X4*X2*X1+xs*X4*X2*X1+x4*X2*X1+x2*X1+x1) >> 1;
-        return back_nbr_spinor[2] + offset*mySpinorSiteSize;
-      }
-      j = (xs*X4*X3*X2*X1 + x4*X3*X2*X1 + new_x3*X2*X1 + x2*X1 + x1) >> 1;
-      break;
-    }
-  case 6://+T 
-    {
-      int x4 = x4_5d_mgpu<type>(i, oddBit);
-      if ( (x4 + nb) >= Z[3] && comm_dim_partitioned(3)) {
-        int offset = ((x4 + nb - Z[3])*Ls*X3*X2*X1+xs*X3*X2*X1+x3*X2*X1+x2*X1+x1) >> 1;
-        return fwd_nbr_spinor[3] + offset*mySpinorSiteSize;
-      }
-      j = neighborIndex_5d_mgpu<type>(i, oddBit, 0, +nb, 0, 0, 0);
-      break;
-    }
-  case 7://-T 
-    {
-      int x4 = x4_5d_mgpu<type>(i, oddBit);
-      if ( (x4 - nb) < 0 && comm_dim_partitioned(3)) {
-        int offset = (( x4 - nb +nFace)*Ls*X3*X2*X1+xs*X3*X2*X1+x3*X2*X1+x2*X1+x1) >> 1;
-        return back_nbr_spinor[3] + offset*mySpinorSiteSize;
-      }
-      j = neighborIndex_5d_mgpu<type>(i, oddBit, 0, -nb, 0, 0, 0);
-      break;
-    }
-  default: j = -1; printf("ERROR: wrong dir\n"); exit(1);
-  }
-
-  return &spinorField[j*(mySpinorSiteSize)];
-}
-
-template <QudaDWFPCType type, typename Float>
-Float *spinorNeighbor_5d(int i, int dir, int oddBit, Float *spinorField) {
-  int j;
-  switch (dir) {
-  case 0: j = neighborIndex_5d<type>(i, oddBit, 0, 0, 0, 0, +1); break;
-  case 1: j = neighborIndex_5d<type>(i, oddBit, 0, 0, 0, 0, -1); break;
-  case 2: j = neighborIndex_5d<type>(i, oddBit, 0, 0, 0, +1, 0); break;
-  case 3: j = neighborIndex_5d<type>(i, oddBit, 0, 0, 0, -1, 0); break;
-  case 4: j = neighborIndex_5d<type>(i, oddBit, 0, 0, +1, 0, 0); break;
-  case 5: j = neighborIndex_5d<type>(i, oddBit, 0, 0, -1, 0, 0); break;
-  case 6: j = neighborIndex_5d<type>(i, oddBit, 0, +1, 0, 0, 0); break;
-  case 7: j = neighborIndex_5d<type>(i, oddBit, 0, -1, 0, 0, 0); break;
-  case 8: j = neighborIndex_5d<type>(i, oddBit, +1, 0, 0, 0, 0); break;
-  case 9: j = neighborIndex_5d<type>(i, oddBit, -1, 0, 0, 0, 0); break;
-  default: j = -1; break;
-  }
-  
-  return &spinorField[j*(4*3*2)];
 }
 
 
@@ -523,7 +325,7 @@ void dslashReference_4d_sgpu(sFloat *res, gFloat **gaugeFull, sFloat *spinorFiel
   }
 }
 
-
+#ifdef MULTI_GPU
 template <QudaDWFPCType type, typename sFloat, typename gFloat>
 void dslashReference_4d_mgpu(sFloat *res, gFloat **gaugeFull, gFloat **ghostGauge, sFloat *spinorField,
 			     sFloat **fwdSpinor, sFloat **backSpinor, int oddBit, int daggerBit)
@@ -569,7 +371,7 @@ void dslashReference_4d_mgpu(sFloat *res, gFloat **gaugeFull, gFloat **ghostGaug
     }
   }
 }
-
+#endif
 
 //Currently we consider only spacetime decomposition (not in 5th dim), so this operator is local
 template <QudaDWFPCType type, bool zero_initialize=false, typename sFloat>

--- a/tests/dslash_util.h
+++ b/tests/dslash_util.h
@@ -144,6 +144,63 @@ static inline Float *spinorNeighbor(int i, int dir, int oddBit, Float *spinorFie
 }
 
 
+// i represents a "half index" into an even or odd "half lattice".
+// when oddBit={0,1} the half lattice is {even,odd}.
+//
+// the displacements, such as dx, refer to the full lattice coordinates.
+//
+// neighborIndex() takes a "half index", displaces it, and returns the
+// new "half index", which can be an index into either the even or odd lattices.
+// displacements of magnitude one always interchange odd and even lattices.
+//
+//
+template<QudaDWFPCType type>
+int neighborIndex_5d(int i, int oddBit, int dxs, int dx4, int dx3, int dx2, int dx1) {
+  // fullLatticeIndex was modified for fullLatticeIndex_4d.  It is in util_quda.cpp.
+  // This code bit may not properly perform 5dPC.
+  int X = type == QUDA_5D_PC ? fullLatticeIndex_5d(i, oddBit) : fullLatticeIndex_5d_4dpc(i, oddBit);
+  // Checked that this matches code in dslash_core_ante.h.
+  int xs = X/(Z[3]*Z[2]*Z[1]*Z[0]);
+  int x4 = (X/(Z[2]*Z[1]*Z[0])) % Z[3];
+  int x3 = (X/(Z[1]*Z[0])) % Z[2];
+  int x2 = (X/Z[0]) % Z[1];
+  int x1 = X % Z[0];
+  // Displace and project back into domain 0,...,Ls-1.
+  // Note that we add Ls to avoid the negative problem
+  // of the C % operator.
+  xs = (xs+dxs+Ls) % Ls;
+  // Etc.
+  x4 = (x4+dx4+Z[3]) % Z[3];
+  x3 = (x3+dx3+Z[2]) % Z[2];
+  x2 = (x2+dx2+Z[1]) % Z[1];
+  x1 = (x1+dx1+Z[0]) % Z[0];
+  // Return linear half index.  Remember that integer division
+  // rounds down.
+  return (xs*(Z[3]*Z[2]*Z[1]*Z[0]) + x4*(Z[2]*Z[1]*Z[0]) + x3*(Z[1]*Z[0]) + x2*(Z[0]) + x1) / 2;
+}
+
+
+template <QudaDWFPCType type, typename Float>
+  Float *spinorNeighbor_5d(int i, int dir, int oddBit, Float *spinorField, int neighbor_distance=1, int siteSize=24) {
+  int nb = neighbor_distance;
+  int j;
+  switch (dir) {
+  case 0: j = neighborIndex_5d<type>(i, oddBit, 0, 0, 0, 0, +nb); break;
+  case 1: j = neighborIndex_5d<type>(i, oddBit, 0, 0, 0, 0, -nb); break;
+  case 2: j = neighborIndex_5d<type>(i, oddBit, 0, 0, 0, +nb, 0); break;
+  case 3: j = neighborIndex_5d<type>(i, oddBit, 0, 0, 0, -nb, 0); break;
+  case 4: j = neighborIndex_5d<type>(i, oddBit, 0, 0, +nb, 0, 0); break;
+  case 5: j = neighborIndex_5d<type>(i, oddBit, 0, 0, -nb, 0, 0); break;
+  case 6: j = neighborIndex_5d<type>(i, oddBit, 0, +nb, 0, 0, 0); break;
+  case 7: j = neighborIndex_5d<type>(i, oddBit, 0, -nb, 0, 0, 0); break;
+  case 8: j = neighborIndex_5d<type>(i, oddBit, +nb, 0, 0, 0, 0); break;
+  case 9: j = neighborIndex_5d<type>(i, oddBit, -nb, 0, 0, 0, 0); break;
+  default: j = -1; break;
+  }
+  return &spinorField[j*siteSize];
+}
+
+
 #ifdef MULTI_GPU
 
 static inline int
@@ -310,7 +367,7 @@ static inline Float *spinorNeighbor_mg4dir(int i, int dir, int oddBit, Float *sp
       j = (x4*X3*X2*X1 + new_x3*X2*X1 + x2*X1 + x1) / 2;
       break;
     }
-  case 6://+T 
+  case 6://+T
     {
       j = neighborIndex_mg(i, oddBit, +nb, 0, 0, 0);
       int x4 = x4_mg(i, oddBit);
@@ -320,7 +377,7 @@ static inline Float *spinorNeighbor_mg4dir(int i, int dir, int oddBit, Float *sp
       }
       break;
     }
-  case 7://-T 
+  case 7://-T
     {
       j = neighborIndex_mg(i, oddBit, -nb, 0, 0, 0);
       int x4 = x4_mg(i, oddBit);
@@ -335,6 +392,148 @@ static inline Float *spinorNeighbor_mg4dir(int i, int dir, int oddBit, Float *sp
 
   return &spinorField[j*(mySpinorSiteSize)];
 }
+
+template<QudaDWFPCType type>
+int neighborIndex_5d_mgpu(int i, int oddBit, int dxs, int dx4, int dx3, int dx2, int dx1)
+{
+  int ret;
+
+  int Y = (type == QUDA_5D_PC) ? fullLatticeIndex_5d(i, oddBit) : fullLatticeIndex_5d_4dpc(i, oddBit);
+
+  int xs = Y/(Z[3]*Z[2]*Z[1]*Z[0]);
+  int x4 = (Y/(Z[2]*Z[1]*Z[0])) % Z[3];
+  int x3 = (Y/(Z[1]*Z[0])) % Z[2];
+  int x2 = (Y/Z[0]) % Z[1];
+  int x1 = Y % Z[0];
+  int ghost_x4 = x4+ dx4;
+
+  xs = (xs+dxs+Ls) % Ls;
+  x4 = (x4+dx4+Z[3]) % Z[3];
+  x3 = (x3+dx3+Z[2]) % Z[2];
+  x2 = (x2+dx2+Z[1]) % Z[1];
+  x1 = (x1+dx1+Z[0]) % Z[0];
+
+  if ( (ghost_x4 >= 0 && ghost_x4) < Z[3] || !comm_dim_partitioned(3)){
+    ret = (xs*Z[3]*Z[2]*Z[1]*Z[0] + x4*Z[2]*Z[1]*Z[0] + x3*Z[1]*Z[0] + x2*Z[0] + x1) >> 1;
+  }else{
+    ret = (xs*Z[2]*Z[1]*Z[0] + x3*Z[1]*Z[0] + x2*Z[0] + x1) >> 1;
+  }
+
+  return ret;
+}
+
+template <QudaDWFPCType type>
+int x4_5d_mgpu(int i, int oddBit)
+{
+  int Y = (type == QUDA_5D_PC) ? fullLatticeIndex_5d(i, oddBit) : fullLatticeIndex_5d_4dpc(i, oddBit);
+  return (Y/(Z[2]*Z[1]*Z[0])) % Z[3];
+}
+
+
+template <QudaDWFPCType type, typename Float>
+Float *spinorNeighbor_5d_mgpu(int i, int dir, int oddBit, Float *spinorField, Float** fwd_nbr_spinor, Float** back_nbr_spinor, int neighbor_distance, int nFace, int spinorSize = 24)
+{
+  int j;
+  int nb = neighbor_distance;
+  int Y = (type == QUDA_5D_PC) ? fullLatticeIndex_5d(i, oddBit) : fullLatticeIndex_5d_4dpc(i, oddBit);
+
+  int xs = Y/(Z[3]*Z[2]*Z[1]*Z[0]);
+  int x4 = (Y/(Z[2]*Z[1]*Z[0])) % Z[3];
+  int x3 = (Y/(Z[1]*Z[0])) % Z[2];
+  int x2 = (Y/Z[0]) % Z[1];
+  int x1 = Y % Z[0];
+
+  int X1= Z[0];
+  int X2= Z[1];
+  int X3= Z[2];
+  int X4= Z[3];
+  switch (dir) {
+  case 0://+X
+    {
+      int new_x1 = (x1 + nb)% X1;
+      if(x1+nb >=X1 && comm_dim_partitioned(0)) {
+        int offset = ((x1 + nb -X1)*Ls*X4*X3*X2+xs*X4*X3*X2+x4*X3*X2 + x3*X2+x2) >> 1;
+        return fwd_nbr_spinor[0] + offset*spinorSize;
+      }
+      j = (xs*X4*X3*X2*X1 + x4*X3*X2*X1 + x3*X2*X1 + x2*X1 + new_x1) >> 1;
+      break;
+    }
+  case 1://-X
+    {
+      int new_x1 = (x1 - nb + X1)% X1;
+      if(x1 - nb < 0 && comm_dim_partitioned(0)) {
+        int offset = (( x1+nFace- nb)*Ls*X4*X3*X2 + xs*X4*X3*X2 + x4*X3*X2 + x3*X2 + x2) >> 1;
+        return back_nbr_spinor[0] + offset*spinorSize;
+      }
+      j = (xs*X4*X3*X2*X1 + x4*X3*X2*X1 + x3*X2*X1 + x2*X1 + new_x1) >> 1;
+      break;
+    }
+  case 2://+Y
+    {
+      int new_x2 = (x2 + nb)% X2;
+      if(x2+nb >=X2 && comm_dim_partitioned(1)) {
+        int offset = (( x2 + nb -X2)*Ls*X4*X3*X1+xs*X4*X3*X1+x4*X3*X1 + x3*X1+x1) >> 1;
+        return fwd_nbr_spinor[1] + offset*spinorSize;
+      }
+      j = (xs*X4*X3*X2*X1 + x4*X3*X2*X1 + x3*X2*X1 + new_x2*X1 + x1) >> 1;
+      break;
+    }
+  case 3:// -Y
+    {
+      int new_x2 = (x2 - nb + X2)% X2;
+      if(x2 - nb < 0 && comm_dim_partitioned(1)) {
+        int offset = (( x2 + nFace -nb)*Ls*X4*X3*X1+xs*X4*X3*X1+ x4*X3*X1 + x3*X1+x1) >> 1;
+        return back_nbr_spinor[1] + offset*spinorSize;
+      }
+      j = (xs*X4*X3*X2*X1 + x4*X3*X2*X1 + x3*X2*X1 + new_x2*X1 + x1) >> 1;
+      break;
+    }
+  case 4://+Z
+    {
+      int new_x3 = (x3 + nb)% X3;
+      if(x3+nb >=X3 && comm_dim_partitioned(2)) {
+        int offset = (( x3 + nb -X3)*Ls*X4*X2*X1+xs*X4*X2*X1+x4*X2*X1 + x2*X1+x1) >> 1;
+        return fwd_nbr_spinor[2] + offset*spinorSize;
+      }
+      j = (xs*X4*X3*X2*X1 + x4*X3*X2*X1 + new_x3*X2*X1 + x2*X1 + x1) >> 1;
+      break;
+    }
+  case 5://-Z
+    {
+      int new_x3 = (x3 - nb + X3)% X3;
+      if(x3 - nb < 0 && comm_dim_partitioned(2)){
+        int offset = (( x3 + nFace -nb)*Ls*X4*X2*X1+xs*X4*X2*X1+x4*X2*X1+x2*X1+x1) >> 1;
+        return back_nbr_spinor[2] + offset*spinorSize;
+      }
+      j = (xs*X4*X3*X2*X1 + x4*X3*X2*X1 + new_x3*X2*X1 + x2*X1 + x1) >> 1;
+      break;
+    }
+  case 6://+T
+    {
+      int x4 = x4_5d_mgpu<type>(i, oddBit);
+      if ( (x4 + nb) >= Z[3] && comm_dim_partitioned(3)) {
+        int offset = ((x4 + nb - Z[3])*Ls*X3*X2*X1+xs*X3*X2*X1+x3*X2*X1+x2*X1+x1) >> 1;
+        return fwd_nbr_spinor[3] + offset*spinorSize;
+      }
+      j = neighborIndex_5d_mgpu<type>(i, oddBit, 0, +nb, 0, 0, 0);
+      break;
+    }
+  case 7://-T
+    {
+      int x4 = x4_5d_mgpu<type>(i, oddBit);
+      if ( (x4 - nb) < 0 && comm_dim_partitioned(3)) {
+        int offset = (( x4 - nb +nFace)*Ls*X3*X2*X1+xs*X3*X2*X1+x3*X2*X1+x2*X1+x1) >> 1;
+        return back_nbr_spinor[3] + offset*spinorSize;
+      }
+      j = neighborIndex_5d_mgpu<type>(i, oddBit, 0, -nb, 0, 0, 0);
+      break;
+    }
+  default: j = -1; printf("ERROR: wrong dir\n"); exit(1);
+  }
+
+  return &spinorField[j*(spinorSize)];
+}
+
 
 #endif // MULTI_GPU
 

--- a/tests/staggered_dslash_reference.cpp
+++ b/tests/staggered_dslash_reference.cpp
@@ -47,7 +47,9 @@ template <typename sFloat, typename gFloat>
 void dslashReference(sFloat *res, gFloat **fatlink, gFloat** longlink, sFloat *spinorField, 
 		     int oddBit, int daggerBit) 
 {
-  for (int i=0; i<Vh*1*3*2; i++) res[i] = 0.0;
+  const int nSrc = Ls; // Ls should already be set
+
+  for (int i=0; i<Vh*mySpinorSiteSize*nSrc; i++) res[i] = 0.0;
   
   gFloat *fatlinkEven[4], *fatlinkOdd[4];
   gFloat *longlinkEven[4], *longlinkOdd[4];
@@ -58,36 +60,38 @@ void dslashReference(sFloat *res, gFloat **fatlink, gFloat** longlink, sFloat *s
     longlinkEven[dir] =longlink[dir];
     longlinkOdd[dir] = longlink[dir] + Vh*gaugeSiteSize;    
   }
-  
-  for (int i = 0; i < Vh; i++) {
-    memset(res + i*mySpinorSiteSize, 0, mySpinorSiteSize*sizeof(sFloat));
-    for (int dir = 0; dir < 8; dir++) {
-      gFloat* fatlnk = gaugeLink(i, dir, oddBit, fatlinkEven, fatlinkOdd, 1);
-      gFloat* longlnk = gaugeLink(i, dir, oddBit, longlinkEven, longlinkOdd, 3);
-      
-      sFloat *first_neighbor_spinor = spinorNeighbor(i, dir, oddBit, spinorField, 1);
-      sFloat *third_neighbor_spinor = spinorNeighbor(i, dir, oddBit, spinorField, 3);
-      
-      
-      sFloat gaugedSpinor[mySpinorSiteSize];
-      
-      if (dir % 2 == 0){
-	su3Mul(gaugedSpinor, fatlnk, first_neighbor_spinor);
-	sum(&res[i*mySpinorSiteSize], &res[i*mySpinorSiteSize], gaugedSpinor, mySpinorSiteSize);	    
-	su3Mul(gaugedSpinor, longlnk, third_neighbor_spinor);
-	sum(&res[i*mySpinorSiteSize], &res[i*mySpinorSiteSize], gaugedSpinor, mySpinorSiteSize);		
-      } else {
-	su3Tmul(gaugedSpinor, fatlnk, first_neighbor_spinor);
-	sub(&res[i*mySpinorSiteSize], &res[i*mySpinorSiteSize], gaugedSpinor, mySpinorSiteSize);       	
-	
-	su3Tmul(gaugedSpinor, longlnk, third_neighbor_spinor);
-	sub(&res[i*mySpinorSiteSize], &res[i*mySpinorSiteSize], gaugedSpinor, mySpinorSiteSize);
-      }	    	    
-    }
-    if (daggerBit){
-      negx(&res[i*mySpinorSiteSize], mySpinorSiteSize);
-    }
-  }
+
+  for (int xs=0; xs<nSrc; xs++) {
+
+    for (int i = 0; i < Vh; i++) {
+      int sid = i + xs*Vh;
+      int offset = mySpinorSiteSize*sid;
+
+      for (int dir = 0; dir < 8; dir++) {
+	gFloat* fatlnk = gaugeLink(i, dir, oddBit, fatlinkEven, fatlinkOdd, 1);
+	gFloat* longlnk = gaugeLink(i, dir, oddBit, longlinkEven, longlinkOdd, 3);
+
+	sFloat *first_neighbor_spinor = spinorNeighbor_5d<QUDA_4D_PC>(sid, dir, oddBit, spinorField, 1, mySpinorSiteSize);
+	sFloat *third_neighbor_spinor = spinorNeighbor_5d<QUDA_4D_PC>(sid, dir, oddBit, spinorField, 3, mySpinorSiteSize);
+
+	sFloat gaugedSpinor[mySpinorSiteSize];
+
+	if (dir % 2 == 0){
+	  su3Mul(gaugedSpinor, fatlnk, first_neighbor_spinor);
+	  sum(&res[offset], &res[offset], gaugedSpinor, mySpinorSiteSize);
+	  su3Mul(gaugedSpinor, longlnk, third_neighbor_spinor);
+	  sum(&res[offset], &res[offset], gaugedSpinor, mySpinorSiteSize);
+	} else {
+	  su3Tmul(gaugedSpinor, fatlnk, first_neighbor_spinor);
+	  sub(&res[offset], &res[offset], gaugedSpinor, mySpinorSiteSize);
+	  su3Tmul(gaugedSpinor, longlnk, third_neighbor_spinor);
+	  sub(&res[offset], &res[offset], gaugedSpinor, mySpinorSiteSize);
+	}
+      }
+
+      if (daggerBit) negx(&res[offset], mySpinorSiteSize);
+    } // 4-d volume
+  } // right-hand-side
   
 }
 
@@ -269,11 +273,10 @@ template <typename sFloat, typename gFloat>
 void dslashReference_mg4dir(sFloat *res, gFloat **fatlink, gFloat** longlink, 
 			    gFloat** ghostFatlink, gFloat** ghostLonglink,
 			    sFloat *spinorField, sFloat** fwd_nbr_spinor, 
-			    sFloat** back_nbr_spinor, int oddBit, int daggerBit)
+			    sFloat** back_nbr_spinor, int oddBit, int daggerBit, int nSrc)
 {
-  for (int i=0; i<Vh*1*3*2; i++) res[i] = 0.0;
+  for (int i=0; i<Vh*mySpinorSiteSize*nSrc; i++) res[i] = 0.0;
 
-  int Vsh[4] = {Vsh_x, Vsh_y, Vsh_z, Vsh_t};
   gFloat *fatlinkEven[4], *fatlinkOdd[4];
   gFloat *longlinkEven[4], *longlinkOdd[4];
   gFloat *ghostFatlinkEven[4], *ghostFatlinkOdd[4];
@@ -286,43 +289,42 @@ void dslashReference_mg4dir(sFloat *res, gFloat **fatlink, gFloat** longlink,
     longlinkOdd[dir] = longlink[dir] + Vh*gaugeSiteSize;
     
     ghostFatlinkEven[dir] = ghostFatlink[dir];
-    ghostFatlinkOdd[dir] = ghostFatlink[dir] + Vsh[dir]*gaugeSiteSize;
+    ghostFatlinkOdd[dir] = ghostFatlink[dir] + (faceVolume[dir]/2)*gaugeSiteSize;
     ghostLonglinkEven[dir] = ghostLonglink[dir];
-    ghostLonglinkOdd[dir] = ghostLonglink[dir] + 3*Vsh[dir]*gaugeSiteSize;
+    ghostLonglinkOdd[dir] = ghostLonglink[dir] + 3*(faceVolume[dir]/2)*gaugeSiteSize;
   }
 
-  for (int i = 0; i < Vh; i++) {
-    memset(res + i*mySpinorSiteSize, 0, mySpinorSiteSize*sizeof(sFloat));
-    for (int dir = 0; dir < 8; dir++) {
-      gFloat* fatlnk = gaugeLink_mg4dir(i, dir, oddBit, fatlinkEven, fatlinkOdd, ghostFatlinkEven, ghostFatlinkOdd, 1, 1);
-      gFloat* longlnk = gaugeLink_mg4dir(i, dir, oddBit, longlinkEven, longlinkOdd, ghostLonglinkEven, ghostLonglinkOdd, 3, 3);
+  for (int xs=0; xs<nSrc; xs++) {
 
-      sFloat *first_neighbor_spinor = spinorNeighbor_mg4dir(i, dir, oddBit, spinorField, fwd_nbr_spinor, back_nbr_spinor, 1, 3);
-      sFloat *third_neighbor_spinor = spinorNeighbor_mg4dir(i, dir, oddBit, spinorField, fwd_nbr_spinor, back_nbr_spinor, 3, 3);
+    for (int i = 0; i < Vh; i++) {
+      int sid = i + xs*Vh;
+      int offset = mySpinorSiteSize*sid;
 
-      sFloat gaugedSpinor[mySpinorSiteSize];
-
-
-      if (dir % 2 == 0){
-        su3Mul(gaugedSpinor, fatlnk, first_neighbor_spinor);
-        sum(&res[i*mySpinorSiteSize], &res[i*mySpinorSiteSize], gaugedSpinor, mySpinorSiteSize);
-        su3Mul(gaugedSpinor, longlnk, third_neighbor_spinor);
-        sum(&res[i*mySpinorSiteSize], &res[i*mySpinorSiteSize], gaugedSpinor, mySpinorSiteSize);                                                        
-      }
-      else{
-        su3Tmul(gaugedSpinor, fatlnk, first_neighbor_spinor);
-        sub(&res[i*mySpinorSiteSize], &res[i*mySpinorSiteSize], gaugedSpinor, mySpinorSiteSize);
-
-        su3Tmul(gaugedSpinor, longlnk, third_neighbor_spinor);
-        sub(&res[i*mySpinorSiteSize], &res[i*mySpinorSiteSize], gaugedSpinor, mySpinorSiteSize);
+      for (int dir = 0; dir < 8; dir++) {
+	gFloat* fatlnk = gaugeLink_mg4dir(i, dir, oddBit, fatlinkEven, fatlinkOdd, ghostFatlinkEven, ghostFatlinkOdd, 1, 1);
+	gFloat* longlnk = gaugeLink_mg4dir(i, dir, oddBit, longlinkEven, longlinkOdd, ghostLonglinkEven, ghostLonglinkOdd, 3, 3);
 	
+	sFloat *first_neighbor_spinor = spinorNeighbor_5d_mgpu<QUDA_4D_PC>(sid, dir, oddBit, spinorField, fwd_nbr_spinor, back_nbr_spinor, 1, 3, mySpinorSiteSize);
+	sFloat *third_neighbor_spinor = spinorNeighbor_5d_mgpu<QUDA_4D_PC>(sid, dir, oddBit, spinorField, fwd_nbr_spinor, back_nbr_spinor, 3, 3, mySpinorSiteSize);
+
+	sFloat gaugedSpinor[mySpinorSiteSize];
+
+	if (dir % 2 == 0){
+	  su3Mul(gaugedSpinor, fatlnk, first_neighbor_spinor);
+	  sum(&res[offset], &res[offset], gaugedSpinor, mySpinorSiteSize);
+	  su3Mul(gaugedSpinor, longlnk, third_neighbor_spinor);
+	  sum(&res[offset], &res[offset], gaugedSpinor, mySpinorSiteSize);
+	} else {
+	  su3Tmul(gaugedSpinor, fatlnk, first_neighbor_spinor);
+	  sub(&res[offset], &res[offset], gaugedSpinor, mySpinorSiteSize);
+	  su3Tmul(gaugedSpinor, longlnk, third_neighbor_spinor);
+	  sub(&res[offset], &res[offset], gaugedSpinor, mySpinorSiteSize);
+	}
       }
 
-    }
-    if (daggerBit){
-      negx(&res[i*mySpinorSiteSize], mySpinorSiteSize);
-    }
-  }
+      if (daggerBit) negx(&res[offset], mySpinorSiteSize);
+    } // 4-d volume
+  } // right-hand-side
 
 }
 
@@ -332,8 +334,7 @@ void staggered_dslash_mg4dir(cpuColorSpinorField* out, void **fatlink, void** lo
 			     void** ghost_longlink, cpuColorSpinorField* in, int oddBit, int daggerBit, 
 			     QudaPrecision sPrecision, QudaPrecision gPrecision)
 {
-  const int Nsrc = out->X(4);
-  const int nFace = 3;
+  const int nSrc = in->X(4);
 
   QudaParity otherparity = QUDA_INVALID_PARITY;
   if (oddBit == QUDA_EVEN_PARITY) {
@@ -349,35 +350,23 @@ void staggered_dslash_mg4dir(cpuColorSpinorField* out, void **fatlink, void** lo
   void** fwd_nbr_spinor = in->fwdGhostFaceBuffer;
   void** back_nbr_spinor = in->backGhostFaceBuffer;
 
-  for (int i=0; i<Nsrc; i++) {
-    void *In = static_cast<char*>(in->V()) + i * 6 * sPrecision * (in->VolumeCB() / Nsrc);
-    void *Out = static_cast<char*>(out->V()) + i * 6 * sPrecision * (in->VolumeCB() / Nsrc);
-
-    void *fwd_ghost[4], *back_ghost[4];
-    for (int d=0; d<4; d++) {
-      fwd_ghost[d] = static_cast<char*>(fwd_nbr_spinor[d]) + i * 6 * nFace * sPrecision * (in->SurfaceCB(d) / Nsrc);
-      back_ghost[d] = static_cast<char*>(back_nbr_spinor[d]) + i * 6 * nFace * sPrecision * (in->SurfaceCB(d) / Nsrc);
-    }
-
-    if (sPrecision == QUDA_DOUBLE_PRECISION) {
-      if (gPrecision == QUDA_DOUBLE_PRECISION) {
-	dslashReference_mg4dir((double*)Out, (double**)fatlink, (double**)longlink, (double**)ghost_fatlink, (double**)ghost_longlink,
-			       (double*)In, (double**)fwd_ghost, (double**)back_ghost, oddBit, daggerBit);
-      } else {
-	dslashReference_mg4dir((double*)Out, (float**)fatlink, (float**)longlink, (float**)ghost_fatlink, (float**)ghost_longlink,
-			       (double*)In, (double**)fwd_ghost, (double**)back_ghost, oddBit, daggerBit);
-      }
+  if (sPrecision == QUDA_DOUBLE_PRECISION) {
+    if (gPrecision == QUDA_DOUBLE_PRECISION) {
+      dslashReference_mg4dir((double*)out->V(), (double**)fatlink, (double**)longlink, (double**)ghost_fatlink, (double**)ghost_longlink,
+			     (double*)in->V(), (double**)fwd_nbr_spinor, (double**)back_nbr_spinor, oddBit, daggerBit, nSrc);
     } else {
-      if (gPrecision == QUDA_DOUBLE_PRECISION) {
-	dslashReference_mg4dir((float*)Out, (double**)fatlink, (double**)longlink, (double**)ghost_fatlink, (double**)ghost_longlink,
-			       (float*)In, (float**)fwd_ghost, (float**)back_ghost, oddBit, daggerBit);
-      } else {
-	dslashReference_mg4dir((float*)Out, (float**)fatlink, (float**)longlink, (float**)ghost_fatlink, (float**)ghost_longlink,
-			       (float*)In, (float**)fwd_ghost, (float**)back_ghost, oddBit, daggerBit);
+      dslashReference_mg4dir((double*)out->V(), (float**)fatlink, (float**)longlink, (float**)ghost_fatlink, (float**)ghost_longlink,
+			     (double*)in->V(), (double**)fwd_nbr_spinor, (double**)back_nbr_spinor, oddBit, daggerBit, nSrc);
       }
+  } else {
+    if (gPrecision == QUDA_DOUBLE_PRECISION) {
+      dslashReference_mg4dir((float*)out->V(), (double**)fatlink, (double**)longlink, (double**)ghost_fatlink, (double**)ghost_longlink,
+			     (float*)in->V(), (float**)fwd_nbr_spinor, (float**)back_nbr_spinor, oddBit, daggerBit, nSrc);
+    } else {
+      dslashReference_mg4dir((float*)out->V(), (float**)fatlink, (float**)longlink, (float**)ghost_fatlink, (float**)ghost_longlink,
+			     (float*)in->V(), (float**)fwd_nbr_spinor, (float**)back_nbr_spinor, oddBit, daggerBit, nSrc);
     }
   }
-  
   
 }
 

--- a/tests/staggered_dslash_reference.cpp
+++ b/tests/staggered_dslash_reference.cpp
@@ -175,7 +175,7 @@ Matdagmat(sFloat *out, gFloat **fatlink, gFloat** longlink, sFloat *in, sFloat m
       dslashReference(outEven, fatlink, longlink, tmp, 0, daggerBit);
 	    
       // lastly apply the mass term
-      axmy(inEven, msq_x4, outEven, Vh*mySpinorSiteSize);
+      axmy(inEven, msq_x4, outEven, Ls*Vh*mySpinorSiteSize);
       break;
     }
   case QUDA_ODD_PARITY:
@@ -186,7 +186,7 @@ Matdagmat(sFloat *out, gFloat **fatlink, gFloat** longlink, sFloat *in, sFloat m
       dslashReference(outOdd, fatlink, longlink, tmp, 1, daggerBit);
 	    
       // lastly apply the mass term
-      axmy(inOdd, msq_x4, outOdd, Vh*mySpinorSiteSize);
+      axmy(inOdd, msq_x4, outOdd, Ls*Vh*mySpinorSiteSize);
       break;	
     }
 	
@@ -264,7 +264,7 @@ staggered_matpc(void *outEven, void **fatlink, void**longlink, void *inEven, dou
 
   // lastly apply the kappa term
   double kappa2 = -kappa*kappa;
-  xpay(inEven, kappa2, outEven, Vh*mySpinorSiteSize, sPrecision);
+  xpay(inEven, kappa2, outEven, Ls*Vh*mySpinorSiteSize, sPrecision);
 }
 
 #ifdef MULTI_GPU
@@ -373,7 +373,7 @@ void staggered_dslash_mg4dir(cpuColorSpinorField* out, void **fatlink, void** lo
 void 
 matdagmat_mg4dir(cpuColorSpinorField* out, void **fatlink, void** longlink, void** ghost_fatlink, void** ghost_longlink, 
 		 cpuColorSpinorField* in, double mass, int dagger_bit,
-		 QudaPrecision sPrecision, QudaPrecision gPrecision, cpuColorSpinorField* tmp, QudaParity parity) 
+		 QudaPrecision sPrecision, QudaPrecision gPrecision, cpuColorSpinorField* tmp, QudaParity parity)
 {
   //assert sPrecision and gPrecision must be the same
   if (sPrecision != gPrecision){
@@ -383,9 +383,9 @@ matdagmat_mg4dir(cpuColorSpinorField* out, void **fatlink, void** longlink, void
   QudaParity otherparity = QUDA_INVALID_PARITY;
   if (parity == QUDA_EVEN_PARITY){
     otherparity = QUDA_ODD_PARITY;
-  }else if (parity == QUDA_ODD_PARITY){
+  } else if (parity == QUDA_ODD_PARITY) {
     otherparity = QUDA_EVEN_PARITY;
-  }else{
+  } else {
     errorQuda("ERROR: full parity not supported in function %s\n", __FUNCTION__);
   }
   
@@ -397,9 +397,9 @@ matdagmat_mg4dir(cpuColorSpinorField* out, void **fatlink, void** longlink, void
   
   double msq_x4 = mass*mass*4;
   if (sPrecision == QUDA_DOUBLE_PRECISION){
-    axmy((double*)in->V(), (double)msq_x4, (double*)out->V(), Vh*mySpinorSiteSize);
+    axmy((double*)in->V(), (double)msq_x4, (double*)out->V(), out->X(4)*Vh*mySpinorSiteSize);
   }else{
-    axmy((float*)in->V(), (float)msq_x4, (float*)out->V(), Vh*mySpinorSiteSize);    
+    axmy((float*)in->V(), (float)msq_x4, (float*)out->V(), out->X(4)*Vh*mySpinorSiteSize);
   }
 
 }

--- a/tests/staggered_dslash_test.cpp
+++ b/tests/staggered_dslash_test.cpp
@@ -95,6 +95,7 @@ void init()
   gaugeParam.X[3] = X[3] = tdim;
 
   setDims(gaugeParam.X);
+  dw_setDims(gaugeParam.X,Nsrc); // so we can use 5-d indexing from dwf
   setSpinorSiteSize(6);
 
   gaugeParam.cpu_prec = QUDA_DOUBLE_PRECISION;
@@ -373,13 +374,7 @@ void staggeredDslashRef()
       staggered_dslash_mg4dir(spinorRef, fatlink, longlink, (void**)ghost_fatlink, (void**)ghost_longlink, 
 			      spinor, parity, dagger, inv_param.cpu_prec, gaugeParam.cpu_prec);
 #else
-      for (int i=0; i<Nsrc; i++) {
-	void *in = (char*)spinor->V() + i * 6 * inv_param.cpu_prec * (spinor->Volume() / Nsrc);
-	void *out = (char*)spinorRef->V() + i * 6 * inv_param.cpu_prec * (spinorRef->Volume() / Nsrc);
-
-	staggered_dslash(out, fatlink, longlink, in, parity, dagger,
-			 inv_param.cpu_prec, gaugeParam.cpu_prec);
-      }
+      staggered_dslash(spinorRef->V(), fatlink, longlink, spinor->V(), parity, dagger, inv_param.cpu_prec, gaugeParam.cpu_prec);
 #endif    
       break;
     case 1: 
@@ -388,12 +383,7 @@ void staggeredDslashRef()
 			      spinor, parity, dagger, inv_param.cpu_prec, gaugeParam.cpu_prec);
 
 #else
-      for (int i=0; i<Nsrc; i++) {
-	void *in = (char*)spinor->V() + i * 6 * inv_param.cpu_prec * (spinor->Volume() / Nsrc);
-	void *out = (char*)spinorRef->V() + i * 6 * inv_param.cpu_prec * (spinorRef->Volume() / Nsrc);
-	staggered_dslash(out, fatlink, longlink, in, parity, dagger,
-			 inv_param.cpu_prec, gaugeParam.cpu_prec);
-      }
+      staggered_dslash(spinorRef->V(), fatlink, longlink, spinor->V(), parity, dagger, inv_param.cpu_prec, gaugeParam.cpu_prec);
 #endif
       break;
     case 2:

--- a/tests/staggered_dslash_test.cpp
+++ b/tests/staggered_dslash_test.cpp
@@ -42,7 +42,7 @@ QudaInvertParam inv_param;
 cpuGaugeField *cpuFat = NULL;
 cpuGaugeField *cpuLong = NULL;
 
-cpuColorSpinorField *spinor, *spinorOut, *spinorRef;
+cpuColorSpinorField *spinor, *spinorOut, *spinorRef, *tmpCpu;
 cudaColorSpinorField *cudaSpinor, *cudaSpinorOut;
 
 cudaColorSpinorField* tmp;
@@ -54,7 +54,7 @@ void *fatlink[4], *longlink[4];
 const void **ghost_fatlink, **ghost_longlink;
 #endif
 
-QudaParity parity;
+QudaParity parity = QUDA_EVEN_PARITY;
 extern QudaDagType dagger;
 int transfer = 0; // include transfer time in the benchmark?
 extern int xdim;
@@ -70,6 +70,8 @@ extern bool verify_results;
 extern int niter;
 
 extern bool kernel_pack_t;
+
+extern double mass; // the mass of the Dirac operator
 
 int X[4];
 extern int Nsrc; // number of spinors to apply to simultaneously
@@ -123,6 +125,7 @@ void init()
   inv_param.dagger = dagger;
   inv_param.matpc_type = QUDA_MATPC_EVEN_EVEN;
   inv_param.dslash_type = dslash_type;
+  inv_param.mass = mass;
 
   // ensure that the default is improved staggered
   if (inv_param.dslash_type != QUDA_STAGGERED_DSLASH &&
@@ -168,6 +171,7 @@ void init()
   spinor = new cpuColorSpinorField(csParam);
   spinorOut = new cpuColorSpinorField(csParam);
   spinorRef = new cpuColorSpinorField(csParam);
+  tmpCpu = new cpuColorSpinorField(csParam);
 
   csParam.siteSubset = QUDA_FULL_SITE_SUBSET;
   csParam.x[0] = gaugeParam.X[0];
@@ -263,9 +267,8 @@ void init()
     double cuda_spinor_norm2=  blas::norm2(*cudaSpinor);
     printfQuda("Source CPU = %f, CUDA=%f\n", spinor_norm2, cuda_spinor_norm2);
 
-    if(test_type == 2){
-      csParam.x[0] /=2;
-    }
+    if(test_type == 2) csParam.x[0] /=2;
+
     csParam.siteSubset = QUDA_PARITY_SITE_SUBSET;
     tmp = new cudaColorSpinorField(csParam);
 
@@ -301,6 +304,7 @@ void end(void)
   delete spinor;
   delete spinorOut;
   delete spinorRef;
+  delete tmpCpu;
 
   if (cpuFat) delete cpuFat;
   if (cpuLong) delete cpuLong;
@@ -318,7 +322,6 @@ double dslashCUDA(int niter) {
   for (int i = 0; i < niter; i++) {
     switch (test_type) {
       case 0:
-        parity = QUDA_EVEN_PARITY;
         if (transfer){
           //dslashQuda(spinorOdd, spinorEven, &inv_param, parity);
         } else {
@@ -326,11 +329,10 @@ double dslashCUDA(int niter) {
         }	   
         break;
       case 1:
-        parity = QUDA_ODD_PARITY;
         if (transfer){
-          //MatPCQuda(spinorOdd, spinorEven, &inv_param);
+          //MatPCDagMatPcQuda(spinorOdd, spinorEven, &inv_param);
         } else {
-          dirac->Dslash(*cudaSpinorOut, *cudaSpinor, parity);
+          dirac->MdagM(*cudaSpinorOut, *cudaSpinor);
         }
         break;
       case 2:
@@ -378,11 +380,10 @@ void staggeredDslashRef()
       break;
     case 1:
 #ifdef MULTI_GPU
-      staggered_dslash_mg4dir(spinorRef, fatlink, longlink, (void**)ghost_fatlink, (void**)ghost_longlink, 
-			      spinor, parity, dagger, inv_param.cpu_prec, gaugeParam.cpu_prec);
-
+      matdagmat_mg4dir(spinorRef, fatlink, longlink, (void**)ghost_fatlink, (void**)ghost_longlink,
+		       spinor, mass, 0, inv_param.cpu_prec, gaugeParam.cpu_prec, tmpCpu, parity);
 #else
-      staggered_dslash(spinorRef->V(), fatlink, longlink, spinor->V(), parity, dagger, inv_param.cpu_prec, gaugeParam.cpu_prec);
+      matdagmat(spinorRef->V(), fatlink, longlink, spinor->V(), mass, 0, inv_param.cpu_prec, gaugeParam.cpu_prec, tmpCpu->V(), parity);
 #endif
       break;
     case 2:

--- a/tests/staggered_dslash_test.cpp
+++ b/tests/staggered_dslash_test.cpp
@@ -364,44 +364,34 @@ double dslashCUDA(int niter) {
 void staggeredDslashRef()
 {
 
-#ifndef MULTI_GPU
-  int cpu_parity = 0;
-#endif
-
   // compare to dslash reference implementation
   printfQuda("Calculating reference implementation...");
   fflush(stdout);
   switch (test_type) {
     case 0:    
 #ifdef MULTI_GPU
-
       staggered_dslash_mg4dir(spinorRef, fatlink, longlink, (void**)ghost_fatlink, (void**)ghost_longlink, 
-          spinor, parity, dagger, inv_param.cpu_prec, gaugeParam.cpu_prec);
+			      spinor, parity, dagger, inv_param.cpu_prec, gaugeParam.cpu_prec);
 #else
-      cpu_parity = 0; //EVEN
-
       for (int i=0; i<Nsrc; i++) {
 	void *in = (char*)spinor->V() + i * 6 * inv_param.cpu_prec * (spinor->Volume() / Nsrc);
 	void *out = (char*)spinorRef->V() + i * 6 * inv_param.cpu_prec * (spinorRef->Volume() / Nsrc);
 
-	staggered_dslash(out, fatlink, longlink, in, cpu_parity, dagger, 
+	staggered_dslash(out, fatlink, longlink, in, parity, dagger,
 			 inv_param.cpu_prec, gaugeParam.cpu_prec);
       }
 #endif    
-
-
       break;
     case 1: 
 #ifdef MULTI_GPU
       staggered_dslash_mg4dir(spinorRef, fatlink, longlink, (void**)ghost_fatlink, (void**)ghost_longlink, 
-          spinor, parity, dagger, inv_param.cpu_prec, gaugeParam.cpu_prec);    
+			      spinor, parity, dagger, inv_param.cpu_prec, gaugeParam.cpu_prec);
 
 #else
-      cpu_parity=1; //ODD
       for (int i=0; i<Nsrc; i++) {
 	void *in = (char*)spinor->V() + i * 6 * inv_param.cpu_prec * (spinor->Volume() / Nsrc);
 	void *out = (char*)spinorRef->V() + i * 6 * inv_param.cpu_prec * (spinorRef->Volume() / Nsrc);
-	staggered_dslash(out, fatlink, longlink, in, cpu_parity, dagger, 
+	staggered_dslash(out, fatlink, longlink, in, parity, dagger,
 			 inv_param.cpu_prec, gaugeParam.cpu_prec);
       }
 #endif

--- a/tests/staggered_dslash_test.cpp
+++ b/tests/staggered_dslash_test.cpp
@@ -54,8 +54,6 @@ void *fatlink[4], *longlink[4];
 const void **ghost_fatlink, **ghost_longlink;
 #endif
 
-const int loops = 100;
-
 QudaParity parity;
 extern QudaDagType dagger;
 int transfer = 0; // include transfer time in the benchmark?
@@ -69,6 +67,7 @@ extern QudaPrecision prec;
 
 extern int device;
 extern bool verify_results;
+extern int niter;
 
 extern bool kernel_pack_t;
 
@@ -369,7 +368,7 @@ void staggeredDslashRef()
   printfQuda("Calculating reference implementation...");
   fflush(stdout);
   switch (test_type) {
-    case 0:    
+    case 0:
 #ifdef MULTI_GPU
       staggered_dslash_mg4dir(spinorRef, fatlink, longlink, (void**)ghost_fatlink, (void**)ghost_longlink, 
 			      spinor, parity, dagger, inv_param.cpu_prec, gaugeParam.cpu_prec);
@@ -377,7 +376,7 @@ void staggeredDslashRef()
       staggered_dslash(spinorRef->V(), fatlink, longlink, spinor->V(), parity, dagger, inv_param.cpu_prec, gaugeParam.cpu_prec);
 #endif    
       break;
-    case 1: 
+    case 1:
 #ifdef MULTI_GPU
       staggered_dslash_mg4dir(spinorRef, fatlink, longlink, (void**)ghost_fatlink, (void**)ghost_longlink, 
 			      spinor, parity, dagger, inv_param.cpu_prec, gaugeParam.cpu_prec);
@@ -420,12 +419,12 @@ static int dslashTest()
       setTuning(QUDA_TUNE_YES);
       dslashCUDA(1);
     }
-    printfQuda("Executing %d kernel loops...", loops);	
+    printfQuda("Executing %d kernel loops...", niter);
 
     // reset flop counter
     dirac->Flops();
 
-    double secs = dslashCUDA(loops);
+    double secs = dslashCUDA(niter);
 
     if (!transfer) *spinorOut = *cudaSpinorOut;
 

--- a/tests/staggered_invert_test.cpp
+++ b/tests/staggered_invert_test.cpp
@@ -64,6 +64,8 @@ extern int zdim;
 extern int tdim;
 extern int gridsize_from_cmdline[];
 
+extern int Nsrc; // number of spinors to apply to simultaneously
+
 // Dirac operator type
 extern QudaDslashType dslash_type;
 
@@ -76,11 +78,13 @@ static void end();
 
 template<typename Float>
 void constructSpinorField(Float *res) {
-  for(int i = 0; i < Vh; i++) {
-    for (int s = 0; s < 1; s++) {
-      for (int m = 0; m < 3; m++) {
-        res[i*(1*3*2) + s*(3*2) + m*(2) + 0] = rand() / (Float)RAND_MAX;
-        res[i*(1*3*2) + s*(3*2) + m*(2) + 1] = rand() / (Float)RAND_MAX;
+  for(int src=0; src<Nsrc; src++) {
+    for(int i = 0; i < Vh; i++) {
+      for (int s = 0; s < 1; s++) {
+	for (int m = 0; m < 3; m++) {
+	  res[(src*Vh + i)*(1*3*2) + s*(3*2) + m*(2) + 0] = rand() / (Float)RAND_MAX;
+	  res[(src*Vh + i)*(1*3*2) + s*(3*2) + m*(2) + 1] = rand() / (Float)RAND_MAX;
+	}
       }
     }
   }
@@ -131,7 +135,7 @@ set_params(QudaGaugeParam* gaugeParam, QudaInvertParam* inv_param,
   inv_param->use_sloppy_partial_accumulator = false;
   inv_param->pipeline = false;
 
-
+  inv_param->Ls = Nsrc;
   
   if(tol_hq == 0 && tol == 0){
     errorQuda("qudaInvert: requesting zero residual\n");
@@ -197,6 +201,7 @@ invert_test(void)
   initQuda(device);
 
   setDims(gaugeParam.X);
+  dw_setDims(gaugeParam.X,Nsrc); // so we can use 5-d indexing from dwf
   setSpinorSiteSize(6);
 
   size_t gSize = (gaugeParam.cpu_prec == QUDA_DOUBLE_PRECISION) ? sizeof(double) : sizeof(float);
@@ -228,11 +233,10 @@ invert_test(void)
   ColorSpinorParam csParam;
   csParam.nColor=3;
   csParam.nSpin=1;
-  csParam.nDim=4;
-  for(int d = 0; d < 4; d++) {
-    csParam.x[d] = gaugeParam.X[d];
-  }
+  csParam.nDim=5;
+  for (int d = 0; d < 4; d++) csParam.x[d] = gaugeParam.X[d];
   csParam.x[0] /= 2;
+  csParam.x[4] = Nsrc;
 
   csParam.precision = inv_param.cpu_prec;
   csParam.pad = 0;
@@ -305,7 +309,7 @@ invert_test(void)
   double src2=0;
   int ret = 0;
 
-
+  int len = Vh*Nsrc;
 
   switch(test_type){
     case 0: //even
@@ -322,8 +326,6 @@ invert_test(void)
       time0 += clock(); 
       time0 /= CLOCKS_PER_SEC;
 
-
-
 #ifdef MULTI_GPU    
       matdagmat_mg4dir(ref, qdp_fatlink, qdp_longlink, ghost_fatlink, ghost_longlink, 
           out, mass, 0, inv_param.cpu_prec, gaugeParam.cpu_prec, tmp, QUDA_EVEN_PARITY);
@@ -331,9 +333,9 @@ invert_test(void)
       matdagmat(ref->V(), qdp_fatlink, qdp_longlink, out->V(), mass, 0, inv_param.cpu_prec, gaugeParam.cpu_prec, tmp->V(), QUDA_EVEN_PARITY);
 #endif
 
-      mxpy(in->V(), ref->V(), Vh*mySpinorSiteSize, inv_param.cpu_prec);
-      nrm2 = norm_2(ref->V(), Vh*mySpinorSiteSize, inv_param.cpu_prec);
-      src2 = norm_2(in->V(), Vh*mySpinorSiteSize, inv_param.cpu_prec);
+      mxpy(in->V(), ref->V(), len*mySpinorSiteSize, inv_param.cpu_prec);
+      nrm2 = norm_2(ref->V(), len*mySpinorSiteSize, inv_param.cpu_prec);
+      src2 = norm_2(in->V(), len*mySpinorSiteSize, inv_param.cpu_prec);
 
       break;
 
@@ -356,9 +358,9 @@ invert_test(void)
 #else
       matdagmat(ref->V(), qdp_fatlink, qdp_longlink, out->V(), mass, 0, inv_param.cpu_prec, gaugeParam.cpu_prec, tmp->V(), QUDA_ODD_PARITY);	
 #endif
-      mxpy(in->V(), ref->V(), Vh*mySpinorSiteSize, inv_param.cpu_prec);
-      nrm2 = norm_2(ref->V(), Vh*mySpinorSiteSize, inv_param.cpu_prec);
-      src2 = norm_2(in->V(), Vh*mySpinorSiteSize, inv_param.cpu_prec);
+      mxpy(in->V(), ref->V(), len*mySpinorSiteSize, inv_param.cpu_prec);
+      nrm2 = norm_2(ref->V(), len*mySpinorSiteSize, inv_param.cpu_prec);
+      src2 = norm_2(in->V(), len*mySpinorSiteSize, inv_param.cpu_prec);
 
       break;
 
@@ -381,7 +383,6 @@ invert_test(void)
           inv_param.tol_hq_offset[i] = inv_param.tol_hq;
         }
         void* outArray[NUM_OFFSETS];
-        int len;
 
         cpuColorSpinorField* spinorOutArray[NUM_OFFSETS];
         spinorOutArray[0] = out;    
@@ -393,8 +394,6 @@ invert_test(void)
           outArray[i] = spinorOutArray[i]->V();
           inv_param.offset[i] = 4*masses[i]*masses[i];
         }
-
-        len=Vh;
 
         if (test_type == 3) {
           inv_param.matpc_type = QUDA_MATPC_EVEN_EVEN;      

--- a/tests/test_util.cpp
+++ b/tests/test_util.cpp
@@ -1577,6 +1577,7 @@ QudaDagType dagger = QUDA_DAG_NO;
 int gridsize_from_cmdline[4] = {1,1,1,1};
 QudaDslashType dslash_type = QUDA_WILSON_DSLASH;
 char latfile[256] = "";
+int Nsrc = 1;
 bool tune = true;
 int niter = 100;
 int test_type = 0;
@@ -1679,6 +1680,7 @@ void usage(char** argv )
   printf("    --mg-generate-all-levels <true/talse>     # true=generate nul space on all levels, false=generate on level 0 and create other levels from that (default true)\n");
   printf("    --mg-load-vec file                        # Load the vectors \"file\" for the multigrid_test (requires QIO)\n");
   printf("    --mg-save-vec file                        # Save the generated null-space vectors \"file\" from the multigrid_test (requires QIO)\n");
+  printf("    --nsrc <n>                                # How many spinors to apply the dslash to simultaneusly (experimental for staggered only)\n");
   printf("    --help                                    # Print out this message\n"); 
 
   usage_extra(argv); 
@@ -2262,6 +2264,20 @@ int process_command_line_option(int argc, char** argv, int* idx)
     goto out;
   }
   
+  if( strcmp(argv[i], "--nsrc") == 0){
+    if (i+1 >= argc){
+      usage(argv);
+    }
+    Nsrc= atoi(argv[i+1]);
+    if (Nsrc < 1 || Nsrc > 64){
+      printf("ERROR: invalid number of sources (%d)\n", Nsrc);
+      usage(argv);
+    }
+    i++;
+    ret = 0;
+    goto out;
+  }
+
   if( strcmp(argv[i], "--test") == 0){
     if (i+1 >= argc){
       usage(argv);


### PR DESCRIPTION
This pull request adds the following functionality to QUDA
* Support for multi-src naive-staggered and improved dslash operators - this is achieved through using 5-d fermion fields, and assigning the 5th dimension to the source index.
* Added support to the staggered reference code for multi sources (uses 4-d domain wall indexing routines)
* Staggered dslash and invert tests now support `--nsrc` flag to set the number of source vectors
* Fixes a bug in the staggered face packing in the t dimension when kernel packing is used for the t face
