### PR TITLE
Improve cmake build 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ set(QUDA_QMPHOME "" CACHE PATH "path to QMP")
 #QUDA ADVANCED OPTIONS
 # that ususally should not be changed by users
 #######################################################################
+set(QUDA_BUILD_ALL_TESTS ON CACHE BOOL "build tests by default")
 set(QUDA_BLAS_TEX ON CACHE BOOL "enable texture reads in BLAS?")
 set(QUDA_FERMI_DBLE_TEX ON CACHE BOOL "enable double-precision texture reads on Fermi?")
 set(QUDA_NUMA_NVML OFF CACHE BOOL "experimental use of NVML to set numa affinity" )
@@ -122,6 +123,7 @@ set(QUDA_SSTEP OFF CACHE BOOL "build s-step linear solvers")
 set(QUDA_MULTIGRID OFF CACHE BOOL "build multigrid solvers")
 set(QUDA_BLOCKSOLVER OFF CACHE BOOL "build block solvers")
 
+mark_as_advanced(QUDA_BUILD_ALL_TESTS)
 mark_as_advanced(QUDA_BLAS_TEX)
 mark_as_advanced(QUDA_FERMI_DBLE_TEX)
 mark_as_advanced(QUDA_NUMA_NVML)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,8 @@ ENDIF(GIT_FOUND)
 
 set(VALID_BUILD_TYPES DEVEL RELEASE STRICT DEBUG HOSTDEBUG DEVICEDEBUG )
 SET(CMAKE_BUILD_TYPE "${DEFBUILD}" CACHE STRING  "Choose the type of build, options are: ${VALID_BUILD_TYPES}")
+set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS DEVEL RELEASE STRICT DEBUG HOSTDEBUG DEVICEDEBUG)
+
 string(TOUPPER ${CMAKE_BUILD_TYPE} CHECK_BUILD_TYPE)
 LIST(FIND VALID_BUILD_TYPES ${CHECK_BUILD_TYPE} BUILD_TYPE_VALID)
 
@@ -51,8 +53,8 @@ project("QUDA")
 # QUDA OPTIONS
 # likely to be changed by users
 #######################################################################
-set(QUDA_GPU_ARCH sm_35 CACHE STRING "set the GPU architecture (sm_20, sm_21, sm_30, sm_35, sm_50, sm_52)")
-
+set(QUDA_GPU_ARCH sm_35 CACHE STRING "set the GPU architecture (sm_20, sm_21, sm_30, sm_35, sm_37, sm_50, sm_52, sm_60)")
+set_property(CACHE QUDA_GPU_ARCH PROPERTY STRINGS sm_20 sm_21 sm_30 sm_35 sm_37 sm_50 sm_52 sm_60)
 # build options
 set(QUDA_DIRAC_WILSON ON CACHE BOOL "build Wilson Dirac operators")
 set(QUDA_DIRAC_CLOVER ON CACHE BOOL "build clover Dirac operators")

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -62,6 +62,7 @@ ENDFOREACH(item ${QUDA_OBJS})
 LIST(REMOVE_ITEM QUDA_OBJS ${QUDA_CU_OBJS})
 if(BUILD_FORTRAN_INTERFACE)
   LIST(APPEND QUDA_OBJS quda_fortran.F90)
+  set_source_files_properties(quda_fortran.F90 PROPERTIES OBJECT_OUTPUTS ${CMAKE_CURRENT_BINARY_DIR}/quda_fortran.mod)
 endif()
 
 # QUDA_CU_OBJS shoudl contain all cuda files now

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,84 +28,109 @@ if(QUDA_NUMA_NVML)
 endif()
 
 
+MACRO (QUDA_CHECKBUILDTEST mytarget qudabuildtests)
+  IF(NOT ${qudabuildtests})
+    set_property(TARGET ${mytarget} PROPERTY EXCLUDE_FROM_ALL 1)
+  ENDIF()
+ENDMACRO()
 #define tests
 
 if(${QUDA_DIRAC_WILSON} OR ${QUDA_DIRAC_CLOVER} OR ${QUDA_DIRAC_TWISTED_MASS} OR ${QUDA_DIRAC_TWISTED_CLOVER} OR ${QUDA_DIRAC_DOMAIN_WALL})
   cuda_add_executable(dslash_test dslash_test.cpp wilson_dslash_reference.cpp domain_wall_dslash_reference.cpp clover_reference.cpp blas_reference.cpp)
   target_link_libraries(dslash_test ${TEST_LIBS} )
+  QUDA_CHECKBUILDTEST(dslash_test QUDA_BUILDALLTESTS)
 
   cuda_add_executable(invert_test invert_test.cpp wilson_dslash_reference.cpp domain_wall_dslash_reference.cpp clover_reference.cpp blas_reference.cpp)
   target_link_libraries(invert_test ${TEST_LIBS})
+  QUDA_CHECKBUILDTEST(invert_test QUDA_BUILDALLTESTS)
+
 
   if(${QUDA_BLOCKSOLVER})
     cuda_add_executable(invertmsrc_test invertmsrc_test.cpp wilson_dslash_reference.cpp domain_wall_dslash_reference.cpp blas_reference.cpp)
     target_link_libraries(invertmsrc_test ${TEST_LIBS})
+    QUDA_CHECKBUILDTEST(invertmsrc_test QUDA_BUILDALLTESTS)
   endif()
 
 endif()
 
 cuda_add_executable(deflation_test deflation_test.cpp wilson_dslash_reference.cpp domain_wall_dslash_reference.cpp blas_reference.cpp)
 target_link_libraries(deflation_test ${TEST_LIBS})
+QUDA_CHECKBUILDTEST(deflation_test QUDA_BUILDALLTESTS)
 
 if(${QUDA_DIRAC_STAGGERED})
   cuda_add_executable(staggered_dslash_test staggered_dslash_test.cpp staggered_dslash_reference.cpp blas_reference.cpp)
   target_link_libraries(staggered_dslash_test ${TEST_LIBS})
+  QUDA_CHECKBUILDTEST(staggered_dslash_test QUDA_BUILDALLTESTS)
 
   cuda_add_executable(staggered_invert_test staggered_invert_test.cpp staggered_dslash_reference.cpp blas_reference.cpp)
   target_link_libraries(staggered_invert_test ${TEST_LIBS})
+  QUDA_CHECKBUILDTEST(staggered_invert_test QUDA_BUILDALLTESTS)
 
   if(${QUDA_BLOCKSOLVER})
     cuda_add_executable(staggered_invertmsrc_test staggered_invertmsrc_test.cpp  staggered_dslash_reference.cpp  blas_reference.cpp)
     target_link_libraries(staggered_invertmsrc_test ${TEST_LIBS})
+    QUDA_CHECKBUILDTEST(staggered_invertmsrc_test QUDA_BUILDALLTESTS)
   endif()
 endif()
 
 if(${QUDA_MULTIGRID})
   cuda_add_executable(multigrid_invert_test multigrid_invert_test.cpp wilson_dslash_reference.cpp clover_reference.cpp domain_wall_dslash_reference.cpp blas_reference.cpp)
   target_link_libraries(multigrid_invert_test ${TEST_LIBS})
+  QUDA_CHECKBUILDTEST(multigrid_invert_test QUDA_BUILDALLTESTS)
 
   cuda_add_executable(multigrid_benchmark_test multigrid_benchmark_test.cu)
   target_link_libraries(multigrid_benchmark_test ${TEST_LIBS})
+  QUDA_CHECKBUILDTEST(multigrid_benchmark_test QUDA_BUILDALLTESTS)
 endif()
 
 cuda_add_executable(su3_test su3_test.cpp)
 target_link_libraries(su3_test ${TEST_LIBS})
+QUDA_CHECKBUILDTEST(su3_test QUDA_BUILDALLTESTS)
 
 cuda_add_executable(pack_test pack_test.cpp)
 target_link_libraries(pack_test ${TEST_LIBS})
+QUDA_CHECKBUILDTEST(pack_test QUDA_BUILDALLTESTS)
 
 cuda_add_executable(blas_test blas_test.cu)
 target_link_libraries(blas_test ${TEST_LIBS})
+QUDA_CHECKBUILDTEST(blas_test QUDA_BUILDALLTESTS)
 
 if(${QUDA_LINK_ASQTAD} OR ${QUDA_LINK_HISQ})
   cuda_add_executable(llfat_test llfat_test.cpp llfat_reference.cpp)
   target_link_libraries(llfat_test ${TEST_LIBS})
+  QUDA_CHECKBUILDTEST(llfat_test QUDA_BUILDALLTESTS)
 endif()
 
 if(${QUDA_LINK_HISQ})
   cuda_add_executable(unitarize_link_test unitarize_link_test.cpp)
   target_link_libraries(unitarize_link_test ${TEST_LIBS})
+  QUDA_CHECKBUILDTEST(unitarize_link_test QUDA_BUILDALLTESTS)
 endif()
 
 if(${QUDA_FORCE_GAUGE})
   cuda_add_executable(gauge_force_test gauge_force_test.cpp gauge_force_reference.cpp)
   target_link_libraries(gauge_force_test ${TEST_LIBS})
+  QUDA_CHECKBUILDTEST(gauge_force_test QUDA_BUILDALLTESTS)
 endif()
 
 if(${QUDA_FORCE_ASQTAD})
   cuda_add_executable(fermion_force_test fermion_force_test.cpp fermion_force_reference.cpp)
   target_link_libraries(fermion_force_test ${TEST_LIBS})
+  QUDA_CHECKBUILDTEST(fermion_force_test QUDA_BUILDALLTESTS)
 endif()
 
 if(${QUDA_GAUGE_ALG})
   cuda_add_executable(gauge_alg_test gauge_alg_test.cpp)
   target_link_libraries(gauge_alg_test ${TEST_LIBS})
+  QUDA_CHECKBUILDTEST(gauge_alg_test QUDA_BUILDALLTESTS)
 endif()
 
 if(${QUDA_FORCE_HISQ})
   cuda_add_executable(hisq_paths_force_test hisq_paths_force_test.cpp hisq_force_reference.cpp hisq_force_reference2.cpp fermion_force_reference.cpp   )
   target_link_libraries(hisq_paths_force_test ${TEST_LIBS})
+  QUDA_CHECKBUILDTEST(hisq_paths_force_test QUDA_BUILDALLTESTS)
 
   cuda_add_executable(hisq_unitarize_force_test hisq_unitarize_force_test.cpp hisq_force_reference.cpp )
   target_link_libraries(hisq_unitarize_force_test ${TEST_LIBS})
+  QUDA_CHECKBUILDTEST(hisq_unitarize_force_test QUDA_BUILDALLTESTS)
 endif()


### PR DESCRIPTION
This adds some small improvements to the cmake build:

* make `QUDA_GPU_ARCH` and `CMAKE_BUILD_TYPE` dropdown lists (in ccmake and cmake-gui)
* regenerate `.mod` files when FORTAN INTERFACE is build
* adds `QUDA_BUILD_ALL_TESTS` advanced options to turn exclude tests from default build