### PR TITLE
Hotfix/milc rhmc

### DIFF
--- a/lib/clover_field.cpp
+++ b/lib/clover_field.cpp
@@ -45,7 +45,7 @@ namespace quda {
     real_length = 2*volumeCB*nColor*nColor*nSpin*nSpin/2;  // block-diagonal Hermitian (72 reals)
     length = 2*stride*nColor*nColor*nSpin*nSpin/2;
 
-    bytes = length*precision;
+    bytes = (size_t)length*precision;
     bytes = 2*ALIGNMENT_ADJUST(bytes/2);
     if (precision == QUDA_HALF_PRECISION) {
       norm_bytes = sizeof(float)*2*stride*2; // 2 chirality

--- a/lib/color_spinor_field.cpp
+++ b/lib/color_spinor_field.cpp
@@ -120,7 +120,7 @@ namespace quda {
       printfQuda("ghost length = %lu, ghost norm length = %lu\n", ghost_length, ghost_norm_length);
     }
 
-    ghost_bytes = ghost_length*precision;
+    ghost_bytes = (size_t)ghost_length*precision;
     if (precision == QUDA_HALF_PRECISION) ghost_bytes += ghost_norm_length*sizeof(float);
     ghost_bytes = (siteSubset == QUDA_FULL_SITE_SUBSET) ? 2*ALIGNMENT_ADJUST(ghost_bytes/2) : ALIGNMENT_ADJUST(ghost_bytes);
 
@@ -167,7 +167,7 @@ namespace quda {
 
     real_length = volume*nColor*nSpin*2; // physical length
 
-    bytes = length * precision; // includes pads and ghost zones
+    bytes = (size_t)length * precision; // includes pads and ghost zones
     bytes = (siteSubset == QUDA_FULL_SITE_SUBSET && fieldOrder != QUDA_QDPJIT_FIELD_ORDER) ? 2*ALIGNMENT_ADJUST(bytes/2) : ALIGNMENT_ADJUST(bytes);
     bytes = (siteSubset == QUDA_FULL_SITE_SUBSET) ? 2*ALIGNMENT_ADJUST(bytes/2) : ALIGNMENT_ADJUST(bytes);
 
@@ -311,7 +311,7 @@ namespace quda {
 
     real_length = volume*nColor*nSpin*2;
 
-    bytes = length * precision; // includes pads
+    bytes = (size_t)length * precision; // includes pads
     bytes = (siteSubset == QUDA_FULL_SITE_SUBSET && fieldOrder != QUDA_QDPJIT_FIELD_ORDER) ? 2*ALIGNMENT_ADJUST(bytes/2) : ALIGNMENT_ADJUST(bytes);
 
     if (precision == QUDA_HALF_PRECISION) {

--- a/lib/gauge_field.cpp
+++ b/lib/gauge_field.cpp
@@ -82,8 +82,8 @@ namespace quda {
 
     if (reconstruct == QUDA_RECONSTRUCT_9 || reconstruct == QUDA_RECONSTRUCT_13) {
       // Need to adjust the phase alignment as well.  
-      int half_phase_bytes = (length/(2*reconstruct))*precision; // number of bytes needed to store phases for a single parity
-      int half_gauge_bytes = (length/2)*precision - half_phase_bytes; // number of bytes needed to store the gauge field for a single parity excluding the phases
+      int half_phase_bytes = ((size_t)length/(2*reconstruct))*precision; // number of bytes needed to store phases for a single parity
+      int half_gauge_bytes = ((size_t)length/2)*precision - half_phase_bytes; // number of bytes needed to store the gauge field for a single parity excluding the phases
       // Adjust the alignments for the gauge and phase separately
       half_phase_bytes = ((half_phase_bytes + (512-1))/512)*512;
       half_gauge_bytes = ((half_gauge_bytes + (512-1))/512)*512;
@@ -92,7 +92,7 @@ namespace quda {
       phase_bytes = half_phase_bytes*2;
       bytes = (half_gauge_bytes + half_phase_bytes)*2;      
     } else {
-      bytes = length*precision;
+      bytes = (size_t)length*precision;
       bytes = 2*ALIGNMENT_ADJUST(bytes/2);
     }
     total_bytes = bytes;

--- a/lib/gauge_force.cu
+++ b/lib/gauge_force.cu
@@ -78,7 +78,7 @@ namespace quda {
     extern __shared__ int s[];
     int tid = (threadIdx.z*blockDim.y + threadIdx.y)*blockDim.x + threadIdx.x;
     s[tid] = 0;
-    char *dx = (char*)&s[tid];
+    signed char *dx = (signed char*)&s[tid];
 #else
     int dx[4] = {0, 0, 0, 0};
 #endif

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -4360,6 +4360,7 @@ computeHISQForceQuda(void* const milc_momentum,
   param.link_type = QUDA_ASQTAD_MOM_LINKS;
   param.reconstruct = QUDA_RECONSTRUCT_10;
   param.gauge = (void*)milc_momentum;
+  param.ghostExchange =  QUDA_GHOST_EXCHANGE_NO;
   cpuGaugeField* cpuMom = (!gParam->use_resident_mom) ? new cpuGaugeField(param) : NULL;
 
   param.create = QUDA_ZERO_FIELD_CREATE;
@@ -4378,7 +4379,6 @@ computeHISQForceQuda(void* const milc_momentum,
   cpuGaugeField cpuULink(param);
   param.create = QUDA_ZERO_FIELD_CREATE;
 
-  param.ghostExchange =  QUDA_GHOST_EXCHANGE_NO;
   param.order = QUDA_FLOAT2_GAUGE_ORDER;
   cudaGaugeField* cudaGauge = new cudaGaugeField(param);
 


### PR DESCRIPTION
Fixes a number of bugs
* Correctly compute the `bytes` of large fields (previously 32-bit overflow issues for fields > 1 GiB)
* Momentum fields in HISQ force computation should not exchange ghosts (fixes GPU reordering for HISQ HMC)
* Fix for gauge force when running on POWER architecture   