### PR TITLE
remove spurious check for compute mode in peer2peer initialization

### DIFF
--- a/lib/comm_mpi.cpp
+++ b/lib/comm_mpi.cpp
@@ -120,7 +120,7 @@ void comm_peer2peer_init(const char* hostname_recv_buf)
     // first check that the local GPU supports UVA
     cudaDeviceProp prop;
     cudaGetDeviceProperties(&prop,gpuid);
-    if(!prop.unifiedAddressing || prop.computeMode != cudaComputeModeDefault) return;
+    if(!prop.unifiedAddressing) return;
 
     comm_set_neighbor_ranks();
 

--- a/lib/comm_qmp.cpp
+++ b/lib/comm_qmp.cpp
@@ -131,10 +131,10 @@ void comm_peer2peer_init(const char* hostname_recv_buf)
 
   if (!peer2peer_init && !disable_peer_to_peer) {
 
-    // first check that the local GPU supports UVA
+    first check that the local GPU supports UVA
     cudaDeviceProp prop;
     cudaGetDeviceProperties(&prop,gpuid);
-    if(!prop.unifiedAddressing || prop.computeMode != cudaComputeModeDefault) return;
+    if(!prop.unifiedAddressing) return;
 
     comm_set_neighbor_ranks();
 


### PR DESCRIPTION
I left the check for UVA for now. Guess we can remove that as well but did not check in detail.