### PR TITLE
Half precision conversion is now done using rounding instead of truncation

### DIFF
--- a/include/convert.h
+++ b/include/convert.h
@@ -1,5 +1,4 @@
-#ifndef _CONVERT_H
-#define _CONVERT_H
+#pragma once
 
 /**
  * @file convert.h
@@ -28,7 +27,7 @@ template<> int vecLength<double4>() { return 4; }
 // MAX_SHORT 32767
 #define MAX_SHORT_INV 3.051850948e-5
 static inline __device__ float s2f(const short &a) { return static_cast<float>(a) * MAX_SHORT_INV; }
-static inline __device__ float s2d(const short &a) { return static_cast<double>(a) * MAX_SHORT_INV; }
+static inline __device__ double s2d(const short &a) { return static_cast<double>(a) * MAX_SHORT_INV; }
 
 template <typename FloatN>
 __device__ inline void copyFloatN(FloatN &a, const FloatN &b) { a = b; }
@@ -44,11 +43,17 @@ __device__ inline void copyFloatN(double2 &a, const float2 &b) { a = make_double
 __device__ inline void copyFloatN(float4 &a, const double4 &b) { a = make_float4(b.x, b.y, b.z, b.w); }
 __device__ inline void copyFloatN(double4 &a, const float4 &b) { a = make_double4(b.x, b.y, b.z, b.w); }
 
+// Fast float to integer round
+__device__ inline int f2i(float f) { f += 12582912.0f; return reinterpret_cast<int&>(f); }
+
+// Fast double to integer round
+__device__ inline int d2i(double d) { d += 6755399441055744.0; return reinterpret_cast<int&>(d); }
+
 /* Here we assume that the input data has already been normalized and shifted. */
-__device__ inline void copyFloatN(short2 &a, const float2 &b) { a = make_short2(b.x, b.y); }
-__device__ inline void copyFloatN(short4 &a, const float4 &b) { a = make_short4(b.x, b.y, b.z, b.w); }
-__device__ inline void copyFloatN(short2 &a, const double2 &b) { a = make_short2(b.x, b.y); }
-__device__ inline void copyFloatN(short4 &a, const double4 &b) { a = make_short4(b.x, b.y, b.z, b.w); }
+__device__ inline void copyFloatN(short2 &a, const float2 &b) { a = make_short2(f2i(b.x), f2i(b.y)); }
+__device__ inline void copyFloatN(short4 &a, const float4 &b) { a = make_short4(f2i(b.x), f2i(b.y), f2i(b.z), f2i(b.w)); }
+__device__ inline void copyFloatN(short2 &a, const double2 &b) { a = make_short2(d2i(b.x), d2i(b.y)); }
+__device__ inline void copyFloatN(short4 &a, const double4 &b) { a = make_short4(d2i(b.x), d2i(b.y), d2i(b.z), d2i(b.w)); }
 
 
 /**
@@ -109,7 +114,7 @@ template<> __device__ inline void convert<float2,float4>(float2 x[], float4 y[],
 
 template<> __device__ inline void convert<short4,float2>(short4 x[], float2 y[], const int N) {
 #pragma unroll
-  for (int j=0; j<N; j++) x[j] = make_short4(y[2*j].x, y[2*j].y, y[2*j+1].x, y[2*j+1].y);
+  for (int j=0; j<N; j++) x[j] = make_short4(f2i(y[2*j].x), f2i(y[2*j].y), f2i(y[2*j+1].x), f2i(y[2*j+1].y));
 }
 
 template<> __device__ inline void convert<float2,short4>(float2 x[], short4 y[], const int N) {
@@ -128,14 +133,14 @@ template<> __device__ inline void convert<float4,short2>(float4 x[], short2 y[],
 template<> __device__ inline void convert<short2,float4>(short2 x[], float4 y[], const int N) {
 #pragma unroll
   for (int j=0; j<N/2; j++) {
-    x[2*j] = make_short2(y[j].x, y[j].y);
-    x[2*j+1] = make_short2(y[j].z, y[j].w);
+    x[2*j] = make_short2(f2i(y[j].x), f2i(y[j].y));
+    x[2*j+1] = make_short2(f2i(y[j].z), f2i(y[j].w));
   }
 }
 
 template<> __device__ inline void convert<short4,double2>(short4 x[], double2 y[], const int N) {
 #pragma unroll
-  for (int j=0; j<N; j++) x[j] = make_short4(y[2*j].x, y[2*j].y, y[2*j+1].x, y[2*j+1].y);
+  for (int j=0; j<N; j++) x[j] = make_short4(d2i(y[2*j].x), d2i(y[2*j].y), d2i(y[2*j+1].x), d2i(y[2*j+1].y));
 }
 
 template<> __device__ inline void convert<double2,short4>(double2 x[], short4 y[], const int N) {
@@ -154,8 +159,8 @@ template<> __device__ inline void convert<double4,short2>(double4 x[], short2 y[
 template<> __device__ inline void convert<short2,double4>(short2 x[], double4 y[], const int N) {
 #pragma unroll
   for (int j=0; j<N/2; j++) {
-    x[2*j] = make_short2(y[j].x, y[j].y);
-    x[2*j+1] = make_short2(y[j].z, y[j].w);
+    x[2*j] = make_short2(d2i(y[j].x), d2i(y[j].y));
+    x[2*j+1] = make_short2(d2i(y[j].z), d2i(y[j].w));
   }
 }
 
@@ -185,4 +190,3 @@ template<> __device__ inline void convert<float2,double4>(float2 x[], double4 y[
   }
 }
 
-#endif // _CONVERT_H

--- a/include/float_vector.h
+++ b/include/float_vector.h
@@ -200,41 +200,5 @@ namespace quda {
     return fmax(fabs(b.x), fabs(b.y));
   };
 
-  /*
-    Precision conversion routines for vector types
-  */
-
-  __forceinline__ __host__ __device__ float2 make_FloatN(const double2 &a) {
-    return make_float2(a.x, a.y);
-  }
-
-  __forceinline__ __host__ __device__ float4 make_FloatN(const double4 &a) {
-    return make_float4(a.x, a.y, a.z, a.w);
-  }
-
-  __forceinline__ __host__ __device__ double2 make_FloatN(const float2 &a) {
-    return make_double2(a.x, a.y);
-  }
-
-  __forceinline__ __host__ __device__ double4 make_FloatN(const float4 &a) {
-    return make_double4(a.x, a.y, a.z, a.w);
-  }
-
-  __forceinline__ __host__ __device__ short4 make_shortN(const float4 &a) {
-    return make_short4(a.x, a.y, a.z, a.w);
-  }
-
-  __forceinline__ __host__ __device__ short2 make_shortN(const float2 &a) {
-    return make_short2(a.x, a.y);
-  }
-
-  __forceinline__ __host__ __device__ short4 make_shortN(const double4 &a) {
-    return make_short4(a.x, a.y, a.z, a.w);
-  }
-
-  __forceinline__ __host__ __device__ short2 make_shortN(const double2 &a) {
-    return make_short2(a.x, a.y);
-  }
-
 }
 

--- a/lib/dslash_constants.h
+++ b/lib/dslash_constants.h
@@ -1,3 +1,5 @@
+#include <convert.h>
+
 enum KernelType {
   INTERIOR_KERNEL = 5,
   EXTERIOR_KERNEL_ALL = 6,

--- a/lib/io_spinor.h
+++ b/lib/io_spinor.h
@@ -311,12 +311,12 @@
   o20_re *= scale; o20_im *= scale; o21_re *= scale; o21_im *= scale;	\
   o22_re *= scale; o22_im *= scale; o30_re *= scale; o30_im *= scale;	\
   o31_re *= scale; o31_im *= scale; o32_re *= scale; o32_im *= scale;	\
-  out[sid+0*(stride)] = make_short4((short)o00_re, (short)o00_im, (short)o01_re, (short)o01_im); \
-  out[sid+1*(stride)] = make_short4((short)o02_re, (short)o02_im, (short)o10_re, (short)o10_im); \
-  out[sid+2*(stride)] = make_short4((short)o11_re, (short)o11_im, (short)o12_re, (short)o12_im); \
-  out[sid+3*(stride)] = make_short4((short)o20_re, (short)o20_im, (short)o21_re, (short)o21_im); \
-  out[sid+4*(stride)] = make_short4((short)o22_re, (short)o22_im, (short)o30_re, (short)o30_im); \
-  out[sid+5*(stride)] = make_short4((short)o31_re, (short)o31_im, (short)o32_re, (short)o32_im);
+  out[sid+0*(stride)] = make_short4(f2i(o00_re), f2i(o00_im), f2i(o01_re), f2i(o01_im)); \
+  out[sid+1*(stride)] = make_short4(f2i(o02_re), f2i(o02_im), f2i(o10_re), f2i(o10_im)); \
+  out[sid+2*(stride)] = make_short4(f2i(o11_re), f2i(o11_im), f2i(o12_re), f2i(o12_im)); \
+  out[sid+3*(stride)] = make_short4(f2i(o20_re), f2i(o20_im), f2i(o21_re), f2i(o21_im)); \
+  out[sid+4*(stride)] = make_short4(f2i(o22_re), f2i(o22_im), f2i(o30_re), f2i(o30_im)); \
+  out[sid+5*(stride)] = make_short4(f2i(o31_re), f2i(o31_im), f2i(o32_re), f2i(o32_im));
 
 #define WRITE_SPINOR_DOUBLE2_STR(stride)			\
   store_streaming_double2(&out[0*stride+sid], o00_re, o00_im);	\
@@ -372,12 +372,12 @@
   o20_re *= scale; o20_im *= scale; o21_re *= scale; o21_im *= scale;	\
   o22_re *= scale; o22_im *= scale; o30_re *= scale; o30_im *= scale;	\
   o31_re *= scale; o31_im *= scale; o32_re *= scale; o32_im *= scale;	\
-  store_streaming_short4(&out[0*(stride)+sid], (short)o00_re, (short)o00_im, (short)o01_re, (short)o01_im); \
-  store_streaming_short4(&out[1*(stride)+sid], (short)o02_re, (short)o02_im, (short)o10_re, (short)o10_im); \
-  store_streaming_short4(&out[2*(stride)+sid], (short)o11_re, (short)o11_im, (short)o12_re, (short)o12_im); \
-  store_streaming_short4(&out[3*(stride)+sid], (short)o20_re, (short)o20_im, (short)o21_re, (short)o21_im); \
-  store_streaming_short4(&out[4*(stride)+sid], (short)o22_re, (short)o22_im, (short)o30_re, (short)o30_im); \
-  store_streaming_short4(&out[5*(stride)+sid], (short)o31_re, (short)o31_im, (short)o32_re, (short)o32_im);
+  store_streaming_short4(&out[0*(stride)+sid], f2i(o00_re), f2i(o00_im), f2i(o01_re), f2i(o01_im)); \
+  store_streaming_short4(&out[1*(stride)+sid], f2i(o02_re), f2i(o02_im), f2i(o10_re), f2i(o10_im)); \
+  store_streaming_short4(&out[2*(stride)+sid], f2i(o11_re), f2i(o11_im), f2i(o12_re), f2i(o12_im)); \
+  store_streaming_short4(&out[3*(stride)+sid], f2i(o20_re), f2i(o20_im), f2i(o21_re), f2i(o21_im)); \
+  store_streaming_short4(&out[4*(stride)+sid], f2i(o22_re), f2i(o22_im), f2i(o30_re), f2i(o30_im)); \
+  store_streaming_short4(&out[5*(stride)+sid], f2i(o31_re), f2i(o31_im), f2i(o32_re), f2i(o32_im));
 
 // macros used for exterior Wilson Dslash kernels and face packing
 
@@ -413,9 +413,9 @@
   a0_re *= scale; a0_im *= scale; a1_re *= scale; a1_im *= scale;	\
   a2_re *= scale; a2_im *= scale; b0_re *= scale; b0_im *= scale;	\
   b1_re *= scale; b1_im *= scale; b2_re *= scale; b2_im *= scale;	\
-  out[sid+0*(stride)] = make_short4((short)a0_re, (short)a0_im, (short)a1_re, (short)a1_im); \
-  out[sid+1*(stride)] = make_short4((short)a2_re, (short)a2_im, (short)b0_re, (short)b0_im); \
-  out[sid+2*(stride)] = make_short4((short)b1_re, (short)b1_im, (short)b2_re, (short)b2_im);
+  out[sid+0*(stride)] = make_short4(f2i(a0_re), f2i(a0_im), f2i(a1_re), f2i(a1_im)); \
+  out[sid+1*(stride)] = make_short4(f2i(a2_re), f2i(a2_im), f2i(b0_re), f2i(b0_im)); \
+  out[sid+2*(stride)] = make_short4(f2i(b1_re), f2i(b1_im), f2i(b2_re), f2i(b2_im));
 
 //!ndeg tm:
 /******************used by non-degenerate twisted mass**********************/
@@ -493,12 +493,12 @@
   o1_20_re *= scale; o1_20_im *= scale; o1_21_re *= scale; o1_21_im *= scale;	\
   o1_22_re *= scale; o1_22_im *= scale; o1_30_re *= scale; o1_30_im *= scale;	\
   o1_31_re *= scale; o1_31_im *= scale; o1_32_re *= scale; o1_32_im *= scale;	\
-  out[sid+0*(param.sp_stride)] = make_short4((short)o1_00_re, (short)o1_00_im, (short)o1_01_re, (short)o1_01_im); \
-  out[sid+1*(param.sp_stride)] = make_short4((short)o1_02_re, (short)o1_02_im, (short)o1_10_re, (short)o1_10_im); \
-  out[sid+2*(param.sp_stride)] = make_short4((short)o1_11_re, (short)o1_11_im, (short)o1_12_re, (short)o1_12_im); \
-  out[sid+3*(param.sp_stride)] = make_short4((short)o1_20_re, (short)o1_20_im, (short)o1_21_re, (short)o1_21_im); \
-  out[sid+4*(param.sp_stride)] = make_short4((short)o1_22_re, (short)o1_22_im, (short)o1_30_re, (short)o1_30_im); \
-  out[sid+5*(param.sp_stride)] = make_short4((short)o1_31_re, (short)o1_31_im, (short)o1_32_re, (short)o1_32_im); \
+  out[sid+0*(param.sp_stride)] = make_short4(f2i(o1_00_re), f2i(o1_00_im), f2i(o1_01_re), f2i(o1_01_im)); \
+  out[sid+1*(param.sp_stride)] = make_short4(f2i(o1_02_re), f2i(o1_02_im), f2i(o1_10_re), f2i(o1_10_im)); \
+  out[sid+2*(param.sp_stride)] = make_short4(f2i(o1_11_re), f2i(o1_11_im), f2i(o1_12_re), f2i(o1_12_im)); \
+  out[sid+3*(param.sp_stride)] = make_short4(f2i(o1_20_re), f2i(o1_20_im), f2i(o1_21_re), f2i(o1_21_im)); \
+  out[sid+4*(param.sp_stride)] = make_short4(f2i(o1_22_re), f2i(o1_22_im), f2i(o1_30_re), f2i(o1_30_im)); \
+  out[sid+5*(param.sp_stride)] = make_short4(f2i(o1_31_re), f2i(o1_31_im), f2i(o1_32_re), f2i(o1_32_im)); \
   c0 = fmaxf(fabsf(o2_00_re), fabsf(o2_00_im));			\
   c1 = fmaxf(fabsf(o2_01_re), fabsf(o2_02_im));			\
   c2 = fmaxf(fabsf(o2_02_re), fabsf(o2_01_im));			\
@@ -530,12 +530,12 @@
   o2_20_re *= scale; o2_20_im *= scale; o2_21_re *= scale; o2_21_im *= scale;	\
   o2_22_re *= scale; o2_22_im *= scale; o2_30_re *= scale; o2_30_im *= scale;	\
   o2_31_re *= scale; o2_31_im *= scale; o2_32_re *= scale; o2_32_im *= scale;	\
-  out[sid+param.fl_stride+0*(param.sp_stride)] = make_short4((short)o2_00_re, (short)o2_00_im, (short)o2_01_re, (short)o2_01_im); \
-  out[sid+param.fl_stride+1*(param.sp_stride)] = make_short4((short)o2_02_re, (short)o2_02_im, (short)o2_10_re, (short)o2_10_im); \
-  out[sid+param.fl_stride+2*(param.sp_stride)] = make_short4((short)o2_11_re, (short)o2_11_im, (short)o2_12_re, (short)o2_12_im); \
-  out[sid+param.fl_stride+3*(param.sp_stride)] = make_short4((short)o2_20_re, (short)o2_20_im, (short)o2_21_re, (short)o2_21_im); \
-  out[sid+param.fl_stride+4*(param.sp_stride)] = make_short4((short)o2_22_re, (short)o2_22_im, (short)o2_30_re, (short)o2_30_im); \
-  out[sid+param.fl_stride+5*(param.sp_stride)] = make_short4((short)o2_31_re, (short)o2_31_im, (short)o2_32_re, (short)o2_32_im);  
+  out[sid+param.fl_stride+0*(param.sp_stride)] = make_short4(f2i(o2_00_re), f2i(o2_00_im), f2i(o2_01_re), f2i(o2_01_im)); \
+  out[sid+param.fl_stride+1*(param.sp_stride)] = make_short4(f2i(o2_02_re), f2i(o2_02_im), f2i(o2_10_re), f2i(o2_10_im)); \
+  out[sid+param.fl_stride+2*(param.sp_stride)] = make_short4(f2i(o2_11_re), f2i(o2_11_im), f2i(o2_12_re), f2i(o2_12_im)); \
+  out[sid+param.fl_stride+3*(param.sp_stride)] = make_short4(f2i(o2_20_re), f2i(o2_20_im), f2i(o2_21_re), f2i(o2_21_im)); \
+  out[sid+param.fl_stride+4*(param.sp_stride)] = make_short4(f2i(o2_22_re), f2i(o2_22_im), f2i(o2_30_re), f2i(o2_30_im)); \
+  out[sid+param.fl_stride+5*(param.sp_stride)] = make_short4(f2i(o2_31_re), f2i(o2_31_im), f2i(o2_32_re), f2i(o2_32_im));
 
 
 /************* the following is used by staggered *****************/
@@ -653,9 +653,9 @@
   float scale = __fdividef(MAX_SHORT, c0);				\
   o00_re *= scale; o00_im *= scale; o01_re *= scale; o01_im *= scale;	\
   o02_re *= scale; o02_im *= scale;					\
-  out[sid+0*mystride] = make_short2((short)o00_re, (short)o00_im);	\
-  out[sid+1*mystride] = make_short2((short)o01_re, (short)o01_im);	\
-  out[sid+2*mystride] = make_short2((short)o02_re, (short)o02_im);
+  out[sid+0*mystride] = make_short2(f2i(o00_re), f2i(o00_im));		\
+  out[sid+1*mystride] = make_short2(f2i(o01_re), f2i(o01_im));		\
+  out[sid+2*mystride] = make_short2(f2i(o02_re), f2i(o02_im));
 
 // Non-cache writes to minimize cache polution
 #define WRITE_ST_SPINOR_DOUBLE2_STR(out, sid, mystride) \
@@ -678,9 +678,9 @@
   float scale = __fdividef(MAX_SHORT, c0);			    \
   o00_re *= scale; o00_im *= scale; o01_re *= scale; o01_im *= scale;	\
   o02_re *= scale; o02_im *= scale;					\
-  store_streaming_short2(&g_out[0*mystride+sid], (short)o00_re, (short)o00_im); \
-  store_streaming_short2(&g_out[1*mystride+sid], (short)o01_re, (short)o01_im); \
-  store_streaming_short2(&g_out[2*mystride+sid], (short)o02_re, (short)o02_im);
+  store_streaming_short2(&g_out[0*mystride+sid], f2i(o00_re), f2i(o00_im)); \
+  store_streaming_short2(&g_out[1*mystride+sid], f2i(o01_re), f2i(o01_im)); \
+  store_streaming_short2(&g_out[2*mystride+sid], f2i(o02_re), f2i(o02_im));
 
 #define READ_AND_SUM_ST_SPINOR_DOUBLE_TEX(spinor,sid) {			\
   double2 tmp0 = fetch_double2((spinor), sid + 0*(param.sp_stride));		\


### PR DESCRIPTION
All conversion to shorts from floating point numbers is now done using round-to-nearest conversion instead of truncation.  This improves the precision of `QUDA_HALF_PRECISION` by an effective half bit of precision.

The effect of this improved precision is noticeable in both dslash_test and solver iteration count.

dslash_test (Truncation)
```
1.000000e-01 Failures: 0 / 3981312  = 0.000000e+00
1.000000e-02 Failures: 0 / 3981312  = 0.000000e+00
1.000000e-03 Failures: 21175 / 3981312  = 5.318598e-03
1.000000e-04 Failures: 3167191 / 3981312  = 7.955144e-01
```
dslash_test (Rounding)
```
1.000000e-01 Failures: 0 / 3981312  = 0.000000e+00
1.000000e-02 Failures: 0 / 3981312  = 0.000000e+00
1.000000e-03 Failures: 0 / 3981312  = 0.000000e+00
1.000000e-04 Failures: 1673160 / 3981312  = 4.202534e-01
```

Below plot shows the progression of the CG residual for double, double-single, double-half (truncation) and double-half (rounding), with Wilson fermions.  The general trend is that 
* double-half (rounding) converges in less iterations (typically bisecting the difference between double-single and double-half (truncation)
* double-half (rounding) convergence follows more closely to double-single / double 
* the reliable update spikes in the residual are much milder with double-half (rounding)

![](https://github.com/lattice/lattice.github.com/blob/master/results/iter_trunate_round.png?raw=true)
