### PR TITLE
Fixed bug in closeMagma, where InitMagma was not reset 

### DIFF
--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -88,23 +88,27 @@ static cudaGaugeField* cudaStapleField1 = NULL;
 
 static bool InitMagma = false;
 
-void openMagma(){
+void openMagma() {
 
-   if(!InitMagma){
-      BlasMagmaArgs::OpenMagma();
-      InitMagma = true;
-   }
-   else printfQuda("\nMAGMA library was already initialized..\n");
+  if (!InitMagma) {
+    BlasMagmaArgs::OpenMagma();
+    InitMagma = true;
+  } else {
+    printfQuda("\nMAGMA library was already initialized..\n");
+  }
 
-   return;
 }
 
 void closeMagma(){
 
-   if(InitMagma) BlasMagmaArgs::CloseMagma();
-   else printfQuda("\nMAGMA library was not initialized..\n");
+  if (InitMagma) {
+    BlasMagmaArgs::CloseMagma();
+    InitMagma = false;
+  } else {
+    printfQuda("\nMAGMA library was not initialized..\n");
+  }
 
-   return;
+  return;
 }
 
 cudaGaugeField *gaugePrecise = NULL;
@@ -2114,7 +2118,7 @@ multigrid_solver::multigrid_solver(QudaMultigridParam &mg_param, TimeProfile &pr
 
 void* newMultigridQuda(QudaMultigridParam *mg_param) {
   profileInvert.TPSTART(QUDA_PROFILE_TOTAL);
-  if(!InitMagma) openMagma();
+  openMagma();
 
   multigrid_solver *mg = new multigrid_solver(*mg_param, profileInvert);
 
@@ -2717,7 +2721,7 @@ void incrementalEigQuda(void *_h_x, void *_h_b, QudaInvertParam *param, void *_h
 {
   setTuning(param->tune);
 
-  if(!InitMagma) openMagma();
+  openMagma();
 
   if (param->dslash_type == QUDA_DOMAIN_WALL_DSLASH) setKernelPackT(true);
 
@@ -2963,7 +2967,9 @@ void incrementalEigQuda(void *_h_x, void *_h_b, QudaInvertParam *param, void *_h
 
   popVerbosity();
 
-  // FIXME: added temporarily so that the cache is written out even if a long benchmarking job gets interrupted
+  closeMagma();
+
+ // FIXME: added temporarily so that the cache is written out even if a long benchmarking job gets interrupted
   saveTuneCache(getVerbosity());
 
   profileInvert.TPSTOP(QUDA_PROFILE_TOTAL);


### PR DESCRIPTION
This fixes a bug where the static `InitMagma` flag was not reset when `closeMagma` was called, preventing MAGMA from being reopened with `openMagma`