### PR TITLE
Create new "pinned" memory allocations on the device

### DIFF
--- a/include/malloc_quda.h
+++ b/include/malloc_quda.h
@@ -13,19 +13,23 @@ namespace quda {
    * macros below instead.
    */
   void *device_malloc_(const char *func, const char *file, int line, size_t size);
+  void *device_pinned_malloc_(const char *func, const char *file, int line, size_t size);
   void *safe_malloc_(const char *func, const char *file, int line, size_t size);
   void *pinned_malloc_(const char *func, const char *file, int line, size_t size);
   void *mapped_malloc_(const char *func, const char *file, int line, size_t size);
   void device_free_(const char *func, const char *file, int line, void *ptr);
+  void device_pinned_free_(const char *func, const char *file, int line, void *ptr);
   void host_free_(const char *func, const char *file, int line, void *ptr);
 
 }
 
 #define device_malloc(size) quda::device_malloc_(__func__, __FILE__, __LINE__, size)
+#define device_pinned_malloc(size) quda::device_pinned_malloc_(__func__, __FILE__, __LINE__, size)
 #define safe_malloc(size) quda::safe_malloc_(__func__, __FILE__, __LINE__, size)
 #define pinned_malloc(size) quda::pinned_malloc_(__func__, __FILE__, __LINE__, size)
 #define mapped_malloc(size) quda::mapped_malloc_(__func__, __FILE__, __LINE__, size)
 #define device_free(ptr) quda::device_free_(__func__, __FILE__, __LINE__, ptr)
+#define device_pinned_free(ptr) quda::device_pinned_free_(__func__, __FILE__, __LINE__, ptr)
 #define host_free(ptr) quda::host_free_(__func__, __FILE__, __LINE__, ptr)
 
 #endif // _MALLOC_QUDA_H

--- a/lib/cuda_color_spinor_field.cu
+++ b/lib/cuda_color_spinor_field.cu
@@ -433,7 +433,7 @@ namespace quda {
 #endif
 
   void cudaColorSpinorField::destroy() {
-    if (ghost_field) device_free(ghost_field);
+    if (ghost_field) device_pinned_free(ghost_field);
 
     if (alloc) {
       device_free(v);
@@ -597,10 +597,12 @@ namespace quda {
 #ifdef USE_TEXTURE_OBJECTS
 	destroyGhostTexObject();
 #endif
-	if (ghostInit && ghost_bytes) device_free(ghost_field);
+	if (ghostInit && ghost_bytes) device_pinned_free(ghost_field);
 
-	// all fields create their own unique ghost zone
-	if (ghost_bytes) ghost_field = device_malloc(ghost_bytes);
+	// all fields create their own unique ghost zone.  Used GPU
+	// pinned allocator to avoid this allocation being redirected,
+	// e.g., by QDPJIT
+	if (ghost_bytes) ghost_field = device_pinned_malloc(ghost_bytes);
 
 #ifdef USE_TEXTURE_OBJECTS
 	createGhostTexObject();

--- a/make.inc.in
+++ b/make.inc.in
@@ -90,13 +90,13 @@ INC = -I$(CUDA_INSTALL_PATH)/include
 
 ifeq ($(strip $(CPU_ARCH)), x86_64)
   ifeq ($(strip $(OS)), osx)
-    LIB = -L$(CUDA_INSTALL_PATH)/lib -lcudart
+    LIB = -L$(CUDA_INSTALL_PATH)/lib -lcudart -lcuda
     NVCCOPT = -m64
   else
-    LIB = -L$(CUDA_INSTALL_PATH)/lib64 -lcudart
+    LIB = -L$(CUDA_INSTALL_PATH)/lib64 -lcudart -lcuda
   endif
 else
-  LIB = -L$(CUDA_INSTALL_PATH)/lib -lcudart -m32
+  LIB = -L$(CUDA_INSTALL_PATH)/lib -lcudart -lcuda -m32
   COPT += -malign-double -m32
   NVCCOPT += -m32
 endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,7 +4,7 @@ include_directories(.)
 #build a common library for all test utilities
 set(QUDA_TEST_COMMON gtest-all.cc test_util.cpp misc.cpp)
 cuda_add_library(quda_test STATIC ${QUDA_TEST_COMMON})
-set(TEST_LIBS quda quda_test ${CMAKE_THREAD_LIBS_INIT} ${QUDA_LIBS})
+set(TEST_LIBS quda quda_test ${CMAKE_THREAD_LIBS_INIT} ${QUDA_LIBS} cuda)
 
 if(QUDA_QIO)
   LIST(APPEND TEST_LIBS ${QIO_LIB} ${LIME_LIB})


### PR DESCRIPTION
Due to the fact that QDJIT/PTX uses a pool allocator redirecting all calls to `cudaMalloc`, yet the CUDA IPC peer-to-peer interface requires base pointers to be exchanged, means that peer-to-peer is broken when used with Chroma and QDPJIT/PTX.  E.g., in general we will never know the base pointer.  This patch creates new allocator and free functions, `device_pinned_malloc` and `device_pinned_free` that uses the CUDA driver API memory functions that are not redirected by QDPJIT to allow QUDA to manage directly memory allocations on the device.  This is used when creating the ghost field for a given quark field.  The overhead of this should be tiny, since this is only deployed for halo regions not entire fields, and in turn halos are only allocated for fields that have a dslash applied to them.