### PR TITLE
Hotfix/bqcd copy

### DIFF
--- a/include/gauge_field.h
+++ b/include/gauge_field.h
@@ -31,12 +31,6 @@ namespace quda {
     // always set to false, requires external override
     bool compute_fat_link_max; 
 
-    /** The extended gauge field radius (if applicable) */
-    int r[QUDA_MAX_DIM];
-
-    /** The type of ghost exchange to be done with this field */
-    QudaGhostExchange ghostExchange;
-
     /** The staggered phase convention to use */
     QudaStaggeredPhase staggeredPhaseType;
 
@@ -62,57 +56,35 @@ namespace quda {
       create(QUDA_REFERENCE_FIELD_CREATE), 
       geometry(QUDA_VECTOR_GEOMETRY),
       compute_fat_link_max(false),
-      ghostExchange(QUDA_GHOST_EXCHANGE_PAD),
-
       staggeredPhaseType(QUDA_STAGGERED_PHASE_NO),
       staggeredPhaseApplied(false),
       i_mu(0.0)
-	{
-	  // variables declared in LatticeFieldParam
-	  precision = QUDA_INVALID_PRECISION;
-	  nDim = 4;
-	  pad  = 0;
-	  for(int dir=0; dir<nDim; ++dir) {
-	    x[dir] = 0;
-	    r[dir] = 0;
-	  }
-	}
+	{ }
 
     GaugeFieldParam(const GaugeField &u);
 
   GaugeFieldParam(const int *x, const QudaPrecision precision, const QudaReconstructType reconstruct,
-		  const int pad, const QudaFieldGeometry geometry, 
+		  const int pad, const QudaFieldGeometry geometry,
 		  const QudaGhostExchange ghostExchange=QUDA_GHOST_EXCHANGE_PAD) 
-    : LatticeFieldParam(), nColor(3), nFace(0), reconstruct(reconstruct),
+    : LatticeFieldParam(4, x, pad, precision, ghostExchange), nColor(3), nFace(0), reconstruct(reconstruct),
       order(QUDA_INVALID_GAUGE_ORDER), fixed(QUDA_GAUGE_FIXED_NO),
       link_type(QUDA_WILSON_LINKS), t_boundary(QUDA_INVALID_T_BOUNDARY), anisotropy(1.0),
       tadpole(1.0), scale(1.0), gauge(0), create(QUDA_NULL_FIELD_CREATE), geometry(geometry),
-      compute_fat_link_max(false), ghostExchange(ghostExchange),
-      staggeredPhaseType(QUDA_STAGGERED_PHASE_NO), staggeredPhaseApplied(false), i_mu(0.0)
-      {
-	// variables declared in LatticeFieldParam
-	this->precision = precision;
-	this->nDim = 4;
-	this->pad = pad;
-	for(int dir=0; dir<nDim; ++dir) {
-	  this->x[dir] = x[dir];
-	  this->r[dir] = 0;
-	}
-      }
+      compute_fat_link_max(false), staggeredPhaseType(QUDA_STAGGERED_PHASE_NO),
+      staggeredPhaseApplied(false), i_mu(0.0)
+      { }
 
   GaugeFieldParam(void *h_gauge, const QudaGaugeParam &param) : LatticeFieldParam(param),
-      nColor(3), nFace(0), reconstruct(QUDA_RECONSTRUCT_NO), order(param.gauge_order), 
-      fixed(param.gauge_fix), link_type(param.type), t_boundary(param.t_boundary), 
-      anisotropy(param.anisotropy), tadpole(param.tadpole_coeff), scale(param.scale), gauge(h_gauge), 
+      nColor(3), nFace(0), reconstruct(QUDA_RECONSTRUCT_NO), order(param.gauge_order),
+      fixed(param.gauge_fix), link_type(param.type), t_boundary(param.t_boundary),
+      anisotropy(param.anisotropy), tadpole(param.tadpole_coeff), scale(param.scale), gauge(h_gauge),
       create(QUDA_REFERENCE_FIELD_CREATE), geometry(QUDA_VECTOR_GEOMETRY),
-      compute_fat_link_max(false), ghostExchange(QUDA_GHOST_EXCHANGE_PAD),
-      staggeredPhaseType(param.staggered_phase_type), 
+      compute_fat_link_max(false), staggeredPhaseType(param.staggered_phase_type),
       staggeredPhaseApplied(param.staggered_phase_applied), i_mu(param.i_mu)
 	{
 	  if (link_type == QUDA_WILSON_LINKS || link_type == QUDA_ASQTAD_FAT_LINKS) nFace = 1;
 	  else if (link_type == QUDA_ASQTAD_LONG_LINKS) nFace = 3;
 	  else errorQuda("Error: invalid link type(%d)\n", link_type);
-	  for (int d=0; d<nDim; d++) r[d] = 0;
 	}
     
     /**
@@ -154,13 +126,8 @@ namespace quda {
     double fat_link_max;
     double scale;
 
-
     QudaFieldCreate create; // used to determine the type of field created
 
-    /** Array storing the length of dimension */
-    int r[QUDA_MAX_DIM];
-
-    QudaGhostExchange ghostExchange; // the type of ghost exchange to perform
     mutable void *ghost[QUDA_MAX_DIM]; // stores the ghost zone of the gauge field (non-native fields only)
 
     /** The staggered phase convention to use */
@@ -199,8 +166,6 @@ namespace quda {
     QudaGaugeFixed GaugeFixed() const { return fixed; }
     QudaGaugeFieldOrder FieldOrder() const { return order; }
     QudaFieldGeometry Geometry() const { return geometry; }
-    const int* R() const { return r; }
-    QudaGhostExchange GhostExchange() const { return ghostExchange; }
     QudaStaggeredPhase StaggeredPhase() const { return staggeredPhaseType; }
     bool StaggeredPhaseApplied() const { return staggeredPhaseApplied; }
 

--- a/include/gauge_field.h
+++ b/include/gauge_field.h
@@ -74,9 +74,10 @@ namespace quda {
       staggeredPhaseApplied(false), i_mu(0.0)
       { }
 
-  GaugeFieldParam(void *h_gauge, const QudaGaugeParam &param) : LatticeFieldParam(param),
-      nColor(3), nFace(0), reconstruct(QUDA_RECONSTRUCT_NO), order(param.gauge_order),
-      fixed(param.gauge_fix), link_type(param.type), t_boundary(param.t_boundary),
+  GaugeFieldParam(void *h_gauge, const QudaGaugeParam &param, QudaLinkType link_type_=QUDA_INVALID_LINKS)
+    : LatticeFieldParam(param), nColor(3), nFace(0), reconstruct(QUDA_RECONSTRUCT_NO),
+      order(param.gauge_order), fixed(param.gauge_fix),
+      link_type(link_type_ != QUDA_INVALID_LINKS ? link_type_ : param.type), t_boundary(param.t_boundary),
       anisotropy(param.anisotropy), tadpole(param.tadpole_coeff), scale(param.scale), gauge(h_gauge),
       create(QUDA_REFERENCE_FIELD_CREATE), geometry(QUDA_VECTOR_GEOMETRY),
       compute_fat_link_max(false), staggeredPhaseType(param.staggered_phase_type),
@@ -84,7 +85,7 @@ namespace quda {
 	{
 	  if (link_type == QUDA_WILSON_LINKS || link_type == QUDA_ASQTAD_FAT_LINKS) nFace = 1;
 	  else if (link_type == QUDA_ASQTAD_LONG_LINKS) nFace = 3;
-	  else errorQuda("Error: invalid link type(%d)\n", link_type);
+	  else if (link_type == QUDA_INVALID_LINKS) errorQuda("Error: invalid link type(%d)\n", link_type);
 	}
     
     /**

--- a/include/gauge_field_order.h
+++ b/include/gauge_field_order.h
@@ -1250,7 +1250,10 @@ namespace quda {
   };
 
     /**
-       struct to define BQCD ordered gauge fields:
+       @brief struct to define BQCD ordered gauge fields:
+
+       Note the convention in BQCD is to store the gauge field
+       variables in and extended fields with inline halos
        [mu][parity][volumecb+halos][col][row]
     */
     template <typename Float, int length> struct BQCDOrder : LegacyOrder<Float,length> {

--- a/include/gauge_field_order.h
+++ b/include/gauge_field_order.h
@@ -1190,15 +1190,14 @@ namespace quda {
     Float *gauge;
     const int volumeCB;
     const Float anisotropy;
-    const int Nc;
+    static constexpr int Nc = 3;
     const int geometry;
   CPSOrder(const GaugeField &u, Float *gauge_=0, Float **ghost_=0)
     : LegacyOrder<Float,length>(u, ghost_), gauge(gauge_ ? gauge_ : (Float*)u.Gauge_p()),
-      volumeCB(u.VolumeCB()), anisotropy(u.Anisotropy()), Nc(3),
-      geometry(u.Geometry())
+      volumeCB(u.VolumeCB()), anisotropy(u.Anisotropy()), geometry(u.Geometry())
       { if (length != 18) errorQuda("Gauge length %d not supported", length); }
   CPSOrder(const CPSOrder &order) : LegacyOrder<Float,length>(order), gauge(order.gauge),
-      volumeCB(order.volumeCB), anisotropy(order.anisotropy), Nc(3), geometry(order.geometry)
+      volumeCB(order.volumeCB), anisotropy(order.anisotropy), geometry(order.geometry)
       { ; }
     virtual ~CPSOrder() { ; }
 
@@ -1261,16 +1260,16 @@ namespace quda {
       Float *gauge;
       const int volumeCB;
       int exVolumeCB; // extended checkerboard volume
-      const int Nc;
+      static constexpr int Nc = 3;
     BQCDOrder(const GaugeField &u, Float *gauge_=0, Float **ghost_=0)
-      : LegacyOrder<Float,length>(u, ghost_), gauge(gauge_ ? gauge_ : (Float*)u.Gauge_p()), volumeCB(u.VolumeCB()), Nc(3) {
+      : LegacyOrder<Float,length>(u, ghost_), gauge(gauge_ ? gauge_ : (Float*)u.Gauge_p()), volumeCB(u.VolumeCB()) {
 	if (length != 18) errorQuda("Gauge length %d not supported", length);
 	// compute volumeCB + halo region
 	exVolumeCB = u.X()[0]/2 + 2;
 	for (int i=1; i<4; i++) exVolumeCB *= u.X()[i] + 2;
       }
     BQCDOrder(const BQCDOrder &order) : LegacyOrder<Float,length>(order), gauge(order.gauge),
-	volumeCB(order.volumeCB), exVolumeCB(order.exVolumeCB), Nc(3) {
+	volumeCB(order.volumeCB), exVolumeCB(order.exVolumeCB) {
 	if (length != 18) errorQuda("Gauge length %d not supported", length);
       }
 
@@ -1329,15 +1328,15 @@ namespace quda {
       typedef typename mapper<Float>::type RegType;
       Float *gauge;
       const int volumeCB;
-      const int Nc;
+      static constexpr int Nc = 3;
       const Float scale;
     TIFROrder(const GaugeField &u, Float *gauge_=0, Float **ghost_=0)
       : LegacyOrder<Float,length>(u, ghost_), gauge(gauge_ ? gauge_ : (Float*)u.Gauge_p()),
-	volumeCB(u.VolumeCB()), Nc(3), scale(u.Scale()) {
+	volumeCB(u.VolumeCB()), scale(u.Scale()) {
 	if (length != 18) errorQuda("Gauge length %d not supported", length);
       }
     TIFROrder(const TIFROrder &order)
-      : LegacyOrder<Float,length>(order), gauge(order.gauge), volumeCB(order.volumeCB), Nc(3), scale(order.scale) {
+      : LegacyOrder<Float,length>(order), gauge(order.gauge), volumeCB(order.volumeCB), scale(order.scale) {
 	if (length != 18) errorQuda("Gauge length %d not supported", length);
       }
 
@@ -1397,13 +1396,13 @@ namespace quda {
       Float *gauge;
       const int volumeCB;
       int exVolumeCB;
-      const int Nc;
+      static constexpr int Nc = 3;
       const Float scale;
       const int dim[4];
       const int exDim[4];
     TIFRPaddedOrder(const GaugeField &u, Float *gauge_=0, Float **ghost_=0)
       : LegacyOrder<Float,length>(u, ghost_), gauge(gauge_ ? gauge_ : (Float*)u.Gauge_p()),
-	volumeCB(u.VolumeCB()), exVolumeCB(1), Nc(3), scale(u.Scale()),
+	volumeCB(u.VolumeCB()), exVolumeCB(1), scale(u.Scale()),
 	dim{ u.X()[0], u.X()[1], u.X()[2], u.X()[3] },
 	exDim{ u.X()[0], u.X()[1], u.X()[2] + 4, u.X()[3] } {
 	if (length != 18) errorQuda("Gauge length %d not supported", length);
@@ -1414,7 +1413,7 @@ namespace quda {
       }
 
     TIFRPaddedOrder(const TIFRPaddedOrder &order)
-      : LegacyOrder<Float,length>(order), gauge(order.gauge), volumeCB(order.volumeCB), exVolumeCB(order.exVolumeCB), Nc(3), scale(order.scale),
+      : LegacyOrder<Float,length>(order), gauge(order.gauge), volumeCB(order.volumeCB), exVolumeCB(order.exVolumeCB), scale(order.scale),
 	  dim{order.dim[0], order.dim[1], order.dim[2], order.dim[3]},
 	  exDim{order.exDim[0], order.exDim[1], order.exDim[2], order.exDim[3]} {
 	if (length != 18) errorQuda("Gauge length %d not supported", length);

--- a/include/lattice_field.h
+++ b/include/lattice_field.h
@@ -103,11 +103,11 @@ namespace quda {
     */
     LatticeFieldParam(const QudaGaugeParam &param) 
     : nDim(4), pad(0), precision(param.cpu_prec), siteSubset(QUDA_FULL_SITE_SUBSET),
-      ghostExchange(QUDA_GHOST_EXCHANGE_PAD)
+      ghostExchange(QUDA_GHOST_EXCHANGE_NO)
     {
       for (int i=0; i<nDim; i++) {
 	this->x[i] = param.X[i];
-	this->r[i] = 0;
+	this->r[i] = param.R[i];
       }
     }
 

--- a/include/lattice_field.h
+++ b/include/lattice_field.h
@@ -107,7 +107,7 @@ namespace quda {
     {
       for (int i=0; i<nDim; i++) {
 	this->x[i] = param.X[i];
-	this->r[i] = param.R[i];
+	this->r[i] = 0;
       }
     }
 
@@ -177,7 +177,6 @@ namespace quda {
 
     /** Resize the device-memory buffer */
     void resizeBufferDevice(size_t bytes) const;
-
 
 
     // The below are additions for inter-GPU communication (merging FaceBuffer functionality)

--- a/include/lattice_field.h
+++ b/include/lattice_field.h
@@ -21,6 +21,8 @@ namespace quda {
   // LatticeField is an abstract base clase for all Field objects.
 
   // Forward declaration of all children
+  class LatticeField;
+
   class ColorSpinorField;
   class cudaColorSpinorField;
   class cpuColorSpinorField;
@@ -42,33 +44,77 @@ namespace quda {
   class cpuCloverField;
 
   struct LatticeFieldParam {
+
+    /** Number of field dimensions */
     int nDim;
+
+    /** Array storing the length of dimension */
     int x[QUDA_MAX_DIM];
+
     int pad;
 
     QudaPrecision precision;
     QudaSiteSubset siteSubset;
   
-    LatticeFieldParam() 
-    : nDim(0), pad(0), precision(QUDA_INVALID_PRECISION), siteSubset(QUDA_INVALID_SITE_SUBSET) {
-      for (int i=0; i<nDim; i++) x[i] = 0; 
+    /** The type of ghost exchange to be done with this field */
+    QudaGhostExchange ghostExchange;
+
+    /** The extended field radius (if applicable) */
+    int r[QUDA_MAX_DIM];
+
+    /**
+       @brief Default constructor for LatticeFieldParam
+    */
+    LatticeFieldParam()
+    : nDim(4), pad(0), precision(QUDA_INVALID_PRECISION), siteSubset(QUDA_INVALID_SITE_SUBSET),
+      ghostExchange(QUDA_GHOST_EXCHANGE_PAD)
+    {
+      for (int i=0; i<nDim; i++) {
+	x[i] = 0;
+	r[i] = 0;
+      }
     }
 
-    LatticeFieldParam(int nDim, const int *x, int pad, QudaPrecision precision)
-    : nDim(nDim), pad(pad), precision(precision), siteSubset(QUDA_FULL_SITE_SUBSET) { 
+    /**
+       @brief Constructor for creating a LatticeFieldParam from a set of parameters
+       @param[in] nDim Number of field dimensions
+       @param[in] x Array of dimension lengths
+       @param[in] pad Field padding
+       @param[in] precision Field Precision
+       @param[in] ghostExchange Type of ghost exchange
+    */
+    LatticeFieldParam(int nDim, const int *x, int pad, QudaPrecision precision,
+		      QudaGhostExchange ghostExchange=QUDA_GHOST_EXCHANGE_PAD)
+    : nDim(nDim), pad(pad), precision(precision), siteSubset(QUDA_FULL_SITE_SUBSET),
+      ghostExchange(ghostExchange)
+    {
       if (nDim > QUDA_MAX_DIM) errorQuda("Number of dimensions too great");
-      for (int i=0; i<nDim; i++) this->x[i] = x[i]; 
+      for (int i=0; i<nDim; i++) {
+	this->x[i] = x[i];
+	this->r[i] = 0;
+      }
     }
     
     /**
-       Constructor for creating a LatticeField from a QudaGaugeParam
-       @param param Contains the metadate for creating the
-       LatticeField
+       @brief Constructor for creating a LatticeFieldParam from a
+       QudaGaugeParam.  Used for wrapping around a CPU reference
+       field.
+       @param[in] param Contains the metadata for filling out the LatticeFieldParam
     */
     LatticeFieldParam(const QudaGaugeParam &param) 
-    : nDim(4), pad(0), precision(param.cpu_prec), siteSubset(QUDA_FULL_SITE_SUBSET) {
-      for (int i=0; i<nDim; i++) this->x[i] = param.X[i];
+    : nDim(4), pad(0), precision(param.cpu_prec), siteSubset(QUDA_FULL_SITE_SUBSET),
+      ghostExchange(QUDA_GHOST_EXCHANGE_PAD)
+    {
+      for (int i=0; i<nDim; i++) {
+	this->x[i] = param.X[i];
+	this->r[i] = 0;
+      }
     }
+
+    /**
+       @brief Contructor for creating LatticeFieldParam from a LatticeField
+    */
+    LatticeFieldParam(const LatticeField &field);
   };
 
   std::ostream& operator<<(std::ostream& output, const LatticeFieldParam& param);
@@ -76,14 +122,18 @@ namespace quda {
   class LatticeField : public Object {
 
   protected:
-    int volume; // lattice volume
-    int volumeCB; // the checkboarded volume
+    /** Lattice volume */
+    int volume;
+
+    /** Checkerboarded volume */
+    int volumeCB;
+
     int stride;
     int pad;
 
     size_t total_bytes;
 
-    /** The number field dimensions */
+    /** Number of field dimensions */
     int nDim;
     
     /** Array storing the length of dimension */
@@ -92,9 +142,10 @@ namespace quda {
     int surface[QUDA_MAX_DIM];
     int surfaceCB[QUDA_MAX_DIM];
 
-    /**
-       The precision of the field 
-    */
+    /** The extended lattice radius (if applicable) */
+    int r[QUDA_MAX_DIM];
+
+    /** Precision of the field */
     QudaPrecision precision;
     
     /** Whether the field is full or single parity */
@@ -170,6 +221,9 @@ namespace quda {
     /** Sets the vol_string for use in tuning */
     virtual void setTuningString();
 
+    /** Type of ghost exchange to perform */
+    QudaGhostExchange ghostExchange;
+
   public:
 
     /**
@@ -231,9 +285,24 @@ namespace quda {
     int Pad() const { return pad; }
     
     /**
+       @return Extended field radius
+    */
+    const int* R() const { return r; }
+
+    /**
+       @return Type of ghost exchange
+     */
+    QudaGhostExchange GhostExchange() const { return ghostExchange; }
+
+    /**
        @return The field precision
     */
     QudaPrecision Precision() const { return precision; }
+
+    /**
+       @return Field subset type
+     */
+    virtual QudaSiteSubset SiteSubset() const { return siteSubset; }
 
     /**
        @return The vector storage length used for native fields , 2
@@ -292,10 +361,11 @@ namespace quda {
     const char *VolString() const { return vol_string; }
   };
   
+  
   /**
-     Helper function for determining if the location of the fields is the same.
-     @param a Input field
-     @param b Input field
+     @brief Helper function for determining if the location of the fields is the same.
+     @param[in] a Input field
+     @param[in] b Input field
      @return If location is unique return the location
    */
   inline QudaFieldLocation Location(const LatticeField &a, const LatticeField &b) {
@@ -306,63 +376,19 @@ namespace quda {
   }
 
   /**
-     Helper function for determining if the location of the fields is the same.
-     @param a Input field
-     @param b Input field
-     @param c Input field
+     @brief Helper function for determining if the location of the fields is the same.
+     @param[in] a Input field
+     @param[in] b Input field
+     @param[in] args List of additional fields to check location on
      @return If location is unique return the location
    */
-  inline QudaFieldLocation Location(const LatticeField &a, const LatticeField &b,
-				    const LatticeField &c) {
-    return static_cast<QudaFieldLocation>(Location(a,b) & Location(b,c));
+  template <typename... Args>
+  inline QudaFieldLocation Location(const LatticeField &a, const LatticeField &b, const Args &... args) {
+    return static_cast<QudaFieldLocation>(Location(a,b) & Location(a,args...));
   }
 
   /**
-     Helper function for determining if the location of the fields is the same.
-     @param a Input field
-     @param b Input field
-     @param c Input field
-     @param d Input field
-     @return If location is unique return the location
-   */
-  inline QudaFieldLocation Location(const LatticeField &a, const LatticeField &b,
-				    const LatticeField &c, const LatticeField &d) {
-    return static_cast<QudaFieldLocation>(Location(a,b) & Location(a,c) & Location(a,d));
-  }
-
-  /**
-     Helper function for determining if the location of the fields is the same.
-     @param a Input field
-     @param b Input field
-     @param c Input field
-     @param d Input field
-     @param e Input field
-     @return If location is unique return the location
-   */
-  inline QudaFieldLocation Location(const LatticeField &a, const LatticeField &b,
-				    const LatticeField &c, const LatticeField &d,
-				    const LatticeField &e) {
-    return static_cast<QudaFieldLocation>(Location(a,b) & Location(a,c) & Location(a,d) & Location(a,e));
-  }
-
-  /**
-     Helper function for determining if the location of the fields is the same.
-     @param a Input field
-     @param b Input field
-     @param c Input field
-     @param d Input field
-     @param e Input field
-     @param f Input field
-     @return If location is unique return the location
-   */
-  inline QudaFieldLocation Location(const LatticeField &a, const LatticeField &b,
-				    const LatticeField &c, const LatticeField &d,
-				    const LatticeField &e, const LatticeField &f) {
-    return static_cast<QudaFieldLocation>(Location(a,b) & Location(a,c) & Location(a,d) & Location(a,e) & Location(a,f));
-  }
-
-  /**
-     Return whether data is reorderd on the CPU or GPU.  This can set
+     @brief Return whether data is reorderd on the CPU or GPU.  This can set
      at QUDA initialization using the environment variable
      QUDA_REORDER_LOCATION.
      @return Reorder location
@@ -370,7 +396,7 @@ namespace quda {
   QudaFieldLocation reorder_location();
 
   /**
-     Set whether data is reorderd on the CPU or GPU.  This can set at
+     @brief Set whether data is reorderd on the CPU or GPU.  This can set at
      QUDA initialization using the environment variable
      QUDA_REORDER_LOCATION.
      @param reorder_location_ The location to set where data will be reordered

--- a/include/quda.h
+++ b/include/quda.h
@@ -50,6 +50,9 @@ extern "C" {
 
     QudaGaugeFixed gauge_fix; /**< Whether the input gauge field is in the axial gauge or not */
 
+    int R[4];         /**< Radius applied to gauge field by the host application (BQCD and certain TIFR codes
+			   employ an extended field with inline halo when storing their gauge field elements) */
+
     int ga_pad;       /**< The pad size that the cudaGaugeField will use (default=0) */
 
     int site_ga_pad;  /**< Used by link fattening and the gauge and fermion forces */

--- a/include/quda.h
+++ b/include/quda.h
@@ -50,9 +50,6 @@ extern "C" {
 
     QudaGaugeFixed gauge_fix; /**< Whether the input gauge field is in the axial gauge or not */
 
-    int R[4];         /**< Radius applied to gauge field by the host application (BQCD and certain TIFR codes
-			   employ an extended field with inline halo when storing their gauge field elements) */
-
     int ga_pad;       /**< The pad size that the cudaGaugeField will use (default=0) */
 
     int site_ga_pad;  /**< Used by link fattening and the gauge and fermion forces */

--- a/include/tune_key.h
+++ b/include/tune_key.h
@@ -8,7 +8,7 @@ namespace quda {
   struct TuneKey {
 
     static const int volume_n = 32;
-    static const int name_n = 256;
+    static const int name_n = 384;
     static const int aux_n = 256;
     char volume[volume_n];
     char name[name_n];

--- a/lib/check_params.h
+++ b/lib/check_params.h
@@ -83,12 +83,6 @@ void printQudaGaugeParam(QudaGaugeParam *param) {
 
   P(gauge_fix, QUDA_GAUGE_FIXED_INVALID);
 
-#if defined INIT_PARAM
-  for (int i=0; i<4; i++) P(R[i], 0);
-#else
-  for (int i=0; i<4; i++) P(R[i], INVALID_INT);
-#endif
-
   P(ga_pad, INVALID_INT);
   
 #if defined INIT_PARAM

--- a/lib/check_params.h
+++ b/lib/check_params.h
@@ -82,6 +82,13 @@ void printQudaGaugeParam(QudaGaugeParam *param) {
 #endif
 
   P(gauge_fix, QUDA_GAUGE_FIXED_INVALID);
+
+#if defined INIT_PARAM
+  for (int i=0; i<4; i++) P(R[i], 0);
+#else
+  for (int i=0; i<4; i++) P(R[i], INVALID_INT);
+#endif
+
   P(ga_pad, INVALID_INT);
   
 #if defined INIT_PARAM

--- a/lib/copy_gauge_extended.cu
+++ b/lib/copy_gauge_extended.cu
@@ -298,8 +298,6 @@ namespace quda {
 
   }
 
-  void checkMomOrder(const GaugeField &u);
-
   template <typename FloatOut, typename FloatIn>
   void copyGaugeEx(GaugeField &out, const GaugeField &in, QudaFieldLocation location,
 		   FloatOut *Out, FloatIn *In) {
@@ -316,42 +314,7 @@ namespace quda {
       // we are doing gauge field packing
       copyGaugeEx<FloatOut,FloatIn,18>(out, in, location, Out, In);
     } else {
-      if (out.Geometry() != QUDA_VECTOR_GEOMETRY) errorQuda("Unsupported geometry %d", out.Geometry());
-
-      checkMomOrder(in);
-      checkMomOrder(out);
-
-      int faceVolumeCB[QUDA_MAX_DIM];
-      for (int d=0; d<in.Ndim(); d++) faceVolumeCB[d] = out.SurfaceCB(d) * out.Nface();
-
-      // momentum only currently supported on MILC (10), TIFR (18) and Float2 (10) fields currently
-      if (out.Order() == QUDA_FLOAT2_GAUGE_ORDER) {
-	if (in.Order() == QUDA_TIFR_GAUGE_ORDER) {
-#ifdef BUILD_TIFR_INTERFACE
-	  typedef FloatNOrder<FloatOut,18,2,11> momOut;
-	  typedef TIFROrder<FloatIn,18> momIn;
-	  copyGaugeEx<FloatOut,FloatIn,18>(momOut(out, Out), momIn(in, In), out.X(), in.X(), faceVolumeCB, out, location);
-#else
-	  errorQuda("TIFR interface has not been built\n");
-#endif
-	} else {
-	  errorQuda("Gauge field orders %d not supported", in.Order());
-	}
-      } else if (out.Order() == QUDA_TIFR_GAUGE_ORDER) {
-#ifdef BUILD_TIFR_INTERFACE
-	if (in.Order() == QUDA_FLOAT2_GAUGE_ORDER) {
-	  typedef TIFROrder<FloatOut,18> momOut;
-	  typedef FloatNOrder<FloatIn,18,2,11> momIn;
-	  copyGaugeEx<FloatOut,FloatIn,18>(momOut(out, Out), momIn(in, In), out.X(), in.X(), faceVolumeCB, out, location);
-	} else {
-	  errorQuda("Gauge field orders %d not supported", in.Order());
-	}
-#else
-	errorQuda("TIFR interface has not been built\n");
-#endif
-      } else {
-	errorQuda("Gauge field orders %d not supported", out.Order());
-      }
+      errorQuda("Not supported");
     }
   }
 

--- a/lib/copy_gauge_extended.cu
+++ b/lib/copy_gauge_extended.cu
@@ -298,6 +298,8 @@ namespace quda {
 
   }
 
+  void checkMomOrder(const GaugeField &u);
+
   template <typename FloatOut, typename FloatIn>
   void copyGaugeEx(GaugeField &out, const GaugeField &in, QudaFieldLocation location,
 		   FloatOut *Out, FloatIn *In) {
@@ -314,7 +316,42 @@ namespace quda {
       // we are doing gauge field packing
       copyGaugeEx<FloatOut,FloatIn,18>(out, in, location, Out, In);
     } else {
-      errorQuda("Not supported");
+      if (out.Geometry() != QUDA_VECTOR_GEOMETRY) errorQuda("Unsupported geometry %d", out.Geometry());
+
+      checkMomOrder(in);
+      checkMomOrder(out);
+
+      int faceVolumeCB[QUDA_MAX_DIM];
+      for (int d=0; d<in.Ndim(); d++) faceVolumeCB[d] = out.SurfaceCB(d) * out.Nface();
+
+      // momentum only currently supported on MILC (10), TIFR (18) and Float2 (10) fields currently
+      if (out.Order() == QUDA_FLOAT2_GAUGE_ORDER) {
+	if (in.Order() == QUDA_TIFR_GAUGE_ORDER) {
+#ifdef BUILD_TIFR_INTERFACE
+	  typedef FloatNOrder<FloatOut,18,2,11> momOut;
+	  typedef TIFROrder<FloatIn,18> momIn;
+	  copyGaugeEx<FloatOut,FloatIn,18>(momOut(out, Out), momIn(in, In), out.X(), in.X(), faceVolumeCB, out, location);
+#else
+	  errorQuda("TIFR interface has not been built\n");
+#endif
+	} else {
+	  errorQuda("Gauge field orders %d not supported", in.Order());
+	}
+      } else if (out.Order() == QUDA_TIFR_GAUGE_ORDER) {
+#ifdef BUILD_TIFR_INTERFACE
+	if (in.Order() == QUDA_FLOAT2_GAUGE_ORDER) {
+	  typedef TIFROrder<FloatOut,18> momOut;
+	  typedef FloatNOrder<FloatIn,18,2,11> momIn;
+	  copyGaugeEx<FloatOut,FloatIn,18>(momOut(out, Out), momIn(in, In), out.X(), in.X(), faceVolumeCB, out, location);
+	} else {
+	  errorQuda("Gauge field orders %d not supported", in.Order());
+	}
+#else
+	errorQuda("TIFR interface has not been built\n");
+#endif
+      } else {
+	errorQuda("Gauge field orders %d not supported", out.Order());
+      }
     }
   }
 

--- a/lib/copy_gauge_extended.cu
+++ b/lib/copy_gauge_extended.cu
@@ -129,7 +129,6 @@ namespace quda {
     void apply(const cudaStream_t &stream) {
       TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
 
-
       if (location == QUDA_CPU_FIELD_LOCATION) {
 	if(arg.regularToextended) copyGaugeEx<FloatOut, FloatIn, length, OutOrder, InOrder, true>(arg);
 	else copyGaugeEx<FloatOut, FloatIn, length, OutOrder, InOrder, false>(arg);

--- a/lib/copy_gauge_inc.cu
+++ b/lib/copy_gauge_inc.cu
@@ -282,7 +282,7 @@ namespace quda {
 #endif
 	  } else if (in.Order() == QUDA_TIFR_GAUGE_ORDER) {
 #ifdef BUILD_TIFR_INTERFACE
-	    typedef FloatNOrder<FloatOut,10,2,11> momOut;
+	    typedef FloatNOrder<FloatOut,18,2,11> momOut;
 	    typedef TIFROrder<FloatIn,18> momIn;
 	    CopyGaugeArg<momOut,momIn> arg(momOut(out, Out), momIn(in, In), in.Volume(),
 				     faceVolumeCB, in.Ndim(), in.Geometry());
@@ -292,7 +292,7 @@ namespace quda {
 #endif
 	  } else if (in.Order() == QUDA_TIFR_PADDED_GAUGE_ORDER) {
 #ifdef BUILD_TIFR_INTERFACE
-	    typedef FloatNOrder<FloatOut,10,2,11> momOut;
+	    typedef FloatNOrder<FloatOut,18,2,11> momOut;
 	    typedef TIFRPaddedOrder<FloatIn,18> momIn;
 	    CopyGaugeArg<momOut,momIn> arg(momOut(out, Out), momIn(in, In), in.Volume(),
 				     faceVolumeCB, in.Ndim(), in.Geometry());

--- a/lib/cpu_gauge_field.cpp
+++ b/lib/cpu_gauge_field.cpp
@@ -7,7 +7,7 @@
 
 namespace quda {
 
-  cpuGaugeField::cpuGaugeField(const GaugeFieldParam &param) : 
+  cpuGaugeField::cpuGaugeField(const GaugeFieldParam &param) :
     GaugeField(param), backed_up(false)
   {
     if (precision == QUDA_HALF_PRECISION) {

--- a/lib/cpu_gauge_field.cpp
+++ b/lib/cpu_gauge_field.cpp
@@ -30,6 +30,13 @@ namespace quda {
     else if (geometry == QUDA_COARSE_GEOMETRY) siteDim = 2*nDim;
     else errorQuda("Unknown geometry type %d", geometry);
 
+    // compute the correct bytes size for these padded field orders
+    if (order == QUDA_TIFR_PADDED_GAUGE_ORDER) {
+      bytes = siteDim * (x[0]*x[1]*(x[2]+4)*x[3]) * nInternal * precision;
+    } else if (order == QUDA_BQCD_GAUGE_ORDER) {
+      bytes = siteDim * (x[0]+4)*(x[1]+2)*(x[2]+2)*(x[3]+2) * nInternal * precision;
+    }
+
     if (order == QUDA_QDP_GAUGE_ORDER) {
       gauge = (void**) safe_malloc(siteDim * sizeof(void*));
 
@@ -50,9 +57,8 @@ namespace quda {
 	       order == QUDA_TIFR_PADDED_GAUGE_ORDER) {
 
       if (create == QUDA_NULL_FIELD_CREATE || create == QUDA_ZERO_FIELD_CREATE) {
-	size_t nbytes = siteDim * volume * nInternal * precision;
-	gauge = (void **) safe_malloc(nbytes);
-	if(create == QUDA_ZERO_FIELD_CREATE) memset(gauge, 0, nbytes);
+	gauge = (void **) safe_malloc(bytes);
+	if(create == QUDA_ZERO_FIELD_CREATE) memset(gauge, 0, bytes);
       } else if (create == QUDA_REFERENCE_FIELD_CREATE) {
 	gauge = (void**) param.gauge;
       } else {

--- a/lib/cuda_gauge_field.cu
+++ b/lib/cuda_gauge_field.cu
@@ -425,8 +425,13 @@ namespace quda {
     } else if (typeid(src) == typeid(cpuGaugeField)) {
       if (reorder_location() == QUDA_CPU_FIELD_LOCATION) { // do reorder on the CPU
 	void *buffer = pool_pinned_malloc(bytes);
-	// copy field and ghost zone into buffer
-	copyGenericGauge(*this, src, QUDA_CPU_FIELD_LOCATION, buffer, static_cast<const cpuGaugeField&>(src).gauge);
+
+	if (src.GhostExchange() != QUDA_GHOST_EXCHANGE_EXTENDED) {
+	  // copy field and ghost zone into buffer
+	  copyGenericGauge(*this, src, QUDA_CPU_FIELD_LOCATION, buffer, static_cast<const cpuGaugeField&>(src).gauge);
+	} else {
+	  copyExtendedGauge(*this, src, QUDA_CPU_FIELD_LOCATION, buffer, static_cast<const cpuGaugeField&>(src).gauge);
+	}
 
 	// this copies over both even and odd
 	qudaMemcpy(gauge, buffer, bytes, cudaMemcpyHostToDevice);
@@ -451,7 +456,11 @@ namespace quda {
 	  for (int d=0; d<4; d++)
 	    qudaMemcpy(ghost_buffer[d], src.Ghost()[d], ghost_bytes[d], cudaMemcpyHostToDevice);
 
-	copyGenericGauge(*this, src, QUDA_CUDA_FIELD_LOCATION, gauge, buffer, 0, ghost_buffer);
+	if (src.GhostExchange() != QUDA_GHOST_EXCHANGE_EXTENDED) {
+	  copyGenericGauge(*this, src, QUDA_CUDA_FIELD_LOCATION, gauge, buffer, 0, ghost_buffer);
+	} else {
+	  copyExtendedGauge(*this, src, QUDA_CUDA_FIELD_LOCATION, gauge, buffer);
+	}
 	free_gauge_buffer(buffer, src.Order(), src.Geometry());
 	if (nFace > 0) free_ghost_buffer(ghost_buffer, src.Order());
       } // reorder_location
@@ -472,9 +481,9 @@ namespace quda {
 
   void cudaGaugeField::saveCPUField(cpuGaugeField &cpu) const
   {
-    QudaFieldLocation pack_location = reorder_location();
+    static_cast<LatticeField&>(cpu).checkField(*this);
 
-    if (pack_location == QUDA_CUDA_FIELD_LOCATION) {
+    if (reorder_location() == QUDA_CUDA_FIELD_LOCATION) {
 
       void *buffer = create_gauge_buffer(cpu.Bytes(), cpu.Order(), cpu.Geometry());
 
@@ -484,7 +493,11 @@ namespace quda {
       for (int d=0; d<4; d++) ghost_bytes[d] = nFace * surface[d] * cpuNinternal * cpu.Precision();
       void **ghost_buffer = (nFace > 0) ? create_ghost_buffer(ghost_bytes, cpu.Order()) : nullptr;
 
-      copyGenericGauge(cpu, *this, QUDA_CUDA_FIELD_LOCATION, buffer, gauge, ghost_buffer, 0);
+      if (cpu.GhostExchange() != QUDA_GHOST_EXCHANGE_EXTENDED) {
+	copyGenericGauge(cpu, *this, QUDA_CUDA_FIELD_LOCATION, buffer, gauge, ghost_buffer, 0);
+      } else {
+	copyExtendedGauge(cpu, *this, QUDA_CUDA_FIELD_LOCATION, buffer, gauge);
+      }
 
       if (cpu.Order() == QUDA_QDP_GAUGE_ORDER) {
 	for (int d=0; d<geometry; d++) qudaMemcpy(((void**)cpu.gauge)[d], ((void**)buffer)[d], cpu.Bytes()/geometry, cudaMemcpyDeviceToHost);
@@ -500,15 +513,20 @@ namespace quda {
       free_gauge_buffer(buffer, cpu.Order(), cpu.Geometry());
       if (nFace > 0) free_ghost_buffer(ghost_buffer, cpu.Order());
 
-    } else if (pack_location == QUDA_CPU_FIELD_LOCATION) { // do copy then host-side reorder
+    } else if (reorder_location() == QUDA_CPU_FIELD_LOCATION) { // do copy then host-side reorder
 
       void *buffer = pool_pinned_malloc(bytes);
       qudaMemcpy(buffer, gauge, bytes, cudaMemcpyDeviceToHost);
-      copyGenericGauge(cpu, *this, QUDA_CPU_FIELD_LOCATION, cpu.gauge, buffer);
+
+      if (cpu.GhostExchange() != QUDA_GHOST_EXCHANGE_EXTENDED) {
+	copyGenericGauge(cpu, *this, QUDA_CPU_FIELD_LOCATION, cpu.gauge, buffer);
+      } else {
+	copyExtendedGauge(cpu, *this, QUDA_CPU_FIELD_LOCATION, cpu.gauge, buffer);
+      }
       pool_pinned_free(buffer);
 
     } else {
-      errorQuda("Invalid pack location %d", pack_location);
+      errorQuda("Invalid pack location %d", reorder_location());
     }
 
     cpu.staggeredPhaseApplied = staggeredPhaseApplied;

--- a/lib/cuda_gauge_field.cu
+++ b/lib/cuda_gauge_field.cu
@@ -15,9 +15,9 @@ namespace quda {
       errorQuda("QDP ordering only supported for reference fields");
     }
 
-    if (order == QUDA_QDP_GAUGE_ORDER || order == QUDA_MILC_GAUGE_ORDER ||
-	order == QUDA_TIFR_GAUGE_ORDER || order == QUDA_BQCD_GAUGE_ORDER ||
-	order == QUDA_CPS_WILSON_GAUGE_ORDER) 
+    if (order == QUDA_MILC_GAUGE_ORDER || order == QUDA_QDP_GAUGE_ORDER ||
+	order == QUDA_TIFR_GAUGE_ORDER || order == QUDA_TIFR_PADDED_GAUGE_ORDER ||
+	order == QUDA_BQCD_GAUGE_ORDER || order == QUDA_CPS_WILSON_GAUGE_ORDER)
       errorQuda("Field ordering %d presently disabled for this type", order);
 
 #ifdef MULTI_GPU

--- a/lib/gauge_field.cpp
+++ b/lib/gauge_field.cpp
@@ -207,16 +207,22 @@ namespace quda {
 
   }
 
-  void GaugeField::checkField(const GaugeField &a) {
-    LatticeField::checkField(a);
-    if (a.link_type != link_type) errorQuda("link_type does not match %d %d", link_type, a.link_type);
-    if (a.nColor != nColor) errorQuda("nColor does not match %d %d", nColor, a.nColor);
-    if (a.nFace != nFace) errorQuda("nFace does not match %d %d", nFace, a.nFace);
-    if (a.fixed != fixed) errorQuda("fixed does not match %d %d", fixed, a.fixed);
-    if (a.t_boundary != t_boundary) errorQuda("t_boundary does not match %d %d", t_boundary, a.t_boundary);
-    if (a.anisotropy != anisotropy) errorQuda("anisotropy does not match %e %e", anisotropy, a.anisotropy);
-    if (a.tadpole != tadpole) errorQuda("tadpole does not match %e %e", tadpole, a.tadpole);
-    //if (a.scale != scale) errorQuda("scale does not match %e %e", scale, a.scale); 
+  void GaugeField::checkField(const LatticeField &l) const {
+    LatticeField::checkField(l);
+    try {
+      const GaugeField &g = dynamic_cast<const GaugeField&>(l);
+      if (g.link_type != link_type) errorQuda("link_type does not match %d %d", link_type, g.link_type);
+      if (g.nColor != nColor) errorQuda("nColor does not match %d %d", nColor, g.nColor);
+      if (g.nFace != nFace) errorQuda("nFace does not match %d %d", nFace, g.nFace);
+      if (g.fixed != fixed) errorQuda("fixed does not match %d %d", fixed, g.fixed);
+      if (g.t_boundary != t_boundary) errorQuda("t_boundary does not match %d %d", t_boundary, g.t_boundary);
+      if (g.anisotropy != anisotropy) errorQuda("anisotropy does not match %e %e", anisotropy, g.anisotropy);
+      if (g.tadpole != tadpole) errorQuda("tadpole does not match %e %e", tadpole, g.tadpole);
+      //if (a.scale != scale) errorQuda("scale does not match %e %e", scale, a.scale);
+    }
+    catch(std::bad_cast &e) {
+      errorQuda("Failed to cast reference to GaugeField");
+    }
   }
 
   std::ostream& operator<<(std::ostream& output, const GaugeFieldParam& param) {

--- a/lib/gauge_field.cpp
+++ b/lib/gauge_field.cpp
@@ -4,7 +4,7 @@
 
 namespace quda {
 
-  GaugeFieldParam::GaugeFieldParam(const GaugeField &u) : LatticeFieldParam(),
+  GaugeFieldParam::GaugeFieldParam(const GaugeField &u) : LatticeFieldParam(u),
     nColor(3),
     nFace(u.Nface()),
     reconstruct(u.Reconstruct()),
@@ -19,21 +19,9 @@ namespace quda {
     create(QUDA_NULL_FIELD_CREATE),
     geometry(u.Geometry()),
     compute_fat_link_max(false),
-    ghostExchange(u.GhostExchange()),
     staggeredPhaseType(u.StaggeredPhase()),
     staggeredPhaseApplied(u.StaggeredPhaseApplied()),
-    i_mu(u.iMu())
-      {
-	precision = u.Precision();
-	nDim = u.Ndim();
-	pad = u.Pad();
-	siteSubset = QUDA_FULL_SITE_SUBSET;
-
-	for(int dir=0; dir<nDim; ++dir) {
-	  x[dir] = u.X()[dir];
-	  r[dir] = u.R()[dir];
-	}
-      }
+    i_mu(u.iMu()) { }
 
 
   GaugeField::GaugeField(const GaugeFieldParam &param) :
@@ -42,7 +30,7 @@ namespace quda {
     nInternal(reconstruct != QUDA_RECONSTRUCT_NO ? reconstruct : nColor * nColor * 2),
     order(param.order), fixed(param.fixed), link_type(param.link_type), t_boundary(param.t_boundary), 
     anisotropy(param.anisotropy), tadpole(param.tadpole), fat_link_max(0.0), scale(param.scale),  
-    create(param.create), ghostExchange(param.ghostExchange), 
+    create(param.create),
     staggeredPhaseType(param.staggeredPhaseType), staggeredPhaseApplied(param.staggeredPhaseApplied), i_mu(param.i_mu)
   {
     if (link_type != QUDA_COARSE_LINKS && nColor != 3)
@@ -72,13 +60,6 @@ namespace quda {
       real_length = 2*nDim*volume*nInternal;
       length = 2*2*nDim*stride*nInternal;  //two comes from being full lattice
     }
-
-    if (ghostExchange == QUDA_GHOST_EXCHANGE_EXTENDED) {
-      for (int d=0; d<nDim; d++) r[d] = param.r[d];
-    } else {
-      for (int d=0; d<nDim; d++) r[d] = 0;
-    }
-
 
     if (reconstruct == QUDA_RECONSTRUCT_9 || reconstruct == QUDA_RECONSTRUCT_13) {
       // Need to adjust the phase alignment as well.  
@@ -255,10 +236,6 @@ namespace quda {
     output << "scale = " << param.scale << std::endl;
     output << "create = " << param.create << std::endl;
     output << "geometry = " << param.geometry << std::endl;
-    output << "ghostExchange = " << param.ghostExchange << std::endl;
-    for (int i=0; i<param.nDim; i++) {
-      output << "r[" << i << "] = " << param.r[i] << std::endl;    
-    }
     output << "staggeredPhaseType = " << param.staggeredPhaseType << std::endl;
     output << "staggeredPhaseApplied = " << param.staggeredPhaseApplied << std::endl;
 

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -545,8 +545,6 @@ void loadGaugeQuda(void *h_gauge, QudaGaugeParam *param)
     static_cast<GaugeField*>(new cpuGaugeField(gauge_param)) :
     static_cast<GaugeField*>(new cudaGaugeField(gauge_param));
 
-  gauge_param.setNative();
-
   // free any current gauge field before new allocations to reduce memory overhead
   switch (param->type) {
     case QUDA_WILSON_LINKS:
@@ -3607,8 +3605,6 @@ void computeKSLinkQuda(void* fatlink, void* longlink, void* ulink, void* inlink,
   cpuGaugeField cpuInLink(gParam);    // create the host sitelink
 
   // create the device fields
-  gParam.setNative();
-  gParam.pad = 0;
   gParam.reconstruct = param->reconstruct;
   gParam.setPrecision(param->cuda_prec);
   gParam.create      = QUDA_NULL_FIELD_CREATE;
@@ -3705,7 +3701,6 @@ int computeGaugeForceQuda(void* mom, void* siteLink,  int*** input_path_buf, int
 
   GaugeFieldParam gParam(siteLink, *qudaGaugeParam);
   cpuGaugeField *cpuSiteLink = (!qudaGaugeParam->use_resident_gauge) ? new cpuGaugeField(gParam) : NULL;
-  gParam.setNative();
 
   cudaGaugeField* cudaSiteLink = NULL;
 
@@ -3762,7 +3757,6 @@ int computeGaugeForceQuda(void* mom, void* siteLink,  int*** input_path_buf, int
   else gParamMom.reconstruct = QUDA_RECONSTRUCT_10;
 
   cpuGaugeField* cpuMom = (!qudaGaugeParam->use_resident_mom) ? new cpuGaugeField(gParamMom) : NULL;
-  gParamMom.setNative();
 
   cudaGaugeField* cudaMom = NULL;
   if (qudaGaugeParam->use_resident_mom) {
@@ -3905,7 +3899,6 @@ void* createGaugeFieldQuda(void* gauge, int geometry, QudaGaugeParam* param)
   cpuGaugeField *cpuGauge = nullptr;
   if (gauge) cpuGauge = new cpuGaugeField(gParam);
 
-  gParam.setNative();
   gParam.order = QUDA_FLOAT2_GAUGE_ORDER;
   gParam.create = QUDA_ZERO_FIELD_CREATE;
   cudaGaugeField* cudaGauge = new cudaGaugeField(gParam);
@@ -3964,7 +3957,6 @@ void destroyGaugeFieldQuda(void* gauge){
   gParam.link_type = QUDA_GENERAL_LINKS;
   gParam.gauge = h_force;
   cpuGaugeField cpuForce(gParam);
-  gParam.setNative();
 
   // create the device momentum field
   gParam.link_type = QUDA_ASQTAD_MOM_LINKS;
@@ -4152,7 +4144,6 @@ void computeAsqtadForceQuda(void* const milc_momentum,
   param.reconstruct = QUDA_RECONSTRUCT_10;
   param.gauge = milc_momentum;
   cpuMom = new cpuGaugeField(param);
-  param.setNative();
 
   // create device fields
   param.create = QUDA_NULL_FIELD_CREATE;
@@ -4583,7 +4574,6 @@ void computeStaggeredOprodQuda(void** oprod,
   cpuGaugeField cpuOprod1(oParam);
 
   // create the device outer-product field
-  oParam.setNative();
   oParam.create = QUDA_ZERO_FIELD_CREATE;
   oParam.order = QUDA_FLOAT2_GAUGE_ORDER;
   cudaGaugeField cudaOprod0(oParam);
@@ -4800,7 +4790,6 @@ void computeCloverForceQuda(void *h_mom, double dt, void **h_x, void **h_p,
   fParam.order = gauge_param->gauge_order;
   fParam.link_type = QUDA_ASQTAD_MOM_LINKS;
   cpuGaugeField cpuMom(fParam);
-  fParam.setNative();
 
   // create the device momentum field
   fParam.create = QUDA_ZERO_FIELD_CREATE;
@@ -5010,7 +4999,6 @@ void updateGaugeFieldQuda(void* gauge,
   cpuGaugeField *cpuMom = !param->use_resident_mom ? new cpuGaugeField(gParamMom) : NULL;
 
   // create the device fields
-  gParam.setNative();
   gParam.create = QUDA_NULL_FIELD_CREATE;
   gParam.order = QUDA_FLOAT2_GAUGE_ORDER;
   gParam.link_type = QUDA_ASQTAD_MOM_LINKS;
@@ -5097,7 +5085,6 @@ void updateGaugeFieldQuda(void* gauge,
    cpuGaugeField *cpuGauge = need_cpu ? new cpuGaugeField(gParam) : NULL;
 
    // create the device fields
-   gParam.setNative();
    gParam.create = QUDA_NULL_FIELD_CREATE;
    gParam.order = QUDA_FLOAT2_GAUGE_ORDER;
    gParam.reconstruct = param->reconstruct;
@@ -5155,7 +5142,6 @@ void updateGaugeFieldQuda(void* gauge,
    cpuGaugeField *cpuGauge = need_cpu ? new cpuGaugeField(gParam) : NULL;
 
    // create the device fields
-   gParam.setNative();
    gParam.create = QUDA_NULL_FIELD_CREATE;
    gParam.order = QUDA_FLOAT2_GAUGE_ORDER;
    gParam.reconstruct = param->reconstruct;
@@ -5215,7 +5201,6 @@ double momActionQuda(void* momentum, QudaGaugeParam* param)
   cpuGaugeField *cpuMom = !param->use_resident_mom ? new cpuGaugeField(gParam) : NULL;
 
   // create the device fields
-  gParam.setNative();
   gParam.create = QUDA_NULL_FIELD_CREATE;
   gParam.order = QUDA_FLOAT2_GAUGE_ORDER;
   gParam.reconstruct = QUDA_RECONSTRUCT_10;
@@ -5720,7 +5705,6 @@ int computeGaugeFixingOVRQuda(void* gauge, const unsigned int gauge_dir,  const 
   cpuGaugeField *cpuGauge = new cpuGaugeField(gParam);
 
   //gParam.pad = getFatLinkPadding(param->X);
-  gParam.setNative();
   gParam.create      = QUDA_NULL_FIELD_CREATE;
   gParam.link_type   = param->type;
   gParam.reconstruct = param->reconstruct;
@@ -5836,7 +5820,6 @@ int computeGaugeFixingFFTQuda(void* gauge, const unsigned int gauge_dir,  const 
   cpuGaugeField *cpuGauge = new cpuGaugeField(gParam);
 
   //gParam.pad = getFatLinkPadding(param->X);
-  gParam.setNative();
   gParam.create      = QUDA_NULL_FIELD_CREATE;
   gParam.link_type   = param->type;
   gParam.reconstruct = param->reconstruct;

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -545,6 +545,8 @@ void loadGaugeQuda(void *h_gauge, QudaGaugeParam *param)
     static_cast<GaugeField*>(new cpuGaugeField(gauge_param)) :
     static_cast<GaugeField*>(new cudaGaugeField(gauge_param));
 
+  gauge_param.setNative();
+
   // free any current gauge field before new allocations to reduce memory overhead
   switch (param->type) {
     case QUDA_WILSON_LINKS:
@@ -573,6 +575,7 @@ void loadGaugeQuda(void *h_gauge, QudaGaugeParam *param)
   gauge_param.create = QUDA_NULL_FIELD_CREATE;
   gauge_param.precision = param->cuda_prec;
   gauge_param.reconstruct = param->reconstruct;
+  gauge_param.ghostExchange = QUDA_GHOST_EXCHANGE_PAD;
   gauge_param.pad = param->ga_pad;
   gauge_param.order = (gauge_param.precision == QUDA_DOUBLE_PRECISION ||
 		       gauge_param.reconstruct == QUDA_RECONSTRUCT_NO ) ?
@@ -3592,27 +3595,23 @@ void computeKSLinkQuda(void* fatlink, void* longlink, void* ulink, void* inlink,
 				     svd_rel_error, svd_abs_error);
   }
 
-  GaugeFieldParam gParam(0, *param);
-  gParam.ghostExchange = QUDA_GHOST_EXCHANGE_NO;
-  gParam.create = QUDA_REFERENCE_FIELD_CREATE;
+  GaugeFieldParam gParam(fatlink, *param);
   gParam.link_type = QUDA_GENERAL_LINKS;
-  gParam.gauge = fatlink;
   cpuGaugeField cpuFatLink(gParam);   // create the host fatlink
   gParam.gauge = longlink;
   cpuGaugeField cpuLongLink(gParam);  // create the host longlink
   gParam.gauge = ulink;
   cpuGaugeField cpuUnitarizedLink(gParam);
-
   gParam.link_type = param->type;
   gParam.gauge     = inlink;
   cpuGaugeField cpuInLink(gParam);    // create the host sitelink
 
   // create the device fields
+  gParam.setNative();
   gParam.pad = 0;
   gParam.reconstruct = param->reconstruct;
   gParam.setPrecision(param->cuda_prec);
   gParam.create      = QUDA_NULL_FIELD_CREATE;
-  gParam.ghostExchange = QUDA_GHOST_EXCHANGE_NO;
   cudaGaugeField* cudaInLink = new cudaGaugeField(gParam);
 
   gParam.ghostExchange = QUDA_GHOST_EXCHANGE_EXTENDED;
@@ -3696,8 +3695,7 @@ int getGaugePadding(GaugeFieldParam& param){
 }
 
 int computeGaugeForceQuda(void* mom, void* siteLink,  int*** input_path_buf, int* path_length,
-			  double* loop_coeff, int num_paths, int max_length, double eb3,
-			  QudaGaugeParam* qudaGaugeParam)
+			  double* loop_coeff, int num_paths, int max_length, double eb3, QudaGaugeParam* qudaGaugeParam)
 {
 #ifdef GPU_GAUGE_FORCE
   profileGaugeForce.TPSTART(QUDA_PROFILE_TOTAL);
@@ -3705,22 +3703,9 @@ int computeGaugeForceQuda(void* mom, void* siteLink,  int*** input_path_buf, int
 
   checkGaugeParam(qudaGaugeParam);
 
-  GaugeFieldParam gParam(0, *qudaGaugeParam);
-  gParam.ghostExchange = QUDA_GHOST_EXCHANGE_NO;
-  gParam.pad = 0;
-
-#ifdef MULTI_GPU
-  // do extended fill so we can reuse this extended gauge field if needed
-  GaugeFieldParam gParamEx(gParam);
-  for (int d=0; d<4; d++) {
-    gParamEx.x[d] = gParam.x[d] + 2*R[d];
-    gParamEx.r[d] = R[d];
-  }
-#endif
-
-  gParam.create = QUDA_REFERENCE_FIELD_CREATE;
-  gParam.gauge = siteLink;
+  GaugeFieldParam gParam(siteLink, *qudaGaugeParam);
   cpuGaugeField *cpuSiteLink = (!qudaGaugeParam->use_resident_gauge) ? new cpuGaugeField(gParam) : NULL;
+  gParam.setNative();
 
   cudaGaugeField* cudaSiteLink = NULL;
 
@@ -3745,19 +3730,18 @@ int computeGaugeForceQuda(void* mom, void* siteLink,  int*** input_path_buf, int
 
   profileGaugeForce.TPSTART(QUDA_PROFILE_INIT);
 
-#ifndef MULTI_GPU
-  cudaGaugeField *cudaGauge = cudaSiteLink;
-  qudaGaugeParam->site_ga_pad = gParam.pad; //need to set this value
-#else
-
+  // do extended fill so we can reuse this extended gauge field if needed
+  GaugeFieldParam gParamEx(gParam);
+  for (int d=0; d<4; d++) {
+    gParamEx.x[d] = gParam.x[d] + 2*R[d];
+    gParamEx.r[d] = R[d];
+  }
   gParamEx.create = QUDA_ZERO_FIELD_CREATE;
   gParamEx.reconstruct = qudaGaugeParam->reconstruct;
   gParamEx.order = (qudaGaugeParam->reconstruct == QUDA_RECONSTRUCT_NO ||
       qudaGaugeParam->cuda_prec == QUDA_DOUBLE_PRECISION) ?
     QUDA_FLOAT2_GAUGE_ORDER : QUDA_FLOAT4_GAUGE_ORDER;
   gParamEx.ghostExchange = QUDA_GHOST_EXCHANGE_EXTENDED;
-
-  qudaGaugeParam->site_ga_pad = gParamEx.pad;//need to set this value
 
   cudaGaugeField *cudaGauge = new cudaGaugeField(gParamEx);
 
@@ -3769,20 +3753,16 @@ int computeGaugeForceQuda(void* mom, void* siteLink,  int*** input_path_buf, int
   cudaGauge->exchangeExtendedGhost(R,redundant_comms);
   profileGaugeForce.TPSTOP(QUDA_PROFILE_COMMS);
   profileGaugeForce.TPSTART(QUDA_PROFILE_INIT);
-#endif
 
-  GaugeFieldParam &gParamMom = gParam;
-  gParamMom.order = qudaGaugeParam->gauge_order;
+  GaugeFieldParam gParamMom(mom, *qudaGaugeParam);
   // FIXME - test program always uses MILC for mom but can use QDP for gauge
   if (gParamMom.order == QUDA_QDP_GAUGE_ORDER) gParamMom.order = QUDA_MILC_GAUGE_ORDER;
-  gParamMom.precision = qudaGaugeParam->cpu_prec;
   gParamMom.link_type = QUDA_ASQTAD_MOM_LINKS;
-  gParamMom.create = QUDA_REFERENCE_FIELD_CREATE;
-  gParamMom.gauge=mom;
   if (gParamMom.order == QUDA_TIFR_GAUGE_ORDER || gParamMom.order == QUDA_TIFR_PADDED_GAUGE_ORDER) gParamMom.reconstruct = QUDA_RECONSTRUCT_NO;
   else gParamMom.reconstruct = QUDA_RECONSTRUCT_10;
 
   cpuGaugeField* cpuMom = (!qudaGaugeParam->use_resident_mom) ? new cpuGaugeField(gParamMom) : NULL;
+  gParamMom.setNative();
 
   cudaGaugeField* cudaMom = NULL;
   if (qudaGaugeParam->use_resident_mom) {
@@ -3831,14 +3811,12 @@ int computeGaugeForceQuda(void* mom, void* siteLink,  int*** input_path_buf, int
   if (cpuSiteLink) delete cpuSiteLink;
   if (cpuMom) delete cpuMom;
 
-#ifdef MULTI_GPU
   if (qudaGaugeParam->make_resident_gauge) {
     if (extendedGaugeResident) delete extendedGaugeResident;
     extendedGaugeResident = cudaGauge;
   } else {
     delete cudaGauge;
   }
-#endif
   profileGaugeForce.TPSTOP(QUDA_PROFILE_FREE);
 
   profileGaugeForce.TPSTOP(QUDA_PROFILE_TOTAL);
@@ -3918,30 +3896,25 @@ void createCloverQuda(QudaInvertParam* invertParam)
 
 void* createGaugeFieldQuda(void* gauge, int geometry, QudaGaugeParam* param)
 {
-
-  GaugeFieldParam gParam(0,*param);
-  if(geometry == 1){
-    gParam.geometry = QUDA_SCALAR_GEOMETRY;
-  }else if(geometry == 4){
-    gParam.geometry = QUDA_VECTOR_GEOMETRY;
-  }else{
+  GaugeFieldParam gParam(gauge, *param);
+  gParam.geometry = static_cast<QudaFieldGeometry>(geometry);
+  if (geometry != QUDA_SCALAR_GEOMETRY && geometry != QUDA_VECTOR_GEOMETRY)
     errorQuda("Only scalar and vector geometries are supported\n");
-  }
-  gParam.pad = 0;
-  gParam.ghostExchange = QUDA_GHOST_EXCHANGE_NO;
-  gParam.gauge = gauge;
   gParam.link_type = QUDA_GENERAL_LINKS;
 
+  cpuGaugeField *cpuGauge = nullptr;
+  if (gauge) cpuGauge = new cpuGaugeField(gParam);
 
+  gParam.setNative();
   gParam.order = QUDA_FLOAT2_GAUGE_ORDER;
   gParam.create = QUDA_ZERO_FIELD_CREATE;
   cudaGaugeField* cudaGauge = new cudaGaugeField(gParam);
-  if(gauge){
-    gParam.order = QUDA_MILC_GAUGE_ORDER;
-    gParam.create = QUDA_REFERENCE_FIELD_CREATE;
-    cpuGaugeField cpuGauge(gParam);
-    cudaGauge->loadCPUField(cpuGauge);
+
+  if (gauge) {
+    cudaGauge->loadCPUField(*cpuGauge);
+    delete cpuGauge;
   }
+
   return cudaGauge;
 }
 
@@ -3950,17 +3923,13 @@ void saveGaugeFieldQuda(void* gauge, void* inGauge, QudaGaugeParam* param){
 
   cudaGaugeField* cudaGauge = reinterpret_cast<cudaGaugeField*>(inGauge);
 
-  GaugeFieldParam gParam(0,*param);
+  GaugeFieldParam gParam(gauge,*param);
   gParam.geometry = cudaGauge->Geometry();
-  gParam.pad = 0;
-  gParam.ghostExchange = QUDA_GHOST_EXCHANGE_NO;
-  gParam.gauge = gauge;
   gParam.link_type = QUDA_GENERAL_LINKS;
-  gParam.order = QUDA_MILC_GAUGE_ORDER;
-  gParam.create = QUDA_REFERENCE_FIELD_CREATE;
 
   cpuGaugeField cpuGauge(gParam);
   cudaGauge->saveCPUField(cpuGauge);
+
 }
 
 
@@ -3982,16 +3951,12 @@ void destroyGaugeFieldQuda(void* gauge){
   profileStaggeredForce.TPSTART(QUDA_PROFILE_TOTAL);
   profileStaggeredForce.TPSTART(QUDA_PROFILE_INIT);
 
-  GaugeFieldParam gParam(0, *gauge_param);
+  GaugeFieldParam gParam(h_mom, *gauge_param);
 
   // create the host momentum field
-  gParam.create = QUDA_REFERENCE_FIELD_CREATE;
   gParam.link_type = QUDA_ASQTAD_MOM_LINKS;
   gParam.reconstruct = gauge_param->reconstruct;
-  gParam.order = gauge_param->gauge_order;
-  gParam.ghostExchange = QUDA_GHOST_EXCHANGE_NO;
   gParam.t_boundary = QUDA_PERIODIC_T;
-  gParam.gauge = h_mom;
   gParam.nFace = 1;
   cpuGaugeField cpuMom(gParam);
 
@@ -3999,6 +3964,7 @@ void destroyGaugeFieldQuda(void* gauge){
   gParam.link_type = QUDA_GENERAL_LINKS;
   gParam.gauge = h_force;
   cpuGaugeField cpuForce(gParam);
+  gParam.setNative();
 
   // create the device momentum field
   gParam.link_type = QUDA_ASQTAD_MOM_LINKS;
@@ -4165,20 +4131,13 @@ void computeAsqtadForceQuda(void* const milc_momentum,
   cudaGaugeField *cudaOutForce_ex = NULL;
 #endif
 
-  GaugeFieldParam param(0, *gParam);
-  param.create = QUDA_NULL_FIELD_CREATE;
+  // create host fields
+  GaugeFieldParam param((void*)link, *gParam);
   param.anisotropy = 1.0;
   param.siteSubset = QUDA_FULL_SITE_SUBSET;
-  param.ghostExchange = QUDA_GHOST_EXCHANGE_NO;
   param.t_boundary = QUDA_PERIODIC_T;
   param.nFace = 1;
-
   param.link_type = QUDA_GENERAL_LINKS;
-  param.reconstruct = QUDA_RECONSTRUCT_NO;
-  param.create = QUDA_REFERENCE_FIELD_CREATE;
-
-  // create host fields
-  param.gauge = (void*)link;
   cpuGauge = new cpuGaugeField(param);
 
   param.order = QUDA_QDP_GAUGE_ORDER;
@@ -4193,6 +4152,7 @@ void computeAsqtadForceQuda(void* const milc_momentum,
   param.reconstruct = QUDA_RECONSTRUCT_10;
   param.gauge = milc_momentum;
   cpuMom = new cpuGaugeField(param);
+  param.setNative();
 
   // create device fields
   param.create = QUDA_NULL_FIELD_CREATE;
@@ -4345,10 +4305,7 @@ computeHISQForceCompleteQuda(void* const milc_momentum,
 }
 
 
-
-
-  void
-computeHISQForceQuda(void* const milc_momentum,
+ void computeHISQForceQuda(void* const milc_momentum,
     long long *flops,
     const double level2_coeff[6],
     const double fat7_coeff[6],
@@ -4361,6 +4318,8 @@ computeHISQForceQuda(void* const milc_momentum,
     const QudaGaugeParam* gParam)
 {
 #ifdef GPU_HISQ_FORCE
+  if (gParam->gauge_order != QUDA_MILC_GAUGE_ORDER)
+    errorQuda("Unsupported input field order %d", gParam->gauge_order);
 
   long long partialFlops;
 
@@ -4372,46 +4331,40 @@ computeHISQForceQuda(void* const milc_momentum,
   // You have to look at the MILC routine to understand the following
   // Basically, I have already absorbed the one-link coefficient
 
-  GaugeFieldParam param(0, *gParam);
-  param.create = QUDA_REFERENCE_FIELD_CREATE;
+  GaugeFieldParam param(milc_momentum, *gParam);
   param.order  = QUDA_MILC_GAUGE_ORDER;
   param.link_type = QUDA_ASQTAD_MOM_LINKS;
   param.reconstruct = QUDA_RECONSTRUCT_10;
-  param.gauge = (void*)milc_momentum;
-  param.ghostExchange =  QUDA_GHOST_EXCHANGE_NO;
   cpuGaugeField* cpuMom = (!gParam->use_resident_mom) ? new cpuGaugeField(param) : NULL;
 
-  param.create = QUDA_ZERO_FIELD_CREATE;
-  param.order  = QUDA_FLOAT2_GAUGE_ORDER;
-  cudaGaugeField* cudaMom = new cudaGaugeField(param);
-
-  param.order = QUDA_MILC_GAUGE_ORDER;
   param.link_type = QUDA_GENERAL_LINKS;
   param.reconstruct = QUDA_RECONSTRUCT_NO;
-  param.create = QUDA_REFERENCE_FIELD_CREATE;
   param.gauge = (void*)w_link;
   cpuGaugeField cpuWLink(param);
   param.gauge = (void*)v_link;
   cpuGaugeField cpuVLink(param);
   param.gauge = (void*)u_link;
   cpuGaugeField cpuULink(param);
+
   param.create = QUDA_ZERO_FIELD_CREATE;
+  param.order  = QUDA_FLOAT2_GAUGE_ORDER;
+  param.link_type = QUDA_ASQTAD_MOM_LINKS;
+  param.reconstruct = QUDA_RECONSTRUCT_10;
+  cudaGaugeField* cudaMom = new cudaGaugeField(param);
 
   param.order = QUDA_FLOAT2_GAUGE_ORDER;
+  param.link_type = QUDA_GENERAL_LINKS;
+  param.reconstruct = QUDA_RECONSTRUCT_NO;
   cudaGaugeField* cudaGauge = new cudaGaugeField(param);
-
-  cpuGaugeField* cpuStapleForce;
-  cpuGaugeField* cpuOneLinkForce;
-  cpuGaugeField* cpuNaikForce;
 
   param.order = QUDA_QDP_GAUGE_ORDER;
   param.create = QUDA_REFERENCE_FIELD_CREATE;
   param.gauge = (void*)staple_src;
-  cpuStapleForce = new cpuGaugeField(param);
+  cpuGaugeField *cpuStapleForce = new cpuGaugeField(param);
   param.gauge = (void*)one_link_src;
-  cpuOneLinkForce = new cpuGaugeField(param);
+  cpuGaugeField *cpuOneLinkForce = new cpuGaugeField(param);
   param.gauge = (void*)naik_src;
-  cpuNaikForce = new cpuGaugeField(param);
+  cpuGaugeField *cpuNaikForce = new cpuGaugeField(param);
   param.create = QUDA_ZERO_FIELD_CREATE;
 
   param.ghostExchange =  QUDA_GHOST_EXCHANGE_NO;
@@ -4437,7 +4390,6 @@ computeHISQForceQuda(void* const milc_momentum,
   cudaGaugeField* inForcePtr = cudaInForce;
   cudaGaugeField* outForcePtr = cudaOutForce;
 #endif
-
 
   {
     // default settings for the unitarization
@@ -4619,25 +4571,19 @@ void computeStaggeredOprodQuda(void** oprod,
   checkGaugeParam(param);
 
   profileStaggeredOprod.TPSTART(QUDA_PROFILE_INIT);
-  GaugeFieldParam oParam(0, *param);
+  GaugeFieldParam oParam(oprod[0], *param);
 
-  oParam.nDim = 4;
   oParam.nFace = 0;
   // create the host outer-product field
-  oParam.pad = 0;
-  oParam.create = QUDA_REFERENCE_FIELD_CREATE;
   oParam.link_type = QUDA_GENERAL_LINKS;
-  oParam.reconstruct = QUDA_RECONSTRUCT_NO;
   oParam.order = QUDA_QDP_GAUGE_ORDER;
-  oParam.ghostExchange = QUDA_GHOST_EXCHANGE_NO;
-  oParam.gauge = oprod[0];
-  oParam.ghostExchange = QUDA_GHOST_EXCHANGE_NO; // no need for ghost exchange here
   cpuGaugeField cpuOprod0(oParam);
 
   oParam.gauge = oprod[1];
   cpuGaugeField cpuOprod1(oParam);
 
   // create the device outer-product field
+  oParam.setNative();
   oParam.create = QUDA_ZERO_FIELD_CREATE;
   oParam.order = QUDA_FLOAT2_GAUGE_ORDER;
   cudaGaugeField cudaOprod0(oParam);
@@ -4651,10 +4597,7 @@ void computeStaggeredOprodQuda(void** oprod,
   cudaOprod1.loadCPUField(cpuOprod1);
   profileStaggeredOprod.TPSTOP(QUDA_PROFILE_H2D);
 
-
   profileStaggeredOprod.TPSTART(QUDA_PROFILE_INIT);
-
-
 
   ColorSpinorParam qParam;
   qParam.nColor = 3;
@@ -4851,15 +4794,13 @@ void computeCloverForceQuda(void *h_mom, double dt, void **h_x, void **h_p,
   checkGaugeParam(gauge_param);
   if (!gaugePrecise) errorQuda("No resident gauge field");
 
-  GaugeFieldParam fParam(0, *gauge_param);
+  GaugeFieldParam fParam(h_mom, *gauge_param);
   // create the host momentum field
-  fParam.create = QUDA_REFERENCE_FIELD_CREATE;
   fParam.reconstruct = QUDA_RECONSTRUCT_10;
   fParam.order = gauge_param->gauge_order;
-  fParam.ghostExchange = QUDA_GHOST_EXCHANGE_NO;
-  fParam.gauge = h_mom;
   fParam.link_type = QUDA_ASQTAD_MOM_LINKS;
   cpuGaugeField cpuMom(fParam);
+  fParam.setNative();
 
   // create the device momentum field
   fParam.create = QUDA_ZERO_FIELD_CREATE;
@@ -5055,25 +4996,21 @@ void updateGaugeFieldQuda(void* gauge,
   checkGaugeParam(param);
 
   profileGaugeUpdate.TPSTART(QUDA_PROFILE_INIT);
-  GaugeFieldParam gParam(0, *param);
 
   // create the host fields
-  gParam.pad = 0;
-  gParam.create = QUDA_REFERENCE_FIELD_CREATE;
+  GaugeFieldParam gParam(gauge, *param);
   gParam.link_type = QUDA_SU3_LINKS;
-  gParam.reconstruct = QUDA_RECONSTRUCT_NO;
-  gParam.gauge = gauge;
-  gParam.ghostExchange = QUDA_GHOST_EXCHANGE_NO;
   bool need_cpu = !param->use_resident_gauge || param->return_result_gauge;
   cpuGaugeField *cpuGauge = need_cpu ? new cpuGaugeField(gParam) : NULL;
 
-  gParam.reconstruct = (gParam.order == QUDA_TIFR_GAUGE_ORDER || gParam.order == QUDA_TIFR_PADDED_GAUGE_ORDER) ?
+  GaugeFieldParam gParamMom(momentum, *param);
+  gParamMom.reconstruct = (gParamMom.order == QUDA_TIFR_GAUGE_ORDER || gParamMom.order == QUDA_TIFR_PADDED_GAUGE_ORDER) ?
    QUDA_RECONSTRUCT_NO : QUDA_RECONSTRUCT_10;
-  gParam.link_type = QUDA_ASQTAD_MOM_LINKS;
-  gParam.gauge = momentum;
-  cpuGaugeField *cpuMom = !param->use_resident_mom ? new cpuGaugeField(gParam) : NULL;
+  gParamMom.link_type = QUDA_ASQTAD_MOM_LINKS;
+  cpuGaugeField *cpuMom = !param->use_resident_mom ? new cpuGaugeField(gParamMom) : NULL;
 
   // create the device fields
+  gParam.setNative();
   gParam.create = QUDA_NULL_FIELD_CREATE;
   gParam.order = QUDA_FLOAT2_GAUGE_ORDER;
   gParam.link_type = QUDA_ASQTAD_MOM_LINKS;
@@ -5083,7 +5020,6 @@ void updateGaugeFieldQuda(void* gauge,
   gParam.pad = param->ga_pad;
   gParam.link_type = QUDA_SU3_LINKS;
   gParam.reconstruct = param->reconstruct;
-
   cudaGaugeField *cudaInGauge = !param->use_resident_gauge ? new cudaGaugeField(gParam) : NULL;
   cudaGaugeField *cudaOutGauge = new cudaGaugeField(gParam);
 
@@ -5155,17 +5091,13 @@ void updateGaugeFieldQuda(void* gauge,
    checkGaugeParam(param);
 
    // create the gauge field
-   GaugeFieldParam gParam(0, *param);
-   gParam.pad = 0;
-   gParam.create = QUDA_REFERENCE_FIELD_CREATE;
-   gParam.ghostExchange = QUDA_GHOST_EXCHANGE_NO;
-   gParam.reconstruct = QUDA_RECONSTRUCT_NO;
+   GaugeFieldParam gParam(gauge_h, *param);
    gParam.link_type = QUDA_GENERAL_LINKS;
-   gParam.gauge = gauge_h;
    bool need_cpu = !param->use_resident_gauge || param->return_result_gauge;
    cpuGaugeField *cpuGauge = need_cpu ? new cpuGaugeField(gParam) : NULL;
 
    // create the device fields
+   gParam.setNative();
    gParam.create = QUDA_NULL_FIELD_CREATE;
    gParam.order = QUDA_FLOAT2_GAUGE_ORDER;
    gParam.reconstruct = param->reconstruct;
@@ -5217,17 +5149,13 @@ void updateGaugeFieldQuda(void* gauge,
    checkGaugeParam(param);
 
    // create the gauge field
-   GaugeFieldParam gParam(0, *param);
-   gParam.pad = 0;
-   gParam.create = QUDA_REFERENCE_FIELD_CREATE;
-   gParam.ghostExchange = QUDA_GHOST_EXCHANGE_NO;
-   gParam.reconstruct = QUDA_RECONSTRUCT_NO;
+   GaugeFieldParam gParam(gauge_h, *param);
    gParam.link_type = QUDA_GENERAL_LINKS;
-   gParam.gauge = gauge_h;
    bool need_cpu = !param->use_resident_gauge || param->return_result_gauge;
    cpuGaugeField *cpuGauge = need_cpu ? new cpuGaugeField(gParam) : NULL;
 
    // create the device fields
+   gParam.setNative();
    gParam.create = QUDA_NULL_FIELD_CREATE;
    gParam.order = QUDA_FLOAT2_GAUGE_ORDER;
    gParam.reconstruct = param->reconstruct;
@@ -5279,18 +5207,15 @@ double momActionQuda(void* momentum, QudaGaugeParam* param)
   checkGaugeParam(param);
 
   // create the momentum fields
-  GaugeFieldParam gParam(0, *param);
-  gParam.pad = 0;
-  gParam.create = QUDA_REFERENCE_FIELD_CREATE;
-  gParam.ghostExchange = QUDA_GHOST_EXCHANGE_NO;
+  GaugeFieldParam gParam(momentum, *param);
   gParam.reconstruct = (gParam.order == QUDA_TIFR_GAUGE_ORDER || gParam.order == QUDA_TIFR_PADDED_GAUGE_ORDER) ?
     QUDA_RECONSTRUCT_NO : QUDA_RECONSTRUCT_10;
   gParam.link_type = QUDA_ASQTAD_MOM_LINKS;
-  gParam.gauge = momentum;
 
   cpuGaugeField *cpuMom = !param->use_resident_mom ? new cpuGaugeField(gParam) : NULL;
 
   // create the device fields
+  gParam.setNative();
   gParam.create = QUDA_NULL_FIELD_CREATE;
   gParam.order = QUDA_FLOAT2_GAUGE_ORDER;
   gParam.reconstruct = QUDA_RECONSTRUCT_10;
@@ -5795,7 +5720,7 @@ int computeGaugeFixingOVRQuda(void* gauge, const unsigned int gauge_dir,  const 
   cpuGaugeField *cpuGauge = new cpuGaugeField(gParam);
 
   //gParam.pad = getFatLinkPadding(param->X);
-  gParam.ghostExchange = QUDA_GHOST_EXCHANGE_NO;
+  gParam.setNative();
   gParam.create      = QUDA_NULL_FIELD_CREATE;
   gParam.link_type   = param->type;
   gParam.reconstruct = param->reconstruct;
@@ -5911,7 +5836,7 @@ int computeGaugeFixingFFTQuda(void* gauge, const unsigned int gauge_dir,  const 
   cpuGaugeField *cpuGauge = new cpuGaugeField(gParam);
 
   //gParam.pad = getFatLinkPadding(param->X);
-  gParam.ghostExchange = QUDA_GHOST_EXCHANGE_NO;
+  gParam.setNative();
   gParam.create      = QUDA_NULL_FIELD_CREATE;
   gParam.link_type   = param->type;
   gParam.reconstruct = param->reconstruct;

--- a/lib/lattice_field.cpp
+++ b/lib/lattice_field.cpp
@@ -17,12 +17,23 @@ namespace quda {
   bool LatticeField::bufferDeviceInit = false;
   size_t LatticeField::bufferDeviceBytes = 0;
 
+  LatticeFieldParam::LatticeFieldParam(const LatticeField &field)
+    : nDim(field.Ndim()), pad(field.Pad()), precision(field.Precision()),
+      siteSubset(field.SiteSubset()), ghostExchange(field.GhostExchange())
+  {
+    for(int dir=0; dir<nDim; ++dir) {
+      x[dir] = field.X()[dir];
+      r[dir] = field.R()[dir];
+    }
+  }
+
   LatticeField::LatticeField(const LatticeFieldParam &param)
     : volume(1), pad(param.pad), total_bytes(0), nDim(param.nDim), precision(param.precision),
-      siteSubset(param.siteSubset)
+      siteSubset(param.siteSubset), ghostExchange(param.ghostExchange)
   {
     for (int i=0; i<nDim; i++) {
       x[i] = param.x[i];
+      r[i] = ghostExchange == QUDA_GHOST_EXCHANGE_EXTENDED ? param.r[i] : 0;
       volume *= param.x[i];
       surface[i] = 1;
       for (int j=0; j<nDim; j++) {
@@ -158,6 +169,11 @@ namespace quda {
     }
     output << "pad = " << param.pad << std::endl;
     output << "precision = " << param.precision << std::endl;
+
+    output << "ghostExchange = " << param.ghostExchange << std::endl;
+    for (int i=0; i<param.nDim; i++) {
+      output << "r[" << i << "] = " << param.r[i] << std::endl;
+    }
 
     return output;  // for multiple << operators.
   }

--- a/lib/quda_fortran.F90
+++ b/lib/quda_fortran.F90
@@ -41,8 +41,6 @@ module quda_fortran
      QudaReconstructType :: reconstruct_precondition
      QudaGaugeFixed :: gauge_fix
 
-     integer(4), dimension(4) :: r ! Host application inline halo settings (BQCD and TIFR only)
-
      integer(4) :: ga_pad
 
      integer(4) :: site_ga_pad ! Used by link fattening and the gauge and fermion forces

--- a/lib/quda_fortran.F90
+++ b/lib/quda_fortran.F90
@@ -43,6 +43,8 @@ module quda_fortran
      QudaReconstructType :: reconstruct_precondition
      QudaGaugeFixed :: gauge_fix
 
+     integer(4), dimension(4) :: r ! Host application inline halo settings (BQCD and TIFR only)
+
      integer(4) :: ga_pad
 
      integer(4) :: site_ga_pad ! Used by link fattening and the gauge and fermion forces

--- a/lib/quda_fortran.F90
+++ b/lib/quda_fortran.F90
@@ -14,9 +14,7 @@
 
 !-------------------------------------------------------------------------------
 
-#define QUDA_MAX_DIM 5
-#define QUDA_MAX_MULTI_SHIFT 32
-#define QUDA_MAX_DWF_LS 128
+#include <quda_constants.h>
 
 module quda_fortran
 

--- a/tests/domain_wall_dslash_reference.cpp
+++ b/tests/domain_wall_dslash_reference.cpp
@@ -505,6 +505,7 @@ void dw_dslash(void *out, void **gauge, void *in, int oddBit, int daggerBit, Qud
 #else
 
     GaugeFieldParam gauge_field_param(gauge, gauge_param);
+    gauge_field_param.ghostExchange = QUDA_GHOST_EXCHANGE_PAD;
     cpuGaugeField cpu(gauge_field_param);
     void **ghostGauge = (void**)cpu.Ghost();    
   
@@ -565,6 +566,7 @@ void dslash_4_4d(void *out, void **gauge, void *in, int oddBit, int daggerBit, Q
 #else
 
     GaugeFieldParam gauge_field_param(gauge, gauge_param);
+    gauge_field_param.ghostExchange = QUDA_GHOST_EXCHANGE_PAD;
     cpuGaugeField cpu(gauge_field_param);
     void **ghostGauge = (void**)cpu.Ghost();    
   

--- a/tests/staggered_dslash_test.cpp
+++ b/tests/staggered_dslash_test.cpp
@@ -195,11 +195,13 @@ void init()
   gaugeParam.type = QUDA_ASQTAD_FAT_LINKS;
   gaugeParam.reconstruct = QUDA_RECONSTRUCT_NO;
   GaugeFieldParam cpuFatParam(fatlink, gaugeParam);
+  cpuFatParam.ghostExchange = QUDA_GHOST_EXCHANGE_PAD;
   cpuFat = new cpuGaugeField(cpuFatParam);
   ghost_fatlink = cpuFat->Ghost();
 
   gaugeParam.type = QUDA_ASQTAD_LONG_LINKS;
   GaugeFieldParam cpuLongParam(longlink, gaugeParam);
+  cpuLongParam.ghostExchange = QUDA_GHOST_EXCHANGE_PAD;
   cpuLong = new cpuGaugeField(cpuLongParam);
   ghost_longlink = cpuLong->Ghost();
 

--- a/tests/staggered_invert_test.cpp
+++ b/tests/staggered_invert_test.cpp
@@ -266,11 +266,13 @@ invert_test(void)
     QUDA_SU3_LINKS : QUDA_ASQTAD_FAT_LINKS;
   gaugeParam.reconstruct = QUDA_RECONSTRUCT_NO;
   GaugeFieldParam cpuFatParam(fatlink, gaugeParam);
+  cpuFatParam.ghostExchange = QUDA_GHOST_EXCHANGE_PAD;
   cpuFat = new cpuGaugeField(cpuFatParam);
   ghost_fatlink = (void**)cpuFat->Ghost();
 
   gaugeParam.type = QUDA_ASQTAD_LONG_LINKS;
   GaugeFieldParam cpuLongParam(longlink, gaugeParam);
+  cpuLongParam.ghostExchange = QUDA_GHOST_EXCHANGE_PAD;
   cpuLong = new cpuGaugeField(cpuLongParam);
   ghost_longlink = (void**)cpuLong->Ghost();
 

--- a/tests/staggered_invertmsrc_test.cpp
+++ b/tests/staggered_invertmsrc_test.cpp
@@ -268,11 +268,13 @@ invert_test(void)
     QUDA_SU3_LINKS : QUDA_ASQTAD_FAT_LINKS;
   gaugeParam.reconstruct = QUDA_RECONSTRUCT_NO;
   GaugeFieldParam cpuFatParam(fatlink, gaugeParam);
+  cpuFatParam.ghostExchange = QUDA_GHOST_EXCHANGE_PAD;
   cpuFat = new cpuGaugeField(cpuFatParam);
   ghost_fatlink = (void**)cpuFat->Ghost();
 
   gaugeParam.type = QUDA_ASQTAD_LONG_LINKS;
   GaugeFieldParam cpuLongParam(longlink, gaugeParam);
+  cpuLongParam.ghostExchange = QUDA_GHOST_EXCHANGE_PAD;
   cpuLong = new cpuGaugeField(cpuLongParam);
   ghost_longlink = (void**)cpuLong->Ghost();
 

--- a/tests/wilson_dslash_reference.cpp
+++ b/tests/wilson_dslash_reference.cpp
@@ -184,6 +184,7 @@ void wil_dslash(void *out, void **gauge, void *in, int oddBit, int daggerBit,
 #else
 
   GaugeFieldParam gauge_field_param(gauge, gauge_param);
+  gauge_field_param.ghostExchange = QUDA_GHOST_EXCHANGE_PAD;
   cpuGaugeField cpu(gauge_field_param);
   void **ghostGauge = (void**)cpu.Ghost();
 


### PR DESCRIPTION
This pull request does the following
* Fixes device-side gauge-field reordering for BQCD and TIFR padded gauge fields (closes #564)
* `GaugeField::copy` now supports input or output fields being extended fields
* Simplification of interface code when creating `GaugeFieldParam` structs
* Optimized gauge-field accessors for BQCD, CPS and TIFR
* Other minor fixes and clean up