### PR TITLE
Enable MPS functionality

### DIFF
--- a/lib/comm_mpi.cpp
+++ b/lib/comm_mpi.cpp
@@ -90,7 +90,13 @@ void comm_init(int ndim, const int *dims, QudaCommsMap rank_from_coords, void *m
     errorQuda("No CUDA devices found");
   }
   if (gpuid >= device_count) {
-    errorQuda("Too few GPUs available on %s", hostname);
+    char *enable_mps_env = getenv("QUDA_ENABLE_MPS");
+    if (enable_mps_env && strcmp(enable_mps_env,"1") == 0) {
+      gpuid = gpuid%device_count;
+      printf("MPS enabled, rank=%d -> gpu=%d\n", comm_rank(), gpuid);
+    } else {
+      errorQuda("Too few GPUs available on %s", comm_hostname());
+    }
   }
 
   comm_peer2peer_init(hostname_recv_buf);

--- a/lib/comm_qmp.cpp
+++ b/lib/comm_qmp.cpp
@@ -102,7 +102,13 @@ void comm_init(int ndim, const int *dims, QudaCommsMap rank_from_coords, void *m
     errorQuda("No CUDA devices found");
   }
   if (gpuid >= device_count) {
-    errorQuda("Too few GPUs available on %s", comm_hostname());
+    char *enable_mps_env = getenv("QUDA_ENABLE_MPS");
+    if (enable_mps_env && strcmp(enable_mps_env,"1") == 0) {
+      gpuid = gpuid%device_count;
+      printf("MPS enabled, rank=%d -> gpu=%d\n", comm_rank(), gpuid);
+    } else {
+      errorQuda("Too few GPUs available on %s", comm_hostname());
+    }
   }
 
   comm_peer2peer_init(hostname_recv_buf);


### PR DESCRIPTION
This pull adds MPS functionality to QUDA: the ability to over subscribe the GPUs if the number of processes requested per node, exceeds the number of GPUs per node.  This is enabled through the environment variable `QUDA_ENABLE_MPS=1` else it will error.