### PR TITLE
Feature/multi shift multi blas

### DIFF
--- a/include/blas_quda.h
+++ b/include/blas_quda.h
@@ -119,6 +119,27 @@ namespace quda {
     */
     void caxpy(const Complex *a, ColorSpinorField &x, ColorSpinorField &y);
 
+    /**
+       @brief Compute the vectorized "axpyBzpcx" with over the set of
+       ColorSpinorFields, where the third vector, z, is constant over the
+       batch.  E.g., it computes
+
+       y = a * x + y
+       x = b * z + c * x
+
+       The dimensions of a, b, c are the same as the size of x and y,
+       with a maximum size of 16.
+
+       @param a[in] Array of coefficients
+       @param b[in] Array of coefficients
+       @param c[in] Array of coefficients
+       @param x[in,out] vector of ColorSpinorFields
+       @param y[in,out] vector of ColorSpinorFields
+       @param z[in] input ColorSpinorField
+    */
+    void axpyBzpcx(const double *a, std::vector<ColorSpinorField*> &x, std::vector<ColorSpinorField*> &y,
+		   const double *b, ColorSpinorField &z, const double *c);
+
     void reDotProduct(double* result, std::vector<cudaColorSpinorField*>& a, std::vector<cudaColorSpinorField*>& b);
     void cDotProduct(Complex* result, std::vector<cudaColorSpinorField*>& a, std::vector<cudaColorSpinorField*>& b);
 

--- a/lib/blas_quda.cu
+++ b/lib/blas_quda.cu
@@ -255,7 +255,7 @@ namespace quda {
     template<int NXZ, typename Float2, typename FloatN>
     struct multicaxpy_ : public MultiBlasFunctor<NXZ, Float2, FloatN> {
       const int NYW;
-      multicaxpy_(const Complex *a, const Float2 &b, const Float2 &c, int NYW) : NYW(NYW) { }
+      multicaxpy_(const Complex *a, int NYW) : NYW(NYW) { }
       __device__ __host__ void operator()(FloatN &x, FloatN &y, FloatN &z, FloatN &w, const int i, const int j)
       {
 #ifdef __CUDA_ARCH__
@@ -273,52 +273,52 @@ namespace quda {
     void caxpy(const Complex *a, std::vector<ColorSpinorField*> &x, std::vector<ColorSpinorField*> &y) {
       switch (x.size()) {
       case 1:
-	multiblasCuda<1,multicaxpy_,0,1,0,0>(a, make_double2(0.0, 0.0), make_double2(0.0, 0.0), x, y, x, y);
+	multiblasCuda<1,multicaxpy_,0,1,0,0>(a, 0, 0, x, y, x, y);
         break;
       case 2:
-	multiblasCuda<2,multicaxpy_,0,1,0,0>(a, make_double2(0.0, 0.0), make_double2(0.0, 0.0), x, y, x, y);
+	multiblasCuda<2,multicaxpy_,0,1,0,0>(a, 0, 0, x, y, x, y);
         break;
       case 3:
-	multiblasCuda<3,multicaxpy_,0,1,0,0>(a, make_double2(0.0, 0.0), make_double2(0.0, 0.0), x, y, x, y);
+	multiblasCuda<3,multicaxpy_,0,1,0,0>(a, 0, 0, x, y, x, y);
         break;
       case 4:
-	multiblasCuda<4,multicaxpy_,0,1,0,0>(a, make_double2(0.0, 0.0), make_double2(0.0, 0.0), x, y, x, y);
+	multiblasCuda<4,multicaxpy_,0,1,0,0>(a, 0, 0, x, y, x, y);
         break;
       case 5:
-	multiblasCuda<5,multicaxpy_,0,1,0,0>(a, make_double2(0.0, 0.0), make_double2(0.0, 0.0), x, y, x, y);
+	multiblasCuda<5,multicaxpy_,0,1,0,0>(a, 0, 0, x, y, x, y);
         break;
       case 6:
-	multiblasCuda<6,multicaxpy_,0,1,0,0>(a, make_double2(0.0, 0.0), make_double2(0.0, 0.0), x, y, x, y);
+	multiblasCuda<6,multicaxpy_,0,1,0,0>(a, 0, 0, x, y, x, y);
         break;
       case 7:
-	multiblasCuda<7,multicaxpy_,0,1,0,0>(a, make_double2(0.0, 0.0), make_double2(0.0, 0.0), x, y, x, y);
+	multiblasCuda<7,multicaxpy_,0,1,0,0>(a, 0, 0, x, y, x, y);
         break;
       case 8:
-	multiblasCuda<8,multicaxpy_,0,1,0,0>(a, make_double2(0.0, 0.0), make_double2(0.0, 0.0), x, y, x, y);
+	multiblasCuda<8,multicaxpy_,0,1,0,0>(a, 0, 0, x, y, x, y);
         break;
       case 9:
-	multiblasCuda<9,multicaxpy_,0,1,0,0>(a, make_double2(0.0, 0.0), make_double2(0.0, 0.0), x, y, x, y);
+	multiblasCuda<9,multicaxpy_,0,1,0,0>(a, 0, 0, x, y, x, y);
         break;
       case 10:
-	multiblasCuda<10,multicaxpy_,0,1,0,0>(a, make_double2(0.0, 0.0), make_double2(0.0, 0.0), x, y, x, y);
+	multiblasCuda<10,multicaxpy_,0,1,0,0>(a, 0, 0, x, y, x, y);
         break;
       case 11:
-	multiblasCuda<11,multicaxpy_,0,1,0,0>(a, make_double2(0.0, 0.0), make_double2(0.0, 0.0), x, y, x, y);
+	multiblasCuda<11,multicaxpy_,0,1,0,0>(a, 0, 0, x, y, x, y);
         break;
       case 12:
-	multiblasCuda<12,multicaxpy_,0,1,0,0>(a, make_double2(0.0, 0.0), make_double2(0.0, 0.0), x, y, x, y);
+	multiblasCuda<12,multicaxpy_,0,1,0,0>(a, 0, 0, x, y, x, y);
         break;
       case 13:
-	multiblasCuda<13,multicaxpy_,0,1,0,0>(a, make_double2(0.0, 0.0), make_double2(0.0, 0.0), x, y, x, y);
+	multiblasCuda<13,multicaxpy_,0,1,0,0>(a, 0, 0, x, y, x, y);
         break;
       case 14:
-	multiblasCuda<14,multicaxpy_,0,1,0,0>(a, make_double2(0.0, 0.0), make_double2(0.0, 0.0), x, y, x, y);
+	multiblasCuda<14,multicaxpy_,0,1,0,0>(a, 0, 0, x, y, x, y);
         break;
       case 15:
-	multiblasCuda<15,multicaxpy_,0,1,0,0>(a, make_double2(0.0, 0.0), make_double2(0.0, 0.0), x, y, x, y);
+	multiblasCuda<15,multicaxpy_,0,1,0,0>(a, 0, 0, x, y, x, y);
         break;
       case 16:
-	multiblasCuda<16,multicaxpy_,0,1,0,0>(a, make_double2(0.0, 0.0), make_double2(0.0, 0.0), x, y, x, y);
+	multiblasCuda<16,multicaxpy_,0,1,0,0>(a, 0, 0, x, y, x, y);
         break;
       default:
 	// split the problem in half and recurse
@@ -431,7 +431,7 @@ namespace quda {
       __device__ __host__ void operator()(FloatN &x, FloatN &y, FloatN &z, FloatN &w)
       { y += a.x*x; x = b.x*z + c.x*x; }
       static int streams() { return 5; } //! total number of input and output streams
-      static int flops() { return 10; } //! flops per element
+      static int flops() { return 5; } //! flops per element
     };
 
     void axpyBzpcx(const double &a, ColorSpinorField& x, ColorSpinorField& y, const double &b,
@@ -447,6 +447,57 @@ namespace quda {
       }
     }
 
+
+    template<int NXZ, typename Float2, typename FloatN>
+    struct multi_axpyBzpcx_ : public MultiBlasFunctor<NXZ, Float2, FloatN> {
+      const int NYW;
+      multi_axpyBzpcx_(const Complex *a, int NYW) : NYW(NYW) { }
+      __device__ __host__ void operator()(FloatN &x, FloatN &y, FloatN &z, FloatN &w, const int i, const int j)
+      {
+#ifdef __CUDA_ARCH__
+	// fetch coefficient arrays from constant memory
+	Float2 *a = reinterpret_cast<Float2*>(Amatrix_d);
+	Float2 *b = reinterpret_cast<Float2*>(Bmatrix_d);
+	Float2 *c = reinterpret_cast<Float2*>(Cmatrix_d);
+#else
+	Float2 *a = reinterpret_cast<Float2*>(Amatrix_h);
+	Float2 *b = reinterpret_cast<Float2*>(Bmatrix_h);
+	Float2 *c = reinterpret_cast<Float2*>(Cmatrix_h);
+#endif
+	w += a[i].x * y;
+	y = b[i].x * x + c[i].x * y;
+      }
+      int streams() { return 4*NYW + NXZ; } //! total number of input and output streams
+      int flops() { return 5*NXZ*NYW; } //! flops per real element
+    };
+
+    void axpyBzpcx(const double *a_, std::vector<ColorSpinorField*> &x_, std::vector<ColorSpinorField*> &y_,
+		   const double *b_, ColorSpinorField &z_, const double *c_) {
+
+      // swizzle order since we are writing to x_ and y_, but the
+      // multi-blas only allow writing to y and w, and moreover the
+      // block width of y and w must match, and x and z must match.
+      std::vector<ColorSpinorField*> &y = x_;
+      std::vector<ColorSpinorField*> &w = y_;
+
+      // wrap a container around the third solo vector
+      std::vector<ColorSpinorField*> x;
+      x.push_back(&z_);
+
+      Complex *a = new Complex[y.size()];
+      Complex *b = new Complex[y.size()];
+      Complex *c = new Complex[y.size()];
+
+      for (unsigned int i=0; i<y.size(); i++) { a[i] = Complex(a_[i]); b[i] = Complex(b_[i]); c[i] = Complex(c_[i]); }
+
+      multiblasCuda<1,multi_axpyBzpcx_,0,1,0,1>(a, b, c, x, y, x, w);
+
+      delete []a;
+      delete []b;
+      delete []c;
+    }
+
+
     /**
        Functor performing the operations: y[i] = a*x[i] + y[i]; x[i] = z[i] + b*x[i]
     */
@@ -458,7 +509,7 @@ namespace quda {
       __device__ __host__ void operator()(FloatN &x, FloatN &y, FloatN &z, FloatN &w)
       { y += a.x*x; x = z + b.x*x; }
       static int streams() { return 5; } //! total number of input and output streams
-      static int flops() { return 8; } //! flops per element
+      static int flops() { return 4; } //! flops per element
     };
 
     void axpyZpbx(const double &a, ColorSpinorField& x, ColorSpinorField& y,
@@ -527,7 +578,7 @@ namespace quda {
       __device__ __host__ void operator()(FloatN &x, FloatN &y, FloatN &z, FloatN &w)
       { _caxpy(a, x, z); _caxpy(b, y, z); }
       static int streams() { return 4; } //! total number of input and output streams
-      static int flops() { return 5; } //! flops per element
+      static int flops() { return 8; } //! flops per element
     };
 
     void caxpbypz(const Complex &a, ColorSpinorField &x, const Complex &b,
@@ -549,7 +600,7 @@ namespace quda {
       { _caxpy(a, x, w); _caxpy(b, y, w); _caxpy(c, z, w); }
 
       static int streams() { return 4; } //! total number of input and output streams
-      static int flops() { return 5; } //! flops per element
+      static int flops() { return 12; } //! flops per element
     };
 
     void caxpbypczpw(const Complex &a, ColorSpinorField &x, const Complex &b,

--- a/lib/inv_multi_cg_quda.cpp
+++ b/lib/inv_multi_cg_quda.cpp
@@ -85,13 +85,23 @@ namespace quda {
     void apply(const cudaStream_t &stream) {      
       static int count = 0;
 
+#if 0
       // on the first call do the first half of the update
       for (int j= (count*n_shift)/n_update+1; j<=((count+1)*n_shift)/n_update && j<n_shift; j++) {
 	beta[j] = beta[j_low] * zeta[j] * alpha[j] /  ( zeta_old[j] * alpha[j_low] );
 	// update p[i] and x[i]
 	blas::axpyBzpcx(alpha[j], *(p[j]), *(x[j]), zeta[j], *r, beta[j]);
       }
-      
+#else
+      int zero = (count*n_shift)/n_update+1;
+      std::vector<ColorSpinorField*> P, X;
+      for (int j= (count*n_shift)/n_update+1; j<=((count+1)*n_shift)/n_update && j<n_shift; j++) {
+	beta[j] = beta[j_low] * zeta[j] * alpha[j] /  ( zeta_old[j] * alpha[j_low] );
+	P.push_back(p[j]);
+	X.push_back(x[j]);
+      }
+      if (P.size()) blas::axpyBzpcx(&alpha[zero], P, X, &zeta[zero], *r, &beta[zero]);
+#endif
       if (++count == n_update) count = 0;
     }
     

--- a/lib/multi_blas_core.h
+++ b/lib/multi_blas_core.h
@@ -3,7 +3,7 @@
  */
 template <int NXZ, template < int MXZ, typename Float, typename FloatN> class Functor,
   int writeX, int writeY, int writeZ, int writeW>
-  void multiblasCuda(const Complex* a, const double2 &b, const double2 &c,
+  void multiblasCuda(const Complex* a, const Complex *b, const Complex *c,
 		     CompositeColorSpinorField &x, CompositeColorSpinorField &y,
 		     CompositeColorSpinorField &z, CompositeColorSpinorField &w) {
 


### PR DESCRIPTION
This pull request is an optimization to the multi-shift solver, were we use the multi-blas framework to construct a vectorized axpyBzpcx routine to reduce memory traffic.

* Add vectorized `blas::axpyBzpcx` to multi-blas
* Call this function in multi-shift solver replacing individual calls per shift
* Augmented blas_test to test this routine
* Fixed some flops counting bugs in blas_quda.cu

I note now that there is a noticeable impact on performance from the overhead of downloading the coefficient arrays, e.g., a difference between what the auto-tuner reports and what blas_test reports.  It's more apparent here than in the multi-blas `caxpy` since the `axpyBzpcx` function is lighter weight, so I should probably have a look to what can be done to reduce this overhead.

This pull will close #113 