### PR TITLE
Feature/multi shift cleanup

### DIFF
--- a/include/register_traits.h
+++ b/include/register_traits.h
@@ -83,6 +83,10 @@ namespace quda {
   template<> struct scalar<float3> { typedef float type; };
   template<> struct scalar<float2> { typedef float type; };
   template<> struct scalar<float> { typedef float type; };
+  template<> struct scalar<short4> { typedef short type; };
+  template<> struct scalar<short3> { typedef short type; };
+  template<> struct scalar<short2> { typedef short type; };
+  template<> struct scalar<short> { typedef short type; };
 
   /* Traits used to determine if a variable is half precision or not */
   template< typename T > struct isHalf{ static const bool value = false; };

--- a/include/tune_quda.h
+++ b/include/tune_quda.h
@@ -104,7 +104,7 @@ namespace quda {
 	  param.block.x = step;
 	} else { // not tuning the grid dimension so have to set a valid grid size
 	  // ensure the blockDim is large enough given the limit on gridDim
-	  param.block = dim3((minThreads()+max_blocks-1)/max_blocks, 1, 1); 
+	  param.block.x = (minThreads()+max_blocks-1)/max_blocks;
 	  param.block.x = ((param.block.x+step-1)/step)*step; // round up to nearest step size
 	  if(param.block.x > max_threads) errorQuda("Local lattice volume is too large for device");
 	}

--- a/lib/blas_quda.cu
+++ b/lib/blas_quda.cu
@@ -80,6 +80,7 @@ namespace quda {
 #include <blas_mixed_core.h>
 #include <multi_blas_core.cuh>
 #include <multi_blas_core.h>
+#include <multi_blas_mixed_core.h>
 
 
     template <typename Float2, typename FloatN>
@@ -447,7 +448,7 @@ namespace quda {
       if (x.Precision() != y.Precision()) {
 	// call hacked mixed precision kernel
 	mixed::blasCuda<axpyBzpcx_,1,1,0,0>(make_double2(a,0.0), make_double2(b,0.0),
-					    make_double2(c,0.0),	x, y, z, x);
+					    make_double2(c,0.0), x, y, z, x);
       } else {
 	// swap arguments around
 	blasCuda<axpyBzpcx_,1,1,0,0>(make_double2(a,0.0), make_double2(b,0.0),
@@ -490,7 +491,12 @@ namespace quda {
 
       // we will curry the parameter arrays into the functor
       coeff_array<double> a(a_,false), b(b_,false), c(c_,false);
-      multiblasCuda<1,multi_axpyBzpcx_,0,1,0,1>(a, b, c, x, y, x, w);
+
+      if (x[0]->Precision() != y[0]->Precision() ) {
+	mixed::multiblasCuda<1,multi_axpyBzpcx_,0,1,0,1>(a, b, c, x, y, x, w);
+      } else {
+	multiblasCuda<1,multi_axpyBzpcx_,0,1,0,1>(a, b, c, x, y, x, w);
+      }
     }
 
 

--- a/lib/blas_quda.cu
+++ b/lib/blas_quda.cu
@@ -255,7 +255,10 @@ namespace quda {
     template<int NXZ, typename Float2, typename FloatN>
     struct multicaxpy_ : public MultiBlasFunctor<NXZ, Float2, FloatN> {
       const int NYW;
-      multicaxpy_(const Complex *a, int NYW) : NYW(NYW) { }
+      // ignore parameter arrays since we place them in constant memory
+      multicaxpy_(const coeff_array<Complex> &a, const coeff_array<Complex> &b,
+		  const coeff_array<Complex> &c, int NYW) : NYW(NYW) { }
+
       __device__ __host__ void operator()(FloatN &x, FloatN &y, FloatN &z, FloatN &w, const int i, const int j)
       {
 #ifdef __CUDA_ARCH__
@@ -266,64 +269,69 @@ namespace quda {
 	_caxpy(a[NYW*j+i], x, y);
 #endif
       }
+
       int streams() { return 2*NYW + NXZ*NYW; } //! total number of input and output streams
       int flops() { return 4*NXZ*NYW; } //! flops per real element
     };
 
-    void caxpy(const Complex *a, std::vector<ColorSpinorField*> &x, std::vector<ColorSpinorField*> &y) {
+    void caxpy(const Complex *a_, std::vector<ColorSpinorField*> &x, std::vector<ColorSpinorField*> &y) {
+
+      // mark true since we will copy the "a" matrix into constant memory
+      coeff_array<Complex> a(a_, true), b, c;
+
       switch (x.size()) {
       case 1:
-	multiblasCuda<1,multicaxpy_,0,1,0,0>(a, 0, 0, x, y, x, y);
+	multiblasCuda<1,multicaxpy_,0,1,0,0>(a, b, c, x, y, x, y);
         break;
       case 2:
-	multiblasCuda<2,multicaxpy_,0,1,0,0>(a, 0, 0, x, y, x, y);
+	multiblasCuda<2,multicaxpy_,0,1,0,0>(a, b, c, x, y, x, y);
         break;
       case 3:
-	multiblasCuda<3,multicaxpy_,0,1,0,0>(a, 0, 0, x, y, x, y);
+	multiblasCuda<3,multicaxpy_,0,1,0,0>(a, b, c, x, y, x, y);
         break;
       case 4:
-	multiblasCuda<4,multicaxpy_,0,1,0,0>(a, 0, 0, x, y, x, y);
+	multiblasCuda<4,multicaxpy_,0,1,0,0>(a, b, c, x, y, x, y);
         break;
       case 5:
-	multiblasCuda<5,multicaxpy_,0,1,0,0>(a, 0, 0, x, y, x, y);
+	multiblasCuda<5,multicaxpy_,0,1,0,0>(a, b, c, x, y, x, y);
         break;
       case 6:
-	multiblasCuda<6,multicaxpy_,0,1,0,0>(a, 0, 0, x, y, x, y);
+	multiblasCuda<6,multicaxpy_,0,1,0,0>(a, b, c, x, y, x, y);
         break;
       case 7:
-	multiblasCuda<7,multicaxpy_,0,1,0,0>(a, 0, 0, x, y, x, y);
+	multiblasCuda<7,multicaxpy_,0,1,0,0>(a, b, c, x, y, x, y);
         break;
       case 8:
-	multiblasCuda<8,multicaxpy_,0,1,0,0>(a, 0, 0, x, y, x, y);
+	multiblasCuda<8,multicaxpy_,0,1,0,0>(a, b, c, x, y, x, y);
         break;
       case 9:
-	multiblasCuda<9,multicaxpy_,0,1,0,0>(a, 0, 0, x, y, x, y);
+	multiblasCuda<9,multicaxpy_,0,1,0,0>(a, b, c, x, y, x, y);
         break;
       case 10:
-	multiblasCuda<10,multicaxpy_,0,1,0,0>(a, 0, 0, x, y, x, y);
+	multiblasCuda<10,multicaxpy_,0,1,0,0>(a, b, c, x, y, x, y);
         break;
       case 11:
-	multiblasCuda<11,multicaxpy_,0,1,0,0>(a, 0, 0, x, y, x, y);
+	multiblasCuda<11,multicaxpy_,0,1,0,0>(a, b, c, x, y, x, y);
         break;
       case 12:
-	multiblasCuda<12,multicaxpy_,0,1,0,0>(a, 0, 0, x, y, x, y);
+	multiblasCuda<12,multicaxpy_,0,1,0,0>(a, b, c, x, y, x, y);
         break;
       case 13:
-	multiblasCuda<13,multicaxpy_,0,1,0,0>(a, 0, 0, x, y, x, y);
+	multiblasCuda<13,multicaxpy_,0,1,0,0>(a, b, c, x, y, x, y);
         break;
       case 14:
-	multiblasCuda<14,multicaxpy_,0,1,0,0>(a, 0, 0, x, y, x, y);
+	multiblasCuda<14,multicaxpy_,0,1,0,0>(a, b, c, x, y, x, y);
         break;
       case 15:
-	multiblasCuda<15,multicaxpy_,0,1,0,0>(a, 0, 0, x, y, x, y);
+	multiblasCuda<15,multicaxpy_,0,1,0,0>(a, b, c, x, y, x, y);
         break;
       case 16:
-	multiblasCuda<16,multicaxpy_,0,1,0,0>(a, 0, 0, x, y, x, y);
+	multiblasCuda<16,multicaxpy_,0,1,0,0>(a, b, c, x, y, x, y);
         break;
       default:
 	// split the problem in half and recurse
-	const Complex *a0 = &a[0];
-	const Complex *a1 = &a[x.size()*y.size()/2];
+	const Complex *a0 = &a_[0];
+	const Complex *a1 = &a_[x.size()*y.size()/2];
 
 	std::vector<ColorSpinorField*> x0(x.begin(), x.begin() + x.size()/2);
 	std::vector<ColorSpinorField*> x1(x.begin() + x.size()/2, x.end());
@@ -450,22 +458,18 @@ namespace quda {
 
     template<int NXZ, typename Float2, typename FloatN>
     struct multi_axpyBzpcx_ : public MultiBlasFunctor<NXZ, Float2, FloatN> {
+      typedef typename scalar<Float2>::type real;
       const int NYW;
-      multi_axpyBzpcx_(const Complex *a, int NYW) : NYW(NYW) { }
+      real a[MAX_MULTI_BLAS_N], b[MAX_MULTI_BLAS_N], c[MAX_MULTI_BLAS_N];
+
+      multi_axpyBzpcx_(const coeff_array<double> &a, const coeff_array<double> &b, const coeff_array<double> &c, int NYW) : NYW(NYW){
+	// copy arguments into the functor
+	for (int i=0; i<NYW; i++) { this->a[i] = a.data[i]; this->b[i] = b.data[i]; this->c[i] = c.data[i]; }
+      }
       __device__ __host__ void operator()(FloatN &x, FloatN &y, FloatN &z, FloatN &w, const int i, const int j)
       {
-#ifdef __CUDA_ARCH__
-	// fetch coefficient arrays from constant memory
-	Float2 *a = reinterpret_cast<Float2*>(Amatrix_d);
-	Float2 *b = reinterpret_cast<Float2*>(Bmatrix_d);
-	Float2 *c = reinterpret_cast<Float2*>(Cmatrix_d);
-#else
-	Float2 *a = reinterpret_cast<Float2*>(Amatrix_h);
-	Float2 *b = reinterpret_cast<Float2*>(Bmatrix_h);
-	Float2 *c = reinterpret_cast<Float2*>(Cmatrix_h);
-#endif
-	w += a[i].x * y;
-	y = b[i].x * x + c[i].x * y;
+	w += a[i] * y;
+	y = b[i] * x + c[i] * y;
       }
       int streams() { return 4*NYW + NXZ; } //! total number of input and output streams
       int flops() { return 5*NXZ*NYW; } //! flops per real element
@@ -484,17 +488,9 @@ namespace quda {
       std::vector<ColorSpinorField*> x;
       x.push_back(&z_);
 
-      Complex *a = new Complex[y.size()];
-      Complex *b = new Complex[y.size()];
-      Complex *c = new Complex[y.size()];
-
-      for (unsigned int i=0; i<y.size(); i++) { a[i] = Complex(a_[i]); b[i] = Complex(b_[i]); c[i] = Complex(c_[i]); }
-
+      // we will curry the parameter arrays into the functor
+      coeff_array<double> a(a_,false), b(b_,false), c(c_,false);
       multiblasCuda<1,multi_axpyBzpcx_,0,1,0,1>(a, b, c, x, y, x, w);
-
-      delete []a;
-      delete []b;
-      delete []c;
     }
 
 

--- a/lib/blas_quda.cu
+++ b/lib/blas_quda.cu
@@ -468,8 +468,8 @@ namespace quda {
       }
       __device__ __host__ void operator()(FloatN &x, FloatN &y, FloatN &z, FloatN &w, const int i, const int j)
       {
-	w += a[i] * y;
-	y = b[i] * x + c[i] * y;
+	y += a[i] * w;
+	w = b[i] * x + c[i] * w;
       }
       int streams() { return 4*NYW + NXZ; } //! total number of input and output streams
       int flops() { return 5*NXZ*NYW; } //! flops per real element
@@ -481,8 +481,8 @@ namespace quda {
       // swizzle order since we are writing to x_ and y_, but the
       // multi-blas only allow writing to y and w, and moreover the
       // block width of y and w must match, and x and z must match.
-      std::vector<ColorSpinorField*> &y = x_;
-      std::vector<ColorSpinorField*> &w = y_;
+      std::vector<ColorSpinorField*> &y = y_;
+      std::vector<ColorSpinorField*> &w = x_;
 
       // wrap a container around the third solo vector
       std::vector<ColorSpinorField*> x;

--- a/lib/clover_deriv_quda.cu
+++ b/lib/clover_deriv_quda.cu
@@ -51,7 +51,8 @@
 
 // When using dynamic mu/nu indexing, to avoid local spills use shared
 // memory for the per thread indexing arrays.
-#define SHARED_ARRAY
+// FIXME for reasons I don't understand, the shared array breaks in multi-GPU mode
+//#define SHARED_ARRAY
 
 #endif // DYNAMIC_MU_NU
 

--- a/lib/gauge_force.cu
+++ b/lib/gauge_force.cu
@@ -12,7 +12,7 @@ namespace quda {
     Mom mom;
     const Gauge u;
 
-    unsigned long threads;
+    int threads;
     int X[4]; // the regular volume parameters
     int E[4]; // the extended volume parameters
     int border[4]; // radius of border

--- a/lib/gauge_update_quda.cu
+++ b/lib/gauge_update_quda.cu
@@ -156,7 +156,7 @@ namespace quda {
   void updateGaugeField(UpdateGaugeArg<Float,Gauge,Mom> arg) {
 
     for (unsigned int parity=0; parity<2; parity++) {
-      for (unsigned int x=0; x<arg.out.volumeCB; x++) {
+      for (int x=0; x<arg.out.volumeCB; x++) {
 	updateGaugeFieldCompute<Float,Gauge,Mom,N,conj_mom,exact>
 	  (arg, x, parity);
       }

--- a/lib/inv_cg_quda.cpp
+++ b/lib/inv_cg_quda.cpp
@@ -239,7 +239,6 @@ namespace quda {
         steps_since_reliable++;
       } else {
 
-        printfQuda("\t * Reliable update \n");
         blas::axpy(alpha, p, xSloppy);
         blas::copy(x, xSloppy); // nop when these pointers alias
 
@@ -298,8 +297,8 @@ namespace quda {
           heavy_quark_restart = false;
         } else {
           // explicitly restore the orthogonality of the gradient vector
-          double rp = blas::reDotProduct(rSloppy, p) / (r2);
-          blas::axpy(-rp, rSloppy, p);
+          Complex rp = blas::cDotProduct(rSloppy, p) / (r2);
+          blas::caxpy(-rp, rSloppy, p);
 
           beta = r2 / r2_old;
           blas::xpay(rSloppy, beta, p);

--- a/lib/inv_cg_quda.cpp
+++ b/lib/inv_cg_quda.cpp
@@ -61,6 +61,7 @@ namespace quda {
       csParam.setPrecision(param.precision_sloppy);
       App = ColorSpinorField::Create(csParam);
       tmpp = ColorSpinorField::Create(csParam);
+
       init = true;
 
     }
@@ -69,14 +70,23 @@ namespace quda {
     ColorSpinorField &Ap = *App;
     ColorSpinorField &tmp = *tmpp;
 
-    mat(r, x, y);
-    double r2 = blas::xmyNorm(b, r);
     csParam.setPrecision(param.precision_sloppy);
+
     // tmp2 only needed for multi-gpu Wilson-like kernels
-    ColorSpinorField *tmp2_p = !mat.isStaggered() ?
-    ColorSpinorField::Create(x, csParam) : &tmp;
+    ColorSpinorField *tmp2_p = !mat.isStaggered() ? ColorSpinorField::Create(x, csParam) : &tmp;
     ColorSpinorField &tmp2 = *tmp2_p;
 
+    // additional high-precision temporary if Wilson and mixed-precision
+    csParam.setPrecision(param.precision);
+    ColorSpinorField *tmp3_p = (param.precision != param.precision_sloppy && !mat.isStaggered()) ?
+      ColorSpinorField::Create(x, csParam) : &tmp;
+    ColorSpinorField &tmp3 = *tmp3_p;
+
+    // compute initial residual
+    mat(r, x, y, tmp3);
+    double r2 = blas::xmyNorm(b, r);
+
+    csParam.setPrecision(param.precision_sloppy);
     ColorSpinorField *r_sloppy;
     if (param.precision_sloppy == x.Precision()) {
       r_sloppy = &r;
@@ -93,13 +103,6 @@ namespace quda {
       csParam.create = QUDA_COPY_FIELD_CREATE;
       x_sloppy = ColorSpinorField::Create(x, csParam);
     }
-
-    // additional high-precision temporary if Wilson and mixed-precision
-    csParam.setPrecision(param.precision);
-    ColorSpinorField *tmp3_p =
-      (param.precision != param.precision_sloppy && !mat.isStaggered()) ?
-      ColorSpinorField::Create(x, csParam) : &tmp;
-    ColorSpinorField &tmp3 = *tmp3_p;
 
     ColorSpinorField &xSloppy = *x_sloppy;
     ColorSpinorField &rSloppy = *r_sloppy;

--- a/lib/inv_multi_cg_quda.cpp
+++ b/lib/inv_multi_cg_quda.cpp
@@ -472,8 +472,14 @@ namespace quda {
     param.gflops = gflops;
     param.iter += k;
 
+    // only allocate temporaries if necessary
+    csParam.setPrecision(param.precision);
+    ColorSpinorField *tmp4_p = reliable ? y[0] : tmp1.Precision() == x[0]->Precision() ? &tmp1 : ColorSpinorField::Create(csParam);
+    ColorSpinorField *tmp5_p = mat.isStaggered() ? tmp4_p :
+      reliable ? y[1] : (tmp2.Precision() == x[0]->Precision() && &tmp1 != tmp2_p) ? tmp2_p : ColorSpinorField::Create(csParam);
+
     for(int i=0; i < num_offset; i++) { 
-      mat(*r, *x[i]); 
+      mat(*r, *x[i], *tmp4_p, *tmp5_p);
       if (r->Nspin()==4) {
 	blas::axpy(offset[i], *x[i], *r); // Offset it.
       } else if (i!=0) {
@@ -493,7 +499,9 @@ namespace quda {
       }
     }
 
-  
+    if (tmp5_p != tmp4_p && tmp5_p != tmp2_p && tmp5_p != y[1]) delete tmp5_p;
+    if (tmp4_p != &tmp1 && tmp4_p != y[0]) delete tmp4_p;
+
     // reset the flops counters
     blas::flops = 0;
     mat.flops();

--- a/lib/inv_multi_cg_quda.cpp
+++ b/lib/inv_multi_cg_quda.cpp
@@ -397,8 +397,8 @@ namespace quda {
 
 	// explicitly restore the orthogonality of the gradient vector
 	for (int j=0; j<num_offset_now; j++) {
-	  double rp = blas::reDotProduct(*r_sloppy, *p[j]) / (r2[0]);
-	  blas::axpy(-rp, *r_sloppy, *p[j]);
+	  Complex rp = blas::cDotProduct(*r_sloppy, *p[j]) / (r2[0]);
+	  blas::caxpy(-rp, *r_sloppy, *p[j]);
 	}
 
 	// update beta and p

--- a/lib/multi_blas_core.cuh
+++ b/lib/multi_blas_core.cuh
@@ -183,12 +183,12 @@ public:
   }
 
   void initTuneParam(TuneParam &param) const {
-    Tunable::initTuneParam(param);
+    TunableVectorY::initTuneParam(param);
     param.grid.z = nParity;
   }
 
   void defaultTuneParam(TuneParam &param) const {
-    Tunable::initTuneParam(param);
+    TunableVectorY::defaultTuneParam(param);
     param.grid.z = nParity;
   }
 

--- a/lib/multi_blas_core.cuh
+++ b/lib/multi_blas_core.cuh
@@ -48,24 +48,24 @@ static signed char *Bmatrix_h;
 static signed char *Cmatrix_h;
 
 template<int k, int NXZ, typename FloatN, int M, typename Arg>
-__device__ inline void compute(Arg &arg, int idx) {
+__device__ inline void compute(Arg &arg, int idx, int parity) {
 
   while (idx < arg.length) {
 
     FloatN x[M], y[M], z[M], w[M];
-    arg.Y[k].load(y, idx);
-    arg.W[k].load(w, idx);
+    arg.Y[k].load(y, idx, parity);
+    arg.W[k].load(w, idx, parity);
 
 #pragma unroll
     for (int l=0; l < NXZ; l++) {
-      arg.X[l].load(x, idx);
-      arg.Z[l].load(z, idx);
+      arg.X[l].load(x, idx, parity);
+      arg.Z[l].load(z, idx, parity);
 
 #pragma unroll
       for (int j=0; j < M; j++) arg.f(x[j], y[j], z[j], w[j], k, l);
     }
-    arg.Y[k].save(y, idx);
-    arg.W[k].save(w, idx);
+    arg.Y[k].save(y, idx, parity);
+    arg.W[k].save(w, idx, parity);
 
     idx += gridDim.x*blockDim.x;
   }
@@ -84,44 +84,45 @@ __global__ void multiblasKernel(MultiBlasArg<NXZ,SpinorX,SpinorY,SpinorZ,SpinorW
   // use i to loop over elements in kernel
   unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
   unsigned int k = blockIdx.y * blockDim.y + threadIdx.y;
+  unsigned int parity = blockIdx.z;
 
   arg.f.init();
   if (k >= arg.NYW) return;
 
   switch(k) {
-    case  0: compute< 0,NXZ,FloatN,M>(arg,i); break;
-    case  1: compute< 1,NXZ,FloatN,M>(arg,i); break;
-    case  2: compute< 2,NXZ,FloatN,M>(arg,i); break;
-    case  3: compute< 3,NXZ,FloatN,M>(arg,i); break;
-    case  4: compute< 4,NXZ,FloatN,M>(arg,i); break;
-    case  5: compute< 5,NXZ,FloatN,M>(arg,i); break;
-    case  6: compute< 6,NXZ,FloatN,M>(arg,i); break;
-    case  7: compute< 7,NXZ,FloatN,M>(arg,i); break;
-    case  8: compute< 8,NXZ,FloatN,M>(arg,i); break;
-    case  9: compute< 9,NXZ,FloatN,M>(arg,i); break;
-    case 10: compute<10,NXZ,FloatN,M>(arg,i); break;
-    case 11: compute<11,NXZ,FloatN,M>(arg,i); break;
-    case 12: compute<12,NXZ,FloatN,M>(arg,i); break;
-    case 13: compute<13,NXZ,FloatN,M>(arg,i); break;
-    case 14: compute<14,NXZ,FloatN,M>(arg,i); break;
-    case 15: compute<15,NXZ,FloatN,M>(arg,i); break;
+  case  0: compute< 0,NXZ,FloatN,M>(arg,i,parity); break;
+  case  1: compute< 1,NXZ,FloatN,M>(arg,i,parity); break;
+  case  2: compute< 2,NXZ,FloatN,M>(arg,i,parity); break;
+  case  3: compute< 3,NXZ,FloatN,M>(arg,i,parity); break;
+  case  4: compute< 4,NXZ,FloatN,M>(arg,i,parity); break;
+  case  5: compute< 5,NXZ,FloatN,M>(arg,i,parity); break;
+  case  6: compute< 6,NXZ,FloatN,M>(arg,i,parity); break;
+  case  7: compute< 7,NXZ,FloatN,M>(arg,i,parity); break;
+  case  8: compute< 8,NXZ,FloatN,M>(arg,i,parity); break;
+  case  9: compute< 9,NXZ,FloatN,M>(arg,i,parity); break;
+  case 10: compute<10,NXZ,FloatN,M>(arg,i,parity); break;
+  case 11: compute<11,NXZ,FloatN,M>(arg,i,parity); break;
+  case 12: compute<12,NXZ,FloatN,M>(arg,i,parity); break;
+  case 13: compute<13,NXZ,FloatN,M>(arg,i,parity); break;
+  case 14: compute<14,NXZ,FloatN,M>(arg,i,parity); break;
+  case 15: compute<15,NXZ,FloatN,M>(arg,i,parity); break;
   }
 
 }
 
 namespace detail
 {
-    template<unsigned... digits>
-      struct to_chars { static const char value[]; };
+  template<unsigned... digits>
+  struct to_chars { static const char value[]; };
 
-    template<unsigned... digits>
-      const char to_chars<digits...>::value[] = {('0' + digits)..., 0};
+  template<unsigned... digits>
+  const char to_chars<digits...>::value[] = {('0' + digits)..., 0};
 
-    template<unsigned rem, unsigned... digits>
-      struct explode : explode<rem / 10, rem % 10, digits...> {};
+  template<unsigned rem, unsigned... digits>
+  struct explode : explode<rem / 10, rem % 10, digits...> {};
 
-    template<unsigned... digits>
-      struct explode<0, digits...> : to_chars<digits...> {};
+  template<unsigned... digits>
+  struct explode<0, digits...> : to_chars<digits...> {};
 }
 
 template<unsigned num>
@@ -135,6 +136,7 @@ class MultiBlasCuda : public TunableVectorY {
 private:
   const int NYW;
   mutable MultiBlasArg<NXZ,SpinorX,SpinorY,SpinorZ,SpinorW,Functor> arg;
+  const int nParity;
 
   // host pointers used for backing up fields when tuning
   // don't curry into the Spinors to minimize parameter size
@@ -146,9 +148,9 @@ private:
 
 public:
   MultiBlasCuda(SpinorX X[], SpinorY Y[], SpinorZ Z[], SpinorW W[], Functor &f,
-		int NYW, int length, size_t **bytes,  size_t **norm_bytes)
-    : TunableVectorY(NYW), NYW(NYW), arg(X, Y, Z, W, f, NYW, length),
-      Y_h(), W_h(), Ynorm_h(), Wnorm_h(),
+		int NYW, int length, int nParity, size_t **bytes,  size_t **norm_bytes)
+    : TunableVectorY(NYW), NYW(NYW), arg(X, Y, Z, W, f, NYW, length/nParity),
+      nParity(nParity), Y_h(), W_h(), Ynorm_h(), Wnorm_h(),
       bytes_(const_cast<const size_t**>(bytes)), norm_bytes_(const_cast<const size_t**>(norm_bytes)) { }
 
   virtual ~MultiBlasCuda() { }
@@ -180,7 +182,17 @@ public:
     }
   }
 
-  long long flops() const { return arg.f.flops()*vec_length<FloatN>::value*(long)arg.length*M; }
+  void initTuneParam(TuneParam &param) const {
+    Tunable::initTuneParam(param);
+    param.grid.z = nParity;
+  }
+
+  void defaultTuneParam(TuneParam &param) const {
+    Tunable::initTuneParam(param);
+    param.grid.z = nParity;
+  }
+
+  long long flops() const { return arg.f.flops()*vec_length<FloatN>::value*(long)arg.length*nParity*M; }
 
   long long bytes() const
   {
@@ -193,7 +205,7 @@ public:
     if (arg.Y[0].Precision() == QUDA_HALF_PRECISION) extra_bytes += sizeof(float);
 
     // the factor two here assumes we are reading and writing to the high precision vector
-    return ((arg.f.streams()-2)*base_bytes + 2*extra_bytes)*arg.length;
+    return ((arg.f.streams()-2)*base_bytes + 2*extra_bytes)*arg.length*nParity;
   }
 
   int tuningIter() const { return 3; }
@@ -216,41 +228,6 @@ void multiblasCuda(const coeff_array<T> &a, const coeff_array<T> &b, const coeff
 		   int length) {
 
   const int NYW = y.size();
-
-  // FIXME implement this as a single kernel
-  if (x[0]->SiteSubset() == QUDA_FULL_SITE_SUBSET) {
-    std::vector<cudaColorSpinorField> xp, yp, zp, wp;
-    std::vector<ColorSpinorField*> xpp, ypp, zpp, wpp;
-    xp.reserve(NXZ); yp.reserve(NYW); zp.reserve(NXZ); wp.reserve(NYW);
-    xpp.reserve(NXZ); ypp.reserve(NYW); zpp.reserve(NXZ); wpp.reserve(NYW);
-
-    for (int i=0; i<NXZ; i++) {
-      xp.push_back(x[i]->Even());zp.push_back(z[i]->Even());
-      xpp.push_back(&xp[i]); zpp.push_back(&zp[i]);
-    }
-    for (int i=0; i<NYW; i++) {
-      yp.push_back(y[i]->Even()); wp.push_back(w[i]->Even());
-      ypp.push_back(&yp[i]); ; wpp.push_back(&wp[i]);
-    }
-
-    multiblasCuda<NXZ, RegType, StoreType, yType, M, Functor, writeX, writeY, writeZ, writeW>
-      (a, b, c, xpp, ypp, zpp, wpp, length);
-
-    for (int i=0; i<NXZ; ++i) {
-      xp.push_back(x[i]->Odd()); zp.push_back(z[i]->Odd());
-      xpp.push_back(&xp[i]);  zpp.push_back(&zp[i]);
-    }
-    for (int i=0; i<NYW; ++i) {
-      yp.push_back(y[i]->Odd()); wp.push_back(w[i]->Odd());
-      ypp.push_back(&yp[i]); wpp.push_back(&wp[i]);
-    }
-
-    multiblasCuda<NXZ, RegType, StoreType, yType, M, Functor, writeX, writeY, writeZ, writeW>
-      (a, b, c, xpp, ypp, zpp, wpp, length);
-
-    return;
-  }
-
 
   typedef typename scalar<RegType>::type Float;
   typedef typename vector<Float,2>::type Float2;
@@ -336,7 +313,7 @@ void multiblasCuda(const coeff_array<T> &a, const coeff_array<T> &b, const coeff
 		SpinorTexture<RegType,StoreType,M,2>,
 		Spinor<RegType,StoreType,M,writeW,3>,
 		decltype(f) >
-    blas(X, Y, Z, W, f, NYW, length, bytes, norm_bytes);
+    blas(X, Y, Z, W, f, NYW, length, x[0]->SiteSubset(), bytes, norm_bytes);
   blas.apply(*blasStream);
 
   blas::bytes += blas.bytes();

--- a/lib/multi_blas_core.h
+++ b/lib/multi_blas_core.h
@@ -9,14 +9,17 @@ template <int NXZ, template < int MXZ, typename Float, typename FloatN> class Fu
 
   if (Location(*x[0], *y[0], *z[0], *w[0]) == QUDA_CUDA_FIELD_LOCATION) {
 
-    if (x[0]->Precision() == QUDA_DOUBLE_PRECISION) {
+    if (y[0]->Precision() == QUDA_DOUBLE_PRECISION && x[0]->Precision() == QUDA_DOUBLE_PRECISION) {
+
 #if defined(GPU_WILSON_DIRAC) || defined(GPU_DOMAIN_WALL_DIRAC) || defined(GPU_STAGGERED_DIRAC)
       const int M = 1;
       multiblasCuda<NXZ,double2,double2,double2,M,Functor,writeX,writeY,writeZ,writeW>(a,b,c,x,y,z,w,x[0]->Length()/(2*M));
 #else
       errorQuda("blas has not been built for Nspin=%d fields", x[0]->Nspin());
 #endif
-    } else if (x[0]->Precision() == QUDA_SINGLE_PRECISION) {
+
+    } else if (y[0]->Precision() == QUDA_SINGLE_PRECISION && x[0]->Precision() == QUDA_SINGLE_PRECISION) {
+
       if (x[0]->Nspin() == 4) {
 #if defined(GPU_WILSON_DIRAC) || defined(GPU_DOMAIN_WALL_DIRAC)
 	const int M = 1;
@@ -24,7 +27,9 @@ template <int NXZ, template < int MXZ, typename Float, typename FloatN> class Fu
 #else
 	errorQuda("blas has not been built for Nspin=%d fields", x[0]->Nspin());
 #endif
+
       } else if (x[0]->Nspin()==2 || x[0]->Nspin()==1) {
+
 #if defined(GPU_WILSON_DIRAC) || defined(GPU_DOMAIN_WALL_DIRAC) || defined(GPU_STAGGERED_DIRAC)
 	const int M = 1;
 	multiblasCuda<NXZ,float2,float2,float2,M,Functor,writeX,writeY,writeZ,writeW>(a,b,c,x,y,z,w,x[0]->Length()/(2*M));
@@ -32,7 +37,9 @@ template <int NXZ, template < int MXZ, typename Float, typename FloatN> class Fu
 	errorQuda("blas has not been built for Nspin=%d fields", x[0]->Nspin());
 #endif
       } else { errorQuda("nSpin=%d is not supported\n", x[0]->Nspin()); }
-    } else {
+
+    } else if (y[0]->Precision() == QUDA_HALF_PRECISION && x[0]->Precision() == QUDA_HALF_PRECISION) {
+
       if (x[0]->Ncolor() != 3) { errorQuda("nColor = %d is not supported", x[0]->Ncolor()); }
       if (x[0]->Nspin() == 4) { //wilson
 #if defined(GPU_WILSON_DIRAC) || defined(GPU_DOMAIN_WALL_DIRAC)
@@ -51,6 +58,11 @@ template <int NXZ, template < int MXZ, typename Float, typename FloatN> class Fu
       } else {
 	errorQuda("nSpin=%d is not supported\n", x[0]->Nspin());
       }
+
+    } else {
+
+      errorQuda("Precision combination x=%d not supported\n", x[0]->Precision());
+
     }
   } else { // fields on the cpu
     // using namespace quda::colorspinor;

--- a/lib/multi_blas_core.h
+++ b/lib/multi_blas_core.h
@@ -2,8 +2,8 @@
    Driver for generic blas routine with four loads and two store.
  */
 template <int NXZ, template < int MXZ, typename Float, typename FloatN> class Functor,
-  int writeX, int writeY, int writeZ, int writeW>
-  void multiblasCuda(const Complex* a, const Complex *b, const Complex *c,
+  int writeX, int writeY, int writeZ, int writeW, typename T>
+  void multiblasCuda(const coeff_array<T> &a, const coeff_array<T> &b, const coeff_array<T> &c,
 		     CompositeColorSpinorField &x, CompositeColorSpinorField &y,
 		     CompositeColorSpinorField &z, CompositeColorSpinorField &w) {
 

--- a/lib/multi_blas_mixed_core.h
+++ b/lib/multi_blas_mixed_core.h
@@ -1,0 +1,88 @@
+namespace mixed {
+
+  /**
+     Driver for generic blas routine with four loads and two store.
+  */
+  template <int NXZ, template < int MXZ, typename Float, typename FloatN> class Functor,
+    int writeX, int writeY, int writeZ, int writeW, typename T>
+    void multiblasCuda(const coeff_array<T> &a, const coeff_array<T> &b, const coeff_array<T> &c,
+		       CompositeColorSpinorField &x, CompositeColorSpinorField &y,
+		       CompositeColorSpinorField &z, CompositeColorSpinorField &w) {
+
+    if (Location(*x[0], *y[0], *z[0], *w[0]) == QUDA_CUDA_FIELD_LOCATION) {
+
+      if (y[0]->Precision() == QUDA_DOUBLE_PRECISION && x[0]->Precision() == QUDA_SINGLE_PRECISION) {
+
+	  if (x[0]->Nspin() == 4) {
+#if defined(GPU_WILSON_DIRAC) || defined(GPU_DOMAIN_WALL_DIRAC)
+	    const int M = 12;
+	    multiblasCuda<NXZ,double2,float4,double2,M,Functor,writeX,writeY,writeZ,writeW>(a,b,c,x,y,z,w,x[0]->Volume());
+#else
+	    errorQuda("blas has not been built for Nspin=%d fields", x[0]->Nspin());
+#endif
+	  } else if (x[0]->Nspin() == 1) {
+#if defined(GPU_STAGGERED_DIRAC)
+	    const int M = 3;
+	    multiblasCuda<NXZ,double2,float2,double2,M,Functor,writeX,writeY,writeZ,writeW>(a,b,c,x,y,z,w,x[0]->Volume());
+#else
+	    errorQuda("blas has not been built for Nspin=%d fields", x[0]->Nspin());
+#endif
+	  }
+
+      } else if (y[0]->Precision() == QUDA_DOUBLE_PRECISION && x[0]->Precision() == QUDA_HALF_PRECISION) {
+
+	if (x[0]->Nspin() == 4) {
+#if defined(GPU_WILSON_DIRAC) || defined(GPU_DOMAIN_WALL_DIRAC)
+	  const int M = 12;
+	  multiblasCuda<NXZ,double2,short4,double2,M,Functor,writeX,writeY,writeZ,writeW>(a,b,c,x,y,z,w,x[0]->Volume());
+#else
+	  errorQuda("blas has not been built for Nspin=%d fields", x[0]->Nspin());
+#endif
+	} else if (x[0]->Nspin() == 1) {
+#if defined(GPU_STAGGERED_DIRAC)
+	  const int M = 3;
+	  multiblasCuda<NXZ,double2,short2,double2,M,Functor,writeX,writeY,writeZ,writeW>(a,b,c,x,y,z,w,x[0]->Volume());
+#else
+	  errorQuda("blas has not been built for Nspin=%d fields", x[0]->Nspin());
+#endif
+	}
+
+      } else if (y[0]->Precision() == QUDA_SINGLE_PRECISION && x[0]->Precision() == QUDA_HALF_PRECISION) {
+
+	if (x[0]->Nspin() == 4) {
+#if defined(GPU_WILSON_DIRAC) || defined(GPU_DOMAIN_WALL_DIRAC)
+	  const int M = 6;
+	  multiblasCuda<NXZ,float4,short4,float4,M,Functor,writeX,writeY,writeZ,writeW>(a,b,c,x,y,z,w,x[0]->Volume());
+#else
+	  errorQuda("blas has not been built for Nspin=%d fields", x[0]->Nspin());
+#endif
+
+	} else if (x[0]->Nspin()==2 || x[0]->Nspin()==1) {
+
+#if defined(GPU_WILSON_DIRAC) || defined(GPU_DOMAIN_WALL_DIRAC) || defined(GPU_STAGGERED_DIRAC)
+	  const int M = 3;
+	  multiblasCuda<NXZ,float2,short2,float2,M,Functor,writeX,writeY,writeZ,writeW>(a,b,c,x,y,z,w,x[0]->Volume());
+#else
+	  errorQuda("blas has not been built for Nspin=%d fields", x[0]->Nspin());
+#endif
+	} else { errorQuda("nSpin=%d is not supported\n", x[0]->Nspin()); }
+
+      } else {
+	errorQuda("Precision combination x=%d y=%d not supported\n", x[0]->Precision(), y[0]->Precision());
+      }
+    } else { // fields on the cpu
+      // using namespace quda::colorspinor;
+      // if (x[0]->Precision() == QUDA_DOUBLE_PRECISION) {
+      //   Functor<NXZ, NYW, double2, double2> f(a, b, c);
+      //   genericMultBlas<double, double, writeX, writeY, writeZ, writeW>(x, y, z, w, f);
+      // } else if (x[0]->Precision() == QUDA_SINGLE_PRECISION) {
+      //   Functor<NXZ, NYW, float2, float2> f(a, make_float2(b.x,b.y), make_float2(c.x,c.y) );
+      //   genericMultBlas<float, float, writeX, writeY, writeZ, writeW>(x, y, z, w, f);
+      // } else {
+      errorQuda("Not implemented");
+      // }
+    }
+
+  }
+
+}

--- a/lib/reduce_mixed_core.h
+++ b/lib/reduce_mixed_core.h
@@ -64,10 +64,9 @@ doubleN reduceCuda(const double2 &a, const double2 &b, ColorSpinorField &x,
       } else if (x.Nspin() == 1) { //staggered
 #ifdef GPU_STAGGERED_DIRAC
 	const int M = 3; // determines how much work per thread to do
-	const int reduce_length = siteUnroll ? x.RealLength() : x.Length();
 	value = reduce::reduceCuda<doubleN,ReduceType,double2,short2,double2,M,Reducer,
 	  writeX,writeY,writeZ,writeW,writeV>
-	  (a, b, x, y, z, w, v, reduce_length/(2*M));
+	  (a, b, x, y, z, w, v, x.Volume());
 #else
 	errorQuda("blas has not been built for Nspin=%d fields", x.Nspin());
 #endif

--- a/lib/reduce_quda.cu
+++ b/lib/reduce_quda.cu
@@ -75,9 +75,9 @@ namespace quda {
     void initReduce()
     {
 
-      const int MaxReduce = 12;
+      const int MaxReduce = 16;
       // reduction buffer size
-      size_t bytes = MaxReduce*3*REDUCE_MAX_BLOCKS*sizeof(QudaSumFloat); // Factor of N for composite reductions
+      size_t bytes = 2*MaxReduce*3*REDUCE_MAX_BLOCKS*sizeof(QudaSumFloat); // Factor of N for composite reductions
 
       if (!d_reduce) d_reduce = (QudaSumFloat *) device_malloc(bytes);
 

--- a/tests/blas_test.cu
+++ b/tests/blas_test.cu
@@ -33,7 +33,7 @@ extern int Msrc;
 
 extern void usage(char** );
 
-const int Nkernels = 37;
+const int Nkernels = 38;
 
 using namespace quda;
 
@@ -425,10 +425,14 @@ double benchmark(int kernel, const int niter) {
       break;
 
     case 35:
-      for (int i=0; i < niter; ++i) blas::caxpy(A, *xmD,* ymD);
+      for (int i=0; i < niter; ++i) blas::axpyReDot(a, *xD, *yD);
       break;
 
     case 36:
+      for (int i=0; i < niter; ++i) blas::caxpy(A, *xmD,* ymD);
+      break;
+
+    case 37:
       for (int i=0; i < niter; ++i) blas::axpyBzpcx((double*)A, xmD->Components(), zmD->Components(), (double*)B, *yD, (double*)C);
       break;
 
@@ -772,6 +776,14 @@ double test(int kernel) {
     break;
 
   case 35:
+    *xD = *xH;
+    *yD = *yH;
+    { double d = blas::axpyReDot(a, *xD, *yD);
+      double h = blas::axpyReDot(a, *xH, *yH);
+      error = ERROR(y) + fabs(d-h)/fabs(h); }
+    break;
+
+  case 36:
     for (int i=0; i < Nsrc; i++) xmD->Component(i) = *(xmH[i]);
     for (int i=0; i < Msrc; i++) ymD->Component(i) = *(ymH[i]);
 
@@ -788,7 +800,7 @@ double test(int kernel) {
     error/= Msrc;
     break;
 
-  case 36:
+  case 37:
     for (int i=0; i < Nsrc; i++) {
       xmD->Component(i) = *(xmH[i]);
       zmD->Component(i) = *(zmH[i]);
@@ -857,8 +869,9 @@ const char *names[] = {
   "xpyHeavyQuarkResidualNorm",
   "tripleCGReduction",
   "tripleCGUpdate",
+  "axpyReDot",
   "caxpy (block)",
-  "axpyBzpcx (block)",
+  "axpyBzpcx (block)"
 };
 
 int main(int argc, char** argv)
@@ -998,8 +1011,9 @@ INSTANTIATE_TEST_CASE_P(HeavyQuarkResidualNorm_half, BlasTest, ::testing::Values
 INSTANTIATE_TEST_CASE_P(xpyHeavyQuarkResidualNorm_half, BlasTest, ::testing::Values( make_int2(0,32) ));
 INSTANTIATE_TEST_CASE_P(TripleCGReduction_half, BlasTest, ::testing::Values( make_int2(0,33) ));
 INSTANTIATE_TEST_CASE_P(TripleCGUpdate_half, BlasTest, ::testing::Values( make_int2(0,34) ));
-INSTANTIATE_TEST_CASE_P(multicaxpy_half, BlasTest, ::testing::Values( make_int2(0,35) ));
-INSTANTIATE_TEST_CASE_P(multiaxpyBzpcx_half, BlasTest, ::testing::Values( make_int2(0,36) ));
+INSTANTIATE_TEST_CASE_P(axpyReDot_half, BlasTest, ::testing::Values( make_int2(0,35) ));
+INSTANTIATE_TEST_CASE_P(multicaxpy_half, BlasTest, ::testing::Values( make_int2(0,36) ));
+INSTANTIATE_TEST_CASE_P(multiaxpyBzpcx_half, BlasTest, ::testing::Values( make_int2(0,37) ));
 
 // single precision
 INSTANTIATE_TEST_CASE_P(copyHS_single, BlasTest, ::testing::Values( make_int2(1,0) ));
@@ -1037,8 +1051,9 @@ INSTANTIATE_TEST_CASE_P(HeavyQuarkResidualNorm_single, BlasTest, ::testing::Valu
 INSTANTIATE_TEST_CASE_P(xpyHeavyQuarkResidualNorm_single, BlasTest, ::testing::Values( make_int2(1,32) ));
 INSTANTIATE_TEST_CASE_P(TripleCGReduction_single, BlasTest, ::testing::Values( make_int2(1,33) ));
 INSTANTIATE_TEST_CASE_P(TripleCGUpdate_single, BlasTest, ::testing::Values( make_int2(1,34) ));
-INSTANTIATE_TEST_CASE_P(multicaxpy_single, BlasTest, ::testing::Values( make_int2(1,35) ));
-INSTANTIATE_TEST_CASE_P(multiaxpyBzpcx_single, BlasTest, ::testing::Values( make_int2(1,36) ));
+INSTANTIATE_TEST_CASE_P(axpyReDot_single, BlasTest, ::testing::Values( make_int2(1,35) ));
+INSTANTIATE_TEST_CASE_P(multicaxpy_single, BlasTest, ::testing::Values( make_int2(1,36) ));
+INSTANTIATE_TEST_CASE_P(multiaxpyBzpcx_single, BlasTest, ::testing::Values( make_int2(1,37) ));
 
 // double precision
 INSTANTIATE_TEST_CASE_P(copyHS_double, BlasTest, ::testing::Values( make_int2(2,0) ));
@@ -1076,5 +1091,6 @@ INSTANTIATE_TEST_CASE_P(HeavyQuarkResidualNorm_double, BlasTest, ::testing::Valu
 INSTANTIATE_TEST_CASE_P(xpyHeavyQuarkResidualNorm_double, BlasTest, ::testing::Values( make_int2(2,32) ));
 INSTANTIATE_TEST_CASE_P(TripleCGReduction_double, BlasTest, ::testing::Values( make_int2(2,33) ));
 INSTANTIATE_TEST_CASE_P(TripleCGUpdate_double, BlasTest, ::testing::Values( make_int2(2,34) ));
-INSTANTIATE_TEST_CASE_P(multicaxpy_double, BlasTest, ::testing::Values( make_int2(2,35) ));
-INSTANTIATE_TEST_CASE_P(multiaxpyBzpcx_double, BlasTest, ::testing::Values( make_int2(2,36) ));
+INSTANTIATE_TEST_CASE_P(axpyReDot_double, BlasTest, ::testing::Values( make_int2(2,35) ));
+INSTANTIATE_TEST_CASE_P(multicaxpy_double, BlasTest, ::testing::Values( make_int2(2,36) ));
+INSTANTIATE_TEST_CASE_P(multiaxpyBzpcx_double, BlasTest, ::testing::Values( make_int2(2,37) ));


### PR DESCRIPTION
This pull request is minor feature and cleanup of the blas and multi-shift solver
* Reduced allocation / free overheads in CG and multi-shift CG, especially apparent for peer-to-peer systems
* Reduced initalization overhead of multi-blas kernels: vector coefficients can be put in the parameter struct instead of explicit copy to `__constant__`
* Mixed-precision support for multi axpyBzpcx kernel and now supports arbitrary length vectors of fields using recursion
* Slight improvement to mixed-precision stability for CG (reprojection of direction vectors should be done using a complex dot product)
* Blas kernels now called directly on full fields instead of recursing to their parity subsets
* Work around for bug in multi-GPU clover derivative on CUDA 7.5
