### PR TITLE
fixed bug in the cg solver 

### DIFF
--- a/lib/inv_cg_quda.cpp
+++ b/lib/inv_cg_quda.cpp
@@ -71,6 +71,7 @@ namespace quda {
     ColorSpinorField &tmp = *tmpp;
 
     csParam.setPrecision(param.precision_sloppy);
+    csParam.create = QUDA_ZERO_FIELD_CREATE;
 
     // tmp2 only needed for multi-gpu Wilson-like kernels
     ColorSpinorField *tmp2_p = !mat.isStaggered() ? ColorSpinorField::Create(x, csParam) : &tmp;


### PR DESCRIPTION
csParam in the solver is not properly initialized (i.e., contains QUDA_INVALID_FIELD_CREATE ) when re-used as a preconditioner. 