### PR TITLE
Feature/tifr milc cleanup

### DIFF
--- a/include/color_spinor_field.h
+++ b/include/color_spinor_field.h
@@ -490,6 +490,7 @@ namespace quda {
 
     static size_t ghostFaceBytes;
     static void *ghost_field[2];     // GPU halo receive buffer
+    void *ghost_field_tex[2]; // instance pointer to GPU halo buffer (used to check if static allocation has changed)
     static void *ghostFaceBuffer[2]; // GPU halo send buffer
     static void *fwdGhostFaceBuffer[2][QUDA_MAX_DIM]; // pointers to ghostFaceBuffer
     static void *backGhostFaceBuffer[2][QUDA_MAX_DIM]; // pointers to ghostFaceBuffer

--- a/lib/cuda_color_spinor_field.cu
+++ b/lib/cuda_color_spinor_field.cu
@@ -429,7 +429,6 @@ namespace quda {
 
   void cudaColorSpinorField::destroyTexObject() {
     if (isNative() && texInit) {
-      cudaDeviceSynchronize();
       cudaDestroyTextureObject(tex);
       if (ghost_bytes) {
 	cudaDestroyTextureObject(ghostTex[0]);
@@ -448,7 +447,6 @@ namespace quda {
 
   void cudaColorSpinorField::destroyGhostTexObject() {
     if (isNative() && ghostTexInit) {
-      cudaDeviceSynchronize();
       cudaDestroyTextureObject(ghostTex[0]);
       cudaDestroyTextureObject(ghostTex[1]);
       if (precision == QUDA_HALF_PRECISION) {
@@ -979,7 +977,6 @@ namespace quda {
     if (!initComms || nFaceComms != nFace || bufferMessageHandler != bufferPinnedResizeCount) {
 
       // if we are requesting a new number of faces destroy and start over
-      destroyIPCComms();
       destroyComms();
 
       if (siteSubset != QUDA_PARITY_SITE_SUBSET) 
@@ -1237,6 +1234,7 @@ namespace quda {
       checkCudaError();
     }
 
+    if (ghost_field_reset) destroyIPCComms();
     createIPCComms();
   }
    

--- a/lib/dslash_core/dw_dslash4_core.h
+++ b/lib/dslash_core/dw_dslash4_core.h
@@ -298,7 +298,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]<X1m1)) |
  const int sp_idx = (coord[0]==X1m1 ? X-X1m1 : X+1) >> 1;
 #endif
 
- const int ga_idx = sid % Vh;
+ const int ga_idx = sid % param.volume4CB;
 
  // read gauge matrix from device memory
  ASSN_GAUGE_MATRIX(G, GAUGE0TEX, 0, ga_idx, ga_stride);
@@ -492,9 +492,9 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]>0)) ||
 #endif
 
 #ifdef MULTI_GPU
- const int ga_idx = ((kernel_type == INTERIOR_KERNEL) ? sp_idx % Vh : Vh+(face_idx % ghostFace[static_cast<int>(kernel_type)]));
+ const int ga_idx = ((kernel_type == INTERIOR_KERNEL) ? sp_idx % param.volume4CB : param.volume4CB+(face_idx % ghostFace[static_cast<int>(kernel_type)]));
 #else
- const int ga_idx = sp_idx % Vh;
+ const int ga_idx = sp_idx % param.volume4CB;
 #endif
 
  // read gauge matrix from device memory
@@ -688,7 +688,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]<X2m1)) |
  const int sp_idx = (coord[1]==X2m1 ? X-X2X1mX1 : X+X1) >> 1;
 #endif
 
- const int ga_idx = sid % Vh;
+ const int ga_idx = sid % param.volume4CB;
 
  // read gauge matrix from device memory
  ASSN_GAUGE_MATRIX(G, GAUGE0TEX, 2, ga_idx, ga_stride);
@@ -882,9 +882,9 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]>0)) ||
 #endif
 
 #ifdef MULTI_GPU
- const int ga_idx = ((kernel_type == INTERIOR_KERNEL) ? sp_idx % Vh : Vh+(face_idx % ghostFace[static_cast<int>(kernel_type)]));
+ const int ga_idx = ((kernel_type == INTERIOR_KERNEL) ? sp_idx % param.volume4CB : param.volume4CB+(face_idx % ghostFace[static_cast<int>(kernel_type)]));
 #else
- const int ga_idx = sp_idx % Vh;
+ const int ga_idx = sp_idx % param.volume4CB;
 #endif
 
  // read gauge matrix from device memory
@@ -1078,7 +1078,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]<X3m1)) |
  const int sp_idx = (coord[2]==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1;
 #endif
 
- const int ga_idx = sid % Vh;
+ const int ga_idx = sid % param.volume4CB;
 
  // read gauge matrix from device memory
  ASSN_GAUGE_MATRIX(G, GAUGE0TEX, 4, ga_idx, ga_stride);
@@ -1272,9 +1272,9 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]>0)) ||
 #endif
 
 #ifdef MULTI_GPU
- const int ga_idx = ((kernel_type == INTERIOR_KERNEL) ? sp_idx % Vh : Vh+(face_idx % ghostFace[static_cast<int>(kernel_type)]));
+ const int ga_idx = ((kernel_type == INTERIOR_KERNEL) ? sp_idx % param.volume4CB : param.volume4CB+(face_idx % ghostFace[static_cast<int>(kernel_type)]));
 #else
- const int ga_idx = sp_idx % Vh;
+ const int ga_idx = sp_idx % param.volume4CB;
 #endif
 
  // read gauge matrix from device memory
@@ -1468,7 +1468,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]<X4m1)) |
  const int sp_idx = (coord[3]==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1;
 #endif
 
- const int ga_idx = sid % Vh;
+ const int ga_idx = sid % param.volume4CB;
 
  if (gauge_fixed && ga_idx < X4X3X2X1hmX3X2X1h)
  {
@@ -1724,9 +1724,9 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]>0)) ||
 #endif
 
 #ifdef MULTI_GPU
- const int ga_idx = ((kernel_type == INTERIOR_KERNEL) ? sp_idx % Vh : Vh+(face_idx % ghostFace[static_cast<int>(kernel_type)]));
+ const int ga_idx = ((kernel_type == INTERIOR_KERNEL) ? sp_idx % param.volume4CB : param.volume4CB+(face_idx % ghostFace[static_cast<int>(kernel_type)]));
 #else
- const int ga_idx = sp_idx % Vh;
+ const int ga_idx = sp_idx % param.volume4CB;
 #endif
 
  if (gauge_fixed && ga_idx < X4X3X2X1hmX3X2X1h)

--- a/lib/dslash_core/dw_dslash4_dagger_core.h
+++ b/lib/dslash_core/dw_dslash4_dagger_core.h
@@ -298,7 +298,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]<X1m1)) |
  const int sp_idx = (coord[0]==X1m1 ? X-X1m1 : X+1) >> 1;
 #endif
 
- const int ga_idx = sid % Vh;
+ const int ga_idx = sid % param.volume4CB;
 
  // read gauge matrix from device memory
  ASSN_GAUGE_MATRIX(G, GAUGE0TEX, 0, ga_idx, ga_stride);
@@ -492,9 +492,9 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]>0)) ||
 #endif
 
 #ifdef MULTI_GPU
- const int ga_idx = ((kernel_type == INTERIOR_KERNEL) ? sp_idx % Vh : Vh+(face_idx % ghostFace[static_cast<int>(kernel_type)]));
+ const int ga_idx = ((kernel_type == INTERIOR_KERNEL) ? sp_idx % param.volume4CB : param.volume4CB+(face_idx % ghostFace[static_cast<int>(kernel_type)]));
 #else
- const int ga_idx = sp_idx % Vh;
+ const int ga_idx = sp_idx % param.volume4CB;
 #endif
 
  // read gauge matrix from device memory
@@ -688,7 +688,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]<X2m1)) |
  const int sp_idx = (coord[1]==X2m1 ? X-X2X1mX1 : X+X1) >> 1;
 #endif
 
- const int ga_idx = sid % Vh;
+ const int ga_idx = sid % param.volume4CB;
 
  // read gauge matrix from device memory
  ASSN_GAUGE_MATRIX(G, GAUGE0TEX, 2, ga_idx, ga_stride);
@@ -882,9 +882,9 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]>0)) ||
 #endif
 
 #ifdef MULTI_GPU
- const int ga_idx = ((kernel_type == INTERIOR_KERNEL) ? sp_idx % Vh : Vh+(face_idx % ghostFace[static_cast<int>(kernel_type)]));
+ const int ga_idx = ((kernel_type == INTERIOR_KERNEL) ? sp_idx % param.volume4CB : param.volume4CB+(face_idx % ghostFace[static_cast<int>(kernel_type)]));
 #else
- const int ga_idx = sp_idx % Vh;
+ const int ga_idx = sp_idx % param.volume4CB;
 #endif
 
  // read gauge matrix from device memory
@@ -1078,7 +1078,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]<X3m1)) |
  const int sp_idx = (coord[2]==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1;
 #endif
 
- const int ga_idx = sid % Vh;
+ const int ga_idx = sid % param.volume4CB;
 
  // read gauge matrix from device memory
  ASSN_GAUGE_MATRIX(G, GAUGE0TEX, 4, ga_idx, ga_stride);
@@ -1272,9 +1272,9 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]>0)) ||
 #endif
 
 #ifdef MULTI_GPU
- const int ga_idx = ((kernel_type == INTERIOR_KERNEL) ? sp_idx % Vh : Vh+(face_idx % ghostFace[static_cast<int>(kernel_type)]));
+ const int ga_idx = ((kernel_type == INTERIOR_KERNEL) ? sp_idx % param.volume4CB : param.volume4CB+(face_idx % ghostFace[static_cast<int>(kernel_type)]));
 #else
- const int ga_idx = sp_idx % Vh;
+ const int ga_idx = sp_idx % param.volume4CB;
 #endif
 
  // read gauge matrix from device memory
@@ -1468,7 +1468,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]<X4m1)) |
  const int sp_idx = (coord[3]==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1;
 #endif
 
- const int ga_idx = sid % Vh;
+ const int ga_idx = sid % param.volume4CB;
 
  if (gauge_fixed && ga_idx < X4X3X2X1hmX3X2X1h)
  {
@@ -1724,9 +1724,9 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]>0)) ||
 #endif
 
 #ifdef MULTI_GPU
- const int ga_idx = ((kernel_type == INTERIOR_KERNEL) ? sp_idx % Vh : Vh+(face_idx % ghostFace[static_cast<int>(kernel_type)]));
+ const int ga_idx = ((kernel_type == INTERIOR_KERNEL) ? sp_idx % param.volume4CB : param.volume4CB+(face_idx % ghostFace[static_cast<int>(kernel_type)]));
 #else
- const int ga_idx = sp_idx % Vh;
+ const int ga_idx = sp_idx % param.volume4CB;
 #endif
 
  if (gauge_fixed && ga_idx < X4X3X2X1hmX3X2X1h)

--- a/lib/dslash_core/dw_dslash5_core.h
+++ b/lib/dslash_core/dw_dslash5_core.h
@@ -155,7 +155,7 @@ coord[4] = X/(X1*X2*X3*X4);
 {
 // 2 P_L = 2 P_- = ( ( +1, -1 ), ( -1, +1 ) )
   {
-     int sp_idx = ( coord[4] == param.Ls-1 ? X-(param.Ls-1)*2*Vh : X+2*Vh ) / 2;
+     int sp_idx = ( coord[4] == param.Ls-1 ? X-(param.Ls-1)*2*param.volume4CB : X+2*param.volume4CB ) / 2;
 
 // read spinor from device memory
      READ_SPINOR( SPINORTEX, param.sp_stride, sp_idx, sp_idx );
@@ -200,7 +200,7 @@ coord[4] = X/(X1*X2*X3*X4);
 
  // 2 P_R = 2 P_+ = ( ( +1, +1 ), ( +1, +1 ) )
   {
-    int sp_idx = ( coord[4] == 0 ? X+(param.Ls-1)*2*Vh : X-2*Vh ) / 2;
+    int sp_idx = ( coord[4] == 0 ? X+(param.Ls-1)*2*param.volume4CB : X-2*param.volume4CB ) / 2;
 
 // read spinor from device memory
     READ_SPINOR( SPINORTEX, param.sp_stride, sp_idx, sp_idx );

--- a/lib/dslash_core/dw_dslash5_dagger_core.h
+++ b/lib/dslash_core/dw_dslash5_dagger_core.h
@@ -155,7 +155,7 @@ coord[4] = X/(X1*X2*X3*X4);
 {
 // 2 P_L = 2 P_- = ( ( +1, -1 ), ( -1, +1 ) )
   {
-     int sp_idx = ( coord[4] == 0 ? X+(param.Ls-1)*2*Vh : X-2*Vh ) / 2;
+     int sp_idx = ( coord[4] == 0 ? X+(param.Ls-1)*2*param.volume4CB : X-2*param.volume4CB ) / 2;
 
 // read spinor from device memory
      READ_SPINOR( SPINORTEX, param.sp_stride, sp_idx, sp_idx );
@@ -200,7 +200,7 @@ coord[4] = X/(X1*X2*X3*X4);
 
  // 2 P_R = 2 P_+ = ( ( +1, +1 ), ( +1, +1 ) )
   {
-    int sp_idx = ( coord[4] == param.Ls-1 ? X-(param.Ls-1)*2*Vh : X+2*Vh ) / 2;
+    int sp_idx = ( coord[4] == param.Ls-1 ? X-(param.Ls-1)*2*param.volume4CB : X+2*param.volume4CB ) / 2;
 
 // read spinor from device memory
     READ_SPINOR( SPINORTEX, param.sp_stride, sp_idx, sp_idx );

--- a/lib/dslash_core/dw_dslash5inv_core.h
+++ b/lib/dslash_core/dw_dslash5inv_core.h
@@ -166,7 +166,7 @@ VOLATILE spinorFloat kappa;
 // 'w' means output vector
 // 'v' means input vector
 {
-  int base_idx = sid%Vh;
+  int base_idx = sid%param.volume4CB;
   int sp_idx;
 
 // let's assume the index,
@@ -183,7 +183,7 @@ VOLATILE spinorFloat kappa;
     int exponent = coord[4] < s ? param.Ls-s+coord[4] : coord[4]-s;
     factorR = inv_d_n * POW(kappa,exponent) * ( coord[4] < s ? -mferm : static_cast<spinorFloat>(1.0) );
 
-    sp_idx = base_idx + s*Vh;
+    sp_idx = base_idx + s*param.volume4CB;
     // read spinor from device memory
     READ_SPINOR( SPINORTEX, param.sp_stride, sp_idx, sp_idx );
 

--- a/lib/dslash_core/dw_dslash5inv_dagger_core.h
+++ b/lib/dslash_core/dw_dslash5inv_dagger_core.h
@@ -166,7 +166,7 @@ VOLATILE spinorFloat kappa;
 // 'w' means output vector
 // 'v' means input vector
 {
-  int base_idx = sid%Vh;
+  int base_idx = sid%param.volume4CB;
   int sp_idx;
 
 // let's assume the index,
@@ -183,7 +183,7 @@ VOLATILE spinorFloat kappa;
     int exponent = coord[4]  > s ? param.Ls-coord[4]+s : s-coord[4];
     factorR = inv_d_n * POW(kappa,exponent) * ( coord[4] > s ? -mferm : static_cast<spinorFloat>(1.0) );
 
-    sp_idx = base_idx + s*Vh;
+    sp_idx = base_idx + s*param.volume4CB;
     // read spinor from device memory
     READ_SPINOR( SPINORTEX, param.sp_stride, sp_idx, sp_idx );
 

--- a/lib/dslash_core/dw_dslash_core.h
+++ b/lib/dslash_core/dw_dslash_core.h
@@ -285,7 +285,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]<X1m1)) |
  const int sp_idx = (coord[0]==X1m1 ? X-X1m1 : X+1) >> 1;
 #endif
 
- const int ga_idx = sid % Vh;
+ const int ga_idx = sid % param.volume4CB;
 
  // read gauge matrix from device memory
  if ( ! s_parity ) { ASSN_GAUGE_MATRIX(G, GAUGE0TEX, 0, ga_idx, ga_stride); }
@@ -480,9 +480,9 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]>0)) ||
 #endif
 
 #ifdef MULTI_GPU
- const int ga_idx = ((kernel_type == INTERIOR_KERNEL) ? sp_idx % Vh : Vh+(face_idx % ghostFace[static_cast<int>(kernel_type)]));
+ const int ga_idx = ((kernel_type == INTERIOR_KERNEL) ? sp_idx % param.volume4CB : param.volume4CB+(face_idx % ghostFace[static_cast<int>(kernel_type)]));
 #else
- const int ga_idx = sp_idx % Vh;
+ const int ga_idx = sp_idx % param.volume4CB;
 #endif
 
  // read gauge matrix from device memory
@@ -677,7 +677,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]<X2m1)) |
  const int sp_idx = (coord[1]==X2m1 ? X-X2X1mX1 : X+X1) >> 1;
 #endif
 
- const int ga_idx = sid % Vh;
+ const int ga_idx = sid % param.volume4CB;
 
  // read gauge matrix from device memory
  if ( ! s_parity ) { ASSN_GAUGE_MATRIX(G, GAUGE0TEX, 2, ga_idx, ga_stride); }
@@ -872,9 +872,9 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]>0)) ||
 #endif
 
 #ifdef MULTI_GPU
- const int ga_idx = ((kernel_type == INTERIOR_KERNEL) ? sp_idx % Vh : Vh+(face_idx % ghostFace[static_cast<int>(kernel_type)]));
+ const int ga_idx = ((kernel_type == INTERIOR_KERNEL) ? sp_idx % param.volume4CB : param.volume4CB+(face_idx % ghostFace[static_cast<int>(kernel_type)]));
 #else
- const int ga_idx = sp_idx % Vh;
+ const int ga_idx = sp_idx % param.volume4CB;
 #endif
 
  // read gauge matrix from device memory
@@ -1069,7 +1069,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]<X3m1)) |
  const int sp_idx = (coord[2]==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1;
 #endif
 
- const int ga_idx = sid % Vh;
+ const int ga_idx = sid % param.volume4CB;
 
  // read gauge matrix from device memory
  if ( ! s_parity ) { ASSN_GAUGE_MATRIX(G, GAUGE0TEX, 4, ga_idx, ga_stride); }
@@ -1264,9 +1264,9 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]>0)) ||
 #endif
 
 #ifdef MULTI_GPU
- const int ga_idx = ((kernel_type == INTERIOR_KERNEL) ? sp_idx % Vh : Vh+(face_idx % ghostFace[static_cast<int>(kernel_type)]));
+ const int ga_idx = ((kernel_type == INTERIOR_KERNEL) ? sp_idx % param.volume4CB : param.volume4CB+(face_idx % ghostFace[static_cast<int>(kernel_type)]));
 #else
- const int ga_idx = sp_idx % Vh;
+ const int ga_idx = sp_idx % param.volume4CB;
 #endif
 
  // read gauge matrix from device memory
@@ -1461,7 +1461,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]<X4m1)) |
  const int sp_idx = (coord[3]==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1;
 #endif
 
- const int ga_idx = sid % Vh;
+ const int ga_idx = sid % param.volume4CB;
 
  if (gauge_fixed && ga_idx < X4X3X2X1hmX3X2X1h)
  {
@@ -1718,9 +1718,9 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]>0)) ||
 #endif
 
 #ifdef MULTI_GPU
- const int ga_idx = ((kernel_type == INTERIOR_KERNEL) ? sp_idx % Vh : Vh+(face_idx % ghostFace[static_cast<int>(kernel_type)]));
+ const int ga_idx = ((kernel_type == INTERIOR_KERNEL) ? sp_idx % param.volume4CB : param.volume4CB+(face_idx % ghostFace[static_cast<int>(kernel_type)]));
 #else
- const int ga_idx = sp_idx % Vh;
+ const int ga_idx = sp_idx % param.volume4CB;
 #endif
 
  if (gauge_fixed && ga_idx < X4X3X2X1hmX3X2X1h)
@@ -1965,7 +1965,7 @@ if(kernel_type == INTERIOR_KERNEL)
 {
 // 2 P_L = 2 P_- = ( ( +1, -1 ), ( -1, +1 ) )
   {
-     int sp_idx = ( coord[4] == param.Ls-1 ? X-(param.Ls-1)*2*Vh : X+2*Vh ) / 2;
+     int sp_idx = ( coord[4] == param.Ls-1 ? X-(param.Ls-1)*2*param.volume4CB : X+2*param.volume4CB ) / 2;
 
 // read spinor from device memory
      READ_SPINOR( SPINORTEX, param.sp_stride, sp_idx, sp_idx );
@@ -2010,7 +2010,7 @@ if(kernel_type == INTERIOR_KERNEL)
 
  // 2 P_R = 2 P_+ = ( ( +1, +1 ), ( +1, +1 ) )
   {
-    int sp_idx = ( coord[4] == 0 ? X+(param.Ls-1)*2*Vh : X-2*Vh ) / 2;
+    int sp_idx = ( coord[4] == 0 ? X+(param.Ls-1)*2*param.volume4CB : X-2*param.volume4CB ) / 2;
 
 // read spinor from device memory
     READ_SPINOR( SPINORTEX, param.sp_stride, sp_idx, sp_idx );

--- a/lib/dslash_core/dw_dslash_dagger_core.h
+++ b/lib/dslash_core/dw_dslash_dagger_core.h
@@ -285,7 +285,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]<X1m1)) |
  const int sp_idx = (coord[0]==X1m1 ? X-X1m1 : X+1) >> 1;
 #endif
 
- const int ga_idx = sid % Vh;
+ const int ga_idx = sid % param.volume4CB;
 
  // read gauge matrix from device memory
  if ( ! s_parity ) { ASSN_GAUGE_MATRIX(G, GAUGE0TEX, 0, ga_idx, ga_stride); }
@@ -480,9 +480,9 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[0] || coord[0]>0)) ||
 #endif
 
 #ifdef MULTI_GPU
- const int ga_idx = ((kernel_type == INTERIOR_KERNEL) ? sp_idx % Vh : Vh+(face_idx % ghostFace[static_cast<int>(kernel_type)]));
+ const int ga_idx = ((kernel_type == INTERIOR_KERNEL) ? sp_idx % param.volume4CB : param.volume4CB+(face_idx % ghostFace[static_cast<int>(kernel_type)]));
 #else
- const int ga_idx = sp_idx % Vh;
+ const int ga_idx = sp_idx % param.volume4CB;
 #endif
 
  // read gauge matrix from device memory
@@ -677,7 +677,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]<X2m1)) |
  const int sp_idx = (coord[1]==X2m1 ? X-X2X1mX1 : X+X1) >> 1;
 #endif
 
- const int ga_idx = sid % Vh;
+ const int ga_idx = sid % param.volume4CB;
 
  // read gauge matrix from device memory
  if ( ! s_parity ) { ASSN_GAUGE_MATRIX(G, GAUGE0TEX, 2, ga_idx, ga_stride); }
@@ -872,9 +872,9 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[1] || coord[1]>0)) ||
 #endif
 
 #ifdef MULTI_GPU
- const int ga_idx = ((kernel_type == INTERIOR_KERNEL) ? sp_idx % Vh : Vh+(face_idx % ghostFace[static_cast<int>(kernel_type)]));
+ const int ga_idx = ((kernel_type == INTERIOR_KERNEL) ? sp_idx % param.volume4CB : param.volume4CB+(face_idx % ghostFace[static_cast<int>(kernel_type)]));
 #else
- const int ga_idx = sp_idx % Vh;
+ const int ga_idx = sp_idx % param.volume4CB;
 #endif
 
  // read gauge matrix from device memory
@@ -1069,7 +1069,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]<X3m1)) |
  const int sp_idx = (coord[2]==X3m1 ? X-X3X2X1mX2X1 : X+X2X1) >> 1;
 #endif
 
- const int ga_idx = sid % Vh;
+ const int ga_idx = sid % param.volume4CB;
 
  // read gauge matrix from device memory
  if ( ! s_parity ) { ASSN_GAUGE_MATRIX(G, GAUGE0TEX, 4, ga_idx, ga_stride); }
@@ -1264,9 +1264,9 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[2] || coord[2]>0)) ||
 #endif
 
 #ifdef MULTI_GPU
- const int ga_idx = ((kernel_type == INTERIOR_KERNEL) ? sp_idx % Vh : Vh+(face_idx % ghostFace[static_cast<int>(kernel_type)]));
+ const int ga_idx = ((kernel_type == INTERIOR_KERNEL) ? sp_idx % param.volume4CB : param.volume4CB+(face_idx % ghostFace[static_cast<int>(kernel_type)]));
 #else
- const int ga_idx = sp_idx % Vh;
+ const int ga_idx = sp_idx % param.volume4CB;
 #endif
 
  // read gauge matrix from device memory
@@ -1461,7 +1461,7 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]<X4m1)) |
  const int sp_idx = (coord[3]==X4m1 ? X-X4X3X2X1mX3X2X1 : X+X3X2X1) >> 1;
 #endif
 
- const int ga_idx = sid % Vh;
+ const int ga_idx = sid % param.volume4CB;
 
  if (gauge_fixed && ga_idx < X4X3X2X1hmX3X2X1h)
  {
@@ -1718,9 +1718,9 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]>0)) ||
 #endif
 
 #ifdef MULTI_GPU
- const int ga_idx = ((kernel_type == INTERIOR_KERNEL) ? sp_idx % Vh : Vh+(face_idx % ghostFace[static_cast<int>(kernel_type)]));
+ const int ga_idx = ((kernel_type == INTERIOR_KERNEL) ? sp_idx % param.volume4CB : param.volume4CB+(face_idx % ghostFace[static_cast<int>(kernel_type)]));
 #else
- const int ga_idx = sp_idx % Vh;
+ const int ga_idx = sp_idx % param.volume4CB;
 #endif
 
  if (gauge_fixed && ga_idx < X4X3X2X1hmX3X2X1h)
@@ -1965,7 +1965,7 @@ if(kernel_type == INTERIOR_KERNEL)
 {
 // 2 P_L = 2 P_- = ( ( +1, -1 ), ( -1, +1 ) )
   {
-     int sp_idx = ( coord[4] == 0 ? X+(param.Ls-1)*2*Vh : X-2*Vh ) / 2;
+     int sp_idx = ( coord[4] == 0 ? X+(param.Ls-1)*2*param.volume4CB : X-2*param.volume4CB ) / 2;
 
 // read spinor from device memory
      READ_SPINOR( SPINORTEX, param.sp_stride, sp_idx, sp_idx );
@@ -2010,7 +2010,7 @@ if(kernel_type == INTERIOR_KERNEL)
 
  // 2 P_R = 2 P_+ = ( ( +1, +1 ), ( +1, +1 ) )
   {
-    int sp_idx = ( coord[4] == param.Ls-1 ? X-(param.Ls-1)*2*Vh : X+2*Vh ) / 2;
+    int sp_idx = ( coord[4] == param.Ls-1 ? X-(param.Ls-1)*2*param.volume4CB : X+2*param.volume4CB ) / 2;
 
 // read spinor from device memory
     READ_SPINOR( SPINORTEX, param.sp_stride, sp_idx, sp_idx );

--- a/lib/dslash_core/dw_fused_exterior_dslash4_core.h
+++ b/lib/dslash_core/dw_fused_exterior_dslash4_core.h
@@ -300,7 +300,7 @@ if (isActive(dim,0,+1,coord,param.commDim,param.X) && coord[0]==X1m1 )
 #endif
 
 
- const int ga_idx = sid % Vh;
+ const int ga_idx = sid % param.volume4CB;
 
  // read gauge matrix from device memory
  ASSN_GAUGE_MATRIX(G, GAUGE0TEX, 0, ga_idx, ga_stride);
@@ -463,7 +463,7 @@ if (isActive(dim,0,-1,coord,param.commDim,param.X) && coord[0]==0 )
 #endif
 
 
- const int ga_idx = Vh+(face_idx % ghostFace[0]);
+ const int ga_idx = param.volume4CB+(face_idx % ghostFace[0]);
 
  // read gauge matrix from device memory
  ASSN_GAUGE_MATRIX(G, GAUGE1TEX, 1, ga_idx, ga_stride);
@@ -626,7 +626,7 @@ if (isActive(dim,1,+1,coord,param.commDim,param.X) && coord[1]==X2m1 )
 #endif
 
 
- const int ga_idx = sid % Vh;
+ const int ga_idx = sid % param.volume4CB;
 
  // read gauge matrix from device memory
  ASSN_GAUGE_MATRIX(G, GAUGE0TEX, 2, ga_idx, ga_stride);
@@ -789,7 +789,7 @@ if (isActive(dim,1,-1,coord,param.commDim,param.X) && coord[1]==0 )
 #endif
 
 
- const int ga_idx = Vh+(face_idx % ghostFace[1]);
+ const int ga_idx = param.volume4CB+(face_idx % ghostFace[1]);
 
  // read gauge matrix from device memory
  ASSN_GAUGE_MATRIX(G, GAUGE1TEX, 3, ga_idx, ga_stride);
@@ -952,7 +952,7 @@ if (isActive(dim,2,+1,coord,param.commDim,param.X) && coord[2]==X3m1 )
 #endif
 
 
- const int ga_idx = sid % Vh;
+ const int ga_idx = sid % param.volume4CB;
 
  // read gauge matrix from device memory
  ASSN_GAUGE_MATRIX(G, GAUGE0TEX, 4, ga_idx, ga_stride);
@@ -1115,7 +1115,7 @@ if (isActive(dim,2,-1,coord,param.commDim,param.X) && coord[2]==0 )
 #endif
 
 
- const int ga_idx = Vh+(face_idx % ghostFace[2]);
+ const int ga_idx = param.volume4CB+(face_idx % ghostFace[2]);
 
  // read gauge matrix from device memory
  ASSN_GAUGE_MATRIX(G, GAUGE1TEX, 5, ga_idx, ga_stride);
@@ -1278,7 +1278,7 @@ if (isActive(dim,3,+1,coord,param.commDim,param.X) && coord[3]==X4m1 )
 #endif
 
 
- const int ga_idx = sid % Vh;
+ const int ga_idx = sid % param.volume4CB;
 
  if (gauge_fixed && ga_idx < X4X3X2X1hmX3X2X1h)
  {
@@ -1479,7 +1479,7 @@ if (isActive(dim,3,-1,coord,param.commDim,param.X) && coord[3]==0 )
 #endif
 
 
- const int ga_idx = Vh+(face_idx % ghostFace[3]);
+ const int ga_idx = param.volume4CB+(face_idx % ghostFace[3]);
 
  if (gauge_fixed && ga_idx < X4X3X2X1hmX3X2X1h)
  {

--- a/lib/dslash_core/dw_fused_exterior_dslash4_dagger_core.h
+++ b/lib/dslash_core/dw_fused_exterior_dslash4_dagger_core.h
@@ -300,7 +300,7 @@ if (isActive(dim,0,+1,coord,param.commDim,param.X) && coord[0]==X1m1 )
 #endif
 
 
- const int ga_idx = sid % Vh;
+ const int ga_idx = sid % param.volume4CB;
 
  // read gauge matrix from device memory
  ASSN_GAUGE_MATRIX(G, GAUGE0TEX, 0, ga_idx, ga_stride);
@@ -463,7 +463,7 @@ if (isActive(dim,0,-1,coord,param.commDim,param.X) && coord[0]==0 )
 #endif
 
 
- const int ga_idx = Vh+(face_idx % ghostFace[0]);
+ const int ga_idx = param.volume4CB+(face_idx % ghostFace[0]);
 
  // read gauge matrix from device memory
  ASSN_GAUGE_MATRIX(G, GAUGE1TEX, 1, ga_idx, ga_stride);
@@ -626,7 +626,7 @@ if (isActive(dim,1,+1,coord,param.commDim,param.X) && coord[1]==X2m1 )
 #endif
 
 
- const int ga_idx = sid % Vh;
+ const int ga_idx = sid % param.volume4CB;
 
  // read gauge matrix from device memory
  ASSN_GAUGE_MATRIX(G, GAUGE0TEX, 2, ga_idx, ga_stride);
@@ -789,7 +789,7 @@ if (isActive(dim,1,-1,coord,param.commDim,param.X) && coord[1]==0 )
 #endif
 
 
- const int ga_idx = Vh+(face_idx % ghostFace[1]);
+ const int ga_idx = param.volume4CB+(face_idx % ghostFace[1]);
 
  // read gauge matrix from device memory
  ASSN_GAUGE_MATRIX(G, GAUGE1TEX, 3, ga_idx, ga_stride);
@@ -952,7 +952,7 @@ if (isActive(dim,2,+1,coord,param.commDim,param.X) && coord[2]==X3m1 )
 #endif
 
 
- const int ga_idx = sid % Vh;
+ const int ga_idx = sid % param.volume4CB;
 
  // read gauge matrix from device memory
  ASSN_GAUGE_MATRIX(G, GAUGE0TEX, 4, ga_idx, ga_stride);
@@ -1115,7 +1115,7 @@ if (isActive(dim,2,-1,coord,param.commDim,param.X) && coord[2]==0 )
 #endif
 
 
- const int ga_idx = Vh+(face_idx % ghostFace[2]);
+ const int ga_idx = param.volume4CB+(face_idx % ghostFace[2]);
 
  // read gauge matrix from device memory
  ASSN_GAUGE_MATRIX(G, GAUGE1TEX, 5, ga_idx, ga_stride);
@@ -1278,7 +1278,7 @@ if (isActive(dim,3,+1,coord,param.commDim,param.X) && coord[3]==X4m1 )
 #endif
 
 
- const int ga_idx = sid % Vh;
+ const int ga_idx = sid % param.volume4CB;
 
  if (gauge_fixed && ga_idx < X4X3X2X1hmX3X2X1h)
  {
@@ -1479,7 +1479,7 @@ if (isActive(dim,3,-1,coord,param.commDim,param.X) && coord[3]==0 )
 #endif
 
 
- const int ga_idx = Vh+(face_idx % ghostFace[3]);
+ const int ga_idx = param.volume4CB+(face_idx % ghostFace[3]);
 
  if (gauge_fixed && ga_idx < X4X3X2X1hmX3X2X1h)
  {

--- a/lib/dslash_core/dw_fused_exterior_dslash_core.h
+++ b/lib/dslash_core/dw_fused_exterior_dslash_core.h
@@ -286,7 +286,7 @@ if (isActive(dim,0,+1,coord,param.commDim,param.X) && coord[0]==X1m1 )
 #endif
 
 
- const int ga_idx = sid % Vh;
+ const int ga_idx = sid % param.volume4CB;
 
  // read gauge matrix from device memory
  if ( ! s_parity ) { ASSN_GAUGE_MATRIX(G, GAUGE0TEX, 0, ga_idx, ga_stride); }
@@ -451,7 +451,7 @@ if (isActive(dim,0,-1,coord,param.commDim,param.X) && coord[0]==0 )
 #endif
 
 
- const int ga_idx = Vh+(face_idx % ghostFace[0]);
+ const int ga_idx = param.volume4CB+(face_idx % ghostFace[0]);
 
  // read gauge matrix from device memory
  if ( ! s_parity ) { ASSN_GAUGE_MATRIX(G, GAUGE1TEX, 1, ga_idx, ga_stride); }
@@ -616,7 +616,7 @@ if (isActive(dim,1,+1,coord,param.commDim,param.X) && coord[1]==X2m1 )
 #endif
 
 
- const int ga_idx = sid % Vh;
+ const int ga_idx = sid % param.volume4CB;
 
  // read gauge matrix from device memory
  if ( ! s_parity ) { ASSN_GAUGE_MATRIX(G, GAUGE0TEX, 2, ga_idx, ga_stride); }
@@ -781,7 +781,7 @@ if (isActive(dim,1,-1,coord,param.commDim,param.X) && coord[1]==0 )
 #endif
 
 
- const int ga_idx = Vh+(face_idx % ghostFace[1]);
+ const int ga_idx = param.volume4CB+(face_idx % ghostFace[1]);
 
  // read gauge matrix from device memory
  if ( ! s_parity ) { ASSN_GAUGE_MATRIX(G, GAUGE1TEX, 3, ga_idx, ga_stride); }
@@ -946,7 +946,7 @@ if (isActive(dim,2,+1,coord,param.commDim,param.X) && coord[2]==X3m1 )
 #endif
 
 
- const int ga_idx = sid % Vh;
+ const int ga_idx = sid % param.volume4CB;
 
  // read gauge matrix from device memory
  if ( ! s_parity ) { ASSN_GAUGE_MATRIX(G, GAUGE0TEX, 4, ga_idx, ga_stride); }
@@ -1111,7 +1111,7 @@ if (isActive(dim,2,-1,coord,param.commDim,param.X) && coord[2]==0 )
 #endif
 
 
- const int ga_idx = Vh+(face_idx % ghostFace[2]);
+ const int ga_idx = param.volume4CB+(face_idx % ghostFace[2]);
 
  // read gauge matrix from device memory
  if ( ! s_parity ) { ASSN_GAUGE_MATRIX(G, GAUGE1TEX, 5, ga_idx, ga_stride); }
@@ -1276,7 +1276,7 @@ if (isActive(dim,3,+1,coord,param.commDim,param.X) && coord[3]==X4m1 )
 #endif
 
 
- const int ga_idx = sid % Vh;
+ const int ga_idx = sid % param.volume4CB;
 
  if (gauge_fixed && ga_idx < X4X3X2X1hmX3X2X1h)
  {
@@ -1480,7 +1480,7 @@ if (isActive(dim,3,-1,coord,param.commDim,param.X) && coord[3]==0 )
 #endif
 
 
- const int ga_idx = Vh+(face_idx % ghostFace[3]);
+ const int ga_idx = param.volume4CB+(face_idx % ghostFace[3]);
 
  if (gauge_fixed && ga_idx < X4X3X2X1hmX3X2X1h)
  {

--- a/lib/dslash_core/dw_fused_exterior_dslash_dagger_core.h
+++ b/lib/dslash_core/dw_fused_exterior_dslash_dagger_core.h
@@ -286,7 +286,7 @@ if (isActive(dim,0,+1,coord,param.commDim,param.X) && coord[0]==X1m1 )
 #endif
 
 
- const int ga_idx = sid % Vh;
+ const int ga_idx = sid % param.volume4CB;
 
  // read gauge matrix from device memory
  if ( ! s_parity ) { ASSN_GAUGE_MATRIX(G, GAUGE0TEX, 0, ga_idx, ga_stride); }
@@ -451,7 +451,7 @@ if (isActive(dim,0,-1,coord,param.commDim,param.X) && coord[0]==0 )
 #endif
 
 
- const int ga_idx = Vh+(face_idx % ghostFace[0]);
+ const int ga_idx = param.volume4CB+(face_idx % ghostFace[0]);
 
  // read gauge matrix from device memory
  if ( ! s_parity ) { ASSN_GAUGE_MATRIX(G, GAUGE1TEX, 1, ga_idx, ga_stride); }
@@ -616,7 +616,7 @@ if (isActive(dim,1,+1,coord,param.commDim,param.X) && coord[1]==X2m1 )
 #endif
 
 
- const int ga_idx = sid % Vh;
+ const int ga_idx = sid % param.volume4CB;
 
  // read gauge matrix from device memory
  if ( ! s_parity ) { ASSN_GAUGE_MATRIX(G, GAUGE0TEX, 2, ga_idx, ga_stride); }
@@ -781,7 +781,7 @@ if (isActive(dim,1,-1,coord,param.commDim,param.X) && coord[1]==0 )
 #endif
 
 
- const int ga_idx = Vh+(face_idx % ghostFace[1]);
+ const int ga_idx = param.volume4CB+(face_idx % ghostFace[1]);
 
  // read gauge matrix from device memory
  if ( ! s_parity ) { ASSN_GAUGE_MATRIX(G, GAUGE1TEX, 3, ga_idx, ga_stride); }
@@ -946,7 +946,7 @@ if (isActive(dim,2,+1,coord,param.commDim,param.X) && coord[2]==X3m1 )
 #endif
 
 
- const int ga_idx = sid % Vh;
+ const int ga_idx = sid % param.volume4CB;
 
  // read gauge matrix from device memory
  if ( ! s_parity ) { ASSN_GAUGE_MATRIX(G, GAUGE0TEX, 4, ga_idx, ga_stride); }
@@ -1111,7 +1111,7 @@ if (isActive(dim,2,-1,coord,param.commDim,param.X) && coord[2]==0 )
 #endif
 
 
- const int ga_idx = Vh+(face_idx % ghostFace[2]);
+ const int ga_idx = param.volume4CB+(face_idx % ghostFace[2]);
 
  // read gauge matrix from device memory
  if ( ! s_parity ) { ASSN_GAUGE_MATRIX(G, GAUGE1TEX, 5, ga_idx, ga_stride); }
@@ -1276,7 +1276,7 @@ if (isActive(dim,3,+1,coord,param.commDim,param.X) && coord[3]==X4m1 )
 #endif
 
 
- const int ga_idx = sid % Vh;
+ const int ga_idx = sid % param.volume4CB;
 
  if (gauge_fixed && ga_idx < X4X3X2X1hmX3X2X1h)
  {
@@ -1480,7 +1480,7 @@ if (isActive(dim,3,-1,coord,param.commDim,param.X) && coord[3]==0 )
 #endif
 
 
- const int ga_idx = Vh+(face_idx % ghostFace[3]);
+ const int ga_idx = param.volume4CB+(face_idx % ghostFace[3]);
 
  if (gauge_fixed && ga_idx < X4X3X2X1hmX3X2X1h)
  {

--- a/lib/generate/dw_dslash_4D_cuda_gen.py
+++ b/lib/generate/dw_dslash_4D_cuda_gen.py
@@ -568,14 +568,14 @@ def gen(dir, pack_only=False):
 
     str += "\n"
     if dir % 2 == 0:
-        if domain_wall: str += "const int ga_idx = sid % Vh;\n"
+        if domain_wall: str += "const int ga_idx = sid % param.volume4CB;\n"
         else: str += "const int ga_idx = sid;\n"
     else:
         str += "#ifdef MULTI_GPU\n"
-        if domain_wall: str += "const int ga_idx = ((kernel_type == INTERIOR_KERNEL) ? sp_idx % Vh : Vh+(face_idx % ghostFace[static_cast<int>(kernel_type)]));\n"
-        else: str += "const int ga_idx = ((kernel_type == INTERIOR_KERNEL) ? sp_idx : Vh+face_idx);\n"
+        if domain_wall: str += "const int ga_idx = ((kernel_type == INTERIOR_KERNEL) ? sp_idx % param.volume4CB : param.volume4CB+(face_idx % ghostFace[static_cast<int>(kernel_type)]));\n"
+        else: str += "const int ga_idx = ((kernel_type == INTERIOR_KERNEL) ? sp_idx : param.volume4CB+face_idx);\n"
         str += "#else\n"
-        if domain_wall: str += "const int ga_idx = sp_idx % Vh;\n"
+        if domain_wall: str += "const int ga_idx = sp_idx % param.volume4CB;\n"
         else: str += "const int ga_idx = sp_idx;\n"
         str += "#endif\n"
     str += "\n"
@@ -756,7 +756,7 @@ def gen_dw():
       str += "#ifdef MULTI_GPU\nif(kernel_type == INTERIOR_KERNEL)\n#endif\n"
     str += "{\n// 2 P_L = 2 P_- = ( ( +1, -1 ), ( -1, +1 ) )\n"
     str += "  {\n"
-    str += "     int sp_idx = ( coord[4] == %s ? X%s(param.Ls-1)*2*Vh : X%s2*Vh ) / 2;\n" % (ledge, rsign, lsign)
+    str += "     int sp_idx = ( coord[4] == %s ? X%s(param.Ls-1)*2*param.volume4CB : X%s2*param.volume4CB ) / 2;\n" % (ledge, rsign, lsign)
     str += "\n"
     str += "// read spinor from device memory\n"
     str += "     READ_SPINOR( SPINORTEX, param.sp_stride, sp_idx, sp_idx );\n"
@@ -799,7 +799,7 @@ def gen_dw():
     str += "  } // end P_L\n\n"
     str += " // 2 P_R = 2 P_+ = ( ( +1, +1 ), ( +1, +1 ) )\n"
     str += "  {\n"
-    str += "    int sp_idx = ( coord[4] == %s ? X%s(param.Ls-1)*2*Vh : X%s2*Vh ) / 2;\n" % (redge, lsign, rsign)
+    str += "    int sp_idx = ( coord[4] == %s ? X%s(param.Ls-1)*2*param.volume4CB : X%s2*param.volume4CB ) / 2;\n" % (redge, lsign, rsign)
     str += "\n"
     str += "// read spinor from device memory\n"
     str += "    READ_SPINOR( SPINORTEX, param.sp_stride, sp_idx, sp_idx );\n"
@@ -912,7 +912,7 @@ def gen_dw_inv():
     str += "// 'w' means output vector\n"
     str += "// 'v' means input vector\n"
     str += "{\n"
-    str += "  int base_idx = sid%Vh;\n"
+    str += "  int base_idx = sid%param.volume4CB;\n"
     str += "  int sp_idx;\n\n"
     str += "// let's assume the index,\n"
     str += "// s = output vector index,\n"
@@ -930,7 +930,7 @@ def gen_dw_inv():
     else : 
         str += "    int exponent = coord[4] < s ? param.Ls-s+coord[4] : coord[4]-s;\n"
         str += "    factorR = inv_d_n * POW(kappa,exponent) * ( coord[4] < s ? -mferm : static_cast<spinorFloat>(1.0) );\n\n"
-    str += "    sp_idx = base_idx + s*Vh;\n"
+    str += "    sp_idx = base_idx + s*param.volume4CB;\n"
     str += "    // read spinor from device memory\n"
     str += "    READ_SPINOR( SPINORTEX, param.sp_stride, sp_idx, sp_idx );\n\n"
     str += "    o00_re += factorR*(i00_re + i20_re);\n" 

--- a/lib/generate/dw_dslash_cuda_gen.py
+++ b/lib/generate/dw_dslash_cuda_gen.py
@@ -535,14 +535,14 @@ def gen(dir, pack_only=False):
 
     str += "\n"
     if dir % 2 == 0:
-        if domain_wall: str += "const int ga_idx = sid % Vh;\n"
+        if domain_wall: str += "const int ga_idx = sid % param.volume4CB;\n"
         else: str += "const int ga_idx = sid;\n"
     else:
         str += "#ifdef MULTI_GPU\n"
-        if domain_wall: str += "const int ga_idx = ((kernel_type == INTERIOR_KERNEL) ? sp_idx % Vh : Vh+(face_idx % ghostFace[static_cast<int>(kernel_type)]));\n"
-        else: str += "const int ga_idx = ((kernel_type == INTERIOR_KERNEL) ? sp_idx : Vh+face_idx);\n"
+        if domain_wall: str += "const int ga_idx = ((kernel_type == INTERIOR_KERNEL) ? sp_idx % param.volume4CB : param.volume4CB+(face_idx % ghostFace[static_cast<int>(kernel_type)]));\n"
+        else: str += "const int ga_idx = ((kernel_type == INTERIOR_KERNEL) ? sp_idx : param.volume4CB+face_idx);\n"
         str += "#else\n"
-        if domain_wall: str += "const int ga_idx = sp_idx % Vh;\n"
+        if domain_wall: str += "const int ga_idx = sp_idx % param.volume4CB;\n"
         else: str += "const int ga_idx = sp_idx;\n"
         str += "#endif\n"
     str += "\n"
@@ -727,7 +727,7 @@ def gen_dw():
     str += "#ifdef MULTI_GPU\nif(kernel_type == INTERIOR_KERNEL)\n#endif\n{\n"
     str += "// 2 P_L = 2 P_- = ( ( +1, -1 ), ( -1, +1 ) )\n"
     str += "  {\n"
-    str += "     int sp_idx = ( coord[4] == %s ? X%s(param.Ls-1)*2*Vh : X%s2*Vh ) / 2;\n" % (ledge, rsign, lsign)
+    str += "     int sp_idx = ( coord[4] == %s ? X%s(param.Ls-1)*2*param.volume4CB : X%s2*param.volume4CB ) / 2;\n" % (ledge, rsign, lsign)
     str += "\n"
     str += "// read spinor from device memory\n"
     str += "     READ_SPINOR( SPINORTEX, param.sp_stride, sp_idx, sp_idx );\n"
@@ -770,7 +770,7 @@ def gen_dw():
     str += "  } // end P_L\n\n"
     str += " // 2 P_R = 2 P_+ = ( ( +1, +1 ), ( +1, +1 ) )\n"
     str += "  {\n"
-    str += "    int sp_idx = ( coord[4] == %s ? X%s(param.Ls-1)*2*Vh : X%s2*Vh ) / 2;\n" % (redge, lsign, rsign)
+    str += "    int sp_idx = ( coord[4] == %s ? X%s(param.Ls-1)*2*param.volume4CB : X%s2*param.volume4CB ) / 2;\n" % (redge, lsign, rsign)
     str += "\n"
     str += "// read spinor from device memory\n"
     str += "    READ_SPINOR( SPINORTEX, param.sp_stride, sp_idx, sp_idx );\n"

--- a/lib/generate/fused_exterior_dw_dslash_4D_cuda_gen.py
+++ b/lib/generate/fused_exterior_dw_dslash_4D_cuda_gen.py
@@ -557,11 +557,11 @@ def gen(dir, pack_only=False):
 
 
     if dir % 2 == 0:
-        if domain_wall: str += "const int ga_idx = sid % Vh;\n"
+        if domain_wall: str += "const int ga_idx = sid % param.volume4CB;\n"
         else: str += "const int ga_idx = sid;\n"
     else:
-        if domain_wall: str += "const int ga_idx = Vh+(face_idx % ghostFace[" + `dir/2` + "]);\n"
-        else: str += "const int ga_idx = Vh+face_idx;\n"
+        if domain_wall: str += "const int ga_idx = param.volume4CB+(face_idx % ghostFace[" + `dir/2` + "]);\n"
+        else: str += "const int ga_idx = param.volume4CB+face_idx;\n"
     str += "\n"
 
     # scan the projector to determine which loads are required
@@ -733,7 +733,7 @@ def gen_dw_inv():
     str += "// 'w' means output vector\n"
     str += "// 'v' means input vector\n"
     str += "{\n"
-    str += "  int base_idx = sid%Vh;\n"
+    str += "  int base_idx = sid%param.volume4CB;\n"
     str += "  int sp_idx;\n\n"
     str += "// let's assume the index,\n"
     str += "// s = output vector index,\n"
@@ -749,7 +749,7 @@ def gen_dw_inv():
         str += "    factorR = ( coord[4] > s ? -inv_d_n*pow(kappa,param.Ls-coord[4]+s)*mferm : inv_d_n*pow(kappa,s-coord[4]))/2.0;\n\n"
     else : 
         str += "    factorR = ( coord[4] < s ? -inv_d_n*pow(kappa,param.Ls-s+coord[4])*mferm : inv_d_n*pow(kappa,coord[4]-s))/2.0;\n\n"
-    str += "    sp_idx = base_idx + s*Vh;\n"
+    str += "    sp_idx = base_idx + s*param.volume4CB;\n"
     str += "    // read spinor from device memory\n"
     str += "    READ_SPINOR( SPINORTEX, param.sp_stride, sp_idx, sp_idx );\n\n"
     str += "    o00_re += factorR*(i00_re + i20_re);\n" 

--- a/lib/generate/fused_exterior_dw_dslash_cuda_gen.py
+++ b/lib/generate/fused_exterior_dw_dslash_cuda_gen.py
@@ -528,11 +528,11 @@ def gen(dir, pack_only=False):
     str += "#endif\n\n"
     str += "\n"
     if dir % 2 == 0:
-        if domain_wall: str += "const int ga_idx = sid % Vh;\n"
+        if domain_wall: str += "const int ga_idx = sid % param.volume4CB;\n"
         else: str += "const int ga_idx = sid;\n"
     else:
-        if domain_wall: str += "const int ga_idx = Vh+(face_idx % ghostFace[" + `dir/2` + "]);\n"
-        else: str += "const int ga_idx = Vh+face_idx;\n"
+        if domain_wall: str += "const int ga_idx = param.volume4CB+(face_idx % ghostFace[" + `dir/2` + "]);\n"
+        else: str += "const int ga_idx = param.volume4CB+face_idx;\n"
     str += "\n"
 
     # scan the projector to determine which loads are required

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -139,10 +139,6 @@ cudaGaugeField *extendedGaugeResident = NULL;
 
 std::vector<cudaColorSpinorField*> solutionResident;
 
-// FIXME - this is temporary hack for persistent quark fields
-std::vector<ColorSpinorField*> quarkX;
-std::vector<ColorSpinorField*> quarkP;
-
 // vector of spinors used for forecasting solutions in HMC
 #define QUDA_MAX_CHRONO 2
 // each entry is a pair for both p and Ap storage
@@ -1195,11 +1191,6 @@ void endQuda(void)
     if(solutionResident[i]) delete solutionResident[i];
   }
   solutionResident.clear();
-
-  for (unsigned int i=0; i<quarkX.size(); i++) delete quarkX[i];
-  quarkX.clear();
-  for (unsigned int i=0; i<quarkP.size(); i++) delete quarkP[i];
-  quarkP.clear();
 
   if(momResident) delete momResident;
 
@@ -4993,20 +4984,10 @@ void computeCloverForceQuda(void *h_mom, double dt, void **h_x, void **h_p,
   qParam.fieldOrder = QUDA_FLOAT2_FIELD_ORDER;
   qParam.gammaBasis = QUDA_UKQCD_GAMMA_BASIS;
 
-#if 0
-  std::vector<ColorSpinorField*> quarkX(nvector);
-  std::vector<ColorSpinorField*> quarkP(nvector);
-#endif
-
-  int x_size = quarkX.size();
-  for (int i=x_size; i<nvector; i++) quarkX.push_back(ColorSpinorField::Create(qParam));
-  int p_size = quarkP.size();
-  for (int i=p_size; i<nvector; i++) quarkP.push_back(ColorSpinorField::Create(qParam));
-
-  std::vector<ColorSpinorField*> quarkX_, quarkP_;
+  std::vector<ColorSpinorField*> quarkX, quarkP;
   for (int i=0; i<nvector; i++) {
-    quarkX_.push_back(quarkX[i]);
-    quarkP_.push_back(quarkP[i]);
+    quarkX.push_back(ColorSpinorField::Create(qParam));
+    quarkP.push_back(ColorSpinorField::Create(qParam));
   }
 
   qParam.siteSubset = QUDA_PARITY_SITE_SUBSET;
@@ -5049,8 +5030,8 @@ void computeCloverForceQuda(void *h_mom, double dt, void **h_x, void **h_p,
   std::vector<double> force_coeff(nvector);
   // loop over different quark fields
   for(int i=0; i<nvector; i++){
-    ColorSpinorField &x = *(quarkX_[i]);
-    ColorSpinorField &p = *(quarkP_[i]);
+    ColorSpinorField &x = *(quarkX[i]);
+    ColorSpinorField &p = *(quarkP[i]);
 
     if (!inv_param->use_resident_solution) {
       // for downloading x_e
@@ -5088,7 +5069,7 @@ void computeCloverForceQuda(void *h_mom, double dt, void **h_x, void **h_p,
     force_coeff[i] = 2.0*dt*coeff[i]*kappa2;
   }
 
-  computeCloverForce(cudaForce, *gaugePrecise, quarkX_, quarkP_, force_coeff);
+  computeCloverForce(cudaForce, *gaugePrecise, quarkX, quarkP, force_coeff);
 
   // In double precision the clover derivative is faster with no reconstruct
   cudaGaugeField *u = &gaugeEx;
@@ -5109,7 +5090,7 @@ void computeCloverForceQuda(void *h_mom, double dt, void **h_x, void **h_p,
     ferm_epsilon[shift][1] = -kappa2 * 2.0*ck*coeff[shift]*dt;
   }
 
-  computeCloverSigmaOprod(oprod, quarkX_, quarkP_, ferm_epsilon);
+  computeCloverSigmaOprod(oprod, quarkX, quarkP, ferm_epsilon);
   copyExtendedGauge(oprodEx, oprod, QUDA_CUDA_FIELD_LOCATION); // FIXME this is unnecessary if we write directly to oprod
   cudaDeviceSynchronize(); // ensure compute timing is correct
 
@@ -5136,12 +5117,12 @@ void computeCloverForceQuda(void *h_mom, double dt, void **h_x, void **h_p,
 
   profileCloverForce.TPSTART(QUDA_PROFILE_FREE);
 
-#if 0
   for (int i=0; i<nvector; i++) {
     delete quarkX[i];
     delete quarkP[i];
   }
 
+#if 0
   if (inv_param->use_resident_solution) {
     for (int i=0; i<nvector; i++) delete solutionResident[i];
     solutionResident.clear();

--- a/lib/inv_multi_cg_quda.cpp
+++ b/lib/inv_multi_cg_quda.cpp
@@ -214,14 +214,6 @@ namespace quda {
       for (int i=0; i<num_offset; i++) y[i] = new cudaColorSpinorField(*r, csParam);
     }
 
-    // FIXME - hack from hell since static ghosts seem to be broken
-    static int hack = 0;
-    if (hack==0 && reliable) {
-      mat(*y[3], *y[2], *y[1], *y[0]);
-      for (int i=0; i<4; i++) blas::zero(*y[i]);
-      hack = 1;
-    }
-
     csParam.setPrecision(param.precision_sloppy);
   
     cudaColorSpinorField *r_sloppy;


### PR DESCRIPTION
This pull fixes some issues introduced with pull #538 which introduced static allocations for the dslash halo buffers in `cudaColorSpinorField` as well as clean up
* Remove persistent `quarkX` and `quarkP` fields for clover force (wastes memory and no longer needed with memory pool allocator)
* Correctly detect when ghost halo has changed and recreate the ghost texture as needed for each `cudaColorSpinorField` instance
* Fixed memory leak with static halos when allocating a low precision field followed by a high precision field
* Remove hacked work around necessary for mixed-precision multi-shift solver now static halos are now robust
* Domain-wall kernels now use `DslashParam::volume4CB` instead of `__constant__ int Vh` for faster indexing 