### PR TITLE
Remove difference between QUDA_TWIST_PLUS and MINUS, put it in the sign of mu

### DIFF
--- a/include/enum_quda.h
+++ b/include/enum_quda.h
@@ -362,8 +362,7 @@ extern "C" {
   } QudaDWFPCType; 
 
   typedef enum QudaTwistFlavorType_s {
-    QUDA_TWIST_MINUS = -1,
-    QUDA_TWIST_PLUS = +1,
+    QUDA_TWIST_SINGLET = 1,
     QUDA_TWIST_NONDEG_DOUBLET = +2,
     QUDA_TWIST_DEG_DOUBLET = -2,    
     QUDA_TWIST_NO  = 0,

--- a/include/enum_quda_fortran.h
+++ b/include/enum_quda_fortran.h
@@ -324,8 +324,7 @@
 #define QUDA_PC_INVALID QUDA_INVALID_ENUM
 
 #define QudaTwistFlavorType integer(4)
-#define QUDA_TWIST_MINUS -1
-#define QUDA_TWIST_PLUS +1
+#define QUDA_TWIST_SINGLET 1
 #define QUDA_TWIST_NONDEG_DOUBLET +2
 #define QUDA_TWIST_DEG_DOUBLET -2
 #define QUDA_TWIST_NO  0

--- a/lib/dirac_twisted_clover.cpp
+++ b/lib/dirac_twisted_clover.cpp
@@ -57,16 +57,15 @@ namespace quda {
     if (in.TwistFlavor() == QUDA_TWIST_NO || in.TwistFlavor() == QUDA_TWIST_INVALID)
       errorQuda("Twist flavor not set %d\n", in.TwistFlavor());
 
-    if (in.TwistFlavor() == QUDA_TWIST_PLUS || in.TwistFlavor() == QUDA_TWIST_MINUS)
+    if (in.TwistFlavor() == QUDA_TWIST_SINGLET)
       {
 
 	FullClover *cs = new FullClover(clover, false);
 	FullClover *cI = new FullClover(clover, true);
 
-	double flavor_mu = in.TwistFlavor() * mu;
 	twistCloverGamma5Cuda(&static_cast<cudaColorSpinorField&>(out),
 			      &static_cast<const cudaColorSpinorField&>(in),
-			      dagger, kappa, flavor_mu, 0.0, twistType, cs, cI, parity);
+			      dagger, kappa, mu, 0.0, twistType, cs, cI, parity);
 
 	if (twistType == QUDA_TWIST_GAMMA5_INVERSE)
 	  flops += 1056ll*in.Volume();
@@ -110,8 +109,8 @@ namespace quda {
     FullClover *cs = new FullClover(clover, false);
     FullClover *cI = new FullClover(clover, true);
 
-    if(in.TwistFlavor() == QUDA_TWIST_PLUS || in.TwistFlavor() == QUDA_TWIST_MINUS){
-      double a = 2.0 * kappa * in.TwistFlavor() * mu;//for direct twist (must be daggered separately)  
+    if(in.TwistFlavor() == QUDA_TWIST_SINGLET){
+      double a = 2.0 * kappa * mu;//for direct twist (must be daggered separately)  
       twistedCloverDslashCuda(&static_cast<cudaColorSpinorField&>(out.Odd()),
 			      *gauge, cs, cI, &static_cast<const cudaColorSpinorField&>(in.Even()),
 			      QUDA_ODD_PARITY, dagger, &static_cast<const cudaColorSpinorField&>(in.Odd()),
@@ -204,8 +203,8 @@ namespace quda {
     FullClover *cs = new FullClover(clover, false);
     FullClover *cI = new FullClover(clover, true);
 
-    if (in.TwistFlavor() == QUDA_TWIST_PLUS || in.TwistFlavor() == QUDA_TWIST_MINUS){
-      double a = -2.0 * kappa * in.TwistFlavor() * mu;  //for invert twist (not daggered)
+    if (in.TwistFlavor() == QUDA_TWIST_SINGLET) {
+      double a = -2.0 * kappa * mu;  //for invert twist (not daggered)
       double b = 1.;// / (1.0 + a*a);                     //for invert twist 
       if (!dagger || matpcType == QUDA_MATPC_EVEN_EVEN_ASYMMETRIC || matpcType == QUDA_MATPC_ODD_ODD_ASYMMETRIC) {
 	twistedCloverDslashCuda(&static_cast<cudaColorSpinorField&>(out), *gauge, cs, cI,
@@ -242,7 +241,7 @@ namespace quda {
     FullClover *cs = new FullClover(clover, false);
     FullClover *cI = new FullClover(clover, true);
 
-    if(in.TwistFlavor() == QUDA_TWIST_PLUS || in.TwistFlavor() == QUDA_TWIST_MINUS){
+    if(in.TwistFlavor() == QUDA_TWIST_SINGLET) {
       double a = -2.0 * kappa * in.TwistFlavor() * mu;  //for invert twist
       //      double b = k / (1.0 + a*a);                     //for invert twist	NO HABRÍA QUE APLICAR CLOVER_TWIST_INV???
       double b = k;                     //for invert twist	NO HABRÍA QUE APLICAR CLOVER_TWIST_INV???
@@ -277,7 +276,7 @@ namespace quda {
     FullClover *cs = new FullClover(clover, false);
     FullClover *cI = new FullClover(clover, true);
 
-    if(in.TwistFlavor() == QUDA_TWIST_PLUS || in.TwistFlavor() == QUDA_TWIST_MINUS){
+    if(in.TwistFlavor() == QUDA_TWIST_SINGLET) {
       if (matpcType == QUDA_MATPC_EVEN_EVEN) {
 	if (dagger) {
 	  TwistCloverInv(*tmp1, in, QUDA_EVEN_PARITY);
@@ -352,7 +351,7 @@ namespace quda {
     bool reset = newTmp(&tmp1, b.Even());
   
     // we desire solution to full system
-    if(b.TwistFlavor() == QUDA_TWIST_PLUS || b.TwistFlavor() == QUDA_TWIST_MINUS){  
+    if(b.TwistFlavor() == QUDA_TWIST_SINGLET) {  
       if (matpcType == QUDA_MATPC_EVEN_EVEN) {
         // src = A_ee^-1 (b_e + k D_eo A_oo^-1 b_o)
         src = &(x.Odd());
@@ -402,7 +401,7 @@ namespace quda {
     bool reset = newTmp(&tmp1, b.Even());
 
     // create full solution
-    if(b.TwistFlavor() == QUDA_TWIST_PLUS || b.TwistFlavor() == QUDA_TWIST_MINUS){    
+    if(b.TwistFlavor() == QUDA_TWIST_SINGLET) {    
       if (matpcType == QUDA_MATPC_EVEN_EVEN || matpcType == QUDA_MATPC_EVEN_EVEN_ASYMMETRIC) {
         // x_o = A_oo^-1 (b_o + k D_oe x_e)
         DiracWilson::DslashXpay(*tmp1, x.Even(), QUDA_ODD_PARITY, b.Odd(), kappa);

--- a/lib/dirac_twisted_mass.cpp
+++ b/lib/dirac_twisted_mass.cpp
@@ -52,12 +52,11 @@ namespace quda {
     if (in.TwistFlavor() == QUDA_TWIST_NO || in.TwistFlavor() == QUDA_TWIST_INVALID)
       errorQuda("Twist flavor not set %d\n", in.TwistFlavor());
 
-    if (in.TwistFlavor() == QUDA_TWIST_PLUS || in.TwistFlavor() == QUDA_TWIST_MINUS) {
-      double flavor_mu = in.TwistFlavor() * mu;
+    if (in.TwistFlavor() == QUDA_TWIST_SINGLET) {
       if (Location(out, in) == QUDA_CUDA_FIELD_LOCATION) {
 	twistGamma5Cuda(&static_cast<cudaColorSpinorField&>(out), 
 			&static_cast<const cudaColorSpinorField&>(in),
-			dagger, kappa, flavor_mu, 0.0, twistType);
+			dagger, kappa, mu, 0.0, twistType);
       } else {
 	errorQuda("Not implemented");
       }
@@ -133,8 +132,8 @@ namespace quda {
     twisted::setFace(face1,face2); // FIXME: temporary hack maintain C linkage for dslashCuda
     ndegtwisted::setFace(face1,face2); // FIXME: temporary hack maintain C linkage for dslashCuda
   
-    if(in.TwistFlavor() == QUDA_TWIST_PLUS || in.TwistFlavor() == QUDA_TWIST_MINUS){
-      double a = 2.0 * kappa * in.TwistFlavor() * mu;//for direct twist (must be daggered separately)  
+    if(in.TwistFlavor() == QUDA_TWIST_SINGLET) {
+      double a = 2.0 * kappa * mu;//for direct twist (must be daggered separately)  
 
       TwistedDslashXpay(out.Odd(), in.Even(), in.Odd(), QUDA_ODD_PARITY, 
 			QUDA_DEG_DSLASH_TWIST_XPAY, a, -kappa, 0.0, 0.0);
@@ -187,7 +186,7 @@ namespace quda {
   }
 
   void DiracTwistedMass::createCoarseOp(GaugeField &Y, GaugeField &X, GaugeField &Xinv, GaugeField &Yhat, const Transfer &T) const {
-    double a = 2.0 * kappa * mu * T.Vectors().TwistFlavor();
+    double a = 2.0 * kappa * mu;
     cudaCloverField *c = NULL;
     CoarseOp(Y, X, Xinv, Yhat, T, *gauge, c, kappa, a, QUDA_TWISTED_MASS_DIRAC, QUDA_MATPC_INVALID);
   }
@@ -231,8 +230,8 @@ namespace quda {
     twisted::setFace(face1,face2); // FIXME: temporary hack maintain C linkage for dslashCuda
     ndegtwisted::setFace(face1,face2); // FIXME: temporary hack maintain C linkage for dslashCuda
   
-    if (in.TwistFlavor() == QUDA_TWIST_PLUS || in.TwistFlavor() == QUDA_TWIST_MINUS){
-      double a = -2.0 * kappa * in.TwistFlavor() * mu;  //for invert twist (not daggered)
+    if (in.TwistFlavor() == QUDA_TWIST_SINGLET) {
+      double a = -2.0 * kappa * mu;  //for invert twist (not daggered)
       double b = 1.0 / (1.0 + a*a);                     //for invert twist
       if (!dagger || matpcType == QUDA_MATPC_EVEN_EVEN_ASYMMETRIC || matpcType == QUDA_MATPC_ODD_ODD_ASYMMETRIC) {
 	TwistedDslash(out, in, parity, QUDA_DEG_DSLASH_TWIST_INV, a, b, 0.0, 0.0);
@@ -278,8 +277,8 @@ namespace quda {
     twisted::setFace(face1,face2); // FIXME: temporary hack maintain C linkage for dslashCuda
     ndegtwisted::setFace(face1,face2); // FIXME: temporary hack maintain C linkage for dslashCuda
   
-    if(in.TwistFlavor() == QUDA_TWIST_PLUS || in.TwistFlavor() == QUDA_TWIST_MINUS){
-      double a = -2.0 * kappa * in.TwistFlavor() * mu;  //for invert twist
+    if(in.TwistFlavor() == QUDA_TWIST_SINGLET) {
+      double a = -2.0 * kappa * mu;  //for invert twist
       double b = k / (1.0 + a*a);                     //for invert twist 
       if (!dagger) {
         TwistedDslashXpay(out, in, x, parity, QUDA_DEG_DSLASH_TWIST_INV, a, b, 0.0, 0.0);
@@ -316,7 +315,7 @@ namespace quda {
 
     bool reset = newTmp(&tmp1, in);
 
-    if(in.TwistFlavor() == QUDA_TWIST_PLUS || in.TwistFlavor() == QUDA_TWIST_MINUS){
+    if(in.TwistFlavor() == QUDA_TWIST_SINGLET) {
       if (matpcType == QUDA_MATPC_EVEN_EVEN) {
 	  Dslash(*tmp1, in, QUDA_ODD_PARITY);
 	  DslashXpay(out, *tmp1, QUDA_EVEN_PARITY, in, kappa2); 
@@ -324,7 +323,7 @@ namespace quda {
 	  Dslash(*tmp1, in, QUDA_EVEN_PARITY);
 	  DslashXpay(out, *tmp1, QUDA_ODD_PARITY, in, kappa2); 
       } else {//asymmetric preconditioning 
-        double a = 2.0 * kappa * in.TwistFlavor() * mu;
+        double a = 2.0 * kappa * mu;
         if (matpcType == QUDA_MATPC_EVEN_EVEN_ASYMMETRIC) {
 	  Dslash(*tmp1, in, QUDA_ODD_PARITY);
           TwistedDslashXpay(out, *tmp1, in, QUDA_EVEN_PARITY, QUDA_DEG_DSLASH_TWIST_XPAY, a, kappa2, 0.0, 0.0);
@@ -391,7 +390,7 @@ namespace quda {
     bool reset = newTmp(&tmp1, b.Even());
   
     // we desire solution to full system
-    if(b.TwistFlavor() == QUDA_TWIST_PLUS || b.TwistFlavor() == QUDA_TWIST_MINUS){  
+    if(b.TwistFlavor() == QUDA_TWIST_SINGLET) {  
       if (matpcType == QUDA_MATPC_EVEN_EVEN) {
         // src = A_ee^-1 (b_e + k D_eo A_oo^-1 b_o)
         src = &(x.Odd());
@@ -505,7 +504,7 @@ namespace quda {
     bool reset = newTmp(&tmp1, b.Even());
 
     // create full solution
-    if(b.TwistFlavor() == QUDA_TWIST_PLUS || b.TwistFlavor() == QUDA_TWIST_MINUS){    
+    if(b.TwistFlavor() == QUDA_TWIST_SINGLET) {    
       if (matpcType == QUDA_MATPC_EVEN_EVEN || matpcType == QUDA_MATPC_EVEN_EVEN_ASYMMETRIC) {
         // x_o = A_oo^-1 (b_o + k D_oe x_e)
         DiracWilson::DslashXpay(*tmp1, x.Even(), QUDA_ODD_PARITY, b.Odd(), kappa);
@@ -546,7 +545,7 @@ namespace quda {
   }
 
   void DiracTwistedMassPC::createCoarseOp(GaugeField &Y, GaugeField &X, GaugeField &Xinv, GaugeField &Yhat, const Transfer &T) const {
-    double a = -2.0 * kappa * mu * T.Vectors().TwistFlavor();
+    double a = -2.0 * kappa * mu;
     cudaCloverField *c = NULL;
     CoarseOp(Y, X, Xinv, Yhat, T, *gauge, c, kappa, a, QUDA_TWISTED_MASSPC_DIRAC, matpcType);
   }

--- a/lib/dslash_pack.cu
+++ b/lib/dslash_pack.cu
@@ -1863,7 +1863,7 @@ namespace quda {
       packFaceStaggered(ghost_buf, in, zero_copy, nFace, dagger, parity, dim, face_num, stream);
     } else if (a!=0.0 || b!=0.0) {
       // Need to update this logic for other multi-src dslash packing
-      if(in.TwistFlavor() == QUDA_TWIST_PLUS || in.TwistFlavor() == QUDA_TWIST_MINUS) {
+      if(in.TwistFlavor() == QUDA_TWIST_SINGLET) {
 	packTwistedFaceWilson(ghost_buf, in, zero_copy, dagger, parity, a, b, stream);
       } else {
 	errorQuda("Cannot perform twisted packing for the spinor.");

--- a/lib/dslash_quda.cu
+++ b/lib/dslash_quda.cu
@@ -411,7 +411,7 @@ class TwistGamma5Cuda : public Tunable {
     dslashParam.in = (void*)in->V();
     dslashParam.inNorm = (float*)in->Norm();
     dslashParam.sp_stride = in->Stride();
-    if((in->TwistFlavor() == QUDA_TWIST_PLUS) || (in->TwistFlavor() == QUDA_TWIST_MINUS)) {
+    if(in->TwistFlavor() == QUDA_TWIST_SINGLET) {
       setTwistParam(dslashParam.a, dslashParam.b, kappa, mu, dagger, twist);
       dslashParam.c = 0.0;
 #if (defined GPU_TWISTED_MASS_DIRAC) || (defined GPU_NDEG_TWISTED_MASS_DIRAC)
@@ -437,7 +437,7 @@ class TwistGamma5Cuda : public Tunable {
 #if (defined GPU_TWISTED_MASS_DIRAC) || (defined GPU_NDEG_TWISTED_MASS_DIRAC)
       TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
       dim3 gridDim( (dslashParam.threads+tp.block.x-1) / tp.block.x, 1, 1);
-      if((in->TwistFlavor() == QUDA_TWIST_PLUS) || (in->TwistFlavor() == QUDA_TWIST_MINUS)) {
+      if(in->TwistFlavor() == QUDA_TWIST_SINGLET) {
         twistGamma5Kernel<sFloat,false><<<gridDim, tp.block, tp.shared_bytes, stream>>>(dslashParam);
       } else {
         twistGamma5Kernel<sFloat,true><<<gridDim, tp.block, tp.shared_bytes, stream>>>(dslashParam);
@@ -471,7 +471,7 @@ class TwistGamma5Cuda : public Tunable {
 void twistGamma5Cuda(cudaColorSpinorField *out, const cudaColorSpinorField *in,
     const int dagger, const double &kappa, const double &mu, const double &epsilon,   const QudaTwistGamma5Type twist)
 {
-  if(in->TwistFlavor() == QUDA_TWIST_PLUS || in->TwistFlavor() == QUDA_TWIST_MINUS)
+  if(in->TwistFlavor() == QUDA_TWIST_SINGLET)
     dslashParam.threads = in->Volume();
   else //twist doublet    
     dslashParam.threads = in->Volume() / 2;
@@ -539,7 +539,7 @@ class TwistCloverGamma5Cuda : public Tunable {
       dslashParam.fl_stride = in->VolumeCB();
 #endif
 
-      if((in->TwistFlavor() == QUDA_TWIST_PLUS) || (in->TwistFlavor() == QUDA_TWIST_MINUS)) {
+      if(in->TwistFlavor() == QUDA_TWIST_SINGLET) {
 	setTwistParam(dslashParam.a, dslashParam.b, kappa, mu, dagger, tw);
       } else {//twist doublet
 	errorQuda("ERROR: Non-degenerated twisted-mass not supported in this regularization\n");
@@ -562,7 +562,7 @@ class TwistCloverGamma5Cuda : public Tunable {
 #if defined(GPU_TWISTED_CLOVER_DIRAC)
       TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
       dim3 gridDim( (dslashParam.threads+tp.block.x-1) / tp.block.x, 1, 1);
-      if((in->TwistFlavor() == QUDA_TWIST_PLUS) || (in->TwistFlavor() == QUDA_TWIST_MINUS)) {	//Idea for the kernel, two spinor inputs (IN and clover applied IN), on output (Clover applied IN + ig5IN)
+      if(in->TwistFlavor() == QUDA_TWIST_SINGLET) {	//Idea for the kernel, two spinor inputs (IN and clover applied IN), on output (Clover applied IN + ig5IN)
         if (twist == QUDA_TWIST_GAMMA5_DIRECT)
           twistCloverGamma5Kernel<sFloat><<<gridDim, tp.block, tp.shared_bytes, stream>>>(dslashParam);
         else if (twist == QUDA_TWIST_GAMMA5_INVERSE)
@@ -599,7 +599,7 @@ class TwistCloverGamma5Cuda : public Tunable {
 void twistCloverGamma5Cuda(cudaColorSpinorField *out, const cudaColorSpinorField *in, const int dagger, const double &kappa, const double &mu,
     const double &epsilon, const QudaTwistGamma5Type twist, const FullClover *clov, const FullClover *clovInv, const int parity)
 {
-  if(in->TwistFlavor() == QUDA_TWIST_PLUS || in->TwistFlavor() == QUDA_TWIST_MINUS)
+  if(in->TwistFlavor() == QUDA_TWIST_SINGLET)
     dslashParam.threads = in->Volume();
   else //twist doublet    
     errorQuda("Twisted doublet not supported in twisted clover dslash");

--- a/lib/dslash_twisted_clover.cu
+++ b/lib/dslash_twisted_clover.cu
@@ -271,7 +271,7 @@ namespace quda {
     int Npad = (in->Ncolor()*in->Nspin()*2)/in->FieldOrder(); // SPINOR_HOP in old code
 
     int ghost_threads[4] = {0};
-    int bulk_threads = ((in->TwistFlavor() == QUDA_TWIST_PLUS) || (in->TwistFlavor() == QUDA_TWIST_MINUS)) ? in->Volume() : in->Volume() / 2;
+    int bulk_threads = (in->TwistFlavor() == QUDA_TWIST_SINGLET) ? in->Volume() : in->Volume() / 2;
 
     for(int i=0;i<4;i++){
       dslashParam.ghostDim[i] = commDimPartitioned(i); // determines whether to use regular or ghost indexing at boundary
@@ -281,7 +281,7 @@ namespace quda {
       dslashParam.ghostNormOffset[i][0] = in->GhostNormOffset(i,0);
       dslashParam.ghostNormOffset[i][1] = in->GhostNormOffset(i,1);
       dslashParam.commDim[i] = (!commOverride[i]) ? 0 : commDimPartitioned(i); // switch off comms if override = 0
-      ghost_threads[i] = ((in->TwistFlavor() == QUDA_TWIST_PLUS) || (in->TwistFlavor() == QUDA_TWIST_MINUS)) ? in->GhostFace()[i] : in->GhostFace()[i] / 2;
+      ghost_threads[i] = (in->TwistFlavor() == QUDA_TWIST_SINGLET) ? in->GhostFace()[i] : in->GhostFace()[i] / 2;
     }
 
 #ifdef MULTI_GPU

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -1320,7 +1320,7 @@ namespace quda {
       break;
     case QUDA_TWISTED_MASS_DSLASH:
       diracParam.type = pc ? QUDA_TWISTED_MASSPC_DIRAC : QUDA_TWISTED_MASS_DIRAC;
-      if (inv_param->twist_flavor == QUDA_TWIST_MINUS || inv_param->twist_flavor == QUDA_TWIST_PLUS) {
+      if (inv_param->twist_flavor == QUDA_TWIST_SINGLET) {
 	diracParam.Ls = 1;
 	diracParam.epsilon = 0.0;
       } else {
@@ -1330,7 +1330,7 @@ namespace quda {
       break;
     case QUDA_TWISTED_CLOVER_DSLASH:
       diracParam.type = pc ? QUDA_TWISTED_CLOVERPC_DIRAC : QUDA_TWISTED_CLOVER_DIRAC;
-      if (inv_param->twist_flavor == QUDA_TWIST_MINUS || inv_param->twist_flavor == QUDA_TWIST_PLUS)  {
+      if (inv_param->twist_flavor == QUDA_TWIST_SINGLET)  {
 	diracParam.Ls = 1;
 	diracParam.epsilon = 0.0;
       } else {

--- a/tests/deflation_test.cpp
+++ b/tests/deflation_test.cpp
@@ -147,7 +147,7 @@ int main(int argc, char **argv)
     inv_param.mu = 0.12;
     inv_param.epsilon = 0.1385;
     //inv_param.twist_flavor = QUDA_TWIST_NONDEG_DOUBLET;
-    inv_param.twist_flavor = QUDA_TWIST_PLUS;
+    inv_param.twist_flavor = QUDA_TWIST_SINGLET;
     inv_param.Ls = (inv_param.twist_flavor == QUDA_TWIST_NONDEG_DOUBLET) ? 2 : 1;
   } else if (dslash_type == QUDA_DOMAIN_WALL_DSLASH) {
     inv_param.mass = 0.02;
@@ -472,7 +472,7 @@ int main(int argc, char **argv)
     if (inv_param.solution_type == QUDA_MAT_SOLUTION) {
 
       if (dslash_type == QUDA_TWISTED_MASS_DSLASH) {
-	if(inv_param.twist_flavor == QUDA_TWIST_PLUS || inv_param.twist_flavor == QUDA_TWIST_MINUS)      
+	if(inv_param.twist_flavor == QUDA_TWIST_SINGLET) 
 	  tm_mat(spinorCheck, gauge, spinorOut, inv_param.kappa, inv_param.mu, inv_param.twist_flavor, 0, inv_param.cpu_prec, gauge_param);
 	else
 	{
@@ -504,7 +504,7 @@ int main(int argc, char **argv)
     } else if(inv_param.solution_type == QUDA_MATPC_SOLUTION) {
 
       if (dslash_type == QUDA_TWISTED_MASS_DSLASH) {
-	if (inv_param.twist_flavor != QUDA_TWIST_MINUS && inv_param.twist_flavor != QUDA_TWIST_PLUS)
+	if (inv_param.twist_flavor != QUDA_TWIST_SINGLET)
 	  errorQuda("Twisted mass solution type not supported");
         tm_matpc(spinorCheck, gauge, spinorOut, inv_param.kappa, inv_param.mu, inv_param.twist_flavor, 
                  inv_param.matpc_type, 0, inv_param.cpu_prec, gauge_param);

--- a/tests/dslash_test.cpp
+++ b/tests/dslash_test.cpp
@@ -268,7 +268,7 @@ void init(int argc, char **argv) {
 //ndeg_tm    
   if (dslash_type == QUDA_TWISTED_MASS_DSLASH || dslash_type == QUDA_TWISTED_CLOVER_DSLASH) {
     csParam.twistFlavor = inv_param.twist_flavor;
-    csParam.nDim = (inv_param.twist_flavor == QUDA_TWIST_PLUS || inv_param.twist_flavor == QUDA_TWIST_MINUS) ? 4 : 5;
+    csParam.nDim = (inv_param.twist_flavor == QUDA_TWIST_SINGLET) ? 4 : 5;
     csParam.x[4] = inv_param.Ls;    
   }
 
@@ -670,7 +670,7 @@ void dslashRef() {
   } else if (dslash_type == QUDA_TWISTED_MASS_DSLASH) {
     switch (test_type) {
     case 0:
-      if(inv_param.twist_flavor == QUDA_TWIST_PLUS || inv_param.twist_flavor == QUDA_TWIST_MINUS)
+      if(inv_param.twist_flavor == QUDA_TWIST_SINGLET)
 	tm_dslash(spinorRef->V(), hostGauge, spinor->V(), inv_param.kappa, inv_param.mu, inv_param.twist_flavor, parity, inv_param.matpc_type, dagger, inv_param.cpu_prec, gauge_param);
       else
       {
@@ -687,7 +687,7 @@ void dslashRef() {
       }
       break;
     case 1:
-      if(inv_param.twist_flavor == QUDA_TWIST_PLUS || inv_param.twist_flavor == QUDA_TWIST_MINUS)      
+      if(inv_param.twist_flavor == QUDA_TWIST_SINGLET)      
 	tm_matpc(spinorRef->V(), hostGauge, spinor->V(), inv_param.kappa, inv_param.mu, inv_param.twist_flavor, inv_param.matpc_type, dagger, inv_param.cpu_prec, gauge_param);
       else
       {
@@ -703,7 +703,7 @@ void dslashRef() {
       }	
       break;
     case 2:
-      if(inv_param.twist_flavor == QUDA_TWIST_PLUS || inv_param.twist_flavor == QUDA_TWIST_MINUS)      
+      if(inv_param.twist_flavor == QUDA_TWIST_SINGLET)      
 	tm_mat(spinorRef->V(), hostGauge, spinor->V(), inv_param.kappa, inv_param.mu, inv_param.twist_flavor, dagger, inv_param.cpu_prec, gauge_param);
       else
       {
@@ -719,7 +719,7 @@ void dslashRef() {
       }
       break;
     case 3:    
-      if(inv_param.twist_flavor == QUDA_TWIST_PLUS || inv_param.twist_flavor == QUDA_TWIST_MINUS) { 
+      if(inv_param.twist_flavor == QUDA_TWIST_SINGLET) { 
 	tm_matpc(spinorTmp->V(), hostGauge, spinor->V(), inv_param.kappa, inv_param.mu, inv_param.twist_flavor,
 	       inv_param.matpc_type, dagger, inv_param.cpu_prec, gauge_param);
 	tm_matpc(spinorRef->V(), hostGauge, spinorTmp->V(), inv_param.kappa, inv_param.mu, inv_param.twist_flavor,
@@ -743,7 +743,7 @@ void dslashRef() {
       }
       break;
     case 4:
-      if(inv_param.twist_flavor == QUDA_TWIST_PLUS || inv_param.twist_flavor == QUDA_TWIST_MINUS) {
+      if(inv_param.twist_flavor == QUDA_TWIST_SINGLET) {
 	tm_mat(spinorTmp->V(), hostGauge, spinor->V(), inv_param.kappa, inv_param.mu, inv_param.twist_flavor,
 	     dagger, inv_param.cpu_prec, gauge_param);
 	tm_mat(spinorRef->V(), hostGauge, spinorTmp->V(), inv_param.kappa, inv_param.mu, inv_param.twist_flavor,
@@ -773,25 +773,25 @@ void dslashRef() {
   } else if (dslash_type == QUDA_TWISTED_CLOVER_DSLASH) {
     switch (test_type) {
     case 0:
-      if(inv_param.twist_flavor == QUDA_TWIST_PLUS || inv_param.twist_flavor == QUDA_TWIST_MINUS)
+      if(inv_param.twist_flavor == QUDA_TWIST_SINGLET)
 	tmc_dslash(spinorRef->V(), hostGauge, spinor->V(), hostClover, hostCloverInv, inv_param.kappa, inv_param.mu, inv_param.twist_flavor, parity, inv_param.matpc_type, dagger, inv_param.cpu_prec, gauge_param);
       else
         errorQuda("Not supported\n");
       break;
     case 1:
-      if(inv_param.twist_flavor == QUDA_TWIST_PLUS || inv_param.twist_flavor == QUDA_TWIST_MINUS)      
+      if(inv_param.twist_flavor == QUDA_TWIST_SINGLET)      
 	tmc_matpc(spinorRef->V(), hostGauge, spinor->V(), hostClover, hostCloverInv, inv_param.kappa, inv_param.mu, inv_param.twist_flavor, inv_param.matpc_type, dagger, inv_param.cpu_prec, gauge_param);
       else
         errorQuda("Not supported\n");
       break;
     case 2:
-      if(inv_param.twist_flavor == QUDA_TWIST_PLUS || inv_param.twist_flavor == QUDA_TWIST_MINUS)      
+      if(inv_param.twist_flavor == QUDA_TWIST_SINGLET)      
 	tmc_mat(spinorRef->V(), hostGauge, hostClover, spinor->V(), inv_param.kappa, inv_param.mu, inv_param.twist_flavor, dagger, inv_param.cpu_prec, gauge_param);
       else
         errorQuda("Not supported\n");
       break;
     case 3:    
-      if(inv_param.twist_flavor == QUDA_TWIST_PLUS || inv_param.twist_flavor == QUDA_TWIST_MINUS) {
+      if(inv_param.twist_flavor == QUDA_TWIST_SINGLET) {
 	tmc_matpc(spinorTmp->V(), hostGauge, spinor->V(), hostClover, hostCloverInv, inv_param.kappa, inv_param.mu, inv_param.twist_flavor,
 	       inv_param.matpc_type, dagger, inv_param.cpu_prec, gauge_param);
 	tmc_matpc(spinorRef->V(), hostGauge, spinorTmp->V(), hostClover, hostCloverInv, inv_param.kappa, inv_param.mu, inv_param.twist_flavor,
@@ -800,7 +800,7 @@ void dslashRef() {
         errorQuda("Not supported\n");
       break;
     case 4:
-      if(inv_param.twist_flavor == QUDA_TWIST_PLUS || inv_param.twist_flavor == QUDA_TWIST_MINUS) {
+      if(inv_param.twist_flavor == QUDA_TWIST_SINGLET) {
 	tmc_mat(spinorTmp->V(), hostGauge, hostClover, spinor->V(), inv_param.kappa, inv_param.mu, inv_param.twist_flavor, dagger, inv_param.cpu_prec, gauge_param);
 	tmc_mat(spinorRef->V(), hostGauge, hostClover, spinorTmp->V(), inv_param.kappa, inv_param.mu, inv_param.twist_flavor, not_dagger, inv_param.cpu_prec, gauge_param);
       } else

--- a/tests/invert_test.cpp
+++ b/tests/invert_test.cpp
@@ -411,14 +411,14 @@ int main(int argc, char **argv)
       ax(0, spinorCheck, V*spinorSiteSize, inv_param.cpu_prec);
       
       if (dslash_type == QUDA_TWISTED_MASS_DSLASH) {
-	if (inv_param.twist_flavor != QUDA_TWIST_MINUS && inv_param.twist_flavor != QUDA_TWIST_PLUS)
+	if (inv_param.twist_flavor != QUDA_TWIST_SINGLET)
 	  errorQuda("Twisted mass solution type not supported");
         tm_matpc(spinorTmp, gauge, spinorOutMulti[i], inv_param.kappa, inv_param.mu, inv_param.twist_flavor, 
                  inv_param.matpc_type, 0, inv_param.cpu_prec, gauge_param);
         tm_matpc(spinorCheck, gauge, spinorTmp, inv_param.kappa, inv_param.mu, inv_param.twist_flavor, 
                  inv_param.matpc_type, 1, inv_param.cpu_prec, gauge_param);
       } else if (dslash_type == QUDA_TWISTED_CLOVER_DSLASH) {
-	if (inv_param.twist_flavor != QUDA_TWIST_MINUS && inv_param.twist_flavor != QUDA_TWIST_PLUS)
+	if (inv_param.twist_flavor != QUDA_TWIST_SINGLET)
 	  errorQuda("Twisted mass solution type not supported");
 	tmc_matpc(spinorTmp, gauge, spinorOutMulti[i], clover, clover_inv, inv_param.kappa, inv_param.mu,
 		  inv_param.twist_flavor, inv_param.matpc_type, 0, inv_param.cpu_prec, gauge_param);
@@ -456,7 +456,7 @@ int main(int argc, char **argv)
     if (inv_param.solution_type == QUDA_MAT_SOLUTION) {
 
       if (dslash_type == QUDA_TWISTED_MASS_DSLASH) {
-	if(inv_param.twist_flavor == QUDA_TWIST_PLUS || inv_param.twist_flavor == QUDA_TWIST_MINUS) {
+	if(inv_param.twist_flavor == QUDA_TWIST_SINGLET) {
 	  tm_mat(spinorCheck, gauge, spinorOut, inv_param.kappa, inv_param.mu, inv_param.twist_flavor, 0, inv_param.cpu_prec, gauge_param);
 	} else {
           int tm_offset = V*spinorSiteSize; //12*spinorRef->Volume(); 	  
@@ -509,12 +509,12 @@ int main(int argc, char **argv)
     } else if(inv_param.solution_type == QUDA_MATPC_SOLUTION) {
 
       if (dslash_type == QUDA_TWISTED_MASS_DSLASH) {
-	if (inv_param.twist_flavor != QUDA_TWIST_MINUS && inv_param.twist_flavor != QUDA_TWIST_PLUS)
+	if (inv_param.twist_flavor != QUDA_TWIST_SINGLET)
 	  errorQuda("Twisted mass solution type not supported");
         tm_matpc(spinorCheck, gauge, spinorOut, inv_param.kappa, inv_param.mu, inv_param.twist_flavor, 
                  inv_param.matpc_type, 0, inv_param.cpu_prec, gauge_param);
       } else if (dslash_type == QUDA_TWISTED_CLOVER_DSLASH) {
-	if (inv_param.twist_flavor != QUDA_TWIST_MINUS && inv_param.twist_flavor != QUDA_TWIST_PLUS)
+	if (inv_param.twist_flavor != QUDA_TWIST_SINGLET)
 	  errorQuda("Twisted mass solution type not supported");
         tmc_matpc(spinorCheck, gauge, spinorOut, clover, clover_inv, inv_param.kappa, inv_param.mu,
 		  inv_param.twist_flavor, inv_param.matpc_type, 0, inv_param.cpu_prec, gauge_param);
@@ -562,14 +562,14 @@ int main(int argc, char **argv)
       ax(0, spinorCheck, V*spinorSiteSize, inv_param.cpu_prec);
       
       if (dslash_type == QUDA_TWISTED_MASS_DSLASH) {
-	if (inv_param.twist_flavor != QUDA_TWIST_MINUS && inv_param.twist_flavor != QUDA_TWIST_PLUS)
+	if (inv_param.twist_flavor != QUDA_TWIST_SINGLET)
 	  errorQuda("Twisted mass solution type not supported");
         tm_matpc(spinorTmp, gauge, spinorOut, inv_param.kappa, inv_param.mu, inv_param.twist_flavor, 
                  inv_param.matpc_type, 0, inv_param.cpu_prec, gauge_param);
         tm_matpc(spinorCheck, gauge, spinorTmp, inv_param.kappa, inv_param.mu, inv_param.twist_flavor, 
                  inv_param.matpc_type, 1, inv_param.cpu_prec, gauge_param);
       } else if (dslash_type == QUDA_TWISTED_CLOVER_DSLASH) {
-	if (inv_param.twist_flavor != QUDA_TWIST_MINUS && inv_param.twist_flavor != QUDA_TWIST_PLUS)
+	if (inv_param.twist_flavor != QUDA_TWIST_SINGLET)
 	  errorQuda("Twisted mass solution type not supported");
         tmc_matpc(spinorTmp, gauge, spinorOut, clover, clover_inv, inv_param.kappa, inv_param.mu,
 		  inv_param.twist_flavor, inv_param.matpc_type, 0, inv_param.cpu_prec, gauge_param);

--- a/tests/invertmsrc_test.cpp
+++ b/tests/invertmsrc_test.cpp
@@ -458,7 +458,7 @@ int main(int argc, char **argv)
 //      ax(0, spinorCheck[i], V*spinorSiteSize, inv_param.cpu_prec);
 //
 //      if (dslash_type == QUDA_TWISTED_MASS_DSLASH || dslash_type == QUDA_TWISTED_CLOVER_DSLASH) {
-//	if (inv_param.twist_flavor != QUDA_TWIST_MINUS && inv_param.twist_flavor != QUDA_TWIST_PLUS)
+//	if (inv_param.twist_flavor != QUDA_TWIST_SINGLET)
 //	  errorQuda("Twisted mass solution type not supported");
 //        tm_matpc(spinorTmp, gauge, spinorOutMulti[i], inv_param.kappa, inv_param.mu, inv_param.twist_flavor,
 //                 inv_param.matpc_type, 0, inv_param.cpu_prec, gauge_param);
@@ -493,7 +493,7 @@ int main(int argc, char **argv)
     if (inv_param.solution_type == QUDA_MAT_SOLUTION) {
 
       if (dslash_type == QUDA_TWISTED_MASS_DSLASH || dslash_type == QUDA_TWISTED_CLOVER_DSLASH) {
-	if(inv_param.twist_flavor == QUDA_TWIST_PLUS || inv_param.twist_flavor == QUDA_TWIST_MINUS)
+	if(inv_param.twist_flavor == QUDA_TWIST_SINGLET)
 	  tm_mat(spinorCheck[i], gauge, spinorOutMulti[i], inv_param.kappa, inv_param.mu, inv_param.twist_flavor, 0, inv_param.cpu_prec, gauge_param);
 	else
 	{
@@ -533,7 +533,7 @@ int main(int argc, char **argv)
     } else if(inv_param.solution_type == QUDA_MATPC_SOLUTION) {
 
       if (dslash_type == QUDA_TWISTED_MASS_DSLASH || dslash_type == QUDA_TWISTED_CLOVER_DSLASH) {
-	if (inv_param.twist_flavor != QUDA_TWIST_MINUS && inv_param.twist_flavor != QUDA_TWIST_PLUS)
+	if (inv_param.twist_flavor != QUDA_TWIST_SINGLET)
 	  errorQuda("Twisted mass solution type not supported");
         tm_matpc(spinorCheck[i], gauge, spinorOutMulti[i], inv_param.kappa, inv_param.mu, inv_param.twist_flavor,
                  inv_param.matpc_type, 0, inv_param.cpu_prec, gauge_param);
@@ -579,7 +579,7 @@ int main(int argc, char **argv)
       ax(0, spinorCheck[i], V*spinorSiteSize, inv_param.cpu_prec);
 
       if (dslash_type == QUDA_TWISTED_MASS_DSLASH || dslash_type == QUDA_TWISTED_CLOVER_DSLASH) {
-	if (inv_param.twist_flavor != QUDA_TWIST_MINUS && inv_param.twist_flavor != QUDA_TWIST_PLUS)
+	if (inv_param.twist_flavor != QUDA_TWIST_SINGLET)
 	  errorQuda("Twisted mass solution type not supported");
         tm_matpc(spinorTmp, gauge, spinorOutMulti[i], inv_param.kappa, inv_param.mu, inv_param.twist_flavor,
                  inv_param.matpc_type, 0, inv_param.cpu_prec, gauge_param);

--- a/tests/misc.cpp
+++ b/tests/misc.cpp
@@ -1002,12 +1002,10 @@ get_solve_str(QudaSolveType type)
 QudaTwistFlavorType
 get_flavor_type(char* s)
 {
-  QudaTwistFlavorType ret =  QUDA_TWIST_MINUS;
+  QudaTwistFlavorType ret =  QUDA_TWIST_SINGLET;
   
-  if (strcmp(s, "minus") == 0){
-    ret = QUDA_TWIST_MINUS;
-  }else if (strcmp(s, "plus") == 0){
-    ret = QUDA_TWIST_PLUS;
+  if (strcmp(s, "singlet") == 0){
+    ret = QUDA_TWIST_SINGLET;
   }else if (strcmp(s, "deg-doublet") == 0){
     ret = QUDA_TWIST_DEG_DOUBLET;
   }else if (strcmp(s, "nondeg-doublet") == 0){
@@ -1028,11 +1026,8 @@ get_flavor_str(QudaTwistFlavorType type)
   const char* ret;
   
   switch(type) {
-  case QUDA_TWIST_MINUS:
-    ret = "minus";
-    break;
-  case QUDA_TWIST_PLUS:
-    ret = "plus";
+  case QUDA_TWIST_SINGLET:
+    ret = "singlet";
     break;
   case QUDA_TWIST_DEG_DOUBLET:
     ret = "deg-doublet";

--- a/tests/multigrid_invert_test.cpp
+++ b/tests/multigrid_invert_test.cpp
@@ -508,7 +508,7 @@ int main(int argc, char **argv)
       wil_mat(spinorCheck, gauge, spinorOut, inv_param.kappa, 0, inv_param.cpu_prec, gauge_param);
     } else {
       if (dslash_type == QUDA_TWISTED_MASS_DSLASH || dslash_type == QUDA_TWISTED_CLOVER_DSLASH) {
-        if(inv_param.twist_flavor == QUDA_TWIST_PLUS || inv_param.twist_flavor == QUDA_TWIST_MINUS) {
+        if(inv_param.twist_flavor == QUDA_TWIST_SINGLET) {
           tm_mat(spinorCheck, gauge, spinorOut, inv_param.kappa, inv_param.mu, inv_param.twist_flavor, 0, inv_param.cpu_prec, gauge_param);
         } else {
           printfQuda("Unsupported dslash_type\n");
@@ -527,7 +527,7 @@ int main(int argc, char **argv)
 		inv_param.cpu_prec, gauge_param);
     } else {
       if (dslash_type == QUDA_TWISTED_MASS_DSLASH || dslash_type == QUDA_TWISTED_CLOVER_DSLASH) {
-        if (inv_param.twist_flavor == QUDA_TWIST_MINUS || inv_param.twist_flavor == QUDA_TWIST_PLUS) {
+        if (inv_param.twist_flavor == QUDA_TWIST_SINGLET) {
           tm_matpc(spinorCheck, gauge, spinorOut, inv_param.kappa, inv_param.mu, inv_param.twist_flavor,
                    inv_param.matpc_type, 0, inv_param.cpu_prec, gauge_param);
         } else {

--- a/tests/test_util.cpp
+++ b/tests/test_util.cpp
@@ -1594,7 +1594,7 @@ double clover_coeff = 0.1;
 bool compute_clover = false;
 double tol = 1e-7;
 double tol_hq = 0.;
-QudaTwistFlavorType twist_flavor = QUDA_TWIST_MINUS;
+QudaTwistFlavorType twist_flavor = QUDA_TWIST_SINGLET;
 bool kernel_pack_t = false;
 QudaMassNormalization normalization = QUDA_KAPPA_NORMALIZATION;
 QudaMatPCType matpc_type = QUDA_MATPC_EVEN_EVEN;
@@ -1650,7 +1650,7 @@ void usage(char** argv )
   printf("    --dslash-type <type>                      # Set the dslash type, the following values are valid\n"
 	 "                                                  wilson/clover/twisted-mass/twisted-clover/staggered\n"
          "                                                  /asqtad/domain-wall/domain-wall-4d/mobius\n");
-  printf("    --flavor <type>                           # Set the twisted mass flavor type (minus (default), plus, deg-doublet, nondeg-doublet)\n");
+  printf("    --flavor <type>                           # Set the twisted mass flavor type (singlet (default), deg-doublet, nondeg-doublet)\n");
   printf("    --load-gauge file                         # Load gauge field \"file\" for the test (requires QIO)\n");
   printf("    --niter <n>                               # The number of iterations to perform (default 10)\n");
   printf("    --ngcrkrylov <n>                          # The number of inner iterations to use for GCR, BiCGstab-l (default 10)\n");


### PR DESCRIPTION
Replaced QUDA_TWIST_{PLUS/MINUS} with QUDA_TWIST_SINGLET. If we want a difference between the plus and the minus in the mu, we can just change the sign of mu (like in the rest of the libraries), and that should do.