### PR TITLE
Correctly set volumeCB for parity subset references 

### DIFF
--- a/lib/color_spinor_field.cpp
+++ b/lib/color_spinor_field.cpp
@@ -286,7 +286,7 @@ namespace quda {
       if (param.x[d] != 0) x[d] = param.x[d];
       volume *= x[d];
     }
-    volumeCB = siteSubset == QUDA_PARITY_SITE_SUBSET ? volume : volume/2;
+    volumeCB = param.siteSubset == QUDA_PARITY_SITE_SUBSET ? volume : volume/2;
 
     if((twistFlavor == QUDA_TWIST_NONDEG_DOUBLET || twistFlavor == QUDA_TWIST_DEG_DOUBLET) && x[4] != 2)
       errorQuda("Must be two flavors for non-degenerate twisted mass spinor (provided with %d)\n", x[4]);


### PR DESCRIPTION
Looks like a long-standing bug that recently made itself apparent.  For parity subset field `volume` and `volumeCB` should be the same value, but in the case of creating a parity subset reference to a full field this wasn't being done correctly.