### PR TITLE
Feature/dslash index

### DIFF
--- a/include/tune_quda.h
+++ b/include/tune_quda.h
@@ -128,11 +128,11 @@ namespace quda {
     {
       if (tuneSharedBytes()) {
 	const int max_shared = deviceProp.sharedMemPerBlock;
-	const int max_blocks_per_sm = 8; // FIXME: derive from deviceProp
+	const int max_blocks_per_sm = std::min(deviceProp.maxThreadsPerMultiProcessor / (param.block.x*param.block.y*param.block.z), 8u);
 	int blocks_per_sm = max_shared / (param.shared_bytes ? param.shared_bytes : 1);
 	if (blocks_per_sm > max_blocks_per_sm) blocks_per_sm = max_blocks_per_sm;
-	if (blocks_per_sm == 0) return false;
-	param.shared_bytes = max_shared / blocks_per_sm + 1;
+	param.shared_bytes = (blocks_per_sm > 0 ? max_shared / blocks_per_sm + 1 : max_shared + 1);
+
 	if (param.shared_bytes > max_shared) {
 	  TuneParam next(param);
 	  advanceBlockDim(next); // to get next blockDim

--- a/lib/dslash_constants.h
+++ b/lib/dslash_constants.h
@@ -22,6 +22,7 @@ enum KernelType {
 
     int_fastdiv block[4]; // dslash tile block parameter
     int_fastdiv grid[4]; // dslash tile grid parameter
+    int_fastdiv swizzle; // block index swizzle factor
 
     int_fastdiv face_XYZT[4];
     int_fastdiv face_XYZ[4];

--- a/lib/dslash_constants.h
+++ b/lib/dslash_constants.h
@@ -25,6 +25,10 @@ enum KernelType {
     int_fastdiv face_XYZT[4];
     int_fastdiv face_XYZ[4];
     int_fastdiv face_XY[4];
+    int_fastdiv face_X[4];
+    int_fastdiv face_Y[4];
+    int_fastdiv face_Z[4];
+    int_fastdiv face_T[4];
 
     KernelType kernel_type; //is it INTERIOR_KERNEL, EXTERIOR_KERNEL_X/Y/Z/T
     int commDim[QUDA_MAX_DIM]; // Whether to do comms or not

--- a/lib/dslash_constants.h
+++ b/lib/dslash_constants.h
@@ -17,6 +17,7 @@ enum KernelType {
     int parity;  // Even-Odd or Odd-Even
     int_fastdiv X[4];
     int_fastdiv Xh[4];
+    int_fastdiv volume4CB;
     int Ls;
 
     int_fastdiv block[4]; // dslash tile block parameter

--- a/lib/dslash_constants.h
+++ b/lib/dslash_constants.h
@@ -15,11 +15,16 @@ enum KernelType {
     char do_not_delete; // work around for bug in CUDA 6.5
     int threads; // the desired number of active threads
     int parity;  // Even-Odd or Odd-Even
-    int X[4];
+    int_fastdiv X[4];
+    int_fastdiv Xh[4];
     int Ls;
 
     int_fastdiv block[4]; // dslash tile block parameter
     int_fastdiv grid[4]; // dslash tile grid parameter
+
+    int_fastdiv face_XYZT[4];
+    int_fastdiv face_XYZ[4];
+    int_fastdiv face_XY[4];
 
     KernelType kernel_type; //is it INTERIOR_KERNEL, EXTERIOR_KERNEL_X/Y/Z/T
     int commDim[QUDA_MAX_DIM]; // Whether to do comms or not
@@ -27,6 +32,7 @@ enum KernelType {
     int ghostOffset[QUDA_MAX_DIM+1][2];
     int ghostNormOffset[QUDA_MAX_DIM+1][2];
     int sp_stride; // spinor stride
+
 #ifdef GPU_CLOVER_DIRAC
     int cl_stride; // clover stride
 #endif
@@ -67,7 +73,7 @@ enum KernelType {
     void print() {
       printfQuda("threads = %d\n", threads);
       printfQuda("parity = %d\n", parity);
-      printfQuda("X = {%d, %d, %d, %d}\n", X[0], X[1], X[2], X[3]);
+      printfQuda("X = {%d, %d, %d, %d}\n", (int)X[0], (int)X[1], (int)X[2], (int)X[3]);
 #ifdef GPU_DOMAIN_WALL_DIRAC
       printfQuda("Ls = %d\n", Ls);
 #endif

--- a/lib/dslash_core/asym_wilson_clover_dslash_dagger_fermi_core.h
+++ b/lib/dslash_core/asym_wilson_clover_dslash_dagger_fermi_core.h
@@ -390,7 +390,7 @@ VOLATILE spinorFloat o32_im;
 #include "read_clover.h"
 #include "io_spinor.h"
 
-int x1, x2, x3, x4;
+int coord[5];
 int X;
 
 int sid;
@@ -401,11 +401,11 @@ if (kernel_type == INTERIOR_KERNEL) {
 #endif
 
   // Assume even dimensions
-  coordsFromIndex3D<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X);
+  coordsFromIndex3D<EVEN_X>(X, x, sid, param.parity, param.X);
 
   // only need to check Y and Z dims currently since X and T set to match exactly
-  if (x2 >= X2) return;
-  if (x3 >= X3) return;
+  if (coord[1] >= param.X[1]) return;
+  if (coord[2] >= param.X[2]) return;
 
   o00_re = 0;  o00_im = 0;
   o01_re = 0;  o01_im = 0;
@@ -882,7 +882,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-  coordsFromFaceIndex<kernel_type,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+  coordsFromFaceIndex<4,QUDA_4D_PC,kernel_type,1>(X, sid, coord, face_idx, face_num, param);
 
   READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 
@@ -903,8 +903,8 @@ if (kernel_type == INTERIOR_KERNEL) {
 
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_X && x1==X1m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]<X1m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_X && coord[0]==X1m1) )
 #endif
 {
   // Projector P0+
@@ -914,13 +914,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
   // -i 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x1==X1m1 ? X-X1m1 : X+1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[0]==X1m1 ? X-X1m1 : X+1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x1==X1m1 ? X-X1m1 : X+1) >> 1;
+  const int sp_idx = (coord[0]==X1m1 ? X-X1m1 : X+1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -1100,8 +1100,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_X && x1==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_X && coord[0]==0) )
 #endif
 {
   // Projector P0-
@@ -1111,13 +1111,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
   // i 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x1==0 ? X+X1m1 : X-1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[0]==0 ? X+X1m1 : X-1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x1==0 ? X+X1m1 : X-1) >> 1;
+  const int sp_idx = (coord[0]==0 ? X+X1m1 : X-1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -1300,8 +1300,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_Y && x2==X2m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]<X2m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_Y && coord[1]==X2m1) )
 #endif
 {
   // Projector P1+
@@ -1311,13 +1311,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
   // 1 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x2==X2m1 ? X-X2X1mX1 : X+X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[1]==X2m1 ? X-X2X1mX1 : X+param.X[0]) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x2==X2m1 ? X-X2X1mX1 : X+X1) >> 1;
+  const int sp_idx = (coord[1]==X2m1 ? X-X2X1mX1 : X+param.X[0]) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -1333,7 +1333,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
   if (kernel_type == INTERIOR_KERNEL) {
 #endif
   
-    if (threadIdx.y == blockDim.y-1 && blockDim.y < X2 ) {
+    if (threadIdx.y == blockDim.y-1 && blockDim.y < param.X[1] ) {
     // read spinor from device memory
     READ_SPINOR(SPINORTEX, param.sp_stride, sp_idx, sp_idx);
     
@@ -1352,7 +1352,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
     b2_im = +i12_im-i22_im;
     } else {
     // load spinor from shared memory
-    int tx = (threadIdx.x + blockDim.x - ((x1+1)&1) ) % blockDim.x;
+    int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1) ) % blockDim.x;
     int ty = (threadIdx.y < blockDim.y - 1) ? threadIdx.y + 1 : 0;
     READ_SPINOR_SHARED(tx, ty, threadIdx.z);
     
@@ -1515,8 +1515,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_Y && x2==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_Y && coord[1]==0) )
 #endif
 {
   // Projector P1-
@@ -1526,13 +1526,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
   // -1 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x2==0 ? X+X2X1mX1 : X-X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[1]==0 ? X+X2X1mX1 : X-param.X[0]) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x2==0 ? X+X2X1mX1 : X-X1) >> 1;
+  const int sp_idx = (coord[1]==0 ? X+X2X1mX1 : X-param.X[0]) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -1552,7 +1552,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
   if (kernel_type == INTERIOR_KERNEL) {
 #endif
   
-    if (threadIdx.y == 0 && blockDim.y < X2) {
+    if (threadIdx.y == 0 && blockDim.y < param.X[1]) {
     // read spinor from device memory
     READ_SPINOR(SPINORTEX, param.sp_stride, sp_idx, sp_idx);
     
@@ -1571,7 +1571,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
     b2_im = +i12_im+i22_im;
     } else {
     // load spinor from shared memory
-    int tx = (threadIdx.x + blockDim.x - ((x1+1)&1)) % blockDim.x;
+    int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1)) % blockDim.x;
     int ty = (threadIdx.y > 0) ? threadIdx.y - 1 : blockDim.y - 1;
     READ_SPINOR_SHARED(tx, ty, threadIdx.z);
     
@@ -1734,8 +1734,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_Z && x3==X3m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]<X3m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_Z && coord[2]==X3m1) )
 #endif
 {
   // Projector P2+
@@ -1745,13 +1745,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
   // 0 i 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x3==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[2]==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x3==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1;
+  const int sp_idx = (coord[2]==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -1767,7 +1767,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
   if (kernel_type == INTERIOR_KERNEL) {
 #endif
   
-    if (threadIdx.z == blockDim.z-1 && blockDim.z < X3) {
+    if (threadIdx.z == blockDim.z-1 && blockDim.z < param.X[2]) {
     // read spinor from device memory
     READ_SPINOR(SPINORTEX, param.sp_stride, sp_idx, sp_idx);
     
@@ -1786,7 +1786,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
     b2_im = +i12_im-i32_re;
     } else {
     // load spinor from shared memory
-    int tx = (threadIdx.x + blockDim.x - ((x1+1)&1) ) % blockDim.x;
+    int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1) ) % blockDim.x;
     int tz = (threadIdx.z < blockDim.z - 1) ? threadIdx.z + 1 : 0;
     READ_SPINOR_SHARED(tx, threadIdx.y, tz);
     
@@ -1949,8 +1949,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_Z && x3==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_Z && coord[2]==0) )
 #endif
 {
   // Projector P2-
@@ -1960,13 +1960,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
   // 0 -i 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x3==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[2]==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x3==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1;
+  const int sp_idx = (coord[2]==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -1986,7 +1986,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
   if (kernel_type == INTERIOR_KERNEL) {
 #endif
   
-    if (threadIdx.z == 0 && blockDim.z < X3) {
+    if (threadIdx.z == 0 && blockDim.z < param.X[2]) {
     // read spinor from device memory
     READ_SPINOR(SPINORTEX, param.sp_stride, sp_idx, sp_idx);
     
@@ -2005,7 +2005,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
     b2_im = +i12_im+i32_re;
     } else {
     // load spinor from shared memory
-    int tx = (threadIdx.x + blockDim.x - ((x1+1)&1)) % blockDim.x;
+    int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1)) % blockDim.x;
     int tz = (threadIdx.z > 0) ? threadIdx.z - 1 : blockDim.z - 1;
     READ_SPINOR_SHARED(tx, threadIdx.y, tz);
     
@@ -2168,8 +2168,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_T && x4==X4m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]<X4m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_T && coord[3]==X4m1) )
 #endif
 {
   // Projector P3+
@@ -2179,13 +2179,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
   // 0 0 0 0 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x4==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[3]==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x4==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1;
+  const int sp_idx = (coord[3]==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -2425,8 +2425,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_T && x4==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_T && coord[3]==0) )
 #endif
 {
   // Projector P3-
@@ -2436,13 +2436,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4>0)) ||
   // 0 0 0 2 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x4==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[3]==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x4==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1;
+  const int sp_idx = (coord[3]==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1;
 #endif
   
 #ifdef MULTI_GPU

--- a/lib/dslash_core/asym_wilson_clover_dslash_dagger_fermi_core.h
+++ b/lib/dslash_core/asym_wilson_clover_dslash_dagger_fermi_core.h
@@ -874,7 +874,6 @@ if (kernel_type == INTERIOR_KERNEL) {
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  const int dim = static_cast<int>(kernel_type);
   const int face_volume = (param.threads >> 1);           // volume of one face
   const int face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
   face_idx = sid - face_num*face_volume;        // index into the respective face
@@ -883,8 +882,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromFaceIndex<1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, dim, face_num, param.parity, dims);
+  coordsFromFaceIndex<kernel_type,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
 
   READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 

--- a/lib/dslash_core/asym_wilson_clover_dslash_dagger_fermi_core.h
+++ b/lib/dslash_core/asym_wilson_clover_dslash_dagger_fermi_core.h
@@ -400,9 +400,8 @@ int face_idx;
 if (kernel_type == INTERIOR_KERNEL) {
 #endif
 
-  // Inline by hand for the moment and assume even dimensions
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromIndex3D<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, dims);
+  // Assume even dimensions
+  coordsFromIndex3D<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X);
 
   // only need to check Y and Z dims currently since X and T set to match exactly
   if (x2 >= X2) return;

--- a/lib/dslash_core/asym_wilson_clover_dslash_dagger_gt200_core.h
+++ b/lib/dslash_core/asym_wilson_clover_dslash_dagger_gt200_core.h
@@ -393,9 +393,8 @@ if (kernel_type == INTERIOR_KERNEL) {
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  // Inline by hand for the moment and assume even dimensions
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromIndex<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, dims, param.block, param.grid);
+  // Assume even dimensions
+  coordsFromIndex<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X, param.block, param.grid);
 
   o00_re = 0;  o00_im = 0;
   o01_re = 0;  o01_im = 0;

--- a/lib/dslash_core/asym_wilson_clover_dslash_dagger_gt200_core.h
+++ b/lib/dslash_core/asym_wilson_clover_dslash_dagger_gt200_core.h
@@ -380,7 +380,7 @@ VOLATILE spinorFloat o32_im;
 #include "read_clover.h"
 #include "io_spinor.h"
 
-int x1, x2, x3, x4;
+int coord[5];
 int X;
 
 int sid;
@@ -394,7 +394,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   if (sid >= param.threads) return;
 
   // Assume even dimensions
-  coordsFromIndex<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X, param.block, param.grid);
+  coordsFromIndex<4,QUDA_4D_PC,EVEN_X>(X, coord, sid, param);
 
   o00_re = 0;  o00_im = 0;
   o01_re = 0;  o01_im = 0;
@@ -871,7 +871,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-  coordsFromFaceIndex<kernel_type,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+  coordsFromFaceIndex<4,QUDA_4D_PC,kernel_type,1>(X, sid, coord, face_idx, face_num, param);
 
   READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 
@@ -892,8 +892,8 @@ if (kernel_type == INTERIOR_KERNEL) {
 
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_X && x1==X1m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]<X1m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_X && coord[0]==X1m1) )
 #endif
 {
   // Projector P0+
@@ -903,13 +903,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
   // -i 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x1==X1m1 ? X-X1m1 : X+1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[0]==X1m1 ? X-X1m1 : X+1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x1==X1m1 ? X-X1m1 : X+1) >> 1;
+  const int sp_idx = (coord[0]==X1m1 ? X-X1m1 : X+1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -1086,8 +1086,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_X && x1==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_X && coord[0]==0) )
 #endif
 {
   // Projector P0-
@@ -1097,13 +1097,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
   // i 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x1==0 ? X+X1m1 : X-1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[0]==0 ? X+X1m1 : X-1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x1==0 ? X+X1m1 : X-1) >> 1;
+  const int sp_idx = (coord[0]==0 ? X+X1m1 : X-1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -1284,8 +1284,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_Y && x2==X2m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]<X2m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_Y && coord[1]==X2m1) )
 #endif
 {
   // Projector P1+
@@ -1295,13 +1295,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
   // 1 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x2==X2m1 ? X-X2X1mX1 : X+X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[1]==X2m1 ? X-X2X1mX1 : X+param.X[0]) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x2==X2m1 ? X-X2X1mX1 : X+X1) >> 1;
+  const int sp_idx = (coord[1]==X2m1 ? X-X2X1mX1 : X+param.X[0]) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -1478,8 +1478,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_Y && x2==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_Y && coord[1]==0) )
 #endif
 {
   // Projector P1-
@@ -1489,13 +1489,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
   // -1 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x2==0 ? X+X2X1mX1 : X-X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[1]==0 ? X+X2X1mX1 : X-param.X[0]) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x2==0 ? X+X2X1mX1 : X-X1) >> 1;
+  const int sp_idx = (coord[1]==0 ? X+X2X1mX1 : X-param.X[0]) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -1676,8 +1676,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_Z && x3==X3m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]<X3m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_Z && coord[2]==X3m1) )
 #endif
 {
   // Projector P2+
@@ -1687,13 +1687,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
   // 0 i 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x3==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[2]==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x3==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1;
+  const int sp_idx = (coord[2]==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -1870,8 +1870,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_Z && x3==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_Z && coord[2]==0) )
 #endif
 {
   // Projector P2-
@@ -1881,13 +1881,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
   // 0 -i 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x3==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[2]==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x3==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1;
+  const int sp_idx = (coord[2]==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -2068,8 +2068,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_T && x4==X4m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]<X4m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_T && coord[3]==X4m1) )
 #endif
 {
   // Projector P3+
@@ -2079,13 +2079,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
   // 0 0 0 0 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x4==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[3]==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x4==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1;
+  const int sp_idx = (coord[3]==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -2325,8 +2325,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_T && x4==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_T && coord[3]==0) )
 #endif
 {
   // Projector P3-
@@ -2336,13 +2336,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4>0)) ||
   // 0 0 0 2 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x4==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[3]==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x4==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1;
+  const int sp_idx = (coord[3]==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1;
 #endif
   
 #ifdef MULTI_GPU

--- a/lib/dslash_core/asym_wilson_clover_dslash_dagger_gt200_core.h
+++ b/lib/dslash_core/asym_wilson_clover_dslash_dagger_gt200_core.h
@@ -863,7 +863,6 @@ if (kernel_type == INTERIOR_KERNEL) {
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  const int dim = static_cast<int>(kernel_type);
   const int face_volume = (param.threads >> 1);           // volume of one face
   const int face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
   face_idx = sid - face_num*face_volume;        // index into the respective face
@@ -872,8 +871,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromFaceIndex<1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, dim, face_num, param.parity, dims);
+  coordsFromFaceIndex<kernel_type,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
 
   READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 

--- a/lib/dslash_core/asym_wilson_clover_dslash_fermi_core.h
+++ b/lib/dslash_core/asym_wilson_clover_dslash_fermi_core.h
@@ -390,7 +390,7 @@ VOLATILE spinorFloat o32_im;
 #include "read_clover.h"
 #include "io_spinor.h"
 
-int x1, x2, x3, x4;
+int coord[5];
 int X;
 
 int sid;
@@ -401,11 +401,11 @@ if (kernel_type == INTERIOR_KERNEL) {
 #endif
 
   // Assume even dimensions
-  coordsFromIndex3D<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X);
+  coordsFromIndex3D<EVEN_X>(X, x, sid, param.parity, param.X);
 
   // only need to check Y and Z dims currently since X and T set to match exactly
-  if (x2 >= X2) return;
-  if (x3 >= X3) return;
+  if (coord[1] >= param.X[1]) return;
+  if (coord[2] >= param.X[2]) return;
 
   o00_re = 0;  o00_im = 0;
   o01_re = 0;  o01_im = 0;
@@ -882,7 +882,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-  coordsFromFaceIndex<kernel_type,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+  coordsFromFaceIndex<4,QUDA_4D_PC,kernel_type,1>(X, sid, coord, face_idx, face_num, param);
 
   READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 
@@ -903,8 +903,8 @@ if (kernel_type == INTERIOR_KERNEL) {
 
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_X && x1==X1m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]<X1m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_X && coord[0]==X1m1) )
 #endif
 {
   // Projector P0-
@@ -914,13 +914,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
   // i 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x1==X1m1 ? X-X1m1 : X+1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[0]==X1m1 ? X-X1m1 : X+1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x1==X1m1 ? X-X1m1 : X+1) >> 1;
+  const int sp_idx = (coord[0]==X1m1 ? X-X1m1 : X+1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -1100,8 +1100,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_X && x1==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_X && coord[0]==0) )
 #endif
 {
   // Projector P0+
@@ -1111,13 +1111,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
   // -i 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x1==0 ? X+X1m1 : X-1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[0]==0 ? X+X1m1 : X-1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x1==0 ? X+X1m1 : X-1) >> 1;
+  const int sp_idx = (coord[0]==0 ? X+X1m1 : X-1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -1300,8 +1300,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_Y && x2==X2m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]<X2m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_Y && coord[1]==X2m1) )
 #endif
 {
   // Projector P1-
@@ -1311,13 +1311,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
   // -1 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x2==X2m1 ? X-X2X1mX1 : X+X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[1]==X2m1 ? X-X2X1mX1 : X+param.X[0]) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x2==X2m1 ? X-X2X1mX1 : X+X1) >> 1;
+  const int sp_idx = (coord[1]==X2m1 ? X-X2X1mX1 : X+param.X[0]) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -1333,7 +1333,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
   if (kernel_type == INTERIOR_KERNEL) {
 #endif
   
-    if (threadIdx.y == blockDim.y-1 && blockDim.y < X2 ) {
+    if (threadIdx.y == blockDim.y-1 && blockDim.y < param.X[1] ) {
     // read spinor from device memory
     READ_SPINOR(SPINORTEX, param.sp_stride, sp_idx, sp_idx);
     
@@ -1352,7 +1352,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
     b2_im = +i12_im+i22_im;
     } else {
     // load spinor from shared memory
-    int tx = (threadIdx.x + blockDim.x - ((x1+1)&1) ) % blockDim.x;
+    int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1) ) % blockDim.x;
     int ty = (threadIdx.y < blockDim.y - 1) ? threadIdx.y + 1 : 0;
     READ_SPINOR_SHARED(tx, ty, threadIdx.z);
     
@@ -1515,8 +1515,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_Y && x2==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_Y && coord[1]==0) )
 #endif
 {
   // Projector P1+
@@ -1526,13 +1526,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
   // 1 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x2==0 ? X+X2X1mX1 : X-X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[1]==0 ? X+X2X1mX1 : X-param.X[0]) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x2==0 ? X+X2X1mX1 : X-X1) >> 1;
+  const int sp_idx = (coord[1]==0 ? X+X2X1mX1 : X-param.X[0]) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -1552,7 +1552,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
   if (kernel_type == INTERIOR_KERNEL) {
 #endif
   
-    if (threadIdx.y == 0 && blockDim.y < X2) {
+    if (threadIdx.y == 0 && blockDim.y < param.X[1]) {
     // read spinor from device memory
     READ_SPINOR(SPINORTEX, param.sp_stride, sp_idx, sp_idx);
     
@@ -1571,7 +1571,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
     b2_im = +i12_im-i22_im;
     } else {
     // load spinor from shared memory
-    int tx = (threadIdx.x + blockDim.x - ((x1+1)&1)) % blockDim.x;
+    int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1)) % blockDim.x;
     int ty = (threadIdx.y > 0) ? threadIdx.y - 1 : blockDim.y - 1;
     READ_SPINOR_SHARED(tx, ty, threadIdx.z);
     
@@ -1734,8 +1734,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_Z && x3==X3m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]<X3m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_Z && coord[2]==X3m1) )
 #endif
 {
   // Projector P2-
@@ -1745,13 +1745,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
   // 0 -i 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x3==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[2]==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x3==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1;
+  const int sp_idx = (coord[2]==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -1767,7 +1767,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
   if (kernel_type == INTERIOR_KERNEL) {
 #endif
   
-    if (threadIdx.z == blockDim.z-1 && blockDim.z < X3) {
+    if (threadIdx.z == blockDim.z-1 && blockDim.z < param.X[2]) {
     // read spinor from device memory
     READ_SPINOR(SPINORTEX, param.sp_stride, sp_idx, sp_idx);
     
@@ -1786,7 +1786,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
     b2_im = +i12_im+i32_re;
     } else {
     // load spinor from shared memory
-    int tx = (threadIdx.x + blockDim.x - ((x1+1)&1) ) % blockDim.x;
+    int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1) ) % blockDim.x;
     int tz = (threadIdx.z < blockDim.z - 1) ? threadIdx.z + 1 : 0;
     READ_SPINOR_SHARED(tx, threadIdx.y, tz);
     
@@ -1949,8 +1949,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_Z && x3==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_Z && coord[2]==0) )
 #endif
 {
   // Projector P2+
@@ -1960,13 +1960,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
   // 0 i 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x3==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[2]==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x3==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1;
+  const int sp_idx = (coord[2]==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -1986,7 +1986,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
   if (kernel_type == INTERIOR_KERNEL) {
 #endif
   
-    if (threadIdx.z == 0 && blockDim.z < X3) {
+    if (threadIdx.z == 0 && blockDim.z < param.X[2]) {
     // read spinor from device memory
     READ_SPINOR(SPINORTEX, param.sp_stride, sp_idx, sp_idx);
     
@@ -2005,7 +2005,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
     b2_im = +i12_im-i32_re;
     } else {
     // load spinor from shared memory
-    int tx = (threadIdx.x + blockDim.x - ((x1+1)&1)) % blockDim.x;
+    int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1)) % blockDim.x;
     int tz = (threadIdx.z > 0) ? threadIdx.z - 1 : blockDim.z - 1;
     READ_SPINOR_SHARED(tx, threadIdx.y, tz);
     
@@ -2168,8 +2168,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_T && x4==X4m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]<X4m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_T && coord[3]==X4m1) )
 #endif
 {
   // Projector P3-
@@ -2179,13 +2179,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
   // 0 0 0 2 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x4==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[3]==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x4==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1;
+  const int sp_idx = (coord[3]==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -2425,8 +2425,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_T && x4==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_T && coord[3]==0) )
 #endif
 {
   // Projector P3+
@@ -2436,13 +2436,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4>0)) ||
   // 0 0 0 0 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x4==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[3]==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x4==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1;
+  const int sp_idx = (coord[3]==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1;
 #endif
   
 #ifdef MULTI_GPU

--- a/lib/dslash_core/asym_wilson_clover_dslash_fermi_core.h
+++ b/lib/dslash_core/asym_wilson_clover_dslash_fermi_core.h
@@ -874,7 +874,6 @@ if (kernel_type == INTERIOR_KERNEL) {
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  const int dim = static_cast<int>(kernel_type);
   const int face_volume = (param.threads >> 1);           // volume of one face
   const int face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
   face_idx = sid - face_num*face_volume;        // index into the respective face
@@ -883,8 +882,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromFaceIndex<1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, dim, face_num, param.parity, dims);
+  coordsFromFaceIndex<kernel_type,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
 
   READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 

--- a/lib/dslash_core/asym_wilson_clover_dslash_fermi_core.h
+++ b/lib/dslash_core/asym_wilson_clover_dslash_fermi_core.h
@@ -400,9 +400,8 @@ int face_idx;
 if (kernel_type == INTERIOR_KERNEL) {
 #endif
 
-  // Inline by hand for the moment and assume even dimensions
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromIndex3D<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, dims);
+  // Assume even dimensions
+  coordsFromIndex3D<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X);
 
   // only need to check Y and Z dims currently since X and T set to match exactly
   if (x2 >= X2) return;

--- a/lib/dslash_core/asym_wilson_clover_dslash_gt200_core.h
+++ b/lib/dslash_core/asym_wilson_clover_dslash_gt200_core.h
@@ -393,9 +393,8 @@ if (kernel_type == INTERIOR_KERNEL) {
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  // Inline by hand for the moment and assume even dimensions
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromIndex<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, dims, param.block, param.grid);
+  // Assume even dimensions
+  coordsFromIndex<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X, param.block, param.grid);
 
   o00_re = 0;  o00_im = 0;
   o01_re = 0;  o01_im = 0;

--- a/lib/dslash_core/asym_wilson_clover_dslash_gt200_core.h
+++ b/lib/dslash_core/asym_wilson_clover_dslash_gt200_core.h
@@ -380,7 +380,7 @@ VOLATILE spinorFloat o32_im;
 #include "read_clover.h"
 #include "io_spinor.h"
 
-int x1, x2, x3, x4;
+int coord[5];
 int X;
 
 int sid;
@@ -394,7 +394,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   if (sid >= param.threads) return;
 
   // Assume even dimensions
-  coordsFromIndex<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X, param.block, param.grid);
+  coordsFromIndex<4,QUDA_4D_PC,EVEN_X>(X, coord, sid, param);
 
   o00_re = 0;  o00_im = 0;
   o01_re = 0;  o01_im = 0;
@@ -871,7 +871,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-  coordsFromFaceIndex<kernel_type,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+  coordsFromFaceIndex<4,QUDA_4D_PC,kernel_type,1>(X, sid, coord, face_idx, face_num, param);
 
   READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 
@@ -892,8 +892,8 @@ if (kernel_type == INTERIOR_KERNEL) {
 
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_X && x1==X1m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]<X1m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_X && coord[0]==X1m1) )
 #endif
 {
   // Projector P0-
@@ -903,13 +903,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
   // i 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x1==X1m1 ? X-X1m1 : X+1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[0]==X1m1 ? X-X1m1 : X+1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x1==X1m1 ? X-X1m1 : X+1) >> 1;
+  const int sp_idx = (coord[0]==X1m1 ? X-X1m1 : X+1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -1086,8 +1086,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_X && x1==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_X && coord[0]==0) )
 #endif
 {
   // Projector P0+
@@ -1097,13 +1097,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
   // -i 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x1==0 ? X+X1m1 : X-1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[0]==0 ? X+X1m1 : X-1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x1==0 ? X+X1m1 : X-1) >> 1;
+  const int sp_idx = (coord[0]==0 ? X+X1m1 : X-1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -1284,8 +1284,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_Y && x2==X2m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]<X2m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_Y && coord[1]==X2m1) )
 #endif
 {
   // Projector P1-
@@ -1295,13 +1295,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
   // -1 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x2==X2m1 ? X-X2X1mX1 : X+X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[1]==X2m1 ? X-X2X1mX1 : X+param.X[0]) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x2==X2m1 ? X-X2X1mX1 : X+X1) >> 1;
+  const int sp_idx = (coord[1]==X2m1 ? X-X2X1mX1 : X+param.X[0]) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -1478,8 +1478,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_Y && x2==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_Y && coord[1]==0) )
 #endif
 {
   // Projector P1+
@@ -1489,13 +1489,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
   // 1 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x2==0 ? X+X2X1mX1 : X-X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[1]==0 ? X+X2X1mX1 : X-param.X[0]) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x2==0 ? X+X2X1mX1 : X-X1) >> 1;
+  const int sp_idx = (coord[1]==0 ? X+X2X1mX1 : X-param.X[0]) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -1676,8 +1676,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_Z && x3==X3m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]<X3m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_Z && coord[2]==X3m1) )
 #endif
 {
   // Projector P2-
@@ -1687,13 +1687,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
   // 0 -i 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x3==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[2]==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x3==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1;
+  const int sp_idx = (coord[2]==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -1870,8 +1870,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_Z && x3==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_Z && coord[2]==0) )
 #endif
 {
   // Projector P2+
@@ -1881,13 +1881,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
   // 0 i 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x3==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[2]==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x3==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1;
+  const int sp_idx = (coord[2]==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -2068,8 +2068,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_T && x4==X4m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]<X4m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_T && coord[3]==X4m1) )
 #endif
 {
   // Projector P3-
@@ -2079,13 +2079,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
   // 0 0 0 2 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x4==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[3]==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x4==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1;
+  const int sp_idx = (coord[3]==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -2325,8 +2325,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_T && x4==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_T && coord[3]==0) )
 #endif
 {
   // Projector P3+
@@ -2336,13 +2336,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4>0)) ||
   // 0 0 0 0 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x4==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[3]==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x4==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1;
+  const int sp_idx = (coord[3]==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1;
 #endif
   
 #ifdef MULTI_GPU

--- a/lib/dslash_core/asym_wilson_clover_dslash_gt200_core.h
+++ b/lib/dslash_core/asym_wilson_clover_dslash_gt200_core.h
@@ -863,7 +863,6 @@ if (kernel_type == INTERIOR_KERNEL) {
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  const int dim = static_cast<int>(kernel_type);
   const int face_volume = (param.threads >> 1);           // volume of one face
   const int face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
   face_idx = sid - face_num*face_volume;        // index into the respective face
@@ -872,8 +871,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromFaceIndex<1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, dim, face_num, param.parity, dims);
+  coordsFromFaceIndex<kernel_type,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
 
   READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 

--- a/lib/dslash_core/asym_wilson_clover_fused_exterior_dslash_dagger_fermi_core.h
+++ b/lib/dslash_core/asym_wilson_clover_fused_exterior_dslash_dagger_fermi_core.h
@@ -401,39 +401,42 @@ int sp_norm_idx;
 
 int sid;
 
-int dim;
-int face_num;
-int face_idx;
-int Y[4] = {X1,X2,X3,X4};
-
-
 
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  dim = dimFromFaceIndex(sid, param); // sid is also modified
+  int dim = dimFromFaceIndex(sid, param); // sid is also modified
 
 
   const int face_volume = ((param.threadDimMapUpper[dim] - param.threadDimMapLower[dim]) >> 1);   // volume of one face
-  face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
-  face_idx = sid - face_num*face_volume;        // index into the respective face
+  int face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
+  int face_idx = sid - face_num*face_volume;        // index into the respective face
 
   // ghostOffset is scaled to include body (includes stride) and number of FloatN arrays (SPINOR_HOP)
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-
-  coordsFromFaceIndex<1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, dim, face_num, param.parity,Y);
-
-  {
-    bool active = false;
-    for(int dir=0; dir<4; ++dir){
-     active = active  || isActive(dim,dir,+1,x1,x2,x3,x4,param.commDim,param.X);
-    }
-    if(!active) return;
+  switch(dim) {
+  case 0:
+    coordsFromFaceIndex<0,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 1:
+    coordsFromFaceIndex<1,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 2:
+    coordsFromFaceIndex<2,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 3:
+    coordsFromFaceIndex<3,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
   }
 
 
+  bool active = false;
+  for(int dir=0; dir<4; ++dir){
+   active = active  || isActive(dim,dir,+1,x1,x2,x3,x4,param.commDim,param.X);
+  }
+  if(!active) return;
 
   READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 
@@ -459,7 +462,7 @@ if ( isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   // 0 -i 1 0 
   // -i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
   const int sp_idx = face_idx + param.ghostOffset[0][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][1];
@@ -621,7 +624,7 @@ if ( isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   // 0 i 1 0 
   // i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
   const int sp_idx = face_idx + param.ghostOffset[0][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][0];
@@ -783,7 +786,7 @@ if ( isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   // 0 -1 1 0 
   // 1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
   const int sp_idx = face_idx + param.ghostOffset[1][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][1];
@@ -945,7 +948,7 @@ if ( isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   // 0 1 1 0 
   // -1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
   const int sp_idx = face_idx + param.ghostOffset[1][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][0];
@@ -1107,7 +1110,7 @@ if ( isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   // -i 0 1 0 
   // 0 i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
   const int sp_idx = face_idx + param.ghostOffset[2][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][1];
@@ -1269,7 +1272,7 @@ if ( isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   // i 0 1 0 
   // 0 -i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
   const int sp_idx = face_idx + param.ghostOffset[2][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][0];
@@ -1431,7 +1434,7 @@ if ( isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   // 0 0 0 0 
   // 0 0 0 0 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
   const int sp_idx = face_idx + param.ghostOffset[3][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][1];
@@ -1631,7 +1634,7 @@ if ( isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
   // 0 0 2 0 
   // 0 0 0 2 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
   const int sp_idx = face_idx + param.ghostOffset[3][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][0];

--- a/lib/dslash_core/asym_wilson_clover_fused_exterior_dslash_dagger_fermi_core.h
+++ b/lib/dslash_core/asym_wilson_clover_fused_exterior_dslash_dagger_fermi_core.h
@@ -392,7 +392,7 @@ VOLATILE spinorFloat o32_im;
 #include "read_clover.h"
 #include "io_spinor.h"
 
-int x1, x2, x3, x4;
+int coord[5];
 int X;
 
 #if (DD_PREC==2) // half precision
@@ -418,23 +418,23 @@ int sid;
 
   switch(dim) {
   case 0:
-    coordsFromFaceIndex<0,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,0,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 1:
-    coordsFromFaceIndex<1,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,1,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 2:
-    coordsFromFaceIndex<2,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,2,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 3:
-    coordsFromFaceIndex<3,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,3,1>(X, sid, coord, face_idx, face_num, param);
     break;
   }
 
 
   bool active = false;
   for(int dir=0; dir<4; ++dir){
-   active = active  || isActive(dim,dir,+1,x1,x2,x3,x4,param.commDim,param.X);
+   active = active  || isActive(dim,dir,+1,coord,param.commDim,param.X);
   }
   if(!active) return;
 
@@ -454,7 +454,7 @@ int sid;
   o32_re = i32_re;  o32_im = i32_im;
 
 
-if ( isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
+if ( isActive(dim,0,+1,coord,param.commDim,param.X) && coord[0]==X1m1 )
 {
   // Projector P0+
   // 1 0 0 i 
@@ -462,7 +462,7 @@ if ( isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   // 0 -i 1 0 
   // -i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,0,param);
   const int sp_idx = face_idx + param.ghostOffset[0][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][1];
@@ -616,7 +616,7 @@ if ( isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   
 }
 
-if ( isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
+if ( isActive(dim,0,-1,coord,param.commDim,param.X) && coord[0]==0 )
 {
   // Projector P0-
   // 1 0 0 -i 
@@ -624,7 +624,7 @@ if ( isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   // 0 i 1 0 
   // i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,0,param);
   const int sp_idx = face_idx + param.ghostOffset[0][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][0];
@@ -778,7 +778,7 @@ if ( isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   
 }
 
-if ( isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
+if ( isActive(dim,1,+1,coord,param.commDim,param.X) && coord[1]==X2m1 )
 {
   // Projector P1+
   // 1 0 0 1 
@@ -786,7 +786,7 @@ if ( isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   // 0 -1 1 0 
   // 1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,1,param);
   const int sp_idx = face_idx + param.ghostOffset[1][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][1];
@@ -940,7 +940,7 @@ if ( isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   
 }
 
-if ( isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
+if ( isActive(dim,1,-1,coord,param.commDim,param.X) && coord[1]==0 )
 {
   // Projector P1-
   // 1 0 0 -1 
@@ -948,7 +948,7 @@ if ( isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   // 0 1 1 0 
   // -1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,1,param);
   const int sp_idx = face_idx + param.ghostOffset[1][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][0];
@@ -1102,7 +1102,7 @@ if ( isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   
 }
 
-if ( isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
+if ( isActive(dim,2,+1,coord,param.commDim,param.X) && coord[2]==X3m1 )
 {
   // Projector P2+
   // 1 0 i 0 
@@ -1110,7 +1110,7 @@ if ( isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   // -i 0 1 0 
   // 0 i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,2,param);
   const int sp_idx = face_idx + param.ghostOffset[2][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][1];
@@ -1264,7 +1264,7 @@ if ( isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   
 }
 
-if ( isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
+if ( isActive(dim,2,-1,coord,param.commDim,param.X) && coord[2]==0 )
 {
   // Projector P2-
   // 1 0 -i 0 
@@ -1272,7 +1272,7 @@ if ( isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   // i 0 1 0 
   // 0 -i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,2,param);
   const int sp_idx = face_idx + param.ghostOffset[2][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][0];
@@ -1426,7 +1426,7 @@ if ( isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   
 }
 
-if ( isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
+if ( isActive(dim,3,+1,coord,param.commDim,param.X) && coord[3]==X4m1 )
 {
   // Projector P3+
   // 2 0 0 0 
@@ -1434,7 +1434,7 @@ if ( isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   // 0 0 0 0 
   // 0 0 0 0 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,3,param);
   const int sp_idx = face_idx + param.ghostOffset[3][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][1];
@@ -1626,7 +1626,7 @@ if ( isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   }
 }
 
-if ( isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
+if ( isActive(dim,3,-1,coord,param.commDim,param.X) && coord[3]==0 )
 {
   // Projector P3-
   // 0 0 0 0 
@@ -1634,7 +1634,7 @@ if ( isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
   // 0 0 2 0 
   // 0 0 0 2 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,3,param);
   const int sp_idx = face_idx + param.ghostOffset[3][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][0];

--- a/lib/dslash_core/asym_wilson_clover_fused_exterior_dslash_dagger_gt200_core.h
+++ b/lib/dslash_core/asym_wilson_clover_fused_exterior_dslash_dagger_gt200_core.h
@@ -391,39 +391,42 @@ int sp_norm_idx;
 
 int sid;
 
-int dim;
-int face_num;
-int face_idx;
-int Y[4] = {X1,X2,X3,X4};
-
-
 
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  dim = dimFromFaceIndex(sid, param); // sid is also modified
+  int dim = dimFromFaceIndex(sid, param); // sid is also modified
 
 
   const int face_volume = ((param.threadDimMapUpper[dim] - param.threadDimMapLower[dim]) >> 1);   // volume of one face
-  face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
-  face_idx = sid - face_num*face_volume;        // index into the respective face
+  int face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
+  int face_idx = sid - face_num*face_volume;        // index into the respective face
 
   // ghostOffset is scaled to include body (includes stride) and number of FloatN arrays (SPINOR_HOP)
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-
-  coordsFromFaceIndex<1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, dim, face_num, param.parity,Y);
-
-  {
-    bool active = false;
-    for(int dir=0; dir<4; ++dir){
-     active = active  || isActive(dim,dir,+1,x1,x2,x3,x4,param.commDim,param.X);
-    }
-    if(!active) return;
+  switch(dim) {
+  case 0:
+    coordsFromFaceIndex<0,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 1:
+    coordsFromFaceIndex<1,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 2:
+    coordsFromFaceIndex<2,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 3:
+    coordsFromFaceIndex<3,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
   }
 
 
+  bool active = false;
+  for(int dir=0; dir<4; ++dir){
+   active = active  || isActive(dim,dir,+1,x1,x2,x3,x4,param.commDim,param.X);
+  }
+  if(!active) return;
 
   READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 
@@ -449,7 +452,7 @@ if ( isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   // 0 -i 1 0 
   // -i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
   const int sp_idx = face_idx + param.ghostOffset[0][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][1];
@@ -611,7 +614,7 @@ if ( isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   // 0 i 1 0 
   // i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
   const int sp_idx = face_idx + param.ghostOffset[0][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][0];
@@ -773,7 +776,7 @@ if ( isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   // 0 -1 1 0 
   // 1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
   const int sp_idx = face_idx + param.ghostOffset[1][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][1];
@@ -935,7 +938,7 @@ if ( isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   // 0 1 1 0 
   // -1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
   const int sp_idx = face_idx + param.ghostOffset[1][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][0];
@@ -1097,7 +1100,7 @@ if ( isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   // -i 0 1 0 
   // 0 i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
   const int sp_idx = face_idx + param.ghostOffset[2][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][1];
@@ -1259,7 +1262,7 @@ if ( isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   // i 0 1 0 
   // 0 -i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
   const int sp_idx = face_idx + param.ghostOffset[2][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][0];
@@ -1421,7 +1424,7 @@ if ( isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   // 0 0 0 0 
   // 0 0 0 0 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
   const int sp_idx = face_idx + param.ghostOffset[3][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][1];
@@ -1621,7 +1624,7 @@ if ( isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
   // 0 0 2 0 
   // 0 0 0 2 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
   const int sp_idx = face_idx + param.ghostOffset[3][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][0];

--- a/lib/dslash_core/asym_wilson_clover_fused_exterior_dslash_dagger_gt200_core.h
+++ b/lib/dslash_core/asym_wilson_clover_fused_exterior_dslash_dagger_gt200_core.h
@@ -382,7 +382,7 @@ VOLATILE spinorFloat o32_im;
 #include "read_clover.h"
 #include "io_spinor.h"
 
-int x1, x2, x3, x4;
+int coord[5];
 int X;
 
 #if (DD_PREC==2) // half precision
@@ -408,23 +408,23 @@ int sid;
 
   switch(dim) {
   case 0:
-    coordsFromFaceIndex<0,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,0,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 1:
-    coordsFromFaceIndex<1,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,1,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 2:
-    coordsFromFaceIndex<2,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,2,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 3:
-    coordsFromFaceIndex<3,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,3,1>(X, sid, coord, face_idx, face_num, param);
     break;
   }
 
 
   bool active = false;
   for(int dir=0; dir<4; ++dir){
-   active = active  || isActive(dim,dir,+1,x1,x2,x3,x4,param.commDim,param.X);
+   active = active  || isActive(dim,dir,+1,coord,param.commDim,param.X);
   }
   if(!active) return;
 
@@ -444,7 +444,7 @@ int sid;
   o32_re = i32_re;  o32_im = i32_im;
 
 
-if ( isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
+if ( isActive(dim,0,+1,coord,param.commDim,param.X) && coord[0]==X1m1 )
 {
   // Projector P0+
   // 1 0 0 i 
@@ -452,7 +452,7 @@ if ( isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   // 0 -i 1 0 
   // -i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,0,param);
   const int sp_idx = face_idx + param.ghostOffset[0][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][1];
@@ -606,7 +606,7 @@ if ( isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   
 }
 
-if ( isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
+if ( isActive(dim,0,-1,coord,param.commDim,param.X) && coord[0]==0 )
 {
   // Projector P0-
   // 1 0 0 -i 
@@ -614,7 +614,7 @@ if ( isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   // 0 i 1 0 
   // i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,0,param);
   const int sp_idx = face_idx + param.ghostOffset[0][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][0];
@@ -768,7 +768,7 @@ if ( isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   
 }
 
-if ( isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
+if ( isActive(dim,1,+1,coord,param.commDim,param.X) && coord[1]==X2m1 )
 {
   // Projector P1+
   // 1 0 0 1 
@@ -776,7 +776,7 @@ if ( isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   // 0 -1 1 0 
   // 1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,1,param);
   const int sp_idx = face_idx + param.ghostOffset[1][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][1];
@@ -930,7 +930,7 @@ if ( isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   
 }
 
-if ( isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
+if ( isActive(dim,1,-1,coord,param.commDim,param.X) && coord[1]==0 )
 {
   // Projector P1-
   // 1 0 0 -1 
@@ -938,7 +938,7 @@ if ( isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   // 0 1 1 0 
   // -1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,1,param);
   const int sp_idx = face_idx + param.ghostOffset[1][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][0];
@@ -1092,7 +1092,7 @@ if ( isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   
 }
 
-if ( isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
+if ( isActive(dim,2,+1,coord,param.commDim,param.X) && coord[2]==X3m1 )
 {
   // Projector P2+
   // 1 0 i 0 
@@ -1100,7 +1100,7 @@ if ( isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   // -i 0 1 0 
   // 0 i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,2,param);
   const int sp_idx = face_idx + param.ghostOffset[2][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][1];
@@ -1254,7 +1254,7 @@ if ( isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   
 }
 
-if ( isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
+if ( isActive(dim,2,-1,coord,param.commDim,param.X) && coord[2]==0 )
 {
   // Projector P2-
   // 1 0 -i 0 
@@ -1262,7 +1262,7 @@ if ( isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   // i 0 1 0 
   // 0 -i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,2,param);
   const int sp_idx = face_idx + param.ghostOffset[2][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][0];
@@ -1416,7 +1416,7 @@ if ( isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   
 }
 
-if ( isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
+if ( isActive(dim,3,+1,coord,param.commDim,param.X) && coord[3]==X4m1 )
 {
   // Projector P3+
   // 2 0 0 0 
@@ -1424,7 +1424,7 @@ if ( isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   // 0 0 0 0 
   // 0 0 0 0 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,3,param);
   const int sp_idx = face_idx + param.ghostOffset[3][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][1];
@@ -1616,7 +1616,7 @@ if ( isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   }
 }
 
-if ( isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
+if ( isActive(dim,3,-1,coord,param.commDim,param.X) && coord[3]==0 )
 {
   // Projector P3-
   // 0 0 0 0 
@@ -1624,7 +1624,7 @@ if ( isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
   // 0 0 2 0 
   // 0 0 0 2 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,3,param);
   const int sp_idx = face_idx + param.ghostOffset[3][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][0];

--- a/lib/dslash_core/asym_wilson_clover_fused_exterior_dslash_fermi_core.h
+++ b/lib/dslash_core/asym_wilson_clover_fused_exterior_dslash_fermi_core.h
@@ -392,7 +392,7 @@ VOLATILE spinorFloat o32_im;
 #include "read_clover.h"
 #include "io_spinor.h"
 
-int x1, x2, x3, x4;
+int coord[5];
 int X;
 
 #if (DD_PREC==2) // half precision
@@ -418,23 +418,23 @@ int sid;
 
   switch(dim) {
   case 0:
-    coordsFromFaceIndex<0,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,0,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 1:
-    coordsFromFaceIndex<1,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,1,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 2:
-    coordsFromFaceIndex<2,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,2,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 3:
-    coordsFromFaceIndex<3,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,3,1>(X, sid, coord, face_idx, face_num, param);
     break;
   }
 
 
   bool active = false;
   for(int dir=0; dir<4; ++dir){
-   active = active  || isActive(dim,dir,+1,x1,x2,x3,x4,param.commDim,param.X);
+   active = active  || isActive(dim,dir,+1,coord,param.commDim,param.X);
   }
   if(!active) return;
 
@@ -454,7 +454,7 @@ int sid;
   o32_re = i32_re;  o32_im = i32_im;
 
 
-if ( isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
+if ( isActive(dim,0,+1,coord,param.commDim,param.X) && coord[0]==X1m1 )
 {
   // Projector P0-
   // 1 0 0 -i 
@@ -462,7 +462,7 @@ if ( isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   // 0 i 1 0 
   // i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,0,param);
   const int sp_idx = face_idx + param.ghostOffset[0][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][1];
@@ -616,7 +616,7 @@ if ( isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   
 }
 
-if ( isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
+if ( isActive(dim,0,-1,coord,param.commDim,param.X) && coord[0]==0 )
 {
   // Projector P0+
   // 1 0 0 i 
@@ -624,7 +624,7 @@ if ( isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   // 0 -i 1 0 
   // -i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,0,param);
   const int sp_idx = face_idx + param.ghostOffset[0][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][0];
@@ -778,7 +778,7 @@ if ( isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   
 }
 
-if ( isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
+if ( isActive(dim,1,+1,coord,param.commDim,param.X) && coord[1]==X2m1 )
 {
   // Projector P1-
   // 1 0 0 -1 
@@ -786,7 +786,7 @@ if ( isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   // 0 1 1 0 
   // -1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,1,param);
   const int sp_idx = face_idx + param.ghostOffset[1][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][1];
@@ -940,7 +940,7 @@ if ( isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   
 }
 
-if ( isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
+if ( isActive(dim,1,-1,coord,param.commDim,param.X) && coord[1]==0 )
 {
   // Projector P1+
   // 1 0 0 1 
@@ -948,7 +948,7 @@ if ( isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   // 0 -1 1 0 
   // 1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,1,param);
   const int sp_idx = face_idx + param.ghostOffset[1][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][0];
@@ -1102,7 +1102,7 @@ if ( isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   
 }
 
-if ( isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
+if ( isActive(dim,2,+1,coord,param.commDim,param.X) && coord[2]==X3m1 )
 {
   // Projector P2-
   // 1 0 -i 0 
@@ -1110,7 +1110,7 @@ if ( isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   // i 0 1 0 
   // 0 -i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,2,param);
   const int sp_idx = face_idx + param.ghostOffset[2][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][1];
@@ -1264,7 +1264,7 @@ if ( isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   
 }
 
-if ( isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
+if ( isActive(dim,2,-1,coord,param.commDim,param.X) && coord[2]==0 )
 {
   // Projector P2+
   // 1 0 i 0 
@@ -1272,7 +1272,7 @@ if ( isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   // -i 0 1 0 
   // 0 i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,2,param);
   const int sp_idx = face_idx + param.ghostOffset[2][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][0];
@@ -1426,7 +1426,7 @@ if ( isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   
 }
 
-if ( isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
+if ( isActive(dim,3,+1,coord,param.commDim,param.X) && coord[3]==X4m1 )
 {
   // Projector P3-
   // 0 0 0 0 
@@ -1434,7 +1434,7 @@ if ( isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   // 0 0 2 0 
   // 0 0 0 2 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,3,param);
   const int sp_idx = face_idx + param.ghostOffset[3][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][1];
@@ -1626,7 +1626,7 @@ if ( isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   }
 }
 
-if ( isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
+if ( isActive(dim,3,-1,coord,param.commDim,param.X) && coord[3]==0 )
 {
   // Projector P3+
   // 2 0 0 0 
@@ -1634,7 +1634,7 @@ if ( isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
   // 0 0 0 0 
   // 0 0 0 0 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,3,param);
   const int sp_idx = face_idx + param.ghostOffset[3][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][0];

--- a/lib/dslash_core/asym_wilson_clover_fused_exterior_dslash_gt200_core.h
+++ b/lib/dslash_core/asym_wilson_clover_fused_exterior_dslash_gt200_core.h
@@ -382,7 +382,7 @@ VOLATILE spinorFloat o32_im;
 #include "read_clover.h"
 #include "io_spinor.h"
 
-int x1, x2, x3, x4;
+int coord[5];
 int X;
 
 #if (DD_PREC==2) // half precision
@@ -408,23 +408,23 @@ int sid;
 
   switch(dim) {
   case 0:
-    coordsFromFaceIndex<0,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,0,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 1:
-    coordsFromFaceIndex<1,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,1,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 2:
-    coordsFromFaceIndex<2,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,2,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 3:
-    coordsFromFaceIndex<3,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,3,1>(X, sid, coord, face_idx, face_num, param);
     break;
   }
 
 
   bool active = false;
   for(int dir=0; dir<4; ++dir){
-   active = active  || isActive(dim,dir,+1,x1,x2,x3,x4,param.commDim,param.X);
+   active = active  || isActive(dim,dir,+1,coord,param.commDim,param.X);
   }
   if(!active) return;
 
@@ -444,7 +444,7 @@ int sid;
   o32_re = i32_re;  o32_im = i32_im;
 
 
-if ( isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
+if ( isActive(dim,0,+1,coord,param.commDim,param.X) && coord[0]==X1m1 )
 {
   // Projector P0-
   // 1 0 0 -i 
@@ -452,7 +452,7 @@ if ( isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   // 0 i 1 0 
   // i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,0,param);
   const int sp_idx = face_idx + param.ghostOffset[0][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][1];
@@ -606,7 +606,7 @@ if ( isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   
 }
 
-if ( isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
+if ( isActive(dim,0,-1,coord,param.commDim,param.X) && coord[0]==0 )
 {
   // Projector P0+
   // 1 0 0 i 
@@ -614,7 +614,7 @@ if ( isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   // 0 -i 1 0 
   // -i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,0,param);
   const int sp_idx = face_idx + param.ghostOffset[0][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][0];
@@ -768,7 +768,7 @@ if ( isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   
 }
 
-if ( isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
+if ( isActive(dim,1,+1,coord,param.commDim,param.X) && coord[1]==X2m1 )
 {
   // Projector P1-
   // 1 0 0 -1 
@@ -776,7 +776,7 @@ if ( isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   // 0 1 1 0 
   // -1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,1,param);
   const int sp_idx = face_idx + param.ghostOffset[1][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][1];
@@ -930,7 +930,7 @@ if ( isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   
 }
 
-if ( isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
+if ( isActive(dim,1,-1,coord,param.commDim,param.X) && coord[1]==0 )
 {
   // Projector P1+
   // 1 0 0 1 
@@ -938,7 +938,7 @@ if ( isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   // 0 -1 1 0 
   // 1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,1,param);
   const int sp_idx = face_idx + param.ghostOffset[1][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][0];
@@ -1092,7 +1092,7 @@ if ( isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   
 }
 
-if ( isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
+if ( isActive(dim,2,+1,coord,param.commDim,param.X) && coord[2]==X3m1 )
 {
   // Projector P2-
   // 1 0 -i 0 
@@ -1100,7 +1100,7 @@ if ( isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   // i 0 1 0 
   // 0 -i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,2,param);
   const int sp_idx = face_idx + param.ghostOffset[2][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][1];
@@ -1254,7 +1254,7 @@ if ( isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   
 }
 
-if ( isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
+if ( isActive(dim,2,-1,coord,param.commDim,param.X) && coord[2]==0 )
 {
   // Projector P2+
   // 1 0 i 0 
@@ -1262,7 +1262,7 @@ if ( isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   // -i 0 1 0 
   // 0 i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,2,param);
   const int sp_idx = face_idx + param.ghostOffset[2][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][0];
@@ -1416,7 +1416,7 @@ if ( isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   
 }
 
-if ( isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
+if ( isActive(dim,3,+1,coord,param.commDim,param.X) && coord[3]==X4m1 )
 {
   // Projector P3-
   // 0 0 0 0 
@@ -1424,7 +1424,7 @@ if ( isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   // 0 0 2 0 
   // 0 0 0 2 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,3,param);
   const int sp_idx = face_idx + param.ghostOffset[3][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][1];
@@ -1616,7 +1616,7 @@ if ( isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   }
 }
 
-if ( isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
+if ( isActive(dim,3,-1,coord,param.commDim,param.X) && coord[3]==0 )
 {
   // Projector P3+
   // 2 0 0 0 
@@ -1624,7 +1624,7 @@ if ( isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
   // 0 0 0 0 
   // 0 0 0 0 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,3,param);
   const int sp_idx = face_idx + param.ghostOffset[3][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][0];

--- a/lib/dslash_core/asym_wilson_clover_fused_exterior_dslash_gt200_core.h
+++ b/lib/dslash_core/asym_wilson_clover_fused_exterior_dslash_gt200_core.h
@@ -391,39 +391,42 @@ int sp_norm_idx;
 
 int sid;
 
-int dim;
-int face_num;
-int face_idx;
-int Y[4] = {X1,X2,X3,X4};
-
-
 
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  dim = dimFromFaceIndex(sid, param); // sid is also modified
+  int dim = dimFromFaceIndex(sid, param); // sid is also modified
 
 
   const int face_volume = ((param.threadDimMapUpper[dim] - param.threadDimMapLower[dim]) >> 1);   // volume of one face
-  face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
-  face_idx = sid - face_num*face_volume;        // index into the respective face
+  int face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
+  int face_idx = sid - face_num*face_volume;        // index into the respective face
 
   // ghostOffset is scaled to include body (includes stride) and number of FloatN arrays (SPINOR_HOP)
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-
-  coordsFromFaceIndex<1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, dim, face_num, param.parity,Y);
-
-  {
-    bool active = false;
-    for(int dir=0; dir<4; ++dir){
-     active = active  || isActive(dim,dir,+1,x1,x2,x3,x4,param.commDim,param.X);
-    }
-    if(!active) return;
+  switch(dim) {
+  case 0:
+    coordsFromFaceIndex<0,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 1:
+    coordsFromFaceIndex<1,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 2:
+    coordsFromFaceIndex<2,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 3:
+    coordsFromFaceIndex<3,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
   }
 
 
+  bool active = false;
+  for(int dir=0; dir<4; ++dir){
+   active = active  || isActive(dim,dir,+1,x1,x2,x3,x4,param.commDim,param.X);
+  }
+  if(!active) return;
 
   READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 
@@ -449,7 +452,7 @@ if ( isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   // 0 i 1 0 
   // i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
   const int sp_idx = face_idx + param.ghostOffset[0][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][1];
@@ -611,7 +614,7 @@ if ( isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   // 0 -i 1 0 
   // -i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
   const int sp_idx = face_idx + param.ghostOffset[0][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][0];
@@ -773,7 +776,7 @@ if ( isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   // 0 1 1 0 
   // -1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
   const int sp_idx = face_idx + param.ghostOffset[1][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][1];
@@ -935,7 +938,7 @@ if ( isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   // 0 -1 1 0 
   // 1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
   const int sp_idx = face_idx + param.ghostOffset[1][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][0];
@@ -1097,7 +1100,7 @@ if ( isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   // i 0 1 0 
   // 0 -i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
   const int sp_idx = face_idx + param.ghostOffset[2][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][1];
@@ -1259,7 +1262,7 @@ if ( isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   // -i 0 1 0 
   // 0 i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
   const int sp_idx = face_idx + param.ghostOffset[2][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][0];
@@ -1421,7 +1424,7 @@ if ( isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   // 0 0 2 0 
   // 0 0 0 2 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
   const int sp_idx = face_idx + param.ghostOffset[3][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][1];
@@ -1621,7 +1624,7 @@ if ( isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
   // 0 0 0 0 
   // 0 0 0 0 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
   const int sp_idx = face_idx + param.ghostOffset[3][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][0];

--- a/lib/dslash_core/dw_dslash4_core.h
+++ b/lib/dslash_core/dw_dslash4_core.h
@@ -221,7 +221,6 @@ xs = X/(X1*X2*X3*X4);
 
 } else { // exterior kernel
 
-const int dim = static_cast<int>(kernel_type);
 const int face_volume = (param.threads*param.Ls >> 1); // volume of one face
 const int face_num = (sid >= face_volume); // is this thread updating face 0 or 1
 face_idx = sid - face_num*face_volume; // index into the respective face
@@ -230,8 +229,7 @@ face_idx = sid - face_num*face_volume; // index into the respective face
 // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
 //sp_idx = face_idx + param.ghostOffset[dim];
 
-const int dims[] = {X1, X2, X3, X4};
-coordsFromDW4DFaceIndex<1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, dim, face_num, param.parity, dims);
+coordsFromDW4DFaceIndex<kernel_type,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
 
 boundaryCrossing = sid/X1h + sid/(X2*X1h) + sid/(X3*X2*X1h);
 

--- a/lib/dslash_core/dw_dslash4_core.h
+++ b/lib/dslash_core/dw_dslash4_core.h
@@ -2,7 +2,6 @@
 
 #define DSLASH_SHARED_FLOATS_PER_THREAD 0
 
-// NB! Don't trust any MULTI_GPU code
 
 #if (CUDA_VERSION >= 4010)
 #define VOLATILE
@@ -187,24 +186,17 @@ VOLATILE spinorFloat o32_im;
 int sid = ((blockIdx.y*blockDim.y + threadIdx.y)*gridDim.x + blockIdx.x)*blockDim.x + threadIdx.x;
 if (sid >= param.threads*param.Ls) return;
 
-int boundaryCrossing;
 
-int X, x1, x2, x3, x4, xs;
+int X, coord[5];
 
 int face_idx;
 if (kernel_type == INTERIOR_KERNEL) {
 
-// Inline by hand for the moment and assume even dimensions
-//coordsFromIndex(X, x1, x2, x3, x4, sid, param.parity);
 
-boundaryCrossing = sid/X1h + sid/(X2*X1h) + sid/(X3*X2*X1h);
 
-X = 2*sid + (boundaryCrossing + param.parity) % 2;
-x1 = X % X1;
-x2 = (X/X1) % X2;
-x3 = (X/(X1*X2)) % X3;
-x4 = (X/(X1*X2*X3)) % X4;
-xs = X/(X1*X2*X3*X4);
+
+  // Assume even dimensions
+  coordsFromIndex<5,QUDA_4D_PC,EVEN_X>(X, coord, sid, param);
 
  o00_re = 0; o00_im = 0;
  o01_re = 0; o01_im = 0;
@@ -229,11 +221,7 @@ face_idx = sid - face_num*face_volume; // index into the respective face
 // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
 //sp_idx = face_idx + param.ghostOffset[dim];
 
-coordsFromDW4DFaceIndex<kernel_type,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
-
-boundaryCrossing = sid/X1h + sid/(X2*X1h) + sid/(X3*X2*X1h);
-
-X = 2*sid + (boundaryCrossing + param.parity) % 2;
+coordsFromFaceIndex<5,QUDA_4D_PC,kernel_type,1>(X, sid, coord, face_idx, face_num, param);
 
 READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
  o00_re = i00_re; o00_im = i00_im;
@@ -284,8 +272,8 @@ float4 G4;
 
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
- (kernel_type == EXTERIOR_KERNEL_X && x1==X1m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]<X1m1)) ||
+ (kernel_type == EXTERIOR_KERNEL_X && coord[0]==X1m1) )
 #endif
 {
  // Projector P0-
@@ -295,13 +283,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
  //  i  0  0  1
 
 #ifdef MULTI_GPU
- const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x1==X1m1 ? X-X1m1 : X+1) >> 1 :
+ const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[0]==X1m1 ? X-X1m1 : X+1) >> 1 :
   face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
  const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
- const int sp_idx = (x1==X1m1 ? X-X1m1 : X+1) >> 1;
+ const int sp_idx = (coord[0]==X1m1 ? X-X1m1 : X+1) >> 1;
 #endif
 
  const int ga_idx = sid % Vh;
@@ -477,8 +465,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
- (kernel_type == EXTERIOR_KERNEL_X && x1==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]>0)) ||
+ (kernel_type == EXTERIOR_KERNEL_X && coord[0]==0) )
 #endif
 {
  // Projector P0+
@@ -488,13 +476,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
  // -i  0  0  1
 
 #ifdef MULTI_GPU
- const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x1==0 ? X+X1m1 : X-1) >> 1 :
+ const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[0]==0 ? X+X1m1 : X-1) >> 1 :
   face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
  const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
- const int sp_idx = (x1==0 ? X+X1m1 : X-1) >> 1;
+ const int sp_idx = (coord[0]==0 ? X+X1m1 : X-1) >> 1;
 #endif
 
 #ifdef MULTI_GPU
@@ -674,8 +662,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
- (kernel_type == EXTERIOR_KERNEL_Y && x2==X2m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]<X2m1)) ||
+ (kernel_type == EXTERIOR_KERNEL_Y && coord[1]==X2m1) )
 #endif
 {
  // Projector P1-
@@ -685,13 +673,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
  // -1  0  0  1
 
 #ifdef MULTI_GPU
- const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x2==X2m1 ? X-X2X1mX1 : X+X1) >> 1 :
+ const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[1]==X2m1 ? X-X2X1mX1 : X+X1) >> 1 :
   face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
  const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
- const int sp_idx = (x2==X2m1 ? X-X2X1mX1 : X+X1) >> 1;
+ const int sp_idx = (coord[1]==X2m1 ? X-X2X1mX1 : X+X1) >> 1;
 #endif
 
  const int ga_idx = sid % Vh;
@@ -867,8 +855,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
- (kernel_type == EXTERIOR_KERNEL_Y && x2==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]>0)) ||
+ (kernel_type == EXTERIOR_KERNEL_Y && coord[1]==0) )
 #endif
 {
  // Projector P1+
@@ -878,13 +866,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
  //  1  0  0  1
 
 #ifdef MULTI_GPU
- const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x2==0 ? X+X2X1mX1 : X-X1) >> 1 :
+ const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[1]==0 ? X+X2X1mX1 : X-X1) >> 1 :
   face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
  const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
- const int sp_idx = (x2==0 ? X+X2X1mX1 : X-X1) >> 1;
+ const int sp_idx = (coord[1]==0 ? X+X2X1mX1 : X-X1) >> 1;
 #endif
 
 #ifdef MULTI_GPU
@@ -1064,8 +1052,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
- (kernel_type == EXTERIOR_KERNEL_Z && x3==X3m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]<X3m1)) ||
+ (kernel_type == EXTERIOR_KERNEL_Z && coord[2]==X3m1) )
 #endif
 {
  // Projector P2-
@@ -1075,13 +1063,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
  //  0 -i  0  1
 
 #ifdef MULTI_GPU
- const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x3==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1 :
+ const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[2]==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1 :
   face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
  const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
- const int sp_idx = (x3==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1;
+ const int sp_idx = (coord[2]==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1;
 #endif
 
  const int ga_idx = sid % Vh;
@@ -1257,8 +1245,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
- (kernel_type == EXTERIOR_KERNEL_Z && x3==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]>0)) ||
+ (kernel_type == EXTERIOR_KERNEL_Z && coord[2]==0) )
 #endif
 {
  // Projector P2+
@@ -1268,13 +1256,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
  //  0  i  0  1
 
 #ifdef MULTI_GPU
- const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x3==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1 :
+ const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[2]==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1 :
   face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
  const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
- const int sp_idx = (x3==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1;
+ const int sp_idx = (coord[2]==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1;
 #endif
 
 #ifdef MULTI_GPU
@@ -1454,8 +1442,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
- (kernel_type == EXTERIOR_KERNEL_T && x4==X4m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]<X4m1)) ||
+ (kernel_type == EXTERIOR_KERNEL_T && coord[3]==X4m1) )
 #endif
 {
  // Projector P3-
@@ -1465,13 +1453,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
  //  0  0  0  2
 
 #ifdef MULTI_GPU
- const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x4==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1 :
+ const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[3]==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1 :
   face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
  const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
- const int sp_idx = (x4==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1;
+ const int sp_idx = (coord[3]==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1;
 #endif
 
  const int ga_idx = sid % Vh;
@@ -1709,8 +1697,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4>0)) ||
- (kernel_type == EXTERIOR_KERNEL_T && x4==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]>0)) ||
+ (kernel_type == EXTERIOR_KERNEL_T && coord[3]==0) )
 #endif
 {
  // Projector P3+
@@ -1720,13 +1708,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4>0)) ||
  //  0  0  0  0
 
 #ifdef MULTI_GPU
- const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x4==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1 :
+ const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[3]==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1 :
   face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
  const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
- const int sp_idx = (x4==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1;
+ const int sp_idx = (coord[3]==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1;
 #endif
 
 #ifdef MULTI_GPU
@@ -1973,13 +1961,13 @@ int incomplete = 0; // Have all 8 contributions been computed for this site?
 
 switch(kernel_type) { // intentional fall-through
 case INTERIOR_KERNEL:
-incomplete = incomplete || (param.commDim[3] && (x4==0 || x4==X4m1));
+  incomplete = incomplete || (param.commDim[3] && (coord[3]==0 || coord[3]==X4m1));
 case EXTERIOR_KERNEL_T:
-incomplete = incomplete || (param.commDim[2] && (x3==0 || x3==X3m1));
+  incomplete = incomplete || (param.commDim[2] && (coord[2]==0 || coord[2]==X3m1));
 case EXTERIOR_KERNEL_Z:
-incomplete = incomplete || (param.commDim[1] && (x2==0 || x2==X2m1));
+  incomplete = incomplete || (param.commDim[1] && (coord[1]==0 || coord[1]==X2m1));
 case EXTERIOR_KERNEL_Y:
-incomplete = incomplete || (param.commDim[0] && (x1==0 || x1==X1m1));
+  incomplete = incomplete || (param.commDim[0] && (coord[0]==0 || coord[0]==X1m1));
 }
 
 if (!incomplete)
@@ -1991,7 +1979,7 @@ if (!incomplete)
  VOLATILE spinorFloat coeff;
 
 #ifdef MDWF_mode
- coeff = static_cast<spinorFloat>(0.5)*a/(mdwf_b5[xs]*(m5+static_cast<spinorFloat>(4.0)) + static_cast<spinorFloat>(1.0));
+ coeff = static_cast<spinorFloat>(0.5)*a/(mdwf_b5[coord[4]]*(m5+static_cast<spinorFloat>(4.0)) + static_cast<spinorFloat>(1.0));
 #else
  coeff = a;
 #endif

--- a/lib/dslash_core/dw_dslash4_dagger_core.h
+++ b/lib/dslash_core/dw_dslash4_dagger_core.h
@@ -221,7 +221,6 @@ xs = X/(X1*X2*X3*X4);
 
 } else { // exterior kernel
 
-const int dim = static_cast<int>(kernel_type);
 const int face_volume = (param.threads*param.Ls >> 1); // volume of one face
 const int face_num = (sid >= face_volume); // is this thread updating face 0 or 1
 face_idx = sid - face_num*face_volume; // index into the respective face
@@ -230,8 +229,7 @@ face_idx = sid - face_num*face_volume; // index into the respective face
 // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
 //sp_idx = face_idx + param.ghostOffset[dim];
 
-const int dims[] = {X1, X2, X3, X4};
-coordsFromDW4DFaceIndex<1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, dim, face_num, param.parity, dims);
+coordsFromDW4DFaceIndex<kernel_type,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
 
 boundaryCrossing = sid/X1h + sid/(X2*X1h) + sid/(X3*X2*X1h);
 

--- a/lib/dslash_core/dw_dslash4_dagger_core.h
+++ b/lib/dslash_core/dw_dslash4_dagger_core.h
@@ -2,7 +2,6 @@
 
 #define DSLASH_SHARED_FLOATS_PER_THREAD 0
 
-// NB! Don't trust any MULTI_GPU code
 
 #if (CUDA_VERSION >= 4010)
 #define VOLATILE
@@ -187,24 +186,17 @@ VOLATILE spinorFloat o32_im;
 int sid = ((blockIdx.y*blockDim.y + threadIdx.y)*gridDim.x + blockIdx.x)*blockDim.x + threadIdx.x;
 if (sid >= param.threads*param.Ls) return;
 
-int boundaryCrossing;
 
-int X, x1, x2, x3, x4, xs;
+int X, coord[5];
 
 int face_idx;
 if (kernel_type == INTERIOR_KERNEL) {
 
-// Inline by hand for the moment and assume even dimensions
-//coordsFromIndex(X, x1, x2, x3, x4, sid, param.parity);
 
-boundaryCrossing = sid/X1h + sid/(X2*X1h) + sid/(X3*X2*X1h);
 
-X = 2*sid + (boundaryCrossing + param.parity) % 2;
-x1 = X % X1;
-x2 = (X/X1) % X2;
-x3 = (X/(X1*X2)) % X3;
-x4 = (X/(X1*X2*X3)) % X4;
-xs = X/(X1*X2*X3*X4);
+
+  // Assume even dimensions
+  coordsFromIndex<5,QUDA_4D_PC,EVEN_X>(X, coord, sid, param);
 
  o00_re = 0; o00_im = 0;
  o01_re = 0; o01_im = 0;
@@ -229,11 +221,7 @@ face_idx = sid - face_num*face_volume; // index into the respective face
 // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
 //sp_idx = face_idx + param.ghostOffset[dim];
 
-coordsFromDW4DFaceIndex<kernel_type,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
-
-boundaryCrossing = sid/X1h + sid/(X2*X1h) + sid/(X3*X2*X1h);
-
-X = 2*sid + (boundaryCrossing + param.parity) % 2;
+coordsFromFaceIndex<5,QUDA_4D_PC,kernel_type,1>(X, sid, coord, face_idx, face_num, param);
 
 READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
  o00_re = i00_re; o00_im = i00_im;
@@ -284,8 +272,8 @@ float4 G4;
 
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
- (kernel_type == EXTERIOR_KERNEL_X && x1==X1m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]<X1m1)) ||
+ (kernel_type == EXTERIOR_KERNEL_X && coord[0]==X1m1) )
 #endif
 {
  // Projector P0+
@@ -295,13 +283,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
  // -i  0  0  1
 
 #ifdef MULTI_GPU
- const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x1==X1m1 ? X-X1m1 : X+1) >> 1 :
+ const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[0]==X1m1 ? X-X1m1 : X+1) >> 1 :
   face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
  const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
- const int sp_idx = (x1==X1m1 ? X-X1m1 : X+1) >> 1;
+ const int sp_idx = (coord[0]==X1m1 ? X-X1m1 : X+1) >> 1;
 #endif
 
  const int ga_idx = sid % Vh;
@@ -477,8 +465,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
- (kernel_type == EXTERIOR_KERNEL_X && x1==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]>0)) ||
+ (kernel_type == EXTERIOR_KERNEL_X && coord[0]==0) )
 #endif
 {
  // Projector P0-
@@ -488,13 +476,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
  //  i  0  0  1
 
 #ifdef MULTI_GPU
- const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x1==0 ? X+X1m1 : X-1) >> 1 :
+ const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[0]==0 ? X+X1m1 : X-1) >> 1 :
   face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
  const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
- const int sp_idx = (x1==0 ? X+X1m1 : X-1) >> 1;
+ const int sp_idx = (coord[0]==0 ? X+X1m1 : X-1) >> 1;
 #endif
 
 #ifdef MULTI_GPU
@@ -674,8 +662,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
- (kernel_type == EXTERIOR_KERNEL_Y && x2==X2m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]<X2m1)) ||
+ (kernel_type == EXTERIOR_KERNEL_Y && coord[1]==X2m1) )
 #endif
 {
  // Projector P1+
@@ -685,13 +673,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
  //  1  0  0  1
 
 #ifdef MULTI_GPU
- const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x2==X2m1 ? X-X2X1mX1 : X+X1) >> 1 :
+ const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[1]==X2m1 ? X-X2X1mX1 : X+X1) >> 1 :
   face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
  const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
- const int sp_idx = (x2==X2m1 ? X-X2X1mX1 : X+X1) >> 1;
+ const int sp_idx = (coord[1]==X2m1 ? X-X2X1mX1 : X+X1) >> 1;
 #endif
 
  const int ga_idx = sid % Vh;
@@ -867,8 +855,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
- (kernel_type == EXTERIOR_KERNEL_Y && x2==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]>0)) ||
+ (kernel_type == EXTERIOR_KERNEL_Y && coord[1]==0) )
 #endif
 {
  // Projector P1-
@@ -878,13 +866,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
  // -1  0  0  1
 
 #ifdef MULTI_GPU
- const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x2==0 ? X+X2X1mX1 : X-X1) >> 1 :
+ const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[1]==0 ? X+X2X1mX1 : X-X1) >> 1 :
   face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
  const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
- const int sp_idx = (x2==0 ? X+X2X1mX1 : X-X1) >> 1;
+ const int sp_idx = (coord[1]==0 ? X+X2X1mX1 : X-X1) >> 1;
 #endif
 
 #ifdef MULTI_GPU
@@ -1064,8 +1052,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
- (kernel_type == EXTERIOR_KERNEL_Z && x3==X3m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]<X3m1)) ||
+ (kernel_type == EXTERIOR_KERNEL_Z && coord[2]==X3m1) )
 #endif
 {
  // Projector P2+
@@ -1075,13 +1063,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
  //  0  i  0  1
 
 #ifdef MULTI_GPU
- const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x3==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1 :
+ const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[2]==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1 :
   face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
  const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
- const int sp_idx = (x3==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1;
+ const int sp_idx = (coord[2]==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1;
 #endif
 
  const int ga_idx = sid % Vh;
@@ -1257,8 +1245,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
- (kernel_type == EXTERIOR_KERNEL_Z && x3==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]>0)) ||
+ (kernel_type == EXTERIOR_KERNEL_Z && coord[2]==0) )
 #endif
 {
  // Projector P2-
@@ -1268,13 +1256,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
  //  0 -i  0  1
 
 #ifdef MULTI_GPU
- const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x3==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1 :
+ const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[2]==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1 :
   face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
  const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
- const int sp_idx = (x3==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1;
+ const int sp_idx = (coord[2]==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1;
 #endif
 
 #ifdef MULTI_GPU
@@ -1454,8 +1442,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
- (kernel_type == EXTERIOR_KERNEL_T && x4==X4m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]<X4m1)) ||
+ (kernel_type == EXTERIOR_KERNEL_T && coord[3]==X4m1) )
 #endif
 {
  // Projector P3+
@@ -1465,13 +1453,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
  //  0  0  0  0
 
 #ifdef MULTI_GPU
- const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x4==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1 :
+ const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[3]==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1 :
   face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
  const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
- const int sp_idx = (x4==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1;
+ const int sp_idx = (coord[3]==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1;
 #endif
 
  const int ga_idx = sid % Vh;
@@ -1709,8 +1697,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4>0)) ||
- (kernel_type == EXTERIOR_KERNEL_T && x4==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]>0)) ||
+ (kernel_type == EXTERIOR_KERNEL_T && coord[3]==0) )
 #endif
 {
  // Projector P3-
@@ -1720,13 +1708,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4>0)) ||
  //  0  0  0  2
 
 #ifdef MULTI_GPU
- const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x4==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1 :
+ const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[3]==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1 :
   face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
  const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
- const int sp_idx = (x4==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1;
+ const int sp_idx = (coord[3]==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1;
 #endif
 
 #ifdef MULTI_GPU
@@ -1973,13 +1961,13 @@ int incomplete = 0; // Have all 8 contributions been computed for this site?
 
 switch(kernel_type) { // intentional fall-through
 case INTERIOR_KERNEL:
-incomplete = incomplete || (param.commDim[3] && (x4==0 || x4==X4m1));
+  incomplete = incomplete || (param.commDim[3] && (coord[3]==0 || coord[3]==X4m1));
 case EXTERIOR_KERNEL_T:
-incomplete = incomplete || (param.commDim[2] && (x3==0 || x3==X3m1));
+  incomplete = incomplete || (param.commDim[2] && (coord[2]==0 || coord[2]==X3m1));
 case EXTERIOR_KERNEL_Z:
-incomplete = incomplete || (param.commDim[1] && (x2==0 || x2==X2m1));
+  incomplete = incomplete || (param.commDim[1] && (coord[1]==0 || coord[1]==X2m1));
 case EXTERIOR_KERNEL_Y:
-incomplete = incomplete || (param.commDim[0] && (x1==0 || x1==X1m1));
+  incomplete = incomplete || (param.commDim[0] && (coord[0]==0 || coord[0]==X1m1));
 }
 
 if (!incomplete)
@@ -1991,7 +1979,7 @@ if (!incomplete)
  VOLATILE spinorFloat coeff;
 
 #ifdef MDWF_mode
- coeff = static_cast<spinorFloat>(0.5)*a/(mdwf_b5[xs]*(m5+static_cast<spinorFloat>(4.0)) + static_cast<spinorFloat>(1.0));
+ coeff = static_cast<spinorFloat>(0.5)*a/(mdwf_b5[coord[4]]*(m5+static_cast<spinorFloat>(4.0)) + static_cast<spinorFloat>(1.0));
 #else
  coeff = a;
 #endif

--- a/lib/dslash_core/dw_dslash5_core.h
+++ b/lib/dslash_core/dw_dslash5_core.h
@@ -2,7 +2,6 @@
 
 #define DSLASH_SHARED_FLOATS_PER_THREAD 0
 
-// NB! Don't trust any MULTI_GPU code
 
 #if (CUDA_VERSION >= 4010)
 #define VOLATILE
@@ -122,17 +121,15 @@ VOLATILE spinorFloat o32_im;
 int sid = ((blockIdx.y*blockDim.y + threadIdx.y)*gridDim.x + blockIdx.x)*blockDim.x + threadIdx.x;
 if (sid >= param.threads*param.Ls) return;
 
-int boundaryCrossing;
 
-int X, xs;
+int X, coord[5], boundaryCrossing;
 
-// Inline by hand for the moment and assume even dimensions
-//coordsFromIndex(X, x1, x2, x3, x4, sid, param.parity);
+
 
 boundaryCrossing = sid/X1h + sid/(X2*X1h) + sid/(X3*X2*X1h);
 
 X = 2*sid + (boundaryCrossing + param.parity) % 2;
-xs = X/(X1*X2*X3*X4);
+coord[4] = X/(X1*X2*X3*X4);
 
  o00_re = 0; o00_im = 0;
  o01_re = 0; o01_im = 0;
@@ -152,12 +149,12 @@ xs = X/(X1*X2*X3*X4);
 {
 // 2 P_L = 2 P_- = ( ( +1, -1 ), ( -1, +1 ) )
   {
-     int sp_idx = ( xs == param.Ls-1 ? X-(param.Ls-1)*2*Vh : X+2*Vh ) / 2;
+     int sp_idx = ( coord[4] == param.Ls-1 ? X-(param.Ls-1)*2*Vh : X+2*Vh ) / 2;
 
 // read spinor from device memory
      READ_SPINOR( SPINORTEX, param.sp_stride, sp_idx, sp_idx );
 
-     if ( xs != param.Ls-1 )
+     if ( coord[4] != param.Ls-1 )
      {
    o00_re += +i00_re-i20_re;   o00_im += +i00_im-i20_im;
    o01_re += +i01_re-i21_re;   o01_im += +i01_im-i21_im;
@@ -192,17 +189,17 @@ xs = X/(X1*X2*X3*X4);
    o30_re += -mferm*(-i10_re+i30_re);   o30_im += -mferm*(-i10_im+i30_im);
    o31_re += -mferm*(-i11_re+i31_re);   o31_im += -mferm*(-i11_im+i31_im);
    o32_re += -mferm*(-i12_re+i32_re);   o32_im += -mferm*(-i12_im+i32_im);
-    } // end if ( xs != param.Ls-1 )
+    } // end if ( coord[4] != param.Ls-1 )
   } // end P_L
 
  // 2 P_R = 2 P_+ = ( ( +1, +1 ), ( +1, +1 ) )
   {
-    int sp_idx = ( xs == 0 ? X+(param.Ls-1)*2*Vh : X-2*Vh ) / 2;
+    int sp_idx = ( coord[4] == 0 ? X+(param.Ls-1)*2*Vh : X-2*Vh ) / 2;
 
 // read spinor from device memory
     READ_SPINOR( SPINORTEX, param.sp_stride, sp_idx, sp_idx );
 
-    if ( xs != 0 )
+    if ( coord[4] != 0 )
     {
    o00_re += +i00_re+i20_re;   o00_im += +i00_im+i20_im;
    o01_re += +i01_re+i21_re;   o01_im += +i01_im+i21_im;
@@ -237,7 +234,7 @@ xs = X/(X1*X2*X3*X4);
    o30_re += -mferm*(+i10_re+i30_re);   o30_im += -mferm*(+i10_im+i30_im);
    o31_re += -mferm*(+i11_re+i31_re);   o31_im += -mferm*(+i11_im+i31_im);
    o32_re += -mferm*(+i12_re+i32_re);   o32_im += -mferm*(+i12_im+i32_im);
-    } // end if ( xs != 0 )
+    } // end if ( coord[4] != 0 )
   } // end P_R
 
   // MDWF Dslash_5 operator is given as follow
@@ -254,8 +251,8 @@ xs = X/(X1*X2*X3*X4);
 #if (MDWF_mode==1)
   VOLATILE spinorFloat C_5;
   VOLATILE spinorFloat B_5;
-  C_5 = mdwf_c5[xs]*static_cast<spinorFloat>(0.5);
-  B_5 = mdwf_b5[xs];
+  C_5 = mdwf_c5[ coord[4] ]*static_cast<spinorFloat>(0.5);
+  B_5 = mdwf_b5[ coord[4] ];
 
   READ_SPINOR( SPINORTEX, param.sp_stride, X/2, X/2 );
   o00_re = C_5*o00_re + B_5*i00_re;
@@ -284,7 +281,7 @@ xs = X/(X1*X2*X3*X4);
   o32_im = C_5*o32_im + B_5*i32_im;
 #elif (MDWF_mode==2)
   VOLATILE spinorFloat C_5;
-  C_5 = static_cast<spinorFloat>(0.5)*(mdwf_c5[xs]*(m5+static_cast<spinorFloat>(4.0)) - static_cast<spinorFloat>(1.0))/(mdwf_b5[xs]*(m5+static_cast<spinorFloat>(4.0)) + static_cast<spinorFloat>(1.0));
+  C_5 = static_cast<spinorFloat>(0.5)*(mdwf_c5[ coord[4] ]*(m5+static_cast<spinorFloat>(4.0)) - static_cast<spinorFloat>(1.0))/(mdwf_b5[ coord[4] ]*(m5+static_cast<spinorFloat>(4.0)) + static_cast<spinorFloat>(1.0));
 
   READ_SPINOR( SPINORTEX, param.sp_stride, X/2, X/2 );
   o00_re = C_5*o00_re + i00_re;
@@ -322,7 +319,7 @@ xs = X/(X1*X2*X3*X4);
  VOLATILE spinorFloat coeff;
 
 #ifdef MDWF_mode
- coeff = static_cast<spinorFloat>(0.5)/(mdwf_b5[xs]*(m5+static_cast<spinorFloat>(4.0)) + static_cast<spinorFloat>(1.0));
+ coeff = static_cast<spinorFloat>(0.5)/(mdwf_b5[coord[4]]*(m5+static_cast<spinorFloat>(4.0)) + static_cast<spinorFloat>(1.0));
  coeff *= coeff;
  coeff *= a;
 #else

--- a/lib/dslash_core/dw_dslash5_dagger_core.h
+++ b/lib/dslash_core/dw_dslash5_dagger_core.h
@@ -2,7 +2,6 @@
 
 #define DSLASH_SHARED_FLOATS_PER_THREAD 0
 
-// NB! Don't trust any MULTI_GPU code
 
 #if (CUDA_VERSION >= 4010)
 #define VOLATILE
@@ -122,17 +121,15 @@ VOLATILE spinorFloat o32_im;
 int sid = ((blockIdx.y*blockDim.y + threadIdx.y)*gridDim.x + blockIdx.x)*blockDim.x + threadIdx.x;
 if (sid >= param.threads*param.Ls) return;
 
-int boundaryCrossing;
 
-int X, xs;
+int X, coord[5], boundaryCrossing;
 
-// Inline by hand for the moment and assume even dimensions
-//coordsFromIndex(X, x1, x2, x3, x4, sid, param.parity);
+
 
 boundaryCrossing = sid/X1h + sid/(X2*X1h) + sid/(X3*X2*X1h);
 
 X = 2*sid + (boundaryCrossing + param.parity) % 2;
-xs = X/(X1*X2*X3*X4);
+coord[4] = X/(X1*X2*X3*X4);
 
  o00_re = 0; o00_im = 0;
  o01_re = 0; o01_im = 0;
@@ -152,12 +149,12 @@ xs = X/(X1*X2*X3*X4);
 {
 // 2 P_L = 2 P_- = ( ( +1, -1 ), ( -1, +1 ) )
   {
-     int sp_idx = ( xs == 0 ? X+(param.Ls-1)*2*Vh : X-2*Vh ) / 2;
+     int sp_idx = ( coord[4] == 0 ? X+(param.Ls-1)*2*Vh : X-2*Vh ) / 2;
 
 // read spinor from device memory
      READ_SPINOR( SPINORTEX, param.sp_stride, sp_idx, sp_idx );
 
-     if ( xs != 0 )
+     if ( coord[4] != 0 )
      {
    o00_re += +i00_re-i20_re;   o00_im += +i00_im-i20_im;
    o01_re += +i01_re-i21_re;   o01_im += +i01_im-i21_im;
@@ -192,17 +189,17 @@ xs = X/(X1*X2*X3*X4);
    o30_re += -mferm*(-i10_re+i30_re);   o30_im += -mferm*(-i10_im+i30_im);
    o31_re += -mferm*(-i11_re+i31_re);   o31_im += -mferm*(-i11_im+i31_im);
    o32_re += -mferm*(-i12_re+i32_re);   o32_im += -mferm*(-i12_im+i32_im);
-    } // end if ( xs != 0 )
+    } // end if ( coord[4] != 0 )
   } // end P_L
 
  // 2 P_R = 2 P_+ = ( ( +1, +1 ), ( +1, +1 ) )
   {
-    int sp_idx = ( xs == param.Ls-1 ? X-(param.Ls-1)*2*Vh : X+2*Vh ) / 2;
+    int sp_idx = ( coord[4] == param.Ls-1 ? X-(param.Ls-1)*2*Vh : X+2*Vh ) / 2;
 
 // read spinor from device memory
     READ_SPINOR( SPINORTEX, param.sp_stride, sp_idx, sp_idx );
 
-    if ( xs != param.Ls-1 )
+    if ( coord[4] != param.Ls-1 )
     {
    o00_re += +i00_re+i20_re;   o00_im += +i00_im+i20_im;
    o01_re += +i01_re+i21_re;   o01_im += +i01_im+i21_im;
@@ -237,7 +234,7 @@ xs = X/(X1*X2*X3*X4);
    o30_re += -mferm*(+i10_re+i30_re);   o30_im += -mferm*(+i10_im+i30_im);
    o31_re += -mferm*(+i11_re+i31_re);   o31_im += -mferm*(+i11_im+i31_im);
    o32_re += -mferm*(+i12_re+i32_re);   o32_im += -mferm*(+i12_im+i32_im);
-    } // end if ( xs != param.Ls-1 )
+    } // end if ( coord[4] != param.Ls-1 )
   } // end P_R
 
   // MDWF Dslash_5 operator is given as follow
@@ -254,8 +251,8 @@ xs = X/(X1*X2*X3*X4);
 #if (MDWF_mode==1)
   VOLATILE spinorFloat C_5;
   VOLATILE spinorFloat B_5;
-  C_5 = mdwf_c5[xs]*static_cast<spinorFloat>(0.5);
-  B_5 = mdwf_b5[xs];
+  C_5 = mdwf_c5[ coord[4] ]*static_cast<spinorFloat>(0.5);
+  B_5 = mdwf_b5[ coord[4] ];
 
   READ_SPINOR( SPINORTEX, param.sp_stride, X/2, X/2 );
   o00_re = C_5*o00_re + B_5*i00_re;
@@ -284,7 +281,7 @@ xs = X/(X1*X2*X3*X4);
   o32_im = C_5*o32_im + B_5*i32_im;
 #elif (MDWF_mode==2)
   VOLATILE spinorFloat C_5;
-  C_5 = static_cast<spinorFloat>(0.5)*(mdwf_c5[xs]*(m5+static_cast<spinorFloat>(4.0)) - static_cast<spinorFloat>(1.0))/(mdwf_b5[xs]*(m5+static_cast<spinorFloat>(4.0)) + static_cast<spinorFloat>(1.0));
+  C_5 = static_cast<spinorFloat>(0.5)*(mdwf_c5[ coord[4] ]*(m5+static_cast<spinorFloat>(4.0)) - static_cast<spinorFloat>(1.0))/(mdwf_b5[ coord[4] ]*(m5+static_cast<spinorFloat>(4.0)) + static_cast<spinorFloat>(1.0));
 
   READ_SPINOR( SPINORTEX, param.sp_stride, X/2, X/2 );
   o00_re = C_5*o00_re + i00_re;
@@ -322,7 +319,7 @@ xs = X/(X1*X2*X3*X4);
  VOLATILE spinorFloat coeff;
 
 #ifdef MDWF_mode
- coeff = static_cast<spinorFloat>(0.5)/(mdwf_b5[xs]*(m5+static_cast<spinorFloat>(4.0)) + static_cast<spinorFloat>(1.0));
+ coeff = static_cast<spinorFloat>(0.5)/(mdwf_b5[coord[4]]*(m5+static_cast<spinorFloat>(4.0)) + static_cast<spinorFloat>(1.0));
  coeff *= coeff;
  coeff *= a;
 #else

--- a/lib/dslash_core/dw_dslash5inv_dagger_core.h
+++ b/lib/dslash_core/dw_dslash5inv_dagger_core.h
@@ -2,7 +2,6 @@
 
 #define DSLASH_SHARED_FLOATS_PER_THREAD 0
 
-// NB! Don't trust any MULTI_GPU code
 
 #if (CUDA_VERSION >= 4010)
 #define VOLATILE
@@ -122,17 +121,15 @@ VOLATILE spinorFloat o32_im;
 int sid = ((blockIdx.y*blockDim.y + threadIdx.y)*gridDim.x + blockIdx.x)*blockDim.x + threadIdx.x;
 if (sid >= param.threads*param.Ls) return;
 
-int boundaryCrossing;
 
-int X, xs;
+int X, coord[5], boundaryCrossing;
 
-// Inline by hand for the moment and assume even dimensions
-//coordsFromIndex(X, x1, x2, x3, x4, sid, param.parity);
+
 
 boundaryCrossing = sid/X1h + sid/(X2*X1h) + sid/(X3*X2*X1h);
 
 X = 2*sid + (boundaryCrossing + param.parity) % 2;
-xs = X/(X1*X2*X3*X4);
+coord[4] = X/(X1*X2*X3*X4);
 
  o00_re = 0; o00_im = 0;
  o01_re = 0; o01_im = 0;
@@ -150,7 +147,7 @@ xs = X/(X1*X2*X3*X4);
 VOLATILE spinorFloat kappa;
 
 #ifdef MDWF_mode   // Check whether MDWF option is enabled
-  kappa = -(mdwf_c5[xs]*(static_cast<spinorFloat>(4.0) + m5) - static_cast<spinorFloat>(1.0))/(mdwf_b5[xs]*(static_cast<spinorFloat>(4.0) + m5) + static_cast<spinorFloat>(1.0));
+  kappa = -(mdwf_c5[ coord[4] ]*(static_cast<spinorFloat>(4.0) + m5) - static_cast<spinorFloat>(1.0))/(mdwf_b5[ coord[4] ]*(static_cast<spinorFloat>(4.0) + m5) + static_cast<spinorFloat>(1.0));
 #else
   kappa = static_cast<spinorFloat>(2.0)*a;
 #endif  // select MDWF mode
@@ -177,8 +174,8 @@ VOLATILE spinorFloat kappa;
 
   for(int s = 0; s < param.Ls; s++)
   {
-    int exponent = xs > s ? param.Ls-xs+s : s-xs;
-    factorR = inv_d_n * POW(kappa,exponent) * ( xs > s ? -mferm : static_cast<spinorFloat>(1.0) );
+    int exponent = coord[4]  > s ? param.Ls-coord[4]+s : s-coord[4];
+    factorR = inv_d_n * POW(kappa,exponent) * ( coord[4] > s ? -mferm : static_cast<spinorFloat>(1.0) );
 
     sp_idx = base_idx + s*Vh;
     // read spinor from device memory
@@ -209,8 +206,8 @@ VOLATILE spinorFloat kappa;
     o32_re += factorR*(i12_re + i32_re);
     o32_im += factorR*(i12_im + i32_im);
 
-    int exponent2 = xs < s ? param.Ls-s+xs : xs-s;
-    factorL = inv_d_n * POW(kappa,exponent2) * ( xs < s ? -mferm : static_cast<spinorFloat>(1.0));
+    int exponent2 = coord[4] < s ? param.Ls-s+coord[4] : coord[4]-s;
+    factorL = inv_d_n * POW(kappa,exponent2) * ( coord[4] < s ? -mferm : static_cast<spinorFloat>(1.0));
 
     o00_re += factorL*(i00_re - i20_re);
     o00_im += factorL*(i00_im - i20_im);
@@ -247,7 +244,7 @@ VOLATILE spinorFloat kappa;
  VOLATILE spinorFloat coeff;
 
 #ifdef MDWF_mode
- coeff = static_cast<spinorFloat>(0.5)/(mdwf_b5[xs]*(m5+static_cast<spinorFloat>(4.0)) + static_cast<spinorFloat>(1.0));
+ coeff = static_cast<spinorFloat>(0.5)/(mdwf_b5[coord[4]]*(m5+static_cast<spinorFloat>(4.0)) + static_cast<spinorFloat>(1.0));
  coeff *= coeff;
  coeff *= a;
 #else

--- a/lib/dslash_core/dw_dslash_core.h
+++ b/lib/dslash_core/dw_dslash_core.h
@@ -174,27 +174,18 @@ VOLATILE spinorFloat o32_im;
 int sid = ((blockIdx.y*blockDim.y + threadIdx.y)*gridDim.x + blockIdx.x)*blockDim.x + threadIdx.x;
 if (sid >= param.threads*param.Ls) return;
 
-int X, x1, x2, x3, x4, xs;
+int X, coord[5];
 
-int s_parity, boundaryCrossing;
+int s_parity;
 
 #ifdef MULTI_GPU
 int face_idx;
 if (kernel_type == INTERIOR_KERNEL) {
 #endif
 
-// Inline by hand for the moment and assume even dimensions
-//coordsFromIndex(X, x1, x2, x3, x4, sid, param.parity);
 
-s_parity = ( sid/(X4*X3*X2*X1h) ) % 2;
-boundaryCrossing = sid/X1h + sid/(X2*X1h) + sid/(X3*X2*X1h) + sid/(X4*X3*X2*X1h);
-
-X = 2*sid + (boundaryCrossing + param.parity) % 2;
-x1 = X % X1;
-x2 = (X/X1) % X2;
-x3 = (X/(X1*X2)) % X3;
-x4 = (X/(X1*X2*X3)) % X4;
-xs = X/(X1*X2*X3*X4);
+coordsFromIndex<5,QUDA_5D_PC,EVEN_X>(X, coord, sid, param);
+s_parity = ( sid/param.volume4CB ) % 2;
 
  o00_re = 0; o00_im = 0;
  o01_re = 0; o01_im = 0;
@@ -220,12 +211,8 @@ face_idx = sid - face_num*face_volume; // index into the respective face
 // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
 //sp_idx = face_idx + param.ghostOffset[dim];
 
-coordsFromDWFaceIndex<kernel_type,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
-
-s_parity = ( sid/(X4*X3*X2*X1h) ) % 2;
-boundaryCrossing = sid/X1h + sid/(X2*X1h) + sid/(X3*X2*X1h) + sid/(X4*X3*X2*X1h);
-
-X = 2*sid + (boundaryCrossing + param.parity) % 2;
+coordsFromFaceIndex<5,QUDA_5D_PC,kernel_type,1>(X, sid, coord, face_idx, face_num, param);
+s_parity = ( sid/param.volume4CB ) % 2;
 
 READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 
@@ -278,8 +265,8 @@ float4 G4;
 
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
- (kernel_type == EXTERIOR_KERNEL_X && x1==X1m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]<X1m1)) ||
+ (kernel_type == EXTERIOR_KERNEL_X && coord[0]==X1m1) )
 #endif
 {
  // Projector P0-
@@ -289,13 +276,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
  //  i  0  0  1
 
 #ifdef MULTI_GPU
- const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x1==X1m1 ? X-X1m1 : X+1) >> 1 :
+ const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[0]==X1m1 ? X-X1m1 : X+1) >> 1 :
   face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
  const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
- const int sp_idx = (x1==X1m1 ? X-X1m1 : X+1) >> 1;
+ const int sp_idx = (coord[0]==X1m1 ? X-X1m1 : X+1) >> 1;
 #endif
 
  const int ga_idx = sid % Vh;
@@ -472,8 +459,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
- (kernel_type == EXTERIOR_KERNEL_X && x1==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]>0)) ||
+ (kernel_type == EXTERIOR_KERNEL_X && coord[0]==0) )
 #endif
 {
  // Projector P0+
@@ -483,13 +470,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
  // -i  0  0  1
 
 #ifdef MULTI_GPU
- const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x1==0 ? X+X1m1 : X-1) >> 1 :
+ const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[0]==0 ? X+X1m1 : X-1) >> 1 :
   face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
  const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
- const int sp_idx = (x1==0 ? X+X1m1 : X-1) >> 1;
+ const int sp_idx = (coord[0]==0 ? X+X1m1 : X-1) >> 1;
 #endif
 
 #ifdef MULTI_GPU
@@ -670,8 +657,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
- (kernel_type == EXTERIOR_KERNEL_Y && x2==X2m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]<X2m1)) ||
+ (kernel_type == EXTERIOR_KERNEL_Y && coord[1]==X2m1) )
 #endif
 {
  // Projector P1-
@@ -681,13 +668,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
  // -1  0  0  1
 
 #ifdef MULTI_GPU
- const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x2==X2m1 ? X-X2X1mX1 : X+X1) >> 1 :
+ const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[1]==X2m1 ? X-X2X1mX1 : X+X1) >> 1 :
   face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
  const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
- const int sp_idx = (x2==X2m1 ? X-X2X1mX1 : X+X1) >> 1;
+ const int sp_idx = (coord[1]==X2m1 ? X-X2X1mX1 : X+X1) >> 1;
 #endif
 
  const int ga_idx = sid % Vh;
@@ -864,8 +851,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
- (kernel_type == EXTERIOR_KERNEL_Y && x2==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]>0)) ||
+ (kernel_type == EXTERIOR_KERNEL_Y && coord[1]==0) )
 #endif
 {
  // Projector P1+
@@ -875,13 +862,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
  //  1  0  0  1
 
 #ifdef MULTI_GPU
- const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x2==0 ? X+X2X1mX1 : X-X1) >> 1 :
+ const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[1]==0 ? X+X2X1mX1 : X-X1) >> 1 :
   face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
  const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
- const int sp_idx = (x2==0 ? X+X2X1mX1 : X-X1) >> 1;
+ const int sp_idx = (coord[1]==0 ? X+X2X1mX1 : X-X1) >> 1;
 #endif
 
 #ifdef MULTI_GPU
@@ -1062,8 +1049,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
- (kernel_type == EXTERIOR_KERNEL_Z && x3==X3m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]<X3m1)) ||
+ (kernel_type == EXTERIOR_KERNEL_Z && coord[2]==X3m1) )
 #endif
 {
  // Projector P2-
@@ -1073,13 +1060,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
  //  0 -i  0  1
 
 #ifdef MULTI_GPU
- const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x3==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1 :
+ const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[2]==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1 :
   face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
  const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
- const int sp_idx = (x3==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1;
+ const int sp_idx = (coord[2]==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1;
 #endif
 
  const int ga_idx = sid % Vh;
@@ -1256,8 +1243,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
- (kernel_type == EXTERIOR_KERNEL_Z && x3==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]>0)) ||
+ (kernel_type == EXTERIOR_KERNEL_Z && coord[2]==0) )
 #endif
 {
  // Projector P2+
@@ -1267,13 +1254,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
  //  0  i  0  1
 
 #ifdef MULTI_GPU
- const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x3==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1 :
+ const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[2]==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1 :
   face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
  const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
- const int sp_idx = (x3==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1;
+ const int sp_idx = (coord[2]==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1;
 #endif
 
 #ifdef MULTI_GPU
@@ -1454,8 +1441,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
- (kernel_type == EXTERIOR_KERNEL_T && x4==X4m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]<X4m1)) ||
+ (kernel_type == EXTERIOR_KERNEL_T && coord[3]==X4m1) )
 #endif
 {
  // Projector P3-
@@ -1465,13 +1452,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
  //  0  0  0  2
 
 #ifdef MULTI_GPU
- const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x4==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1 :
+ const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[3]==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1 :
   face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
  const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
- const int sp_idx = (x4==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1;
+ const int sp_idx = (coord[3]==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1;
 #endif
 
  const int ga_idx = sid % Vh;
@@ -1710,8 +1697,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4>0)) ||
- (kernel_type == EXTERIOR_KERNEL_T && x4==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]>0)) ||
+ (kernel_type == EXTERIOR_KERNEL_T && coord[3]==0) )
 #endif
 {
  // Projector P3+
@@ -1721,13 +1708,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4>0)) ||
  //  0  0  0  0
 
 #ifdef MULTI_GPU
- const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x4==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1 :
+ const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[3]==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1 :
   face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
  const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
- const int sp_idx = (x4==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1;
+ const int sp_idx = (coord[3]==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1;
 #endif
 
 #ifdef MULTI_GPU
@@ -1978,12 +1965,12 @@ if(kernel_type == INTERIOR_KERNEL)
 {
 // 2 P_L = 2 P_- = ( ( +1, -1 ), ( -1, +1 ) )
   {
-     int sp_idx = ( xs == param.Ls-1 ? X-(param.Ls-1)*2*Vh : X+2*Vh ) / 2;
+     int sp_idx = ( coord[4] == param.Ls-1 ? X-(param.Ls-1)*2*Vh : X+2*Vh ) / 2;
 
 // read spinor from device memory
      READ_SPINOR( SPINORTEX, param.sp_stride, sp_idx, sp_idx );
 
-     if ( xs != param.Ls-1 )
+     if ( coord[4] != param.Ls-1 )
      {
    o00_re += +i00_re-i20_re;   o00_im += +i00_im-i20_im;
    o01_re += +i01_re-i21_re;   o01_im += +i01_im-i21_im;
@@ -2018,17 +2005,17 @@ if(kernel_type == INTERIOR_KERNEL)
    o30_re += -mferm*(-i10_re+i30_re);   o30_im += -mferm*(-i10_im+i30_im);
    o31_re += -mferm*(-i11_re+i31_re);   o31_im += -mferm*(-i11_im+i31_im);
    o32_re += -mferm*(-i12_re+i32_re);   o32_im += -mferm*(-i12_im+i32_im);
-    } // end if ( xs != param.Ls-1 )
+    } // end if ( coord[4]!= param.Ls-1 )
   } // end P_L
 
  // 2 P_R = 2 P_+ = ( ( +1, +1 ), ( +1, +1 ) )
   {
-    int sp_idx = ( xs == 0 ? X+(param.Ls-1)*2*Vh : X-2*Vh ) / 2;
+    int sp_idx = ( coord[4] == 0 ? X+(param.Ls-1)*2*Vh : X-2*Vh ) / 2;
 
 // read spinor from device memory
     READ_SPINOR( SPINORTEX, param.sp_stride, sp_idx, sp_idx );
 
-    if ( xs != 0 )
+    if ( coord[4] != 0 )
     {
    o00_re += +i00_re+i20_re;   o00_im += +i00_im+i20_im;
    o01_re += +i01_re+i21_re;   o01_im += +i01_im+i21_im;
@@ -2063,7 +2050,7 @@ if(kernel_type == INTERIOR_KERNEL)
    o30_re += -mferm*(+i10_re+i30_re);   o30_im += -mferm*(+i10_im+i30_im);
    o31_re += -mferm*(+i11_re+i31_re);   o31_im += -mferm*(+i11_im+i31_im);
    o32_re += -mferm*(+i12_re+i32_re);   o32_im += -mferm*(+i12_im+i32_im);
-    } // end if ( xs != 0 )
+    } // end if ( coord[4] != 0 )
   } // end P_R
 } // end 5th dimension
 
@@ -2137,13 +2124,13 @@ int incomplete = 0; // Have all 8 contributions been computed for this site?
 
 switch(kernel_type) { // intentional fall-through
 case INTERIOR_KERNEL:
-incomplete = incomplete || (param.commDim[3] && (x4==0 || x4==X4m1));
+  incomplete = incomplete || (param.commDim[3] && (coord[3]==0 || coord[3]==X4m1));
 case EXTERIOR_KERNEL_T:
-incomplete = incomplete || (param.commDim[2] && (x3==0 || x3==X3m1));
+  incomplete = incomplete || (param.commDim[2] && (coord[2]==0 || coord[2]==X3m1));
 case EXTERIOR_KERNEL_Z:
-incomplete = incomplete || (param.commDim[1] && (x2==0 || x2==X2m1));
+  incomplete = incomplete || (param.commDim[1] && (coord[1]==0 || coord[1]==X2m1));
 case EXTERIOR_KERNEL_Y:
-incomplete = incomplete || (param.commDim[0] && (x1==0 || x1==X1m1));
+  incomplete = incomplete || (param.commDim[0] && (coord[0]==0 || coord[0]==X1m1));
 }
 
 if (!incomplete)

--- a/lib/dslash_core/dw_dslash_core.h
+++ b/lib/dslash_core/dw_dslash_core.h
@@ -212,7 +212,6 @@ xs = X/(X1*X2*X3*X4);
 #ifdef MULTI_GPU
 } else { // exterior kernel
 
-const int dim = static_cast<int>(kernel_type);
 const int face_volume = (param.threads*param.Ls >> 1); // volume of one face
 const int face_num = (sid >= face_volume); // is this thread updating face 0 or 1
 face_idx = sid - face_num*face_volume; // index into the respective face
@@ -221,8 +220,7 @@ face_idx = sid - face_num*face_volume; // index into the respective face
 // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
 //sp_idx = face_idx + param.ghostOffset[dim];
 
-const int dims[] = {X1, X2, X3, X4};
-coordsFromDWFaceIndex<1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, dim, face_num, param.parity, dims);
+coordsFromDWFaceIndex<kernel_type,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
 
 s_parity = ( sid/(X4*X3*X2*X1h) ) % 2;
 boundaryCrossing = sid/X1h + sid/(X2*X1h) + sid/(X3*X2*X1h) + sid/(X4*X3*X2*X1h);

--- a/lib/dslash_core/dw_dslash_dagger_core.h
+++ b/lib/dslash_core/dw_dslash_dagger_core.h
@@ -212,7 +212,6 @@ xs = X/(X1*X2*X3*X4);
 #ifdef MULTI_GPU
 } else { // exterior kernel
 
-const int dim = static_cast<int>(kernel_type);
 const int face_volume = (param.threads*param.Ls >> 1); // volume of one face
 const int face_num = (sid >= face_volume); // is this thread updating face 0 or 1
 face_idx = sid - face_num*face_volume; // index into the respective face
@@ -221,8 +220,7 @@ face_idx = sid - face_num*face_volume; // index into the respective face
 // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
 //sp_idx = face_idx + param.ghostOffset[dim];
 
-const int dims[] = {X1, X2, X3, X4};
-coordsFromDWFaceIndex<1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, dim, face_num, param.parity, dims);
+coordsFromDWFaceIndex<kernel_type,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
 
 s_parity = ( sid/(X4*X3*X2*X1h) ) % 2;
 boundaryCrossing = sid/X1h + sid/(X2*X1h) + sid/(X3*X2*X1h) + sid/(X4*X3*X2*X1h);

--- a/lib/dslash_core/dw_fused_exterior_dslash4_core.h
+++ b/lib/dslash_core/dw_fused_exterior_dslash4_core.h
@@ -186,8 +186,6 @@ if (sid >= param.threads*param.Ls) return;
 
 int dim;
 int face_idx;
-int Y[4] = {X1,X2,X3,X4};
-
 
 
 
@@ -207,9 +205,20 @@ face_idx = sid - face_num*face_volume; // index into the respective face
 // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
 //sp_idx = face_idx + param.ghostOffset[dim];
 
-
-const int dims[] = {X1, X2, X3, X4};
-coordsFromDW4DFaceIndex<1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, dim, face_num, param.parity, dims);
+switch(dim) {
+case 0:
+  coordsFromDW4DFaceIndex<0,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
+  break;
+case 1:
+  coordsFromDW4DFaceIndex<1,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
+  break;
+case 2:
+  coordsFromDW4DFaceIndex<2,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
+  break;
+case 3:
+  coordsFromDW4DFaceIndex<3,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
+  break;
+}
 
 {
   bool active = false;
@@ -277,7 +286,7 @@ if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
  //  0  i  1  0
  //  i  0  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,0,Y);
+ faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,0,param.X);
  const int sp_idx = face_idx + param.ghostOffset[0][1];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[0][1];
@@ -440,7 +449,7 @@ if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
  //  0 -i  1  0
  // -i  0  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,0,Y);
+ faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,0,param.X);
  const int sp_idx = face_idx + param.ghostOffset[0][0];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[0][0];
@@ -603,7 +612,7 @@ if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
  //  0  1  1  0
  // -1  0  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,1,Y);
+ faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,1,param.X);
  const int sp_idx = face_idx + param.ghostOffset[1][1];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[1][1];
@@ -766,7 +775,7 @@ if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
  //  0 -1  1  0
  //  1  0  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,1,Y);
+ faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,1,param.X);
  const int sp_idx = face_idx + param.ghostOffset[1][0];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[1][0];
@@ -929,7 +938,7 @@ if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
  //  i  0  1  0
  //  0 -i  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,2,Y);
+ faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,2,param.X);
  const int sp_idx = face_idx + param.ghostOffset[2][1];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[2][1];
@@ -1092,7 +1101,7 @@ if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
  // -i  0  1  0
  //  0  i  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,2,Y);
+ faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,2,param.X);
  const int sp_idx = face_idx + param.ghostOffset[2][0];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[2][0];
@@ -1255,7 +1264,7 @@ if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
  //  0  0  2  0
  //  0  0  0  2
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,3,Y);
+ faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,3,param.X);
  const int sp_idx = face_idx + param.ghostOffset[3][1];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[3][1];
@@ -1456,7 +1465,7 @@ if (isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
  //  0  0  0  0
  //  0  0  0  0
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,3,Y);
+ faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,3,param.X);
  const int sp_idx = face_idx + param.ghostOffset[3][0];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[3][0];

--- a/lib/dslash_core/dw_fused_exterior_dslash4_core.h
+++ b/lib/dslash_core/dw_fused_exterior_dslash4_core.h
@@ -189,11 +189,12 @@ int face_idx;
 
 
 
-int x1, x2, x3, x4, xs;
+int coord[5];
+int X;
 
 { // exterior kernel
 
-dim = dimFromDWFaceIndex(sid, param); // sid is also modified
+dim = dimFromFaceIndex<5>(sid, param); // sid is also modified
 
 //const int face_volume = (param.threads*param.Ls >> 1); // volume of one face
 const int face_volume = ((param.threadDimMapUpper[dim] - param.threadDimMapLower[dim])*param.Ls >> 1);
@@ -207,23 +208,23 @@ face_idx = sid - face_num*face_volume; // index into the respective face
 
 switch(dim) {
 case 0:
-  coordsFromDW4DFaceIndex<0,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
+  coordsFromFaceIndex<5,QUDA_4D_PC,0,1>(X, sid, coord, face_idx, face_num, param);
   break;
 case 1:
-  coordsFromDW4DFaceIndex<1,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
+  coordsFromFaceIndex<5,QUDA_4D_PC,1,1>(X, sid, coord, face_idx, face_num, param);
   break;
 case 2:
-  coordsFromDW4DFaceIndex<2,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
+  coordsFromFaceIndex<5,QUDA_4D_PC,2,1>(X, sid, coord, face_idx, face_num, param);
   break;
 case 3:
-  coordsFromDW4DFaceIndex<3,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
+  coordsFromFaceIndex<5,QUDA_4D_PC,3,1>(X, sid, coord, face_idx, face_num, param);
   break;
 }
 
 {
   bool active = false;
   for(int dir=0; dir<4; ++dir){
-    active = active || isActive(dim,dir,+1,x1,x2,x3,x4,param.commDim,param.X);
+    active = active || isActive(dim,dir,+1,coord,param.commDim,param.X);
   }
   if(!active) return;
 }
@@ -278,7 +279,7 @@ float4 G4;
 
 
 
-if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
+if (isActive(dim,0,+1,coord,param.commDim,param.X) && coord[0]==X1m1 )
 {
  // Projector P0-
  //  1  0  0 -i
@@ -286,7 +287,7 @@ if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
  //  0  i  1  0
  //  i  0  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,0,param.X);
+ faceIndexFromCoords<5,1>(face_idx,coord,0,param);
  const int sp_idx = face_idx + param.ghostOffset[0][1];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[0][1];
@@ -441,7 +442,7 @@ if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
  o32_im += A2_re;
 }
 
-if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
+if (isActive(dim,0,-1,coord,param.commDim,param.X) && coord[0]==0 )
 {
  // Projector P0+
  //  1  0  0  i
@@ -449,7 +450,7 @@ if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
  //  0 -i  1  0
  // -i  0  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,0,param.X);
+ faceIndexFromCoords<5,1>(face_idx,coord,0,param);
  const int sp_idx = face_idx + param.ghostOffset[0][0];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[0][0];
@@ -604,7 +605,7 @@ if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
  o32_im -= A2_re;
 }
 
-if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
+if (isActive(dim,1,+1,coord,param.commDim,param.X) && coord[1]==X2m1 )
 {
  // Projector P1-
  //  1  0  0 -1
@@ -612,7 +613,7 @@ if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
  //  0  1  1  0
  // -1  0  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,1,param.X);
+ faceIndexFromCoords<5,1>(face_idx,coord,1,param);
  const int sp_idx = face_idx + param.ghostOffset[1][1];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[1][1];
@@ -767,7 +768,7 @@ if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
  o32_im -= A2_im;
 }
 
-if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
+if (isActive(dim,1,-1,coord,param.commDim,param.X) && coord[1]==0 )
 {
  // Projector P1+
  //  1  0  0  1
@@ -775,7 +776,7 @@ if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
  //  0 -1  1  0
  //  1  0  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,1,param.X);
+ faceIndexFromCoords<5,1>(face_idx,coord,1,param);
  const int sp_idx = face_idx + param.ghostOffset[1][0];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[1][0];
@@ -930,7 +931,7 @@ if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
  o32_im += A2_im;
 }
 
-if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
+if (isActive(dim,2,+1,coord,param.commDim,param.X) && coord[2]==X3m1 )
 {
  // Projector P2-
  //  1  0 -i  0
@@ -938,7 +939,7 @@ if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
  //  i  0  1  0
  //  0 -i  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,2,param.X);
+ faceIndexFromCoords<5,1>(face_idx,coord,2,param);
  const int sp_idx = face_idx + param.ghostOffset[2][1];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[2][1];
@@ -1093,7 +1094,7 @@ if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
  o32_im -= B2_re;
 }
 
-if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
+if (isActive(dim,2,-1,coord,param.commDim,param.X) && coord[2]==0 )
 {
  // Projector P2+
  //  1  0  i  0
@@ -1101,7 +1102,7 @@ if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
  // -i  0  1  0
  //  0  i  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,2,param.X);
+ faceIndexFromCoords<5,1>(face_idx,coord,2,param);
  const int sp_idx = face_idx + param.ghostOffset[2][0];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[2][0];
@@ -1256,7 +1257,7 @@ if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
  o32_im += B2_re;
 }
 
-if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
+if (isActive(dim,3,+1,coord,param.commDim,param.X) && coord[3]==X4m1 )
 {
  // Projector P3-
  //  0  0  0  0
@@ -1264,7 +1265,7 @@ if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
  //  0  0  2  0
  //  0  0  0  2
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,3,param.X);
+ faceIndexFromCoords<5,1>(face_idx,coord,3,param);
  const int sp_idx = face_idx + param.ghostOffset[3][1];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[3][1];
@@ -1457,7 +1458,7 @@ if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
  }
 }
 
-if (isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
+if (isActive(dim,3,-1,coord,param.commDim,param.X) && coord[3]==0 )
 {
  // Projector P3+
  //  2  0  0  0
@@ -1465,7 +1466,7 @@ if (isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
  //  0  0  0  0
  //  0  0  0  0
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,3,param.X);
+ faceIndexFromCoords<5,1>(face_idx,coord,3,param);
  const int sp_idx = face_idx + param.ghostOffset[3][0];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[3][0];
@@ -1665,7 +1666,7 @@ if (isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
  VOLATILE spinorFloat coeff;
 
 #ifdef MDWF_mode
- coeff = (spinorFloat)(0.5*a/(mdwf_b5[xs]*(m5+4.0) + 1.0));
+ coeff = (spinorFloat)(0.5*a/(mdwf_b5[coord[4]]*(m5+4.0) + 1.0));
 #else
  coeff = a;
 #endif

--- a/lib/dslash_core/dw_fused_exterior_dslash4_dagger_core.h
+++ b/lib/dslash_core/dw_fused_exterior_dslash4_dagger_core.h
@@ -186,8 +186,6 @@ if (sid >= param.threads*param.Ls) return;
 
 int dim;
 int face_idx;
-int Y[4] = {X1,X2,X3,X4};
-
 
 
 
@@ -207,9 +205,20 @@ face_idx = sid - face_num*face_volume; // index into the respective face
 // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
 //sp_idx = face_idx + param.ghostOffset[dim];
 
-
-const int dims[] = {X1, X2, X3, X4};
-coordsFromDW4DFaceIndex<1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, dim, face_num, param.parity, dims);
+switch(dim) {
+case 0:
+  coordsFromDW4DFaceIndex<0,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
+  break;
+case 1:
+  coordsFromDW4DFaceIndex<1,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
+  break;
+case 2:
+  coordsFromDW4DFaceIndex<2,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
+  break;
+case 3:
+  coordsFromDW4DFaceIndex<3,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
+  break;
+}
 
 {
   bool active = false;
@@ -277,7 +286,7 @@ if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
  //  0 -i  1  0
  // -i  0  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,0,Y);
+ faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,0,param.X);
  const int sp_idx = face_idx + param.ghostOffset[0][1];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[0][1];
@@ -440,7 +449,7 @@ if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
  //  0  i  1  0
  //  i  0  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,0,Y);
+ faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,0,param.X);
  const int sp_idx = face_idx + param.ghostOffset[0][0];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[0][0];
@@ -603,7 +612,7 @@ if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
  //  0 -1  1  0
  //  1  0  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,1,Y);
+ faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,1,param.X);
  const int sp_idx = face_idx + param.ghostOffset[1][1];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[1][1];
@@ -766,7 +775,7 @@ if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
  //  0  1  1  0
  // -1  0  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,1,Y);
+ faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,1,param.X);
  const int sp_idx = face_idx + param.ghostOffset[1][0];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[1][0];
@@ -929,7 +938,7 @@ if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
  // -i  0  1  0
  //  0  i  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,2,Y);
+ faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,2,param.X);
  const int sp_idx = face_idx + param.ghostOffset[2][1];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[2][1];
@@ -1092,7 +1101,7 @@ if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
  //  i  0  1  0
  //  0 -i  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,2,Y);
+ faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,2,param.X);
  const int sp_idx = face_idx + param.ghostOffset[2][0];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[2][0];
@@ -1255,7 +1264,7 @@ if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
  //  0  0  0  0
  //  0  0  0  0
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,3,Y);
+ faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,3,param.X);
  const int sp_idx = face_idx + param.ghostOffset[3][1];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[3][1];
@@ -1456,7 +1465,7 @@ if (isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
  //  0  0  2  0
  //  0  0  0  2
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,3,Y);
+ faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,3,param.X);
  const int sp_idx = face_idx + param.ghostOffset[3][0];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[3][0];

--- a/lib/dslash_core/dw_fused_exterior_dslash4_dagger_core.h
+++ b/lib/dslash_core/dw_fused_exterior_dslash4_dagger_core.h
@@ -189,11 +189,12 @@ int face_idx;
 
 
 
-int x1, x2, x3, x4, xs;
+int coord[5];
+int X;
 
 { // exterior kernel
 
-dim = dimFromDWFaceIndex(sid, param); // sid is also modified
+dim = dimFromFaceIndex<5>(sid, param); // sid is also modified
 
 //const int face_volume = (param.threads*param.Ls >> 1); // volume of one face
 const int face_volume = ((param.threadDimMapUpper[dim] - param.threadDimMapLower[dim])*param.Ls >> 1);
@@ -207,23 +208,23 @@ face_idx = sid - face_num*face_volume; // index into the respective face
 
 switch(dim) {
 case 0:
-  coordsFromDW4DFaceIndex<0,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
+  coordsFromFaceIndex<5,QUDA_4D_PC,0,1>(X, sid, coord, face_idx, face_num, param);
   break;
 case 1:
-  coordsFromDW4DFaceIndex<1,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
+  coordsFromFaceIndex<5,QUDA_4D_PC,1,1>(X, sid, coord, face_idx, face_num, param);
   break;
 case 2:
-  coordsFromDW4DFaceIndex<2,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
+  coordsFromFaceIndex<5,QUDA_4D_PC,2,1>(X, sid, coord, face_idx, face_num, param);
   break;
 case 3:
-  coordsFromDW4DFaceIndex<3,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
+  coordsFromFaceIndex<5,QUDA_4D_PC,3,1>(X, sid, coord, face_idx, face_num, param);
   break;
 }
 
 {
   bool active = false;
   for(int dir=0; dir<4; ++dir){
-    active = active || isActive(dim,dir,+1,x1,x2,x3,x4,param.commDim,param.X);
+    active = active || isActive(dim,dir,+1,coord,param.commDim,param.X);
   }
   if(!active) return;
 }
@@ -278,7 +279,7 @@ float4 G4;
 
 
 
-if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
+if (isActive(dim,0,+1,coord,param.commDim,param.X) && coord[0]==X1m1 )
 {
  // Projector P0+
  //  1  0  0  i
@@ -286,7 +287,7 @@ if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
  //  0 -i  1  0
  // -i  0  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,0,param.X);
+ faceIndexFromCoords<5,1>(face_idx,coord,0,param);
  const int sp_idx = face_idx + param.ghostOffset[0][1];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[0][1];
@@ -441,7 +442,7 @@ if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
  o32_im -= A2_re;
 }
 
-if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
+if (isActive(dim,0,-1,coord,param.commDim,param.X) && coord[0]==0 )
 {
  // Projector P0-
  //  1  0  0 -i
@@ -449,7 +450,7 @@ if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
  //  0  i  1  0
  //  i  0  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,0,param.X);
+ faceIndexFromCoords<5,1>(face_idx,coord,0,param);
  const int sp_idx = face_idx + param.ghostOffset[0][0];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[0][0];
@@ -604,7 +605,7 @@ if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
  o32_im += A2_re;
 }
 
-if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
+if (isActive(dim,1,+1,coord,param.commDim,param.X) && coord[1]==X2m1 )
 {
  // Projector P1+
  //  1  0  0  1
@@ -612,7 +613,7 @@ if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
  //  0 -1  1  0
  //  1  0  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,1,param.X);
+ faceIndexFromCoords<5,1>(face_idx,coord,1,param);
  const int sp_idx = face_idx + param.ghostOffset[1][1];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[1][1];
@@ -767,7 +768,7 @@ if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
  o32_im += A2_im;
 }
 
-if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
+if (isActive(dim,1,-1,coord,param.commDim,param.X) && coord[1]==0 )
 {
  // Projector P1-
  //  1  0  0 -1
@@ -775,7 +776,7 @@ if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
  //  0  1  1  0
  // -1  0  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,1,param.X);
+ faceIndexFromCoords<5,1>(face_idx,coord,1,param);
  const int sp_idx = face_idx + param.ghostOffset[1][0];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[1][0];
@@ -930,7 +931,7 @@ if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
  o32_im -= A2_im;
 }
 
-if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
+if (isActive(dim,2,+1,coord,param.commDim,param.X) && coord[2]==X3m1 )
 {
  // Projector P2+
  //  1  0  i  0
@@ -938,7 +939,7 @@ if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
  // -i  0  1  0
  //  0  i  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,2,param.X);
+ faceIndexFromCoords<5,1>(face_idx,coord,2,param);
  const int sp_idx = face_idx + param.ghostOffset[2][1];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[2][1];
@@ -1093,7 +1094,7 @@ if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
  o32_im += B2_re;
 }
 
-if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
+if (isActive(dim,2,-1,coord,param.commDim,param.X) && coord[2]==0 )
 {
  // Projector P2-
  //  1  0 -i  0
@@ -1101,7 +1102,7 @@ if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
  //  i  0  1  0
  //  0 -i  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,2,param.X);
+ faceIndexFromCoords<5,1>(face_idx,coord,2,param);
  const int sp_idx = face_idx + param.ghostOffset[2][0];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[2][0];
@@ -1256,7 +1257,7 @@ if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
  o32_im -= B2_re;
 }
 
-if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
+if (isActive(dim,3,+1,coord,param.commDim,param.X) && coord[3]==X4m1 )
 {
  // Projector P3+
  //  2  0  0  0
@@ -1264,7 +1265,7 @@ if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
  //  0  0  0  0
  //  0  0  0  0
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,3,param.X);
+ faceIndexFromCoords<5,1>(face_idx,coord,3,param);
  const int sp_idx = face_idx + param.ghostOffset[3][1];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[3][1];
@@ -1457,7 +1458,7 @@ if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
  }
 }
 
-if (isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
+if (isActive(dim,3,-1,coord,param.commDim,param.X) && coord[3]==0 )
 {
  // Projector P3-
  //  0  0  0  0
@@ -1465,7 +1466,7 @@ if (isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
  //  0  0  2  0
  //  0  0  0  2
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,3,param.X);
+ faceIndexFromCoords<5,1>(face_idx,coord,3,param);
  const int sp_idx = face_idx + param.ghostOffset[3][0];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[3][0];
@@ -1665,7 +1666,7 @@ if (isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
  VOLATILE spinorFloat coeff;
 
 #ifdef MDWF_mode
- coeff = (spinorFloat)(0.5*a/(mdwf_b5[xs]*(m5+4.0) + 1.0));
+ coeff = (spinorFloat)(0.5*a/(mdwf_b5[coord[4]]*(m5+4.0) + 1.0));
 #else
  coeff = a;
 #endif

--- a/lib/dslash_core/dw_fused_exterior_dslash_core.h
+++ b/lib/dslash_core/dw_fused_exterior_dslash_core.h
@@ -178,14 +178,9 @@ int sp_norm_idx;
 int sid = ((blockIdx.y*blockDim.y + threadIdx.y)*gridDim.x + blockIdx.x)*blockDim.x + threadIdx.x;
 if (sid >= param.threads*param.Ls) return;
 
-
-int dim; 
+int dim;
 int face_idx;
-int Y[4] = {X1,X2,X3,X4};
-
-
 int x1, x2, x3, x4, xs;
-
 int s_parity;
 
 
@@ -202,16 +197,26 @@ face_idx = sid - face_num*face_volume; // index into the respective face
 // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
 //sp_idx = face_idx + param.ghostOffset[dim];
 
-const int dims[] = {X1, X2, X3, X4};
-coordsFromDWFaceIndex<1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, dim, face_num, param.parity, dims);
-
-{
-  bool active = false;
-  for(int dir=0; dir<4; ++dir){
-    active = active || isActive(dim,dir,+1,x1,x2,x3,x4,param.commDim,param.X);
-  }
-  if(!active) return;
+switch(dim) {
+case 0:
+  coordsFromDWFaceIndex<0,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
+  break;
+case 1:
+  coordsFromDWFaceIndex<1,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
+  break;
+case 2:
+  coordsFromDWFaceIndex<2,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
+  break;
+case 3:
+  coordsFromDWFaceIndex<3,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
+  break;
 }
+
+bool active = false;
+for(int dir=0; dir<4; ++dir){
+  active = active || isActive(dim,dir,+1,x1,x2,x3,x4,param.commDim,param.X);
+}
+if(!active) return;
 
 
 s_parity = ( sid/(X4*X3*X2*X1h) ) % 2;
@@ -273,7 +278,7 @@ if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
  //  0  i  1  0
  //  i  0  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,0,Y);
+ faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,0,param.X);
  const int sp_idx = face_idx + param.ghostOffset[0][1];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[0][1];
@@ -438,7 +443,7 @@ if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
  //  0 -i  1  0
  // -i  0  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,0,Y);
+ faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,0,param.X);
  const int sp_idx = face_idx + param.ghostOffset[0][0];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[0][0];
@@ -603,7 +608,7 @@ if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
  //  0  1  1  0
  // -1  0  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,1,Y);
+ faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,1,param.X);
  const int sp_idx = face_idx + param.ghostOffset[1][1];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[1][1];
@@ -768,7 +773,7 @@ if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
  //  0 -1  1  0
  //  1  0  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,1,Y);
+ faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,1,param.X);
  const int sp_idx = face_idx + param.ghostOffset[1][0];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[1][0];
@@ -933,7 +938,7 @@ if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
  //  i  0  1  0
  //  0 -i  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,2,Y);
+ faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,2,param.X);
  const int sp_idx = face_idx + param.ghostOffset[2][1];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[2][1];
@@ -1098,7 +1103,7 @@ if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
  // -i  0  1  0
  //  0  i  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,2,Y);
+ faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,2,param.X);
  const int sp_idx = face_idx + param.ghostOffset[2][0];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[2][0];
@@ -1263,7 +1268,7 @@ if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
  //  0  0  2  0
  //  0  0  0  2
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,3,Y);
+ faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,3,param.X);
  const int sp_idx = face_idx + param.ghostOffset[3][1];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[3][1];
@@ -1467,7 +1472,7 @@ if (isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
  //  0  0  0  0
  //  0  0  0  0
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,3,Y);
+ faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,3,param.X);
  const int sp_idx = face_idx + param.ghostOffset[3][0];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[3][0];

--- a/lib/dslash_core/dw_fused_exterior_dslash_core.h
+++ b/lib/dslash_core/dw_fused_exterior_dslash_core.h
@@ -180,14 +180,15 @@ if (sid >= param.threads*param.Ls) return;
 
 int dim;
 int face_idx;
-int x1, x2, x3, x4, xs;
+int coord[5];
+int X;
 int s_parity;
 
 
 
 { // exterior kernel
 
-dim = dimFromDWFaceIndex(sid, param); // sid is also modified
+dim = dimFromFaceIndex<5>(sid, param); // sid is also modified
 
 const int face_volume = ((param.threadDimMapUpper[dim] - param.threadDimMapLower[dim])*param.Ls >> 1);
 const int face_num = (sid >= face_volume); // is this thread updating face 0 or 1
@@ -199,27 +200,27 @@ face_idx = sid - face_num*face_volume; // index into the respective face
 
 switch(dim) {
 case 0:
-  coordsFromDWFaceIndex<0,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
+  coordsFromFaceIndex<5,QUDA_5D_PC,0,1>(X, sid, coord, face_idx, face_num, param);
   break;
 case 1:
-  coordsFromDWFaceIndex<1,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
+  coordsFromFaceIndex<5,QUDA_5D_PC,1,1>(X, sid, coord, face_idx, face_num, param);
   break;
 case 2:
-  coordsFromDWFaceIndex<2,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
+  coordsFromFaceIndex<5,QUDA_5D_PC,2,1>(X, sid, coord, face_idx, face_num, param);
   break;
 case 3:
-  coordsFromDWFaceIndex<3,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
+  coordsFromFaceIndex<5,QUDA_5D_PC,3,1>(X, sid, coord, face_idx, face_num, param);
   break;
 }
 
 bool active = false;
 for(int dir=0; dir<4; ++dir){
-  active = active || isActive(dim,dir,+1,x1,x2,x3,x4,param.commDim,param.X);
+  active = active || isActive(dim,dir,+1,coord,param.commDim,param.X);
 }
 if(!active) return;
 
 
-s_parity = ( sid/(X4*X3*X2*X1h) ) % 2;
+s_parity = ( sid/param.volume4CB ) % 2;
 
 READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 
@@ -270,7 +271,7 @@ float4 G4;
 
 
 
-if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
+if (isActive(dim,0,+1,coord,param.commDim,param.X) && coord[0]==X1m1 )
 {
  // Projector P0-
  //  1  0  0 -i
@@ -278,7 +279,7 @@ if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
  //  0  i  1  0
  //  i  0  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,0,param.X);
+ faceIndexFromCoords<5,1>(face_idx,coord,0,param);
  const int sp_idx = face_idx + param.ghostOffset[0][1];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[0][1];
@@ -435,7 +436,7 @@ if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
  o32_im += A2_re;
 }
 
-if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
+if (isActive(dim,0,-1,coord,param.commDim,param.X) && coord[0]==0 )
 {
  // Projector P0+
  //  1  0  0  i
@@ -443,7 +444,7 @@ if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
  //  0 -i  1  0
  // -i  0  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,0,param.X);
+ faceIndexFromCoords<5,1>(face_idx,coord,0,param);
  const int sp_idx = face_idx + param.ghostOffset[0][0];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[0][0];
@@ -600,7 +601,7 @@ if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
  o32_im -= A2_re;
 }
 
-if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
+if (isActive(dim,1,+1,coord,param.commDim,param.X) && coord[1]==X2m1 )
 {
  // Projector P1-
  //  1  0  0 -1
@@ -608,7 +609,7 @@ if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
  //  0  1  1  0
  // -1  0  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,1,param.X);
+ faceIndexFromCoords<5,1>(face_idx,coord,1,param);
  const int sp_idx = face_idx + param.ghostOffset[1][1];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[1][1];
@@ -765,7 +766,7 @@ if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
  o32_im -= A2_im;
 }
 
-if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
+if (isActive(dim,1,-1,coord,param.commDim,param.X) && coord[1]==0 )
 {
  // Projector P1+
  //  1  0  0  1
@@ -773,7 +774,7 @@ if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
  //  0 -1  1  0
  //  1  0  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,1,param.X);
+ faceIndexFromCoords<5,1>(face_idx,coord,1,param);
  const int sp_idx = face_idx + param.ghostOffset[1][0];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[1][0];
@@ -930,7 +931,7 @@ if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
  o32_im += A2_im;
 }
 
-if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
+if (isActive(dim,2,+1,coord,param.commDim,param.X) && coord[2]==X3m1 )
 {
  // Projector P2-
  //  1  0 -i  0
@@ -938,7 +939,7 @@ if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
  //  i  0  1  0
  //  0 -i  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,2,param.X);
+ faceIndexFromCoords<5,1>(face_idx,coord,2,param);
  const int sp_idx = face_idx + param.ghostOffset[2][1];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[2][1];
@@ -1095,7 +1096,7 @@ if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
  o32_im -= B2_re;
 }
 
-if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
+if (isActive(dim,2,-1,coord,param.commDim,param.X) && coord[2]==0 )
 {
  // Projector P2+
  //  1  0  i  0
@@ -1103,7 +1104,7 @@ if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
  // -i  0  1  0
  //  0  i  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,2,param.X);
+ faceIndexFromCoords<5,1>(face_idx,coord,2,param);
  const int sp_idx = face_idx + param.ghostOffset[2][0];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[2][0];
@@ -1260,7 +1261,7 @@ if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
  o32_im += B2_re;
 }
 
-if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
+if (isActive(dim,3,+1,coord,param.commDim,param.X) && coord[3]==X4m1 )
 {
  // Projector P3-
  //  0  0  0  0
@@ -1268,7 +1269,7 @@ if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
  //  0  0  2  0
  //  0  0  0  2
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,3,param.X);
+ faceIndexFromCoords<5,1>(face_idx,coord,3,param);
  const int sp_idx = face_idx + param.ghostOffset[3][1];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[3][1];
@@ -1464,7 +1465,7 @@ if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
  }
 }
 
-if (isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
+if (isActive(dim,3,-1,coord,param.commDim,param.X) && coord[3]==0 )
 {
  // Projector P3+
  //  2  0  0  0
@@ -1472,7 +1473,7 @@ if (isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
  //  0  0  0  0
  //  0  0  0  0
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,3,param.X);
+ faceIndexFromCoords<5,1>(face_idx,coord,3,param);
  const int sp_idx = face_idx + param.ghostOffset[3][0];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[3][0];

--- a/lib/dslash_core/dw_fused_exterior_dslash_dagger_core.h
+++ b/lib/dslash_core/dw_fused_exterior_dslash_dagger_core.h
@@ -178,14 +178,9 @@ int sp_norm_idx;
 int sid = ((blockIdx.y*blockDim.y + threadIdx.y)*gridDim.x + blockIdx.x)*blockDim.x + threadIdx.x;
 if (sid >= param.threads*param.Ls) return;
 
-
-int dim; 
+int dim;
 int face_idx;
-int Y[4] = {X1,X2,X3,X4};
-
-
 int x1, x2, x3, x4, xs;
-
 int s_parity;
 
 
@@ -202,16 +197,26 @@ face_idx = sid - face_num*face_volume; // index into the respective face
 // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
 //sp_idx = face_idx + param.ghostOffset[dim];
 
-const int dims[] = {X1, X2, X3, X4};
-coordsFromDWFaceIndex<1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, dim, face_num, param.parity, dims);
-
-{
-  bool active = false;
-  for(int dir=0; dir<4; ++dir){
-    active = active || isActive(dim,dir,+1,x1,x2,x3,x4,param.commDim,param.X);
-  }
-  if(!active) return;
+switch(dim) {
+case 0:
+  coordsFromDWFaceIndex<0,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
+  break;
+case 1:
+  coordsFromDWFaceIndex<1,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
+  break;
+case 2:
+  coordsFromDWFaceIndex<2,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
+  break;
+case 3:
+  coordsFromDWFaceIndex<3,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
+  break;
 }
+
+bool active = false;
+for(int dir=0; dir<4; ++dir){
+  active = active || isActive(dim,dir,+1,x1,x2,x3,x4,param.commDim,param.X);
+}
+if(!active) return;
 
 
 s_parity = ( sid/(X4*X3*X2*X1h) ) % 2;
@@ -273,7 +278,7 @@ if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
  //  0 -i  1  0
  // -i  0  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,0,Y);
+ faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,0,param.X);
  const int sp_idx = face_idx + param.ghostOffset[0][1];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[0][1];
@@ -438,7 +443,7 @@ if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
  //  0  i  1  0
  //  i  0  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,0,Y);
+ faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,0,param.X);
  const int sp_idx = face_idx + param.ghostOffset[0][0];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[0][0];
@@ -603,7 +608,7 @@ if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
  //  0 -1  1  0
  //  1  0  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,1,Y);
+ faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,1,param.X);
  const int sp_idx = face_idx + param.ghostOffset[1][1];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[1][1];
@@ -768,7 +773,7 @@ if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
  //  0  1  1  0
  // -1  0  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,1,Y);
+ faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,1,param.X);
  const int sp_idx = face_idx + param.ghostOffset[1][0];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[1][0];
@@ -933,7 +938,7 @@ if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
  // -i  0  1  0
  //  0  i  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,2,Y);
+ faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,2,param.X);
  const int sp_idx = face_idx + param.ghostOffset[2][1];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[2][1];
@@ -1098,7 +1103,7 @@ if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
  //  i  0  1  0
  //  0 -i  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,2,Y);
+ faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,2,param.X);
  const int sp_idx = face_idx + param.ghostOffset[2][0];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[2][0];
@@ -1263,7 +1268,7 @@ if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
  //  0  0  0  0
  //  0  0  0  0
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,3,Y);
+ faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,3,param.X);
  const int sp_idx = face_idx + param.ghostOffset[3][1];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[3][1];
@@ -1467,7 +1472,7 @@ if (isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
  //  0  0  2  0
  //  0  0  0  2
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,3,Y);
+ faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,3,param.X);
  const int sp_idx = face_idx + param.ghostOffset[3][0];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[3][0];

--- a/lib/dslash_core/dw_fused_exterior_dslash_dagger_core.h
+++ b/lib/dslash_core/dw_fused_exterior_dslash_dagger_core.h
@@ -180,14 +180,15 @@ if (sid >= param.threads*param.Ls) return;
 
 int dim;
 int face_idx;
-int x1, x2, x3, x4, xs;
+int coord[5];
+int X;
 int s_parity;
 
 
 
 { // exterior kernel
 
-dim = dimFromDWFaceIndex(sid, param); // sid is also modified
+dim = dimFromFaceIndex<5>(sid, param); // sid is also modified
 
 const int face_volume = ((param.threadDimMapUpper[dim] - param.threadDimMapLower[dim])*param.Ls >> 1);
 const int face_num = (sid >= face_volume); // is this thread updating face 0 or 1
@@ -199,27 +200,27 @@ face_idx = sid - face_num*face_volume; // index into the respective face
 
 switch(dim) {
 case 0:
-  coordsFromDWFaceIndex<0,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
+  coordsFromFaceIndex<5,QUDA_5D_PC,0,1>(X, sid, coord, face_idx, face_num, param);
   break;
 case 1:
-  coordsFromDWFaceIndex<1,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
+  coordsFromFaceIndex<5,QUDA_5D_PC,1,1>(X, sid, coord, face_idx, face_num, param);
   break;
 case 2:
-  coordsFromDWFaceIndex<2,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
+  coordsFromFaceIndex<5,QUDA_5D_PC,2,1>(X, sid, coord, face_idx, face_num, param);
   break;
 case 3:
-  coordsFromDWFaceIndex<3,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
+  coordsFromFaceIndex<5,QUDA_5D_PC,3,1>(X, sid, coord, face_idx, face_num, param);
   break;
 }
 
 bool active = false;
 for(int dir=0; dir<4; ++dir){
-  active = active || isActive(dim,dir,+1,x1,x2,x3,x4,param.commDim,param.X);
+  active = active || isActive(dim,dir,+1,coord,param.commDim,param.X);
 }
 if(!active) return;
 
 
-s_parity = ( sid/(X4*X3*X2*X1h) ) % 2;
+s_parity = ( sid/param.volume4CB ) % 2;
 
 READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 
@@ -270,7 +271,7 @@ float4 G4;
 
 
 
-if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
+if (isActive(dim,0,+1,coord,param.commDim,param.X) && coord[0]==X1m1 )
 {
  // Projector P0+
  //  1  0  0  i
@@ -278,7 +279,7 @@ if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
  //  0 -i  1  0
  // -i  0  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,0,param.X);
+ faceIndexFromCoords<5,1>(face_idx,coord,0,param);
  const int sp_idx = face_idx + param.ghostOffset[0][1];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[0][1];
@@ -435,7 +436,7 @@ if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
  o32_im -= A2_re;
 }
 
-if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
+if (isActive(dim,0,-1,coord,param.commDim,param.X) && coord[0]==0 )
 {
  // Projector P0-
  //  1  0  0 -i
@@ -443,7 +444,7 @@ if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
  //  0  i  1  0
  //  i  0  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,0,param.X);
+ faceIndexFromCoords<5,1>(face_idx,coord,0,param);
  const int sp_idx = face_idx + param.ghostOffset[0][0];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[0][0];
@@ -600,7 +601,7 @@ if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
  o32_im += A2_re;
 }
 
-if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
+if (isActive(dim,1,+1,coord,param.commDim,param.X) && coord[1]==X2m1 )
 {
  // Projector P1+
  //  1  0  0  1
@@ -608,7 +609,7 @@ if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
  //  0 -1  1  0
  //  1  0  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,1,param.X);
+ faceIndexFromCoords<5,1>(face_idx,coord,1,param);
  const int sp_idx = face_idx + param.ghostOffset[1][1];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[1][1];
@@ -765,7 +766,7 @@ if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
  o32_im += A2_im;
 }
 
-if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
+if (isActive(dim,1,-1,coord,param.commDim,param.X) && coord[1]==0 )
 {
  // Projector P1-
  //  1  0  0 -1
@@ -773,7 +774,7 @@ if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
  //  0  1  1  0
  // -1  0  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,1,param.X);
+ faceIndexFromCoords<5,1>(face_idx,coord,1,param);
  const int sp_idx = face_idx + param.ghostOffset[1][0];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[1][0];
@@ -930,7 +931,7 @@ if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
  o32_im -= A2_im;
 }
 
-if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
+if (isActive(dim,2,+1,coord,param.commDim,param.X) && coord[2]==X3m1 )
 {
  // Projector P2+
  //  1  0  i  0
@@ -938,7 +939,7 @@ if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
  // -i  0  1  0
  //  0  i  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,2,param.X);
+ faceIndexFromCoords<5,1>(face_idx,coord,2,param);
  const int sp_idx = face_idx + param.ghostOffset[2][1];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[2][1];
@@ -1095,7 +1096,7 @@ if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
  o32_im += B2_re;
 }
 
-if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
+if (isActive(dim,2,-1,coord,param.commDim,param.X) && coord[2]==0 )
 {
  // Projector P2-
  //  1  0 -i  0
@@ -1103,7 +1104,7 @@ if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
  //  i  0  1  0
  //  0 -i  0  1
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,2,param.X);
+ faceIndexFromCoords<5,1>(face_idx,coord,2,param);
  const int sp_idx = face_idx + param.ghostOffset[2][0];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[2][0];
@@ -1260,7 +1261,7 @@ if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
  o32_im -= B2_re;
 }
 
-if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
+if (isActive(dim,3,+1,coord,param.commDim,param.X) && coord[3]==X4m1 )
 {
  // Projector P3+
  //  2  0  0  0
@@ -1268,7 +1269,7 @@ if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
  //  0  0  0  0
  //  0  0  0  0
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,3,param.X);
+ faceIndexFromCoords<5,1>(face_idx,coord,3,param);
  const int sp_idx = face_idx + param.ghostOffset[3][1];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[3][1];
@@ -1464,7 +1465,7 @@ if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
  }
 }
 
-if (isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
+if (isActive(dim,3,-1,coord,param.commDim,param.X) && coord[3]==0 )
 {
  // Projector P3-
  //  0  0  0  0
@@ -1472,7 +1473,7 @@ if (isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
  //  0  0  2  0
  //  0  0  0  2
 
- faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs,3,param.X);
+ faceIndexFromCoords<5,1>(face_idx,coord,3,param);
  const int sp_idx = face_idx + param.ghostOffset[3][0];
 #if (DD_PREC==2) // half precision
    sp_norm_idx = face_idx + param.ghostNormOffset[3][0];

--- a/lib/dslash_core/staggered_dslash_core.h
+++ b/lib/dslash_core/staggered_dslash_core.h
@@ -334,7 +334,8 @@ spinorFloat o02_im;
 #define NFACE 1
 #endif
 
-  const int *X = param.X;
+  const auto *X = param.X;
+  const auto *Xh = param.Xh;
   const int& fat_stride = param.gauge_stride;
 #if (DD_IMPROVED == 1)
   const int& long_stride = param.long_gauge_stride;
@@ -374,8 +375,8 @@ spinorFloat o02_im;
 
   if(kernel_type == INTERIOR_KERNEL){
     //data order: X4 X3 X2 X1h
-    za = sid/(X[0]>>1);
-    x0h = sid - za*(X[0]>>1);
+    za = sid/Xh[0];
+    x0h = sid - za*Xh[0];
     zb = za / X[1];
     y[1] = za - zb*X[1];
     y[3] = zb / X[2];
@@ -384,7 +385,7 @@ spinorFloat o02_im;
     y[0] = 2*x0h + x0odd;
     full_idx = 2*sid + x0odd;
   }else{
-    coordsFromFaceIndexStaggered<NFACE,2>(y, sid, param.parity, kernel_type, X);
+    coordsFromFaceIndexStaggered<NFACE,2>(y, sid, param.parity, kernel_type, X, Xh);
     full_idx = ((y[3]*X[2] +y[2])*X[1] +y[1])*X[0]+y[0];
     sid = full_idx>>1;
   }

--- a/lib/dslash_core/staggered_dslash_core.h
+++ b/lib/dslash_core/staggered_dslash_core.h
@@ -373,7 +373,7 @@ spinorFloat o02_im;
   int x0odd;
   int full_idx;
 
-  if(kernel_type == INTERIOR_KERNEL){
+  if (kernel_type == INTERIOR_KERNEL) {
     //data order: X4 X3 X2 X1h
     za = sid/Xh[0];
     x0h = sid - za*Xh[0];
@@ -384,10 +384,8 @@ spinorFloat o02_im;
     x0odd = (y[1] + y[2] + y[3] + param.parity) & 1;
     y[0] = 2*x0h + x0odd;
     full_idx = 2*sid + x0odd;
-  }else{
-    coordsFromFaceIndexStaggered<NFACE,2>(y, sid, param.parity, kernel_type, X, Xh);
-    full_idx = ((y[3]*X[2] +y[2])*X[1] +y[1])*X[0]+y[0];
-    sid = full_idx>>1;
+  } else {
+    coordsFromFaceIndexStaggered<kernel_type,NFACE,2>(y, sid, param);
   }
 
 

--- a/lib/dslash_core/staggered_dslash_core.h
+++ b/lib/dslash_core/staggered_dslash_core.h
@@ -352,7 +352,7 @@ spinorFloat o02_im;
 #endif
 #endif
 
-  int sid = blockIdx.x*blockDim.x + threadIdx.x;
+  int sid = block_idx(param.swizzle)*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
   int src_idx = blockIdx.y*blockDim.y + threadIdx.y;

--- a/lib/dslash_core/staggered_dslash_core.h
+++ b/lib/dslash_core/staggered_dslash_core.h
@@ -386,6 +386,8 @@ spinorFloat o02_im;
     full_idx = 2*sid + x0odd;
   } else {
     coordsFromFaceIndexStaggered<kernel_type,NFACE,2>(y, sid, param);
+    full_idx = ((y[3]*X[2] +y[2])*X[1] +y[1])*X[0]+y[0];
+    sid = full_idx>>1;
   }
 
 

--- a/lib/dslash_core/staggered_fused_exterior_dslash_core.h
+++ b/lib/dslash_core/staggered_fused_exterior_dslash_core.h
@@ -336,7 +336,6 @@ spinorFloat o02_im;
 #endif
 
   const auto *X = param.X;
-  const auto *Xh = param.Xh;
   const int& fat_stride = param.gauge_stride;
 #if (DD_IMPROVED == 1)
   const int& long_stride = param.long_gauge_stride;
@@ -373,13 +372,13 @@ int full_idx=0;
   int dim = dimFromFaceIndex (idx, param);
     
   if(dim == 0){
-    coordsFromFaceIndexStaggered<NFACE,2>(y, idx, param.parity, EXTERIOR_KERNEL_X, X, Xh);
+    coordsFromFaceIndexStaggered<EXTERIOR_KERNEL_X,NFACE,2>(y, idx, param);
   }else if(dim == 1){
-    coordsFromFaceIndexStaggered<NFACE,2>(y, idx, param.parity, EXTERIOR_KERNEL_Y, X, Xh);
+    coordsFromFaceIndexStaggered<EXTERIOR_KERNEL_Y,NFACE,2>(y, idx, param);
   }else if(dim == 2){
-    coordsFromFaceIndexStaggered<NFACE,2>(y, idx, param.parity, EXTERIOR_KERNEL_Z, X, Xh);
+    coordsFromFaceIndexStaggered<EXTERIOR_KERNEL_Z,NFACE,2>(y, idx, param);
   }else if(dim == 3){
-    coordsFromFaceIndexStaggered<NFACE,2>(y, idx, param.parity, EXTERIOR_KERNEL_T, X, Xh);
+    coordsFromFaceIndexStaggered<EXTERIOR_KERNEL_T,NFACE,2>(y, idx, param);
   }
 
   const int half_volume = (X[0]*X[1]*X[2]*X[3] >> 1);

--- a/lib/dslash_core/staggered_fused_exterior_dslash_core.h
+++ b/lib/dslash_core/staggered_fused_exterior_dslash_core.h
@@ -335,7 +335,8 @@ spinorFloat o02_im;
 #define NFACE 1
 #endif
 
-  const int *X = param.X;
+  const auto *X = param.X;
+  const auto *Xh = param.Xh;
   const int& fat_stride = param.gauge_stride;
 #if (DD_IMPROVED == 1)
   const int& long_stride = param.long_gauge_stride;
@@ -372,13 +373,13 @@ int full_idx=0;
   int dim = dimFromFaceIndex (idx, param);
     
   if(dim == 0){
-    coordsFromFaceIndexStaggered<NFACE,2>(y, idx, param.parity, EXTERIOR_KERNEL_X, X);
+    coordsFromFaceIndexStaggered<NFACE,2>(y, idx, param.parity, EXTERIOR_KERNEL_X, X, Xh);
   }else if(dim == 1){
-    coordsFromFaceIndexStaggered<NFACE,2>(y, idx, param.parity, EXTERIOR_KERNEL_Y, X);
+    coordsFromFaceIndexStaggered<NFACE,2>(y, idx, param.parity, EXTERIOR_KERNEL_Y, X, Xh);
   }else if(dim == 2){
-    coordsFromFaceIndexStaggered<NFACE,2>(y, idx, param.parity, EXTERIOR_KERNEL_Z, X);
+    coordsFromFaceIndexStaggered<NFACE,2>(y, idx, param.parity, EXTERIOR_KERNEL_Z, X, Xh);
   }else if(dim == 3){
-    coordsFromFaceIndexStaggered<NFACE,2>(y, idx, param.parity, EXTERIOR_KERNEL_T, X);
+    coordsFromFaceIndexStaggered<NFACE,2>(y, idx, param.parity, EXTERIOR_KERNEL_T, X, Xh);
   }
 
   const int half_volume = (X[0]*X[1]*X[2]*X[3] >> 1);

--- a/lib/dslash_core/staggered_fused_exterior_dslash_core.h
+++ b/lib/dslash_core/staggered_fused_exterior_dslash_core.h
@@ -352,7 +352,7 @@ spinorFloat o02_im;
 #endif
 #endif
 
-  int idx = blockIdx.x*blockDim.x + threadIdx.x;
+  int idx = block_idx(param.swizzle)*blockDim.x + threadIdx.x;
   if(idx >= param.threads) return;
  
   int src_idx = blockIdx.y*blockDim.y + threadIdx.y;

--- a/lib/dslash_core/tm_dslash_dagger_fermi_core.h
+++ b/lib/dslash_core/tm_dslash_dagger_fermi_core.h
@@ -223,9 +223,8 @@ int face_idx;
 if (kernel_type == INTERIOR_KERNEL) {
 #endif
 
-  // Inline by hand for the moment and assume even dimensions
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromIndex3D<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, dims);
+  // Assume even dimensions
+  coordsFromIndex3D<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X);
 
   // only need to check Y and Z dims currently since X and T set to match exactly
   if (x2 >= X2) return;
@@ -250,7 +249,6 @@ if (kernel_type == INTERIOR_KERNEL) {
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  const int dim = static_cast<int>(kernel_type);
   const int face_volume = (param.threads >> 1);           // volume of one face
   const int face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
   face_idx = sid - face_num*face_volume;        // index into the respective face
@@ -259,8 +257,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromFaceIndex<1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, dim, face_num, param.parity, dims);
+  coordsFromFaceIndex<kernel_type,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
 
   READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 

--- a/lib/dslash_core/tm_dslash_dagger_fermi_core.h
+++ b/lib/dslash_core/tm_dslash_dagger_fermi_core.h
@@ -213,7 +213,7 @@ VOLATILE spinorFloat o32_im;
 #include "read_gauge.h"
 #include "io_spinor.h"
 
-int x1, x2, x3, x4;
+int coord[5];
 int X;
 
 int sid;
@@ -224,11 +224,11 @@ if (kernel_type == INTERIOR_KERNEL) {
 #endif
 
   // Assume even dimensions
-  coordsFromIndex3D<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X);
+  coordsFromIndex3D<EVEN_X>(X, coord, sid, param);
 
   // only need to check Y and Z dims currently since X and T set to match exactly
-  if (x2 >= X2) return;
-  if (x3 >= X3) return;
+  if (coord[1] >= param.X[1]) return;
+  if (cpprd[2] >= param.X[2]) return;
 
   o00_re = 0;  o00_im = 0;
   o01_re = 0;  o01_im = 0;
@@ -257,7 +257,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-  coordsFromFaceIndex<kernel_type,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+  coordsFromFaceIndex<4,QUDA_4D_PC,kernel_type,1>(X, sid, coord, face_idx, face_num, param);
 
   READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 
@@ -278,8 +278,8 @@ if (kernel_type == INTERIOR_KERNEL) {
 
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_X && x1==X1m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]<X1m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_X && coord[0]==X1m1) )
 #endif
 {
   // Projector P0+
@@ -289,13 +289,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
   // -i 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x1==X1m1 ? X-X1m1 : X+1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[0]==X1m1 ? X-X1m1 : X+1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x1==X1m1 ? X-X1m1 : X+1) >> 1;
+  const int sp_idx = (coord[0]==X1m1 ? X-X1m1 : X+1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -478,8 +478,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_X && x1==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_X && coord[0]==0) )
 #endif
 {
   // Projector P0-
@@ -489,13 +489,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
   // i 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x1==0 ? X+X1m1 : X-1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[0]==0 ? X+X1m1 : X-1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x1==0 ? X+X1m1 : X-1) >> 1;
+  const int sp_idx = (coord[0]==0 ? X+X1m1 : X-1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -678,8 +678,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_Y && x2==X2m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]<X2m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_Y && coord[1]==X2m1) )
 #endif
 {
   // Projector P1+
@@ -689,13 +689,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
   // 1 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x2==X2m1 ? X-X2X1mX1 : X+X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[1]==X2m1 ? X-X2X1mX1 : X+X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x2==X2m1 ? X-X2X1mX1 : X+X1) >> 1;
+  const int sp_idx = (coord[1]==X2m1 ? X-X2X1mX1 : X+X1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -733,7 +733,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
     b2_im = +i12_im-i22_im;
     } else {
     // load spinor from shared memory
-    int tx = (threadIdx.x + blockDim.x - ((x1+1)&1) ) % blockDim.x;
+    int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1) ) % blockDim.x;
     int ty = (threadIdx.y < blockDim.y - 1) ? threadIdx.y + 1 : 0;
     READ_SPINOR_SHARED(tx, ty, threadIdx.z);
     
@@ -896,8 +896,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_Y && x2==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_Y && coord[1]==0) )
 #endif
 {
   // Projector P1-
@@ -907,13 +907,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
   // -1 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x2==0 ? X+X2X1mX1 : X-X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[1]==0 ? X+X2X1mX1 : X-X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x2==0 ? X+X2X1mX1 : X-X1) >> 1;
+  const int sp_idx = (coord[1]==0 ? X+X2X1mX1 : X-X1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -955,7 +955,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
     b2_im = +i12_im+i22_im;
     } else {
     // load spinor from shared memory
-    int tx = (threadIdx.x + blockDim.x - ((x1+1)&1)) % blockDim.x;
+    int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1)) % blockDim.x;
     int ty = (threadIdx.y > 0) ? threadIdx.y - 1 : blockDim.y - 1;
     READ_SPINOR_SHARED(tx, ty, threadIdx.z);
     
@@ -1118,8 +1118,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_Z && x3==X3m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]<X3m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_Z && coord[2]==X3m1) )
 #endif
 {
   // Projector P2+
@@ -1129,13 +1129,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
   // 0 i 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x3==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[2]==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x3==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1;
+  const int sp_idx = (coord[2]==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -1173,7 +1173,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
     b2_im = +i12_im-i32_re;
     } else {
     // load spinor from shared memory
-    int tx = (threadIdx.x + blockDim.x - ((x1+1)&1) ) % blockDim.x;
+    int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1) ) % blockDim.x;
     int tz = (threadIdx.z < blockDim.z - 1) ? threadIdx.z + 1 : 0;
     READ_SPINOR_SHARED(tx, threadIdx.y, tz);
     
@@ -1336,8 +1336,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_Z && x3==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_Z && coord[2]==0) )
 #endif
 {
   // Projector P2-
@@ -1347,13 +1347,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
   // 0 -i 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x3==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[2]==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x3==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1;
+  const int sp_idx = (coord[2]==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -1395,7 +1395,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
     b2_im = +i12_im+i32_re;
     } else {
     // load spinor from shared memory
-    int tx = (threadIdx.x + blockDim.x - ((x1+1)&1)) % blockDim.x;
+    int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1)) % blockDim.x;
     int tz = (threadIdx.z > 0) ? threadIdx.z - 1 : blockDim.z - 1;
     READ_SPINOR_SHARED(tx, threadIdx.y, tz);
     
@@ -1558,8 +1558,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_T && x4==X4m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]<X4m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_T && coord[3]==X4m1) )
 #endif
 {
   // Projector P3+
@@ -1569,13 +1569,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
   // 0 0 0 0 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x4==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[3]==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x4==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1;
+  const int sp_idx = (coord[3]==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -1843,8 +1843,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_T && x4==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_T && coord[3]==0) )
 #endif
 {
   // Projector P3-
@@ -1854,13 +1854,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4>0)) ||
   // 0 0 0 2 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x4==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[3]==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x4==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1;
+  const int sp_idx = (coord[3]==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -2137,13 +2137,13 @@ int incomplete = 0; // Have all 8 contributions been computed for this site?
 
 switch(kernel_type) { // intentional fall-through
 case INTERIOR_KERNEL:
-  incomplete = incomplete || (param.commDim[3] && (x4==0 || x4==X4m1));
+  incomplete = incomplete || (param.commDim[3] && (coord[3]==0 || coord[3]==X4m1));
 case EXTERIOR_KERNEL_T:
-  incomplete = incomplete || (param.commDim[2] && (x3==0 || x3==X3m1));
+  incomplete = incomplete || (param.commDim[2] && (coord[2]==0 || coord[2]==X3m1));
 case EXTERIOR_KERNEL_Z:
-  incomplete = incomplete || (param.commDim[1] && (x2==0 || x2==X2m1));
+  incomplete = incomplete || (param.commDim[1] && (coord[1]==0 || coord[1]==X2m1));
 case EXTERIOR_KERNEL_Y:
-  incomplete = incomplete || (param.commDim[0] && (x1==0 || x1==X1m1));
+  incomplete = incomplete || (param.commDim[0] && (coord[0]==0 || coord[0]==X1m1));
 }
 
 if (!incomplete)

--- a/lib/dslash_core/tm_dslash_dagger_gt200_core.h
+++ b/lib/dslash_core/tm_dslash_dagger_gt200_core.h
@@ -216,9 +216,8 @@ if (kernel_type == INTERIOR_KERNEL) {
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  // Inline by hand for the moment and assume even dimensions
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromIndex<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, dims, param.block, param.grid);
+  // Assume even dimensions
+  coordsFromIndex<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X, param.block, param.grid);
 
   o00_re = 0;  o00_im = 0;
   o01_re = 0;  o01_im = 0;
@@ -239,7 +238,6 @@ if (kernel_type == INTERIOR_KERNEL) {
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  const int dim = static_cast<int>(kernel_type);
   const int face_volume = (param.threads >> 1);           // volume of one face
   const int face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
   face_idx = sid - face_num*face_volume;        // index into the respective face
@@ -248,8 +246,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromFaceIndex<1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, dim, face_num, param.parity, dims);
+  coordsFromFaceIndex<kernel_type,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
 
   READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 

--- a/lib/dslash_core/tm_dslash_dagger_gt200_core.h
+++ b/lib/dslash_core/tm_dslash_dagger_gt200_core.h
@@ -203,7 +203,7 @@ VOLATILE spinorFloat o32_im;
 #include "read_gauge.h"
 #include "io_spinor.h"
 
-int x1, x2, x3, x4;
+int coord[5];
 int X;
 
 int sid;
@@ -217,7 +217,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   if (sid >= param.threads) return;
 
   // Assume even dimensions
-  coordsFromIndex<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X, param.block, param.grid);
+  coordsFromIndex<4,QUDA_4D_PC,EVEN_X>(X, coord, sid, param);
 
   o00_re = 0;  o00_im = 0;
   o01_re = 0;  o01_im = 0;
@@ -246,7 +246,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-  coordsFromFaceIndex<kernel_type,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+  coordsFromFaceIndex<4,QUDA_4D_PC,kernel_type,1>(X, sid, coord, face_idx, face_num, param);
 
   READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 
@@ -267,8 +267,8 @@ if (kernel_type == INTERIOR_KERNEL) {
 
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_X && x1==X1m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]<X1m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_X && coord[0]==X1m1) )
 #endif
 {
   // Projector P0+
@@ -278,13 +278,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
   // -i 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x1==X1m1 ? X-X1m1 : X+1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[0]==X1m1 ? X-X1m1 : X+1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x1==X1m1 ? X-X1m1 : X+1) >> 1;
+  const int sp_idx = (coord[0]==X1m1 ? X-X1m1 : X+1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -464,8 +464,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_X && x1==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_X && coord[0]==0) )
 #endif
 {
   // Projector P0-
@@ -475,13 +475,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
   // i 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x1==0 ? X+X1m1 : X-1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[0]==0 ? X+X1m1 : X-1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x1==0 ? X+X1m1 : X-1) >> 1;
+  const int sp_idx = (coord[0]==0 ? X+X1m1 : X-1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -665,8 +665,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_Y && x2==X2m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]<X2m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_Y && coord[1]==X2m1) )
 #endif
 {
   // Projector P1+
@@ -676,13 +676,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
   // 1 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x2==X2m1 ? X-X2X1mX1 : X+X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[1]==X2m1 ? X-X2X1mX1 : X+X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x2==X2m1 ? X-X2X1mX1 : X+X1) >> 1;
+  const int sp_idx = (coord[1]==X2m1 ? X-X2X1mX1 : X+X1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -862,8 +862,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_Y && x2==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_Y && coord[1]==0) )
 #endif
 {
   // Projector P1-
@@ -873,13 +873,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
   // -1 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x2==0 ? X+X2X1mX1 : X-X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[1]==0 ? X+X2X1mX1 : X-X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x2==0 ? X+X2X1mX1 : X-X1) >> 1;
+  const int sp_idx = (coord[1]==0 ? X+X2X1mX1 : X-X1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -1063,8 +1063,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_Z && x3==X3m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]<X3m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_Z && coord[2]==X3m1) )
 #endif
 {
   // Projector P2+
@@ -1074,13 +1074,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
   // 0 i 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x3==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[2]==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x3==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1;
+  const int sp_idx = (coord[2]==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -1260,8 +1260,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_Z && x3==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_Z && coord[2]==0) )
 #endif
 {
   // Projector P2-
@@ -1271,13 +1271,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
   // 0 -i 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x3==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[2]==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x3==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1;
+  const int sp_idx = (coord[2]==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -1461,8 +1461,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_T && x4==X4m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]<X4m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_T && coord[3]==X4m1) )
 #endif
 {
   // Projector P3+
@@ -1472,13 +1472,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
   // 0 0 0 0 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x4==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[3]==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x4==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1;
+  const int sp_idx = (coord[3]==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -1746,8 +1746,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_T && x4==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_T && coord[3]==0) )
 #endif
 {
   // Projector P3-
@@ -1757,13 +1757,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4>0)) ||
   // 0 0 0 2 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x4==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[3]==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x4==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1;
+  const int sp_idx = (coord[3]==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -2040,13 +2040,13 @@ int incomplete = 0; // Have all 8 contributions been computed for this site?
 
 switch(kernel_type) { // intentional fall-through
 case INTERIOR_KERNEL:
-  incomplete = incomplete || (param.commDim[3] && (x4==0 || x4==X4m1));
+  incomplete = incomplete || (param.commDim[3] && (coord[3]==0 || coord[3]==X4m1));
 case EXTERIOR_KERNEL_T:
-  incomplete = incomplete || (param.commDim[2] && (x3==0 || x3==X3m1));
+  incomplete = incomplete || (param.commDim[2] && (coord[2]==0 || coord[2]==X3m1));
 case EXTERIOR_KERNEL_Z:
-  incomplete = incomplete || (param.commDim[1] && (x2==0 || x2==X2m1));
+  incomplete = incomplete || (param.commDim[1] && (coord[1]==0 || coord[1]==X2m1));
 case EXTERIOR_KERNEL_Y:
-  incomplete = incomplete || (param.commDim[0] && (x1==0 || x1==X1m1));
+  incomplete = incomplete || (param.commDim[0] && (coord[0]==0 || coord[0]==X1m1));
 }
 
 if (!incomplete)

--- a/lib/dslash_core/tm_dslash_fermi_core.h
+++ b/lib/dslash_core/tm_dslash_fermi_core.h
@@ -213,7 +213,7 @@ VOLATILE spinorFloat o32_im;
 #include "read_gauge.h"
 #include "io_spinor.h"
 
-int x1, x2, x3, x4;
+int coord[5];
 int X;
 
 int sid;
@@ -224,11 +224,11 @@ if (kernel_type == INTERIOR_KERNEL) {
 #endif
 
   // Assume even dimensions
-  coordsFromIndex3D<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X);
+  coordsFromIndex3D<EVEN_X>(X, coord, sid, param);
 
   // only need to check Y and Z dims currently since X and T set to match exactly
-  if (x2 >= X2) return;
-  if (x3 >= X3) return;
+  if (coord[1] >= param.X[1]) return;
+  if (cpprd[2] >= param.X[2]) return;
 
   o00_re = 0;  o00_im = 0;
   o01_re = 0;  o01_im = 0;
@@ -257,7 +257,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-  coordsFromFaceIndex<kernel_type,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+  coordsFromFaceIndex<4,QUDA_4D_PC,kernel_type,1>(X, sid, coord, face_idx, face_num, param);
 
   READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 
@@ -278,8 +278,8 @@ if (kernel_type == INTERIOR_KERNEL) {
 
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_X && x1==X1m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]<X1m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_X && coord[0]==X1m1) )
 #endif
 {
   // Projector P0-
@@ -289,13 +289,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
   // i 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x1==X1m1 ? X-X1m1 : X+1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[0]==X1m1 ? X-X1m1 : X+1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x1==X1m1 ? X-X1m1 : X+1) >> 1;
+  const int sp_idx = (coord[0]==X1m1 ? X-X1m1 : X+1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -478,8 +478,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_X && x1==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_X && coord[0]==0) )
 #endif
 {
   // Projector P0+
@@ -489,13 +489,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
   // -i 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x1==0 ? X+X1m1 : X-1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[0]==0 ? X+X1m1 : X-1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x1==0 ? X+X1m1 : X-1) >> 1;
+  const int sp_idx = (coord[0]==0 ? X+X1m1 : X-1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -678,8 +678,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_Y && x2==X2m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]<X2m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_Y && coord[1]==X2m1) )
 #endif
 {
   // Projector P1-
@@ -689,13 +689,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
   // -1 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x2==X2m1 ? X-X2X1mX1 : X+X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[1]==X2m1 ? X-X2X1mX1 : X+X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x2==X2m1 ? X-X2X1mX1 : X+X1) >> 1;
+  const int sp_idx = (coord[1]==X2m1 ? X-X2X1mX1 : X+X1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -733,7 +733,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
     b2_im = +i12_im+i22_im;
     } else {
     // load spinor from shared memory
-    int tx = (threadIdx.x + blockDim.x - ((x1+1)&1) ) % blockDim.x;
+    int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1) ) % blockDim.x;
     int ty = (threadIdx.y < blockDim.y - 1) ? threadIdx.y + 1 : 0;
     READ_SPINOR_SHARED(tx, ty, threadIdx.z);
     
@@ -896,8 +896,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_Y && x2==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_Y && coord[1]==0) )
 #endif
 {
   // Projector P1+
@@ -907,13 +907,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
   // 1 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x2==0 ? X+X2X1mX1 : X-X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[1]==0 ? X+X2X1mX1 : X-X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x2==0 ? X+X2X1mX1 : X-X1) >> 1;
+  const int sp_idx = (coord[1]==0 ? X+X2X1mX1 : X-X1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -955,7 +955,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
     b2_im = +i12_im-i22_im;
     } else {
     // load spinor from shared memory
-    int tx = (threadIdx.x + blockDim.x - ((x1+1)&1)) % blockDim.x;
+    int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1)) % blockDim.x;
     int ty = (threadIdx.y > 0) ? threadIdx.y - 1 : blockDim.y - 1;
     READ_SPINOR_SHARED(tx, ty, threadIdx.z);
     
@@ -1118,8 +1118,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_Z && x3==X3m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]<X3m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_Z && coord[2]==X3m1) )
 #endif
 {
   // Projector P2-
@@ -1129,13 +1129,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
   // 0 -i 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x3==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[2]==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x3==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1;
+  const int sp_idx = (coord[2]==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -1173,7 +1173,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
     b2_im = +i12_im+i32_re;
     } else {
     // load spinor from shared memory
-    int tx = (threadIdx.x + blockDim.x - ((x1+1)&1) ) % blockDim.x;
+    int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1) ) % blockDim.x;
     int tz = (threadIdx.z < blockDim.z - 1) ? threadIdx.z + 1 : 0;
     READ_SPINOR_SHARED(tx, threadIdx.y, tz);
     
@@ -1336,8 +1336,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_Z && x3==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_Z && coord[2]==0) )
 #endif
 {
   // Projector P2+
@@ -1347,13 +1347,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
   // 0 i 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x3==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[2]==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x3==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1;
+  const int sp_idx = (coord[2]==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -1395,7 +1395,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
     b2_im = +i12_im-i32_re;
     } else {
     // load spinor from shared memory
-    int tx = (threadIdx.x + blockDim.x - ((x1+1)&1)) % blockDim.x;
+    int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1)) % blockDim.x;
     int tz = (threadIdx.z > 0) ? threadIdx.z - 1 : blockDim.z - 1;
     READ_SPINOR_SHARED(tx, threadIdx.y, tz);
     
@@ -1558,8 +1558,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_T && x4==X4m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]<X4m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_T && coord[3]==X4m1) )
 #endif
 {
   // Projector P3-
@@ -1569,13 +1569,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
   // 0 0 0 2 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x4==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[3]==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x4==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1;
+  const int sp_idx = (coord[3]==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -1843,8 +1843,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_T && x4==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_T && coord[3]==0) )
 #endif
 {
   // Projector P3+
@@ -1854,13 +1854,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4>0)) ||
   // 0 0 0 0 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x4==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[3]==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x4==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1;
+  const int sp_idx = (coord[3]==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -2137,13 +2137,13 @@ int incomplete = 0; // Have all 8 contributions been computed for this site?
 
 switch(kernel_type) { // intentional fall-through
 case INTERIOR_KERNEL:
-  incomplete = incomplete || (param.commDim[3] && (x4==0 || x4==X4m1));
+  incomplete = incomplete || (param.commDim[3] && (coord[3]==0 || coord[3]==X4m1));
 case EXTERIOR_KERNEL_T:
-  incomplete = incomplete || (param.commDim[2] && (x3==0 || x3==X3m1));
+  incomplete = incomplete || (param.commDim[2] && (coord[2]==0 || coord[2]==X3m1));
 case EXTERIOR_KERNEL_Z:
-  incomplete = incomplete || (param.commDim[1] && (x2==0 || x2==X2m1));
+  incomplete = incomplete || (param.commDim[1] && (coord[1]==0 || coord[1]==X2m1));
 case EXTERIOR_KERNEL_Y:
-  incomplete = incomplete || (param.commDim[0] && (x1==0 || x1==X1m1));
+  incomplete = incomplete || (param.commDim[0] && (coord[0]==0 || coord[0]==X1m1));
 }
 
 if (!incomplete)

--- a/lib/dslash_core/tm_dslash_fermi_core.h
+++ b/lib/dslash_core/tm_dslash_fermi_core.h
@@ -223,9 +223,8 @@ int face_idx;
 if (kernel_type == INTERIOR_KERNEL) {
 #endif
 
-  // Inline by hand for the moment and assume even dimensions
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromIndex3D<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, dims);
+  // Assume even dimensions
+  coordsFromIndex3D<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X);
 
   // only need to check Y and Z dims currently since X and T set to match exactly
   if (x2 >= X2) return;
@@ -250,7 +249,6 @@ if (kernel_type == INTERIOR_KERNEL) {
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  const int dim = static_cast<int>(kernel_type);
   const int face_volume = (param.threads >> 1);           // volume of one face
   const int face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
   face_idx = sid - face_num*face_volume;        // index into the respective face
@@ -259,8 +257,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromFaceIndex<1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, dim, face_num, param.parity, dims);
+  coordsFromFaceIndex<kernel_type,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
 
   READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 

--- a/lib/dslash_core/tm_dslash_gt200_core.h
+++ b/lib/dslash_core/tm_dslash_gt200_core.h
@@ -203,7 +203,7 @@ VOLATILE spinorFloat o32_im;
 #include "read_gauge.h"
 #include "io_spinor.h"
 
-int x1, x2, x3, x4;
+int coord[5];
 int X;
 
 int sid;
@@ -217,7 +217,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   if (sid >= param.threads) return;
 
   // Assume even dimensions
-  coordsFromIndex<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X, param.block, param.grid);
+  coordsFromIndex<4,QUDA_4D_PC,EVEN_X>(X, coord, sid, param);
 
   o00_re = 0;  o00_im = 0;
   o01_re = 0;  o01_im = 0;
@@ -246,7 +246,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-  coordsFromFaceIndex<kernel_type,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+  coordsFromFaceIndex<4,QUDA_4D_PC,kernel_type,1>(X, sid, coord, face_idx, face_num, param);
 
   READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 
@@ -267,8 +267,8 @@ if (kernel_type == INTERIOR_KERNEL) {
 
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_X && x1==X1m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]<X1m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_X && coord[0]==X1m1) )
 #endif
 {
   // Projector P0-
@@ -278,13 +278,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
   // i 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x1==X1m1 ? X-X1m1 : X+1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[0]==X1m1 ? X-X1m1 : X+1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x1==X1m1 ? X-X1m1 : X+1) >> 1;
+  const int sp_idx = (coord[0]==X1m1 ? X-X1m1 : X+1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -464,8 +464,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_X && x1==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_X && coord[0]==0) )
 #endif
 {
   // Projector P0+
@@ -475,13 +475,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
   // -i 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x1==0 ? X+X1m1 : X-1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[0]==0 ? X+X1m1 : X-1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x1==0 ? X+X1m1 : X-1) >> 1;
+  const int sp_idx = (coord[0]==0 ? X+X1m1 : X-1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -665,8 +665,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_Y && x2==X2m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]<X2m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_Y && coord[1]==X2m1) )
 #endif
 {
   // Projector P1-
@@ -676,13 +676,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
   // -1 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x2==X2m1 ? X-X2X1mX1 : X+X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[1]==X2m1 ? X-X2X1mX1 : X+X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x2==X2m1 ? X-X2X1mX1 : X+X1) >> 1;
+  const int sp_idx = (coord[1]==X2m1 ? X-X2X1mX1 : X+X1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -862,8 +862,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_Y && x2==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_Y && coord[1]==0) )
 #endif
 {
   // Projector P1+
@@ -873,13 +873,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
   // 1 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x2==0 ? X+X2X1mX1 : X-X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[1]==0 ? X+X2X1mX1 : X-X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x2==0 ? X+X2X1mX1 : X-X1) >> 1;
+  const int sp_idx = (coord[1]==0 ? X+X2X1mX1 : X-X1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -1063,8 +1063,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_Z && x3==X3m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]<X3m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_Z && coord[2]==X3m1) )
 #endif
 {
   // Projector P2-
@@ -1074,13 +1074,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
   // 0 -i 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x3==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[2]==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x3==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1;
+  const int sp_idx = (coord[2]==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -1260,8 +1260,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_Z && x3==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_Z && coord[2]==0) )
 #endif
 {
   // Projector P2+
@@ -1271,13 +1271,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
   // 0 i 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x3==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[2]==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x3==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1;
+  const int sp_idx = (coord[2]==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -1461,8 +1461,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_T && x4==X4m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]<X4m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_T && coord[3]==X4m1) )
 #endif
 {
   // Projector P3-
@@ -1472,13 +1472,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
   // 0 0 0 2 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x4==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[3]==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x4==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1;
+  const int sp_idx = (coord[3]==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -1746,8 +1746,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_T && x4==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_T && coord[3]==0) )
 #endif
 {
   // Projector P3+
@@ -1757,13 +1757,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4>0)) ||
   // 0 0 0 0 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x4==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[3]==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x4==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1;
+  const int sp_idx = (coord[3]==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -2040,13 +2040,13 @@ int incomplete = 0; // Have all 8 contributions been computed for this site?
 
 switch(kernel_type) { // intentional fall-through
 case INTERIOR_KERNEL:
-  incomplete = incomplete || (param.commDim[3] && (x4==0 || x4==X4m1));
+  incomplete = incomplete || (param.commDim[3] && (coord[3]==0 || coord[3]==X4m1));
 case EXTERIOR_KERNEL_T:
-  incomplete = incomplete || (param.commDim[2] && (x3==0 || x3==X3m1));
+  incomplete = incomplete || (param.commDim[2] && (coord[2]==0 || coord[2]==X3m1));
 case EXTERIOR_KERNEL_Z:
-  incomplete = incomplete || (param.commDim[1] && (x2==0 || x2==X2m1));
+  incomplete = incomplete || (param.commDim[1] && (coord[1]==0 || coord[1]==X2m1));
 case EXTERIOR_KERNEL_Y:
-  incomplete = incomplete || (param.commDim[0] && (x1==0 || x1==X1m1));
+  incomplete = incomplete || (param.commDim[0] && (coord[0]==0 || coord[0]==X1m1));
 }
 
 if (!incomplete)

--- a/lib/dslash_core/tm_dslash_gt200_core.h
+++ b/lib/dslash_core/tm_dslash_gt200_core.h
@@ -216,9 +216,8 @@ if (kernel_type == INTERIOR_KERNEL) {
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  // Inline by hand for the moment and assume even dimensions
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromIndex<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, dims, param.block, param.grid);
+  // Assume even dimensions
+  coordsFromIndex<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X, param.block, param.grid);
 
   o00_re = 0;  o00_im = 0;
   o01_re = 0;  o01_im = 0;
@@ -239,7 +238,6 @@ if (kernel_type == INTERIOR_KERNEL) {
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  const int dim = static_cast<int>(kernel_type);
   const int face_volume = (param.threads >> 1);           // volume of one face
   const int face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
   face_idx = sid - face_num*face_volume;        // index into the respective face
@@ -248,8 +246,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromFaceIndex<1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, dim, face_num, param.parity, dims);
+  coordsFromFaceIndex<kernel_type,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
 
   READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 

--- a/lib/dslash_core/tm_fused_exterior_dslash_dagger_fermi_core.h
+++ b/lib/dslash_core/tm_fused_exterior_dslash_dagger_fermi_core.h
@@ -224,23 +224,31 @@ int sp_norm_idx;
 
 int sid;
 
-int dim;
-int face_idx;
-int Y[4] = {X1,X2,X3,X4};
-
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
 
-  dim = dimFromFaceIndex(sid, param); // sid is also modified
+  int dim = dimFromFaceIndex(sid, param); // sid is also modified
 
   const int face_volume = ((param.threadDimMapUpper[dim] - param.threadDimMapLower[dim]) >> 1);
   const int face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
-  face_idx = sid - face_num*face_volume;        // index into the respective face
+  int face_idx = sid - face_num*face_volume;        // index into the respective face
 
+  switch(dim) {
+  case 0:
+    coordsFromFaceIndex<0,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 1:
+    coordsFromFaceIndex<1,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 2:
+    coordsFromFaceIndex<2,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 3:
+    coordsFromFaceIndex<3,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  }
 
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromFaceIndex<1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, dim, face_num, param.parity, dims);
 
   bool active = false;
   for(int dir=0; dir<4; ++dir){
@@ -271,7 +279,7 @@ if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   // 0 -i 1 0 
   // -i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
   const int sp_idx = face_idx + param.ghostOffset[0][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][1];
@@ -432,7 +440,7 @@ if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   // 0 i 1 0 
   // i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
   const int sp_idx = face_idx + param.ghostOffset[0][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][0];
@@ -593,7 +601,7 @@ if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   // 0 -1 1 0 
   // 1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
   const int sp_idx = face_idx + param.ghostOffset[1][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][1];
@@ -754,7 +762,7 @@ if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   // 0 1 1 0 
   // -1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
   const int sp_idx = face_idx + param.ghostOffset[1][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][0];
@@ -915,7 +923,7 @@ if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   // -i 0 1 0 
   // 0 i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
   const int sp_idx = face_idx + param.ghostOffset[2][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][1];
@@ -1076,7 +1084,7 @@ if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   // i 0 1 0 
   // 0 -i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
   const int sp_idx = face_idx + param.ghostOffset[2][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][0];
@@ -1237,7 +1245,7 @@ if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   // 0 0 0 0 
   // 0 0 0 0 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
   const int sp_idx = face_idx + param.ghostOffset[3][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][1];
@@ -1453,7 +1461,7 @@ if (isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
   // 0 0 2 0 
   // 0 0 0 2 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
   const int sp_idx = face_idx + param.ghostOffset[3][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][0];

--- a/lib/dslash_core/tm_fused_exterior_dslash_dagger_fermi_core.h
+++ b/lib/dslash_core/tm_fused_exterior_dslash_dagger_fermi_core.h
@@ -215,7 +215,7 @@ VOLATILE spinorFloat o32_im;
 #include "read_gauge.h"
 #include "io_spinor.h"
 
-int x1, x2, x3, x4;
+int coord[5];
 int X;
 
 #if (DD_PREC==2) // half precision
@@ -236,23 +236,23 @@ int sid;
 
   switch(dim) {
   case 0:
-    coordsFromFaceIndex<0,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,0,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 1:
-    coordsFromFaceIndex<1,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,1,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 2:
-    coordsFromFaceIndex<2,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,2,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 3:
-    coordsFromFaceIndex<3,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,3,1>(X, sid, coord, face_idx, face_num, param);
     break;
   }
 
 
   bool active = false;
   for(int dir=0; dir<4; ++dir){
-    active = active || isActive(dim,dir,+1,x1,x2,x3,x4,param.commDim,param.X);
+    active = active || isActive(dim,dir,+1,coord,param.commDim,param.X);
   }
   if(!active) return;
 
@@ -271,7 +271,7 @@ int sid;
   o30_re = i30_re;  o30_im = i30_im;
   o31_re = i31_re;  o31_im = i31_im;
   o32_re = i32_re;  o32_im = i32_im;
-if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
+if (isActive(dim,0,+1,coord,param.commDim,param.X) && coord[0]==X1m1 )
 {
   // Projector P0+
   // 1 0 0 i 
@@ -279,7 +279,7 @@ if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   // 0 -i 1 0 
   // -i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,0,param);
   const int sp_idx = face_idx + param.ghostOffset[0][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][1];
@@ -432,7 +432,7 @@ if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   
 }
 
-if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
+if (isActive(dim,0,-1,coord,param.commDim,param.X) && coord[0]==0 )
 {
   // Projector P0-
   // 1 0 0 -i 
@@ -440,7 +440,7 @@ if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   // 0 i 1 0 
   // i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,0,param);
   const int sp_idx = face_idx + param.ghostOffset[0][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][0];
@@ -593,7 +593,7 @@ if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   
 }
 
-if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
+if (isActive(dim,1,+1,coord,param.commDim,param.X) && coord[1]==X2m1 )
 {
   // Projector P1+
   // 1 0 0 1 
@@ -601,7 +601,7 @@ if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   // 0 -1 1 0 
   // 1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,1,param);
   const int sp_idx = face_idx + param.ghostOffset[1][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][1];
@@ -754,7 +754,7 @@ if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   
 }
 
-if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
+if (isActive(dim,1,-1,coord,param.commDim,param.X) && coord[1]==0 )
 {
   // Projector P1-
   // 1 0 0 -1 
@@ -762,7 +762,7 @@ if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   // 0 1 1 0 
   // -1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,1,param);
   const int sp_idx = face_idx + param.ghostOffset[1][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][0];
@@ -915,7 +915,7 @@ if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   
 }
 
-if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
+if (isActive(dim,2,+1,coord,param.commDim,param.X) && coord[2]==X3m1 )
 {
   // Projector P2+
   // 1 0 i 0 
@@ -923,7 +923,7 @@ if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   // -i 0 1 0 
   // 0 i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,2,param);
   const int sp_idx = face_idx + param.ghostOffset[2][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][1];
@@ -1076,7 +1076,7 @@ if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   
 }
 
-if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
+if (isActive(dim,2,-1,coord,param.commDim,param.X) && coord[2]==0 )
 {
   // Projector P2-
   // 1 0 -i 0 
@@ -1084,7 +1084,7 @@ if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   // i 0 1 0 
   // 0 -i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,2,param);
   const int sp_idx = face_idx + param.ghostOffset[2][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][0];
@@ -1237,7 +1237,7 @@ if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   
 }
 
-if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
+if (isActive(dim,3,+1,coord,param.commDim,param.X) && coord[3]==X4m1 )
 {
   // Projector P3+
   // 2 0 0 0 
@@ -1245,7 +1245,7 @@ if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   // 0 0 0 0 
   // 0 0 0 0 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,3,param);
   const int sp_idx = face_idx + param.ghostOffset[3][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][1];
@@ -1453,7 +1453,7 @@ if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   }
 }
 
-if (isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
+if (isActive(dim,3,-1,coord,param.commDim,param.X) && coord[3]==0 )
 {
   // Projector P3-
   // 0 0 0 0 
@@ -1461,7 +1461,7 @@ if (isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
   // 0 0 2 0 
   // 0 0 0 2 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,3,param);
   const int sp_idx = face_idx + param.ghostOffset[3][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][0];

--- a/lib/dslash_core/tm_fused_exterior_dslash_dagger_gt200_core.h
+++ b/lib/dslash_core/tm_fused_exterior_dslash_dagger_gt200_core.h
@@ -205,7 +205,7 @@ VOLATILE spinorFloat o32_im;
 #include "read_gauge.h"
 #include "io_spinor.h"
 
-int x1, x2, x3, x4;
+int coord[5];
 int X;
 
 #if (DD_PREC==2) // half precision
@@ -226,23 +226,23 @@ int sid;
 
   switch(dim) {
   case 0:
-    coordsFromFaceIndex<0,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,0,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 1:
-    coordsFromFaceIndex<1,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,1,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 2:
-    coordsFromFaceIndex<2,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,2,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 3:
-    coordsFromFaceIndex<3,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,3,1>(X, sid, coord, face_idx, face_num, param);
     break;
   }
 
 
   bool active = false;
   for(int dir=0; dir<4; ++dir){
-    active = active || isActive(dim,dir,+1,x1,x2,x3,x4,param.commDim,param.X);
+    active = active || isActive(dim,dir,+1,coord,param.commDim,param.X);
   }
   if(!active) return;
 
@@ -261,7 +261,7 @@ int sid;
   o30_re = i30_re;  o30_im = i30_im;
   o31_re = i31_re;  o31_im = i31_im;
   o32_re = i32_re;  o32_im = i32_im;
-if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
+if (isActive(dim,0,+1,coord,param.commDim,param.X) && coord[0]==X1m1 )
 {
   // Projector P0+
   // 1 0 0 i 
@@ -269,7 +269,7 @@ if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   // 0 -i 1 0 
   // -i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,0,param);
   const int sp_idx = face_idx + param.ghostOffset[0][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][1];
@@ -422,7 +422,7 @@ if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   
 }
 
-if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
+if (isActive(dim,0,-1,coord,param.commDim,param.X) && coord[0]==0 )
 {
   // Projector P0-
   // 1 0 0 -i 
@@ -430,7 +430,7 @@ if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   // 0 i 1 0 
   // i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,0,param);
   const int sp_idx = face_idx + param.ghostOffset[0][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][0];
@@ -583,7 +583,7 @@ if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   
 }
 
-if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
+if (isActive(dim,1,+1,coord,param.commDim,param.X) && coord[1]==X2m1 )
 {
   // Projector P1+
   // 1 0 0 1 
@@ -591,7 +591,7 @@ if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   // 0 -1 1 0 
   // 1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,1,param);
   const int sp_idx = face_idx + param.ghostOffset[1][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][1];
@@ -744,7 +744,7 @@ if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   
 }
 
-if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
+if (isActive(dim,1,-1,coord,param.commDim,param.X) && coord[1]==0 )
 {
   // Projector P1-
   // 1 0 0 -1 
@@ -752,7 +752,7 @@ if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   // 0 1 1 0 
   // -1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,1,param);
   const int sp_idx = face_idx + param.ghostOffset[1][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][0];
@@ -905,7 +905,7 @@ if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   
 }
 
-if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
+if (isActive(dim,2,+1,coord,param.commDim,param.X) && coord[2]==X3m1 )
 {
   // Projector P2+
   // 1 0 i 0 
@@ -913,7 +913,7 @@ if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   // -i 0 1 0 
   // 0 i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,2,param);
   const int sp_idx = face_idx + param.ghostOffset[2][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][1];
@@ -1066,7 +1066,7 @@ if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   
 }
 
-if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
+if (isActive(dim,2,-1,coord,param.commDim,param.X) && coord[2]==0 )
 {
   // Projector P2-
   // 1 0 -i 0 
@@ -1074,7 +1074,7 @@ if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   // i 0 1 0 
   // 0 -i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,2,param);
   const int sp_idx = face_idx + param.ghostOffset[2][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][0];
@@ -1227,7 +1227,7 @@ if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   
 }
 
-if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
+if (isActive(dim,3,+1,coord,param.commDim,param.X) && coord[3]==X4m1 )
 {
   // Projector P3+
   // 2 0 0 0 
@@ -1235,7 +1235,7 @@ if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   // 0 0 0 0 
   // 0 0 0 0 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,3,param);
   const int sp_idx = face_idx + param.ghostOffset[3][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][1];
@@ -1443,7 +1443,7 @@ if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   }
 }
 
-if (isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
+if (isActive(dim,3,-1,coord,param.commDim,param.X) && coord[3]==0 )
 {
   // Projector P3-
   // 0 0 0 0 
@@ -1451,7 +1451,7 @@ if (isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
   // 0 0 2 0 
   // 0 0 0 2 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,3,param);
   const int sp_idx = face_idx + param.ghostOffset[3][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][0];

--- a/lib/dslash_core/tm_fused_exterior_dslash_dagger_gt200_core.h
+++ b/lib/dslash_core/tm_fused_exterior_dslash_dagger_gt200_core.h
@@ -214,23 +214,31 @@ int sp_norm_idx;
 
 int sid;
 
-int dim;
-int face_idx;
-int Y[4] = {X1,X2,X3,X4};
-
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
 
-  dim = dimFromFaceIndex(sid, param); // sid is also modified
+  int dim = dimFromFaceIndex(sid, param); // sid is also modified
 
   const int face_volume = ((param.threadDimMapUpper[dim] - param.threadDimMapLower[dim]) >> 1);
   const int face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
-  face_idx = sid - face_num*face_volume;        // index into the respective face
+  int face_idx = sid - face_num*face_volume;        // index into the respective face
 
+  switch(dim) {
+  case 0:
+    coordsFromFaceIndex<0,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 1:
+    coordsFromFaceIndex<1,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 2:
+    coordsFromFaceIndex<2,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 3:
+    coordsFromFaceIndex<3,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  }
 
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromFaceIndex<1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, dim, face_num, param.parity, dims);
 
   bool active = false;
   for(int dir=0; dir<4; ++dir){
@@ -261,7 +269,7 @@ if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   // 0 -i 1 0 
   // -i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
   const int sp_idx = face_idx + param.ghostOffset[0][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][1];
@@ -422,7 +430,7 @@ if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   // 0 i 1 0 
   // i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
   const int sp_idx = face_idx + param.ghostOffset[0][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][0];
@@ -583,7 +591,7 @@ if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   // 0 -1 1 0 
   // 1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
   const int sp_idx = face_idx + param.ghostOffset[1][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][1];
@@ -744,7 +752,7 @@ if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   // 0 1 1 0 
   // -1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
   const int sp_idx = face_idx + param.ghostOffset[1][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][0];
@@ -905,7 +913,7 @@ if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   // -i 0 1 0 
   // 0 i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
   const int sp_idx = face_idx + param.ghostOffset[2][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][1];
@@ -1066,7 +1074,7 @@ if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   // i 0 1 0 
   // 0 -i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
   const int sp_idx = face_idx + param.ghostOffset[2][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][0];
@@ -1227,7 +1235,7 @@ if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   // 0 0 0 0 
   // 0 0 0 0 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
   const int sp_idx = face_idx + param.ghostOffset[3][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][1];
@@ -1443,7 +1451,7 @@ if (isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
   // 0 0 2 0 
   // 0 0 0 2 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
   const int sp_idx = face_idx + param.ghostOffset[3][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][0];

--- a/lib/dslash_core/tm_fused_exterior_dslash_fermi_core.h
+++ b/lib/dslash_core/tm_fused_exterior_dslash_fermi_core.h
@@ -224,23 +224,31 @@ int sp_norm_idx;
 
 int sid;
 
-int dim;
-int face_idx;
-int Y[4] = {X1,X2,X3,X4};
-
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
 
-  dim = dimFromFaceIndex(sid, param); // sid is also modified
+  int dim = dimFromFaceIndex(sid, param); // sid is also modified
 
   const int face_volume = ((param.threadDimMapUpper[dim] - param.threadDimMapLower[dim]) >> 1);
   const int face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
-  face_idx = sid - face_num*face_volume;        // index into the respective face
+  int face_idx = sid - face_num*face_volume;        // index into the respective face
 
+  switch(dim) {
+  case 0:
+    coordsFromFaceIndex<0,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 1:
+    coordsFromFaceIndex<1,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 2:
+    coordsFromFaceIndex<2,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 3:
+    coordsFromFaceIndex<3,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  }
 
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromFaceIndex<1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, dim, face_num, param.parity, dims);
 
   bool active = false;
   for(int dir=0; dir<4; ++dir){
@@ -271,7 +279,7 @@ if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   // 0 i 1 0 
   // i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
   const int sp_idx = face_idx + param.ghostOffset[0][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][1];
@@ -432,7 +440,7 @@ if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   // 0 -i 1 0 
   // -i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
   const int sp_idx = face_idx + param.ghostOffset[0][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][0];
@@ -593,7 +601,7 @@ if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   // 0 1 1 0 
   // -1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
   const int sp_idx = face_idx + param.ghostOffset[1][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][1];
@@ -754,7 +762,7 @@ if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   // 0 -1 1 0 
   // 1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
   const int sp_idx = face_idx + param.ghostOffset[1][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][0];
@@ -915,7 +923,7 @@ if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   // i 0 1 0 
   // 0 -i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
   const int sp_idx = face_idx + param.ghostOffset[2][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][1];
@@ -1076,7 +1084,7 @@ if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   // -i 0 1 0 
   // 0 i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
   const int sp_idx = face_idx + param.ghostOffset[2][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][0];
@@ -1237,7 +1245,7 @@ if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   // 0 0 2 0 
   // 0 0 0 2 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
   const int sp_idx = face_idx + param.ghostOffset[3][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][1];
@@ -1453,7 +1461,7 @@ if (isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
   // 0 0 0 0 
   // 0 0 0 0 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
   const int sp_idx = face_idx + param.ghostOffset[3][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][0];

--- a/lib/dslash_core/tm_fused_exterior_dslash_fermi_core.h
+++ b/lib/dslash_core/tm_fused_exterior_dslash_fermi_core.h
@@ -215,7 +215,7 @@ VOLATILE spinorFloat o32_im;
 #include "read_gauge.h"
 #include "io_spinor.h"
 
-int x1, x2, x3, x4;
+int coord[5];
 int X;
 
 #if (DD_PREC==2) // half precision
@@ -236,23 +236,23 @@ int sid;
 
   switch(dim) {
   case 0:
-    coordsFromFaceIndex<0,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,0,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 1:
-    coordsFromFaceIndex<1,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,1,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 2:
-    coordsFromFaceIndex<2,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,2,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 3:
-    coordsFromFaceIndex<3,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,3,1>(X, sid, coord, face_idx, face_num, param);
     break;
   }
 
 
   bool active = false;
   for(int dir=0; dir<4; ++dir){
-    active = active || isActive(dim,dir,+1,x1,x2,x3,x4,param.commDim,param.X);
+    active = active || isActive(dim,dir,+1,coord,param.commDim,param.X);
   }
   if(!active) return;
 
@@ -271,7 +271,7 @@ int sid;
   o30_re = i30_re;  o30_im = i30_im;
   o31_re = i31_re;  o31_im = i31_im;
   o32_re = i32_re;  o32_im = i32_im;
-if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
+if (isActive(dim,0,+1,coord,param.commDim,param.X) && coord[0]==X1m1 )
 {
   // Projector P0-
   // 1 0 0 -i 
@@ -279,7 +279,7 @@ if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   // 0 i 1 0 
   // i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,0,param);
   const int sp_idx = face_idx + param.ghostOffset[0][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][1];
@@ -432,7 +432,7 @@ if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   
 }
 
-if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
+if (isActive(dim,0,-1,coord,param.commDim,param.X) && coord[0]==0 )
 {
   // Projector P0+
   // 1 0 0 i 
@@ -440,7 +440,7 @@ if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   // 0 -i 1 0 
   // -i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,0,param);
   const int sp_idx = face_idx + param.ghostOffset[0][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][0];
@@ -593,7 +593,7 @@ if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   
 }
 
-if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
+if (isActive(dim,1,+1,coord,param.commDim,param.X) && coord[1]==X2m1 )
 {
   // Projector P1-
   // 1 0 0 -1 
@@ -601,7 +601,7 @@ if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   // 0 1 1 0 
   // -1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,1,param);
   const int sp_idx = face_idx + param.ghostOffset[1][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][1];
@@ -754,7 +754,7 @@ if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   
 }
 
-if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
+if (isActive(dim,1,-1,coord,param.commDim,param.X) && coord[1]==0 )
 {
   // Projector P1+
   // 1 0 0 1 
@@ -762,7 +762,7 @@ if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   // 0 -1 1 0 
   // 1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,1,param);
   const int sp_idx = face_idx + param.ghostOffset[1][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][0];
@@ -915,7 +915,7 @@ if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   
 }
 
-if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
+if (isActive(dim,2,+1,coord,param.commDim,param.X) && coord[2]==X3m1 )
 {
   // Projector P2-
   // 1 0 -i 0 
@@ -923,7 +923,7 @@ if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   // i 0 1 0 
   // 0 -i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,2,param);
   const int sp_idx = face_idx + param.ghostOffset[2][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][1];
@@ -1076,7 +1076,7 @@ if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   
 }
 
-if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
+if (isActive(dim,2,-1,coord,param.commDim,param.X) && coord[2]==0 )
 {
   // Projector P2+
   // 1 0 i 0 
@@ -1084,7 +1084,7 @@ if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   // -i 0 1 0 
   // 0 i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,2,param);
   const int sp_idx = face_idx + param.ghostOffset[2][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][0];
@@ -1237,7 +1237,7 @@ if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   
 }
 
-if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
+if (isActive(dim,3,+1,coord,param.commDim,param.X) && coord[3]==X4m1 )
 {
   // Projector P3-
   // 0 0 0 0 
@@ -1245,7 +1245,7 @@ if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   // 0 0 2 0 
   // 0 0 0 2 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,3,param);
   const int sp_idx = face_idx + param.ghostOffset[3][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][1];
@@ -1453,7 +1453,7 @@ if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   }
 }
 
-if (isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
+if (isActive(dim,3,-1,coord,param.commDim,param.X) && coord[3]==0 )
 {
   // Projector P3+
   // 2 0 0 0 
@@ -1461,7 +1461,7 @@ if (isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
   // 0 0 0 0 
   // 0 0 0 0 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,3,param);
   const int sp_idx = face_idx + param.ghostOffset[3][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][0];

--- a/lib/dslash_core/tm_fused_exterior_dslash_gt200_core.h
+++ b/lib/dslash_core/tm_fused_exterior_dslash_gt200_core.h
@@ -205,7 +205,7 @@ VOLATILE spinorFloat o32_im;
 #include "read_gauge.h"
 #include "io_spinor.h"
 
-int x1, x2, x3, x4;
+int coord[5];
 int X;
 
 #if (DD_PREC==2) // half precision
@@ -226,23 +226,23 @@ int sid;
 
   switch(dim) {
   case 0:
-    coordsFromFaceIndex<0,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,0,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 1:
-    coordsFromFaceIndex<1,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,1,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 2:
-    coordsFromFaceIndex<2,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,2,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 3:
-    coordsFromFaceIndex<3,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,3,1>(X, sid, coord, face_idx, face_num, param);
     break;
   }
 
 
   bool active = false;
   for(int dir=0; dir<4; ++dir){
-    active = active || isActive(dim,dir,+1,x1,x2,x3,x4,param.commDim,param.X);
+    active = active || isActive(dim,dir,+1,coord,param.commDim,param.X);
   }
   if(!active) return;
 
@@ -261,7 +261,7 @@ int sid;
   o30_re = i30_re;  o30_im = i30_im;
   o31_re = i31_re;  o31_im = i31_im;
   o32_re = i32_re;  o32_im = i32_im;
-if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
+if (isActive(dim,0,+1,coord,param.commDim,param.X) && coord[0]==X1m1 )
 {
   // Projector P0-
   // 1 0 0 -i 
@@ -269,7 +269,7 @@ if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   // 0 i 1 0 
   // i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,0,param);
   const int sp_idx = face_idx + param.ghostOffset[0][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][1];
@@ -422,7 +422,7 @@ if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   
 }
 
-if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
+if (isActive(dim,0,-1,coord,param.commDim,param.X) && coord[0]==0 )
 {
   // Projector P0+
   // 1 0 0 i 
@@ -430,7 +430,7 @@ if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   // 0 -i 1 0 
   // -i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,0,param);
   const int sp_idx = face_idx + param.ghostOffset[0][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][0];
@@ -583,7 +583,7 @@ if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   
 }
 
-if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
+if (isActive(dim,1,+1,coord,param.commDim,param.X) && coord[1]==X2m1 )
 {
   // Projector P1-
   // 1 0 0 -1 
@@ -591,7 +591,7 @@ if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   // 0 1 1 0 
   // -1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,1,param);
   const int sp_idx = face_idx + param.ghostOffset[1][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][1];
@@ -744,7 +744,7 @@ if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   
 }
 
-if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
+if (isActive(dim,1,-1,coord,param.commDim,param.X) && coord[1]==0 )
 {
   // Projector P1+
   // 1 0 0 1 
@@ -752,7 +752,7 @@ if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   // 0 -1 1 0 
   // 1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,1,param);
   const int sp_idx = face_idx + param.ghostOffset[1][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][0];
@@ -905,7 +905,7 @@ if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   
 }
 
-if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
+if (isActive(dim,2,+1,coord,param.commDim,param.X) && coord[2]==X3m1 )
 {
   // Projector P2-
   // 1 0 -i 0 
@@ -913,7 +913,7 @@ if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   // i 0 1 0 
   // 0 -i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,2,param);
   const int sp_idx = face_idx + param.ghostOffset[2][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][1];
@@ -1066,7 +1066,7 @@ if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   
 }
 
-if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
+if (isActive(dim,2,-1,coord,param.commDim,param.X) && coord[2]==0 )
 {
   // Projector P2+
   // 1 0 i 0 
@@ -1074,7 +1074,7 @@ if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   // -i 0 1 0 
   // 0 i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,2,param);
   const int sp_idx = face_idx + param.ghostOffset[2][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][0];
@@ -1227,7 +1227,7 @@ if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   
 }
 
-if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
+if (isActive(dim,3,+1,coord,param.commDim,param.X) && coord[3]==X4m1 )
 {
   // Projector P3-
   // 0 0 0 0 
@@ -1235,7 +1235,7 @@ if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   // 0 0 2 0 
   // 0 0 0 2 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,3,param);
   const int sp_idx = face_idx + param.ghostOffset[3][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][1];
@@ -1443,7 +1443,7 @@ if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   }
 }
 
-if (isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
+if (isActive(dim,3,-1,coord,param.commDim,param.X) && coord[3]==0 )
 {
   // Projector P3+
   // 2 0 0 0 
@@ -1451,7 +1451,7 @@ if (isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
   // 0 0 0 0 
   // 0 0 0 0 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,3,param);
   const int sp_idx = face_idx + param.ghostOffset[3][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][0];

--- a/lib/dslash_core/tm_fused_exterior_dslash_gt200_core.h
+++ b/lib/dslash_core/tm_fused_exterior_dslash_gt200_core.h
@@ -214,23 +214,31 @@ int sp_norm_idx;
 
 int sid;
 
-int dim;
-int face_idx;
-int Y[4] = {X1,X2,X3,X4};
-
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
 
-  dim = dimFromFaceIndex(sid, param); // sid is also modified
+  int dim = dimFromFaceIndex(sid, param); // sid is also modified
 
   const int face_volume = ((param.threadDimMapUpper[dim] - param.threadDimMapLower[dim]) >> 1);
   const int face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
-  face_idx = sid - face_num*face_volume;        // index into the respective face
+  int face_idx = sid - face_num*face_volume;        // index into the respective face
 
+  switch(dim) {
+  case 0:
+    coordsFromFaceIndex<0,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 1:
+    coordsFromFaceIndex<1,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 2:
+    coordsFromFaceIndex<2,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 3:
+    coordsFromFaceIndex<3,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  }
 
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromFaceIndex<1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, dim, face_num, param.parity, dims);
 
   bool active = false;
   for(int dir=0; dir<4; ++dir){
@@ -261,7 +269,7 @@ if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   // 0 i 1 0 
   // i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
   const int sp_idx = face_idx + param.ghostOffset[0][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][1];
@@ -422,7 +430,7 @@ if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   // 0 -i 1 0 
   // -i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
   const int sp_idx = face_idx + param.ghostOffset[0][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][0];
@@ -583,7 +591,7 @@ if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   // 0 1 1 0 
   // -1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
   const int sp_idx = face_idx + param.ghostOffset[1][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][1];
@@ -744,7 +752,7 @@ if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   // 0 -1 1 0 
   // 1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
   const int sp_idx = face_idx + param.ghostOffset[1][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][0];
@@ -905,7 +913,7 @@ if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   // i 0 1 0 
   // 0 -i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
   const int sp_idx = face_idx + param.ghostOffset[2][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][1];
@@ -1066,7 +1074,7 @@ if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   // -i 0 1 0 
   // 0 i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
   const int sp_idx = face_idx + param.ghostOffset[2][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][0];
@@ -1227,7 +1235,7 @@ if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   // 0 0 2 0 
   // 0 0 0 2 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
   const int sp_idx = face_idx + param.ghostOffset[3][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][1];
@@ -1443,7 +1451,7 @@ if (isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
   // 0 0 0 0 
   // 0 0 0 0 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
   const int sp_idx = face_idx + param.ghostOffset[3][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][0];

--- a/lib/dslash_core/tm_ndeg_dslash_core.h
+++ b/lib/dslash_core/tm_ndeg_dslash_core.h
@@ -182,7 +182,7 @@ VOLATILE spinorFloat o2_32_im;
 #include "read_gauge.h"
 #include "io_spinor.h"
 
-int x1, x2, x3, x4;
+int coord[5];
 int X;
 
 int sid;
@@ -196,7 +196,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   if (sid >= param.threads) return;
 
   // Assume even dimensions
-  coordsFromIndex<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X, param.block, param.grid);
+  coordsFromIndex<4,QUDA_4D_PC,EVEN_X>(X, coord, sid, param);
 
   o1_00_re = 0;  o1_00_im = 0;
   o1_01_re = 0;  o1_01_im = 0;
@@ -238,7 +238,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-  coordsFromFaceIndex<kernel_type,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+  coordsFromFaceIndex<4,QUDA_4D_PC,kernel_type,1>(X, sid, coord, face_idx, face_num, param);
 
 
   {
@@ -280,8 +280,8 @@ if (kernel_type == INTERIOR_KERNEL) {
 
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_X && x1==X1m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]<X1m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_X && coord[0]==X1m1) )
 #endif
 {
   // Projector P0-
@@ -291,13 +291,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
   // i 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x1==X1m1 ? X-X1m1 : X+1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[0]==X1m1 ? X-X1m1 : X+1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x1==X1m1 ? X-X1m1 : X+1) >> 1;
+  const int sp_idx = (coord[0]==X1m1 ? X-X1m1 : X+1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -635,8 +635,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_X && x1==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_X && coord[0]==0) )
 #endif
 {
   // Projector P0+
@@ -646,13 +646,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
   // -i 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x1==0 ? X+X1m1 : X-1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[0]==0 ? X+X1m1 : X-1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x1==0 ? X+X1m1 : X-1) >> 1;
+  const int sp_idx = (coord[0]==0 ? X+X1m1 : X-1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -994,8 +994,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_Y && x2==X2m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]<X2m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_Y && coord[1]==X2m1) )
 #endif
 {
   // Projector P1-
@@ -1005,13 +1005,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
   // -1 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x2==X2m1 ? X-X2X1mX1 : X+X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[1]==X2m1 ? X-X2X1mX1 : X+X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x2==X2m1 ? X-X2X1mX1 : X+X1) >> 1;
+  const int sp_idx = (coord[1]==X2m1 ? X-X2X1mX1 : X+X1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -1349,8 +1349,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_Y && x2==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_Y && coord[1]==0) )
 #endif
 {
   // Projector P1+
@@ -1360,13 +1360,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
   // 1 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x2==0 ? X+X2X1mX1 : X-X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[1]==0 ? X+X2X1mX1 : X-X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x2==0 ? X+X2X1mX1 : X-X1) >> 1;
+  const int sp_idx = (coord[1]==0 ? X+X2X1mX1 : X-X1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -1708,8 +1708,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_Z && x3==X3m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]<X3m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_Z && coord[2]==X3m1) )
 #endif
 {
   // Projector P2-
@@ -1719,13 +1719,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
   // 0 -i 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x3==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[2]==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x3==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1;
+  const int sp_idx = (coord[2]==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -2063,8 +2063,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_Z && x3==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_Z && coord[2]==0) )
 #endif
 {
   // Projector P2+
@@ -2074,13 +2074,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
   // 0 i 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x3==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[2]==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x3==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1;
+  const int sp_idx = (coord[2]==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -2422,8 +2422,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_T && x4==X4m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]<X4m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_T && coord[3]==X4m1) )
 #endif
 {
   // Projector P3-
@@ -2433,13 +2433,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
   // 0 0 0 2 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x4==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[3]==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x4==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1;
+  const int sp_idx = (coord[3]==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -2886,8 +2886,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_T && x4==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_T && coord[3]==0) )
 #endif
 {
   // Projector P3+
@@ -2897,13 +2897,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4>0)) ||
   // 0 0 0 0 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x4==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[3]==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x4==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1;
+  const int sp_idx = (coord[3]==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -3359,13 +3359,13 @@ int incomplete = 0; // Have all 8 contributions been computed for this site?
 
 switch(kernel_type) { // intentional fall-through
 case INTERIOR_KERNEL:
-  incomplete = incomplete || (param.commDim[3] && (x4==0 || x4==X4m1));
+  incomplete = incomplete || (param.commDim[3] && (coord[3]==0 || coord[3]==X4m1));
 case EXTERIOR_KERNEL_T:
-  incomplete = incomplete || (param.commDim[2] && (x3==0 || x3==X3m1));
+  incomplete = incomplete || (param.commDim[2] && (coord[2]==0 || coord[2]==X3m1));
 case EXTERIOR_KERNEL_Z:
-  incomplete = incomplete || (param.commDim[1] && (x2==0 || x2==X2m1));
+  incomplete = incomplete || (param.commDim[1] && (coord[1]==0 || coord[1]==X2m1));
 case EXTERIOR_KERNEL_Y:
-  incomplete = incomplete || (param.commDim[0] && (x1==0 || x1==X1m1));
+  incomplete = incomplete || (param.commDim[0] && (coord[0]==0 || coord[0]==X1m1));
 }
 
 

--- a/lib/dslash_core/tm_ndeg_dslash_core.h
+++ b/lib/dslash_core/tm_ndeg_dslash_core.h
@@ -195,9 +195,8 @@ if (kernel_type == INTERIOR_KERNEL) {
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  // Inline by hand for the moment and assume even dimensions
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromIndex<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, dims, param.block, param.grid);
+  // Assume even dimensions
+  coordsFromIndex<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X, param.block, param.grid);
 
   o1_00_re = 0;  o1_00_im = 0;
   o1_01_re = 0;  o1_01_im = 0;
@@ -231,7 +230,6 @@ if (kernel_type == INTERIOR_KERNEL) {
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  const int dim = static_cast<int>(kernel_type);
   const int face_volume = (param.threads >> 1);           // volume of one face (per flavor)
   const int face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
   face_idx = sid - face_num*face_volume;        // index into the respective face
@@ -240,8 +238,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromFaceIndex<1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, dim, face_num, param.parity, dims);
+  coordsFromFaceIndex<kernel_type,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
 
 
   {

--- a/lib/dslash_core/tm_ndeg_dslash_dagger_core.h
+++ b/lib/dslash_core/tm_ndeg_dslash_dagger_core.h
@@ -195,9 +195,8 @@ if (kernel_type == INTERIOR_KERNEL) {
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  // Inline by hand for the moment and assume even dimensions
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromIndex<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, dims, param.block, param.grid);
+  // Assume even dimensions
+  coordsFromIndex<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X, param.block, param.grid);
 
   o1_00_re = 0;  o1_00_im = 0;
   o1_01_re = 0;  o1_01_im = 0;
@@ -231,7 +230,6 @@ if (kernel_type == INTERIOR_KERNEL) {
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  const int dim = static_cast<int>(kernel_type);
   const int face_volume = (param.threads >> 1);           // volume of one face (per flavor)
   const int face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
   face_idx = sid - face_num*face_volume;        // index into the respective face
@@ -240,8 +238,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromFaceIndex<1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, dim, face_num, param.parity, dims);
+  coordsFromFaceIndex<kernel_type,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
 
 
   {

--- a/lib/dslash_core/tm_ndeg_dslash_dagger_core.h
+++ b/lib/dslash_core/tm_ndeg_dslash_dagger_core.h
@@ -182,7 +182,7 @@ VOLATILE spinorFloat o2_32_im;
 #include "read_gauge.h"
 #include "io_spinor.h"
 
-int x1, x2, x3, x4;
+int coord[5];
 int X;
 
 int sid;
@@ -196,7 +196,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   if (sid >= param.threads) return;
 
   // Assume even dimensions
-  coordsFromIndex<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X, param.block, param.grid);
+  coordsFromIndex<4,QUDA_4D_PC,EVEN_X>(X, coord, sid, param);
 
   o1_00_re = 0;  o1_00_im = 0;
   o1_01_re = 0;  o1_01_im = 0;
@@ -238,7 +238,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-  coordsFromFaceIndex<kernel_type,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+  coordsFromFaceIndex<4,QUDA_4D_PC,kernel_type,1>(X, sid, coord, face_idx, face_num, param);
 
 
   {
@@ -280,8 +280,8 @@ if (kernel_type == INTERIOR_KERNEL) {
 
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_X && x1==X1m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]<X1m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_X && coord[0]==X1m1) )
 #endif
 {
   // Projector P0+
@@ -291,13 +291,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
   // -i 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x1==X1m1 ? X-X1m1 : X+1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[0]==X1m1 ? X-X1m1 : X+1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x1==X1m1 ? X-X1m1 : X+1) >> 1;
+  const int sp_idx = (coord[0]==X1m1 ? X-X1m1 : X+1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -635,8 +635,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_X && x1==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_X && coord[0]==0) )
 #endif
 {
   // Projector P0-
@@ -646,13 +646,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
   // i 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x1==0 ? X+X1m1 : X-1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[0]==0 ? X+X1m1 : X-1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x1==0 ? X+X1m1 : X-1) >> 1;
+  const int sp_idx = (coord[0]==0 ? X+X1m1 : X-1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -994,8 +994,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_Y && x2==X2m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]<X2m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_Y && coord[1]==X2m1) )
 #endif
 {
   // Projector P1+
@@ -1005,13 +1005,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
   // 1 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x2==X2m1 ? X-X2X1mX1 : X+X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[1]==X2m1 ? X-X2X1mX1 : X+X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x2==X2m1 ? X-X2X1mX1 : X+X1) >> 1;
+  const int sp_idx = (coord[1]==X2m1 ? X-X2X1mX1 : X+X1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -1349,8 +1349,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_Y && x2==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_Y && coord[1]==0) )
 #endif
 {
   // Projector P1-
@@ -1360,13 +1360,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
   // -1 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x2==0 ? X+X2X1mX1 : X-X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[1]==0 ? X+X2X1mX1 : X-X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x2==0 ? X+X2X1mX1 : X-X1) >> 1;
+  const int sp_idx = (coord[1]==0 ? X+X2X1mX1 : X-X1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -1708,8 +1708,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_Z && x3==X3m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]<X3m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_Z && coord[2]==X3m1) )
 #endif
 {
   // Projector P2+
@@ -1719,13 +1719,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
   // 0 i 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x3==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[2]==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x3==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1;
+  const int sp_idx = (coord[2]==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -2063,8 +2063,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_Z && x3==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_Z && coord[2]==0) )
 #endif
 {
   // Projector P2-
@@ -2074,13 +2074,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
   // 0 -i 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x3==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[2]==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x3==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1;
+  const int sp_idx = (coord[2]==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -2422,8 +2422,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_T && x4==X4m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]<X4m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_T && coord[3]==X4m1) )
 #endif
 {
   // Projector P3+
@@ -2433,13 +2433,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
   // 0 0 0 0 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x4==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[3]==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x4==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1;
+  const int sp_idx = (coord[3]==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -2886,8 +2886,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_T && x4==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_T && coord[3]==0) )
 #endif
 {
   // Projector P3-
@@ -2897,13 +2897,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4>0)) ||
   // 0 0 0 2 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x4==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[3]==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x4==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1;
+  const int sp_idx = (coord[3]==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -3359,13 +3359,13 @@ int incomplete = 0; // Have all 8 contributions been computed for this site?
 
 switch(kernel_type) { // intentional fall-through
 case INTERIOR_KERNEL:
-  incomplete = incomplete || (param.commDim[3] && (x4==0 || x4==X4m1));
+  incomplete = incomplete || (param.commDim[3] && (coord[3]==0 || coord[3]==X4m1));
 case EXTERIOR_KERNEL_T:
-  incomplete = incomplete || (param.commDim[2] && (x3==0 || x3==X3m1));
+  incomplete = incomplete || (param.commDim[2] && (coord[2]==0 || coord[2]==X3m1));
 case EXTERIOR_KERNEL_Z:
-  incomplete = incomplete || (param.commDim[1] && (x2==0 || x2==X2m1));
+  incomplete = incomplete || (param.commDim[1] && (coord[1]==0 || coord[1]==X2m1));
 case EXTERIOR_KERNEL_Y:
-  incomplete = incomplete || (param.commDim[0] && (x1==0 || x1==X1m1));
+  incomplete = incomplete || (param.commDim[0] && (coord[0]==0 || coord[0]==X1m1));
 }
 
 

--- a/lib/dslash_core/tm_ndeg_fused_exterior_dslash_core.h
+++ b/lib/dslash_core/tm_ndeg_fused_exterior_dslash_core.h
@@ -191,27 +191,34 @@ int sp_norm_idx;
 
 int sid;
 
-int dim;
-int face_idx;
-int Y[4] = {X1,X2,X3,X4};
-
-
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  dim = dimFromFaceIndex(sid, param); // sid is also modified
+  int dim = dimFromFaceIndex(sid, param); // sid is also modified
 
   const int face_volume = ((param.threadDimMapUpper[dim] - param.threadDimMapLower[dim]) >> 1);
   // volume of one face (per flavor)
   const int face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
-  face_idx = sid - face_num*face_volume;        // index into the respective face
+  int face_idx = sid - face_num*face_volume;        // index into the respective face
 
   // ghostOffset is scaled to include body (includes stride) and number of FloatN arrays (SPINOR_HOP)
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
 
+  switch(dim) {
+  case 0:
+    coordsFromFaceIndex<0,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 1:
+    coordsFromFaceIndex<1,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 2:
+    coordsFromFaceIndex<2,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 3:
+    coordsFromFaceIndex<3,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  }
 
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromFaceIndex<1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, dim, face_num, param.parity, dims);
 
   bool active = false;
   for(int dir=0; dir<4; ++dir){
@@ -263,7 +270,7 @@ if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1)
   // 0 i 1 0 
   // i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
   const int sp_idx =  face_idx + param.ghostOffset[0][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][1];
@@ -559,7 +566,7 @@ if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0)
   // 0 -i 1 0 
   // -i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
   const int sp_idx =  face_idx + param.ghostOffset[0][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][0];
@@ -855,7 +862,7 @@ if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1)
   // 0 1 1 0 
   // -1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
   const int sp_idx =  face_idx + param.ghostOffset[1][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][1];
@@ -1151,7 +1158,7 @@ if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0)
   // 0 -1 1 0 
   // 1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
   const int sp_idx =  face_idx + param.ghostOffset[1][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][0];
@@ -1447,7 +1454,7 @@ if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1)
   // i 0 1 0 
   // 0 -i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
   const int sp_idx =  face_idx + param.ghostOffset[2][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][1];
@@ -1743,7 +1750,7 @@ if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0)
   // -i 0 1 0 
   // 0 i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
   const int sp_idx =  face_idx + param.ghostOffset[2][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][0];
@@ -2039,7 +2046,7 @@ if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1)
   // 0 0 2 0 
   // 0 0 0 2 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
   const int sp_idx =  face_idx + param.ghostOffset[3][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][1];
@@ -2393,7 +2400,7 @@ if (isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0)
   // 0 0 0 0 
   // 0 0 0 0 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
   const int sp_idx =  face_idx + param.ghostOffset[3][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][0];

--- a/lib/dslash_core/tm_ndeg_fused_exterior_dslash_core.h
+++ b/lib/dslash_core/tm_ndeg_fused_exterior_dslash_core.h
@@ -182,7 +182,7 @@ VOLATILE spinorFloat o2_32_im;
 #include "read_gauge.h"
 #include "io_spinor.h"
 
-int x1, x2, x3, x4;
+int coord[5];
 int X;
 
 #if (DD_PREC==2) // half precision
@@ -203,26 +203,26 @@ int sid;
 
   // ghostOffset is scaled to include body (includes stride) and number of FloatN arrays (SPINOR_HOP)
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
-
+  // 4-d for first template argument here since both flavor are done by the same thread
   switch(dim) {
   case 0:
-    coordsFromFaceIndex<0,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,0,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 1:
-    coordsFromFaceIndex<1,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,1,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 2:
-    coordsFromFaceIndex<2,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,2,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 3:
-    coordsFromFaceIndex<3,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,3,1>(X, sid, coord, face_idx, face_num, param);
     break;
   }
 
 
   bool active = false;
   for(int dir=0; dir<4; ++dir){
-    active = active || isActive(dim,dir,+1,x1,x2,x3,x4,param.commDim,param.X);
+   active = active  || isActive(dim,dir,+1,coord,param.commDim,param.X);
   }
   if(!active) return;
 
@@ -262,7 +262,7 @@ int sid;
 
   }
 
-if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1)
+if (isActive(dim,0,+1,coord,param.commDim,param.X) && coord[0]==X1m1)
 {
   // Projector P0-
   // 1 0 0 -i 
@@ -270,7 +270,7 @@ if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1)
   // 0 i 1 0 
   // i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,0,param);
   const int sp_idx =  face_idx + param.ghostOffset[0][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][1];
@@ -558,7 +558,7 @@ if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1)
   }
 }
 
-if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0)
+if (isActive(dim,0,-1,coord,param.commDim,param.X) && coord[0]==0)
 {
   // Projector P0+
   // 1 0 0 i 
@@ -566,7 +566,7 @@ if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0)
   // 0 -i 1 0 
   // -i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,0,param);
   const int sp_idx =  face_idx + param.ghostOffset[0][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][0];
@@ -854,7 +854,7 @@ if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0)
   }
 }
 
-if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1)
+if (isActive(dim,1,+1,coord,param.commDim,param.X) && coord[1]==X2m1)
 {
   // Projector P1-
   // 1 0 0 -1 
@@ -862,7 +862,7 @@ if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1)
   // 0 1 1 0 
   // -1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,1,param);
   const int sp_idx =  face_idx + param.ghostOffset[1][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][1];
@@ -1150,7 +1150,7 @@ if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1)
   }
 }
 
-if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0)
+if (isActive(dim,1,-1,coord,param.commDim,param.X) && coord[1]==0)
 {
   // Projector P1+
   // 1 0 0 1 
@@ -1158,7 +1158,7 @@ if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0)
   // 0 -1 1 0 
   // 1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,1,param);
   const int sp_idx =  face_idx + param.ghostOffset[1][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][0];
@@ -1446,7 +1446,7 @@ if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0)
   }
 }
 
-if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1)
+if (isActive(dim,2,+1,coord,param.commDim,param.X) && coord[2]==X3m1)
 {
   // Projector P2-
   // 1 0 -i 0 
@@ -1454,7 +1454,7 @@ if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1)
   // i 0 1 0 
   // 0 -i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,2,param);
   const int sp_idx =  face_idx + param.ghostOffset[2][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][1];
@@ -1742,7 +1742,7 @@ if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1)
   }
 }
 
-if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0)
+if (isActive(dim,2,-1,coord,param.commDim,param.X) && coord[2]==0)
 {
   // Projector P2+
   // 1 0 i 0 
@@ -1750,7 +1750,7 @@ if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0)
   // -i 0 1 0 
   // 0 i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,2,param);
   const int sp_idx =  face_idx + param.ghostOffset[2][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][0];
@@ -2038,7 +2038,7 @@ if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0)
   }
 }
 
-if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1)
+if (isActive(dim,3,+1,coord,param.commDim,param.X) && coord[3]==X4m1)
 {
   // Projector P3-
   // 0 0 0 0 
@@ -2046,7 +2046,7 @@ if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1)
   // 0 0 2 0 
   // 0 0 0 2 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,3,param);
   const int sp_idx =  face_idx + param.ghostOffset[3][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][1];
@@ -2392,7 +2392,7 @@ if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1)
   }
 }
 
-if (isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0)
+if (isActive(dim,3,-1,coord,param.commDim,param.X) && coord[3]==0)
 {
   // Projector P3+
   // 2 0 0 0 
@@ -2400,7 +2400,7 @@ if (isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0)
   // 0 0 0 0 
   // 0 0 0 0 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,3,param);
   const int sp_idx =  face_idx + param.ghostOffset[3][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][0];

--- a/lib/dslash_core/tm_ndeg_fused_exterior_dslash_dagger_core.h
+++ b/lib/dslash_core/tm_ndeg_fused_exterior_dslash_dagger_core.h
@@ -191,27 +191,34 @@ int sp_norm_idx;
 
 int sid;
 
-int dim;
-int face_idx;
-int Y[4] = {X1,X2,X3,X4};
-
-
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  dim = dimFromFaceIndex(sid, param); // sid is also modified
+  int dim = dimFromFaceIndex(sid, param); // sid is also modified
 
   const int face_volume = ((param.threadDimMapUpper[dim] - param.threadDimMapLower[dim]) >> 1);
   // volume of one face (per flavor)
   const int face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
-  face_idx = sid - face_num*face_volume;        // index into the respective face
+  int face_idx = sid - face_num*face_volume;        // index into the respective face
 
   // ghostOffset is scaled to include body (includes stride) and number of FloatN arrays (SPINOR_HOP)
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
 
+  switch(dim) {
+  case 0:
+    coordsFromFaceIndex<0,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 1:
+    coordsFromFaceIndex<1,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 2:
+    coordsFromFaceIndex<2,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 3:
+    coordsFromFaceIndex<3,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  }
 
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromFaceIndex<1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, dim, face_num, param.parity, dims);
 
   bool active = false;
   for(int dir=0; dir<4; ++dir){
@@ -263,7 +270,7 @@ if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1)
   // 0 -i 1 0 
   // -i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
   const int sp_idx =  face_idx + param.ghostOffset[0][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][1];
@@ -559,7 +566,7 @@ if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0)
   // 0 i 1 0 
   // i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
   const int sp_idx =  face_idx + param.ghostOffset[0][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][0];
@@ -855,7 +862,7 @@ if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1)
   // 0 -1 1 0 
   // 1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
   const int sp_idx =  face_idx + param.ghostOffset[1][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][1];
@@ -1151,7 +1158,7 @@ if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0)
   // 0 1 1 0 
   // -1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
   const int sp_idx =  face_idx + param.ghostOffset[1][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][0];
@@ -1447,7 +1454,7 @@ if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1)
   // -i 0 1 0 
   // 0 i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
   const int sp_idx =  face_idx + param.ghostOffset[2][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][1];
@@ -1743,7 +1750,7 @@ if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0)
   // i 0 1 0 
   // 0 -i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
   const int sp_idx =  face_idx + param.ghostOffset[2][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][0];
@@ -2039,7 +2046,7 @@ if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1)
   // 0 0 0 0 
   // 0 0 0 0 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
   const int sp_idx =  face_idx + param.ghostOffset[3][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][1];
@@ -2393,7 +2400,7 @@ if (isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0)
   // 0 0 2 0 
   // 0 0 0 2 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
   const int sp_idx =  face_idx + param.ghostOffset[3][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][0];

--- a/lib/dslash_core/tm_ndeg_fused_exterior_dslash_dagger_core.h
+++ b/lib/dslash_core/tm_ndeg_fused_exterior_dslash_dagger_core.h
@@ -182,7 +182,7 @@ VOLATILE spinorFloat o2_32_im;
 #include "read_gauge.h"
 #include "io_spinor.h"
 
-int x1, x2, x3, x4;
+int coord[5];
 int X;
 
 #if (DD_PREC==2) // half precision
@@ -203,26 +203,26 @@ int sid;
 
   // ghostOffset is scaled to include body (includes stride) and number of FloatN arrays (SPINOR_HOP)
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
-
+  // 4-d for first template argument here since both flavor are done by the same thread
   switch(dim) {
   case 0:
-    coordsFromFaceIndex<0,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,0,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 1:
-    coordsFromFaceIndex<1,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,1,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 2:
-    coordsFromFaceIndex<2,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,2,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 3:
-    coordsFromFaceIndex<3,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,3,1>(X, sid, coord, face_idx, face_num, param);
     break;
   }
 
 
   bool active = false;
   for(int dir=0; dir<4; ++dir){
-    active = active || isActive(dim,dir,+1,x1,x2,x3,x4,param.commDim,param.X);
+   active = active  || isActive(dim,dir,+1,coord,param.commDim,param.X);
   }
   if(!active) return;
 
@@ -262,7 +262,7 @@ int sid;
 
   }
 
-if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1)
+if (isActive(dim,0,+1,coord,param.commDim,param.X) && coord[0]==X1m1)
 {
   // Projector P0+
   // 1 0 0 i 
@@ -270,7 +270,7 @@ if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1)
   // 0 -i 1 0 
   // -i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,0,param);
   const int sp_idx =  face_idx + param.ghostOffset[0][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][1];
@@ -558,7 +558,7 @@ if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1)
   }
 }
 
-if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0)
+if (isActive(dim,0,-1,coord,param.commDim,param.X) && coord[0]==0)
 {
   // Projector P0-
   // 1 0 0 -i 
@@ -566,7 +566,7 @@ if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0)
   // 0 i 1 0 
   // i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,0,param);
   const int sp_idx =  face_idx + param.ghostOffset[0][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][0];
@@ -854,7 +854,7 @@ if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0)
   }
 }
 
-if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1)
+if (isActive(dim,1,+1,coord,param.commDim,param.X) && coord[1]==X2m1)
 {
   // Projector P1+
   // 1 0 0 1 
@@ -862,7 +862,7 @@ if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1)
   // 0 -1 1 0 
   // 1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,1,param);
   const int sp_idx =  face_idx + param.ghostOffset[1][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][1];
@@ -1150,7 +1150,7 @@ if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1)
   }
 }
 
-if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0)
+if (isActive(dim,1,-1,coord,param.commDim,param.X) && coord[1]==0)
 {
   // Projector P1-
   // 1 0 0 -1 
@@ -1158,7 +1158,7 @@ if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0)
   // 0 1 1 0 
   // -1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,1,param);
   const int sp_idx =  face_idx + param.ghostOffset[1][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][0];
@@ -1446,7 +1446,7 @@ if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0)
   }
 }
 
-if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1)
+if (isActive(dim,2,+1,coord,param.commDim,param.X) && coord[2]==X3m1)
 {
   // Projector P2+
   // 1 0 i 0 
@@ -1454,7 +1454,7 @@ if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1)
   // -i 0 1 0 
   // 0 i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,2,param);
   const int sp_idx =  face_idx + param.ghostOffset[2][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][1];
@@ -1742,7 +1742,7 @@ if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1)
   }
 }
 
-if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0)
+if (isActive(dim,2,-1,coord,param.commDim,param.X) && coord[2]==0)
 {
   // Projector P2-
   // 1 0 -i 0 
@@ -1750,7 +1750,7 @@ if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0)
   // i 0 1 0 
   // 0 -i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,2,param);
   const int sp_idx =  face_idx + param.ghostOffset[2][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][0];
@@ -2038,7 +2038,7 @@ if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0)
   }
 }
 
-if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1)
+if (isActive(dim,3,+1,coord,param.commDim,param.X) && coord[3]==X4m1)
 {
   // Projector P3+
   // 2 0 0 0 
@@ -2046,7 +2046,7 @@ if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1)
   // 0 0 0 0 
   // 0 0 0 0 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,3,param);
   const int sp_idx =  face_idx + param.ghostOffset[3][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][1];
@@ -2392,7 +2392,7 @@ if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1)
   }
 }
 
-if (isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0)
+if (isActive(dim,3,-1,coord,param.commDim,param.X) && coord[3]==0)
 {
   // Projector P3-
   // 0 0 0 0 
@@ -2400,7 +2400,7 @@ if (isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0)
   // 0 0 2 0 
   // 0 0 0 2 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,3,param);
   const int sp_idx =  face_idx + param.ghostOffset[3][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][0];

--- a/lib/dslash_core/tmc_dslash_dagger_fermi_core.h
+++ b/lib/dslash_core/tmc_dslash_dagger_fermi_core.h
@@ -619,9 +619,8 @@ int face_idx;
 if (kernel_type == INTERIOR_KERNEL) {
 #endif
 
-  // Inline by hand for the moment and assume even dimensions
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromIndex3D<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, dims);
+  // Assume even dimensions
+  coordsFromIndex3D<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X);
 
   // only need to check Y and Z dims currently since X and T set to match exactly
   if (x2 >= X2) return;
@@ -646,7 +645,6 @@ if (kernel_type == INTERIOR_KERNEL) {
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  const int dim = static_cast<int>(kernel_type);
   const int face_volume = (param.threads >> 1);           // volume of one face
   const int face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
   face_idx = sid - face_num*face_volume;        // index into the respective face
@@ -655,8 +653,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromFaceIndex<1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, dim, face_num, param.parity, dims);
+  coordsFromFaceIndex<kernel_type,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
 
   READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 

--- a/lib/dslash_core/tmc_dslash_dagger_fermi_core.h
+++ b/lib/dslash_core/tmc_dslash_dagger_fermi_core.h
@@ -609,7 +609,7 @@ VOLATILE spinorFloat o32_im;
 #include "read_clover.h"
 #include "tmc_core.h"
 
-int x1, x2, x3, x4;
+int coord[5];
 int X;
 
 int sid;
@@ -620,11 +620,11 @@ if (kernel_type == INTERIOR_KERNEL) {
 #endif
 
   // Assume even dimensions
-  coordsFromIndex3D<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X);
+  coordsFromIndex3D<EVEN_X>(X, coord, sid, param);
 
   // only need to check Y and Z dims currently since X and T set to match exactly
-  if (x2 >= X2) return;
-  if (x3 >= X3) return;
+  if (coord[1] >= param.X[1]) return;
+  if (coord[2] >= param.X[2]) return;
 
   o00_re = 0;  o00_im = 0;
   o01_re = 0;  o01_im = 0;
@@ -653,7 +653,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-  coordsFromFaceIndex<kernel_type,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+  coordsFromFaceIndex<4,QUDA_4D_PC,kernel_type,1>(X, sid, coord, face_idx, face_num, param);
 
   READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 
@@ -674,8 +674,8 @@ if (kernel_type == INTERIOR_KERNEL) {
 
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_X && x1==X1m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]<X1m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_X && coord[0]==X1m1) )
 #endif
 {
   // Projector P0+
@@ -685,13 +685,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
   // -i 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x1==X1m1 ? X-X1m1 : X+1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[0]==X1m1 ? X-X1m1 : X+1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x1==X1m1 ? X-X1m1 : X+1) >> 1;
+  const int sp_idx = (coord[0]==X1m1 ? X-X1m1 : X+1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -871,8 +871,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_X && x1==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_X && coord[0]==0) )
 #endif
 {
   // Projector P0-
@@ -882,13 +882,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
   // i 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x1==0 ? X+X1m1 : X-1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[0]==0 ? X+X1m1 : X-1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x1==0 ? X+X1m1 : X-1) >> 1;
+  const int sp_idx = (coord[0]==0 ? X+X1m1 : X-1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -1071,8 +1071,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_Y && x2==X2m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]<X2m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_Y && coord[1]==X2m1) )
 #endif
 {
   // Projector P1+
@@ -1082,13 +1082,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
   // 1 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x2==X2m1 ? X-X2X1mX1 : X+X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[1]==X2m1 ? X-X2X1mX1 : X+X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x2==X2m1 ? X-X2X1mX1 : X+X1) >> 1;
+  const int sp_idx = (coord[1]==X2m1 ? X-X2X1mX1 : X+X1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -1123,7 +1123,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
     b2_im = +i12_im-i22_im;
     } else {
     // load spinor from shared memory
-    int tx = (threadIdx.x + blockDim.x - ((x1+1)&1) ) % blockDim.x;
+    int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1) ) % blockDim.x;
     int ty = (threadIdx.y < blockDim.y - 1) ? threadIdx.y + 1 : 0;
     READ_SPINOR_SHARED(tx, ty, threadIdx.z);
     
@@ -1286,8 +1286,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_Y && x2==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_Y && coord[1]==0) )
 #endif
 {
   // Projector P1-
@@ -1297,13 +1297,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
   // -1 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x2==0 ? X+X2X1mX1 : X-X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[1]==0 ? X+X2X1mX1 : X-X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x2==0 ? X+X2X1mX1 : X-X1) >> 1;
+  const int sp_idx = (coord[1]==0 ? X+X2X1mX1 : X-X1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -1342,7 +1342,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
     b2_im = +i12_im+i22_im;
     } else {
     // load spinor from shared memory
-    int tx = (threadIdx.x + blockDim.x - ((x1+1)&1)) % blockDim.x;
+    int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1)) % blockDim.x;
     int ty = (threadIdx.y > 0) ? threadIdx.y - 1 : blockDim.y - 1;
     READ_SPINOR_SHARED(tx, ty, threadIdx.z);
     
@@ -1505,8 +1505,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_Z && x3==X3m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]<X3m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_Z && coord[2]==X3m1) )
 #endif
 {
   // Projector P2+
@@ -1516,13 +1516,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
   // 0 i 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x3==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[2]==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x3==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1;
+  const int sp_idx = (coord[2]==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -1557,7 +1557,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
     b2_im = +i12_im-i32_re;
     } else {
     // load spinor from shared memory
-    int tx = (threadIdx.x + blockDim.x - ((x1+1)&1) ) % blockDim.x;
+    int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1) ) % blockDim.x;
     int tz = (threadIdx.z < blockDim.z - 1) ? threadIdx.z + 1 : 0;
     READ_SPINOR_SHARED(tx, threadIdx.y, tz);
     
@@ -1720,8 +1720,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_Z && x3==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_Z && coord[2]==0) )
 #endif
 {
   // Projector P2-
@@ -1731,13 +1731,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
   // 0 -i 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x3==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[2]==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x3==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1;
+  const int sp_idx = (coord[2]==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -1776,7 +1776,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
     b2_im = +i12_im+i32_re;
     } else {
     // load spinor from shared memory
-    int tx = (threadIdx.x + blockDim.x - ((x1+1)&1)) % blockDim.x;
+    int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1)) % blockDim.x;
     int tz = (threadIdx.z > 0) ? threadIdx.z - 1 : blockDim.z - 1;
     READ_SPINOR_SHARED(tx, threadIdx.y, tz);
     
@@ -1939,8 +1939,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_T && x4==X4m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]<X4m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_T && coord[3]==X4m1) )
 #endif
 {
   // Projector P3+
@@ -1950,13 +1950,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
   // 0 0 0 0 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x4==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[3]==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x4==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1;
+  const int sp_idx = (coord[3]==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -2196,8 +2196,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_T && x4==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_T && coord[3]==0) )
 #endif
 {
   // Projector P3-
@@ -2207,13 +2207,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4>0)) ||
   // 0 0 0 2 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x4==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[3]==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x4==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1;
+  const int sp_idx = (coord[3]==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -2461,14 +2461,15 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4>0)) ||
 int incomplete = 0; // Have all 8 contributions been computed for this site?
 
 switch(kernel_type) { // intentional fall-through
+
 case INTERIOR_KERNEL:
-  incomplete = incomplete || (param.commDim[3] && (x4==0 || x4==X4m1));
+  incomplete = incomplete || (param.commDim[3] && (coord[3]==0 || coord[3]==X4m1));
 case EXTERIOR_KERNEL_T:
-  incomplete = incomplete || (param.commDim[2] && (x3==0 || x3==X3m1));
+  incomplete = incomplete || (param.commDim[2] && (coord[2]==0 || coord[2]==X3m1));
 case EXTERIOR_KERNEL_Z:
-  incomplete = incomplete || (param.commDim[1] && (x2==0 || x2==X2m1));
+  incomplete = incomplete || (param.commDim[1] && (coord[1]==0 || coord[1]==X2m1));
 case EXTERIOR_KERNEL_Y:
-  incomplete = incomplete || (param.commDim[0] && (x1==0 || x1==X1m1));
+  incomplete = incomplete || (param.commDim[0] && (coord[0]==0 || coord[0]==X1m1));
 }
 
 if (!incomplete)

--- a/lib/dslash_core/tmc_dslash_dagger_gt200_core.h
+++ b/lib/dslash_core/tmc_dslash_dagger_gt200_core.h
@@ -612,9 +612,8 @@ if (kernel_type == INTERIOR_KERNEL) {
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  // Inline by hand for the moment and assume even dimensions
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromIndex<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, dims, param.block, param.grid);
+  // Assume even dimensions
+  coordsFromIndex<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X, param.block, param.grid);
 
   o00_re = 0;  o00_im = 0;
   o01_re = 0;  o01_im = 0;
@@ -635,7 +634,6 @@ if (kernel_type == INTERIOR_KERNEL) {
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  const int dim = static_cast<int>(kernel_type);
   const int face_volume = (param.threads >> 1);           // volume of one face
   const int face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
   face_idx = sid - face_num*face_volume;        // index into the respective face
@@ -644,8 +642,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromFaceIndex<1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, dim, face_num, param.parity, dims);
+  coordsFromFaceIndex<kernel_type,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
 
   READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 

--- a/lib/dslash_core/tmc_dslash_dagger_gt200_core.h
+++ b/lib/dslash_core/tmc_dslash_dagger_gt200_core.h
@@ -599,7 +599,7 @@ VOLATILE spinorFloat o32_im;
 #include "read_clover.h"
 #include "tmc_core.h"
 
-int x1, x2, x3, x4;
+int coord[5];
 int X;
 
 int sid;
@@ -613,7 +613,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   if (sid >= param.threads) return;
 
   // Assume even dimensions
-  coordsFromIndex<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X, param.block, param.grid);
+  coordsFromIndex<4,QUDA_4D_PC,EVEN_X>(X, coord, sid, param);
 
   o00_re = 0;  o00_im = 0;
   o01_re = 0;  o01_im = 0;
@@ -642,7 +642,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-  coordsFromFaceIndex<kernel_type,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+  coordsFromFaceIndex<4,QUDA_4D_PC,kernel_type,1>(X, sid, coord, face_idx, face_num, param);
 
   READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 
@@ -663,8 +663,8 @@ if (kernel_type == INTERIOR_KERNEL) {
 
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_X && x1==X1m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]<X1m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_X && coord[0]==X1m1) )
 #endif
 {
   // Projector P0+
@@ -674,13 +674,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
   // -i 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x1==X1m1 ? X-X1m1 : X+1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[0]==X1m1 ? X-X1m1 : X+1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x1==X1m1 ? X-X1m1 : X+1) >> 1;
+  const int sp_idx = (coord[0]==X1m1 ? X-X1m1 : X+1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -857,8 +857,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_X && x1==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_X && coord[0]==0) )
 #endif
 {
   // Projector P0-
@@ -868,13 +868,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
   // i 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x1==0 ? X+X1m1 : X-1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[0]==0 ? X+X1m1 : X-1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x1==0 ? X+X1m1 : X-1) >> 1;
+  const int sp_idx = (coord[0]==0 ? X+X1m1 : X-1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -1055,8 +1055,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_Y && x2==X2m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]<X2m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_Y && coord[1]==X2m1) )
 #endif
 {
   // Projector P1+
@@ -1066,13 +1066,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
   // 1 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x2==X2m1 ? X-X2X1mX1 : X+X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[1]==X2m1 ? X-X2X1mX1 : X+X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x2==X2m1 ? X-X2X1mX1 : X+X1) >> 1;
+  const int sp_idx = (coord[1]==X2m1 ? X-X2X1mX1 : X+X1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -1249,8 +1249,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_Y && x2==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_Y && coord[1]==0) )
 #endif
 {
   // Projector P1-
@@ -1260,13 +1260,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
   // -1 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x2==0 ? X+X2X1mX1 : X-X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[1]==0 ? X+X2X1mX1 : X-X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x2==0 ? X+X2X1mX1 : X-X1) >> 1;
+  const int sp_idx = (coord[1]==0 ? X+X2X1mX1 : X-X1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -1447,8 +1447,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_Z && x3==X3m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]<X3m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_Z && coord[2]==X3m1) )
 #endif
 {
   // Projector P2+
@@ -1458,13 +1458,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
   // 0 i 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x3==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[2]==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x3==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1;
+  const int sp_idx = (coord[2]==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -1641,8 +1641,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_Z && x3==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_Z && coord[2]==0) )
 #endif
 {
   // Projector P2-
@@ -1652,13 +1652,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
   // 0 -i 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x3==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[2]==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x3==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1;
+  const int sp_idx = (coord[2]==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -1839,8 +1839,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_T && x4==X4m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]<X4m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_T && coord[3]==X4m1) )
 #endif
 {
   // Projector P3+
@@ -1850,13 +1850,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
   // 0 0 0 0 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x4==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[3]==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x4==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1;
+  const int sp_idx = (coord[3]==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -2096,8 +2096,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_T && x4==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_T && coord[3]==0) )
 #endif
 {
   // Projector P3-
@@ -2107,13 +2107,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4>0)) ||
   // 0 0 0 2 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x4==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[3]==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x4==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1;
+  const int sp_idx = (coord[3]==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -2361,14 +2361,15 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4>0)) ||
 int incomplete = 0; // Have all 8 contributions been computed for this site?
 
 switch(kernel_type) { // intentional fall-through
+
 case INTERIOR_KERNEL:
-  incomplete = incomplete || (param.commDim[3] && (x4==0 || x4==X4m1));
+  incomplete = incomplete || (param.commDim[3] && (coord[3]==0 || coord[3]==X4m1));
 case EXTERIOR_KERNEL_T:
-  incomplete = incomplete || (param.commDim[2] && (x3==0 || x3==X3m1));
+  incomplete = incomplete || (param.commDim[2] && (coord[2]==0 || coord[2]==X3m1));
 case EXTERIOR_KERNEL_Z:
-  incomplete = incomplete || (param.commDim[1] && (x2==0 || x2==X2m1));
+  incomplete = incomplete || (param.commDim[1] && (coord[1]==0 || coord[1]==X2m1));
 case EXTERIOR_KERNEL_Y:
-  incomplete = incomplete || (param.commDim[0] && (x1==0 || x1==X1m1));
+  incomplete = incomplete || (param.commDim[0] && (coord[0]==0 || coord[0]==X1m1));
 }
 
 if (!incomplete)

--- a/lib/dslash_core/tmc_dslash_fermi_core.h
+++ b/lib/dslash_core/tmc_dslash_fermi_core.h
@@ -616,9 +616,8 @@ int face_idx;
 if (kernel_type == INTERIOR_KERNEL) {
 #endif
 
-  // Inline by hand for the moment and assume even dimensions
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromIndex3D<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, dims);
+  // Assume even dimensions
+  coordsFromIndex3D<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X);
 
   // only need to check Y and Z dims currently since X and T set to match exactly
   if (x2 >= X2) return;
@@ -643,7 +642,6 @@ if (kernel_type == INTERIOR_KERNEL) {
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  const int dim = static_cast<int>(kernel_type);
   const int face_volume = (param.threads >> 1);           // volume of one face
   const int face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
   face_idx = sid - face_num*face_volume;        // index into the respective face
@@ -652,8 +650,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromFaceIndex<1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, dim, face_num, param.parity, dims);
+  coordsFromFaceIndex<kernel_type,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
 
   READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 

--- a/lib/dslash_core/tmc_dslash_fermi_core.h
+++ b/lib/dslash_core/tmc_dslash_fermi_core.h
@@ -606,7 +606,7 @@ VOLATILE spinorFloat o32_im;
 #include "read_clover.h"
 #include "tmc_core.h"
 
-int x1, x2, x3, x4;
+int coord[5];
 int X;
 
 int sid;
@@ -617,11 +617,11 @@ if (kernel_type == INTERIOR_KERNEL) {
 #endif
 
   // Assume even dimensions
-  coordsFromIndex3D<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X);
+  coordsFromIndex3D<EVEN_X>(X, coord, sid, param);
 
   // only need to check Y and Z dims currently since X and T set to match exactly
-  if (x2 >= X2) return;
-  if (x3 >= X3) return;
+  if (coord[1] >= param.X[1]) return;
+  if (coord[2] >= param.X[2]) return;
 
   o00_re = 0;  o00_im = 0;
   o01_re = 0;  o01_im = 0;
@@ -650,7 +650,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-  coordsFromFaceIndex<kernel_type,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+  coordsFromFaceIndex<4,QUDA_4D_PC,kernel_type,1>(X, sid, coord, face_idx, face_num, param);
 
   READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 
@@ -671,8 +671,8 @@ if (kernel_type == INTERIOR_KERNEL) {
 
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_X && x1==X1m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]<X1m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_X && coord[0]==X1m1) )
 #endif
 {
   // Projector P0-
@@ -682,13 +682,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
   // i 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x1==X1m1 ? X-X1m1 : X+1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[0]==X1m1 ? X-X1m1 : X+1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x1==X1m1 ? X-X1m1 : X+1) >> 1;
+  const int sp_idx = (coord[0]==X1m1 ? X-X1m1 : X+1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -868,8 +868,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_X && x1==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_X && coord[0]==0) )
 #endif
 {
   // Projector P0+
@@ -879,13 +879,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
   // -i 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x1==0 ? X+X1m1 : X-1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[0]==0 ? X+X1m1 : X-1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x1==0 ? X+X1m1 : X-1) >> 1;
+  const int sp_idx = (coord[0]==0 ? X+X1m1 : X-1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -1068,8 +1068,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_Y && x2==X2m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]<X2m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_Y && coord[1]==X2m1) )
 #endif
 {
   // Projector P1-
@@ -1079,13 +1079,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
   // -1 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x2==X2m1 ? X-X2X1mX1 : X+X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[1]==X2m1 ? X-X2X1mX1 : X+X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x2==X2m1 ? X-X2X1mX1 : X+X1) >> 1;
+  const int sp_idx = (coord[1]==X2m1 ? X-X2X1mX1 : X+X1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -1120,7 +1120,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
     b2_im = +i12_im+i22_im;
     } else {
     // load spinor from shared memory
-    int tx = (threadIdx.x + blockDim.x - ((x1+1)&1) ) % blockDim.x;
+    int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1) ) % blockDim.x;
     int ty = (threadIdx.y < blockDim.y - 1) ? threadIdx.y + 1 : 0;
     READ_SPINOR_SHARED(tx, ty, threadIdx.z);
     
@@ -1283,8 +1283,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_Y && x2==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_Y && coord[1]==0) )
 #endif
 {
   // Projector P1+
@@ -1294,13 +1294,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
   // 1 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x2==0 ? X+X2X1mX1 : X-X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[1]==0 ? X+X2X1mX1 : X-X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x2==0 ? X+X2X1mX1 : X-X1) >> 1;
+  const int sp_idx = (coord[1]==0 ? X+X2X1mX1 : X-X1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -1339,7 +1339,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
     b2_im = +i12_im-i22_im;
     } else {
     // load spinor from shared memory
-    int tx = (threadIdx.x + blockDim.x - ((x1+1)&1)) % blockDim.x;
+    int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1)) % blockDim.x;
     int ty = (threadIdx.y > 0) ? threadIdx.y - 1 : blockDim.y - 1;
     READ_SPINOR_SHARED(tx, ty, threadIdx.z);
     
@@ -1502,8 +1502,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_Z && x3==X3m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]<X3m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_Z && coord[2]==X3m1) )
 #endif
 {
   // Projector P2-
@@ -1513,13 +1513,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
   // 0 -i 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x3==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[2]==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x3==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1;
+  const int sp_idx = (coord[2]==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -1554,7 +1554,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
     b2_im = +i12_im+i32_re;
     } else {
     // load spinor from shared memory
-    int tx = (threadIdx.x + blockDim.x - ((x1+1)&1) ) % blockDim.x;
+    int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1) ) % blockDim.x;
     int tz = (threadIdx.z < blockDim.z - 1) ? threadIdx.z + 1 : 0;
     READ_SPINOR_SHARED(tx, threadIdx.y, tz);
     
@@ -1717,8 +1717,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_Z && x3==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_Z && coord[2]==0) )
 #endif
 {
   // Projector P2+
@@ -1728,13 +1728,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
   // 0 i 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x3==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[2]==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x3==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1;
+  const int sp_idx = (coord[2]==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -1773,7 +1773,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
     b2_im = +i12_im-i32_re;
     } else {
     // load spinor from shared memory
-    int tx = (threadIdx.x + blockDim.x - ((x1+1)&1)) % blockDim.x;
+    int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1)) % blockDim.x;
     int tz = (threadIdx.z > 0) ? threadIdx.z - 1 : blockDim.z - 1;
     READ_SPINOR_SHARED(tx, threadIdx.y, tz);
     
@@ -1936,8 +1936,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_T && x4==X4m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]<X4m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_T && coord[3]==X4m1) )
 #endif
 {
   // Projector P3-
@@ -1947,13 +1947,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
   // 0 0 0 2 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x4==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[3]==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x4==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1;
+  const int sp_idx = (coord[3]==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -2193,8 +2193,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_T && x4==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_T && coord[3]==0) )
 #endif
 {
   // Projector P3+
@@ -2204,13 +2204,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4>0)) ||
   // 0 0 0 0 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x4==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[3]==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x4==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1;
+  const int sp_idx = (coord[3]==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -2458,14 +2458,15 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4>0)) ||
 int incomplete = 0; // Have all 8 contributions been computed for this site?
 
 switch(kernel_type) { // intentional fall-through
+
 case INTERIOR_KERNEL:
-  incomplete = incomplete || (param.commDim[3] && (x4==0 || x4==X4m1));
+  incomplete = incomplete || (param.commDim[3] && (coord[3]==0 || coord[3]==X4m1));
 case EXTERIOR_KERNEL_T:
-  incomplete = incomplete || (param.commDim[2] && (x3==0 || x3==X3m1));
+  incomplete = incomplete || (param.commDim[2] && (coord[2]==0 || coord[2]==X3m1));
 case EXTERIOR_KERNEL_Z:
-  incomplete = incomplete || (param.commDim[1] && (x2==0 || x2==X2m1));
+  incomplete = incomplete || (param.commDim[1] && (coord[1]==0 || coord[1]==X2m1));
 case EXTERIOR_KERNEL_Y:
-  incomplete = incomplete || (param.commDim[0] && (x1==0 || x1==X1m1));
+  incomplete = incomplete || (param.commDim[0] && (coord[0]==0 || coord[0]==X1m1));
 }
 
 if (!incomplete)

--- a/lib/dslash_core/tmc_dslash_gt200_core.h
+++ b/lib/dslash_core/tmc_dslash_gt200_core.h
@@ -609,9 +609,8 @@ if (kernel_type == INTERIOR_KERNEL) {
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  // Inline by hand for the moment and assume even dimensions
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromIndex<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, dims, param.block, param.grid);
+  // Assume even dimensions
+  coordsFromIndex<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X, param.block, param.grid);
 
   o00_re = 0;  o00_im = 0;
   o01_re = 0;  o01_im = 0;
@@ -632,7 +631,6 @@ if (kernel_type == INTERIOR_KERNEL) {
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  const int dim = static_cast<int>(kernel_type);
   const int face_volume = (param.threads >> 1);           // volume of one face
   const int face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
   face_idx = sid - face_num*face_volume;        // index into the respective face
@@ -641,8 +639,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromFaceIndex<1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, dim, face_num, param.parity, dims);
+  coordsFromFaceIndex<kernel_type,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
 
   READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 

--- a/lib/dslash_core/tmc_dslash_gt200_core.h
+++ b/lib/dslash_core/tmc_dslash_gt200_core.h
@@ -596,7 +596,7 @@ VOLATILE spinorFloat o32_im;
 #include "read_clover.h"
 #include "tmc_core.h"
 
-int x1, x2, x3, x4;
+int coord[5];
 int X;
 
 int sid;
@@ -610,7 +610,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   if (sid >= param.threads) return;
 
   // Assume even dimensions
-  coordsFromIndex<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X, param.block, param.grid);
+  coordsFromIndex<4,QUDA_4D_PC,EVEN_X>(X, coord, sid, param);
 
   o00_re = 0;  o00_im = 0;
   o01_re = 0;  o01_im = 0;
@@ -639,7 +639,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-  coordsFromFaceIndex<kernel_type,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+  coordsFromFaceIndex<4,QUDA_4D_PC,kernel_type,1>(X, sid, coord, face_idx, face_num, param);
 
   READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 
@@ -660,8 +660,8 @@ if (kernel_type == INTERIOR_KERNEL) {
 
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_X && x1==X1m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]<X1m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_X && coord[0]==X1m1) )
 #endif
 {
   // Projector P0-
@@ -671,13 +671,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
   // i 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x1==X1m1 ? X-X1m1 : X+1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[0]==X1m1 ? X-X1m1 : X+1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x1==X1m1 ? X-X1m1 : X+1) >> 1;
+  const int sp_idx = (coord[0]==X1m1 ? X-X1m1 : X+1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -854,8 +854,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_X && x1==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_X && coord[0]==0) )
 #endif
 {
   // Projector P0+
@@ -865,13 +865,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
   // -i 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x1==0 ? X+X1m1 : X-1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[0]==0 ? X+X1m1 : X-1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x1==0 ? X+X1m1 : X-1) >> 1;
+  const int sp_idx = (coord[0]==0 ? X+X1m1 : X-1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -1052,8 +1052,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_Y && x2==X2m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]<X2m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_Y && coord[1]==X2m1) )
 #endif
 {
   // Projector P1-
@@ -1063,13 +1063,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
   // -1 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x2==X2m1 ? X-X2X1mX1 : X+X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[1]==X2m1 ? X-X2X1mX1 : X+X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x2==X2m1 ? X-X2X1mX1 : X+X1) >> 1;
+  const int sp_idx = (coord[1]==X2m1 ? X-X2X1mX1 : X+X1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -1246,8 +1246,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_Y && x2==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_Y && coord[1]==0) )
 #endif
 {
   // Projector P1+
@@ -1257,13 +1257,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
   // 1 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x2==0 ? X+X2X1mX1 : X-X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[1]==0 ? X+X2X1mX1 : X-X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x2==0 ? X+X2X1mX1 : X-X1) >> 1;
+  const int sp_idx = (coord[1]==0 ? X+X2X1mX1 : X-X1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -1444,8 +1444,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_Z && x3==X3m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]<X3m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_Z && coord[2]==X3m1) )
 #endif
 {
   // Projector P2-
@@ -1455,13 +1455,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
   // 0 -i 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x3==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[2]==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x3==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1;
+  const int sp_idx = (coord[2]==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -1638,8 +1638,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_Z && x3==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_Z && coord[2]==0) )
 #endif
 {
   // Projector P2+
@@ -1649,13 +1649,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
   // 0 i 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x3==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[2]==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x3==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1;
+  const int sp_idx = (coord[2]==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -1836,8 +1836,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_T && x4==X4m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]<X4m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_T && coord[3]==X4m1) )
 #endif
 {
   // Projector P3-
@@ -1847,13 +1847,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
   // 0 0 0 2 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x4==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[3]==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x4==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1;
+  const int sp_idx = (coord[3]==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -2093,8 +2093,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_T && x4==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_T && coord[3]==0) )
 #endif
 {
   // Projector P3+
@@ -2104,13 +2104,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4>0)) ||
   // 0 0 0 0 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x4==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[3]==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x4==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1;
+  const int sp_idx = (coord[3]==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -2358,14 +2358,15 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4>0)) ||
 int incomplete = 0; // Have all 8 contributions been computed for this site?
 
 switch(kernel_type) { // intentional fall-through
+
 case INTERIOR_KERNEL:
-  incomplete = incomplete || (param.commDim[3] && (x4==0 || x4==X4m1));
+  incomplete = incomplete || (param.commDim[3] && (coord[3]==0 || coord[3]==X4m1));
 case EXTERIOR_KERNEL_T:
-  incomplete = incomplete || (param.commDim[2] && (x3==0 || x3==X3m1));
+  incomplete = incomplete || (param.commDim[2] && (coord[2]==0 || coord[2]==X3m1));
 case EXTERIOR_KERNEL_Z:
-  incomplete = incomplete || (param.commDim[1] && (x2==0 || x2==X2m1));
+  incomplete = incomplete || (param.commDim[1] && (coord[1]==0 || coord[1]==X2m1));
 case EXTERIOR_KERNEL_Y:
-  incomplete = incomplete || (param.commDim[0] && (x1==0 || x1==X1m1));
+  incomplete = incomplete || (param.commDim[0] && (coord[0]==0 || coord[0]==X1m1));
 }
 
 if (!incomplete)

--- a/lib/dslash_core/tmc_fused_exterior_dslash_dagger_fermi_core.h
+++ b/lib/dslash_core/tmc_fused_exterior_dslash_dagger_fermi_core.h
@@ -620,23 +620,31 @@ int sp_norm_idx;
 
 int sid;
 
-int dim;
-int face_idx;
-int Y[4] = {X1,X2,X3,X4};
-
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
 
-  dim = dimFromFaceIndex(sid, param); // sid is also modified
+  int dim = dimFromFaceIndex(sid, param); // sid is also modified
 
   const int face_volume = ((param.threadDimMapUpper[dim] - param.threadDimMapLower[dim]) >> 1);
   const int face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
-  face_idx = sid - face_num*face_volume;        // index into the respective face
+  int face_idx = sid - face_num*face_volume;        // index into the respective face
 
+  switch(dim) {
+  case 0:
+    coordsFromFaceIndex<0,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 1:
+    coordsFromFaceIndex<1,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 2:
+    coordsFromFaceIndex<2,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 3:
+    coordsFromFaceIndex<3,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  }
 
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromFaceIndex<1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, dim, face_num, param.parity, dims);
 
   bool active = false;
   for(int dir=0; dir<4; ++dir){
@@ -667,7 +675,7 @@ if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   // 0 -i 1 0 
   // -i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
   const int sp_idx = face_idx + param.ghostOffset[0][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][1];
@@ -828,7 +836,7 @@ if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   // 0 i 1 0 
   // i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
   const int sp_idx = face_idx + param.ghostOffset[0][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][0];
@@ -989,7 +997,7 @@ if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   // 0 -1 1 0 
   // 1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
   const int sp_idx = face_idx + param.ghostOffset[1][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][1];
@@ -1150,7 +1158,7 @@ if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   // 0 1 1 0 
   // -1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
   const int sp_idx = face_idx + param.ghostOffset[1][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][0];
@@ -1311,7 +1319,7 @@ if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   // -i 0 1 0 
   // 0 i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
   const int sp_idx = face_idx + param.ghostOffset[2][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][1];
@@ -1472,7 +1480,7 @@ if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   // i 0 1 0 
   // 0 -i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
   const int sp_idx = face_idx + param.ghostOffset[2][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][0];
@@ -1633,7 +1641,7 @@ if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   // 0 0 0 0 
   // 0 0 0 0 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
   const int sp_idx = face_idx + param.ghostOffset[3][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][1];
@@ -1831,7 +1839,7 @@ if (isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
   // 0 0 2 0 
   // 0 0 0 2 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
   const int sp_idx = face_idx + param.ghostOffset[3][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][0];

--- a/lib/dslash_core/tmc_fused_exterior_dslash_dagger_fermi_core.h
+++ b/lib/dslash_core/tmc_fused_exterior_dslash_dagger_fermi_core.h
@@ -611,7 +611,7 @@ VOLATILE spinorFloat o32_im;
 #include "read_clover.h"
 #include "tmc_core.h"
 
-int x1, x2, x3, x4;
+int coord[5];
 int X;
 
 #if (DD_PREC==2) // half precision
@@ -632,23 +632,23 @@ int sid;
 
   switch(dim) {
   case 0:
-    coordsFromFaceIndex<0,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,0,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 1:
-    coordsFromFaceIndex<1,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,1,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 2:
-    coordsFromFaceIndex<2,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,2,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 3:
-    coordsFromFaceIndex<3,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,3,1>(X, sid, coord, face_idx, face_num, param);
     break;
   }
 
 
   bool active = false;
   for(int dir=0; dir<4; ++dir){
-    active = active || isActive(dim,dir,+1,x1,x2,x3,x4,param.commDim,param.X);
+    active = active || isActive(dim,dir,+1,coord,param.commDim,param.X);
   }
   if(!active) return;
 
@@ -667,7 +667,7 @@ int sid;
   o30_re = i30_re;  o30_im = i30_im;
   o31_re = i31_re;  o31_im = i31_im;
   o32_re = i32_re;  o32_im = i32_im;
-if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
+if (isActive(dim,0,+1,coord,param.commDim,param.X) && coord[0]==X1m1 )
 {
   // Projector P0+
   // 1 0 0 i 
@@ -675,7 +675,7 @@ if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   // 0 -i 1 0 
   // -i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,0,param);
   const int sp_idx = face_idx + param.ghostOffset[0][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][1];
@@ -828,7 +828,7 @@ if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   
 }
 
-if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
+if (isActive(dim,0,-1,coord,param.commDim,param.X) && coord[0]==0 )
 {
   // Projector P0-
   // 1 0 0 -i 
@@ -836,7 +836,7 @@ if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   // 0 i 1 0 
   // i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,0,param);
   const int sp_idx = face_idx + param.ghostOffset[0][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][0];
@@ -989,7 +989,7 @@ if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   
 }
 
-if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
+if (isActive(dim,1,+1,coord,param.commDim,param.X) && coord[1]==X2m1 )
 {
   // Projector P1+
   // 1 0 0 1 
@@ -997,7 +997,7 @@ if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   // 0 -1 1 0 
   // 1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,1,param);
   const int sp_idx = face_idx + param.ghostOffset[1][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][1];
@@ -1150,7 +1150,7 @@ if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   
 }
 
-if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
+if (isActive(dim,1,-1,coord,param.commDim,param.X) && coord[1]==0 )
 {
   // Projector P1-
   // 1 0 0 -1 
@@ -1158,7 +1158,7 @@ if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   // 0 1 1 0 
   // -1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,1,param);
   const int sp_idx = face_idx + param.ghostOffset[1][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][0];
@@ -1311,7 +1311,7 @@ if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   
 }
 
-if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
+if (isActive(dim,2,+1,coord,param.commDim,param.X) && coord[2]==X3m1 )
 {
   // Projector P2+
   // 1 0 i 0 
@@ -1319,7 +1319,7 @@ if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   // -i 0 1 0 
   // 0 i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,2,param);
   const int sp_idx = face_idx + param.ghostOffset[2][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][1];
@@ -1472,7 +1472,7 @@ if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   
 }
 
-if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
+if (isActive(dim,2,-1,coord,param.commDim,param.X) && coord[2]==0 )
 {
   // Projector P2-
   // 1 0 -i 0 
@@ -1480,7 +1480,7 @@ if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   // i 0 1 0 
   // 0 -i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,2,param);
   const int sp_idx = face_idx + param.ghostOffset[2][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][0];
@@ -1633,7 +1633,7 @@ if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   
 }
 
-if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
+if (isActive(dim,3,+1,coord,param.commDim,param.X) && coord[3]==X4m1 )
 {
   // Projector P3+
   // 2 0 0 0 
@@ -1641,7 +1641,7 @@ if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   // 0 0 0 0 
   // 0 0 0 0 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,3,param);
   const int sp_idx = face_idx + param.ghostOffset[3][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][1];
@@ -1831,7 +1831,7 @@ if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   }
 }
 
-if (isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
+if (isActive(dim,3,-1,coord,param.commDim,param.X) && coord[3]==0 )
 {
   // Projector P3-
   // 0 0 0 0 
@@ -1839,7 +1839,7 @@ if (isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
   // 0 0 2 0 
   // 0 0 0 2 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,3,param);
   const int sp_idx = face_idx + param.ghostOffset[3][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][0];

--- a/lib/dslash_core/tmc_fused_exterior_dslash_dagger_gt200_core.h
+++ b/lib/dslash_core/tmc_fused_exterior_dslash_dagger_gt200_core.h
@@ -610,23 +610,31 @@ int sp_norm_idx;
 
 int sid;
 
-int dim;
-int face_idx;
-int Y[4] = {X1,X2,X3,X4};
-
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
 
-  dim = dimFromFaceIndex(sid, param); // sid is also modified
+  int dim = dimFromFaceIndex(sid, param); // sid is also modified
 
   const int face_volume = ((param.threadDimMapUpper[dim] - param.threadDimMapLower[dim]) >> 1);
   const int face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
-  face_idx = sid - face_num*face_volume;        // index into the respective face
+  int face_idx = sid - face_num*face_volume;        // index into the respective face
 
+  switch(dim) {
+  case 0:
+    coordsFromFaceIndex<0,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 1:
+    coordsFromFaceIndex<1,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 2:
+    coordsFromFaceIndex<2,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 3:
+    coordsFromFaceIndex<3,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  }
 
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromFaceIndex<1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, dim, face_num, param.parity, dims);
 
   bool active = false;
   for(int dir=0; dir<4; ++dir){
@@ -657,7 +665,7 @@ if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   // 0 -i 1 0 
   // -i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
   const int sp_idx = face_idx + param.ghostOffset[0][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][1];
@@ -818,7 +826,7 @@ if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   // 0 i 1 0 
   // i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
   const int sp_idx = face_idx + param.ghostOffset[0][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][0];
@@ -979,7 +987,7 @@ if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   // 0 -1 1 0 
   // 1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
   const int sp_idx = face_idx + param.ghostOffset[1][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][1];
@@ -1140,7 +1148,7 @@ if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   // 0 1 1 0 
   // -1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
   const int sp_idx = face_idx + param.ghostOffset[1][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][0];
@@ -1301,7 +1309,7 @@ if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   // -i 0 1 0 
   // 0 i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
   const int sp_idx = face_idx + param.ghostOffset[2][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][1];
@@ -1462,7 +1470,7 @@ if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   // i 0 1 0 
   // 0 -i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
   const int sp_idx = face_idx + param.ghostOffset[2][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][0];
@@ -1623,7 +1631,7 @@ if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   // 0 0 0 0 
   // 0 0 0 0 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
   const int sp_idx = face_idx + param.ghostOffset[3][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][1];
@@ -1821,7 +1829,7 @@ if (isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
   // 0 0 2 0 
   // 0 0 0 2 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
   const int sp_idx = face_idx + param.ghostOffset[3][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][0];

--- a/lib/dslash_core/tmc_fused_exterior_dslash_dagger_gt200_core.h
+++ b/lib/dslash_core/tmc_fused_exterior_dslash_dagger_gt200_core.h
@@ -601,7 +601,7 @@ VOLATILE spinorFloat o32_im;
 #include "read_clover.h"
 #include "tmc_core.h"
 
-int x1, x2, x3, x4;
+int coord[5];
 int X;
 
 #if (DD_PREC==2) // half precision
@@ -622,23 +622,23 @@ int sid;
 
   switch(dim) {
   case 0:
-    coordsFromFaceIndex<0,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,0,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 1:
-    coordsFromFaceIndex<1,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,1,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 2:
-    coordsFromFaceIndex<2,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,2,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 3:
-    coordsFromFaceIndex<3,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,3,1>(X, sid, coord, face_idx, face_num, param);
     break;
   }
 
 
   bool active = false;
   for(int dir=0; dir<4; ++dir){
-    active = active || isActive(dim,dir,+1,x1,x2,x3,x4,param.commDim,param.X);
+    active = active || isActive(dim,dir,+1,coord,param.commDim,param.X);
   }
   if(!active) return;
 
@@ -657,7 +657,7 @@ int sid;
   o30_re = i30_re;  o30_im = i30_im;
   o31_re = i31_re;  o31_im = i31_im;
   o32_re = i32_re;  o32_im = i32_im;
-if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
+if (isActive(dim,0,+1,coord,param.commDim,param.X) && coord[0]==X1m1 )
 {
   // Projector P0+
   // 1 0 0 i 
@@ -665,7 +665,7 @@ if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   // 0 -i 1 0 
   // -i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,0,param);
   const int sp_idx = face_idx + param.ghostOffset[0][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][1];
@@ -818,7 +818,7 @@ if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   
 }
 
-if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
+if (isActive(dim,0,-1,coord,param.commDim,param.X) && coord[0]==0 )
 {
   // Projector P0-
   // 1 0 0 -i 
@@ -826,7 +826,7 @@ if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   // 0 i 1 0 
   // i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,0,param);
   const int sp_idx = face_idx + param.ghostOffset[0][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][0];
@@ -979,7 +979,7 @@ if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   
 }
 
-if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
+if (isActive(dim,1,+1,coord,param.commDim,param.X) && coord[1]==X2m1 )
 {
   // Projector P1+
   // 1 0 0 1 
@@ -987,7 +987,7 @@ if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   // 0 -1 1 0 
   // 1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,1,param);
   const int sp_idx = face_idx + param.ghostOffset[1][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][1];
@@ -1140,7 +1140,7 @@ if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   
 }
 
-if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
+if (isActive(dim,1,-1,coord,param.commDim,param.X) && coord[1]==0 )
 {
   // Projector P1-
   // 1 0 0 -1 
@@ -1148,7 +1148,7 @@ if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   // 0 1 1 0 
   // -1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,1,param);
   const int sp_idx = face_idx + param.ghostOffset[1][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][0];
@@ -1301,7 +1301,7 @@ if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   
 }
 
-if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
+if (isActive(dim,2,+1,coord,param.commDim,param.X) && coord[2]==X3m1 )
 {
   // Projector P2+
   // 1 0 i 0 
@@ -1309,7 +1309,7 @@ if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   // -i 0 1 0 
   // 0 i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,2,param);
   const int sp_idx = face_idx + param.ghostOffset[2][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][1];
@@ -1462,7 +1462,7 @@ if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   
 }
 
-if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
+if (isActive(dim,2,-1,coord,param.commDim,param.X) && coord[2]==0 )
 {
   // Projector P2-
   // 1 0 -i 0 
@@ -1470,7 +1470,7 @@ if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   // i 0 1 0 
   // 0 -i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,2,param);
   const int sp_idx = face_idx + param.ghostOffset[2][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][0];
@@ -1623,7 +1623,7 @@ if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   
 }
 
-if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
+if (isActive(dim,3,+1,coord,param.commDim,param.X) && coord[3]==X4m1 )
 {
   // Projector P3+
   // 2 0 0 0 
@@ -1631,7 +1631,7 @@ if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   // 0 0 0 0 
   // 0 0 0 0 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,3,param);
   const int sp_idx = face_idx + param.ghostOffset[3][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][1];
@@ -1821,7 +1821,7 @@ if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   }
 }
 
-if (isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
+if (isActive(dim,3,-1,coord,param.commDim,param.X) && coord[3]==0 )
 {
   // Projector P3-
   // 0 0 0 0 
@@ -1829,7 +1829,7 @@ if (isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
   // 0 0 2 0 
   // 0 0 0 2 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,3,param);
   const int sp_idx = face_idx + param.ghostOffset[3][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][0];

--- a/lib/dslash_core/tmc_fused_exterior_dslash_fermi_core.h
+++ b/lib/dslash_core/tmc_fused_exterior_dslash_fermi_core.h
@@ -617,23 +617,31 @@ int sp_norm_idx;
 
 int sid;
 
-int dim;
-int face_idx;
-int Y[4] = {X1,X2,X3,X4};
-
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
 
-  dim = dimFromFaceIndex(sid, param); // sid is also modified
+  int dim = dimFromFaceIndex(sid, param); // sid is also modified
 
   const int face_volume = ((param.threadDimMapUpper[dim] - param.threadDimMapLower[dim]) >> 1);
   const int face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
-  face_idx = sid - face_num*face_volume;        // index into the respective face
+  int face_idx = sid - face_num*face_volume;        // index into the respective face
 
+  switch(dim) {
+  case 0:
+    coordsFromFaceIndex<0,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 1:
+    coordsFromFaceIndex<1,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 2:
+    coordsFromFaceIndex<2,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 3:
+    coordsFromFaceIndex<3,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  }
 
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromFaceIndex<1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, dim, face_num, param.parity, dims);
 
   bool active = false;
   for(int dir=0; dir<4; ++dir){
@@ -664,7 +672,7 @@ if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   // 0 i 1 0 
   // i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
   const int sp_idx = face_idx + param.ghostOffset[0][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][1];
@@ -825,7 +833,7 @@ if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   // 0 -i 1 0 
   // -i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
   const int sp_idx = face_idx + param.ghostOffset[0][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][0];
@@ -986,7 +994,7 @@ if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   // 0 1 1 0 
   // -1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
   const int sp_idx = face_idx + param.ghostOffset[1][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][1];
@@ -1147,7 +1155,7 @@ if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   // 0 -1 1 0 
   // 1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
   const int sp_idx = face_idx + param.ghostOffset[1][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][0];
@@ -1308,7 +1316,7 @@ if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   // i 0 1 0 
   // 0 -i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
   const int sp_idx = face_idx + param.ghostOffset[2][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][1];
@@ -1469,7 +1477,7 @@ if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   // -i 0 1 0 
   // 0 i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
   const int sp_idx = face_idx + param.ghostOffset[2][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][0];
@@ -1630,7 +1638,7 @@ if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   // 0 0 2 0 
   // 0 0 0 2 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
   const int sp_idx = face_idx + param.ghostOffset[3][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][1];
@@ -1846,7 +1854,7 @@ if (isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
   // 0 0 0 0 
   // 0 0 0 0 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
   const int sp_idx = face_idx + param.ghostOffset[3][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][0];

--- a/lib/dslash_core/tmc_fused_exterior_dslash_fermi_core.h
+++ b/lib/dslash_core/tmc_fused_exterior_dslash_fermi_core.h
@@ -608,7 +608,7 @@ VOLATILE spinorFloat o32_im;
 #include "read_clover.h"
 #include "tmc_core.h"
 
-int x1, x2, x3, x4;
+int coord[5];
 int X;
 
 #if (DD_PREC==2) // half precision
@@ -629,23 +629,23 @@ int sid;
 
   switch(dim) {
   case 0:
-    coordsFromFaceIndex<0,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,0,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 1:
-    coordsFromFaceIndex<1,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,1,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 2:
-    coordsFromFaceIndex<2,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,2,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 3:
-    coordsFromFaceIndex<3,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,3,1>(X, sid, coord, face_idx, face_num, param);
     break;
   }
 
 
   bool active = false;
   for(int dir=0; dir<4; ++dir){
-    active = active || isActive(dim,dir,+1,x1,x2,x3,x4,param.commDim,param.X);
+    active = active || isActive(dim,dir,+1,coord,param.commDim,param.X);
   }
   if(!active) return;
 
@@ -664,7 +664,7 @@ int sid;
   o30_re = i30_re;  o30_im = i30_im;
   o31_re = i31_re;  o31_im = i31_im;
   o32_re = i32_re;  o32_im = i32_im;
-if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
+if (isActive(dim,0,+1,coord,param.commDim,param.X) && coord[0]==X1m1 )
 {
   // Projector P0-
   // 1 0 0 -i 
@@ -672,7 +672,7 @@ if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   // 0 i 1 0 
   // i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,0,param);
   const int sp_idx = face_idx + param.ghostOffset[0][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][1];
@@ -825,7 +825,7 @@ if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   
 }
 
-if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
+if (isActive(dim,0,-1,coord,param.commDim,param.X) && coord[0]==0 )
 {
   // Projector P0+
   // 1 0 0 i 
@@ -833,7 +833,7 @@ if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   // 0 -i 1 0 
   // -i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,0,param);
   const int sp_idx = face_idx + param.ghostOffset[0][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][0];
@@ -986,7 +986,7 @@ if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   
 }
 
-if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
+if (isActive(dim,1,+1,coord,param.commDim,param.X) && coord[1]==X2m1 )
 {
   // Projector P1-
   // 1 0 0 -1 
@@ -994,7 +994,7 @@ if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   // 0 1 1 0 
   // -1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,1,param);
   const int sp_idx = face_idx + param.ghostOffset[1][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][1];
@@ -1147,7 +1147,7 @@ if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   
 }
 
-if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
+if (isActive(dim,1,-1,coord,param.commDim,param.X) && coord[1]==0 )
 {
   // Projector P1+
   // 1 0 0 1 
@@ -1155,7 +1155,7 @@ if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   // 0 -1 1 0 
   // 1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,1,param);
   const int sp_idx = face_idx + param.ghostOffset[1][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][0];
@@ -1308,7 +1308,7 @@ if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   
 }
 
-if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
+if (isActive(dim,2,+1,coord,param.commDim,param.X) && coord[2]==X3m1 )
 {
   // Projector P2-
   // 1 0 -i 0 
@@ -1316,7 +1316,7 @@ if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   // i 0 1 0 
   // 0 -i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,2,param);
   const int sp_idx = face_idx + param.ghostOffset[2][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][1];
@@ -1469,7 +1469,7 @@ if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   
 }
 
-if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
+if (isActive(dim,2,-1,coord,param.commDim,param.X) && coord[2]==0 )
 {
   // Projector P2+
   // 1 0 i 0 
@@ -1477,7 +1477,7 @@ if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   // -i 0 1 0 
   // 0 i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,2,param);
   const int sp_idx = face_idx + param.ghostOffset[2][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][0];
@@ -1630,7 +1630,7 @@ if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   
 }
 
-if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
+if (isActive(dim,3,+1,coord,param.commDim,param.X) && coord[3]==X4m1 )
 {
   // Projector P3-
   // 0 0 0 0 
@@ -1638,7 +1638,7 @@ if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   // 0 0 2 0 
   // 0 0 0 2 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,3,param);
   const int sp_idx = face_idx + param.ghostOffset[3][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][1];
@@ -1846,7 +1846,7 @@ if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   }
 }
 
-if (isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
+if (isActive(dim,3,-1,coord,param.commDim,param.X) && coord[3]==0 )
 {
   // Projector P3+
   // 2 0 0 0 
@@ -1854,7 +1854,7 @@ if (isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
   // 0 0 0 0 
   // 0 0 0 0 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,3,param);
   const int sp_idx = face_idx + param.ghostOffset[3][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][0];

--- a/lib/dslash_core/tmc_fused_exterior_dslash_gt200_core.h
+++ b/lib/dslash_core/tmc_fused_exterior_dslash_gt200_core.h
@@ -598,7 +598,7 @@ VOLATILE spinorFloat o32_im;
 #include "read_clover.h"
 #include "tmc_core.h"
 
-int x1, x2, x3, x4;
+int coord[5];
 int X;
 
 #if (DD_PREC==2) // half precision
@@ -619,23 +619,23 @@ int sid;
 
   switch(dim) {
   case 0:
-    coordsFromFaceIndex<0,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,0,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 1:
-    coordsFromFaceIndex<1,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,1,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 2:
-    coordsFromFaceIndex<2,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,2,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 3:
-    coordsFromFaceIndex<3,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,3,1>(X, sid, coord, face_idx, face_num, param);
     break;
   }
 
 
   bool active = false;
   for(int dir=0; dir<4; ++dir){
-    active = active || isActive(dim,dir,+1,x1,x2,x3,x4,param.commDim,param.X);
+    active = active || isActive(dim,dir,+1,coord,param.commDim,param.X);
   }
   if(!active) return;
 
@@ -654,7 +654,7 @@ int sid;
   o30_re = i30_re;  o30_im = i30_im;
   o31_re = i31_re;  o31_im = i31_im;
   o32_re = i32_re;  o32_im = i32_im;
-if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
+if (isActive(dim,0,+1,coord,param.commDim,param.X) && coord[0]==X1m1 )
 {
   // Projector P0-
   // 1 0 0 -i 
@@ -662,7 +662,7 @@ if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   // 0 i 1 0 
   // i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,0,param);
   const int sp_idx = face_idx + param.ghostOffset[0][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][1];
@@ -815,7 +815,7 @@ if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   
 }
 
-if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
+if (isActive(dim,0,-1,coord,param.commDim,param.X) && coord[0]==0 )
 {
   // Projector P0+
   // 1 0 0 i 
@@ -823,7 +823,7 @@ if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   // 0 -i 1 0 
   // -i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,0,param);
   const int sp_idx = face_idx + param.ghostOffset[0][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][0];
@@ -976,7 +976,7 @@ if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   
 }
 
-if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
+if (isActive(dim,1,+1,coord,param.commDim,param.X) && coord[1]==X2m1 )
 {
   // Projector P1-
   // 1 0 0 -1 
@@ -984,7 +984,7 @@ if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   // 0 1 1 0 
   // -1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,1,param);
   const int sp_idx = face_idx + param.ghostOffset[1][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][1];
@@ -1137,7 +1137,7 @@ if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   
 }
 
-if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
+if (isActive(dim,1,-1,coord,param.commDim,param.X) && coord[1]==0 )
 {
   // Projector P1+
   // 1 0 0 1 
@@ -1145,7 +1145,7 @@ if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   // 0 -1 1 0 
   // 1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,1,param);
   const int sp_idx = face_idx + param.ghostOffset[1][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][0];
@@ -1298,7 +1298,7 @@ if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   
 }
 
-if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
+if (isActive(dim,2,+1,coord,param.commDim,param.X) && coord[2]==X3m1 )
 {
   // Projector P2-
   // 1 0 -i 0 
@@ -1306,7 +1306,7 @@ if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   // i 0 1 0 
   // 0 -i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,2,param);
   const int sp_idx = face_idx + param.ghostOffset[2][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][1];
@@ -1459,7 +1459,7 @@ if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   
 }
 
-if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
+if (isActive(dim,2,-1,coord,param.commDim,param.X) && coord[2]==0 )
 {
   // Projector P2+
   // 1 0 i 0 
@@ -1467,7 +1467,7 @@ if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   // -i 0 1 0 
   // 0 i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,2,param);
   const int sp_idx = face_idx + param.ghostOffset[2][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][0];
@@ -1620,7 +1620,7 @@ if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   
 }
 
-if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
+if (isActive(dim,3,+1,coord,param.commDim,param.X) && coord[3]==X4m1 )
 {
   // Projector P3-
   // 0 0 0 0 
@@ -1628,7 +1628,7 @@ if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   // 0 0 2 0 
   // 0 0 0 2 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,3,param);
   const int sp_idx = face_idx + param.ghostOffset[3][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][1];
@@ -1836,7 +1836,7 @@ if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   }
 }
 
-if (isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
+if (isActive(dim,3,-1,coord,param.commDim,param.X) && coord[3]==0 )
 {
   // Projector P3+
   // 2 0 0 0 
@@ -1844,7 +1844,7 @@ if (isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
   // 0 0 0 0 
   // 0 0 0 0 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,3,param);
   const int sp_idx = face_idx + param.ghostOffset[3][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][0];

--- a/lib/dslash_core/tmc_fused_exterior_dslash_gt200_core.h
+++ b/lib/dslash_core/tmc_fused_exterior_dslash_gt200_core.h
@@ -607,23 +607,31 @@ int sp_norm_idx;
 
 int sid;
 
-int dim;
-int face_idx;
-int Y[4] = {X1,X2,X3,X4};
-
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
 
-  dim = dimFromFaceIndex(sid, param); // sid is also modified
+  int dim = dimFromFaceIndex(sid, param); // sid is also modified
 
   const int face_volume = ((param.threadDimMapUpper[dim] - param.threadDimMapLower[dim]) >> 1);
   const int face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
-  face_idx = sid - face_num*face_volume;        // index into the respective face
+  int face_idx = sid - face_num*face_volume;        // index into the respective face
 
+  switch(dim) {
+  case 0:
+    coordsFromFaceIndex<0,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 1:
+    coordsFromFaceIndex<1,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 2:
+    coordsFromFaceIndex<2,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 3:
+    coordsFromFaceIndex<3,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  }
 
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromFaceIndex<1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, dim, face_num, param.parity, dims);
 
   bool active = false;
   for(int dir=0; dir<4; ++dir){
@@ -654,7 +662,7 @@ if (isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   // 0 i 1 0 
   // i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
   const int sp_idx = face_idx + param.ghostOffset[0][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][1];
@@ -815,7 +823,7 @@ if (isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   // 0 -i 1 0 
   // -i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
   const int sp_idx = face_idx + param.ghostOffset[0][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][0];
@@ -976,7 +984,7 @@ if (isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   // 0 1 1 0 
   // -1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
   const int sp_idx = face_idx + param.ghostOffset[1][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][1];
@@ -1137,7 +1145,7 @@ if (isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   // 0 -1 1 0 
   // 1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
   const int sp_idx = face_idx + param.ghostOffset[1][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][0];
@@ -1298,7 +1306,7 @@ if (isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   // i 0 1 0 
   // 0 -i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
   const int sp_idx = face_idx + param.ghostOffset[2][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][1];
@@ -1459,7 +1467,7 @@ if (isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   // -i 0 1 0 
   // 0 i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
   const int sp_idx = face_idx + param.ghostOffset[2][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][0];
@@ -1620,7 +1628,7 @@ if (isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   // 0 0 2 0 
   // 0 0 0 2 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
   const int sp_idx = face_idx + param.ghostOffset[3][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][1];
@@ -1836,7 +1844,7 @@ if (isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
   // 0 0 0 0 
   // 0 0 0 0 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
   const int sp_idx = face_idx + param.ghostOffset[3][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][0];

--- a/lib/dslash_core/wilson_dslash_dagger_fermi_core.h
+++ b/lib/dslash_core/wilson_dslash_dagger_fermi_core.h
@@ -426,7 +426,6 @@ if (kernel_type == INTERIOR_KERNEL) {
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  const int dim = static_cast<int>(kernel_type);
   const int face_volume = (param.threads >> 1);           // volume of one face
   const int face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
   face_idx = sid - face_num*face_volume;        // index into the respective face
@@ -435,8 +434,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromFaceIndex<1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, dim, face_num, param.parity, dims);
+  coordsFromFaceIndex<kernel_type,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
 
   READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 

--- a/lib/dslash_core/wilson_dslash_dagger_fermi_core.h
+++ b/lib/dslash_core/wilson_dslash_dagger_fermi_core.h
@@ -390,7 +390,7 @@ VOLATILE spinorFloat o32_im;
 #include "read_clover.h"
 #include "io_spinor.h"
 
-int x1, x2, x3, x4;
+int coord[5];
 int X;
 
 int sid;
@@ -401,11 +401,11 @@ if (kernel_type == INTERIOR_KERNEL) {
 #endif
 
   // Assume even dimensions
-  coordsFromIndex3D<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X);
+  coordsFromIndex3D<EVEN_X>(X, x, sid, param.parity, param.X);
 
   // only need to check Y and Z dims currently since X and T set to match exactly
-  if (x2 >= X2) return;
-  if (x3 >= X3) return;
+  if (coord[1] >= param.X[1]) return;
+  if (coord[2] >= param.X[2]) return;
 
   o00_re = 0;  o00_im = 0;
   o01_re = 0;  o01_im = 0;
@@ -434,7 +434,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-  coordsFromFaceIndex<kernel_type,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+  coordsFromFaceIndex<4,QUDA_4D_PC,kernel_type,1>(X, sid, coord, face_idx, face_num, param);
 
   READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 
@@ -455,8 +455,8 @@ if (kernel_type == INTERIOR_KERNEL) {
 
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_X && x1==X1m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]<X1m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_X && coord[0]==X1m1) )
 #endif
 {
   // Projector P0+
@@ -466,13 +466,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
   // -i 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x1==X1m1 ? X-X1m1 : X+1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[0]==X1m1 ? X-X1m1 : X+1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x1==X1m1 ? X-X1m1 : X+1) >> 1;
+  const int sp_idx = (coord[0]==X1m1 ? X-X1m1 : X+1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -652,8 +652,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_X && x1==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_X && coord[0]==0) )
 #endif
 {
   // Projector P0-
@@ -663,13 +663,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
   // i 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x1==0 ? X+X1m1 : X-1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[0]==0 ? X+X1m1 : X-1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x1==0 ? X+X1m1 : X-1) >> 1;
+  const int sp_idx = (coord[0]==0 ? X+X1m1 : X-1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -852,8 +852,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_Y && x2==X2m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]<X2m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_Y && coord[1]==X2m1) )
 #endif
 {
   // Projector P1+
@@ -863,13 +863,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
   // 1 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x2==X2m1 ? X-X2X1mX1 : X+X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[1]==X2m1 ? X-X2X1mX1 : X+param.X[0]) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x2==X2m1 ? X-X2X1mX1 : X+X1) >> 1;
+  const int sp_idx = (coord[1]==X2m1 ? X-X2X1mX1 : X+param.X[0]) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -885,7 +885,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
   if (kernel_type == INTERIOR_KERNEL) {
 #endif
   
-    if (threadIdx.y == blockDim.y-1 && blockDim.y < X2 ) {
+    if (threadIdx.y == blockDim.y-1 && blockDim.y < param.X[1] ) {
     // read spinor from device memory
     READ_SPINOR(SPINORTEX, param.sp_stride, sp_idx, sp_idx);
     
@@ -904,7 +904,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
     b2_im = +i12_im-i22_im;
     } else {
     // load spinor from shared memory
-    int tx = (threadIdx.x + blockDim.x - ((x1+1)&1) ) % blockDim.x;
+    int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1) ) % blockDim.x;
     int ty = (threadIdx.y < blockDim.y - 1) ? threadIdx.y + 1 : 0;
     READ_SPINOR_SHARED(tx, ty, threadIdx.z);
     
@@ -1067,8 +1067,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_Y && x2==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_Y && coord[1]==0) )
 #endif
 {
   // Projector P1-
@@ -1078,13 +1078,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
   // -1 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x2==0 ? X+X2X1mX1 : X-X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[1]==0 ? X+X2X1mX1 : X-param.X[0]) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x2==0 ? X+X2X1mX1 : X-X1) >> 1;
+  const int sp_idx = (coord[1]==0 ? X+X2X1mX1 : X-param.X[0]) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -1104,7 +1104,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
   if (kernel_type == INTERIOR_KERNEL) {
 #endif
   
-    if (threadIdx.y == 0 && blockDim.y < X2) {
+    if (threadIdx.y == 0 && blockDim.y < param.X[1]) {
     // read spinor from device memory
     READ_SPINOR(SPINORTEX, param.sp_stride, sp_idx, sp_idx);
     
@@ -1123,7 +1123,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
     b2_im = +i12_im+i22_im;
     } else {
     // load spinor from shared memory
-    int tx = (threadIdx.x + blockDim.x - ((x1+1)&1)) % blockDim.x;
+    int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1)) % blockDim.x;
     int ty = (threadIdx.y > 0) ? threadIdx.y - 1 : blockDim.y - 1;
     READ_SPINOR_SHARED(tx, ty, threadIdx.z);
     
@@ -1286,8 +1286,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_Z && x3==X3m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]<X3m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_Z && coord[2]==X3m1) )
 #endif
 {
   // Projector P2+
@@ -1297,13 +1297,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
   // 0 i 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x3==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[2]==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x3==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1;
+  const int sp_idx = (coord[2]==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -1319,7 +1319,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
   if (kernel_type == INTERIOR_KERNEL) {
 #endif
   
-    if (threadIdx.z == blockDim.z-1 && blockDim.z < X3) {
+    if (threadIdx.z == blockDim.z-1 && blockDim.z < param.X[2]) {
     // read spinor from device memory
     READ_SPINOR(SPINORTEX, param.sp_stride, sp_idx, sp_idx);
     
@@ -1338,7 +1338,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
     b2_im = +i12_im-i32_re;
     } else {
     // load spinor from shared memory
-    int tx = (threadIdx.x + blockDim.x - ((x1+1)&1) ) % blockDim.x;
+    int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1) ) % blockDim.x;
     int tz = (threadIdx.z < blockDim.z - 1) ? threadIdx.z + 1 : 0;
     READ_SPINOR_SHARED(tx, threadIdx.y, tz);
     
@@ -1501,8 +1501,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_Z && x3==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_Z && coord[2]==0) )
 #endif
 {
   // Projector P2-
@@ -1512,13 +1512,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
   // 0 -i 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x3==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[2]==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x3==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1;
+  const int sp_idx = (coord[2]==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -1538,7 +1538,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
   if (kernel_type == INTERIOR_KERNEL) {
 #endif
   
-    if (threadIdx.z == 0 && blockDim.z < X3) {
+    if (threadIdx.z == 0 && blockDim.z < param.X[2]) {
     // read spinor from device memory
     READ_SPINOR(SPINORTEX, param.sp_stride, sp_idx, sp_idx);
     
@@ -1557,7 +1557,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
     b2_im = +i12_im+i32_re;
     } else {
     // load spinor from shared memory
-    int tx = (threadIdx.x + blockDim.x - ((x1+1)&1)) % blockDim.x;
+    int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1)) % blockDim.x;
     int tz = (threadIdx.z > 0) ? threadIdx.z - 1 : blockDim.z - 1;
     READ_SPINOR_SHARED(tx, threadIdx.y, tz);
     
@@ -1720,8 +1720,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_T && x4==X4m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]<X4m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_T && coord[3]==X4m1) )
 #endif
 {
   // Projector P3+
@@ -1731,13 +1731,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
   // 0 0 0 0 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x4==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[3]==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x4==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1;
+  const int sp_idx = (coord[3]==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -1977,8 +1977,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_T && x4==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_T && coord[3]==0) )
 #endif
 {
   // Projector P3-
@@ -1988,13 +1988,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4>0)) ||
   // 0 0 0 2 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x4==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[3]==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x4==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1;
+  const int sp_idx = (coord[3]==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -2243,13 +2243,13 @@ int incomplete = 0; // Have all 8 contributions been computed for this site?
 
 switch(kernel_type) { // intentional fall-through
 case INTERIOR_KERNEL:
-  incomplete = incomplete || (param.commDim[3] && (x4==0 || x4==X4m1));
+  incomplete = incomplete || (param.commDim[3] && (coord[3]==0 || coord[3]==X4m1));
 case EXTERIOR_KERNEL_T:
-  incomplete = incomplete || (param.commDim[2] && (x3==0 || x3==X3m1));
+  incomplete = incomplete || (param.commDim[2] && (coord[2]==0 || coord[2]==X3m1));
 case EXTERIOR_KERNEL_Z:
-  incomplete = incomplete || (param.commDim[1] && (x2==0 || x2==X2m1));
+  incomplete = incomplete || (param.commDim[1] && (coord[1]==0 || coord[1]==X2m1));
 case EXTERIOR_KERNEL_Y:
-  incomplete = incomplete || (param.commDim[0] && (x1==0 || x1==X1m1));
+  incomplete = incomplete || (param.commDim[0] && (coord[0]==0 || coord[0]==X1m1));
 }
 
 if (!incomplete)

--- a/lib/dslash_core/wilson_dslash_dagger_fermi_core.h
+++ b/lib/dslash_core/wilson_dslash_dagger_fermi_core.h
@@ -400,9 +400,8 @@ int face_idx;
 if (kernel_type == INTERIOR_KERNEL) {
 #endif
 
-  // Inline by hand for the moment and assume even dimensions
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromIndex3D<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, dims);
+  // Assume even dimensions
+  coordsFromIndex3D<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X);
 
   // only need to check Y and Z dims currently since X and T set to match exactly
   if (x2 >= X2) return;

--- a/lib/dslash_core/wilson_dslash_dagger_gt200_core.h
+++ b/lib/dslash_core/wilson_dslash_dagger_gt200_core.h
@@ -393,9 +393,8 @@ if (kernel_type == INTERIOR_KERNEL) {
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  // Inline by hand for the moment and assume even dimensions
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromIndex<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, dims, param.block, param.grid);
+  // Assume even dimensions
+  coordsFromIndex<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X, param.block, param.grid);
 
   o00_re = 0;  o00_im = 0;
   o01_re = 0;  o01_im = 0;

--- a/lib/dslash_core/wilson_dslash_dagger_gt200_core.h
+++ b/lib/dslash_core/wilson_dslash_dagger_gt200_core.h
@@ -415,7 +415,6 @@ if (kernel_type == INTERIOR_KERNEL) {
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  const int dim = static_cast<int>(kernel_type);
   const int face_volume = (param.threads >> 1);           // volume of one face
   const int face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
   face_idx = sid - face_num*face_volume;        // index into the respective face
@@ -424,8 +423,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromFaceIndex<1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, dim, face_num, param.parity, dims);
+  coordsFromFaceIndex<kernel_type,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
 
   READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 

--- a/lib/dslash_core/wilson_dslash_dagger_gt200_core.h
+++ b/lib/dslash_core/wilson_dslash_dagger_gt200_core.h
@@ -380,7 +380,7 @@ VOLATILE spinorFloat o32_im;
 #include "read_clover.h"
 #include "io_spinor.h"
 
-int x1, x2, x3, x4;
+int coord[5];
 int X;
 
 int sid;
@@ -394,7 +394,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   if (sid >= param.threads) return;
 
   // Assume even dimensions
-  coordsFromIndex<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X, param.block, param.grid);
+  coordsFromIndex<4,QUDA_4D_PC,EVEN_X>(X, coord, sid, param);
 
   o00_re = 0;  o00_im = 0;
   o01_re = 0;  o01_im = 0;
@@ -423,7 +423,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-  coordsFromFaceIndex<kernel_type,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+  coordsFromFaceIndex<4,QUDA_4D_PC,kernel_type,1>(X, sid, coord, face_idx, face_num, param);
 
   READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 
@@ -444,8 +444,8 @@ if (kernel_type == INTERIOR_KERNEL) {
 
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_X && x1==X1m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]<X1m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_X && coord[0]==X1m1) )
 #endif
 {
   // Projector P0+
@@ -455,13 +455,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
   // -i 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x1==X1m1 ? X-X1m1 : X+1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[0]==X1m1 ? X-X1m1 : X+1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x1==X1m1 ? X-X1m1 : X+1) >> 1;
+  const int sp_idx = (coord[0]==X1m1 ? X-X1m1 : X+1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -638,8 +638,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_X && x1==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_X && coord[0]==0) )
 #endif
 {
   // Projector P0-
@@ -649,13 +649,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
   // i 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x1==0 ? X+X1m1 : X-1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[0]==0 ? X+X1m1 : X-1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x1==0 ? X+X1m1 : X-1) >> 1;
+  const int sp_idx = (coord[0]==0 ? X+X1m1 : X-1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -836,8 +836,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_Y && x2==X2m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]<X2m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_Y && coord[1]==X2m1) )
 #endif
 {
   // Projector P1+
@@ -847,13 +847,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
   // 1 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x2==X2m1 ? X-X2X1mX1 : X+X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[1]==X2m1 ? X-X2X1mX1 : X+param.X[0]) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x2==X2m1 ? X-X2X1mX1 : X+X1) >> 1;
+  const int sp_idx = (coord[1]==X2m1 ? X-X2X1mX1 : X+param.X[0]) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -1030,8 +1030,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_Y && x2==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_Y && coord[1]==0) )
 #endif
 {
   // Projector P1-
@@ -1041,13 +1041,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
   // -1 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x2==0 ? X+X2X1mX1 : X-X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[1]==0 ? X+X2X1mX1 : X-param.X[0]) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x2==0 ? X+X2X1mX1 : X-X1) >> 1;
+  const int sp_idx = (coord[1]==0 ? X+X2X1mX1 : X-param.X[0]) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -1228,8 +1228,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_Z && x3==X3m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]<X3m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_Z && coord[2]==X3m1) )
 #endif
 {
   // Projector P2+
@@ -1239,13 +1239,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
   // 0 i 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x3==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[2]==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x3==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1;
+  const int sp_idx = (coord[2]==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -1422,8 +1422,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_Z && x3==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_Z && coord[2]==0) )
 #endif
 {
   // Projector P2-
@@ -1433,13 +1433,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
   // 0 -i 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x3==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[2]==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x3==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1;
+  const int sp_idx = (coord[2]==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -1620,8 +1620,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_T && x4==X4m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]<X4m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_T && coord[3]==X4m1) )
 #endif
 {
   // Projector P3+
@@ -1631,13 +1631,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
   // 0 0 0 0 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x4==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[3]==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x4==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1;
+  const int sp_idx = (coord[3]==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -1877,8 +1877,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_T && x4==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_T && coord[3]==0) )
 #endif
 {
   // Projector P3-
@@ -1888,13 +1888,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4>0)) ||
   // 0 0 0 2 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x4==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[3]==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x4==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1;
+  const int sp_idx = (coord[3]==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -2143,13 +2143,13 @@ int incomplete = 0; // Have all 8 contributions been computed for this site?
 
 switch(kernel_type) { // intentional fall-through
 case INTERIOR_KERNEL:
-  incomplete = incomplete || (param.commDim[3] && (x4==0 || x4==X4m1));
+  incomplete = incomplete || (param.commDim[3] && (coord[3]==0 || coord[3]==X4m1));
 case EXTERIOR_KERNEL_T:
-  incomplete = incomplete || (param.commDim[2] && (x3==0 || x3==X3m1));
+  incomplete = incomplete || (param.commDim[2] && (coord[2]==0 || coord[2]==X3m1));
 case EXTERIOR_KERNEL_Z:
-  incomplete = incomplete || (param.commDim[1] && (x2==0 || x2==X2m1));
+  incomplete = incomplete || (param.commDim[1] && (coord[1]==0 || coord[1]==X2m1));
 case EXTERIOR_KERNEL_Y:
-  incomplete = incomplete || (param.commDim[0] && (x1==0 || x1==X1m1));
+  incomplete = incomplete || (param.commDim[0] && (coord[0]==0 || coord[0]==X1m1));
 }
 
 if (!incomplete)

--- a/lib/dslash_core/wilson_dslash_fermi_core.h
+++ b/lib/dslash_core/wilson_dslash_fermi_core.h
@@ -426,7 +426,6 @@ if (kernel_type == INTERIOR_KERNEL) {
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  const int dim = static_cast<int>(kernel_type);
   const int face_volume = (param.threads >> 1);           // volume of one face
   const int face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
   face_idx = sid - face_num*face_volume;        // index into the respective face
@@ -435,8 +434,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromFaceIndex<1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, dim, face_num, param.parity, dims);
+  coordsFromFaceIndex<kernel_type,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
 
   READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 

--- a/lib/dslash_core/wilson_dslash_fermi_core.h
+++ b/lib/dslash_core/wilson_dslash_fermi_core.h
@@ -390,7 +390,7 @@ VOLATILE spinorFloat o32_im;
 #include "read_clover.h"
 #include "io_spinor.h"
 
-int x1, x2, x3, x4;
+int coord[5];
 int X;
 
 int sid;
@@ -401,11 +401,11 @@ if (kernel_type == INTERIOR_KERNEL) {
 #endif
 
   // Assume even dimensions
-  coordsFromIndex3D<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X);
+  coordsFromIndex3D<EVEN_X>(X, x, sid, param.parity, param.X);
 
   // only need to check Y and Z dims currently since X and T set to match exactly
-  if (x2 >= X2) return;
-  if (x3 >= X3) return;
+  if (coord[1] >= param.X[1]) return;
+  if (coord[2] >= param.X[2]) return;
 
   o00_re = 0;  o00_im = 0;
   o01_re = 0;  o01_im = 0;
@@ -434,7 +434,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-  coordsFromFaceIndex<kernel_type,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+  coordsFromFaceIndex<4,QUDA_4D_PC,kernel_type,1>(X, sid, coord, face_idx, face_num, param);
 
   READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 
@@ -455,8 +455,8 @@ if (kernel_type == INTERIOR_KERNEL) {
 
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_X && x1==X1m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]<X1m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_X && coord[0]==X1m1) )
 #endif
 {
   // Projector P0-
@@ -466,13 +466,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
   // i 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x1==X1m1 ? X-X1m1 : X+1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[0]==X1m1 ? X-X1m1 : X+1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x1==X1m1 ? X-X1m1 : X+1) >> 1;
+  const int sp_idx = (coord[0]==X1m1 ? X-X1m1 : X+1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -652,8 +652,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1<X1m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_X && x1==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_X && coord[0]==0) )
 #endif
 {
   // Projector P0+
@@ -663,13 +663,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
   // -i 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x1==0 ? X+X1m1 : X-1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[0]==0 ? X+X1m1 : X-1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x1==0 ? X+X1m1 : X-1) >> 1;
+  const int sp_idx = (coord[0]==0 ? X+X1m1 : X-1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -852,8 +852,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || x1>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_Y && x2==X2m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]<X2m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_Y && coord[1]==X2m1) )
 #endif
 {
   // Projector P1-
@@ -863,13 +863,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
   // -1 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x2==X2m1 ? X-X2X1mX1 : X+X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[1]==X2m1 ? X-X2X1mX1 : X+param.X[0]) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x2==X2m1 ? X-X2X1mX1 : X+X1) >> 1;
+  const int sp_idx = (coord[1]==X2m1 ? X-X2X1mX1 : X+param.X[0]) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -885,7 +885,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
   if (kernel_type == INTERIOR_KERNEL) {
 #endif
   
-    if (threadIdx.y == blockDim.y-1 && blockDim.y < X2 ) {
+    if (threadIdx.y == blockDim.y-1 && blockDim.y < param.X[1] ) {
     // read spinor from device memory
     READ_SPINOR(SPINORTEX, param.sp_stride, sp_idx, sp_idx);
     
@@ -904,7 +904,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
     b2_im = +i12_im+i22_im;
     } else {
     // load spinor from shared memory
-    int tx = (threadIdx.x + blockDim.x - ((x1+1)&1) ) % blockDim.x;
+    int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1) ) % blockDim.x;
     int ty = (threadIdx.y < blockDim.y - 1) ? threadIdx.y + 1 : 0;
     READ_SPINOR_SHARED(tx, ty, threadIdx.z);
     
@@ -1067,8 +1067,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2<X2m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_Y && x2==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_Y && coord[1]==0) )
 #endif
 {
   // Projector P1+
@@ -1078,13 +1078,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
   // 1 0 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x2==0 ? X+X2X1mX1 : X-X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[1]==0 ? X+X2X1mX1 : X-param.X[0]) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x2==0 ? X+X2X1mX1 : X-X1) >> 1;
+  const int sp_idx = (coord[1]==0 ? X+X2X1mX1 : X-param.X[0]) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -1104,7 +1104,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
   if (kernel_type == INTERIOR_KERNEL) {
 #endif
   
-    if (threadIdx.y == 0 && blockDim.y < X2) {
+    if (threadIdx.y == 0 && blockDim.y < param.X[1]) {
     // read spinor from device memory
     READ_SPINOR(SPINORTEX, param.sp_stride, sp_idx, sp_idx);
     
@@ -1123,7 +1123,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
     b2_im = +i12_im-i22_im;
     } else {
     // load spinor from shared memory
-    int tx = (threadIdx.x + blockDim.x - ((x1+1)&1)) % blockDim.x;
+    int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1)) % blockDim.x;
     int ty = (threadIdx.y > 0) ? threadIdx.y - 1 : blockDim.y - 1;
     READ_SPINOR_SHARED(tx, ty, threadIdx.z);
     
@@ -1286,8 +1286,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || x2>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_Z && x3==X3m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]<X3m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_Z && coord[2]==X3m1) )
 #endif
 {
   // Projector P2-
@@ -1297,13 +1297,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
   // 0 -i 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x3==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[2]==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x3==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1;
+  const int sp_idx = (coord[2]==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -1319,7 +1319,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
   if (kernel_type == INTERIOR_KERNEL) {
 #endif
   
-    if (threadIdx.z == blockDim.z-1 && blockDim.z < X3) {
+    if (threadIdx.z == blockDim.z-1 && blockDim.z < param.X[2]) {
     // read spinor from device memory
     READ_SPINOR(SPINORTEX, param.sp_stride, sp_idx, sp_idx);
     
@@ -1338,7 +1338,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
     b2_im = +i12_im+i32_re;
     } else {
     // load spinor from shared memory
-    int tx = (threadIdx.x + blockDim.x - ((x1+1)&1) ) % blockDim.x;
+    int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1) ) % blockDim.x;
     int tz = (threadIdx.z < blockDim.z - 1) ? threadIdx.z + 1 : 0;
     READ_SPINOR_SHARED(tx, threadIdx.y, tz);
     
@@ -1501,8 +1501,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3<X3m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_Z && x3==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_Z && coord[2]==0) )
 #endif
 {
   // Projector P2+
@@ -1512,13 +1512,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
   // 0 i 0 1 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x3==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[2]==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x3==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1;
+  const int sp_idx = (coord[2]==0 ? X+X3X2X1mX2X1 : X-X2X1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -1538,7 +1538,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
   if (kernel_type == INTERIOR_KERNEL) {
 #endif
   
-    if (threadIdx.z == 0 && blockDim.z < X3) {
+    if (threadIdx.z == 0 && blockDim.z < param.X[2]) {
     // read spinor from device memory
     READ_SPINOR(SPINORTEX, param.sp_stride, sp_idx, sp_idx);
     
@@ -1557,7 +1557,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
     b2_im = +i12_im-i32_re;
     } else {
     // load spinor from shared memory
-    int tx = (threadIdx.x + blockDim.x - ((x1+1)&1)) % blockDim.x;
+    int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1)) % blockDim.x;
     int tz = (threadIdx.z > 0) ? threadIdx.z - 1 : blockDim.z - 1;
     READ_SPINOR_SHARED(tx, threadIdx.y, tz);
     
@@ -1720,8 +1720,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || x3>0)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
-     (kernel_type == EXTERIOR_KERNEL_T && x4==X4m1) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]<X4m1)) ||
+     (kernel_type == EXTERIOR_KERNEL_T && coord[3]==X4m1) )
 #endif
 {
   // Projector P3-
@@ -1731,13 +1731,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
   // 0 0 0 2 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x4==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[3]==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][1];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][1];
 #endif
 #else
-  const int sp_idx = (x4==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1;
+  const int sp_idx = (coord[3]==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1;
 #endif
   
   const int ga_idx = sid;
@@ -1977,8 +1977,8 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4<X4m1)) ||
 }
 
 #ifdef MULTI_GPU
-if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4>0)) ||
-     (kernel_type == EXTERIOR_KERNEL_T && x4==0) )
+if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]>0)) ||
+     (kernel_type == EXTERIOR_KERNEL_T && coord[3]==0) )
 #endif
 {
   // Projector P3+
@@ -1988,13 +1988,13 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || x4>0)) ||
   // 0 0 0 0 
   
 #ifdef MULTI_GPU
-  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (x4==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1 :
+  const int sp_idx = (kernel_type == INTERIOR_KERNEL) ? (coord[3]==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1 :
     face_idx + param.ghostOffset[static_cast<int>(kernel_type)][0];
 #if (DD_PREC==2) // half precision
   const int sp_norm_idx = face_idx + param.ghostNormOffset[static_cast<int>(kernel_type)][0];
 #endif
 #else
-  const int sp_idx = (x4==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1;
+  const int sp_idx = (coord[3]==0 ? X+X4X3X2X1mX3X2X1 : X-X3X2X1) >> 1;
 #endif
   
 #ifdef MULTI_GPU
@@ -2243,13 +2243,13 @@ int incomplete = 0; // Have all 8 contributions been computed for this site?
 
 switch(kernel_type) { // intentional fall-through
 case INTERIOR_KERNEL:
-  incomplete = incomplete || (param.commDim[3] && (x4==0 || x4==X4m1));
+  incomplete = incomplete || (param.commDim[3] && (coord[3]==0 || coord[3]==X4m1));
 case EXTERIOR_KERNEL_T:
-  incomplete = incomplete || (param.commDim[2] && (x3==0 || x3==X3m1));
+  incomplete = incomplete || (param.commDim[2] && (coord[2]==0 || coord[2]==X3m1));
 case EXTERIOR_KERNEL_Z:
-  incomplete = incomplete || (param.commDim[1] && (x2==0 || x2==X2m1));
+  incomplete = incomplete || (param.commDim[1] && (coord[1]==0 || coord[1]==X2m1));
 case EXTERIOR_KERNEL_Y:
-  incomplete = incomplete || (param.commDim[0] && (x1==0 || x1==X1m1));
+  incomplete = incomplete || (param.commDim[0] && (coord[0]==0 || coord[0]==X1m1));
 }
 
 if (!incomplete)

--- a/lib/dslash_core/wilson_dslash_fermi_core.h
+++ b/lib/dslash_core/wilson_dslash_fermi_core.h
@@ -400,9 +400,8 @@ int face_idx;
 if (kernel_type == INTERIOR_KERNEL) {
 #endif
 
-  // Inline by hand for the moment and assume even dimensions
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromIndex3D<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, dims);
+  // Assume even dimensions
+  coordsFromIndex3D<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X);
 
   // only need to check Y and Z dims currently since X and T set to match exactly
   if (x2 >= X2) return;

--- a/lib/dslash_core/wilson_dslash_gt200_core.h
+++ b/lib/dslash_core/wilson_dslash_gt200_core.h
@@ -393,9 +393,8 @@ if (kernel_type == INTERIOR_KERNEL) {
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  // Inline by hand for the moment and assume even dimensions
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromIndex<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, dims, param.block, param.grid);
+  // Assume even dimensions
+  coordsFromIndex<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X, param.block, param.grid);
 
   o00_re = 0;  o00_im = 0;
   o01_re = 0;  o01_im = 0;

--- a/lib/dslash_core/wilson_dslash_gt200_core.h
+++ b/lib/dslash_core/wilson_dslash_gt200_core.h
@@ -415,7 +415,6 @@ if (kernel_type == INTERIOR_KERNEL) {
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  const int dim = static_cast<int>(kernel_type);
   const int face_volume = (param.threads >> 1);           // volume of one face
   const int face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
   face_idx = sid - face_num*face_volume;        // index into the respective face
@@ -424,8 +423,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromFaceIndex<1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, dim, face_num, param.parity, dims);
+  coordsFromFaceIndex<kernel_type,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
 
   READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 

--- a/lib/dslash_core/wilson_fused_exterior_dslash_dagger_fermi_core.h
+++ b/lib/dslash_core/wilson_fused_exterior_dslash_dagger_fermi_core.h
@@ -401,39 +401,42 @@ int sp_norm_idx;
 
 int sid;
 
-int dim;
-int face_num;
-int face_idx;
-int Y[4] = {X1,X2,X3,X4};
-
-
 
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  dim = dimFromFaceIndex(sid, param); // sid is also modified
+  int dim = dimFromFaceIndex(sid, param); // sid is also modified
 
 
   const int face_volume = ((param.threadDimMapUpper[dim] - param.threadDimMapLower[dim]) >> 1);   // volume of one face
-  face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
-  face_idx = sid - face_num*face_volume;        // index into the respective face
+  int face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
+  int face_idx = sid - face_num*face_volume;        // index into the respective face
 
   // ghostOffset is scaled to include body (includes stride) and number of FloatN arrays (SPINOR_HOP)
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-
-  coordsFromFaceIndex<1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, dim, face_num, param.parity,Y);
-
-  {
-    bool active = false;
-    for(int dir=0; dir<4; ++dir){
-     active = active  || isActive(dim,dir,+1,x1,x2,x3,x4,param.commDim,param.X);
-    }
-    if(!active) return;
+  switch(dim) {
+  case 0:
+    coordsFromFaceIndex<0,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 1:
+    coordsFromFaceIndex<1,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 2:
+    coordsFromFaceIndex<2,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 3:
+    coordsFromFaceIndex<3,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
   }
 
 
+  bool active = false;
+  for(int dir=0; dir<4; ++dir){
+   active = active  || isActive(dim,dir,+1,x1,x2,x3,x4,param.commDim,param.X);
+  }
+  if(!active) return;
 
   READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 
@@ -459,7 +462,7 @@ if ( isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   // 0 -i 1 0 
   // -i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
   const int sp_idx = face_idx + param.ghostOffset[0][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][1];
@@ -621,7 +624,7 @@ if ( isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   // 0 i 1 0 
   // i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
   const int sp_idx = face_idx + param.ghostOffset[0][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][0];
@@ -783,7 +786,7 @@ if ( isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   // 0 -1 1 0 
   // 1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
   const int sp_idx = face_idx + param.ghostOffset[1][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][1];
@@ -945,7 +948,7 @@ if ( isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   // 0 1 1 0 
   // -1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
   const int sp_idx = face_idx + param.ghostOffset[1][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][0];
@@ -1107,7 +1110,7 @@ if ( isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   // -i 0 1 0 
   // 0 i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
   const int sp_idx = face_idx + param.ghostOffset[2][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][1];
@@ -1269,7 +1272,7 @@ if ( isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   // i 0 1 0 
   // 0 -i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
   const int sp_idx = face_idx + param.ghostOffset[2][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][0];
@@ -1431,7 +1434,7 @@ if ( isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   // 0 0 0 0 
   // 0 0 0 0 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
   const int sp_idx = face_idx + param.ghostOffset[3][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][1];
@@ -1631,7 +1634,7 @@ if ( isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
   // 0 0 2 0 
   // 0 0 0 2 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
   const int sp_idx = face_idx + param.ghostOffset[3][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][0];

--- a/lib/dslash_core/wilson_fused_exterior_dslash_dagger_fermi_core.h
+++ b/lib/dslash_core/wilson_fused_exterior_dslash_dagger_fermi_core.h
@@ -392,7 +392,7 @@ VOLATILE spinorFloat o32_im;
 #include "read_clover.h"
 #include "io_spinor.h"
 
-int x1, x2, x3, x4;
+int coord[5];
 int X;
 
 #if (DD_PREC==2) // half precision
@@ -418,23 +418,23 @@ int sid;
 
   switch(dim) {
   case 0:
-    coordsFromFaceIndex<0,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,0,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 1:
-    coordsFromFaceIndex<1,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,1,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 2:
-    coordsFromFaceIndex<2,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,2,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 3:
-    coordsFromFaceIndex<3,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,3,1>(X, sid, coord, face_idx, face_num, param);
     break;
   }
 
 
   bool active = false;
   for(int dir=0; dir<4; ++dir){
-   active = active  || isActive(dim,dir,+1,x1,x2,x3,x4,param.commDim,param.X);
+   active = active  || isActive(dim,dir,+1,coord,param.commDim,param.X);
   }
   if(!active) return;
 
@@ -454,7 +454,7 @@ int sid;
   o32_re = i32_re;  o32_im = i32_im;
 
 
-if ( isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
+if ( isActive(dim,0,+1,coord,param.commDim,param.X) && coord[0]==X1m1 )
 {
   // Projector P0+
   // 1 0 0 i 
@@ -462,7 +462,7 @@ if ( isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   // 0 -i 1 0 
   // -i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,0,param);
   const int sp_idx = face_idx + param.ghostOffset[0][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][1];
@@ -616,7 +616,7 @@ if ( isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   
 }
 
-if ( isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
+if ( isActive(dim,0,-1,coord,param.commDim,param.X) && coord[0]==0 )
 {
   // Projector P0-
   // 1 0 0 -i 
@@ -624,7 +624,7 @@ if ( isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   // 0 i 1 0 
   // i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,0,param);
   const int sp_idx = face_idx + param.ghostOffset[0][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][0];
@@ -778,7 +778,7 @@ if ( isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   
 }
 
-if ( isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
+if ( isActive(dim,1,+1,coord,param.commDim,param.X) && coord[1]==X2m1 )
 {
   // Projector P1+
   // 1 0 0 1 
@@ -786,7 +786,7 @@ if ( isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   // 0 -1 1 0 
   // 1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,1,param);
   const int sp_idx = face_idx + param.ghostOffset[1][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][1];
@@ -940,7 +940,7 @@ if ( isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   
 }
 
-if ( isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
+if ( isActive(dim,1,-1,coord,param.commDim,param.X) && coord[1]==0 )
 {
   // Projector P1-
   // 1 0 0 -1 
@@ -948,7 +948,7 @@ if ( isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   // 0 1 1 0 
   // -1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,1,param);
   const int sp_idx = face_idx + param.ghostOffset[1][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][0];
@@ -1102,7 +1102,7 @@ if ( isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   
 }
 
-if ( isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
+if ( isActive(dim,2,+1,coord,param.commDim,param.X) && coord[2]==X3m1 )
 {
   // Projector P2+
   // 1 0 i 0 
@@ -1110,7 +1110,7 @@ if ( isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   // -i 0 1 0 
   // 0 i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,2,param);
   const int sp_idx = face_idx + param.ghostOffset[2][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][1];
@@ -1264,7 +1264,7 @@ if ( isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   
 }
 
-if ( isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
+if ( isActive(dim,2,-1,coord,param.commDim,param.X) && coord[2]==0 )
 {
   // Projector P2-
   // 1 0 -i 0 
@@ -1272,7 +1272,7 @@ if ( isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   // i 0 1 0 
   // 0 -i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,2,param);
   const int sp_idx = face_idx + param.ghostOffset[2][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][0];
@@ -1426,7 +1426,7 @@ if ( isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   
 }
 
-if ( isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
+if ( isActive(dim,3,+1,coord,param.commDim,param.X) && coord[3]==X4m1 )
 {
   // Projector P3+
   // 2 0 0 0 
@@ -1434,7 +1434,7 @@ if ( isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   // 0 0 0 0 
   // 0 0 0 0 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,3,param);
   const int sp_idx = face_idx + param.ghostOffset[3][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][1];
@@ -1626,7 +1626,7 @@ if ( isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   }
 }
 
-if ( isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
+if ( isActive(dim,3,-1,coord,param.commDim,param.X) && coord[3]==0 )
 {
   // Projector P3-
   // 0 0 0 0 
@@ -1634,7 +1634,7 @@ if ( isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
   // 0 0 2 0 
   // 0 0 0 2 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,3,param);
   const int sp_idx = face_idx + param.ghostOffset[3][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][0];

--- a/lib/dslash_core/wilson_fused_exterior_dslash_dagger_gt200_core.h
+++ b/lib/dslash_core/wilson_fused_exterior_dslash_dagger_gt200_core.h
@@ -391,39 +391,42 @@ int sp_norm_idx;
 
 int sid;
 
-int dim;
-int face_num;
-int face_idx;
-int Y[4] = {X1,X2,X3,X4};
-
-
 
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  dim = dimFromFaceIndex(sid, param); // sid is also modified
+  int dim = dimFromFaceIndex(sid, param); // sid is also modified
 
 
   const int face_volume = ((param.threadDimMapUpper[dim] - param.threadDimMapLower[dim]) >> 1);   // volume of one face
-  face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
-  face_idx = sid - face_num*face_volume;        // index into the respective face
+  int face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
+  int face_idx = sid - face_num*face_volume;        // index into the respective face
 
   // ghostOffset is scaled to include body (includes stride) and number of FloatN arrays (SPINOR_HOP)
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-
-  coordsFromFaceIndex<1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, dim, face_num, param.parity,Y);
-
-  {
-    bool active = false;
-    for(int dir=0; dir<4; ++dir){
-     active = active  || isActive(dim,dir,+1,x1,x2,x3,x4,param.commDim,param.X);
-    }
-    if(!active) return;
+  switch(dim) {
+  case 0:
+    coordsFromFaceIndex<0,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 1:
+    coordsFromFaceIndex<1,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 2:
+    coordsFromFaceIndex<2,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 3:
+    coordsFromFaceIndex<3,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
   }
 
 
+  bool active = false;
+  for(int dir=0; dir<4; ++dir){
+   active = active  || isActive(dim,dir,+1,x1,x2,x3,x4,param.commDim,param.X);
+  }
+  if(!active) return;
 
   READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 
@@ -449,7 +452,7 @@ if ( isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   // 0 -i 1 0 
   // -i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
   const int sp_idx = face_idx + param.ghostOffset[0][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][1];
@@ -611,7 +614,7 @@ if ( isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   // 0 i 1 0 
   // i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
   const int sp_idx = face_idx + param.ghostOffset[0][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][0];
@@ -773,7 +776,7 @@ if ( isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   // 0 -1 1 0 
   // 1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
   const int sp_idx = face_idx + param.ghostOffset[1][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][1];
@@ -935,7 +938,7 @@ if ( isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   // 0 1 1 0 
   // -1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
   const int sp_idx = face_idx + param.ghostOffset[1][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][0];
@@ -1097,7 +1100,7 @@ if ( isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   // -i 0 1 0 
   // 0 i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
   const int sp_idx = face_idx + param.ghostOffset[2][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][1];
@@ -1259,7 +1262,7 @@ if ( isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   // i 0 1 0 
   // 0 -i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
   const int sp_idx = face_idx + param.ghostOffset[2][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][0];
@@ -1421,7 +1424,7 @@ if ( isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   // 0 0 0 0 
   // 0 0 0 0 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
   const int sp_idx = face_idx + param.ghostOffset[3][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][1];
@@ -1621,7 +1624,7 @@ if ( isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
   // 0 0 2 0 
   // 0 0 0 2 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
   const int sp_idx = face_idx + param.ghostOffset[3][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][0];

--- a/lib/dslash_core/wilson_fused_exterior_dslash_dagger_gt200_core.h
+++ b/lib/dslash_core/wilson_fused_exterior_dslash_dagger_gt200_core.h
@@ -382,7 +382,7 @@ VOLATILE spinorFloat o32_im;
 #include "read_clover.h"
 #include "io_spinor.h"
 
-int x1, x2, x3, x4;
+int coord[5];
 int X;
 
 #if (DD_PREC==2) // half precision
@@ -408,23 +408,23 @@ int sid;
 
   switch(dim) {
   case 0:
-    coordsFromFaceIndex<0,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,0,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 1:
-    coordsFromFaceIndex<1,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,1,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 2:
-    coordsFromFaceIndex<2,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,2,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 3:
-    coordsFromFaceIndex<3,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,3,1>(X, sid, coord, face_idx, face_num, param);
     break;
   }
 
 
   bool active = false;
   for(int dir=0; dir<4; ++dir){
-   active = active  || isActive(dim,dir,+1,x1,x2,x3,x4,param.commDim,param.X);
+   active = active  || isActive(dim,dir,+1,coord,param.commDim,param.X);
   }
   if(!active) return;
 
@@ -444,7 +444,7 @@ int sid;
   o32_re = i32_re;  o32_im = i32_im;
 
 
-if ( isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
+if ( isActive(dim,0,+1,coord,param.commDim,param.X) && coord[0]==X1m1 )
 {
   // Projector P0+
   // 1 0 0 i 
@@ -452,7 +452,7 @@ if ( isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   // 0 -i 1 0 
   // -i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,0,param);
   const int sp_idx = face_idx + param.ghostOffset[0][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][1];
@@ -606,7 +606,7 @@ if ( isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   
 }
 
-if ( isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
+if ( isActive(dim,0,-1,coord,param.commDim,param.X) && coord[0]==0 )
 {
   // Projector P0-
   // 1 0 0 -i 
@@ -614,7 +614,7 @@ if ( isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   // 0 i 1 0 
   // i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,0,param);
   const int sp_idx = face_idx + param.ghostOffset[0][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][0];
@@ -768,7 +768,7 @@ if ( isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   
 }
 
-if ( isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
+if ( isActive(dim,1,+1,coord,param.commDim,param.X) && coord[1]==X2m1 )
 {
   // Projector P1+
   // 1 0 0 1 
@@ -776,7 +776,7 @@ if ( isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   // 0 -1 1 0 
   // 1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,1,param);
   const int sp_idx = face_idx + param.ghostOffset[1][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][1];
@@ -930,7 +930,7 @@ if ( isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   
 }
 
-if ( isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
+if ( isActive(dim,1,-1,coord,param.commDim,param.X) && coord[1]==0 )
 {
   // Projector P1-
   // 1 0 0 -1 
@@ -938,7 +938,7 @@ if ( isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   // 0 1 1 0 
   // -1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,1,param);
   const int sp_idx = face_idx + param.ghostOffset[1][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][0];
@@ -1092,7 +1092,7 @@ if ( isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   
 }
 
-if ( isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
+if ( isActive(dim,2,+1,coord,param.commDim,param.X) && coord[2]==X3m1 )
 {
   // Projector P2+
   // 1 0 i 0 
@@ -1100,7 +1100,7 @@ if ( isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   // -i 0 1 0 
   // 0 i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,2,param);
   const int sp_idx = face_idx + param.ghostOffset[2][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][1];
@@ -1254,7 +1254,7 @@ if ( isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   
 }
 
-if ( isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
+if ( isActive(dim,2,-1,coord,param.commDim,param.X) && coord[2]==0 )
 {
   // Projector P2-
   // 1 0 -i 0 
@@ -1262,7 +1262,7 @@ if ( isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   // i 0 1 0 
   // 0 -i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,2,param);
   const int sp_idx = face_idx + param.ghostOffset[2][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][0];
@@ -1416,7 +1416,7 @@ if ( isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   
 }
 
-if ( isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
+if ( isActive(dim,3,+1,coord,param.commDim,param.X) && coord[3]==X4m1 )
 {
   // Projector P3+
   // 2 0 0 0 
@@ -1424,7 +1424,7 @@ if ( isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   // 0 0 0 0 
   // 0 0 0 0 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,3,param);
   const int sp_idx = face_idx + param.ghostOffset[3][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][1];
@@ -1616,7 +1616,7 @@ if ( isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   }
 }
 
-if ( isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
+if ( isActive(dim,3,-1,coord,param.commDim,param.X) && coord[3]==0 )
 {
   // Projector P3-
   // 0 0 0 0 
@@ -1624,7 +1624,7 @@ if ( isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
   // 0 0 2 0 
   // 0 0 0 2 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,3,param);
   const int sp_idx = face_idx + param.ghostOffset[3][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][0];

--- a/lib/dslash_core/wilson_fused_exterior_dslash_fermi_core.h
+++ b/lib/dslash_core/wilson_fused_exterior_dslash_fermi_core.h
@@ -392,7 +392,7 @@ VOLATILE spinorFloat o32_im;
 #include "read_clover.h"
 #include "io_spinor.h"
 
-int x1, x2, x3, x4;
+int coord[5];
 int X;
 
 #if (DD_PREC==2) // half precision
@@ -418,23 +418,23 @@ int sid;
 
   switch(dim) {
   case 0:
-    coordsFromFaceIndex<0,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,0,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 1:
-    coordsFromFaceIndex<1,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,1,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 2:
-    coordsFromFaceIndex<2,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,2,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 3:
-    coordsFromFaceIndex<3,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,3,1>(X, sid, coord, face_idx, face_num, param);
     break;
   }
 
 
   bool active = false;
   for(int dir=0; dir<4; ++dir){
-   active = active  || isActive(dim,dir,+1,x1,x2,x3,x4,param.commDim,param.X);
+   active = active  || isActive(dim,dir,+1,coord,param.commDim,param.X);
   }
   if(!active) return;
 
@@ -454,7 +454,7 @@ int sid;
   o32_re = i32_re;  o32_im = i32_im;
 
 
-if ( isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
+if ( isActive(dim,0,+1,coord,param.commDim,param.X) && coord[0]==X1m1 )
 {
   // Projector P0-
   // 1 0 0 -i 
@@ -462,7 +462,7 @@ if ( isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   // 0 i 1 0 
   // i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,0,param);
   const int sp_idx = face_idx + param.ghostOffset[0][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][1];
@@ -616,7 +616,7 @@ if ( isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   
 }
 
-if ( isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
+if ( isActive(dim,0,-1,coord,param.commDim,param.X) && coord[0]==0 )
 {
   // Projector P0+
   // 1 0 0 i 
@@ -624,7 +624,7 @@ if ( isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   // 0 -i 1 0 
   // -i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,0,param);
   const int sp_idx = face_idx + param.ghostOffset[0][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][0];
@@ -778,7 +778,7 @@ if ( isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   
 }
 
-if ( isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
+if ( isActive(dim,1,+1,coord,param.commDim,param.X) && coord[1]==X2m1 )
 {
   // Projector P1-
   // 1 0 0 -1 
@@ -786,7 +786,7 @@ if ( isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   // 0 1 1 0 
   // -1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,1,param);
   const int sp_idx = face_idx + param.ghostOffset[1][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][1];
@@ -940,7 +940,7 @@ if ( isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   
 }
 
-if ( isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
+if ( isActive(dim,1,-1,coord,param.commDim,param.X) && coord[1]==0 )
 {
   // Projector P1+
   // 1 0 0 1 
@@ -948,7 +948,7 @@ if ( isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   // 0 -1 1 0 
   // 1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,1,param);
   const int sp_idx = face_idx + param.ghostOffset[1][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][0];
@@ -1102,7 +1102,7 @@ if ( isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   
 }
 
-if ( isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
+if ( isActive(dim,2,+1,coord,param.commDim,param.X) && coord[2]==X3m1 )
 {
   // Projector P2-
   // 1 0 -i 0 
@@ -1110,7 +1110,7 @@ if ( isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   // i 0 1 0 
   // 0 -i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,2,param);
   const int sp_idx = face_idx + param.ghostOffset[2][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][1];
@@ -1264,7 +1264,7 @@ if ( isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   
 }
 
-if ( isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
+if ( isActive(dim,2,-1,coord,param.commDim,param.X) && coord[2]==0 )
 {
   // Projector P2+
   // 1 0 i 0 
@@ -1272,7 +1272,7 @@ if ( isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   // -i 0 1 0 
   // 0 i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,2,param);
   const int sp_idx = face_idx + param.ghostOffset[2][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][0];
@@ -1426,7 +1426,7 @@ if ( isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   
 }
 
-if ( isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
+if ( isActive(dim,3,+1,coord,param.commDim,param.X) && coord[3]==X4m1 )
 {
   // Projector P3-
   // 0 0 0 0 
@@ -1434,7 +1434,7 @@ if ( isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   // 0 0 2 0 
   // 0 0 0 2 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,3,param);
   const int sp_idx = face_idx + param.ghostOffset[3][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][1];
@@ -1626,7 +1626,7 @@ if ( isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   }
 }
 
-if ( isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
+if ( isActive(dim,3,-1,coord,param.commDim,param.X) && coord[3]==0 )
 {
   // Projector P3+
   // 2 0 0 0 
@@ -1634,7 +1634,7 @@ if ( isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
   // 0 0 0 0 
   // 0 0 0 0 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,3,param);
   const int sp_idx = face_idx + param.ghostOffset[3][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][0];

--- a/lib/dslash_core/wilson_fused_exterior_dslash_gt200_core.h
+++ b/lib/dslash_core/wilson_fused_exterior_dslash_gt200_core.h
@@ -382,7 +382,7 @@ VOLATILE spinorFloat o32_im;
 #include "read_clover.h"
 #include "io_spinor.h"
 
-int x1, x2, x3, x4;
+int coord[5];
 int X;
 
 #if (DD_PREC==2) // half precision
@@ -408,23 +408,23 @@ int sid;
 
   switch(dim) {
   case 0:
-    coordsFromFaceIndex<0,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,0,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 1:
-    coordsFromFaceIndex<1,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,1,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 2:
-    coordsFromFaceIndex<2,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,2,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 3:
-    coordsFromFaceIndex<3,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,3,1>(X, sid, coord, face_idx, face_num, param);
     break;
   }
 
 
   bool active = false;
   for(int dir=0; dir<4; ++dir){
-   active = active  || isActive(dim,dir,+1,x1,x2,x3,x4,param.commDim,param.X);
+   active = active  || isActive(dim,dir,+1,coord,param.commDim,param.X);
   }
   if(!active) return;
 
@@ -444,7 +444,7 @@ int sid;
   o32_re = i32_re;  o32_im = i32_im;
 
 
-if ( isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
+if ( isActive(dim,0,+1,coord,param.commDim,param.X) && coord[0]==X1m1 )
 {
   // Projector P0-
   // 1 0 0 -i 
@@ -452,7 +452,7 @@ if ( isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   // 0 i 1 0 
   // i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,0,param);
   const int sp_idx = face_idx + param.ghostOffset[0][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][1];
@@ -606,7 +606,7 @@ if ( isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   
 }
 
-if ( isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
+if ( isActive(dim,0,-1,coord,param.commDim,param.X) && coord[0]==0 )
 {
   // Projector P0+
   // 1 0 0 i 
@@ -614,7 +614,7 @@ if ( isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   // 0 -i 1 0 
   // -i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,0,param);
   const int sp_idx = face_idx + param.ghostOffset[0][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][0];
@@ -768,7 +768,7 @@ if ( isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   
 }
 
-if ( isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
+if ( isActive(dim,1,+1,coord,param.commDim,param.X) && coord[1]==X2m1 )
 {
   // Projector P1-
   // 1 0 0 -1 
@@ -776,7 +776,7 @@ if ( isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   // 0 1 1 0 
   // -1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,1,param);
   const int sp_idx = face_idx + param.ghostOffset[1][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][1];
@@ -930,7 +930,7 @@ if ( isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   
 }
 
-if ( isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
+if ( isActive(dim,1,-1,coord,param.commDim,param.X) && coord[1]==0 )
 {
   // Projector P1+
   // 1 0 0 1 
@@ -938,7 +938,7 @@ if ( isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   // 0 -1 1 0 
   // 1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,1,param);
   const int sp_idx = face_idx + param.ghostOffset[1][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][0];
@@ -1092,7 +1092,7 @@ if ( isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   
 }
 
-if ( isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
+if ( isActive(dim,2,+1,coord,param.commDim,param.X) && coord[2]==X3m1 )
 {
   // Projector P2-
   // 1 0 -i 0 
@@ -1100,7 +1100,7 @@ if ( isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   // i 0 1 0 
   // 0 -i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,2,param);
   const int sp_idx = face_idx + param.ghostOffset[2][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][1];
@@ -1254,7 +1254,7 @@ if ( isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   
 }
 
-if ( isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
+if ( isActive(dim,2,-1,coord,param.commDim,param.X) && coord[2]==0 )
 {
   // Projector P2+
   // 1 0 i 0 
@@ -1262,7 +1262,7 @@ if ( isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   // -i 0 1 0 
   // 0 i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,2,param);
   const int sp_idx = face_idx + param.ghostOffset[2][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][0];
@@ -1416,7 +1416,7 @@ if ( isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   
 }
 
-if ( isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
+if ( isActive(dim,3,+1,coord,param.commDim,param.X) && coord[3]==X4m1 )
 {
   // Projector P3-
   // 0 0 0 0 
@@ -1424,7 +1424,7 @@ if ( isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   // 0 0 2 0 
   // 0 0 0 2 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,3,param);
   const int sp_idx = face_idx + param.ghostOffset[3][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][1];
@@ -1616,7 +1616,7 @@ if ( isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   }
 }
 
-if ( isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
+if ( isActive(dim,3,-1,coord,param.commDim,param.X) && coord[3]==0 )
 {
   // Projector P3+
   // 2 0 0 0 
@@ -1624,7 +1624,7 @@ if ( isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
   // 0 0 0 0 
   // 0 0 0 0 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
+  faceIndexFromCoords<4,1>(face_idx,coord,3,param);
   const int sp_idx = face_idx + param.ghostOffset[3][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][0];

--- a/lib/dslash_core/wilson_fused_exterior_dslash_gt200_core.h
+++ b/lib/dslash_core/wilson_fused_exterior_dslash_gt200_core.h
@@ -391,39 +391,42 @@ int sp_norm_idx;
 
 int sid;
 
-int dim;
-int face_num;
-int face_idx;
-int Y[4] = {X1,X2,X3,X4};
-
-
 
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  dim = dimFromFaceIndex(sid, param); // sid is also modified
+  int dim = dimFromFaceIndex(sid, param); // sid is also modified
 
 
   const int face_volume = ((param.threadDimMapUpper[dim] - param.threadDimMapLower[dim]) >> 1);   // volume of one face
-  face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
-  face_idx = sid - face_num*face_volume;        // index into the respective face
+  int face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
+  int face_idx = sid - face_num*face_volume;        // index into the respective face
 
   // ghostOffset is scaled to include body (includes stride) and number of FloatN arrays (SPINOR_HOP)
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-
-  coordsFromFaceIndex<1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, dim, face_num, param.parity,Y);
-
-  {
-    bool active = false;
-    for(int dir=0; dir<4; ++dir){
-     active = active  || isActive(dim,dir,+1,x1,x2,x3,x4,param.commDim,param.X);
-    }
-    if(!active) return;
+  switch(dim) {
+  case 0:
+    coordsFromFaceIndex<0,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 1:
+    coordsFromFaceIndex<1,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 2:
+    coordsFromFaceIndex<2,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 3:
+    coordsFromFaceIndex<3,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
   }
 
 
+  bool active = false;
+  for(int dir=0; dir<4; ++dir){
+   active = active  || isActive(dim,dir,+1,x1,x2,x3,x4,param.commDim,param.X);
+  }
+  if(!active) return;
 
   READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 
@@ -449,7 +452,7 @@ if ( isActive(dim,0,+1,x1,x2,x3,x4,param.commDim,param.X) && x1==X1m1 )
   // 0 i 1 0 
   // i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
   const int sp_idx = face_idx + param.ghostOffset[0][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][1];
@@ -611,7 +614,7 @@ if ( isActive(dim,0,-1,x1,x2,x3,x4,param.commDim,param.X) && x1==0 )
   // 0 -i 1 0 
   // -i 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,0,param.X);
   const int sp_idx = face_idx + param.ghostOffset[0][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[0][0];
@@ -773,7 +776,7 @@ if ( isActive(dim,1,+1,x1,x2,x3,x4,param.commDim,param.X) && x2==X2m1 )
   // 0 1 1 0 
   // -1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
   const int sp_idx = face_idx + param.ghostOffset[1][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][1];
@@ -935,7 +938,7 @@ if ( isActive(dim,1,-1,x1,x2,x3,x4,param.commDim,param.X) && x2==0 )
   // 0 -1 1 0 
   // 1 0 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,1,param.X);
   const int sp_idx = face_idx + param.ghostOffset[1][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[1][0];
@@ -1097,7 +1100,7 @@ if ( isActive(dim,2,+1,x1,x2,x3,x4,param.commDim,param.X) && x3==X3m1 )
   // i 0 1 0 
   // 0 -i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
   const int sp_idx = face_idx + param.ghostOffset[2][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][1];
@@ -1259,7 +1262,7 @@ if ( isActive(dim,2,-1,x1,x2,x3,x4,param.commDim,param.X) && x3==0 )
   // -i 0 1 0 
   // 0 i 0 1 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,2,param.X);
   const int sp_idx = face_idx + param.ghostOffset[2][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[2][0];
@@ -1421,7 +1424,7 @@ if ( isActive(dim,3,+1,x1,x2,x3,x4,param.commDim,param.X) && x4==X4m1 )
   // 0 0 2 0 
   // 0 0 0 2 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
   const int sp_idx = face_idx + param.ghostOffset[3][1];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][1];
@@ -1621,7 +1624,7 @@ if ( isActive(dim,3,-1,x1,x2,x3,x4,param.commDim,param.X) && x4==0 )
   // 0 0 0 0 
   // 0 0 0 0 
   
-  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,Y);
+  faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4,3,param.X);
   const int sp_idx = face_idx + param.ghostOffset[3][0];
 #if (DD_PREC==2)
     sp_norm_idx = face_idx + param.ghostNormOffset[3][0];

--- a/lib/dslash_improved_staggered.cu
+++ b/lib/dslash_improved_staggered.cu
@@ -120,8 +120,6 @@ namespace quda {
 	param.grid.y = (nSrc + param.block.y - 1) / param.block.y;
 	return true;
       } else {
-	param.block.y = 1;
-	param.grid.y = nSrc;
 	bool rtn = DslashCuda::advanceBlockDim(param);
 	param.block.y = 1;
 	param.grid.y = nSrc;

--- a/lib/dslash_pack.cu
+++ b/lib/dslash_pack.cu
@@ -48,28 +48,6 @@ namespace quda {
 
 #ifdef MULTI_GPU
 
-  template <typename T>
-  __device__ inline int block_idx(const T &swizzle) {
-#ifdef SWIZZLE
-    // the portion of the grid that is exactly divisible by the number of SMs
-    const int gridp = gridDim.x - gridDim.x % swizzle;
-
-    int block_idx = blockIdx.x;
-    if (blockIdx.x < gridp) {
-      // this is the portion of the block that we are going to transpose
-      const int i = blockIdx.x % swizzle;
-      const int j = blockIdx.x / swizzle;
-
-      // transpose the coordinates
-      block_idx = i * (gridp / swizzle) + j;
-    }
-    return block_idx;
-#else
-    return blockIdx.x;
-#endif
-  }
-
-
   template <typename FloatN>
   struct PackParam {
 

--- a/lib/dslash_pack.cu
+++ b/lib/dslash_pack.cu
@@ -1098,11 +1098,11 @@ namespace quda {
       const int face_num = (param.face_num==2) ? ((face_idx >= Ls*nFace*param.ghostFace[2]) ? 1 : 0) : param.face_num;
       if(param.face_num==2) face_idx -= face_num*Ls*nFace*param.ghostFace[2];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndexStaggered<2,nFace,0>(face_idx,Ls*param.ghostFace[2],param);
+	const int idx = indexFromFaceIndexStaggered<2,nFace,0>(face_idx,param);
 	packFaceStaggeredCore(param.out[4], param.outNorm[4], face_idx,
 			      Ls*nFace*param.ghostFace[2], param.in, param.inNorm, idx, param);
       } else {
-	const int idx = indexFromFaceIndexStaggered<2,nFace,1>(face_idx,Ls*param.ghostFace[2],param);
+	const int idx = indexFromFaceIndexStaggered<2,nFace,1>(face_idx,param);
 	packFaceStaggeredCore(param.out[5], param.outNorm[5], face_idx,
 			      Ls*nFace*param.ghostFace[2], param.in, param.inNorm, idx, param);
       }
@@ -1110,11 +1110,11 @@ namespace quda {
       const int face_num = (param.face_num==2) ? ((face_idx >= Ls*nFace*param.ghostFace[3]) ? 1 : 0) : param.face_num;
       if(param.face_num==2) face_idx -= face_num*Ls*nFace*param.ghostFace[3];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndexStaggered<3,nFace,0>(face_idx,Ls*param.ghostFace[3],param);
+	const int idx = indexFromFaceIndexStaggered<3,nFace,0>(face_idx,param);
 	packFaceStaggeredCore(param.out[6], param.outNorm[6], face_idx,
 			      Ls*nFace*param.ghostFace[3], param.in, param.inNorm,idx, param);
       } else {
-	const int idx = indexFromFaceIndexStaggered<3,nFace,1>(face_idx,Ls*param.ghostFace[3],param);
+	const int idx = indexFromFaceIndexStaggered<3,nFace,1>(face_idx,param);
 	packFaceStaggeredCore(param.out[7], param.outNorm[7], face_idx, 
 			      Ls*nFace*param.ghostFace[3], param.in, param.inNorm, idx, param);
       }

--- a/lib/dslash_pack.cu
+++ b/lib/dslash_pack.cu
@@ -76,6 +76,9 @@ namespace quda {
     int_fastdiv dims[4][3];
 
     int_fastdiv face_X[4];
+    int_fastdiv face_Y[4];
+    int_fastdiv face_Z[4];
+    int_fastdiv face_T[4];
     int_fastdiv face_XY[4];
     int_fastdiv face_XYZ[4];
     int_fastdiv face_XYZT[4];
@@ -301,11 +304,11 @@ namespace quda {
       const int face_num = (face_idx >= nFace*param.ghostFace[0]) ? 1 : 0;
       face_idx -= face_num*nFace*param.ghostFace[0];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndex<0,nFace,0>(face_idx,param.ghostFace[0],param.parity,param.X);
+	const int idx = indexFromFaceIndex<0,nFace,0>(face_idx,param.ghostFace[0],param);
 	packFaceWilsonCore<0,dagger,0>(param.out[0], param.outNorm[0], param.in, 
 				       param.inNorm,idx, face_idx, param.ghostFace[0], param);
       } else {
-	const int idx = indexFromFaceIndex<0,nFace,1>(face_idx,param.ghostFace[0],param.parity,param.X);
+	const int idx = indexFromFaceIndex<0,nFace,1>(face_idx,param.ghostFace[0],param);
 	packFaceWilsonCore<0,dagger,1>(param.out[1], param.outNorm[1], param.in, 
 				       param.inNorm,idx, face_idx, param.ghostFace[0], param);
       }
@@ -314,11 +317,11 @@ namespace quda {
       const int face_num = (face_idx >= nFace*param.ghostFace[1]) ? 1 : 0;
       face_idx -= face_num*nFace*param.ghostFace[1];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndex<1,nFace,0>(face_idx,param.ghostFace[1],param.parity,param.X);
+	const int idx = indexFromFaceIndex<1,nFace,0>(face_idx,param.ghostFace[1],param);
 	packFaceWilsonCore<1, dagger,0>(param.out[2], param.outNorm[2], param.in, 
 					param.inNorm,idx, face_idx, param.ghostFace[1], param);
       } else {
-	const int idx = indexFromFaceIndex<1,nFace,1>(face_idx,param.ghostFace[1],param.parity,param.X);
+	const int idx = indexFromFaceIndex<1,nFace,1>(face_idx,param.ghostFace[1],param);
 	packFaceWilsonCore<1, dagger,1>(param.out[3], param.outNorm[3], param.in, 
 					param.inNorm,idx, face_idx, param.ghostFace[1], param);
       }
@@ -327,11 +330,11 @@ namespace quda {
       const int face_num = (face_idx >= nFace*param.ghostFace[2]) ? 1 : 0;
       face_idx -= face_num*nFace*param.ghostFace[2];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndex<2,nFace,0>(face_idx,param.ghostFace[2],param.parity,param.X);
+	const int idx = indexFromFaceIndex<2,nFace,0>(face_idx,param.ghostFace[2],param);
 	packFaceWilsonCore<2, dagger,0>(param.out[4], param.outNorm[4], param.in, 
 					param.inNorm,idx, face_idx, param.ghostFace[2], param);
       } else {
-	const int idx = indexFromFaceIndex<2,nFace,1>(face_idx,param.ghostFace[2],param.parity,param.X);
+	const int idx = indexFromFaceIndex<2,nFace,1>(face_idx,param.ghostFace[2],param);
 	packFaceWilsonCore<2, dagger,1>(param.out[5], param.outNorm[5], param.in, 
 					param.inNorm,idx, face_idx, param.ghostFace[2], param);
       }
@@ -340,11 +343,11 @@ namespace quda {
       const int face_num = (face_idx >= nFace*param.ghostFace[3]) ? 1 : 0;
       face_idx -= face_num*nFace*param.ghostFace[3];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndex<3,nFace,0>(face_idx,param.ghostFace[3],param.parity,param.X);
+	const int idx = indexFromFaceIndex<3,nFace,0>(face_idx,param.ghostFace[3],param);
 	packFaceWilsonCore<3, dagger,0>(param.out[6], param.outNorm[6], param.in, 
 					param.inNorm,idx, face_idx, param.ghostFace[3], param);
       } else {
-	const int idx = indexFromFaceIndex<3,nFace,1>(face_idx,param.ghostFace[3],param.parity,param.X);
+	const int idx = indexFromFaceIndex<3,nFace,1>(face_idx,param.ghostFace[3],param);
 	packFaceWilsonCore<3, dagger,1>(param.out[7], param.outNorm[7], param.in, 
 					param.inNorm,idx, face_idx, param.ghostFace[3], param);
       }
@@ -372,11 +375,11 @@ namespace quda {
       const int face_num = (param.face_num==2) ? ((face_idx >= nFace*param.ghostFace[0]) ? 1 : 0) : param.face_num;
       if(param.face_num==2) face_idx -= face_num*nFace*param.ghostFace[0];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndexExtended<0,nFace,0>(face_idx,param.ghostFace[0],param.parity,param.X,param.R);
+	const int idx = indexFromFaceIndexExtended<0,nFace,0>(face_idx,param.ghostFace[0],param);
 	packFaceWilsonCore<0,dagger,0>(param.out[0], param.outNorm[0], param.in, 
 				       param.inNorm,idx, face_idx, param.ghostFace[0], param);
       } else {
-	const int idx = indexFromFaceIndexExtended<0,nFace,1>(face_idx,param.ghostFace[0],param.parity,param.X,param.R);
+	const int idx = indexFromFaceIndexExtended<0,nFace,1>(face_idx,param.ghostFace[0],param);
 	packFaceWilsonCore<0,dagger,1>(param.out[1], param.outNorm[1], param.in, 
 				       param.inNorm,idx, face_idx, param.ghostFace[0], param);
       }
@@ -384,11 +387,11 @@ namespace quda {
       const int face_num = (param.face_num==2) ? ((face_idx >= nFace*param.ghostFace[1]) ? 1 : 0) : param.face_num;
       if(param.face_num==2) face_idx -= face_num*nFace*param.ghostFace[1];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndexExtended<1,nFace,0>(face_idx,param.ghostFace[1],param.parity,param.X,param.R);
+	const int idx = indexFromFaceIndexExtended<1,nFace,0>(face_idx,param.ghostFace[1],param);
 	packFaceWilsonCore<1, dagger,0>(param.out[2], param.outNorm[2], param.in, 
 					param.inNorm,idx, face_idx, param.ghostFace[1], param);
       } else {
-	const int idx = indexFromFaceIndexExtended<1,nFace,1>(face_idx,param.ghostFace[1],param.parity,param.X,param.R);
+	const int idx = indexFromFaceIndexExtended<1,nFace,1>(face_idx,param.ghostFace[1],param);
 	packFaceWilsonCore<1, dagger,1>(param.out[3], param.outNorm[3], param.in, 
 					param.inNorm,idx, face_idx, param.ghostFace[1], param);
       }
@@ -396,11 +399,11 @@ namespace quda {
       const int face_num = (param.face_num==2) ? ((face_idx >= nFace*param.ghostFace[2]) ? 1 : 0) : param.face_num;
       if(param.face_num==2) face_idx -= face_num*nFace*param.ghostFace[2];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndexExtended<2,nFace,0>(face_idx,param.ghostFace[2],param.parity,param.X,param.R);
+	const int idx = indexFromFaceIndexExtended<2,nFace,0>(face_idx,param.ghostFace[2],param);
 	packFaceWilsonCore<2, dagger,0>(param.out[4], param.outNorm[4], param.in, 
 					param.inNorm,idx, face_idx, param.ghostFace[2], param);
       } else {
-	const int idx = indexFromFaceIndexExtended<2,nFace,1>(face_idx,param.ghostFace[2],param.parity,param.X,param.R);
+	const int idx = indexFromFaceIndexExtended<2,nFace,1>(face_idx,param.ghostFace[2],param);
 	packFaceWilsonCore<2, dagger,1>(param.out[5], param.outNorm[5], param.in, 
 					param.inNorm,idx, face_idx, param.ghostFace[2], param);
       }
@@ -409,11 +412,11 @@ namespace quda {
       if(param.face_num==2) face_idx -= face_num*nFace*param.ghostFace[3];
 
       if (face_num == 0) {
-	const int idx = indexFromFaceIndexExtended<3,nFace,0>(face_idx,param.ghostFace[3],param.parity,param.X,param.R);
+	const int idx = indexFromFaceIndexExtended<3,nFace,0>(face_idx,param.ghostFace[3],param);
 	packFaceWilsonCore<3, dagger,0>(param.out[6], param.outNorm[6], param.in, 
 					param.inNorm,idx, face_idx, param.ghostFace[3], param);
       } else {
-	const int idx = indexFromFaceIndexExtended<3,nFace,1>(face_idx,param.ghostFace[3],param.parity,param.X,param.R);
+	const int idx = indexFromFaceIndexExtended<3,nFace,1>(face_idx,param.ghostFace[3],param);
 	packFaceWilsonCore<3, dagger,1>(param.out[7], param.outNorm[7], param.in, 
 					param.inNorm,idx, face_idx, param.ghostFace[3], param);
       }
@@ -442,11 +445,11 @@ namespace quda {
       if(param.face_num==2) face_idx -= face_num*nFace*param.ghostFace[0];
 
       if (face_num == 0) {
-	const int idx = indexFromFaceIndexExtended<0,nFace,0>(face_idx,param.ghostFace[0],param.parity,param.X,param.R);
+	const int idx = indexFromFaceIndexExtended<0,nFace,0>(face_idx,param.ghostFace[0],param);
 	unpackFaceWilsonCore<0,dagger,0>(param.out[0], param.outNorm[0], param.in, 
 					 param.inNorm,idx, face_idx, param.ghostFace[0], param);
       } else {
-	const int idx = indexFromFaceIndexExtended<0,nFace,1>(face_idx,param.ghostFace[0],param.parity,param.X,param.R);
+	const int idx = indexFromFaceIndexExtended<0,nFace,1>(face_idx,param.ghostFace[0],param);
 	unpackFaceWilsonCore<0,dagger,1>(param.out[1], param.outNorm[1], param.in, 
 					 param.inNorm,idx, face_idx, param.ghostFace[0], param);
       }
@@ -455,11 +458,11 @@ namespace quda {
       if(param.face_num==2) face_idx -= face_num*nFace*param.ghostFace[1];
 
       if (face_num == 0) {
-	const int idx = indexFromFaceIndexExtended<1,nFace,0>(face_idx,param.ghostFace[1],param.parity,param.X,param.R);
+	const int idx = indexFromFaceIndexExtended<1,nFace,0>(face_idx,param.ghostFace[1],param);
 	unpackFaceWilsonCore<1, dagger,0>(param.out[2], param.outNorm[2], param.in, 
 					  param.inNorm,idx, face_idx, param.ghostFace[1], param);
       } else {
-	const int idx = indexFromFaceIndexExtended<1,nFace,1>(face_idx,param.ghostFace[1],param.parity,param.X,param.R);
+	const int idx = indexFromFaceIndexExtended<1,nFace,1>(face_idx,param.ghostFace[1],param);
 	unpackFaceWilsonCore<1, dagger,1>(param.out[3], param.outNorm[3], param.in, 
 					  param.inNorm,idx, face_idx, param.ghostFace[1], param);
       }
@@ -468,11 +471,11 @@ namespace quda {
       if(param.face_num==2) face_idx -= face_num*nFace*param.ghostFace[2];
 
       if (face_num == 0) {
-	const int idx = indexFromFaceIndexExtended<2,nFace,0>(face_idx,param.ghostFace[2],param.parity,param.X,param.R);
+	const int idx = indexFromFaceIndexExtended<2,nFace,0>(face_idx,param.ghostFace[2],param);
 	unpackFaceWilsonCore<2, dagger,0>(param.out[4], param.outNorm[4], param.in, 
 					  param.inNorm,idx, face_idx, param.ghostFace[2], param);
       } else {
-	const int idx = indexFromFaceIndexExtended<2,nFace,1>(face_idx,param.ghostFace[2],param.parity,param.X,param.R);
+	const int idx = indexFromFaceIndexExtended<2,nFace,1>(face_idx,param.ghostFace[2],param);
 	unpackFaceWilsonCore<2, dagger,1>(param.out[5], param.outNorm[5], param.in, 
 					  param.inNorm,idx, face_idx, param.ghostFace[2], param);
       }
@@ -481,11 +484,11 @@ namespace quda {
       if(param.face_num==2) face_idx -= face_num*nFace*param.ghostFace[3];
 
       if (face_num == 0) {
-	const int idx = indexFromFaceIndexExtended<3,nFace,0>(face_idx,param.ghostFace[3],param.parity,param.X,param.R);
+	const int idx = indexFromFaceIndexExtended<3,nFace,0>(face_idx,param.ghostFace[3],param);
 	unpackFaceWilsonCore<3, dagger,0>(param.out[6], param.outNorm[6], param.in, 
 					  param.inNorm,idx, face_idx, param.ghostFace[3], param);
       } else {
-	const int idx = indexFromFaceIndexExtended<3,nFace,1>(face_idx,param.ghostFace[3],param.parity,param.X,param.R);
+	const int idx = indexFromFaceIndexExtended<3,nFace,1>(face_idx,param.ghostFace[3],param);
 	unpackFaceWilsonCore<3, dagger,1>(param.out[7], param.outNorm[7], param.in, 
 					  param.inNorm,idx, face_idx, param.ghostFace[3], param);
       }
@@ -639,11 +642,11 @@ namespace quda {
       const int face_num = (face_idx >= nFace*param.ghostFace[0]) ? 1 : 0;
       face_idx -= face_num*nFace*param.ghostFace[0];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndex<0,nFace,0>(face_idx,param.ghostFace[0],param.parity,param.X);
+	const int idx = indexFromFaceIndex<0,nFace,0>(face_idx,param.ghostFace[0],param);
 	packTwistedFaceWilsonCore<0,dagger,0>(param.out[0], param.outNorm[0], param.in, 
 					      param.inNorm, a, b, idx, face_idx, param.ghostFace[0], param);
       } else {
-	const int idx = indexFromFaceIndex<0,nFace,1>(face_idx,param.ghostFace[0],param.parity,param.X);
+	const int idx = indexFromFaceIndex<0,nFace,1>(face_idx,param.ghostFace[0],param);
 	packTwistedFaceWilsonCore<0,dagger,1>(param.out[1], param.outNorm[1], param.in, 
 					      param.inNorm, a, b, idx, face_idx, param.ghostFace[0], param);
       }
@@ -651,11 +654,11 @@ namespace quda {
       const int face_num = (face_idx >= nFace*param.ghostFace[1]) ? 1 : 0;
       face_idx -= face_num*nFace*param.ghostFace[1];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndex<1,nFace,0>(face_idx,param.ghostFace[1],param.parity,param.X);
+	const int idx = indexFromFaceIndex<1,nFace,0>(face_idx,param.ghostFace[1],param);
 	packTwistedFaceWilsonCore<1, dagger,0>(param.out[2], param.outNorm[2], param.in, 
 					       param.inNorm, a, b, idx, face_idx, param.ghostFace[1], param);
       } else {
-	const int idx = indexFromFaceIndex<1,nFace,1>(face_idx,param.ghostFace[1],param.parity,param.X);
+	const int idx = indexFromFaceIndex<1,nFace,1>(face_idx,param.ghostFace[1],param);
 	packTwistedFaceWilsonCore<1, dagger,1>(param.out[3], param.outNorm[3], param.in, 
 					       param.inNorm, a, b, idx, face_idx, param.ghostFace[1], param);
       }
@@ -663,11 +666,11 @@ namespace quda {
       const int face_num = (face_idx >= nFace*param.ghostFace[2]) ? 1 : 0;
       face_idx -= face_num*nFace*param.ghostFace[2];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndex<2,nFace,0>(face_idx,param.ghostFace[2],param.parity,param.X);
+	const int idx = indexFromFaceIndex<2,nFace,0>(face_idx,param.ghostFace[2],param);
 	packTwistedFaceWilsonCore<2, dagger,0>(param.out[4], param.outNorm[4], param.in, 
 					       param.inNorm, a, b, idx, face_idx, param.ghostFace[2], param);
       } else {
-	const int idx = indexFromFaceIndex<2,nFace,1>(face_idx,param.ghostFace[2],param.parity,param.X);
+	const int idx = indexFromFaceIndex<2,nFace,1>(face_idx,param.ghostFace[2],param);
 	packTwistedFaceWilsonCore<2, dagger,1>(param.out[5], param.outNorm[5], param.in, 
 					       param.inNorm, a, b, idx, face_idx, param.ghostFace[2], param);
       }
@@ -675,11 +678,11 @@ namespace quda {
       const int face_num = (face_idx >= nFace*param.ghostFace[3]) ? 1 : 0;
       face_idx -= face_num*nFace*param.ghostFace[3];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndex<3,nFace,0>(face_idx,param.ghostFace[3],param.parity,param.X);
+	const int idx = indexFromFaceIndex<3,nFace,0>(face_idx,param.ghostFace[3],param);
 	packTwistedFaceWilsonCore<3, dagger,0>(param.out[6], param.outNorm[6], param.in, 
 					       param.inNorm, a, b,idx, face_idx, param.ghostFace[3], param);
       } else {
-	const int idx = indexFromFaceIndex<3,nFace,1>(face_idx,param.ghostFace[3],param.parity,param.X);
+	const int idx = indexFromFaceIndex<3,nFace,1>(face_idx,param.ghostFace[3],param);
 	packTwistedFaceWilsonCore<3, dagger,1>(param.out[7], param.outNorm[7], param.in, 
 					       param.inNorm, a, b, idx, face_idx, param.ghostFace[3], param);
       }
@@ -767,7 +770,7 @@ namespace quda {
         prev=i;
       }
 
-      param.volume_4d = in->VolumeCB()*2 / in->X(4);
+      param.volume_4d = in->VolumeCB()*2 / (in->Ndim() == 5 ? in->X(4) : 1);
       param.ghostFace[0] = param.X[1]*param.X[2]*param.X[3]/2;
       param.ghostFace[1] = param.X[0]*param.X[2]*param.X[3]/2;
       param.ghostFace[2] = param.X[0]*param.X[1]*param.X[3]/2;
@@ -795,6 +798,9 @@ namespace quda {
 	face[dim] = nFace;
 
 	param.face_X[dim] = face[0];
+	param.face_Y[dim] = face[1];
+	param.face_Z[dim] = face[2];
+	param.face_T[dim] = face[3];
 	param.face_XY[dim] = param.face_X[dim] * face[1];
 	param.face_XYZ[dim] = param.face_XY[dim] * face[2];
 	param.face_XYZT[dim] = param.face_XYZ[dim] * face[3];
@@ -1157,11 +1163,11 @@ namespace quda {
       const int face_num = (param.face_num==2) ? ((face_idx >= nFace*param.ghostFace[0]) ? 1 : 0) : param.face_num;
       if(param.face_num==2) face_idx -= face_num*nFace*param.ghostFace[0];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndexExtendedStaggered<0,nFace,0>(face_idx,param.ghostFace[0],param.parity,param.X,param.R);
+	const int idx = indexFromFaceIndexExtendedStaggered<0,nFace,0>(face_idx,param.ghostFace[0],param);
 	packFaceStaggeredCore(param.out[0], param.outNorm[0], face_idx, 
 			      nFace*param.ghostFace[0], param.in, param.inNorm, idx, param);
       } else {
-	const int idx = indexFromFaceIndexExtendedStaggered<0,nFace,1>(face_idx,param.ghostFace[0],param.parity,param.X,param.R);
+	const int idx = indexFromFaceIndexExtendedStaggered<0,nFace,1>(face_idx,param.ghostFace[0],param);
 	packFaceStaggeredCore(param.out[1], param.outNorm[1], face_idx,
 			      nFace*param.ghostFace[0], param.in, param.inNorm, idx, param);
       }
@@ -1169,11 +1175,11 @@ namespace quda {
       const int face_num = (param.face_num==2) ? ((face_idx >= nFace*param.ghostFace[1]) ? 1 : 0) : param.face_num;
       if(param.face_num==2) face_idx -= face_num*nFace*param.ghostFace[1];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndexExtendedStaggered<1,nFace,0>(face_idx,param.ghostFace[1],param.parity,param.X,param.R);
+	const int idx = indexFromFaceIndexExtendedStaggered<1,nFace,0>(face_idx,param.ghostFace[1],param);
 	packFaceStaggeredCore(param.out[2], param.outNorm[2], face_idx, 
 			      nFace*param.ghostFace[1], param.in, param.inNorm, idx, param);
       } else {
-	const int idx = indexFromFaceIndexExtendedStaggered<1,nFace,1>(face_idx,param.ghostFace[1],param.parity,param.X,param.R);
+	const int idx = indexFromFaceIndexExtendedStaggered<1,nFace,1>(face_idx,param.ghostFace[1],param);
 	packFaceStaggeredCore(param.out[3], param.outNorm[3], face_idx, 
 			      nFace*param.ghostFace[1], param.in, param.inNorm, idx, param);
       }
@@ -1181,11 +1187,11 @@ namespace quda {
       const int face_num = (param.face_num==2) ? ((face_idx >= nFace*param.ghostFace[2]) ? 1 : 0) : param.face_num;
       if(param.face_num==2) face_idx -= face_num*nFace*param.ghostFace[2];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndexExtendedStaggered<2,nFace,0>(face_idx,param.ghostFace[2],param.parity,param.X,param.R);
+	const int idx = indexFromFaceIndexExtendedStaggered<2,nFace,0>(face_idx,param.ghostFace[2],param);
 	packFaceStaggeredCore(param.out[4], param.outNorm[4], face_idx,
 			      nFace*param.ghostFace[2], param.in, param.inNorm, idx, param);
       } else {
-	const int idx = indexFromFaceIndexExtendedStaggered<2,nFace,1>(face_idx,param.ghostFace[2],param.parity,param.X,param.R);
+	const int idx = indexFromFaceIndexExtendedStaggered<2,nFace,1>(face_idx,param.ghostFace[2],param);
 	packFaceStaggeredCore(param.out[5], param.outNorm[5], face_idx,
 			      nFace*param.ghostFace[2], param.in, param.inNorm, idx, param);
       }
@@ -1193,11 +1199,11 @@ namespace quda {
       const int face_num = (param.face_num==2) ? ((face_idx >= nFace*param.ghostFace[3]) ? 1 : 0) : param.face_num;
       if(param.face_num==2) face_idx -= face_num*nFace*param.ghostFace[3];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndexExtendedStaggered<3,nFace,0>(face_idx,param.ghostFace[3],param.parity,param.X,param.R);
+	const int idx = indexFromFaceIndexExtendedStaggered<3,nFace,0>(face_idx,param.ghostFace[3],param);
 	packFaceStaggeredCore(param.out[6], param.outNorm[6], face_idx,
 			      nFace*param.ghostFace[3], param.in, param.inNorm,idx, param);
       } else {
-	const int idx = indexFromFaceIndexExtendedStaggered<3,nFace,1>(face_idx,param.ghostFace[3],param.parity,param.X,param.R);
+	const int idx = indexFromFaceIndexExtendedStaggered<3,nFace,1>(face_idx,param.ghostFace[3],param);
 	packFaceStaggeredCore(param.out[7], param.outNorm[7], face_idx, 
 			      nFace*param.ghostFace[3], param.in, param.inNorm, idx, param);
       }
@@ -1225,11 +1231,11 @@ namespace quda {
       const int face_num = (param.face_num==2) ? ((face_idx >= nFace*param.ghostFace[0]) ? 1 : 0) : param.face_num;
       if(param.face_num==2) face_idx -= face_num*nFace*param.ghostFace[0];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndexExtendedStaggered<0,nFace,0>(face_idx,param.ghostFace[0],param.parity,param.X,param.R);
+	const int idx = indexFromFaceIndexExtendedStaggered<0,nFace,0>(face_idx,param.ghostFace[0],param);
 	packFaceStaggeredCore(param.in, param.inNorm, idx, 
 			      param.sp_stride, param.out[0], param.outNorm[0], face_idx, nFace*param.ghostFace[0]);
       } else {
-	const int idx = indexFromFaceIndexExtendedStaggered<0,nFace,1>(face_idx,param.ghostFace[0],param.parity,param.X,param.R);
+	const int idx = indexFromFaceIndexExtendedStaggered<0,nFace,1>(face_idx,param.ghostFace[0],param);
 	packFaceStaggeredCore(param.in, param.inNorm, idx, 
 			      param.sp_stride, param.out[1], param.outNorm[1], face_idx, nFace*param.ghostFace[0]);
       }
@@ -1237,11 +1243,11 @@ namespace quda {
       const int face_num = (param.face_num==2) ? ((face_idx >= nFace*param.ghostFace[1]) ? 1 : 0) : param.face_num;
       if(param.face_num==2) face_idx -= face_num*nFace*param.ghostFace[1];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndexExtendedStaggered<1,nFace,0>(face_idx,param.ghostFace[1],param.parity,param.X,param.R);
+	const int idx = indexFromFaceIndexExtendedStaggered<1,nFace,0>(face_idx,param.ghostFace[1],param);
 	packFaceStaggeredCore(param.in, param.inNorm, idx, 
 			      param.sp_stride, param.out[2], param.outNorm[2], face_idx, nFace*param.ghostFace[1]);
       } else {
-	const int idx = indexFromFaceIndexExtendedStaggered<1,nFace,1>(face_idx,param.ghostFace[1],param.parity,param.X,param.R);
+	const int idx = indexFromFaceIndexExtendedStaggered<1,nFace,1>(face_idx,param.ghostFace[1],param);
 	packFaceStaggeredCore(param.in, param.inNorm, idx, 
 			      param.sp_stride, param.out[3], param.outNorm[3], face_idx, nFace*param.ghostFace[1]);
       }
@@ -1249,11 +1255,11 @@ namespace quda {
       const int face_num = (param.face_num==2) ? ((face_idx >= nFace*param.ghostFace[2]) ? 1 : 0) : param.face_num;
       if(param.face_num==2) face_idx -= face_num*nFace*param.ghostFace[2];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndexExtendedStaggered<2,nFace,0>(face_idx,param.ghostFace[2],param.parity,param.X,param.R);
+	const int idx = indexFromFaceIndexExtendedStaggered<2,nFace,0>(face_idx,param.ghostFace[2],param);
 	packFaceStaggeredCore(param.in, param.inNorm, idx, 
 			      param.sp_stride, param.out[4], param.outNorm[4], face_idx, nFace*param.ghostFace[2]);
       } else {
-	const int idx = indexFromFaceIndexExtendedStaggered<2,nFace,1>(face_idx,param.ghostFace[2],param.parity,param.X,param.R);
+	const int idx = indexFromFaceIndexExtendedStaggered<2,nFace,1>(face_idx,param.ghostFace[2],param);
 	packFaceStaggeredCore(param.in, param.inNorm, idx, 
 			      param.sp_stride, param.out[5], param.outNorm[5], face_idx, nFace*param.ghostFace[2]);
       }
@@ -1261,11 +1267,11 @@ namespace quda {
       const int face_num = (param.face_num==2) ? ((face_idx >= nFace*param.ghostFace[3]) ? 1 : 0) : param.face_num;
       if(param.face_num==2) face_idx -= face_num*nFace*param.ghostFace[3];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndexExtendedStaggered<3,nFace,0>(face_idx,param.ghostFace[3],param.parity,param.X,param.R);
+	const int idx = indexFromFaceIndexExtendedStaggered<3,nFace,0>(face_idx,param.ghostFace[3],param);
 	packFaceStaggeredCore(param.in, param.inNorm, idx, 
 			      param.sp_stride, param.out[6], param.outNorm[6], face_idx, nFace*param.ghostFace[3]);
       } else {
-	const int idx = indexFromFaceIndexExtendedStaggered<3,nFace,1>(face_idx,param.ghostFace[3],param.parity,param.X,param.R);
+	const int idx = indexFromFaceIndexExtendedStaggered<3,nFace,1>(face_idx,param.ghostFace[3],param);
 	packFaceStaggeredCore(param.in, param.inNorm, idx, 
 			      param.sp_stride, param.out[7], param.outNorm[7], face_idx, nFace*param.ghostFace[3]);
       }
@@ -1446,11 +1452,11 @@ namespace quda {
       const int face_num = (face_idx >= nFace*Ls*param.ghostFace[0]) ? 1 : 0; 
       face_idx -= face_num*nFace*Ls*param.ghostFace[0];
       if (face_num == 0) {
-	const int idx = indexFromDWFaceIndex<0,nFace,0>(face_idx,Ls*param.ghostFace[0],param.parity,param.X);
+	const int idx = indexFromDWFaceIndex<0,nFace,0>(face_idx,Ls*param.ghostFace[0],param);
 	packFaceWilsonCore<0,dagger,0>(param.out[0], param.outNorm[0], param.in, 
 				       param.inNorm, idx, face_idx, Ls*param.ghostFace[0], param);
       } else {
-	const int idx = indexFromDWFaceIndex<0,nFace,1>(face_idx,Ls*param.ghostFace[0],param.parity,param.X);
+	const int idx = indexFromDWFaceIndex<0,nFace,1>(face_idx,Ls*param.ghostFace[0],param);
 	packFaceWilsonCore<0,dagger,1>(param.out[1], param.outNorm[1], param.in, 
 				       param.inNorm, idx, face_idx, Ls*param.ghostFace[0], param);
       }
@@ -1458,11 +1464,11 @@ namespace quda {
       const int face_num = (face_idx >= nFace*Ls*param.ghostFace[1]) ? 1 : 0; 
       face_idx -= face_num*nFace*Ls*param.ghostFace[1];
       if (face_num == 0) {
-	const int idx = indexFromDWFaceIndex<1,nFace,0>(face_idx,Ls*param.ghostFace[1],param.parity,param.X);
+	const int idx = indexFromDWFaceIndex<1,nFace,0>(face_idx,Ls*param.ghostFace[1],param);
 	packFaceWilsonCore<1, dagger,0>(param.out[2], param.outNorm[2], param.in, 
 					param.inNorm, idx, face_idx, Ls*param.ghostFace[1], param);
       } else {
-	const int idx = indexFromDWFaceIndex<1,nFace,1>(face_idx,Ls*param.ghostFace[1],param.parity,param.X);
+	const int idx = indexFromDWFaceIndex<1,nFace,1>(face_idx,Ls*param.ghostFace[1],param);
 	packFaceWilsonCore<1, dagger,1>(param.out[3], param.outNorm[3], param.in, 
 					param.inNorm, idx, face_idx, Ls*param.ghostFace[1], param);
       }
@@ -1470,11 +1476,11 @@ namespace quda {
       const int face_num = (face_idx >= nFace*Ls*param.ghostFace[2]) ? 1 : 0; 
       face_idx -= face_num*nFace*Ls*param.ghostFace[2];
       if (face_num == 0) {
-	const int idx = indexFromDWFaceIndex<2,nFace,0>(face_idx,Ls*param.ghostFace[2],param.parity,param.X);
+	const int idx = indexFromDWFaceIndex<2,nFace,0>(face_idx,Ls*param.ghostFace[2],param);
 	packFaceWilsonCore<2, dagger,0>(param.out[4], param.outNorm[4], param.in, 
 					param.inNorm, idx, face_idx, Ls*param.ghostFace[2], param);
       } else {
-	const int idx = indexFromDWFaceIndex<2,nFace,1>(face_idx,Ls*param.ghostFace[2],param.parity,param.X);
+	const int idx = indexFromDWFaceIndex<2,nFace,1>(face_idx,Ls*param.ghostFace[2],param);
 	packFaceWilsonCore<2, dagger,1>(param.out[5], param.outNorm[5], param.in, 
 					param.inNorm, idx, face_idx, Ls*param.ghostFace[2], param);
       }
@@ -1482,11 +1488,11 @@ namespace quda {
       const int face_num = (face_idx >= nFace*Ls*param.ghostFace[3]) ? 1 : 0; 
       face_idx -= face_num*nFace*Ls*param.ghostFace[3];
       if (face_num == 0) {
-	const int idx = indexFromDWFaceIndex<3,nFace,0>(face_idx,Ls*param.ghostFace[3],param.parity,param.X);
+	const int idx = indexFromDWFaceIndex<3,nFace,0>(face_idx,Ls*param.ghostFace[3],param);
 	packFaceWilsonCore<3, dagger,0>(param.out[6], param.outNorm[6], param.in, 
 					param.inNorm, idx, face_idx, Ls*param.ghostFace[3], param);
       } else {
-	const int idx = indexFromDWFaceIndex<3,nFace,1>(face_idx,Ls*param.ghostFace[3],param.parity,param.X);
+	const int idx = indexFromDWFaceIndex<3,nFace,1>(face_idx,Ls*param.ghostFace[3],param);
 	packFaceWilsonCore<3, dagger,1>(param.out[7], param.outNorm[7], param.in, 
 					param.inNorm, idx, face_idx, Ls*param.ghostFace[3], param);
       }
@@ -1516,11 +1522,11 @@ namespace quda {
       const int face_num = (face_idx >= nFace*Ls*param.ghostFace[0]) ? 1 : 0; 
       face_idx -= face_num*nFace*Ls*param.ghostFace[0];
         if (face_num == 0) {
-	const int idx = indexFromDW4DFaceIndex<0,nFace,0>(face_idx,Ls*param.ghostFace[0],param.parity,param.X);
+	const int idx = indexFromDW4DFaceIndex<0,nFace,0>(face_idx,Ls*param.ghostFace[0],param);
 	packFaceWilsonCore<0,dagger,0>(param.out[0], param.outNorm[0], param.in, 
 				       param.inNorm, idx, face_idx, Ls*param.ghostFace[0], param);
       } else {
-	const int idx = indexFromDW4DFaceIndex<0,nFace,1>(face_idx,Ls*param.ghostFace[0],param.parity,param.X);
+	const int idx = indexFromDW4DFaceIndex<0,nFace,1>(face_idx,Ls*param.ghostFace[0],param);
 	packFaceWilsonCore<0,dagger,1>(param.out[1], param.outNorm[1], param.in, 
 				       param.inNorm, idx, face_idx, Ls*param.ghostFace[0], param);
       }
@@ -1528,11 +1534,11 @@ namespace quda {
       const int face_num = (face_idx >= nFace*Ls*param.ghostFace[1]) ? 1 : 0; 
       face_idx -= face_num*nFace*Ls*param.ghostFace[1];
       if (face_num == 0) {
-	const int idx = indexFromDW4DFaceIndex<1,nFace,0>(face_idx,Ls*param.ghostFace[1],param.parity,param.X);
+	const int idx = indexFromDW4DFaceIndex<1,nFace,0>(face_idx,Ls*param.ghostFace[1],param);
 	packFaceWilsonCore<1, dagger,0>(param.out[2], param.outNorm[2], param.in, 
 					param.inNorm, idx, face_idx, Ls*param.ghostFace[1], param);
       } else {
-	const int idx = indexFromDW4DFaceIndex<1,nFace,1>(face_idx,Ls*param.ghostFace[1],param.parity,param.X);
+	const int idx = indexFromDW4DFaceIndex<1,nFace,1>(face_idx,Ls*param.ghostFace[1],param);
 	packFaceWilsonCore<1, dagger,1>(param.out[3], param.outNorm[3], param.in, 
 					param.inNorm, idx, face_idx, Ls*param.ghostFace[1], param);
       }
@@ -1540,11 +1546,11 @@ namespace quda {
       const int face_num = (face_idx >= nFace*Ls*param.ghostFace[2]) ? 1 : 0; 
       face_idx -= face_num*nFace*Ls*param.ghostFace[2];
       if (face_num == 0) {
-	const int idx = indexFromDW4DFaceIndex<2,nFace,0>(face_idx,Ls*param.ghostFace[2],param.parity,param.X);
+	const int idx = indexFromDW4DFaceIndex<2,nFace,0>(face_idx,Ls*param.ghostFace[2],param);
 	packFaceWilsonCore<2, dagger,0>(param.out[4], param.outNorm[4], param.in, 
 					param.inNorm, idx, face_idx, Ls*param.ghostFace[2], param);
       } else {
-	const int idx = indexFromDW4DFaceIndex<2,nFace,1>(face_idx,Ls*param.ghostFace[2],param.parity,param.X);
+	const int idx = indexFromDW4DFaceIndex<2,nFace,1>(face_idx,Ls*param.ghostFace[2],param);
 	packFaceWilsonCore<2, dagger,1>(param.out[5], param.outNorm[5], param.in, 
 					param.inNorm, idx, face_idx, Ls*param.ghostFace[2], param);
       }
@@ -1552,11 +1558,11 @@ namespace quda {
       const int face_num = (face_idx >= nFace*Ls*param.ghostFace[3]) ? 1 : 0; 
       face_idx -= face_num*nFace*Ls*param.ghostFace[3];
       if (face_num == 0) {
-	const int idx = indexFromDW4DFaceIndex<3,nFace,0>(face_idx,Ls*param.ghostFace[3],param.parity,param.X);
+	const int idx = indexFromDW4DFaceIndex<3,nFace,0>(face_idx,Ls*param.ghostFace[3],param);
 	packFaceWilsonCore<3, dagger,0>(param.out[6], param.outNorm[6], param.in, 
 					param.inNorm, idx, face_idx, Ls*param.ghostFace[3], param);
       } else {
-	const int idx = indexFromDW4DFaceIndex<3,nFace,1>(face_idx,Ls*param.ghostFace[3],param.parity,param.X);
+	const int idx = indexFromDW4DFaceIndex<3,nFace,1>(face_idx,Ls*param.ghostFace[3],param);
 	packFaceWilsonCore<3, dagger,1>(param.out[7], param.outNorm[7], param.in, 
 					param.inNorm, idx, face_idx, Ls*param.ghostFace[3], param);
       }
@@ -1707,11 +1713,11 @@ namespace quda {
       const int face_num = (face_idx >= nFace*Nf*param.ghostFace[0]) ? 1 : 0;
       face_idx -= face_num*nFace*Nf*param.ghostFace[0];
       if (face_num == 0) {
-	const int idx = indexFromNdegTMFaceIndex<0,nFace,0>(face_idx,Nf*param.ghostFace[0],param.parity,param.X);
+	const int idx = indexFromNdegTMFaceIndex<0,nFace,0>(face_idx,Nf*param.ghostFace[0],param);
 	packFaceWilsonCore<0,dagger,0>(param.out[0], param.outNorm[0], param.in, 
 				       param.inNorm, idx, face_idx, Nf*param.ghostFace[0], param);
       } else {
-	const int idx = indexFromNdegTMFaceIndex<0,nFace,1>(face_idx,Nf*param.ghostFace[0],param.parity,param.X);
+	const int idx = indexFromNdegTMFaceIndex<0,nFace,1>(face_idx,Nf*param.ghostFace[0],param);
 	packFaceWilsonCore<0,dagger,1>(param.out[1], param.outNorm[1], param.in, 
 				       param.inNorm, idx, face_idx, Nf*param.ghostFace[0], param);
       }
@@ -1719,11 +1725,11 @@ namespace quda {
       const int face_num = (face_idx >= nFace*Nf*param.ghostFace[1]) ? 1 : 0;
       face_idx -= face_num*nFace*Nf*param.ghostFace[1];
       if (face_num == 0) {
-	const int idx = indexFromNdegTMFaceIndex<1,nFace,0>(face_idx,Nf*param.ghostFace[1],param.parity,param.X);
+	const int idx = indexFromNdegTMFaceIndex<1,nFace,0>(face_idx,Nf*param.ghostFace[1],param);
 	packFaceWilsonCore<1, dagger,0>(param.out[2], param.outNorm[2], param.in, 
 					param.inNorm, idx, face_idx, Nf*param.ghostFace[1], param);
       } else {
-	const int idx = indexFromNdegTMFaceIndex<1,nFace,1>(face_idx,Nf*param.ghostFace[1],param.parity,param.X);
+	const int idx = indexFromNdegTMFaceIndex<1,nFace,1>(face_idx,Nf*param.ghostFace[1],param);
 	packFaceWilsonCore<1, dagger,1>(param.out[3], param.outNorm[3], param.in, 
 					param.inNorm, idx, face_idx, Nf*param.ghostFace[1], param);
       }
@@ -1731,11 +1737,11 @@ namespace quda {
       const int face_num = (face_idx >= nFace*Nf*param.ghostFace[2]) ? 1 : 0;
       face_idx -= face_num*nFace*Nf*param.ghostFace[2];
       if (face_num == 0) {
-	const int idx = indexFromNdegTMFaceIndex<2,nFace,0>(face_idx,Nf*param.ghostFace[2],param.parity,param.X);
+	const int idx = indexFromNdegTMFaceIndex<2,nFace,0>(face_idx,Nf*param.ghostFace[2],param);
 	packFaceWilsonCore<2, dagger,0>(param.out[4], param.outNorm[4], param.in, 
 					param.inNorm, idx, face_idx, Nf*param.ghostFace[2], param);
       } else {
-	const int idx = indexFromNdegTMFaceIndex<2,nFace,1>(face_idx,Nf*param.ghostFace[2],param.parity,param.X);
+	const int idx = indexFromNdegTMFaceIndex<2,nFace,1>(face_idx,Nf*param.ghostFace[2],param);
 	packFaceWilsonCore<2, dagger,1>(param.out[5], param.outNorm[5], param.in, 
 					param.inNorm, idx, face_idx, Nf*param.ghostFace[2], param);
       }
@@ -1743,11 +1749,11 @@ namespace quda {
       const int face_num = (face_idx >= nFace*Nf*param.ghostFace[3]) ? 1 : 0;
       face_idx -= face_num*nFace*Nf*param.ghostFace[3];
       if (face_num == 0) {
-	const int idx = indexFromNdegTMFaceIndex<3,nFace,0>(face_idx,Nf*param.ghostFace[3],param.parity,param.X);
+	const int idx = indexFromNdegTMFaceIndex<3,nFace,0>(face_idx,Nf*param.ghostFace[3],param);
 	packFaceWilsonCore<3, dagger,0>(param.out[6], param.outNorm[6], param.in, 
 					param.inNorm, idx, face_idx, Nf*param.ghostFace[3], param);
       } else {
-	const int idx = indexFromNdegTMFaceIndex<3,nFace,1>(face_idx,Nf*param.ghostFace[3],param.parity,param.X);
+	const int idx = indexFromNdegTMFaceIndex<3,nFace,1>(face_idx,Nf*param.ghostFace[3],param);
 	packFaceWilsonCore<3, dagger,1>(param.out[7], param.outNorm[7], param.in, 
 					param.inNorm, idx, face_idx, Nf*param.ghostFace[3], param);
       }

--- a/lib/dslash_pack.cu
+++ b/lib/dslash_pack.cu
@@ -830,7 +830,7 @@ namespace quda {
       unbindSpinorTex<FloatN>(in);
     }
 
-    virtual int tuningIter() const { return 100; }
+    virtual int tuningIter() const { return 3; }
 
     virtual TuneKey tuneKey() const {
       return TuneKey(in->VolString(), typeid(*this).name(), aux);

--- a/lib/dslash_pack.cu
+++ b/lib/dslash_pack.cu
@@ -55,7 +55,7 @@ namespace quda {
     FloatN *in;
     float *inNorm;
     
-    int threads; // total number of threads
+    int_fastdiv threads; // total number of threads
     
     // offsets which determine thread mapping to dimension
     int threadDimMapLower[4]; // lowest thread which maps to dim

--- a/lib/dslash_pack.cu
+++ b/lib/dslash_pack.cu
@@ -112,27 +112,6 @@ namespace quda {
       int R[QUDA_MAX_DIM]; // boundary dimensions
     };
 
-  /**
-   * Determines which face a given thread is computing.  Also rescale
-   * face_idx so that is relative to a given dimension.
-   */
-/*
-  template <typename Param>
-    __device__ inline int dimFromFaceIndex (int &face_idx, const Param &param) {
-    if (face_idx < param.threadDimMapUpper[0]) {
-      return 0;
-    } else if (face_idx < param.threadDimMapUpper[1]) {
-      face_idx -= param.threadDimMapLower[1];
-      return 1;
-    } else if (face_idx < param.threadDimMapUpper[2]) {
-      face_idx -= param.threadDimMapLower[2];
-      return 2;
-    } else { // this is only called if we use T kernel packing 
-      face_idx -= param.threadDimMapLower[3];
-      return 3;
-    }
-  }
-*/
 #if defined(GPU_WILSON_DIRAC) || defined(GPU_DOMAIN_WALL_DIRAC)
 
   // double precision
@@ -304,11 +283,11 @@ namespace quda {
       const int face_num = (face_idx >= nFace*param.ghostFace[0]) ? 1 : 0;
       face_idx -= face_num*nFace*param.ghostFace[0];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndex<0,nFace,0>(face_idx,param.ghostFace[0],param);
+	const int idx = indexFromFaceIndex<4,QUDA_4D_PC,0,nFace,0>(face_idx,param);
 	packFaceWilsonCore<0,dagger,0>(param.out[0], param.outNorm[0], param.in, 
 				       param.inNorm,idx, face_idx, param.ghostFace[0], param);
       } else {
-	const int idx = indexFromFaceIndex<0,nFace,1>(face_idx,param.ghostFace[0],param);
+	const int idx = indexFromFaceIndex<4,QUDA_4D_PC,0,nFace,1>(face_idx,param);
 	packFaceWilsonCore<0,dagger,1>(param.out[1], param.outNorm[1], param.in, 
 				       param.inNorm,idx, face_idx, param.ghostFace[0], param);
       }
@@ -317,11 +296,11 @@ namespace quda {
       const int face_num = (face_idx >= nFace*param.ghostFace[1]) ? 1 : 0;
       face_idx -= face_num*nFace*param.ghostFace[1];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndex<1,nFace,0>(face_idx,param.ghostFace[1],param);
+	const int idx = indexFromFaceIndex<4,QUDA_4D_PC,1,nFace,0>(face_idx,param);
 	packFaceWilsonCore<1, dagger,0>(param.out[2], param.outNorm[2], param.in, 
 					param.inNorm,idx, face_idx, param.ghostFace[1], param);
       } else {
-	const int idx = indexFromFaceIndex<1,nFace,1>(face_idx,param.ghostFace[1],param);
+	const int idx = indexFromFaceIndex<4,QUDA_4D_PC,1,nFace,1>(face_idx,param);
 	packFaceWilsonCore<1, dagger,1>(param.out[3], param.outNorm[3], param.in, 
 					param.inNorm,idx, face_idx, param.ghostFace[1], param);
       }
@@ -330,11 +309,11 @@ namespace quda {
       const int face_num = (face_idx >= nFace*param.ghostFace[2]) ? 1 : 0;
       face_idx -= face_num*nFace*param.ghostFace[2];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndex<2,nFace,0>(face_idx,param.ghostFace[2],param);
+	const int idx = indexFromFaceIndex<4,QUDA_4D_PC,2,nFace,0>(face_idx,param);
 	packFaceWilsonCore<2, dagger,0>(param.out[4], param.outNorm[4], param.in, 
 					param.inNorm,idx, face_idx, param.ghostFace[2], param);
       } else {
-	const int idx = indexFromFaceIndex<2,nFace,1>(face_idx,param.ghostFace[2],param);
+	const int idx = indexFromFaceIndex<4,QUDA_4D_PC,2,nFace,1>(face_idx,param);
 	packFaceWilsonCore<2, dagger,1>(param.out[5], param.outNorm[5], param.in, 
 					param.inNorm,idx, face_idx, param.ghostFace[2], param);
       }
@@ -343,11 +322,11 @@ namespace quda {
       const int face_num = (face_idx >= nFace*param.ghostFace[3]) ? 1 : 0;
       face_idx -= face_num*nFace*param.ghostFace[3];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndex<3,nFace,0>(face_idx,param.ghostFace[3],param);
+	const int idx = indexFromFaceIndex<4,QUDA_4D_PC,3,nFace,0>(face_idx,param);
 	packFaceWilsonCore<3, dagger,0>(param.out[6], param.outNorm[6], param.in, 
 					param.inNorm,idx, face_idx, param.ghostFace[3], param);
       } else {
-	const int idx = indexFromFaceIndex<3,nFace,1>(face_idx,param.ghostFace[3],param);
+	const int idx = indexFromFaceIndex<4,QUDA_4D_PC,3,nFace,1>(face_idx,param);
 	packFaceWilsonCore<3, dagger,1>(param.out[7], param.outNorm[7], param.in, 
 					param.inNorm,idx, face_idx, param.ghostFace[3], param);
       }
@@ -375,11 +354,11 @@ namespace quda {
       const int face_num = (param.face_num==2) ? ((face_idx >= nFace*param.ghostFace[0]) ? 1 : 0) : param.face_num;
       if(param.face_num==2) face_idx -= face_num*nFace*param.ghostFace[0];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndexExtended<0,nFace,0>(face_idx,param.ghostFace[0],param);
+	const int idx = indexFromFaceIndexExtended<0,nFace,0>(face_idx,param);
 	packFaceWilsonCore<0,dagger,0>(param.out[0], param.outNorm[0], param.in, 
 				       param.inNorm,idx, face_idx, param.ghostFace[0], param);
       } else {
-	const int idx = indexFromFaceIndexExtended<0,nFace,1>(face_idx,param.ghostFace[0],param);
+	const int idx = indexFromFaceIndexExtended<0,nFace,1>(face_idx,param);
 	packFaceWilsonCore<0,dagger,1>(param.out[1], param.outNorm[1], param.in, 
 				       param.inNorm,idx, face_idx, param.ghostFace[0], param);
       }
@@ -387,11 +366,11 @@ namespace quda {
       const int face_num = (param.face_num==2) ? ((face_idx >= nFace*param.ghostFace[1]) ? 1 : 0) : param.face_num;
       if(param.face_num==2) face_idx -= face_num*nFace*param.ghostFace[1];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndexExtended<1,nFace,0>(face_idx,param.ghostFace[1],param);
+	const int idx = indexFromFaceIndexExtended<1,nFace,0>(face_idx,param);
 	packFaceWilsonCore<1, dagger,0>(param.out[2], param.outNorm[2], param.in, 
 					param.inNorm,idx, face_idx, param.ghostFace[1], param);
       } else {
-	const int idx = indexFromFaceIndexExtended<1,nFace,1>(face_idx,param.ghostFace[1],param);
+	const int idx = indexFromFaceIndexExtended<1,nFace,1>(face_idx,param);
 	packFaceWilsonCore<1, dagger,1>(param.out[3], param.outNorm[3], param.in, 
 					param.inNorm,idx, face_idx, param.ghostFace[1], param);
       }
@@ -399,11 +378,11 @@ namespace quda {
       const int face_num = (param.face_num==2) ? ((face_idx >= nFace*param.ghostFace[2]) ? 1 : 0) : param.face_num;
       if(param.face_num==2) face_idx -= face_num*nFace*param.ghostFace[2];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndexExtended<2,nFace,0>(face_idx,param.ghostFace[2],param);
+	const int idx = indexFromFaceIndexExtended<2,nFace,0>(face_idx,param);
 	packFaceWilsonCore<2, dagger,0>(param.out[4], param.outNorm[4], param.in, 
 					param.inNorm,idx, face_idx, param.ghostFace[2], param);
       } else {
-	const int idx = indexFromFaceIndexExtended<2,nFace,1>(face_idx,param.ghostFace[2],param);
+	const int idx = indexFromFaceIndexExtended<2,nFace,1>(face_idx,param);
 	packFaceWilsonCore<2, dagger,1>(param.out[5], param.outNorm[5], param.in, 
 					param.inNorm,idx, face_idx, param.ghostFace[2], param);
       }
@@ -412,11 +391,11 @@ namespace quda {
       if(param.face_num==2) face_idx -= face_num*nFace*param.ghostFace[3];
 
       if (face_num == 0) {
-	const int idx = indexFromFaceIndexExtended<3,nFace,0>(face_idx,param.ghostFace[3],param);
+	const int idx = indexFromFaceIndexExtended<3,nFace,0>(face_idx,param);
 	packFaceWilsonCore<3, dagger,0>(param.out[6], param.outNorm[6], param.in, 
 					param.inNorm,idx, face_idx, param.ghostFace[3], param);
       } else {
-	const int idx = indexFromFaceIndexExtended<3,nFace,1>(face_idx,param.ghostFace[3],param);
+	const int idx = indexFromFaceIndexExtended<3,nFace,1>(face_idx,param);
 	packFaceWilsonCore<3, dagger,1>(param.out[7], param.outNorm[7], param.in, 
 					param.inNorm,idx, face_idx, param.ghostFace[3], param);
       }
@@ -445,11 +424,11 @@ namespace quda {
       if(param.face_num==2) face_idx -= face_num*nFace*param.ghostFace[0];
 
       if (face_num == 0) {
-	const int idx = indexFromFaceIndexExtended<0,nFace,0>(face_idx,param.ghostFace[0],param);
+	const int idx = indexFromFaceIndexExtended<0,nFace,0>(face_idx,param);
 	unpackFaceWilsonCore<0,dagger,0>(param.out[0], param.outNorm[0], param.in, 
 					 param.inNorm,idx, face_idx, param.ghostFace[0], param);
       } else {
-	const int idx = indexFromFaceIndexExtended<0,nFace,1>(face_idx,param.ghostFace[0],param);
+	const int idx = indexFromFaceIndexExtended<0,nFace,1>(face_idx,param);
 	unpackFaceWilsonCore<0,dagger,1>(param.out[1], param.outNorm[1], param.in, 
 					 param.inNorm,idx, face_idx, param.ghostFace[0], param);
       }
@@ -458,11 +437,11 @@ namespace quda {
       if(param.face_num==2) face_idx -= face_num*nFace*param.ghostFace[1];
 
       if (face_num == 0) {
-	const int idx = indexFromFaceIndexExtended<1,nFace,0>(face_idx,param.ghostFace[1],param);
+	const int idx = indexFromFaceIndexExtended<1,nFace,0>(face_idx,param);
 	unpackFaceWilsonCore<1, dagger,0>(param.out[2], param.outNorm[2], param.in, 
 					  param.inNorm,idx, face_idx, param.ghostFace[1], param);
       } else {
-	const int idx = indexFromFaceIndexExtended<1,nFace,1>(face_idx,param.ghostFace[1],param);
+	const int idx = indexFromFaceIndexExtended<1,nFace,1>(face_idx,param);
 	unpackFaceWilsonCore<1, dagger,1>(param.out[3], param.outNorm[3], param.in, 
 					  param.inNorm,idx, face_idx, param.ghostFace[1], param);
       }
@@ -471,11 +450,11 @@ namespace quda {
       if(param.face_num==2) face_idx -= face_num*nFace*param.ghostFace[2];
 
       if (face_num == 0) {
-	const int idx = indexFromFaceIndexExtended<2,nFace,0>(face_idx,param.ghostFace[2],param);
+	const int idx = indexFromFaceIndexExtended<2,nFace,0>(face_idx,param);
 	unpackFaceWilsonCore<2, dagger,0>(param.out[4], param.outNorm[4], param.in, 
 					  param.inNorm,idx, face_idx, param.ghostFace[2], param);
       } else {
-	const int idx = indexFromFaceIndexExtended<2,nFace,1>(face_idx,param.ghostFace[2],param);
+	const int idx = indexFromFaceIndexExtended<2,nFace,1>(face_idx,param);
 	unpackFaceWilsonCore<2, dagger,1>(param.out[5], param.outNorm[5], param.in, 
 					  param.inNorm,idx, face_idx, param.ghostFace[2], param);
       }
@@ -484,11 +463,11 @@ namespace quda {
       if(param.face_num==2) face_idx -= face_num*nFace*param.ghostFace[3];
 
       if (face_num == 0) {
-	const int idx = indexFromFaceIndexExtended<3,nFace,0>(face_idx,param.ghostFace[3],param);
+	const int idx = indexFromFaceIndexExtended<3,nFace,0>(face_idx,param);
 	unpackFaceWilsonCore<3, dagger,0>(param.out[6], param.outNorm[6], param.in, 
 					  param.inNorm,idx, face_idx, param.ghostFace[3], param);
       } else {
-	const int idx = indexFromFaceIndexExtended<3,nFace,1>(face_idx,param.ghostFace[3],param);
+	const int idx = indexFromFaceIndexExtended<3,nFace,1>(face_idx,param);
 	unpackFaceWilsonCore<3, dagger,1>(param.out[7], param.outNorm[7], param.in, 
 					  param.inNorm,idx, face_idx, param.ghostFace[3], param);
       }
@@ -642,11 +621,11 @@ namespace quda {
       const int face_num = (face_idx >= nFace*param.ghostFace[0]) ? 1 : 0;
       face_idx -= face_num*nFace*param.ghostFace[0];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndex<0,nFace,0>(face_idx,param.ghostFace[0],param);
+	const int idx = indexFromFaceIndex<4,QUDA_4D_PC,0,nFace,0>(face_idx,param);
 	packTwistedFaceWilsonCore<0,dagger,0>(param.out[0], param.outNorm[0], param.in, 
 					      param.inNorm, a, b, idx, face_idx, param.ghostFace[0], param);
       } else {
-	const int idx = indexFromFaceIndex<0,nFace,1>(face_idx,param.ghostFace[0],param);
+	const int idx = indexFromFaceIndex<4,QUDA_4D_PC,0,nFace,1>(face_idx,param);
 	packTwistedFaceWilsonCore<0,dagger,1>(param.out[1], param.outNorm[1], param.in, 
 					      param.inNorm, a, b, idx, face_idx, param.ghostFace[0], param);
       }
@@ -654,11 +633,11 @@ namespace quda {
       const int face_num = (face_idx >= nFace*param.ghostFace[1]) ? 1 : 0;
       face_idx -= face_num*nFace*param.ghostFace[1];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndex<1,nFace,0>(face_idx,param.ghostFace[1],param);
+	const int idx = indexFromFaceIndex<4,QUDA_4D_PC,1,nFace,0>(face_idx,param);
 	packTwistedFaceWilsonCore<1, dagger,0>(param.out[2], param.outNorm[2], param.in, 
 					       param.inNorm, a, b, idx, face_idx, param.ghostFace[1], param);
       } else {
-	const int idx = indexFromFaceIndex<1,nFace,1>(face_idx,param.ghostFace[1],param);
+	const int idx = indexFromFaceIndex<4,QUDA_4D_PC,1,nFace,1>(face_idx,param);
 	packTwistedFaceWilsonCore<1, dagger,1>(param.out[3], param.outNorm[3], param.in, 
 					       param.inNorm, a, b, idx, face_idx, param.ghostFace[1], param);
       }
@@ -666,11 +645,11 @@ namespace quda {
       const int face_num = (face_idx >= nFace*param.ghostFace[2]) ? 1 : 0;
       face_idx -= face_num*nFace*param.ghostFace[2];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndex<2,nFace,0>(face_idx,param.ghostFace[2],param);
+	const int idx = indexFromFaceIndex<4,QUDA_4D_PC,2,nFace,0>(face_idx,param);
 	packTwistedFaceWilsonCore<2, dagger,0>(param.out[4], param.outNorm[4], param.in, 
 					       param.inNorm, a, b, idx, face_idx, param.ghostFace[2], param);
       } else {
-	const int idx = indexFromFaceIndex<2,nFace,1>(face_idx,param.ghostFace[2],param);
+	const int idx = indexFromFaceIndex<4,QUDA_4D_PC,2,nFace,1>(face_idx,param);
 	packTwistedFaceWilsonCore<2, dagger,1>(param.out[5], param.outNorm[5], param.in, 
 					       param.inNorm, a, b, idx, face_idx, param.ghostFace[2], param);
       }
@@ -678,11 +657,11 @@ namespace quda {
       const int face_num = (face_idx >= nFace*param.ghostFace[3]) ? 1 : 0;
       face_idx -= face_num*nFace*param.ghostFace[3];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndex<3,nFace,0>(face_idx,param.ghostFace[3],param);
+	const int idx = indexFromFaceIndex<4,QUDA_4D_PC,3,nFace,0>(face_idx,param);
 	packTwistedFaceWilsonCore<3, dagger,0>(param.out[6], param.outNorm[6], param.in, 
 					       param.inNorm, a, b,idx, face_idx, param.ghostFace[3], param);
       } else {
-	const int idx = indexFromFaceIndex<3,nFace,1>(face_idx,param.ghostFace[3],param);
+	const int idx = indexFromFaceIndex<4,QUDA_4D_PC,3,nFace,1>(face_idx,param);
 	packTwistedFaceWilsonCore<3, dagger,1>(param.out[7], param.outNorm[7], param.in, 
 					       param.inNorm, a, b, idx, face_idx, param.ghostFace[3], param);
       }
@@ -851,7 +830,7 @@ namespace quda {
       unbindSpinorTex<FloatN>(in);
     }
 
-    virtual int tuningIter() const { return 3; }
+    virtual int tuningIter() const { return 100; }
 
     virtual TuneKey tuneKey() const {
       return TuneKey(in->VolString(), typeid(*this).name(), aux);
@@ -1095,11 +1074,11 @@ namespace quda {
       const int face_num = (param.face_num==2) ? ((face_idx >= Ls*nFace*param.ghostFace[0]) ? 1 : 0) : param.face_num;
       if(param.face_num==2) face_idx -= face_num*Ls*nFace*param.ghostFace[0];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndexStaggered<0,nFace,0>(face_idx,Ls*param.ghostFace[0],param);
+	const int idx = indexFromFaceIndexStaggered<0,nFace,0>(face_idx,param);
 	packFaceStaggeredCore(param.out[0], param.outNorm[0], face_idx, 
 			      Ls*nFace*param.ghostFace[0], param.in, param.inNorm, idx, param);
       } else {
-	const int idx = indexFromFaceIndexStaggered<0,nFace,1>(face_idx,Ls*param.ghostFace[0],param);
+	const int idx = indexFromFaceIndexStaggered<0,nFace,1>(face_idx,param);
 	packFaceStaggeredCore(param.out[1], param.outNorm[1], face_idx,
 			      Ls*nFace*param.ghostFace[0], param.in, param.inNorm, idx, param);
       }
@@ -1107,11 +1086,11 @@ namespace quda {
       const int face_num = (param.face_num==2) ? ((face_idx >= Ls*nFace*param.ghostFace[1]) ? 1 : 0) : param.face_num;
       if(param.face_num==2) face_idx -= face_num*Ls*nFace*param.ghostFace[1];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndexStaggered<1,nFace,0>(face_idx,Ls*param.ghostFace[1],param);
+	const int idx = indexFromFaceIndexStaggered<1,nFace,0>(face_idx,param);
 	packFaceStaggeredCore(param.out[2], param.outNorm[2], face_idx, 
 			      Ls*nFace*param.ghostFace[1], param.in, param.inNorm, idx, param);
       } else {
-	const int idx = indexFromFaceIndexStaggered<1,nFace,1>(face_idx,Ls*param.ghostFace[1],param);
+	const int idx = indexFromFaceIndexStaggered<1,nFace,1>(face_idx,param);
 	packFaceStaggeredCore(param.out[3], param.outNorm[3], face_idx, 
 			      Ls*nFace*param.ghostFace[1], param.in, param.inNorm, idx, param);
       }
@@ -1163,11 +1142,11 @@ namespace quda {
       const int face_num = (param.face_num==2) ? ((face_idx >= nFace*param.ghostFace[0]) ? 1 : 0) : param.face_num;
       if(param.face_num==2) face_idx -= face_num*nFace*param.ghostFace[0];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndexExtendedStaggered<0,nFace,0>(face_idx,param.ghostFace[0],param);
+	const int idx = indexFromFaceIndexExtendedStaggered<0,nFace,0>(face_idx,param);
 	packFaceStaggeredCore(param.out[0], param.outNorm[0], face_idx, 
 			      nFace*param.ghostFace[0], param.in, param.inNorm, idx, param);
       } else {
-	const int idx = indexFromFaceIndexExtendedStaggered<0,nFace,1>(face_idx,param.ghostFace[0],param);
+	const int idx = indexFromFaceIndexExtendedStaggered<0,nFace,1>(face_idx,param);
 	packFaceStaggeredCore(param.out[1], param.outNorm[1], face_idx,
 			      nFace*param.ghostFace[0], param.in, param.inNorm, idx, param);
       }
@@ -1175,11 +1154,11 @@ namespace quda {
       const int face_num = (param.face_num==2) ? ((face_idx >= nFace*param.ghostFace[1]) ? 1 : 0) : param.face_num;
       if(param.face_num==2) face_idx -= face_num*nFace*param.ghostFace[1];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndexExtendedStaggered<1,nFace,0>(face_idx,param.ghostFace[1],param);
+	const int idx = indexFromFaceIndexExtendedStaggered<1,nFace,0>(face_idx,param);
 	packFaceStaggeredCore(param.out[2], param.outNorm[2], face_idx, 
 			      nFace*param.ghostFace[1], param.in, param.inNorm, idx, param);
       } else {
-	const int idx = indexFromFaceIndexExtendedStaggered<1,nFace,1>(face_idx,param.ghostFace[1],param);
+	const int idx = indexFromFaceIndexExtendedStaggered<1,nFace,1>(face_idx,param);
 	packFaceStaggeredCore(param.out[3], param.outNorm[3], face_idx, 
 			      nFace*param.ghostFace[1], param.in, param.inNorm, idx, param);
       }
@@ -1187,11 +1166,11 @@ namespace quda {
       const int face_num = (param.face_num==2) ? ((face_idx >= nFace*param.ghostFace[2]) ? 1 : 0) : param.face_num;
       if(param.face_num==2) face_idx -= face_num*nFace*param.ghostFace[2];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndexExtendedStaggered<2,nFace,0>(face_idx,param.ghostFace[2],param);
+	const int idx = indexFromFaceIndexExtendedStaggered<2,nFace,0>(face_idx,param);
 	packFaceStaggeredCore(param.out[4], param.outNorm[4], face_idx,
 			      nFace*param.ghostFace[2], param.in, param.inNorm, idx, param);
       } else {
-	const int idx = indexFromFaceIndexExtendedStaggered<2,nFace,1>(face_idx,param.ghostFace[2],param);
+	const int idx = indexFromFaceIndexExtendedStaggered<2,nFace,1>(face_idx,param);
 	packFaceStaggeredCore(param.out[5], param.outNorm[5], face_idx,
 			      nFace*param.ghostFace[2], param.in, param.inNorm, idx, param);
       }
@@ -1199,11 +1178,11 @@ namespace quda {
       const int face_num = (param.face_num==2) ? ((face_idx >= nFace*param.ghostFace[3]) ? 1 : 0) : param.face_num;
       if(param.face_num==2) face_idx -= face_num*nFace*param.ghostFace[3];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndexExtendedStaggered<3,nFace,0>(face_idx,param.ghostFace[3],param);
+	const int idx = indexFromFaceIndexExtendedStaggered<3,nFace,0>(face_idx,param);
 	packFaceStaggeredCore(param.out[6], param.outNorm[6], face_idx,
 			      nFace*param.ghostFace[3], param.in, param.inNorm,idx, param);
       } else {
-	const int idx = indexFromFaceIndexExtendedStaggered<3,nFace,1>(face_idx,param.ghostFace[3],param);
+	const int idx = indexFromFaceIndexExtendedStaggered<3,nFace,1>(face_idx,param);
 	packFaceStaggeredCore(param.out[7], param.outNorm[7], face_idx, 
 			      nFace*param.ghostFace[3], param.in, param.inNorm, idx, param);
       }
@@ -1231,11 +1210,11 @@ namespace quda {
       const int face_num = (param.face_num==2) ? ((face_idx >= nFace*param.ghostFace[0]) ? 1 : 0) : param.face_num;
       if(param.face_num==2) face_idx -= face_num*nFace*param.ghostFace[0];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndexExtendedStaggered<0,nFace,0>(face_idx,param.ghostFace[0],param);
+	const int idx = indexFromFaceIndexExtendedStaggered<0,nFace,0>(face_idx,param);
 	packFaceStaggeredCore(param.in, param.inNorm, idx, 
 			      param.sp_stride, param.out[0], param.outNorm[0], face_idx, nFace*param.ghostFace[0]);
       } else {
-	const int idx = indexFromFaceIndexExtendedStaggered<0,nFace,1>(face_idx,param.ghostFace[0],param);
+	const int idx = indexFromFaceIndexExtendedStaggered<0,nFace,1>(face_idx,param);
 	packFaceStaggeredCore(param.in, param.inNorm, idx, 
 			      param.sp_stride, param.out[1], param.outNorm[1], face_idx, nFace*param.ghostFace[0]);
       }
@@ -1243,11 +1222,11 @@ namespace quda {
       const int face_num = (param.face_num==2) ? ((face_idx >= nFace*param.ghostFace[1]) ? 1 : 0) : param.face_num;
       if(param.face_num==2) face_idx -= face_num*nFace*param.ghostFace[1];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndexExtendedStaggered<1,nFace,0>(face_idx,param.ghostFace[1],param);
+	const int idx = indexFromFaceIndexExtendedStaggered<1,nFace,0>(face_idx,param);
 	packFaceStaggeredCore(param.in, param.inNorm, idx, 
 			      param.sp_stride, param.out[2], param.outNorm[2], face_idx, nFace*param.ghostFace[1]);
       } else {
-	const int idx = indexFromFaceIndexExtendedStaggered<1,nFace,1>(face_idx,param.ghostFace[1],param);
+	const int idx = indexFromFaceIndexExtendedStaggered<1,nFace,1>(face_idx,param);
 	packFaceStaggeredCore(param.in, param.inNorm, idx, 
 			      param.sp_stride, param.out[3], param.outNorm[3], face_idx, nFace*param.ghostFace[1]);
       }
@@ -1255,11 +1234,11 @@ namespace quda {
       const int face_num = (param.face_num==2) ? ((face_idx >= nFace*param.ghostFace[2]) ? 1 : 0) : param.face_num;
       if(param.face_num==2) face_idx -= face_num*nFace*param.ghostFace[2];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndexExtendedStaggered<2,nFace,0>(face_idx,param.ghostFace[2],param);
+	const int idx = indexFromFaceIndexExtendedStaggered<2,nFace,0>(face_idx,param);
 	packFaceStaggeredCore(param.in, param.inNorm, idx, 
 			      param.sp_stride, param.out[4], param.outNorm[4], face_idx, nFace*param.ghostFace[2]);
       } else {
-	const int idx = indexFromFaceIndexExtendedStaggered<2,nFace,1>(face_idx,param.ghostFace[2],param);
+	const int idx = indexFromFaceIndexExtendedStaggered<2,nFace,1>(face_idx,param);
 	packFaceStaggeredCore(param.in, param.inNorm, idx, 
 			      param.sp_stride, param.out[5], param.outNorm[5], face_idx, nFace*param.ghostFace[2]);
       }
@@ -1267,11 +1246,11 @@ namespace quda {
       const int face_num = (param.face_num==2) ? ((face_idx >= nFace*param.ghostFace[3]) ? 1 : 0) : param.face_num;
       if(param.face_num==2) face_idx -= face_num*nFace*param.ghostFace[3];
       if (face_num == 0) {
-	const int idx = indexFromFaceIndexExtendedStaggered<3,nFace,0>(face_idx,param.ghostFace[3],param);
+	const int idx = indexFromFaceIndexExtendedStaggered<3,nFace,0>(face_idx,param);
 	packFaceStaggeredCore(param.in, param.inNorm, idx, 
 			      param.sp_stride, param.out[6], param.outNorm[6], face_idx, nFace*param.ghostFace[3]);
       } else {
-	const int idx = indexFromFaceIndexExtendedStaggered<3,nFace,1>(face_idx,param.ghostFace[3],param);
+	const int idx = indexFromFaceIndexExtendedStaggered<3,nFace,1>(face_idx,param);
 	packFaceStaggeredCore(param.in, param.inNorm, idx, 
 			      param.sp_stride, param.out[7], param.outNorm[7], face_idx, nFace*param.ghostFace[3]);
       }
@@ -1452,11 +1431,11 @@ namespace quda {
       const int face_num = (face_idx >= nFace*Ls*param.ghostFace[0]) ? 1 : 0; 
       face_idx -= face_num*nFace*Ls*param.ghostFace[0];
       if (face_num == 0) {
-	const int idx = indexFromDWFaceIndex<0,nFace,0>(face_idx,Ls*param.ghostFace[0],param);
+	const int idx = indexFromFaceIndex<5,QUDA_5D_PC,0,nFace,0>(face_idx,param);
 	packFaceWilsonCore<0,dagger,0>(param.out[0], param.outNorm[0], param.in, 
 				       param.inNorm, idx, face_idx, Ls*param.ghostFace[0], param);
       } else {
-	const int idx = indexFromDWFaceIndex<0,nFace,1>(face_idx,Ls*param.ghostFace[0],param);
+	const int idx = indexFromFaceIndex<5,QUDA_5D_PC,0,nFace,1>(face_idx,param);
 	packFaceWilsonCore<0,dagger,1>(param.out[1], param.outNorm[1], param.in, 
 				       param.inNorm, idx, face_idx, Ls*param.ghostFace[0], param);
       }
@@ -1464,11 +1443,11 @@ namespace quda {
       const int face_num = (face_idx >= nFace*Ls*param.ghostFace[1]) ? 1 : 0; 
       face_idx -= face_num*nFace*Ls*param.ghostFace[1];
       if (face_num == 0) {
-	const int idx = indexFromDWFaceIndex<1,nFace,0>(face_idx,Ls*param.ghostFace[1],param);
+	const int idx = indexFromFaceIndex<5,QUDA_5D_PC,1,nFace,0>(face_idx,param);
 	packFaceWilsonCore<1, dagger,0>(param.out[2], param.outNorm[2], param.in, 
 					param.inNorm, idx, face_idx, Ls*param.ghostFace[1], param);
       } else {
-	const int idx = indexFromDWFaceIndex<1,nFace,1>(face_idx,Ls*param.ghostFace[1],param);
+	const int idx = indexFromFaceIndex<5,QUDA_5D_PC,1,nFace,1>(face_idx,param);
 	packFaceWilsonCore<1, dagger,1>(param.out[3], param.outNorm[3], param.in, 
 					param.inNorm, idx, face_idx, Ls*param.ghostFace[1], param);
       }
@@ -1476,11 +1455,11 @@ namespace quda {
       const int face_num = (face_idx >= nFace*Ls*param.ghostFace[2]) ? 1 : 0; 
       face_idx -= face_num*nFace*Ls*param.ghostFace[2];
       if (face_num == 0) {
-	const int idx = indexFromDWFaceIndex<2,nFace,0>(face_idx,Ls*param.ghostFace[2],param);
+	const int idx = indexFromFaceIndex<5,QUDA_5D_PC,2,nFace,0>(face_idx,param);
 	packFaceWilsonCore<2, dagger,0>(param.out[4], param.outNorm[4], param.in, 
 					param.inNorm, idx, face_idx, Ls*param.ghostFace[2], param);
       } else {
-	const int idx = indexFromDWFaceIndex<2,nFace,1>(face_idx,Ls*param.ghostFace[2],param);
+	const int idx = indexFromFaceIndex<5,QUDA_5D_PC,2,nFace,1>(face_idx,param);
 	packFaceWilsonCore<2, dagger,1>(param.out[5], param.outNorm[5], param.in, 
 					param.inNorm, idx, face_idx, Ls*param.ghostFace[2], param);
       }
@@ -1488,11 +1467,11 @@ namespace quda {
       const int face_num = (face_idx >= nFace*Ls*param.ghostFace[3]) ? 1 : 0; 
       face_idx -= face_num*nFace*Ls*param.ghostFace[3];
       if (face_num == 0) {
-	const int idx = indexFromDWFaceIndex<3,nFace,0>(face_idx,Ls*param.ghostFace[3],param);
+	const int idx = indexFromFaceIndex<5,QUDA_5D_PC,3,nFace,0>(face_idx,param);
 	packFaceWilsonCore<3, dagger,0>(param.out[6], param.outNorm[6], param.in, 
 					param.inNorm, idx, face_idx, Ls*param.ghostFace[3], param);
       } else {
-	const int idx = indexFromDWFaceIndex<3,nFace,1>(face_idx,Ls*param.ghostFace[3],param);
+	const int idx = indexFromFaceIndex<5,QUDA_5D_PC,3,nFace,1>(face_idx,param);
 	packFaceWilsonCore<3, dagger,1>(param.out[7], param.outNorm[7], param.in, 
 					param.inNorm, idx, face_idx, Ls*param.ghostFace[3], param);
       }
@@ -1522,11 +1501,11 @@ namespace quda {
       const int face_num = (face_idx >= nFace*Ls*param.ghostFace[0]) ? 1 : 0; 
       face_idx -= face_num*nFace*Ls*param.ghostFace[0];
         if (face_num == 0) {
-	const int idx = indexFromDW4DFaceIndex<0,nFace,0>(face_idx,Ls*param.ghostFace[0],param);
+	const int idx = indexFromFaceIndex<5,QUDA_4D_PC,0,nFace,0>(face_idx,param);
 	packFaceWilsonCore<0,dagger,0>(param.out[0], param.outNorm[0], param.in, 
 				       param.inNorm, idx, face_idx, Ls*param.ghostFace[0], param);
       } else {
-	const int idx = indexFromDW4DFaceIndex<0,nFace,1>(face_idx,Ls*param.ghostFace[0],param);
+	const int idx = indexFromFaceIndex<5,QUDA_4D_PC,0,nFace,1>(face_idx,param);
 	packFaceWilsonCore<0,dagger,1>(param.out[1], param.outNorm[1], param.in, 
 				       param.inNorm, idx, face_idx, Ls*param.ghostFace[0], param);
       }
@@ -1534,11 +1513,11 @@ namespace quda {
       const int face_num = (face_idx >= nFace*Ls*param.ghostFace[1]) ? 1 : 0; 
       face_idx -= face_num*nFace*Ls*param.ghostFace[1];
       if (face_num == 0) {
-	const int idx = indexFromDW4DFaceIndex<1,nFace,0>(face_idx,Ls*param.ghostFace[1],param);
+	const int idx = indexFromFaceIndex<5,QUDA_4D_PC,1,nFace,0>(face_idx,param);
 	packFaceWilsonCore<1, dagger,0>(param.out[2], param.outNorm[2], param.in, 
 					param.inNorm, idx, face_idx, Ls*param.ghostFace[1], param);
       } else {
-	const int idx = indexFromDW4DFaceIndex<1,nFace,1>(face_idx,Ls*param.ghostFace[1],param);
+	const int idx = indexFromFaceIndex<5,QUDA_4D_PC,1,nFace,1>(face_idx,param);
 	packFaceWilsonCore<1, dagger,1>(param.out[3], param.outNorm[3], param.in, 
 					param.inNorm, idx, face_idx, Ls*param.ghostFace[1], param);
       }
@@ -1546,11 +1525,11 @@ namespace quda {
       const int face_num = (face_idx >= nFace*Ls*param.ghostFace[2]) ? 1 : 0; 
       face_idx -= face_num*nFace*Ls*param.ghostFace[2];
       if (face_num == 0) {
-	const int idx = indexFromDW4DFaceIndex<2,nFace,0>(face_idx,Ls*param.ghostFace[2],param);
+	const int idx = indexFromFaceIndex<5,QUDA_4D_PC,2,nFace,0>(face_idx,param);
 	packFaceWilsonCore<2, dagger,0>(param.out[4], param.outNorm[4], param.in, 
 					param.inNorm, idx, face_idx, Ls*param.ghostFace[2], param);
       } else {
-	const int idx = indexFromDW4DFaceIndex<2,nFace,1>(face_idx,Ls*param.ghostFace[2],param);
+	const int idx = indexFromFaceIndex<5,QUDA_4D_PC,2,nFace,1>(face_idx,param);
 	packFaceWilsonCore<2, dagger,1>(param.out[5], param.outNorm[5], param.in, 
 					param.inNorm, idx, face_idx, Ls*param.ghostFace[2], param);
       }
@@ -1558,11 +1537,11 @@ namespace quda {
       const int face_num = (face_idx >= nFace*Ls*param.ghostFace[3]) ? 1 : 0; 
       face_idx -= face_num*nFace*Ls*param.ghostFace[3];
       if (face_num == 0) {
-	const int idx = indexFromDW4DFaceIndex<3,nFace,0>(face_idx,Ls*param.ghostFace[3],param);
+	const int idx = indexFromFaceIndex<5,QUDA_4D_PC,3,nFace,0>(face_idx,param);
 	packFaceWilsonCore<3, dagger,0>(param.out[6], param.outNorm[6], param.in, 
 					param.inNorm, idx, face_idx, Ls*param.ghostFace[3], param);
       } else {
-	const int idx = indexFromDW4DFaceIndex<3,nFace,1>(face_idx,Ls*param.ghostFace[3],param);
+	const int idx = indexFromFaceIndex<5,QUDA_4D_PC,3,nFace,1>(face_idx,param);
 	packFaceWilsonCore<3, dagger,1>(param.out[7], param.outNorm[7], param.in, 
 					param.inNorm, idx, face_idx, Ls*param.ghostFace[3], param);
       }
@@ -1708,16 +1687,17 @@ namespace quda {
     // compute an index into the local volume from the index into the face
     // read spinor, spin-project, and write half spinor to face
     if (dim == 0) {
-      // face_num determines which end of the lattice we are packing: 0 = beginning, 1 = end
-      // FIXME these param.ghostFace constants do not include the Nf dimension
+      // face_num determines which end of the lattice we are packing:
+      // 0 = beginning, 1 = end FIXME these param.ghostFace constants
+      // do not include the Nf dimension
       const int face_num = (face_idx >= nFace*Nf*param.ghostFace[0]) ? 1 : 0;
       face_idx -= face_num*nFace*Nf*param.ghostFace[0];
       if (face_num == 0) {
-	const int idx = indexFromNdegTMFaceIndex<0,nFace,0>(face_idx,Nf*param.ghostFace[0],param);
+	const int idx = indexFromFaceIndex<5,QUDA_4D_PC,0,nFace,0>(face_idx,param);
 	packFaceWilsonCore<0,dagger,0>(param.out[0], param.outNorm[0], param.in, 
 				       param.inNorm, idx, face_idx, Nf*param.ghostFace[0], param);
       } else {
-	const int idx = indexFromNdegTMFaceIndex<0,nFace,1>(face_idx,Nf*param.ghostFace[0],param);
+	const int idx = indexFromFaceIndex<5,QUDA_4D_PC,0,nFace,1>(face_idx,param);
 	packFaceWilsonCore<0,dagger,1>(param.out[1], param.outNorm[1], param.in, 
 				       param.inNorm, idx, face_idx, Nf*param.ghostFace[0], param);
       }
@@ -1725,11 +1705,11 @@ namespace quda {
       const int face_num = (face_idx >= nFace*Nf*param.ghostFace[1]) ? 1 : 0;
       face_idx -= face_num*nFace*Nf*param.ghostFace[1];
       if (face_num == 0) {
-	const int idx = indexFromNdegTMFaceIndex<1,nFace,0>(face_idx,Nf*param.ghostFace[1],param);
+	const int idx = indexFromFaceIndex<5,QUDA_4D_PC,1,nFace,0>(face_idx,param);
 	packFaceWilsonCore<1, dagger,0>(param.out[2], param.outNorm[2], param.in, 
 					param.inNorm, idx, face_idx, Nf*param.ghostFace[1], param);
       } else {
-	const int idx = indexFromNdegTMFaceIndex<1,nFace,1>(face_idx,Nf*param.ghostFace[1],param);
+	const int idx = indexFromFaceIndex<5,QUDA_4D_PC,1,nFace,1>(face_idx,param);
 	packFaceWilsonCore<1, dagger,1>(param.out[3], param.outNorm[3], param.in, 
 					param.inNorm, idx, face_idx, Nf*param.ghostFace[1], param);
       }
@@ -1737,11 +1717,11 @@ namespace quda {
       const int face_num = (face_idx >= nFace*Nf*param.ghostFace[2]) ? 1 : 0;
       face_idx -= face_num*nFace*Nf*param.ghostFace[2];
       if (face_num == 0) {
-	const int idx = indexFromNdegTMFaceIndex<2,nFace,0>(face_idx,Nf*param.ghostFace[2],param);
+	const int idx = indexFromFaceIndex<5,QUDA_4D_PC,2,nFace,0>(face_idx,param);
 	packFaceWilsonCore<2, dagger,0>(param.out[4], param.outNorm[4], param.in, 
 					param.inNorm, idx, face_idx, Nf*param.ghostFace[2], param);
       } else {
-	const int idx = indexFromNdegTMFaceIndex<2,nFace,1>(face_idx,Nf*param.ghostFace[2],param);
+	const int idx = indexFromFaceIndex<5,QUDA_4D_PC,2,nFace,1>(face_idx,param);
 	packFaceWilsonCore<2, dagger,1>(param.out[5], param.outNorm[5], param.in, 
 					param.inNorm, idx, face_idx, Nf*param.ghostFace[2], param);
       }
@@ -1749,11 +1729,11 @@ namespace quda {
       const int face_num = (face_idx >= nFace*Nf*param.ghostFace[3]) ? 1 : 0;
       face_idx -= face_num*nFace*Nf*param.ghostFace[3];
       if (face_num == 0) {
-	const int idx = indexFromNdegTMFaceIndex<3,nFace,0>(face_idx,Nf*param.ghostFace[3],param);
+	const int idx = indexFromFaceIndex<5,QUDA_4D_PC,3,nFace,0>(face_idx,param);
 	packFaceWilsonCore<3, dagger,0>(param.out[6], param.outNorm[6], param.in, 
 					param.inNorm, idx, face_idx, Nf*param.ghostFace[3], param);
       } else {
-	const int idx = indexFromNdegTMFaceIndex<3,nFace,1>(face_idx,Nf*param.ghostFace[3],param);
+	const int idx = indexFromFaceIndex<5,QUDA_4D_PC,3,nFace,1>(face_idx,param);
 	packFaceWilsonCore<3, dagger,1>(param.out[7], param.outNorm[7], param.in, 
 					param.inNorm, idx, face_idx, Nf*param.ghostFace[3], param);
       }

--- a/lib/dslash_quda.cuh
+++ b/lib/dslash_quda.cuh
@@ -376,6 +376,21 @@ public:
 #endif
     dslashParam.Xh[0] = in->X(0);
     for (int i=1; i<4; i++) dslashParam.Xh[i] = in->X(i)/2;
+
+    int face[4];
+    for (int dim=0; dim<4; dim++) {
+      for (int j=0; j<4; j++) face[j] = dslashParam.X[j];
+      face[dim] = Nface()/2;
+      
+      dslashParam.face_X[dim] = face[0];
+      dslashParam.face_Y[dim] = face[1];
+      dslashParam.face_Z[dim] = face[2];
+      dslashParam.face_T[dim] = face[3];
+      dslashParam.face_XY[dim] = dslashParam.face_X[dim] * face[1];
+      dslashParam.face_XYZ[dim] = dslashParam.face_XY[dim] * face[2];
+      dslashParam.face_XYZT[dim] = dslashParam.face_XYZ[dim] * face[3];
+    }
+
   }
 
   virtual ~DslashCuda() { }

--- a/lib/dslash_quda.cuh
+++ b/lib/dslash_quda.cuh
@@ -368,12 +368,14 @@ public:
     // this sets the communications pattern for the packing kernel
     setPackComms(dslashParam.commDim);
 
-    for (int i=0; i<4; i++) dslashParam.X[i] = in->X(i);
+    // this is a c/b field so double the x dimension
+    dslashParam.X[0] = in->X(0)*2;
+    for (int i=1; i<4; i++) dslashParam.X[i] = in->X(i);
 #ifdef GPU_DOMAIN_WALL_DIRAC
     dslashParam.Ls = in->X(4); // needed by tuneLaunch()
 #endif
-    // this is a c/b field so double the x dimension
-    dslashParam.X[0] *= 2;
+    dslashParam.Xh[0] = in->X(0);
+    for (int i=1; i<4; i++) dslashParam.Xh[i] = in->X(i)/2;
   }
 
   virtual ~DslashCuda() { }

--- a/lib/dslash_quda.cuh
+++ b/lib/dslash_quda.cuh
@@ -376,6 +376,7 @@ public:
 #endif
     dslashParam.Xh[0] = in->X(0);
     for (int i=1; i<4; i++) dslashParam.Xh[i] = in->X(i)/2;
+    dslashParam.volume4CB = in->VolumeCB() / (in->Ndim()==5 ? in-> X(4) : 1);
 
     int face[4];
     for (int dim=0; dim<4; dim++) {

--- a/lib/dslash_staggered.cu
+++ b/lib/dslash_staggered.cu
@@ -114,8 +114,6 @@ namespace quda {
 	param.grid.y = (nSrc + param.block.y - 1) / param.block.y;
 	return true;
       } else {
-	param.block.y = 1;
-	param.grid.y = nSrc;
 	bool rtn = DslashCuda::advanceBlockDim(param);
 	param.block.y = 1;
 	param.grid.y = nSrc;

--- a/lib/generate/deg_tm_dslash_cuda_gen.py
+++ b/lib/generate/deg_tm_dslash_cuda_gen.py
@@ -308,9 +308,8 @@ int face_idx;
 if (kernel_type == INTERIOR_KERNEL) {
 #endif
 
-  // Inline by hand for the moment and assume even dimensions
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromIndex3D<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, dims);
+  // Assume even dimensions
+  coordsFromIndex3D<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X);
 
   // only need to check Y and Z dims currently since X and T set to match exactly
   if (x2 >= X2) return;
@@ -328,9 +327,8 @@ if (kernel_type == INTERIOR_KERNEL) {
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  // Inline by hand for the moment and assume even dimensions
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromIndex<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, dims, param.block, param.grid);
+  // Assume even dimensions
+  coordsFromIndex<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X, param.block, param.grid);
 
 """)
 
@@ -348,7 +346,6 @@ if (kernel_type == INTERIOR_KERNEL) {
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  const int dim = static_cast<int>(kernel_type);
   const int face_volume = (param.threads >> 1);           // volume of one face
   const int face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
   face_idx = sid - face_num*face_volume;        // index into the respective face
@@ -357,8 +354,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromFaceIndex<1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, dim, face_num, param.parity, dims);
+  coordsFromFaceIndex<kernel_type,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
 
   READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 

--- a/lib/generate/deg_tm_dslash_cuda_gen.py
+++ b/lib/generate/deg_tm_dslash_cuda_gen.py
@@ -294,7 +294,7 @@ VOLATILE spinorFloat *s = (spinorFloat*)s_data + DSLASH_SHARED_FLOATS_PER_THREAD
 #include "read_gauge.h"
 #include "io_spinor.h"
 
-int x1, x2, x3, x4;
+int coord[5];
 int X;
 
 int sid;
@@ -309,11 +309,11 @@ if (kernel_type == INTERIOR_KERNEL) {
 #endif
 
   // Assume even dimensions
-  coordsFromIndex3D<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X);
+  coordsFromIndex3D<EVEN_X>(X, coord, sid, param);
 
   // only need to check Y and Z dims currently since X and T set to match exactly
-  if (x2 >= X2) return;
-  if (x3 >= X3) return;
+  if (coord[1] >= param.X[1]) return;
+  if (cpprd[2] >= param.X[2]) return;
 
 """)
         else:
@@ -328,7 +328,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   if (sid >= param.threads) return;
 
   // Assume even dimensions
-  coordsFromIndex<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X, param.block, param.grid);
+  coordsFromIndex<4,QUDA_4D_PC,EVEN_X>(X, coord, sid, param);
 
 """)
 
@@ -354,7 +354,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-  coordsFromFaceIndex<kernel_type,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+  coordsFromFaceIndex<4,QUDA_4D_PC,kernel_type,1>(X, sid, coord, face_idx, face_num, param);
 
   READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 
@@ -387,8 +387,8 @@ def gen(dir, pack_only=False):
         if proj(i,1) == 0j:
             return (0, proj(i,0))
 
-    boundary = ["x1==X1m1", "x1==0", "x2==X2m1", "x2==0", "x3==X3m1", "x3==0", "x4==X4m1", "x4==0"]
-    interior = ["x1<X1m1", "x1>0", "x2<X2m1", "x2>0", "x3<X3m1", "x3>0", "x4<X4m1", "x4>0"]
+    boundary = ["coord[0]==X1m1", "coord[0]==0", "coord[1]==X2m1", "coord[1]==0", "coord[2]==X3m1", "coord[2]==0", "coord[3]==X4m1", "coord[3]==0"]
+    interior = ["coord[0]<X1m1", "coord[0]>0", "coord[1]<X2m1", "coord[1]>0", "coord[2]<X3m1", "coord[2]>0", "coord[3]<X4m1", "coord[3]>0"]
     dim = ["X", "Y", "Z", "T"]
 
     # index of neighboring site when not on boundary
@@ -553,28 +553,28 @@ READ_SPINOR_SHARED(tx, threadIdx.y, threadIdx.z);\n
 
     load_shared_2 = (
 """// load spinor from shared memory
-int tx = (threadIdx.x + blockDim.x - ((x1+1)&1) ) % blockDim.x;
+int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1) ) % blockDim.x;
 int ty = (threadIdx.y < blockDim.y - 1) ? threadIdx.y + 1 : 0;
 READ_SPINOR_SHARED(tx, ty, threadIdx.z);\n
 """)
 
     load_shared_3 = (
 """// load spinor from shared memory
-int tx = (threadIdx.x + blockDim.x - ((x1+1)&1)) % blockDim.x;
+int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1)) % blockDim.x;
 int ty = (threadIdx.y > 0) ? threadIdx.y - 1 : blockDim.y - 1;
 READ_SPINOR_SHARED(tx, ty, threadIdx.z);\n
 """)
 
     load_shared_4 = (
 """// load spinor from shared memory
-int tx = (threadIdx.x + blockDim.x - ((x1+1)&1) ) % blockDim.x;
+int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1) ) % blockDim.x;
 int tz = (threadIdx.z < blockDim.z - 1) ? threadIdx.z + 1 : 0;
 READ_SPINOR_SHARED(tx, threadIdx.y, tz);\n
 """)
 
     load_shared_5 = (
 """// load spinor from shared memory
-int tx = (threadIdx.x + blockDim.x - ((x1+1)&1)) % blockDim.x;
+int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1)) % blockDim.x;
 int tz = (threadIdx.z > 0) ? threadIdx.z - 1 : blockDim.z - 1;
 READ_SPINOR_SHARED(tx, threadIdx.y, tz);\n
 """)
@@ -789,13 +789,13 @@ int incomplete = 0; // Have all 8 contributions been computed for this site?
 
 switch(kernel_type) { // intentional fall-through
 case INTERIOR_KERNEL:
-  incomplete = incomplete || (param.commDim[3] && (x4==0 || x4==X4m1));
+  incomplete = incomplete || (param.commDim[3] && (coord[3]==0 || coord[3]==X4m1));
 case EXTERIOR_KERNEL_T:
-  incomplete = incomplete || (param.commDim[2] && (x3==0 || x3==X3m1));
+  incomplete = incomplete || (param.commDim[2] && (coord[2]==0 || coord[2]==X3m1));
 case EXTERIOR_KERNEL_Z:
-  incomplete = incomplete || (param.commDim[1] && (x2==0 || x2==X2m1));
+  incomplete = incomplete || (param.commDim[1] && (coord[1]==0 || coord[1]==X2m1));
 case EXTERIOR_KERNEL_Y:
-  incomplete = incomplete || (param.commDim[0] && (x1==0 || x1==X1m1));
+  incomplete = incomplete || (param.commDim[0] && (coord[0]==0 || coord[0]==X1m1));
 }
 
 """)    

--- a/lib/generate/deg_tmc_dslash_cuda_gen.py
+++ b/lib/generate/deg_tmc_dslash_cuda_gen.py
@@ -475,9 +475,8 @@ int face_idx;
 if (kernel_type == INTERIOR_KERNEL) {
 #endif
 
-  // Inline by hand for the moment and assume even dimensions
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromIndex3D<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, dims);
+  // Assume even dimensions
+  coordsFromIndex3D<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X);
 
   // only need to check Y and Z dims currently since X and T set to match exactly
   if (x2 >= X2) return;
@@ -495,9 +494,8 @@ if (kernel_type == INTERIOR_KERNEL) {
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  // Inline by hand for the moment and assume even dimensions
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromIndex<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, dims, param.block, param.grid);
+  // Assume even dimensions
+  coordsFromIndex<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X, param.block, param.grid);
 
 """)
 
@@ -515,7 +513,6 @@ if (kernel_type == INTERIOR_KERNEL) {
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  const int dim = static_cast<int>(kernel_type);
   const int face_volume = (param.threads >> 1);           // volume of one face
   const int face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
   face_idx = sid - face_num*face_volume;        // index into the respective face
@@ -524,8 +521,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromFaceIndex<1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, dim, face_num, param.parity, dims);
+  coordsFromFaceIndex<kernel_type,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
 
   READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 

--- a/lib/generate/deg_tmc_dslash_cuda_gen.py
+++ b/lib/generate/deg_tmc_dslash_cuda_gen.py
@@ -461,7 +461,7 @@ VOLATILE spinorFloat *s = (spinorFloat*)s_data + DSLASH_SHARED_FLOATS_PER_THREAD
 #include "read_clover.h"
 #include "tmc_core.h"
 
-int x1, x2, x3, x4;
+int coord[5];
 int X;
 
 int sid;
@@ -476,11 +476,11 @@ if (kernel_type == INTERIOR_KERNEL) {
 #endif
 
   // Assume even dimensions
-  coordsFromIndex3D<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X);
+  coordsFromIndex3D<EVEN_X>(X, coord, sid, param);
 
   // only need to check Y and Z dims currently since X and T set to match exactly
-  if (x2 >= X2) return;
-  if (x3 >= X3) return;
+  if (coord[1] >= param.X[1]) return;
+  if (coord[2] >= param.X[2]) return;
 
 """)
         else:
@@ -495,7 +495,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   if (sid >= param.threads) return;
 
   // Assume even dimensions
-  coordsFromIndex<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X, param.block, param.grid);
+  coordsFromIndex<4,QUDA_4D_PC,EVEN_X>(X, coord, sid, param);
 
 """)
 
@@ -521,7 +521,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-  coordsFromFaceIndex<kernel_type,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+  coordsFromFaceIndex<4,QUDA_4D_PC,kernel_type,1>(X, sid, coord, face_idx, face_num, param);
 
   READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 
@@ -554,8 +554,8 @@ def gen(dir, pack_only=False):
         if proj(i,1) == 0j:
             return (0, proj(i,0))
 
-    boundary = ["x1==X1m1", "x1==0", "x2==X2m1", "x2==0", "x3==X3m1", "x3==0", "x4==X4m1", "x4==0"]
-    interior = ["x1<X1m1", "x1>0", "x2<X2m1", "x2>0", "x3<X3m1", "x3>0", "x4<X4m1", "x4>0"]
+    boundary = ["coord[0]==X1m1", "coord[0]==0", "coord[1]==X2m1", "coord[1]==0", "coord[2]==X3m1", "coord[2]==0", "coord[3]==X4m1", "coord[3]==0"]
+    interior = ["coord[0]<X1m1", "coord[0]>0", "coord[1]<X2m1", "coord[1]>0", "coord[2]<X3m1", "coord[2]>0", "coord[3]<X4m1", "coord[3]>0"]
     dim = ["X", "Y", "Z", "T"]
 
     # index of neighboring site when not on boundary
@@ -695,28 +695,28 @@ READ_SPINOR_SHARED(tx, threadIdx.y, threadIdx.z);\n
 
     load_shared_2 = (
 """// load spinor from shared memory
-int tx = (threadIdx.x + blockDim.x - ((x1+1)&1) ) % blockDim.x;
+int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1) ) % blockDim.x;
 int ty = (threadIdx.y < blockDim.y - 1) ? threadIdx.y + 1 : 0;
 READ_SPINOR_SHARED(tx, ty, threadIdx.z);\n
 """)
 
     load_shared_3 = (
 """// load spinor from shared memory
-int tx = (threadIdx.x + blockDim.x - ((x1+1)&1)) % blockDim.x;
+int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1)) % blockDim.x;
 int ty = (threadIdx.y > 0) ? threadIdx.y - 1 : blockDim.y - 1;
 READ_SPINOR_SHARED(tx, ty, threadIdx.z);\n
 """)
 
     load_shared_4 = (
 """// load spinor from shared memory
-int tx = (threadIdx.x + blockDim.x - ((x1+1)&1) ) % blockDim.x;
+int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1) ) % blockDim.x;
 int tz = (threadIdx.z < blockDim.z - 1) ? threadIdx.z + 1 : 0;
 READ_SPINOR_SHARED(tx, threadIdx.y, tz);\n
 """)
 
     load_shared_5 = (
 """// load spinor from shared memory
-int tx = (threadIdx.x + blockDim.x - ((x1+1)&1)) % blockDim.x;
+int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1)) % blockDim.x;
 int tz = (threadIdx.z > 0) ? threadIdx.z - 1 : blockDim.z - 1;
 READ_SPINOR_SHARED(tx, threadIdx.y, tz);\n
 """)
@@ -940,14 +940,15 @@ def epilog():
 int incomplete = 0; // Have all 8 contributions been computed for this site?
 
 switch(kernel_type) { // intentional fall-through
+
 case INTERIOR_KERNEL:
-  incomplete = incomplete || (param.commDim[3] && (x4==0 || x4==X4m1));
+  incomplete = incomplete || (param.commDim[3] && (coord[3]==0 || coord[3]==X4m1));
 case EXTERIOR_KERNEL_T:
-  incomplete = incomplete || (param.commDim[2] && (x3==0 || x3==X3m1));
+  incomplete = incomplete || (param.commDim[2] && (coord[2]==0 || coord[2]==X3m1));
 case EXTERIOR_KERNEL_Z:
-  incomplete = incomplete || (param.commDim[1] && (x2==0 || x2==X2m1));
+  incomplete = incomplete || (param.commDim[1] && (coord[1]==0 || coord[1]==X2m1));
 case EXTERIOR_KERNEL_Y:
-  incomplete = incomplete || (param.commDim[0] && (x1==0 || x1==X1m1));
+  incomplete = incomplete || (param.commDim[0] && (coord[0]==0 || coord[0]==X1m1));
 }
 
 """)    

--- a/lib/generate/dslash_cuda_gen.py
+++ b/lib/generate/dslash_cuda_gen.py
@@ -421,7 +421,6 @@ if (kernel_type == INTERIOR_KERNEL) {
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  const int dim = static_cast<int>(kernel_type);
   const int face_volume = (param.threads >> 1);           // volume of one face
   const int face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
   face_idx = sid - face_num*face_volume;        // index into the respective face
@@ -430,8 +429,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromFaceIndex<1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, dim, face_num, param.parity, dims);
+  coordsFromFaceIndex<kernel_type,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
 
   READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 

--- a/lib/generate/dslash_cuda_gen.py
+++ b/lib/generate/dslash_cuda_gen.py
@@ -382,9 +382,8 @@ int face_idx;
 if (kernel_type == INTERIOR_KERNEL) {
 #endif
 
-  // Inline by hand for the moment and assume even dimensions
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromIndex3D<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, dims);
+  // Assume even dimensions
+  coordsFromIndex3D<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X);
 
   // only need to check Y and Z dims currently since X and T set to match exactly
   if (x2 >= X2) return;
@@ -402,9 +401,8 @@ if (kernel_type == INTERIOR_KERNEL) {
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  // Inline by hand for the moment and assume even dimensions
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromIndex<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, dims, param.block, param.grid);
+  // Assume even dimensions
+  coordsFromIndex<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X, param.block, param.grid);
 
 """)
 

--- a/lib/generate/dw_dslash_4D_cuda_gen.py
+++ b/lib/generate/dw_dslash_4D_cuda_gen.py
@@ -444,7 +444,6 @@ X += aux1;
 """
 } else { // exterior kernel
 
-const int dim = static_cast<int>(kernel_type);
 const int face_volume = (param.threads*param.Ls >> 1); // volume of one face
 const int face_num = (sid >= face_volume); // is this thread updating face 0 or 1
 face_idx = sid - face_num*face_volume; // index into the respective face
@@ -453,8 +452,7 @@ face_idx = sid - face_num*face_volume; // index into the respective face
 // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
 //sp_idx = face_idx + param.ghostOffset[dim];
 
-const int dims[] = {X1, X2, X3, X4};
-coordsFromDW4DFaceIndex<1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, dim, face_num, param.parity, dims);
+coordsFromDW4DFaceIndex<kernel_type,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
 
 boundaryCrossing = sid/X1h + sid/(X2*X1h) + sid/(X3*X2*X1h);
 

--- a/lib/generate/dw_dslash_cuda_gen.py
+++ b/lib/generate/dw_dslash_cuda_gen.py
@@ -402,7 +402,6 @@ X += aux1;
 #ifdef MULTI_GPU
 } else { // exterior kernel
 
-const int dim = static_cast<int>(kernel_type);
 const int face_volume = (param.threads*param.Ls >> 1); // volume of one face
 const int face_num = (sid >= face_volume); // is this thread updating face 0 or 1
 face_idx = sid - face_num*face_volume; // index into the respective face
@@ -411,8 +410,7 @@ face_idx = sid - face_num*face_volume; // index into the respective face
 // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
 //sp_idx = face_idx + param.ghostOffset[dim];
 
-const int dims[] = {X1, X2, X3, X4};
-coordsFromDWFaceIndex<1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, dim, face_num, param.parity, dims);
+coordsFromDWFaceIndex<kernel_type,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
 
 s_parity = ( sid/(X4*X3*X2*X1h) ) % 2;
 boundaryCrossing = sid/X1h + sid/(X2*X1h) + sid/(X3*X2*X1h) + sid/(X4*X3*X2*X1h);

--- a/lib/generate/fused_exterior_deg_tm_dslash_cuda_gen.py
+++ b/lib/generate/fused_exterior_deg_tm_dslash_cuda_gen.py
@@ -306,20 +306,6 @@ int sp_norm_idx;
 int sid;
 """)
 
-        if sharedDslash:
-            prolog_str += (
-"""
-int dim;
-int face_idx;
-int Y[4] = {X1,X2,X3,X4};
-""")
-        else:
-            prolog_str += (
-"""
-int dim;
-int face_idx;
-int Y[4] = {X1,X2,X3,X4};
-""")
 
         prolog_str+= (
 """
@@ -327,15 +313,27 @@ int Y[4] = {X1,X2,X3,X4};
   if (sid >= param.threads) return;
 
 
-  dim = dimFromFaceIndex(sid, param); // sid is also modified
+  int dim = dimFromFaceIndex(sid, param); // sid is also modified
 
   const int face_volume = ((param.threadDimMapUpper[dim] - param.threadDimMapLower[dim]) >> 1);
   const int face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
-  face_idx = sid - face_num*face_volume;        // index into the respective face
+  int face_idx = sid - face_num*face_volume;        // index into the respective face
 
+  switch(dim) {
+  case 0:
+    coordsFromFaceIndex<0,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 1:
+    coordsFromFaceIndex<1,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 2:
+    coordsFromFaceIndex<2,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 3:
+    coordsFromFaceIndex<3,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  }
 
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromFaceIndex<1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, dim, face_num, param.parity, dims);
 
   bool active = false;
   for(int dir=0; dir<4; ++dir){
@@ -400,7 +398,7 @@ def gen(dir, pack_only=False):
         str += "// "+l+"\n"
     str += "\n"
 
-    str += "faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4," + `dir/2` + ",Y);\n"
+    str += "faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4," + `dir/2` + ",param.X);\n"
     str += "const int sp_idx = face_idx + param.ghostOffset[" + `dir/2` + "][" + `1-dir%2` +"];\n"
 
 

--- a/lib/generate/fused_exterior_deg_tmc_dslash_cuda_gen.py
+++ b/lib/generate/fused_exterior_deg_tmc_dslash_cuda_gen.py
@@ -474,36 +474,33 @@ int sp_norm_idx;
 int sid;
 """)
 
-        if sharedDslash:
-            prolog_str += (
-"""
-int dim;
-int face_idx;
-int Y[4] = {X1,X2,X3,X4};
-""")
-        else:
-            prolog_str += (
-"""
-int dim;
-int face_idx;
-int Y[4] = {X1,X2,X3,X4};
-""")
-
         prolog_str+= (
 """
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
 
-  dim = dimFromFaceIndex(sid, param); // sid is also modified
+  int dim = dimFromFaceIndex(sid, param); // sid is also modified
 
   const int face_volume = ((param.threadDimMapUpper[dim] - param.threadDimMapLower[dim]) >> 1);
   const int face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
-  face_idx = sid - face_num*face_volume;        // index into the respective face
+  int face_idx = sid - face_num*face_volume;        // index into the respective face
 
+  switch(dim) {
+  case 0:
+    coordsFromFaceIndex<0,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 1:
+    coordsFromFaceIndex<1,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 2:
+    coordsFromFaceIndex<2,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 3:
+    coordsFromFaceIndex<3,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  }
 
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromFaceIndex<1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, dim, face_num, param.parity, dims);
 
   bool active = false;
   for(int dir=0; dir<4; ++dir){
@@ -568,7 +565,7 @@ def gen(dir, pack_only=False):
         str += "// "+l+"\n"
     str += "\n"
 
-    str += "faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4," + `dir/2` + ",Y);\n"
+    str += "faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4," + `dir/2` + ",param.X);\n"
     str += "const int sp_idx = face_idx + param.ghostOffset[" + `dir/2` + "][" + `1-dir%2` +"];\n"
 
     str += "#if (DD_PREC==2)\n"

--- a/lib/generate/fused_exterior_deg_tmc_dslash_cuda_gen.py
+++ b/lib/generate/fused_exterior_deg_tmc_dslash_cuda_gen.py
@@ -464,7 +464,7 @@ VOLATILE spinorFloat *s = (spinorFloat*)s_data + DSLASH_SHARED_FLOATS_PER_THREAD
 #include "read_clover.h"
 #include "tmc_core.h"
 
-int x1, x2, x3, x4;
+int coord[5];
 int X;
 
 #if (DD_PREC==2) // half precision
@@ -488,23 +488,23 @@ int sid;
 
   switch(dim) {
   case 0:
-    coordsFromFaceIndex<0,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,0,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 1:
-    coordsFromFaceIndex<1,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,1,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 2:
-    coordsFromFaceIndex<2,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,2,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 3:
-    coordsFromFaceIndex<3,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,3,1>(X, sid, coord, face_idx, face_num, param);
     break;
   }
 
 
   bool active = false;
   for(int dir=0; dir<4; ++dir){
-    active = active || isActive(dim,dir,+1,x1,x2,x3,x4,param.commDim,param.X);
+    active = active || isActive(dim,dir,+1,coord,param.commDim,param.X);
   }
   if(!active) return;
 
@@ -540,8 +540,8 @@ def gen(dir, pack_only=False):
         if proj(i,1) == 0j:
             return (0, proj(i,0))
 
-    boundary = ["x1==X1m1", "x1==0", "x2==X2m1", "x2==0", "x3==X3m1", "x3==0", "x4==X4m1", "x4==0"]
-    interior = ["x1<X1m1", "x1>0", "x2<X2m1", "x2>0", "x3<X3m1", "x3>0", "x4<X4m1", "x4>0"]
+    boundary = ["coord[0]==X1m1", "coord[0]==0", "coord[1]==X2m1", "coord[1]==0", "coord[2]==X3m1", "coord[2]==0", "coord[3]==X4m1", "coord[3]==0"]
+    interior = ["coord[0]<X1m1", "coord[0]>0", "coord[1]<X2m1", "coord[1]>0", "coord[2]<X3m1", "coord[2]>0", "coord[3]<X4m1", "coord[3]>0"]
     offset = ["+1","-1","+1","-1","+1","-1","+1","-1"];
     dim = ["X", "Y", "Z", "T"]
 
@@ -554,7 +554,7 @@ def gen(dir, pack_only=False):
 
     cond = ""
 #    cond += "#ifdef MULTI_GPU\n"
-    cond += "if (isActive(dim," + `dir/2` + "," + offset[dir] + ",x1,x2,x3,x4,param.commDim,param.X) && " +boundary[dir]+" )\n"
+    cond += "if (isActive(dim," + `dir/2` + "," + offset[dir] + ",coord,param.commDim,param.X) && " +boundary[dir]+" )\n"
 #    cond += "#endif\n"
 
     str = ""
@@ -565,7 +565,7 @@ def gen(dir, pack_only=False):
         str += "// "+l+"\n"
     str += "\n"
 
-    str += "faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4," + `dir/2` + ",param.X);\n"
+    str += "faceIndexFromCoords<4,1>(face_idx,coord," + `dir/2` + ",param);\n"
     str += "const int sp_idx = face_idx + param.ghostOffset[" + `dir/2` + "][" + `1-dir%2` +"];\n"
 
     str += "#if (DD_PREC==2)\n"
@@ -743,28 +743,28 @@ READ_SPINOR_SHARED(tx, threadIdx.y, threadIdx.z);\n
 
     load_shared_2 = (
 """// load spinor from shared memory
-int tx = (threadIdx.x + blockDim.x - ((x1+1)&1) ) % blockDim.x;
+int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1) ) % blockDim.x;
 int ty = (threadIdx.y < blockDim.y - 1) ? threadIdx.y + 1 : 0;
 READ_SPINOR_SHARED(tx, ty, threadIdx.z);\n
 """)
 
     load_shared_3 = (
 """// load spinor from shared memory
-int tx = (threadIdx.x + blockDim.x - ((x1+1)&1)) % blockDim.x;
+int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1)) % blockDim.x;
 int ty = (threadIdx.y > 0) ? threadIdx.y - 1 : blockDim.y - 1;
 READ_SPINOR_SHARED(tx, ty, threadIdx.z);\n
 """)
 
     load_shared_4 = (
 """// load spinor from shared memory
-int tx = (threadIdx.x + blockDim.x - ((x1+1)&1) ) % blockDim.x;
+int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1) ) % blockDim.x;
 int tz = (threadIdx.z < blockDim.z - 1) ? threadIdx.z + 1 : 0;
 READ_SPINOR_SHARED(tx, threadIdx.y, tz);\n
 """)
 
     load_shared_5 = (
 """// load spinor from shared memory
-int tx = (threadIdx.x + blockDim.x - ((x1+1)&1)) % blockDim.x;
+int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1)) % blockDim.x;
 int tz = (threadIdx.z > 0) ? threadIdx.z - 1 : blockDim.z - 1;
 READ_SPINOR_SHARED(tx, threadIdx.y, tz);\n
 """)

--- a/lib/generate/fused_exterior_dslash_gen.py
+++ b/lib/generate/fused_exterior_dslash_gen.py
@@ -369,7 +369,7 @@ VOLATILE spinorFloat *s = (spinorFloat*)s_data + CLOVER_SHARED_FLOATS_PER_THREAD
 #include "read_clover.h"
 #include "io_spinor.h"
 
-int x1, x2, x3, x4;
+int coord[5];
 int X;
 
 #if (DD_PREC==2) // half precision
@@ -398,23 +398,23 @@ int sid;
 
   switch(dim) {
   case 0:
-    coordsFromFaceIndex<0,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,0,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 1:
-    coordsFromFaceIndex<1,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,1,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 2:
-    coordsFromFaceIndex<2,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,2,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 3:
-    coordsFromFaceIndex<3,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,3,1>(X, sid, coord, face_idx, face_num, param);
     break;
   }
 
 
   bool active = false;
   for(int dir=0; dir<4; ++dir){
-   active = active  || isActive(dim,dir,+1,x1,x2,x3,x4,param.commDim,param.X);
+   active = active  || isActive(dim,dir,+1,coord,param.commDim,param.X);
   }
   if(!active) return;
 
@@ -460,10 +460,8 @@ def gen(dir, pack_only=False):
         if proj(i,1) == 0j:
             return (0, proj(i,0))
 
-#    boundary = ["x1==X1m1", "x1==0", "x2==X2m1", "x2==0", "x3==X3m1", "x3==0", "x4==X4m1", "x4==0"]
-#    interior = ["x1<X1m1", "x1>0", "x2<X2m1", "x2>0", "x3<X3m1", "x3>0", "x4<X4m1", "x4>0"]
-    boundary = ["x1==X1m1", "x1==0", "x2==X2m1", "x2==0", "x3==X3m1", "x3==0", "x4==X4m1", "x4==0"]
-    interior = ["x1<X1m1", "x1>0", "x2<X2m1", "x2>0", "x3<X3m1", "x3>0", "x4<X4m1", "x4>0"]
+    boundary = ["coord[0]==X1m1", "coord[0]==0", "coord[1]==X2m1", "coord[1]==0", "coord[2]==X3m1", "coord[2]==0", "coord[3]==X4m1", "coord[3]==0"]
+    interior = ["coord[0]<X1m1", "coord[0]>0", "coord[1]<X2m1", "coord[1]>0", "coord[2]<X3m1", "coord[2]>0", "coord[3]<X4m1", "coord[3]>0"]
     offset = ["+1", "-1", "+1", "-1", "+1", "-1", "+1", "-1"]
     dim = ["X", "Y", "Z", "T"]
 
@@ -475,7 +473,7 @@ def gen(dir, pack_only=False):
                    "X-X4X3X2X1mX3X2X1", "X+X4X3X2X1mX3X2X1"]
 
     cond = ""
-    cond += "if ( isActive(dim," + `dir/2` + "," + offset[dir] + ",x1,x2,x3,x4,param.commDim,param.X) && " +boundary[dir]+" )\n"
+    cond += "if ( isActive(dim," + `dir/2` + "," + offset[dir] + ",coord,param.commDim,param.X) && " +boundary[dir]+" )\n"
 
     str = ""
 
@@ -485,7 +483,7 @@ def gen(dir, pack_only=False):
         str += "// "+l+"\n"
     str += "\n"
 
-    str += "faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4," + `dir/2` + ",param.X);\n"
+    str += "faceIndexFromCoords<4,1>(face_idx,coord," + `dir/2` + ",param);\n"
     str += "const int sp_idx = face_idx + param.ghostOffset[" + `dir/2` + "][" + `1-dir%2` + "];\n"
 
     str += "#if (DD_PREC==2)\n"
@@ -587,28 +585,28 @@ READ_SPINOR_SHARED(tx, threadIdx.y, threadIdx.z);\n
 
     load_shared_2 = (
 """// load spinor from shared memory
-int tx = (threadIdx.x + blockDim.x - ((x1+1)&1) ) % blockDim.x;
+int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1) ) % blockDim.x;
 int ty = (threadIdx.y < blockDim.y - 1) ? threadIdx.y + 1 : 0;
 READ_SPINOR_SHARED(tx, ty, threadIdx.z);\n
 """)
 
     load_shared_3 = (
 """// load spinor from shared memory
-int tx = (threadIdx.x + blockDim.x - ((x1+1)&1)) % blockDim.x;
+int tx = (threadIdx.x + blockDim.x - ((coord[1]+1)&1)) % blockDim.x;
 int ty = (threadIdx.y > 0) ? threadIdx.y - 1 : blockDim.y - 1;
 READ_SPINOR_SHARED(tx, ty, threadIdx.z);\n
 """)
 
     load_shared_4 = (
 """// load spinor from shared memory
-int tx = (threadIdx.x + blockDim.x - ((x1+1)&1) ) % blockDim.x;
+int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1) ) % blockDim.x;
 int tz = (threadIdx.z < blockDim.z - 1) ? threadIdx.z + 1 : 0;
 READ_SPINOR_SHARED(tx, threadIdx.y, tz);\n
 """)
 
     load_shared_5 = (
 """// load spinor from shared memory
-int tx = (threadIdx.x + blockDim.x - ((x1+1)&1)) % blockDim.x;
+int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1)) % blockDim.x;
 int tz = (threadIdx.z > 0) ? threadIdx.z - 1 : blockDim.z - 1;
 READ_SPINOR_SHARED(tx, threadIdx.y, tz);\n
 """)

--- a/lib/generate/fused_exterior_dw_dslash_4D_cuda_gen.py
+++ b/lib/generate/fused_exterior_dw_dslash_4D_cuda_gen.py
@@ -366,8 +366,6 @@ if (sid >= param.threads*param.Ls) return;
 
 int dim;
 int face_idx;
-int Y[4] = {X1,X2,X3,X4};
-
 
 
 """)
@@ -407,9 +405,20 @@ face_idx = sid - face_num*face_volume; // index into the respective face
 // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
 //sp_idx = face_idx + param.ghostOffset[dim];
 
-
-const int dims[] = {X1, X2, X3, X4};
-coordsFromDW4DFaceIndex<1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, dim, face_num, param.parity, dims);
+switch(dim) {
+case 0:
+  coordsFromDW4DFaceIndex<0,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
+  break;
+case 1:
+  coordsFromDW4DFaceIndex<1,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
+  break;
+case 2:
+  coordsFromDW4DFaceIndex<2,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
+  break;
+case 3:
+  coordsFromDW4DFaceIndex<3,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
+  break;
+}
 
 {
   bool active = false;
@@ -529,7 +538,7 @@ def gen(dir, pack_only=False):
         str += "//"+l+"\n"
     str += "\n"
 
-    str += "faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs," + `dir/2` + ",Y);\n"
+    str += "faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs," + `dir/2` + ",param.X);\n"
     str += "const int sp_idx = face_idx + param.ghostOffset[" + `dir/2` + "][" + `1-dir%2` + "];\n"
     str += "#if (DD_PREC==2) // half precision\n"
     str += "  sp_norm_idx = face_idx + "

--- a/lib/generate/fused_exterior_dw_dslash_cuda_gen.py
+++ b/lib/generate/fused_exterior_dw_dslash_cuda_gen.py
@@ -353,14 +353,9 @@ int sp_norm_idx;
 int sid = ((blockIdx.y*blockDim.y + threadIdx.y)*gridDim.x + blockIdx.x)*blockDim.x + threadIdx.x;
 if (sid >= param.threads*param.Ls) return;
 
-
-int dim; 
+int dim;
 int face_idx;
-int Y[4] = {X1,X2,X3,X4};
-
-
 int x1, x2, x3, x4, xs;
-
 int s_parity;
 
 
@@ -381,16 +376,26 @@ face_idx = sid - face_num*face_volume; // index into the respective face
 // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
 //sp_idx = face_idx + param.ghostOffset[dim];
 
-const int dims[] = {X1, X2, X3, X4};
-coordsFromDWFaceIndex<1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, dim, face_num, param.parity, dims);
-
-{
-  bool active = false;
-  for(int dir=0; dir<4; ++dir){
-    active = active || isActive(dim,dir,+1,x1,x2,x3,x4,param.commDim,param.X);
-  }
-  if(!active) return;
+switch(dim) {
+case 0:
+  coordsFromDWFaceIndex<0,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
+  break;
+case 1:
+  coordsFromDWFaceIndex<1,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
+  break;
+case 2:
+  coordsFromDWFaceIndex<2,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
+  break;
+case 3:
+  coordsFromDWFaceIndex<3,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
+  break;
 }
+
+bool active = false;
+for(int dir=0; dir<4; ++dir){
+  active = active || isActive(dim,dir,+1,x1,x2,x3,x4,param.commDim,param.X);
+}
+if(!active) return;
 
 
 s_parity = ( sid/(X4*X3*X2*X1h) ) % 2;
@@ -514,7 +519,7 @@ def gen(dir, pack_only=False):
         str += "//"+l+"\n"
     str += "\n"
 
-    str += "faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs," + `dir/2` + ",Y);\n"
+    str += "faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs," + `dir/2` + ",param.X);\n"
     str += "const int sp_idx = face_idx + param.ghostOffset[" + `dir/2` + "][" + `1-dir%2` + "];\n"
     str += "#if (DD_PREC==2) // half precision\n"
     str += "  sp_norm_idx = face_idx + "

--- a/lib/generate/fused_exterior_dw_dslash_cuda_gen.py
+++ b/lib/generate/fused_exterior_dw_dslash_cuda_gen.py
@@ -355,7 +355,8 @@ if (sid >= param.threads*param.Ls) return;
 
 int dim;
 int face_idx;
-int x1, x2, x3, x4, xs;
+int coord[5];
+int X;
 int s_parity;
 
 
@@ -366,7 +367,7 @@ int s_parity;
 """
 { // exterior kernel
 
-dim = dimFromDWFaceIndex(sid, param); // sid is also modified
+dim = dimFromFaceIndex<5>(sid, param); // sid is also modified
 
 const int face_volume = ((param.threadDimMapUpper[dim] - param.threadDimMapLower[dim])*param.Ls >> 1);
 const int face_num = (sid >= face_volume); // is this thread updating face 0 or 1
@@ -378,27 +379,27 @@ face_idx = sid - face_num*face_volume; // index into the respective face
 
 switch(dim) {
 case 0:
-  coordsFromDWFaceIndex<0,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
+  coordsFromFaceIndex<5,QUDA_5D_PC,0,1>(X, sid, coord, face_idx, face_num, param);
   break;
 case 1:
-  coordsFromDWFaceIndex<1,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
+  coordsFromFaceIndex<5,QUDA_5D_PC,1,1>(X, sid, coord, face_idx, face_num, param);
   break;
 case 2:
-  coordsFromDWFaceIndex<2,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
+  coordsFromFaceIndex<5,QUDA_5D_PC,2,1>(X, sid, coord, face_idx, face_num, param);
   break;
 case 3:
-  coordsFromDWFaceIndex<3,1>(sid, x1, x2, x3, x4, xs, face_idx, face_volume, face_num, param);
+  coordsFromFaceIndex<5,QUDA_5D_PC,3,1>(X, sid, coord, face_idx, face_num, param);
   break;
 }
 
 bool active = false;
 for(int dir=0; dir<4; ++dir){
-  active = active || isActive(dim,dir,+1,x1,x2,x3,x4,param.commDim,param.X);
+  active = active || isActive(dim,dir,+1,coord,param.commDim,param.X);
 }
 if(!active) return;
 
 
-s_parity = ( sid/(X4*X3*X2*X1h) ) % 2;
+s_parity = ( sid/param.volume4CB ) % 2;
 
 READ_INTERMEDIATE_SPINOR(INTERTEX, param.sp_stride, sid, sid);
 
@@ -493,10 +494,8 @@ def gen(dir, pack_only=False):
         if proj(i,1) == 0j:
             return (0, proj(i,0))
 
-# boundary = ["x1==X1m1", "x1==0", "x2==X2m1", "x2==0", "x3==X3m1", "x3==0", "x4==X4m1", "x4==0"]
-# interior = ["x1<X1m1", "x1>0", "x2<X2m1", "x2>0", "x3<X3m1", "x3>0", "x4<X4m1", "x4>0"]
-    boundary = ["x1==X1m1", "x1==0", "x2==X2m1", "x2==0", "x3==X3m1", "x3==0", "x4==X4m1", "x4==0"]
-    interior = ["x1<X1m1", "x1>0", "x2<X2m1", "x2>0", "x3<X3m1", "x3>0", "x4<X4m1", "x4>0"]
+    boundary = ["coord[0]==X1m1", "coord[0]==0", "coord[1]==X2m1", "coord[1]==0", "coord[2]==X3m1", "coord[2]==0", "coord[3]==X4m1", "coord[3]==0"]
+    interior = ["coord[0]<X1m1", "coord[0]>0", "coord[1]<X2m1", "coord[1]>0", "coord[2]<X3m1", "coord[2]>0", "coord[3]<X4m1", "coord[3]>0"]
     offset = ["+1", "-1", "+1", "-1", "+1", "-1", "+1", "-1"]
     dim = ["X", "Y", "Z", "T"]
 
@@ -508,7 +507,7 @@ def gen(dir, pack_only=False):
                    "X-X4X3X2X1mX3X2X1", "X+X4X3X2X1mX3X2X1"]
 
     cond = ""
-    cond += "if (isActive(dim," + `dir/2` + "," + offset[dir] + ",x1,x2,x3,x4,param.commDim,param.X) && " + boundary[dir] + " )\n"
+    cond += "if (isActive(dim," + `dir/2` + "," + offset[dir] + ",coord,param.commDim,param.X) && " + boundary[dir] + " )\n"
 
 
     str = ""
@@ -519,7 +518,7 @@ def gen(dir, pack_only=False):
         str += "//"+l+"\n"
     str += "\n"
 
-    str += "faceIndexFromDWCoords<1>(face_idx,x1,x2,x3,x4,xs," + `dir/2` + ",param.X);\n"
+    str += "faceIndexFromCoords<5,1>(face_idx,coord," + `dir/2` + ",param);\n"
     str += "const int sp_idx = face_idx + param.ghostOffset[" + `dir/2` + "][" + `1-dir%2` + "];\n"
     str += "#if (DD_PREC==2) // half precision\n"
     str += "  sp_norm_idx = face_idx + "

--- a/lib/generate/fused_exterior_ndeg_tm_dslash_cuda_gen.py
+++ b/lib/generate/fused_exterior_ndeg_tm_dslash_cuda_gen.py
@@ -302,7 +302,7 @@ VOLATILE spinorFloat *s = (spinorFloat*)s_data + SHARED_TMNDEG_FLOATS_PER_THREAD
 #include "read_gauge.h"
 #include "io_spinor.h"
 
-int x1, x2, x3, x4;
+int coord[5];
 int X;
 
 #if (DD_PREC==2) // half precision
@@ -326,26 +326,26 @@ int sid;
 
   // ghostOffset is scaled to include body (includes stride) and number of FloatN arrays (SPINOR_HOP)
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
-
+  // 4-d for first template argument here since both flavor are done by the same thread
   switch(dim) {
   case 0:
-    coordsFromFaceIndex<0,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,0,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 1:
-    coordsFromFaceIndex<1,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,1,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 2:
-    coordsFromFaceIndex<2,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,2,1>(X, sid, coord, face_idx, face_num, param);
     break;
   case 3:
-    coordsFromFaceIndex<3,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    coordsFromFaceIndex<4,QUDA_4D_PC,3,1>(X, sid, coord, face_idx, face_num, param);
     break;
   }
 
 
   bool active = false;
   for(int dir=0; dir<4; ++dir){
-    active = active || isActive(dim,dir,+1,x1,x2,x3,x4,param.commDim,param.X);
+   active = active  || isActive(dim,dir,+1,coord,param.commDim,param.X);
   }
   if(!active) return;
 
@@ -415,10 +415,8 @@ def gen(dir, pack_only=False):
         if proj(i,1) == 0j:
             return (0, proj(i,0))
 
-#    boundary = ["x1==X1m1", "x1==0", "x2==X2m1", "x2==0", "x3==X3m1", "x3==0", "x4==X4m1", "x4==0"]
-#    interior = ["x1<X1m1", "x1>0", "x2<X2m1", "x2>0", "x3<X3m1", "x3>0", "x4<X4m1", "x4>0"]
-    boundary = ["x1==X1m1", "x1==0", "x2==X2m1", "x2==0", "x3==X3m1", "x3==0", "x4==X4m1", "x4==0"]
-    interior = ["x1<X1m1", "x1>0", "x2<X2m1", "x2>0", "x3<X3m1", "x3>0", "x4<X4m1", "x4>0"]
+    boundary = ["coord[0]==X1m1", "coord[0]==0", "coord[1]==X2m1", "coord[1]==0", "coord[2]==X3m1", "coord[2]==0", "coord[3]==X4m1", "coord[3]==0"]
+    interior = ["coord[0]<X1m1", "coord[0]>0", "coord[1]<X2m1", "coord[1]>0", "coord[2]<X3m1", "coord[2]>0", "coord[3]<X4m1", "coord[3]>0"]
     offset = ["+1","-1","+1","-1","+1","-1","+1","-1"];
     dim = ["X", "Y", "Z", "T"]
 
@@ -434,7 +432,7 @@ def gen(dir, pack_only=False):
 #    cond += "if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim["+`dir/2`+"] || "+interior[dir]+")) ||\n"
 #    cond += "     (kernel_type == EXTERIOR_KERNEL_"+dim[dir/2]+" && "+boundary[dir]+") )\n"
 #    cond += "#endif\n"
-    cond += "if (isActive(dim,"  + `dir/2` + "," + offset[dir] + ",x1,x2,x3,x4,param.commDim,param.X) && " + boundary[dir] +")\n"
+    cond += "if (isActive(dim,"  + `dir/2` + "," + offset[dir] + ",coord,param.commDim,param.X) && " + boundary[dir] +")\n"
 
     str = ""
 
@@ -444,7 +442,7 @@ def gen(dir, pack_only=False):
         str += "// "+l+"\n"
     str += "\n"
 
-    str += "faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4," + `dir/2` + ",param.X);\n"
+    str += "faceIndexFromCoords<4,1>(face_idx,coord," + `dir/2` + ",param);\n"
     str += "const int sp_idx =  face_idx + param.ghostOffset[" + `dir/2` + "]["  + `1-dir%2` + "];\n"
 
     str += "#if (DD_PREC==2)\n"
@@ -581,28 +579,28 @@ READ_SPINOR_SHARED(tx, threadIdx.y, threadIdx.z);\n
 
     load_shared_2 = (
 """// load spinor from shared memory
-int tx = (threadIdx.x + blockDim.x - ((x1+1)&1) ) % blockDim.x;
+int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1) ) % blockDim.x;
 int ty = (threadIdx.y < blockDim.y - 1) ? threadIdx.y + 1 : 0;
 READ_SPINOR_SHARED(tx, ty, threadIdx.z);\n
 """)
 
     load_shared_3 = (
 """// load spinor from shared memory
-int tx = (threadIdx.x + blockDim.x - ((x1+1)&1)) % blockDim.x;
+int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1)) % blockDim.x;
 int ty = (threadIdx.y > 0) ? threadIdx.y - 1 : blockDim.y - 1;
 READ_SPINOR_SHARED(tx, ty, threadIdx.z);\n
 """)
 
     load_shared_4 = (
 """// load spinor from shared memory
-int tx = (threadIdx.x + blockDim.x - ((x1+1)&1) ) % blockDim.x;
+int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1) ) % blockDim.x;
 int tz = (threadIdx.z < blockDim.z - 1) ? threadIdx.z + 1 : 0;
 READ_SPINOR_SHARED(tx, threadIdx.y, tz);\n
 """)
 
     load_shared_5 = (
 """// load spinor from shared memory
-int tx = (threadIdx.x + blockDim.x - ((x1+1)&1)) % blockDim.x;
+int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1)) % blockDim.x;
 int tz = (threadIdx.z > 0) ? threadIdx.z - 1 : blockDim.z - 1;
 READ_SPINOR_SHARED(tx, threadIdx.y, tz);\n
 """)

--- a/lib/generate/fused_exterior_ndeg_tm_dslash_cuda_gen.py
+++ b/lib/generate/fused_exterior_ndeg_tm_dslash_cuda_gen.py
@@ -312,41 +312,36 @@ int sp_norm_idx;
 int sid;
 """)
 
-        if sharedDslash:
-            prolog_str += (
-"""
-int dim;
-int face_idx;
-int Y[4] = {X1,X2,X3,X4};
-
-""")
-        else:
-            prolog_str += (
-"""
-int dim;
-int face_idx;
-int Y[4] = {X1,X2,X3,X4};
-
-""")
-
         prolog_str+= (
 """
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  dim = dimFromFaceIndex(sid, param); // sid is also modified
+  int dim = dimFromFaceIndex(sid, param); // sid is also modified
 
   const int face_volume = ((param.threadDimMapUpper[dim] - param.threadDimMapLower[dim]) >> 1);
   // volume of one face (per flavor)
   const int face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
-  face_idx = sid - face_num*face_volume;        // index into the respective face
+  int face_idx = sid - face_num*face_volume;        // index into the respective face
 
   // ghostOffset is scaled to include body (includes stride) and number of FloatN arrays (SPINOR_HOP)
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
 
+  switch(dim) {
+  case 0:
+    coordsFromFaceIndex<0,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 1:
+    coordsFromFaceIndex<1,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 2:
+    coordsFromFaceIndex<2,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  case 3:
+    coordsFromFaceIndex<3,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+    break;
+  }
 
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromFaceIndex<1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, dim, face_num, param.parity, dims);
 
   bool active = false;
   for(int dir=0; dir<4; ++dir){
@@ -449,7 +444,7 @@ def gen(dir, pack_only=False):
         str += "// "+l+"\n"
     str += "\n"
 
-    str += "faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4," + `dir/2` + ",Y);\n"
+    str += "faceIndexFromCoords<1>(face_idx,x1,x2,x3,x4," + `dir/2` + ",param.X);\n"
     str += "const int sp_idx =  face_idx + param.ghostOffset[" + `dir/2` + "]["  + `1-dir%2` + "];\n"
 
     str += "#if (DD_PREC==2)\n"

--- a/lib/generate/ndeg_tm_dslash_cuda_gen.py
+++ b/lib/generate/ndeg_tm_dslash_cuda_gen.py
@@ -302,7 +302,7 @@ VOLATILE spinorFloat *s = (spinorFloat*)s_data + SHARED_TMNDEG_FLOATS_PER_THREAD
 #include "read_gauge.h"
 #include "io_spinor.h"
 
-int x1, x2, x3, x4;
+int coord[5];
 int X;
 
 int sid;
@@ -317,11 +317,11 @@ if (kernel_type == INTERIOR_KERNEL) {
 #endif
 
   // Assume even dimensions
-  coordsFromIndex3D<EVEN_X>(X, x1, x2, x3, x4, sid, param);
+  coordsFromIndex3D<EVEN_X>(X, coord, sid, param);
 
   // only need to check Y and Z dims currently since X and T set to match exactly
-  if (x2 >= X2) return;
-  if (x3 >= X3) return; 
+  if (coord[1] >= param.X[1]) return;
+  if (coord[2] >= param.X[2]) return; 
 
 """)
         else:
@@ -336,7 +336,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   if (sid >= param.threads) return;
 
   // Assume even dimensions
-  coordsFromIndex<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X, param.block, param.grid);
+  coordsFromIndex<4,QUDA_4D_PC,EVEN_X>(X, coord, sid, param);
 
 """)
 
@@ -369,7 +369,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-  coordsFromFaceIndex<kernel_type,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
+  coordsFromFaceIndex<4,QUDA_4D_PC,kernel_type,1>(X, sid, coord, face_idx, face_num, param);
 
 """)
 
@@ -438,10 +438,8 @@ def gen(dir, pack_only=False):
         if proj(i,1) == 0j:
             return (0, proj(i,0))
 
-#    boundary = ["x1==X1m1", "x1==0", "x2==X2m1", "x2==0", "x3==X3m1", "x3==0", "x4==X4m1", "x4==0"]
-#    interior = ["x1<X1m1", "x1>0", "x2<X2m1", "x2>0", "x3<X3m1", "x3>0", "x4<X4m1", "x4>0"]
-    boundary = ["x1==X1m1", "x1==0", "x2==X2m1", "x2==0", "x3==X3m1", "x3==0", "x4==X4m1", "x4==0"]
-    interior = ["x1<X1m1", "x1>0", "x2<X2m1", "x2>0", "x3<X3m1", "x3>0", "x4<X4m1", "x4>0"]
+    boundary = ["coord[0]==X1m1", "coord[0]==0", "coord[1]==X2m1", "coord[1]==0", "coord[2]==X3m1", "coord[2]==0", "coord[3]==X4m1", "coord[3]==0"]
+    interior = ["coord[0]<X1m1", "coord[0]>0", "coord[1]<X2m1", "coord[1]>0", "coord[2]<X3m1", "coord[2]>0", "coord[3]<X4m1", "coord[3]>0"]
     dim = ["X", "Y", "Z", "T"]
 
     # index of neighboring site when not on boundary
@@ -609,28 +607,28 @@ READ_SPINOR_SHARED(tx, threadIdx.y, threadIdx.z);\n
 
     load_shared_2 = (
 """// load spinor from shared memory
-int tx = (threadIdx.x + blockDim.x - ((x1+1)&1) ) % blockDim.x;
+int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1) ) % blockDim.x;
 int ty = (threadIdx.y < blockDim.y - 1) ? threadIdx.y + 1 : 0;
 READ_SPINOR_SHARED(tx, ty, threadIdx.z);\n
 """)
 
     load_shared_3 = (
 """// load spinor from shared memory
-int tx = (threadIdx.x + blockDim.x - ((x1+1)&1)) % blockDim.x;
+int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1)) % blockDim.x;
 int ty = (threadIdx.y > 0) ? threadIdx.y - 1 : blockDim.y - 1;
 READ_SPINOR_SHARED(tx, ty, threadIdx.z);\n
 """)
 
     load_shared_4 = (
 """// load spinor from shared memory
-int tx = (threadIdx.x + blockDim.x - ((x1+1)&1) ) % blockDim.x;
+int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1) ) % blockDim.x;
 int tz = (threadIdx.z < blockDim.z - 1) ? threadIdx.z + 1 : 0;
 READ_SPINOR_SHARED(tx, threadIdx.y, tz);\n
 """)
 
     load_shared_5 = (
 """// load spinor from shared memory
-int tx = (threadIdx.x + blockDim.x - ((x1+1)&1)) % blockDim.x;
+int tx = (threadIdx.x + blockDim.x - ((coord[0]+1)&1)) % blockDim.x;
 int tz = (threadIdx.z > 0) ? threadIdx.z - 1 : blockDim.z - 1;
 READ_SPINOR_SHARED(tx, threadIdx.y, tz);\n
 """)
@@ -1025,13 +1023,13 @@ int incomplete = 0; // Have all 8 contributions been computed for this site?
 
 switch(kernel_type) { // intentional fall-through
 case INTERIOR_KERNEL:
-  incomplete = incomplete || (param.commDim[3] && (x4==0 || x4==X4m1));
+  incomplete = incomplete || (param.commDim[3] && (coord[3]==0 || coord[3]==X4m1));
 case EXTERIOR_KERNEL_T:
-  incomplete = incomplete || (param.commDim[2] && (x3==0 || x3==X3m1));
+  incomplete = incomplete || (param.commDim[2] && (coord[2]==0 || coord[2]==X3m1));
 case EXTERIOR_KERNEL_Z:
-  incomplete = incomplete || (param.commDim[1] && (x2==0 || x2==X2m1));
+  incomplete = incomplete || (param.commDim[1] && (coord[1]==0 || coord[1]==X2m1));
 case EXTERIOR_KERNEL_Y:
-  incomplete = incomplete || (param.commDim[0] && (x1==0 || x1==X1m1));
+  incomplete = incomplete || (param.commDim[0] && (coord[0]==0 || coord[0]==X1m1));
 }
 
 """)    

--- a/lib/generate/ndeg_tm_dslash_cuda_gen.py
+++ b/lib/generate/ndeg_tm_dslash_cuda_gen.py
@@ -316,9 +316,8 @@ int face_idx;
 if (kernel_type == INTERIOR_KERNEL) {
 #endif
 
-  // Inline by hand for the moment and assume even dimensions
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromIndex3D<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, dims);
+  // Assume even dimensions
+  coordsFromIndex3D<EVEN_X>(X, x1, x2, x3, x4, sid, param);
 
   // only need to check Y and Z dims currently since X and T set to match exactly
   if (x2 >= X2) return;
@@ -336,9 +335,8 @@ if (kernel_type == INTERIOR_KERNEL) {
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  // Inline by hand for the moment and assume even dimensions
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromIndex<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, dims, param.block, param.grid);
+  // Assume even dimensions
+  coordsFromIndex<EVEN_X>(X, x1, x2, x3, x4, sid, param.parity, param.X, param.block, param.grid);
 
 """)
 
@@ -363,7 +361,6 @@ if (kernel_type == INTERIOR_KERNEL) {
   sid = blockIdx.x*blockDim.x + threadIdx.x;
   if (sid >= param.threads) return;
 
-  const int dim = static_cast<int>(kernel_type);
   const int face_volume = (param.threads >> 1);           // volume of one face (per flavor)
   const int face_num = (sid >= face_volume);              // is this thread updating face 0 or 1
   face_idx = sid - face_num*face_volume;        // index into the respective face
@@ -372,8 +369,7 @@ if (kernel_type == INTERIOR_KERNEL) {
   // face_idx not sid since faces are spin projected and share the same volume index (modulo UP/DOWN reading)
   //sp_idx = face_idx + param.ghostOffset[dim];
 
-  const int dims[] = {X1, X2, X3, X4};
-  coordsFromFaceIndex<1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, dim, face_num, param.parity, dims);
+  coordsFromFaceIndex<kernel_type,1>(X, sid, x1, x2, x3, x4, face_idx, face_volume, face_num, param);
 
 """)
 


### PR DESCRIPTION
This pull optimizes the 4-d and 5-d indexing of all dslash kernels using the int_fastdiv class for fast integer division.  This has a performance benefit especially at small volumes for the packing and halo update kernels, since it reduces the latency before actual memory requests / computation is done.

An example of the performance improvement (in GFLOPS) is shown in the table below (clover fermions, half precision, 12 reconstruct, M6000 GPU).  The improvement is likely greater when with peer-to-peer communication since this case is less comms bound and more latency bound.

 L | old | new 
 ----- | ----- | -----
 6   |  53 | 54  
 8  |  169 | 174 
 10  |  385 | 392
12  | 418 | 438
14  | 538 | 558
16  | 710 | 732
18  | 813 | 818
20 | 824 | 863
22 | 893 | 897
24 | 913 | 920
