### PR TITLE
Hotfix/recon9

### DIFF
--- a/include/gauge_field.h
+++ b/include/gauge_field.h
@@ -242,9 +242,14 @@ namespace quda {
     virtual const void* Even_p() const { errorQuda("Not implemented"); return (void*)0;}
     virtual const void* Odd_p() const { errorQuda("Not implemented"); return (void*)0;}
 
-    const void** Ghost() const { 
+    const void** Ghost() const {
       if ( isNative() ) errorQuda("No ghost zone pointer for quda-native gauge fields");
-      return (const void**)ghost; 
+      return (const void**)ghost;
+    }
+
+    void** Ghost() {
+      if ( isNative() ) errorQuda("No ghost zone pointer for quda-native gauge fields");
+      return ghost;
     }
 
     /**

--- a/include/gauge_field_order.h
+++ b/include/gauge_field_order.h
@@ -302,50 +302,6 @@ namespace quda {
       };
 
 
-    // a += b*c
-    template <typename Float>
-      __device__ __host__ inline void accumulateComplexProduct(Float *a, const Float *b, const Float *c, Float sign) {
-      a[0] += sign*(b[0]*c[0] - b[1]*c[1]);
-      a[1] += sign*(b[0]*c[1] + b[1]*c[0]);
-    }
-
-    // a = b*c
-    template <typename Float>
-      __device__ __host__ inline void complexProduct(Float *a, const Float *b, const Float *c) {
-      a[0] = b[0]*c[0] - b[1]*c[1];
-      a[1] = b[0]*c[1] + b[1]*c[0];
-    }
-
-    // a = conj(b)*c
-    template <typename Float>
-      __device__ __host__ inline void complexDotProduct(Float *a, const Float *b, const Float *c) {
-      a[0] = b[0]*c[0] + b[1]*c[1];
-      a[1] = b[0]*c[1] - b[1]*c[0];
-    }
-
-    // a = b/c
-    template <typename Float>
-      __device__ __host__ inline void complexQuotient(Float *a, const Float *b, const Float *c){
-      complexDotProduct(a, c, b);
-      Float denom = c[0]*c[0] + c[1]*c[1];
-      a[0] /= denom;
-      a[1] /= denom;
-    }
-
-    // a += conj(b) * conj(c)
-    template <typename Float>
-      __device__ __host__ inline void accumulateConjugateProduct(Float *a, const Float *b, const Float *c, int sign) {
-      a[0] += sign * (b[0]*c[0] - b[1]*c[1]);
-      a[1] -= sign * (b[0]*c[1] + b[1]*c[0]);
-    }
-
-    // a = conj(b)*conj(c)
-    template <typename Float>
-      __device__ __host__ inline void complexConjugateProduct(Float *a, const Float *b, const Float *c) {
-      a[0] = b[0]*c[0] - b[1]*c[1];
-      a[1] = -b[0]*c[1] - b[1]*c[0];
-    }
-
     /** Generic reconstruction is no reconstruction */
     template <int N, typename Float>
       struct Reconstruct {
@@ -428,6 +384,7 @@ namespace quda {
       template <typename Float>
       struct Reconstruct<12,Float> {
 	typedef typename mapper<Float>::type RegType;
+	typedef complex<RegType> Complex;
 	int X[QUDA_MAX_DIM];
 	int R[QUDA_MAX_DIM];
 	const RegType anisotropy;
@@ -450,24 +407,21 @@ namespace quda {
 	  for (int i=0; i<12; i++) out[i] = in[i];
 	}
 
-	__device__ __host__ inline void Unpack(RegType out[18], const RegType in[12],
-					       int idx, int dir, const RegType phase) const {
-	  for (int i=0; i<12; i++) out[i] = in[i];
-	  for (int i=12; i<18; i++) out[i] = 0.0;
-	  accumulateConjugateProduct(&out[12], &out[2], &out[10], +1);
-	  accumulateConjugateProduct(&out[12], &out[4], &out[8], -1);
-	  accumulateConjugateProduct(&out[14], &out[4], &out[6], +1);
-	  accumulateConjugateProduct(&out[14], &out[0], &out[10], -1);
-	  accumulateConjugateProduct(&out[16], &out[0], &out[8], +1);
-	  accumulateConjugateProduct(&out[16], &out[2], &out[6], -1);
+	__device__ __host__ inline void Unpack(RegType out[18], const RegType in[12], int idx, int dir, const RegType phase) const {
+	  const Complex *In = reinterpret_cast<const Complex*>(in);
+	  Complex *Out = reinterpret_cast<Complex*>(out);
 
-	  RegType u0 = dir < 3 ? anisotropy :
+	  const RegType u0 = dir < 3 ? anisotropy :
 	    timeBoundary<RegType>(idx, X, R, tBoundary,isFirstTimeSlice, isLastTimeSlice, ghostExchange);
 
-	  for (int i=12; i<18; i++) out[i]*=u0;
+	  for(int i=0; i<6; ++i) Out[i] = In[i];
+
+	  Out[6] = u0*conj(Out[1]*Out[5] - Out[2]*Out[4]);
+	  Out[7] = u0*conj(Out[2]*Out[3] - Out[0]*Out[5]);
+	  Out[8] = u0*conj(Out[0]*Out[4] - Out[1]*Out[3]);
 	}
 
-	__device__ __host__ inline void getPhase(RegType* phase, const RegType in[18]){ *phase=0; return; }
+	__device__ __host__ inline void getPhase(RegType* phase, const RegType in[18]) { *phase=0; return; }
 
       };
 
@@ -507,14 +461,14 @@ namespace quda {
 	  out[17] = in[8];
 	}
 
-	__device__ __host__ inline void getPhase(RegType* phase, const RegType in[18])
-	{ *phase=0; return; }
+	__device__ __host__ inline void getPhase(RegType* phase, const RegType in[18]) { *phase=0; return; }
 
       };
 
       template <typename Float>
       struct Reconstruct<13,Float> {
       typedef typename mapper<Float>::type RegType;
+      typedef complex<RegType> Complex;
       const Reconstruct<12,Float> reconstruct_12;
       const RegType scale;
 
@@ -525,42 +479,32 @@ namespace quda {
       }
 
       __device__ __host__ inline void Unpack(RegType out[18], const RegType in[12], int idx, int dir, const RegType phase) const {
-	for(int i=0; i<12; ++i) out[i] = in[i];
-	for(int i=12; i<18; ++i) out[i] = 0.0;
+	const Complex *In = reinterpret_cast<const Complex*>(in);
+	Complex *Out = reinterpret_cast<Complex*>(out);
+	const RegType coeff = static_cast<RegType>(1.0)/scale;
 
-	const RegType coeff = 1./scale;
+	for(int i=0; i<6; ++i) Out[i] = In[i];
 
-	accumulateConjugateProduct(&out[12], &out[2], &out[10], +coeff);
-	accumulateConjugateProduct(&out[12], &out[4], &out[8], -coeff);
-	accumulateConjugateProduct(&out[14], &out[4], &out[6], +coeff);
-	accumulateConjugateProduct(&out[14], &out[0], &out[10], -coeff);
-	accumulateConjugateProduct(&out[16], &out[0], &out[8], +coeff);
-	accumulateConjugateProduct(&out[16], &out[2], &out[6], -coeff);
+	Out[6] = coeff*conj(Out[1]*Out[5] - Out[2]*Out[4]);
+	Out[7] = coeff*conj(Out[2]*Out[3] - Out[0]*Out[5]);
+	Out[8] = coeff*conj(Out[0]*Out[4] - Out[1]*Out[3]);
 
-	// Multiply the third row by exp(I*3*phase)
+	// Multiply the third row by exp(I*3*phase), since the cross product will end up in a scale factor of exp(-I*2*phase)
 	RegType cos_sin[2];
 	Trig<isHalf<RegType>::value,RegType>::SinCos(static_cast<RegType>(3.*phase), &cos_sin[1], &cos_sin[0]);
-	RegType tmp[2];
-	complexProduct(tmp, cos_sin, &out[12]); out[12] = tmp[0]; out[13] = tmp[1];
-	complexProduct(tmp, cos_sin, &out[14]); out[14] = tmp[0]; out[15] = tmp[1];
-	complexProduct(tmp, cos_sin, &out[16]); out[16] = tmp[0]; out[17] = tmp[1];
+	Complex A(cos_sin[0], cos_sin[1]);
+
+	Out[6] *= A;
+	Out[7] *= A;
+	Out[8] *= A;
       }
 
       __device__ __host__ inline void getPhase(RegType *phase, const RegType in[18]) const {
-	RegType denom[2];
+	const Complex *In = reinterpret_cast<const Complex*>(in);
 	// denominator = (U[0][0]*U[1][1] - U[0][1]*U[1][0])*
-	complexProduct(denom, in, in+8);
-	accumulateComplexProduct(denom, in+2, in+6, static_cast<RegType>(-1.0));
-
-	denom[0] /= scale;
-	denom[1] /= (-scale); // complex conjugate
-
-	RegType expI3Phase[2];
-	// numerator = U[2][2]
-	complexQuotient(expI3Phase, in+16, denom);
-
-	*phase = Trig<isHalf<RegType>::value,RegType>::Atan2(expI3Phase[1], expI3Phase[0])/3.;
-	return;
+	Complex denom = conj(In[0]*In[4] - In[1]*In[3]) / scale;
+	Complex expI3Phase = In[8] / denom; // numerator = U[2][2]
+	*phase = arg(expI3Phase)/static_cast<RegType>(3.0);
       }
 
     };
@@ -569,6 +513,7 @@ namespace quda {
  template <typename Float>
     struct Reconstruct<8,Float> {
     typedef typename mapper<Float>::type RegType;
+    typedef complex<RegType> Complex;
     int X[QUDA_MAX_DIM];
     int R[QUDA_MAX_DIM];
     const RegType anisotropy;
@@ -594,66 +539,44 @@ namespace quda {
     }
 
     __device__ __host__ inline void Unpack(RegType out[18], const RegType in[8],
-					   int idx, int dir, const RegType phase) const {
+					   int idx, int dir, const RegType phase, const RegType scale=1.0) const {
+      const Complex *In = reinterpret_cast<const Complex*>(in);
+      Complex *Out = reinterpret_cast<Complex*>(out);
+
       // First reconstruct first row
-      RegType row_sum = 0.0;
-      for (int i=2; i<6; i++) {
-	out[i] = in[i];
-	row_sum += in[i]*in[i];
-      }
+      Out[1] = In[1];
+      Out[2] = In[2];
+      RegType row_sum = norm(Out[1]) + norm(Out[2]);
 
       RegType u0 = dir < 3 ? anisotropy :
 	timeBoundary<RegType>(idx, X, R, tBoundary,isFirstTimeSlice, isLastTimeSlice, ghostExchange);
+      u0 *= scale;
 
       RegType diff = static_cast<RegType>(1.0)/(u0*u0) - row_sum;
       RegType U00_mag = sqrt(diff >= static_cast<RegType>(0.0) ? diff : static_cast<RegType>(0.0));
 
-      out[0] = U00_mag * Trig<isHalf<Float>::value,RegType>::Cos(in[0]);
-      out[1] = U00_mag * Trig<isHalf<Float>::value,RegType>::Sin(in[0]);
+      Out[0] = U00_mag * Complex(Trig<isHalf<Float>::value,RegType>::Cos(in[0]), Trig<isHalf<Float>::value,RegType>::Sin(in[0]));
 
       // Now reconstruct first column
-      RegType column_sum = 0.0;
-      for (int i=0; i<2; i++) column_sum += out[i]*out[i];
-      for (int i=6; i<8; i++) {
-	out[i] = in[i];
-	column_sum += in[i]*in[i];
-      }
-      diff = 1.f/(u0*u0) - column_sum;
+      Out[3] = In[3];
+      RegType column_sum = norm(Out[0]) + norm(Out[3]);
+
+      diff = static_cast<RegType>(1.0)/(u0*u0) - column_sum;
       RegType U20_mag = sqrt(diff >= static_cast<RegType>(0.0) ? diff : static_cast<RegType>(0.0));
 
-      out[12] = U20_mag * Trig<isHalf<Float>::value,RegType>::Cos(in[1]);
-      out[13] = U20_mag * Trig<isHalf<Float>::value,RegType>::Sin(in[1]);
+      Out[6] = U20_mag * Complex( Trig<isHalf<Float>::value,RegType>::Cos(in[1]), Trig<isHalf<Float>::value,RegType>::Sin(in[1]));
       // First column now restored
 
       // finally reconstruct last elements from SU(2) rotation
       RegType r_inv2 = static_cast<RegType>(1.0)/(u0*row_sum);
 
-      // U11
-      RegType A[2];
-      complexDotProduct(A, out+0, out+6);
-      complexConjugateProduct(out+8, out+12, out+4);
-      accumulateComplexProduct(out+8, A, out+2, u0);
-      out[8] *= -r_inv2;
-      out[9] *= -r_inv2;
+      Complex A = conj(Out[0])*Out[3];
+      Out[4] = -(conj(Out[6])*conj(Out[2]) + u0*A*Out[1])*r_inv2; // U11
+      Out[5] = (conj(Out[6])*conj(Out[1]) - u0*A*Out[2])*r_inv2;  // U12
 
-      // U12
-      complexConjugateProduct(out+10, out+12, out+2);
-      accumulateComplexProduct(out+10, A, out+4, -u0);
-      out[10] *= r_inv2;
-      out[11] *= r_inv2;
-
-      // U21
-      complexDotProduct(A, out+0, out+12);
-      complexConjugateProduct(out+14, out+6, out+4);
-      accumulateComplexProduct(out+14, A, out+2, -u0);
-      out[14] *= r_inv2;
-      out[15] *= r_inv2;
-
-      // U12
-      complexConjugateProduct(out+16, out+6, out+2);
-      accumulateComplexProduct(out+16, A, out+4, u0);
-      out[16] *= -r_inv2;
-      out[17] *= -r_inv2;
+      A = conj(Out[0])*Out[6];
+      Out[7] = (conj(Out[3])*conj(Out[2]) - u0*A*Out[1])*r_inv2;  // U21
+      Out[8] = -(conj(Out[3])*conj(Out[1]) + u0*A*Out[2])*r_inv2; // U12
     }
 
     __device__ __host__ inline void getPhase(RegType* phase, const RegType in[18]){ *phase=0; return; }
@@ -663,64 +586,38 @@ namespace quda {
     template <typename Float>
       struct Reconstruct<9,Float> {
       typedef typename mapper<Float>::type RegType;
+      typedef complex<RegType> Complex;
       const Reconstruct<8,Float> reconstruct_8;
       const RegType scale;
 
     Reconstruct(const GaugeField &u) : reconstruct_8(u), scale(u.Scale()) {}
 
       __device__ __host__ inline void getPhase(RegType *phase, const RegType in[18]) const {
-
-	RegType denom[2];
+	const Complex *In = reinterpret_cast<const Complex*>(in);
 	// denominator = (U[0][0]*U[1][1] - U[0][1]*U[1][0])*
-	complexProduct(denom, in, in+8);
-	accumulateComplexProduct(denom, in+2, in+6, static_cast<RegType>(-1.0));
-
-	denom[0] /= scale;
-	denom[1] /= (-scale); // complex conjugate
-
-	RegType expI3Phase[2];
-	// numerator = U[2][2]
-	complexQuotient(expI3Phase, in+16, denom);
-
-	*phase = Trig<isHalf<RegType>::value,RegType>::Atan2(expI3Phase[1], expI3Phase[0])/3.;
+	Complex denom = conj(In[0]*In[4] - In[1]*In[3]) / scale;
+	Complex expI3Phase = In[8] / denom; // numerator = U[2][2]
+	*phase = arg(expI3Phase)/static_cast<RegType>(3.0);
       }
 
+	// Rescale the U3 input matrix by exp(-I*phase) to obtain an SU3 matrix multiplied by a real scale factor,
       __device__ __host__ inline void Pack(RegType out[8], const RegType in[18], int idx) const {
-
 	RegType phase;
 	getPhase(&phase,in);
 	RegType cos_sin[2];
-	sincos(-phase, &cos_sin[1], &cos_sin[0]);
-	// Rescale the U3 input matrix by exp(-I*phase) to obtain an SU3 matrix multiplied by a real scale factor,
-	// which the macros in read_gauge.h can handle.
-	// NB: Only 5 complex matrix elements are used in the reconstruct 8 packing routine,
-	// so only need to rescale those elements.
-	RegType su3[18];
-	for(int i=0; i<4; ++i){
-	  complexProduct(su3 + 2*i, cos_sin, in + 2*i);
-	}
-	complexProduct(&su3[12], cos_sin, &in[12]);
-	reconstruct_8.Pack(out, su3, idx);
+	Trig<isHalf<RegType>::value,RegType>::SinCos(static_cast<RegType>(-phase), &cos_sin[1], &cos_sin[0]);
+	Complex z(cos_sin[0], cos_sin[1]);
+	Complex su3[9];
+	for (int i=0; i<9; i++) su3[i] = z * reinterpret_cast<const Complex*>(in)[i];
+	reconstruct_8.Pack(out, reinterpret_cast<RegType*>(su3), idx);
       }
 
       __device__ __host__ inline void Unpack(RegType out[18], const RegType in[8], int idx, int dir, const RegType phase) const {
-	reconstruct_8.Unpack(out, in, idx, dir, phase);
+	reconstruct_8.Unpack(out, in, idx, dir, phase, scale);
 	RegType cos_sin[2];
-	Trig<isHalf<RegType>::value,RegType>::SinCos(phase, &cos_sin[1], &cos_sin[0]);
-	RegType tmp[2];
-	cos_sin[0] *= scale;
-	cos_sin[1] *= scale;
-
-	// rescale the matrix by exp(I*phase)*scale
-	complexProduct(tmp, cos_sin, &out[0]);  out[0] = tmp[0]; out[1] = tmp[1];
-	complexProduct(tmp, cos_sin, &out[2]);  out[2] = tmp[0]; out[3] = tmp[1];
-	complexProduct(tmp, cos_sin, &out[4]);  out[4] = tmp[0]; out[5] = tmp[1];
-	complexProduct(tmp, cos_sin, &out[6]);  out[6] = tmp[0]; out[7] = tmp[1];
-	complexProduct(tmp, cos_sin, &out[8]);  out[8] = tmp[0]; out[9] = tmp[1];
-	complexProduct(tmp, cos_sin, &out[10]); out[10] = tmp[0]; out[11] = tmp[1];
-	complexProduct(tmp, cos_sin, &out[12]); out[12] = tmp[0]; out[13] = tmp[1];
-	complexProduct(tmp, cos_sin, &out[14]); out[14] = tmp[0]; out[15] = tmp[1];
-	complexProduct(tmp, cos_sin, &out[16]); out[16] = tmp[0]; out[17] = tmp[1];
+	Trig<isHalf<RegType>::value,RegType>::SinCos(static_cast<RegType>(phase), &cos_sin[1], &cos_sin[0]);
+	Complex z(cos_sin[0], cos_sin[1]);
+	for (int i=0; i<9; i++) reinterpret_cast<Complex*>(out)[i] *= z;
       }
 
     };

--- a/include/gauge_field_order.h
+++ b/include/gauge_field_order.h
@@ -890,9 +890,9 @@ namespace quda {
 	typedef S<Float,length> structure;
 	trove::coalesced_ptr<structure> ghost_((structure*)ghost[dir]);
 	structure v_ = ghost_[parity*faceVolumeCB[dir] + x];
-	for (int i=0; i<length; i++) v[i] = v_.v[i];
+	for (int i=0; i<length; i++) v[i] = (RegType)v_.v[i];
 #else
-	for (int i=0; i<length; i++) v[i] = ghost[dir][(parity*faceVolumeCB[dir] + x)*length + i];
+	for (int i=0; i<length; i++) v[i] = (RegType)ghost[dir][(parity*faceVolumeCB[dir] + x)*length + i];
 #endif
       }
 
@@ -901,10 +901,10 @@ namespace quda {
 	typedef S<Float,length> structure;
 	trove::coalesced_ptr<structure> ghost_((structure*)ghost[dir]);
 	structure v_;
-	for (int i=0; i<length; i++) v_.v[i] = v[i];
+	for (int i=0; i<length; i++) v_.v[i] = (Float)v[i];
 	ghost_[parity*faceVolumeCB[dir] + x] = v_;
 #else
-	for (int i=0; i<length; i++) ghost[dir][(parity*faceVolumeCB[dir] + x)*length + i] = v[i];
+	for (int i=0; i<length; i++) ghost[dir][(parity*faceVolumeCB[dir] + x)*length + i] = (Float)v[i];
 #endif
       }
 
@@ -914,11 +914,10 @@ namespace quda {
 	typedef S<Float,length> structure;
 	trove::coalesced_ptr<structure> ghost_((structure*)ghost[dim]);
 	structure v_ = ghost_[((dir*2+parity)*R[dim]*faceVolumeCB[dim] + x)*geometry+g];
-	for (int i=0; i<length; i++) v[i] = v_.v[i];
+	for (int i=0; i<length; i++) v[i] = (RegType)v_.v[i];
 #else
 	for (int i=0; i<length; i++) {
-	  v[i] = ghost[dim]
-	    [(((dir*2+parity)*R[dim]*faceVolumeCB[dim] + x)*geometry+g)*length + i];
+	  v[i] = (RegType)ghost[dim][(((dir*2+parity)*R[dim]*faceVolumeCB[dim] + x)*geometry+g)*length + i];
 	}
 #endif
       }
@@ -929,12 +928,12 @@ namespace quda {
 	typedef S<Float,length> structure;
 	trove::coalesced_ptr<structure> ghost_((structure*)ghost[dim]);
 	structure v_;
-	for (int i=0; i<length; i++) v_.v[i] = v[i];
+	for (int i=0; i<length; i++) v_.v[i] = (Float)v[i];
 	ghost_[((dir*2+parity)*R[dim]*faceVolumeCB[dim] + x)*geometry+g] = v_;
 #else
 	for (int i=0; i<length; i++) {
 	  ghost[dim]
-	    [(((dir*2+parity)*R[dim]*faceVolumeCB[dim] + x)*geometry+g)*length + i] = v[i];
+	    [(((dir*2+parity)*R[dim]*faceVolumeCB[dim] + x)*geometry+g)*length + i] = (Float)v[i];
 	}
 #endif
       }

--- a/include/trove/ptr.h
+++ b/include/trove/ptr.h
@@ -69,10 +69,6 @@ struct coalesced_ptr {
     __device__ trove::detail::coalesced_ref<T> operator[](const I& idx) {
         return trove::detail::coalesced_ref<T>(m_ptr + idx);
     }
-    template<typename I>
-    __device__ trove::detail::coalesced_ref<T> operator[](const I& idx) const {
-        return trove::detail::coalesced_ref<T>(m_ptr + idx);
-    }
     __device__ operator T*() {
         return m_ptr;
     }

--- a/lib/cuda_gauge_field.cu
+++ b/lib/cuda_gauge_field.cu
@@ -465,30 +465,7 @@ namespace quda {
     checkCudaError();
   }
 
-  void cudaGaugeField::loadCPUField(const cpuGaugeField &cpu)
-  {
-    QudaFieldLocation pack_location = reorder_location();
-
-    if (pack_location == QUDA_CUDA_FIELD_LOCATION) {
-
-      void *buffer = create_gauge_buffer(cpu.Bytes(), cpu.Order(), cpu.Geometry());
-      if (cpu.Order() == QUDA_QDP_GAUGE_ORDER) {
-	for (int d=0; d<geometry; d++) qudaMemcpy(((void**)buffer)[d], ((void**)cpu.gauge)[d], cpu.Bytes()/geometry, cudaMemcpyHostToDevice);
-      } else {
-	qudaMemcpy(buffer, cpu.gauge, cpu.Bytes(), cudaMemcpyHostToDevice);
-      }
-      copyGenericGauge(*this, cpu, QUDA_CUDA_FIELD_LOCATION, gauge, buffer);
-      free_gauge_buffer(buffer, cpu.Order(), cpu.Geometry());
-
-    } else if (pack_location == QUDA_CPU_FIELD_LOCATION) {
-
-      copy(cpu);
-
-    } else {
-      errorQuda("Invalid pack location %d", pack_location);
-    }
-
-  }
+  void cudaGaugeField::loadCPUField(const cpuGaugeField &cpu) { copy(cpu); }
 
   void cudaGaugeField::saveCPUField(cpuGaugeField &cpu) const
   {
@@ -497,13 +474,28 @@ namespace quda {
     if (pack_location == QUDA_CUDA_FIELD_LOCATION) {
 
       void *buffer = create_gauge_buffer(cpu.Bytes(), cpu.Order(), cpu.Geometry());
-      copyGenericGauge(cpu, *this, QUDA_CUDA_FIELD_LOCATION, buffer, gauge);
+
+      // Allocate space for ghost zone if required
+      size_t ghost_bytes[4];
+      int cpuNinternal = cpu.Reconstruct() != QUDA_RECONSTRUCT_NO ? cpu.Reconstruct() : 2*nColor*nColor;
+      for (int d=0; d<4; d++) ghost_bytes[d] = nFace * surface[d] * cpuNinternal * cpu.Precision();
+      void **ghost_buffer = (nFace > 0) ? create_ghost_buffer(ghost_bytes, cpu.Order()) : nullptr;
+
+      copyGenericGauge(cpu, *this, QUDA_CUDA_FIELD_LOCATION, buffer, gauge, ghost_buffer, 0);
+
       if (cpu.Order() == QUDA_QDP_GAUGE_ORDER) {
 	for (int d=0; d<geometry; d++) qudaMemcpy(((void**)cpu.gauge)[d], ((void**)buffer)[d], cpu.Bytes()/geometry, cudaMemcpyDeviceToHost);
       } else {
 	qudaMemcpy(cpu.gauge, buffer, cpu.Bytes(), cudaMemcpyDeviceToHost);
       }
+
+      if (cpu.Order() > 4 && GhostExchange() == QUDA_GHOST_EXCHANGE_PAD &&
+	  cpu.GhostExchange() == QUDA_GHOST_EXCHANGE_PAD && nFace)
+	for (int d=0; d<4; d++)
+	  qudaMemcpy(cpu.Ghost()[d], ghost_buffer[d], ghost_bytes[d], cudaMemcpyDeviceToHost);
+
       free_gauge_buffer(buffer, cpu.Order(), cpu.Geometry());
+      if (nFace > 0) free_ghost_buffer(ghost_buffer, cpu.Order());
 
     } else if (pack_location == QUDA_CPU_FIELD_LOCATION) { // do copy then host-side reorder
 

--- a/lib/gauge_field.cpp
+++ b/lib/gauge_field.cpp
@@ -270,29 +270,14 @@ namespace quda {
      errorQuda("Not implemented for this order %d", a.FieldOrder());
 
     if (a.LinkType() == QUDA_COARSE_LINKS) errorQuda("Not implemented for coarse-link type");
-
-    int spin = 0;
-    switch (a.Geometry()) {
-    case QUDA_SCALAR_GEOMETRY:
-    case QUDA_TENSOR_GEOMETRY:
-      spin = 1;
-      break;
-    case QUDA_VECTOR_GEOMETRY:
-      spin = a.Ndim();
-      break;
-    default:
-      errorQuda("Unsupported field geometry %d", a.Geometry());
-    }
+    if (a.Ncolor() != 3) errorQuda("Not implemented for Ncolor = %d", a.Ncolor());
 
     if (a.Precision() == QUDA_HALF_PRECISION)
       errorQuda("Casting a GaugeField into ColorSpinorField not possible in half precision");
 
-    if (a.Reconstruct() == QUDA_RECONSTRUCT_13 || a.Reconstruct() == QUDA_RECONSTRUCT_9)
-      errorQuda("Unsupported field reconstruct %d", a.Reconstruct());
-
     ColorSpinorParam spinor_param;
-    spinor_param.nColor = a.Reconstruct()/2 * (a.Geometry() == QUDA_TENSOR_GEOMETRY ? 6 : 1);
-    spinor_param.nSpin = spin;
+    spinor_param.nColor = (a.Geometry()*a.Reconstruct())/2;
+    spinor_param.nSpin = 1;
     spinor_param.nDim = a.Ndim();
     for (int d=0; d<a.Ndim(); d++) spinor_param.x[d] = a.X()[d];
     spinor_param.precision = a.Precision();

--- a/lib/quda_matrix.h
+++ b/lib/quda_matrix.h
@@ -69,6 +69,7 @@ namespace quda {
     };
 
 
+
   template<class T>
     struct Zero
     {
@@ -126,6 +127,8 @@ namespace quda {
         T data[N*N];
 
 	__device__ __host__ Matrix() { for (int i=0; i<N*N; i++) zero(data[i]); }
+
+	__device__ __host__ Matrix(const T data_[]) { for (int i=0; i<N*N; i++) data[i] = data_[i]; }
 
         __device__ __host__ inline T const & operator()(int i, int j) const{
           return data[index<N>(i,j)];

--- a/tests/staggered_dslash_test.cpp
+++ b/tests/staggered_dslash_test.cpp
@@ -51,7 +51,7 @@ void *hostGauge[4];
 void *fatlink[4], *longlink[4];
 
 #ifdef MULTI_GPU
-const void **ghost_fatlink, **ghost_longlink;
+void **ghost_fatlink, **ghost_longlink;
 #endif
 
 QudaParity parity = QUDA_EVEN_PARITY;
@@ -372,7 +372,7 @@ void staggeredDslashRef()
   switch (test_type) {
     case 0:
 #ifdef MULTI_GPU
-      staggered_dslash_mg4dir(spinorRef, fatlink, longlink, (void**)ghost_fatlink, (void**)ghost_longlink, 
+      staggered_dslash_mg4dir(spinorRef, fatlink, longlink, ghost_fatlink, ghost_longlink,
 			      spinor, parity, dagger, inv_param.cpu_prec, gaugeParam.cpu_prec);
 #else
       staggered_dslash(spinorRef->V(), fatlink, longlink, spinor->V(), parity, dagger, inv_param.cpu_prec, gaugeParam.cpu_prec);
@@ -380,7 +380,7 @@ void staggeredDslashRef()
       break;
     case 1:
 #ifdef MULTI_GPU
-      matdagmat_mg4dir(spinorRef, fatlink, longlink, (void**)ghost_fatlink, (void**)ghost_longlink,
+      matdagmat_mg4dir(spinorRef, fatlink, longlink, ghost_fatlink, ghost_longlink,
 		       spinor, mass, 0, inv_param.cpu_prec, gaugeParam.cpu_prec, tmpCpu, parity);
 #else
       matdagmat(spinorRef->V(), fatlink, longlink, spinor->V(), mass, 0, inv_param.cpu_prec, gaugeParam.cpu_prec, tmpCpu->V(), parity);

--- a/tests/test_util.cpp
+++ b/tests/test_util.cpp
@@ -774,8 +774,8 @@ void applyGaugeFieldScaling_long(Float **gauge, int Vh, QudaGaugeParam *param, Q
 	}
       }
 
-      for (int j=0;j < 6; j++){
-	gauge[d][i*gaugeSiteSize + 12+ j] *= sign;
+      for (int j=0; j < 18; j++) {
+	gauge[d][i*gaugeSiteSize + j] *= sign;
       }
     }
     //odd
@@ -804,8 +804,8 @@ void applyGaugeFieldScaling_long(Float **gauge, int Vh, QudaGaugeParam *param, Q
 	}
       }
 
-      for (int j=0;j < 6; j++){
-	gauge[d][(Vh+i)*gaugeSiteSize + 12 + j] *= sign;
+      for (int j=0; j<18; j++){
+	gauge[d][(Vh+i)*gaugeSiteSize + j] *= sign;
       }
     }
 
@@ -825,9 +825,9 @@ void applyGaugeFieldScaling_long(Float **gauge, int Vh, QudaGaugeParam *param, Q
 	}
       }
 
-      for (int i = 0; i < 6; i++) {
-	gauge[3][j*gaugeSiteSize+ 12+ i ] *= sign;
-	gauge[3][(Vh+j)*gaugeSiteSize+12 +i] *= sign;
+      for (int i=0; i<18; i++) {
+	gauge[3][j*gaugeSiteSize + i] *= sign;
+	gauge[3][(Vh+j)*gaugeSiteSize + i] *= sign;
       }
     }
   }
@@ -1060,7 +1060,7 @@ construct_fat_long_gauge_field(void **fatlink, void** longlink, int type,
   if (param->reconstruct == QUDA_RECONSTRUCT_9 || param->reconstruct == QUDA_RECONSTRUCT_13) {
     // incorporate non-trivial phase into long links
 
-    const double phase = M_PI/3;
+    const double phase = (M_PI * rand())/RAND_MAX;
     const complex<double> z = polar(1.0, phase);
     for (int dir=0; dir<4; ++dir) {
       for (int i=0; i<V; ++i) {

--- a/tests/test_util.cpp
+++ b/tests/test_util.cpp
@@ -943,7 +943,7 @@ static void constructGaugeField(Float **res, QudaGaugeParam *param, QudaDslashTy
 	for (int m = 0; m < 3; m++) { // last 2 rows
 	  for (int n = 0; n < 3; n++) { // 3 columns
 	    resEven[dir][i*(3*3*2) + m*(3*2) + n*(2) + 0] =1.0* rand() / (Float)RAND_MAX;
-	    resEven[dir][i*(3*3*2) + m*(3*2) + n*(2) + 1] =2.0* rand() / (Float)RAND_MAX;
+	    resEven[dir][i*(3*3*2) + m*(3*2) + n*(2) + 1] = 2.0* rand() / (Float)RAND_MAX;
 	    resOdd[dir][i*(3*3*2) + m*(3*2) + n*(2) + 0] = 3.0*rand() / (Float)RAND_MAX;
 	    resOdd[dir][i*(3*3*2) + m*(3*2) + n*(2) + 1] = 4.0*rand() / (Float)RAND_MAX;
 	  }
@@ -1057,23 +1057,20 @@ construct_fat_long_gauge_field(void **fatlink, void** longlink, int type,
     }
   }
 
-  if(param->reconstruct == QUDA_RECONSTRUCT_9 || 
-     param->reconstruct == QUDA_RECONSTRUCT_13){ // incorporate non-trivial phase into long links
-    const double cos_pi_3 = 0.5; // Cos(pi/3)
-    const double sin_pi_3 = sqrt(0.75); // Sin(pi/3)
-    for(int dir=0; dir<4; ++dir){
-      for(int i=0; i<V; ++i){
-        for(int j=0; j<gaugeSiteSize; j+=2){
-          if(precision == QUDA_DOUBLE_PRECISION){
-            const double real = ((double*)longlink[dir])[i*gaugeSiteSize + j];
-            const double imag = ((double*)longlink[dir])[i*gaugeSiteSize + j + 1];
-            ((double*)longlink[dir])[i*gaugeSiteSize + j] = real*cos_pi_3 - imag*sin_pi_3;
-            ((double*)longlink[dir])[i*gaugeSiteSize + j + 1] = real*sin_pi_3 + imag*cos_pi_3;
-          }else{
-            const float real = ((float*)longlink[dir])[i*gaugeSiteSize + j];
-            const float imag = ((float*)longlink[dir])[i*gaugeSiteSize + j + 1];
-            ((float*)longlink[dir])[i*gaugeSiteSize + j] = real*cos_pi_3 - imag*sin_pi_3;
-            ((float*)longlink[dir])[i*gaugeSiteSize + j + 1] = real*sin_pi_3 + imag*cos_pi_3;
+  if (param->reconstruct == QUDA_RECONSTRUCT_9 || param->reconstruct == QUDA_RECONSTRUCT_13) {
+    // incorporate non-trivial phase into long links
+
+    const double phase = M_PI/3;
+    const complex<double> z = polar(1.0, phase);
+    for (int dir=0; dir<4; ++dir) {
+      for (int i=0; i<V; ++i) {
+        for (int j=0; j<gaugeSiteSize; j+=2) {
+          if (precision == QUDA_DOUBLE_PRECISION) {
+            complex<double> *l = (complex<double>*)( &(((double*)longlink[dir])[i*gaugeSiteSize + j]) );
+	    *l *= z;
+          } else {
+            complex<float> *l = (complex<float>*)( &(((float*)longlink[dir])[i*gaugeSiteSize + j]) );
+	    *l *= z;
           }
         } 
       }


### PR DESCRIPTION
This is a bug fix / clean up pull
* Clean up of `gauge::FloatNOrder` reconstruct methods with complex class
* staggered_invert_test now respects `--niter` flag
* Bug fix in `cudaGaugeField::saveCPUField` for when a ghost zone is defined when using GPU-sided reordering
* Some fixes in 13/9 reconstruction for HISQ fermions (though not all issues fully resolved yet)
* Fix clover derivative performance on CUDA 7.5 (see https://github.com/lattice/quda/pull/492#issuecomment-243914699)