### PR TITLE
Hotfix/multigrid

### DIFF
--- a/include/gauge_field.h
+++ b/include/gauge_field.h
@@ -262,6 +262,16 @@ namespace quda {
      * @param[in] src Source from which we are copying
      */
     virtual void copy(const GaugeField &src) = 0;
+
+    /**
+       @brief Backs up the cpuGaugeField
+    */
+    virtual void backup() const = 0;
+
+    /**
+       @brief Restores the cpuGaugeField
+    */
+    virtual void restore() = 0;
   };
 
   class cudaGaugeField : public GaugeField {
@@ -332,9 +342,15 @@ namespace quda {
 
     mutable char *backup_h;
     mutable bool backed_up;
-    // backs up the cudaGaugeField to CPU memory
+
+    /**
+       @brief Backs up the cudaGaugeField to CPU memory
+    */
     void backup() const;
-    // restores the cudaGaugeField to CUDA memory
+
+    /**
+       @brief Restores the cudaGaugeField to CUDA memory
+    */
     void restore();
 
     void setGauge(void* _gauge); //only allowed when create== QUDA_REFERENCE_FIELD_CREATE
@@ -387,6 +403,20 @@ namespace quda {
 
     void* Gauge_p() { return gauge; }
     const void* Gauge_p() const { return gauge; }
+
+    mutable char *backup_h;
+    mutable bool backed_up;
+
+    /**
+     @brief Backs up the cpuGaugeField
+    */
+    void backup() const;
+
+    /**
+       @brief Restores the cpuGaugeField
+    */
+    void restore();
+
     void setGauge(void** _gauge); //only allowed when create== QUDA_REFERENCE_FIELD_CREATE
 
     /**

--- a/include/tune_quda.h
+++ b/include/tune_quda.h
@@ -368,9 +368,18 @@ namespace quda {
 
   };
 
-  void loadTuneCache(QudaVerbosity verbosity);
-  void saveTuneCache(QudaVerbosity verbosity);
-  void saveProfile(QudaVerbosity verbosity);
+  void loadTuneCache();
+  void saveTuneCache();
+
+  /**
+   * @brief Save profile to disk.
+   */
+  void saveProfile(const std::string label = "");
+
+  /**
+   * @brief Flush profile contents, setting all counts to zero.
+   */
+  void flushProfile();
 
   TuneParam& tuneLaunch(Tunable &tunable, QudaTune enabled, QudaVerbosity verbosity);
 

--- a/lib/coarse_op.cu
+++ b/lib/coarse_op.cu
@@ -164,6 +164,7 @@ namespace quda {
     gf_param.gauge = NULL;
     gf_param.create = QUDA_NULL_FIELD_CREATE;
     gf_param.siteSubset = QUDA_FULL_SITE_SUBSET;
+    gf_param.nFace = 1;
 
     cpuGaugeField g(gf_param);
 

--- a/lib/dirac_coarse.cpp
+++ b/lib/dirac_coarse.cpp
@@ -81,6 +81,9 @@ namespace quda {
     Y_h = new cpuGaugeField(gParam);
     Yhat_h = new cpuGaugeField(gParam);
 
+    gParam.ghostExchange = QUDA_GHOST_EXCHANGE_NO;
+    gParam.nFace = 0;
+
     gParam.geometry = QUDA_SCALAR_GEOMETRY;
     X_h = new cpuGaugeField(gParam);
     Xinv_h = new cpuGaugeField(gParam);
@@ -88,6 +91,8 @@ namespace quda {
     dirac->createCoarseOp(*Y_h,*X_h,*Xinv_h,*Yhat_h,*transfer);
 
     if (enable_gpu) {
+      gParam.ghostExchange = QUDA_GHOST_EXCHANGE_PAD;
+      gParam.nFace = 1;
       gParam.order = QUDA_FLOAT2_GAUGE_ORDER;
       gParam.geometry = QUDA_COARSE_GEOMETRY;
       int pad = std::max( { (x[0]*x[1]*x[2])/2, (x[1]*x[2]*x[3])/2, (x[0]*x[2]*x[3])/2, (x[0]*x[1]*x[3])/2 } );
@@ -96,6 +101,10 @@ namespace quda {
       Yhat_d = new cudaGaugeField(gParam);
       Y_d->copy(*Y_h);
       Yhat_d->copy(*Yhat_h);
+
+      gParam.ghostExchange = QUDA_GHOST_EXCHANGE_NO;
+      gParam.nFace = 0;
+      gParam.pad = 0;
 
       gParam.geometry = QUDA_SCALAR_GEOMETRY;
       gParam.ghostExchange = QUDA_GHOST_EXCHANGE_NO;

--- a/lib/dslash_coarse.cu
+++ b/lib/dslash_coarse.cu
@@ -11,7 +11,7 @@ namespace quda {
 #ifdef GPU_MULTIGRID
 
   template <typename Float, typename F, typename G>
-  struct CoarseDslashArg {
+  struct DslashCoarseArg {
     F out;
     const F inA;
     const F inB;
@@ -25,7 +25,7 @@ namespace quda {
     const int dim[5];   // full lattice dimensions (ghost indexer expects a fifth dimension)
     const int commDim[4]; // whether a given dimension is partitioned or not
 
-    CoarseDslashArg(F &out, const F &inA, const F &inB, const G &Y, const G &X,
+    DslashCoarseArg(F &out, const F &inA, const F &inB, const G &Y, const G &X,
 		    Float kappa, int parity, const ColorSpinorField &meta)
       : out(out), inA(inA), inB(inB), Y(Y), X(X), kappa(kappa), parity(parity),
 	nParity(meta.SiteSubset()), volumeCB(meta.VolumeCB()), nFace(1),
@@ -46,7 +46,7 @@ namespace quda {
    */
   extern __shared__ float s[];
   template <typename Float, typename F, typename G, int nDim, int Ns, int Nc, int Mc, int color_stride, int dim_stride, int thread_dir, int thread_dim>
-  __device__ __host__ inline void applyDslash(complex<Float> out[], CoarseDslashArg<Float,F,G> &arg, int x_cb, int parity, int s_row, int color_block, int color_offset) {
+  __device__ __host__ inline void applyDslash(complex<Float> out[], DslashCoarseArg<Float,F,G> &arg, int x_cb, int parity, int s_row, int color_block, int color_offset) {
     const int their_spinor_parity = (arg.nParity == 2) ? (parity+1)&1 : 0;
 
     int coord[5];
@@ -208,7 +208,7 @@ namespace quda {
      @param x_cb The checkerboarded site index
    */
   template <typename Float, typename F, typename G, int Ns, int Nc, int Mc, int color_stride>
-  __device__ __host__ inline void applyClover(complex<Float> out[], CoarseDslashArg<Float,F,G> &arg, int x_cb, int parity, int s, int color_block, int color_offset) {
+  __device__ __host__ inline void applyClover(complex<Float> out[], DslashCoarseArg<Float,F,G> &arg, int x_cb, int parity, int s, int color_block, int color_offset) {
     const int spinor_parity = (arg.nParity == 2) ? parity : 0;
 
     // M is number of colors per thread
@@ -231,7 +231,7 @@ namespace quda {
   //out(x) = M*in = \sum_mu Y_{-\mu}(x)in(x+mu) + Y^\dagger_mu(x-mu)in(x-mu)
   template <typename Float, typename F, typename G, int nDim, int Ns, int Nc, int Mc, int color_stride,
 	    int dim_thread_split, bool dslash, bool clover, int dir, int dim>
-  __device__ __host__ inline void coarseDslash(CoarseDslashArg<Float,F,G> &arg, int x_cb, int parity, int s, int color_block, int color_offset)
+  __device__ __host__ inline void coarseDslash(DslashCoarseArg<Float,F,G> &arg, int x_cb, int parity, int s, int color_block, int color_offset)
   {
     complex <Float> out[Mc];
 #pragma unroll
@@ -257,7 +257,7 @@ namespace quda {
 
   // CPU kernel for applying the coarse Dslash to a vector
   template <typename Float, typename F, typename G, int nDim, int Ns, int Nc, int Mc, bool dslash, bool clover>
-  void coarseDslash(CoarseDslashArg<Float,F,G> arg)
+  void coarseDslash(DslashCoarseArg<Float,F,G> arg)
   {
     // the fine-grain parameters mean nothing for CPU variant
     const int color_stride = 1;
@@ -284,7 +284,7 @@ namespace quda {
 
   // GPU Kernel for applying the coarse Dslash to a vector
   template <typename Float, typename F, typename G, int nDim, int Ns, int Nc, int Mc, int color_stride, int dim_thread_split, bool dslash, bool clover>
-  __global__ void coarseDslashKernel(CoarseDslashArg<Float,F,G> arg)
+  __global__ void coarseDslashKernel(DslashCoarseArg<Float,F,G> arg)
   {
     constexpr int warp_size = 32;
     const int lane_id = threadIdx.x % warp_size;
@@ -323,10 +323,10 @@ namespace quda {
   }
 
   template <typename Float, typename F, typename G, int nDim, int Ns, int Nc, int Mc, bool dslash, bool clover>
-  class CoarseDslash : public Tunable {
+  class DslashCoarse : public Tunable {
 
   protected:
-    CoarseDslashArg<Float,F,G> &arg;
+    DslashCoarseArg<Float,F,G> &arg;
     const ColorSpinorField &meta;
 
     const int max_color_col_stride = 4;
@@ -477,7 +477,7 @@ namespace quda {
     }
 
   public:
-    CoarseDslash(CoarseDslashArg<Float,F,G> &arg, const ColorSpinorField &meta)
+    DslashCoarse(DslashCoarseArg<Float,F,G> &arg, const ColorSpinorField &meta)
       : arg(arg), meta(meta) {
       strcpy(aux, meta.AuxString());
 #ifdef MULTI_GPU
@@ -491,7 +491,7 @@ namespace quda {
       strcat(aux,comm);
 #endif
     }
-    virtual ~CoarseDslash() { }
+    virtual ~DslashCoarse() { }
 
     void apply(const cudaStream_t &stream) {
       if (meta.Location() == QUDA_CPU_FIELD_LOCATION) {
@@ -570,20 +570,20 @@ namespace quda {
     F inAccessorB(const_cast<ColorSpinorField&>(inB));
     G yAccessor(const_cast<GaugeField&>(Y));
     G xAccessor(const_cast<GaugeField&>(X));
-    CoarseDslashArg<Float,F,G> arg(outAccessor, inAccessorA, inAccessorB, yAccessor, xAccessor, (Float)kappa, parity, inA);
+    DslashCoarseArg<Float,F,G> arg(outAccessor, inAccessorA, inAccessorB, yAccessor, xAccessor, (Float)kappa, parity, inA);
 
     const int colors_per_thread = 1;
     if (dslash) {
       if (clover) {
-	CoarseDslash<Float,F,G,4,coarseSpin,coarseColor,colors_per_thread,true,true> dslash(arg, inA);
+	DslashCoarse<Float,F,G,4,coarseSpin,coarseColor,colors_per_thread,true,true> dslash(arg, inA);
 	dslash.apply(0);
       } else {
-	CoarseDslash<Float,F,G,4,coarseSpin,coarseColor,colors_per_thread,true,false> dslash(arg, inA);
+	DslashCoarse<Float,F,G,4,coarseSpin,coarseColor,colors_per_thread,true,false> dslash(arg, inA);
 	dslash.apply(0);
       }
     } else {
       if (clover) {
-	CoarseDslash<Float,F,G,4,coarseSpin,coarseColor,colors_per_thread,false,true> dslash(arg, inA);
+	DslashCoarse<Float,F,G,4,coarseSpin,coarseColor,colors_per_thread,false,true> dslash(arg, inA);
 	dslash.apply(0);
       } else {
 	errorQuda("Unsupported dslash=false clover=false");
@@ -658,40 +658,141 @@ namespace quda {
 
 #endif // GPU_MULTIGRID
 
+  struct DslashCoarseLaunch {
+
+    ColorSpinorField &out;
+    const ColorSpinorField &inA;
+    const ColorSpinorField &inB;
+    const GaugeField &Y;
+    const GaugeField &X;
+    double kappa;
+    int parity;
+    bool dslash;
+    bool clover;
+
+    DslashCoarseLaunch(ColorSpinorField &out, const ColorSpinorField &inA, const ColorSpinorField &inB,
+		       const GaugeField &Y, const GaugeField &X, double kappa, int parity, bool dslash, bool clover)
+      : out(out), inA(inA), inB(inB), Y(Y), X(X), kappa(kappa), parity(parity), dslash(dslash), clover(clover) { }
+
+    void operator()() {
+#ifdef GPU_MULTIGRID
+      if (inA.V() == out.V()) errorQuda("Aliasing pointers");
+
+      if (out.Precision() != inA.Precision() || Y.Precision() != inA.Precision() || X.Precision() != inA.Precision())
+	errorQuda("Precision mismatch out=%d inA=%d inB=%d Y=%d X=%d",
+		  out.Precision(), inA.Precision(), inB.Precision(), Y.Precision(), X.Precision());
+
+      // check all locations match
+      Location(out, inA, inB, Y, X);
+
+      inA.exchangeGhost((QudaParity)(1-parity), 0); // last parameter is dummy
+
+      if (Y.Precision() == QUDA_DOUBLE_PRECISION) {
+#ifdef GPU_MULTIGRID_DOUBLE
+	ApplyCoarse<double>(out, inA, inB, Y, X, kappa, parity, dslash, clover);
+#else
+	errorQuda("Double precision multigrid has not been enabled");
+#endif
+      } else if (Y.Precision() == QUDA_SINGLE_PRECISION) {
+	ApplyCoarse<float>(out, inA, inB, Y, X, kappa, parity, dslash, clover);
+      } else {
+	errorQuda("Unsupported precision %d\n", Y.Precision());
+      }
+#else
+      errorQuda("Multigrid has not been built");
+#endif
+    }
+
+  };
+
+  // hooks into tune.cpp variables for policy tuning
+  typedef std::map<TuneKey, TuneParam> map;
+  const map& getTuneCache();
+
+  void disableProfileCount();
+  void enableProfileCount();
+
+ class DslashCoarsePolicyTune : public Tunable {
+
+   DslashCoarseLaunch &dslash;
+
+   unsigned int sharedBytesPerThread() const { return 0; }
+   unsigned int sharedBytesPerBlock(const TuneParam &param) const { return 0; }
+
+ public:
+   DslashCoarsePolicyTune(DslashCoarseLaunch &dslash) : dslash(dslash)
+   {
+      strcpy(aux,"policy,");
+      if (dslash.dslash) strcat(aux,"dslash");
+      strcat(aux, dslash.clover ? "clover," : ",");
+      strcat(aux,dslash.inA.AuxString());
+#ifdef MULTI_GPU
+      char comm[5];
+      comm[0] = (comm_dim_partitioned(0) ? '1' : '0');
+      comm[1] = (comm_dim_partitioned(1) ? '1' : '0');
+      comm[2] = (comm_dim_partitioned(2) ? '1' : '0');
+      comm[3] = (comm_dim_partitioned(3) ? '1' : '0');
+      comm[4] = '\0';
+      strcat(aux,",comm=");
+      strcat(aux,comm);
+#endif
+
+     // before we do policy tuning we must ensure the kernel
+     // constituents have been tuned since we can't do nested tuning
+     if (getTuneCache().find(tuneKey()) == getTuneCache().end()) {
+       disableProfileCount();
+       dslash();
+       enableProfileCount();
+     }
+    }
+
+   virtual ~DslashCoarsePolicyTune() { }
+
+   void apply(const cudaStream_t &stream) {
+     TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
+     dslash();
+   }
+
+   int tuningIter() const { return 10; }
+
+   bool advanceTuneParam(TuneParam &param) const { return false; }
+
+   TuneKey tuneKey() const {
+     return TuneKey(dslash.inA.VolString(), typeid(*this).name(), aux);
+   }
+
+   long long flops() const {
+     int nDim = 4;
+     int Ns = dslash.inA.Nspin();
+     int Nc = dslash.inA.Ncolor();
+     int nParity = dslash.inA.SiteSubset();
+     int volumeCB = dslash.inA.VolumeCB();
+     return ((dslash.dslash*2*nDim+dslash.clover*1)*(8*Ns*Nc*Ns*Nc)-2*Ns*Nc)*nParity*volumeCB;
+   }
+
+   long long bytes() const {
+     int nParity = dslash.inA.SiteSubset();
+     return (dslash.dslash||dslash.clover) * dslash.out.Bytes() +
+       dslash.dslash*8*dslash.inA.Bytes() + dslash.clover*dslash.inB.Bytes() +
+       nParity*(dslash.dslash*dslash.Y.Bytes()*dslash.Y.VolumeCB()/(2*dslash.Y.Stride())
+		+ dslash.clover*dslash.X.Bytes()/2);
+     // multiply Y by volume / stride to correct for pad
+   }
+  };
+
+
   //Apply the coarse Dirac matrix to a coarse grid vector
   //out(x) = M*in = X*in - kappa*\sum_mu Y_{-\mu}(x)in(x+mu) + Y^\dagger_mu(x-mu)in(x-mu)
   //Uses the kappa normalization for the Wilson operator.
   void ApplyCoarse(ColorSpinorField &out, const ColorSpinorField &inA, const ColorSpinorField &inB,
-		   const GaugeField &Y, const GaugeField &X, double kappa, int parity, bool dslash, bool clover) {
-#ifdef GPU_MULTIGRID
-    if (inA.V() == out.V()) errorQuda("Aliasing pointers");
+	           const GaugeField &Y, const GaugeField &X, double kappa, int parity, bool dslash, bool clover) {
 
-    if (out.Precision() != inA.Precision() ||
-	Y.Precision() != inA.Precision() ||
-	X.Precision() != inA.Precision())
-      errorQuda("Precision mismatch out=%d inA=%d inB=%d Y=%d X=%d",
-		out.Precision(), inA.Precision(), inB.Precision(), Y.Precision(), X.Precision());
+    DslashCoarseLaunch Dslash(out, inA, inB, Y, X, kappa, parity, dslash, clover);
 
-    // check all locations match
-    Location(out, inA, inB, Y, X);
+    DslashCoarsePolicyTune policy(Dslash);
+    policy.apply(0);
 
-    int dummy = 0; // ignored
-    inA.exchangeGhost((QudaParity)(1-parity), dummy);
-
-    if (Y.Precision() == QUDA_DOUBLE_PRECISION) {
-#ifdef GPU_MULTIGRID_DOUBLE
-      ApplyCoarse<double>(out, inA, inB, Y, X, kappa, parity, dslash, clover);
-#else
-      errorQuda("Double precision multigrid has not been enabled");
-#endif
-    } else if (Y.Precision() == QUDA_SINGLE_PRECISION) {
-      ApplyCoarse<float>(out, inA, inB, Y, X, kappa, parity, dslash, clover);
-    } else {
-      errorQuda("Unsupported precision %d\n", Y.Precision());
-    }
-#else
-    errorQuda("Multigrid has not been built");
-#endif
   }//ApplyCoarse
+
 
 } // namespace quda

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -484,7 +484,7 @@ void initQudaMemory()
   num_failures_h = static_cast<int*>(mapped_malloc(sizeof(int)));
   cudaHostGetDevicePointer(&num_failures_d, num_failures_h, 0);
 
-  loadTuneCache(getVerbosity());
+  loadTuneCache();
 
   for (int d=0; d<4; d++) R[d] = 2 * (redundant_comms || commDimPartitioned(d));
 
@@ -1197,8 +1197,8 @@ void endQuda(void)
   destroyStaggeredOprodEvents();
 #endif
 
-  saveTuneCache(getVerbosity());
-  saveProfile(getVerbosity());
+  saveTuneCache();
+  saveProfile();
 
   initialized = false;
 
@@ -2138,7 +2138,7 @@ void lanczosQuda(int k0, int m, void *hp_Apsi, void *hp_r, void *hp_V,
 
   popVerbosity();
 
-  saveTuneCache(getVerbosity());
+  saveTuneCache();
   profileInvert.TPSTOP(QUDA_PROFILE_TOTAL);
 }
 
@@ -2219,6 +2219,9 @@ void* newMultigridQuda(QudaMultigridParam *mg_param) {
 
   closeMagma();
   profileInvert.TPSTOP(QUDA_PROFILE_TOTAL);
+
+  saveProfile(__func__);
+  flushProfile();
   return static_cast<void*>(mg);
 }
 
@@ -2482,8 +2485,8 @@ void invertQuda(void *hp_x, void *hp_b, QudaInvertParam *param)
 
   popVerbosity();
 
-  // FIXME: added temporarily so that the cache is written out even if a long benchmarking job gets interrupted
-  saveTuneCache(getVerbosity());
+  // cache is written out even if a long benchmarking job gets interrupted
+  saveTuneCache();
 
   profileInvert.TPSTOP(QUDA_PROFILE_TOTAL);
 }
@@ -2827,8 +2830,8 @@ void invertMultiShiftQuda(void **_hp_x, void *_hp_b, QudaInvertParam *param)
 
   popVerbosity();
 
-  // FIXME: added temporarily so that the cache is written out even if a long benchmarking job gets interrupted
-  saveTuneCache(getVerbosity());
+  // cache is written out even if a long benchmarking job gets interrupted
+  saveTuneCache();
 
   profileMulti.TPSTOP(QUDA_PROFILE_TOTAL);
 }
@@ -3086,8 +3089,8 @@ void incrementalEigQuda(void *_h_x, void *_h_b, QudaInvertParam *param, void *_h
 
   closeMagma();
 
- // FIXME: added temporarily so that the cache is written out even if a long benchmarking job gets interrupted
-  saveTuneCache(getVerbosity());
+  // cache is written out even if a long benchmarking job gets interrupted
+  saveTuneCache();
 
   profileInvert.TPSTOP(QUDA_PROFILE_TOTAL);
 }

--- a/lib/tune.cpp
+++ b/lib/tune.cpp
@@ -210,7 +210,7 @@ namespace quda {
   /*
    * Read tunecache from disk.
    */
-  void loadTuneCache(QudaVerbosity verbosity)
+  void loadTuneCache()
   {
     char *path;
     struct stat pstat;
@@ -269,7 +269,7 @@ namespace quda {
 	cache_file.close();
 	initial_cache_size = tunecache.size();
 
-	if (verbosity >= QUDA_SUMMARIZE) {
+	if (getVerbosity() >= QUDA_SUMMARIZE) {
 	  printfQuda("Loaded %d sets of cached parameters from %s\n", static_cast<int>(initial_cache_size), cache_path.c_str());
 	}
 
@@ -290,7 +290,7 @@ namespace quda {
   /**
    * Write tunecache to disk.
    */
-  void saveTuneCache(QudaVerbosity verbosity)
+  void saveTuneCache()
   {
     time_t now;
     int lock_handle;
@@ -327,7 +327,7 @@ namespace quda {
       cache_path = resource_path + "/tunecache.tsv";
       cache_file.open(cache_path.c_str());
 
-      if (verbosity >= QUDA_SUMMARIZE) {
+      if (getVerbosity() >= QUDA_SUMMARIZE) {
 	printfQuda("Saving %d sets of cached parameters to %s\n", static_cast<int>(tunecache.size()), cache_path.c_str());
       }
 
@@ -354,11 +354,20 @@ namespace quda {
 #endif
   }
 
+  // flush profile, setting counts to zero
+  void flushProfile()
+  {
 
-  /**
-   * Write profile to disk.
-   */
-  void saveProfile(QudaVerbosity verbosity)
+    for (map::iterator entry = tunecache.begin(); entry != tunecache.end(); entry++) {
+      // set all n_calls = 0
+      TuneParam &param = entry->second;
+      param.n_calls = 0;
+    }
+
+  }
+
+  // save profile
+  void saveProfile(const std::string label)
   {
     time_t now;
     int lock_handle;
@@ -386,20 +395,26 @@ namespace quda {
       int stat = write(lock_handle, msg, sizeof(msg)); // check status to avoid compiler warning
       if (stat == -1) warningQuda("Unable to write to lock file for some bizarre reason");
 
+      // profile counter for writing out unique profiles
+      static int count = 0;
+
       char *profile_fname = getenv("QUDA_PROFILE_OUTPUT_BASE");
 
       if (!profile_fname) {
 	warningQuda("Environment variable QUDA_PROFILE_OUTPUT_BASE is not set; writing to profile.tsv and profile_async.tsv");
-	profile_path = resource_path + "/profile.tsv";
-	async_profile_path = resource_path + "/profile_async.tsv";
+	profile_path = resource_path + "/profile_" + std::to_string(count) + ".tsv";
+	async_profile_path = resource_path + "/profile_async_" + std::to_string(count) + ".tsv";
       } else {
-	profile_path = resource_path + "/" + profile_fname + ".tsv";
-	async_profile_path = resource_path + "/" + profile_fname + "_async.tsv";
+	profile_path = resource_path + "/" + profile_fname + "_" + std::to_string(count) + ".tsv";
+	async_profile_path = resource_path + "/" + profile_fname + "_" + std::to_string(count) + "_async.tsv";
       }
+
+      count++;
+
       profile_file.open(profile_path.c_str());
       async_profile_file.open(async_profile_path.c_str());
 
-      if (verbosity >= QUDA_SUMMARIZE) {
+      if (getVerbosity() >= QUDA_SUMMARIZE) {
 	// compute number of non-zero entries that will be output in the profile
 	int n_entry = 0;
 	int n_policy = 0;
@@ -419,7 +434,9 @@ namespace quda {
 
       time(&now);
 
-      profile_file << "profile\t" << quda_version;
+      std::string Label = label.empty() ? "profile" : label;
+
+      profile_file << Label << "\t" << quda_version;
 #ifdef GITVERSION
       profile_file << "\t" << gitversion;
 #else
@@ -428,7 +445,7 @@ namespace quda {
       profile_file << "\t" << quda_hash << "\t# Last updated " << ctime(&now) << std::endl;
       profile_file << std::setw(12) << "total time" << "\t" << std::setw(12) << "percentage" << "\t" << std::setw(12) << "calls" << "\t" << std::setw(12) << "time / call" << "\t" << std::setw(16) << "volume" << "\tname\taux\tcomment" << std::endl;
 
-      async_profile_file << "profile\t" << quda_version;
+      async_profile_file << Label << "\t" << quda_version;
 #ifdef GITVERSION
       async_profile_file << "\t" << gitversion;
 #else


### PR DESCRIPTION
This is mainly  cleanup and bug fix pull, and fills in some gaps
* Include coarse Dslash in the asynchronous profile by adding a dummy policy tuner around the ghost exchange / kernel application
* Set `GaugeField::nFace` parameter to prevent potential silent errors when copying GPU gauge field to CPU in coarse-link creation
* Do not allocate a ghost zone for the coarse clover fields (saves memory)
* Adds ability to backup / restore cpuGaugeField instances (necessary to add tunecache support for CPU routines)
* Include most time consuming CPU routines in the tunecache and profile for getting a full trace of MG setup (coarse-link creation, block orthogonalization, etc.)
* Added the ability to write out different profiles, and flush the profile, `flushProfile()`, to provide multiple profiles from one run, allowing for directed profiling.  Profiles have an ordinal in their filename indicating the order in which they have been created.
* When running MG, we save and flush the profile after the setup is complete to get a separate profile for the setup and solver.
