### PR TITLE
Feature/bqcd optimize

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,9 +140,6 @@ set(QUDA_INTERFACE_NVTX OFF CACHE BOOL "add nvtx markup to interface calls for t
 # GPUdirect options
 set(QUDA_GPU_DIRECT ON CACHE BOOL "set to 'yes' to allow GPU and NIC to shared pinned buffers")
 
-# Packing option
-set(QUDA_DEVICE_PACK ON CACHE BOOL "set to 'yes' to enable packing and unpacking on the device")
-
 # features in development
 set(QUDA_SSTEP OFF CACHE BOOL "build s-step linear solvers")
 set(QUDA_MULTIGRID OFF CACHE BOOL "build multigrid solvers")
@@ -163,8 +160,6 @@ mark_as_advanced(QUDA_MPI_NVTX)
 mark_as_advanced(QUDA_INTERFACE_NVTX)
 
 mark_as_advanced(QUDA_GPU_DIRECT)
-
-mark_as_advanced(QUDA_DEVICE_PACK)
 
 mark_as_advanced(QUDA_SSTEP)
 mark_as_advanced(QUDA_EIGEN)
@@ -455,10 +450,6 @@ if(QUDA_INTERFACE_TIFR OR QUDA_INTERFACE_BQCD)
   SET(BUILD_FORTRAN_INTERFACE ON)
   enable_language(Fortran)
 endif()
-
-if(DEVICE_PACK)
-  add_definitions(-DDEVICE_PACK)
-endif(DEVICE_PACK)
 
 
 

--- a/configure
+++ b/configure
@@ -586,10 +586,10 @@ PACKAGE_URL=''
 
 ac_subst_vars='LTLIBOBJS
 LIBOBJS
-BUILD_MAGMA_VARS
-BUILD_MAGMA
 BUILD_ARPACK_VARS
 BUILD_ARPACK
+BUILD_MAGMA_VARS
+BUILD_MAGMA
 QDP_INSTALL_PATH
 USE_QDPJIT
 FERMI_DBLE_TEX
@@ -601,7 +601,6 @@ FEF90
 FECXX
 FECC
 BUILD_QIO
-DEVICE_PACK
 BUILD_TIFR_INTERFACE
 BUILD_BQCD_INTERFACE
 BUILD_QDPJIT_INTERFACE
@@ -734,7 +733,6 @@ enable_multi_gpu
 enable_gpu_direct
 enable_mpi_nvtx
 enable_interface_nvtx
-enable_device_pack
 with_mpi
 enable_pthreads
 with_qmp
@@ -743,6 +741,8 @@ enable_qdp_jit
 with_qdp
 enable_magma
 enable_magma_vars
+enable_arpack
+enable_arpack_vars
 enable_blas_tex
 enable_fermi_double_tex
 enable_force_ac
@@ -1424,8 +1424,6 @@ Optional Features:
                           the visual profiler (default: disabled)
   --enable-interface-nvtx Enable NVTX markup for profiling interface calls in
                           the visual profiler (default: disabled)
-  --enable-device-pack    Enable the packing / unpacking of fields on the
-                          device (default: disabled)
   --enable-pthreads       Enable pthreads in the multi-GPU dslash build
                           (default: disabled)
   --enable-qdp-jit        Enable QDP-JIT support, requires --with-qdp
@@ -1434,9 +1432,10 @@ Optional Features:
                           magma)
   --enable-magma-vars     Build with MAGMA using env vars: MAGMA_INC and
                           MAGMA_LIB
-  --enable-arpack          Build with (P)ARPACK (requires pkg-config to detect
+  --enable-arpack         Build with ARPACK (requires pkg-config to detect
                           arpack)
-  --enable-arpack-vars     Build with (P)ARPACK using env vars: ARPACK_LIB
+  --enable-arpack-vars    Build with ARPACK using env vars: ARPACK_INC and
+                          ARPACK_LIB
   --enable-blas-tex       Enable texture reads for blas (default: enabled)
   --enable-fermi-double-tex
                           Enable double-precision texture reads on Fermi
@@ -2336,15 +2335,6 @@ if test "${enable_interface_nvtx+set}" = set; then :
   enableval=$enable_interface_nvtx;  interface_nvtx=${enableval}
 else
    interface_nvtx="no"
-
-fi
-
-
-# Check whether --enable-device-pack was given.
-if test "${enable_device_pack+set}" = set; then :
-  enableval=$enable_device_pack;  device_pack=${enableval}
-else
-   device_pack="no"
 
 fi
 
@@ -3891,6 +3881,25 @@ else
 fi
 
 
+# Check whether --enable-arpack was given.
+if test "${enable_arpack+set}" = set; then :
+  enableval=$enable_arpack;  build_arpack=${enableval}
+else
+   build_arpack="no"
+
+fi
+
+
+# Check whether --enable-arpack-vars was given.
+if test "${enable_arpack_vars+set}" = set; then :
+  enableval=$enable_arpack_vars;  build_arpack_vars=${enableval}
+else
+   build_arpack_vars="no"
+
+fi
+
+
+
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: User supplied NVCCFLAGS: ${NVCCFLAGS} " >&5
 $as_echo "$as_me: User supplied NVCCFLAGS: ${NVCCFLAGS} " >&6;}
@@ -4529,11 +4538,6 @@ $as_echo "$as_me: Setting BUILD_TIFR_INTERFACE= ${build_tifr_interface}" >&6;}
 BUILD_TIFR_INTERFACE=${build_tifr_interface}
 
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: Setting DEVICE_PACK= ${device_pack}" >&5
-$as_echo "$as_me: Setting DEVICE_PACK= ${device_pack}" >&6;}
-DEVICE_PACK=${device_pack}
-
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: Setting BUILD_QIO = ${build_qio} " >&5
 $as_echo "$as_me: Setting BUILD_QIO = ${build_qio} " >&6;}
 BUILD_QIO=${build_qio}
@@ -4593,13 +4597,21 @@ QDP_INSTALL_PATH=${qdp_home}
 $as_echo "$as_me: Setting BUILD_MAGMA = ${build_magma}" >&6;}
 BUILD_MAGMA=${build_magma}
 
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: Setting BUILD_MAGMA_VARS = ${build_magma_vars}" >&5
+$as_echo "$as_me: Setting BUILD_MAGMA_VARS = ${build_magma_vars}" >&6;}
+BUILD_MAGMA_VARS=${build_magma_vars}
+
+
 { $as_echo "$as_me:${as_lineno-$LINENO}: Setting BUILD_ARPACK = ${build_arpack}" >&5
 $as_echo "$as_me: Setting BUILD_ARPACK = ${build_arpack}" >&6;}
 BUILD_ARPACK=${build_arpack}
 
+
 { $as_echo "$as_me:${as_lineno-$LINENO}: Setting BUILD_ARPACK_VARS = ${build_arpack_vars}" >&5
 $as_echo "$as_me: Setting BUILD_ARPACK_VARS = ${build_arpack_vars}" >&6;}
 BUILD_ARPACK_VARS=${build_arpack_vars}
+
 
 
 if test "X${force_ac}X" = "XnoX";

--- a/configure.ac
+++ b/configure.ac
@@ -228,13 +228,6 @@ AC_ARG_ENABLE(interface-nvtx,
   [ interface_nvtx="no" ]
 )
 
-dnl enable packing and unpacking on the device
-AC_ARG_ENABLE(device-pack,
-  AC_HELP_STRING([--enable-device-pack], [ Enable the packing / unpacking of fields on the device (default: disabled)]),
-  [ device_pack=${enableval}],
-  [ device_pack="no" ]
-)
-
 AC_ARG_WITH(mpi,
  AC_HELP_STRING([--with-mpi=MPIDIR], [ Specify MPI installation directory]),
  [ mpi_home=${withval}; build_mpi="yes"],
@@ -813,9 +806,6 @@ AC_SUBST( BUILD_BQCD_INTERFACE, [${build_bqcd_interface}])
 
 AC_MSG_NOTICE([Setting BUILD_TIFR_INTERFACE= ${build_tifr_interface}])
 AC_SUBST( BUILD_TIFR_INTERFACE, [${build_tifr_interface}])
-
-AC_MSG_NOTICE([Setting DEVICE_PACK= ${device_pack}])
-AC_SUBST( DEVICE_PACK, [${device_pack}])
 
 AC_MSG_NOTICE([Setting BUILD_QIO = ${build_qio} ])
 AC_SUBST( BUILD_QIO, [${build_qio}])

--- a/include/clover_field.h
+++ b/include/clover_field.h
@@ -132,8 +132,9 @@ namespace quda {
 #endif
 
     /**
-       Copy into this CloverField from the generic CloverField src
+       @brief Copy into this CloverField from the generic CloverField src
        @param src The clover field from which we want to copy
+       @param inverse Are we copying the inverse or direct field
      */
     void copy(const CloverField &src, bool inverse=true);
 
@@ -245,8 +246,8 @@ namespace quda {
      @param outNorm The output norm buffer (optional)
      @param inNorm The input norm buffer (optional)
   */
-  void copyGenericClover(CloverField &out, const CloverField &in, bool inverse, QudaFieldLocation location,
-			 void *Out=0, void *In=0, void *outNorm=0, void *inNorm=0);
+  void copyGenericClover(CloverField &out, const CloverField &in, bool inverse,
+			 QudaFieldLocation location, void *Out=0, void *In=0, void *outNorm=0, void *inNorm=0);
   
 
 
@@ -259,6 +260,14 @@ namespace quda {
      @param location The location of the field
   */
   void cloverInvert(CloverField &clover, bool computeTraceLog, QudaFieldLocation location);
+
+  /**
+     @brief This function adds a real scalar onto the clover diagonal (only to the direct field not the inverse)
+
+     @param clover The clover field
+     @param rho Real scalar to be added on
+  */
+  void cloverRho(CloverField &clover, double rho);
 
   /**
      @brief Compute the force contribution from the solver solution fields

--- a/include/quda.h
+++ b/include/quda.h
@@ -202,6 +202,7 @@ extern "C" {
     QudaUseInitGuess use_init_guess;       /**< Whether to use an initial guess in the solver or not */
 
     double clover_coeff;                   /**< Coefficient of the clover term */
+    double clover_rho;                     /**< Real number added to the clover diagonal (not to inverse) */
 
     int compute_clover_trlog;              /**< Whether to compute the trace log of the clover term */
     double trlogA[2];                      /**< The trace log of the clover term (even/odd computed separately) */

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -27,7 +27,7 @@ set (QUDA_OBJS
   multi_blas_quda.cu copy_quda.cu reduce_quda.cu
   multi_reduce_quda.cu face_buffer.cpp face_gauge.cpp
   comm_common.cpp ${COMM_OBJS} ${NUMA_AFFINITY_OBJS} ${QIO_UTIL}
-  clover_deriv_quda.cu clover_invert.cu copy_gauge_extended.cu
+  clover_deriv_quda.cu clover_invert.cu clover_rho.cu copy_gauge_extended.cu
   extract_gauge_ghost_extended.cu copy_color_spinor.cu spinor_gauss.cu
   copy_color_spinor_dd.cu copy_color_spinor_ds.cu
   copy_color_spinor_dh.cu copy_color_spinor_ss.cu

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -53,7 +53,7 @@ QUDA_OBJS = dirac_coarse.o dslash_coarse.o coarse_op.o			\
 	copy_color_spinor_mg_dd.o copy_color_spinor_mg_ds.o		\
 	copy_color_spinor_mg_sd.o copy_color_spinor_mg_ss.o		\
 	quda_memcpy.o quda_arpack_interface.o deflation.o ${QIO_UTIL}   \
-	spinor_gauss.o gauge_random.o
+	spinor_gauss.o gauge_random.o clover_rho.o
 
 # header files, found in include/
 QUDA_HDRS = blas_quda.h clover_field.h color_spinor_field.h convert.h	\

--- a/lib/check_params.h
+++ b/lib/check_params.h
@@ -370,6 +370,7 @@ void printQudaInvertParam(QudaInvertParam *param) {
     P(compute_clover_inverse, 0);
     P(return_clover, 0);
     P(return_clover_inverse, 0);
+    P(clover_rho, 0.0);
 #else
     if (param->clover_cuda_prec_precondition == QUDA_INVALID_PRECISION)
       param->clover_cuda_prec_precondition = param->clover_cuda_prec_sloppy;
@@ -378,6 +379,7 @@ void printQudaInvertParam(QudaInvertParam *param) {
     P(compute_clover_inverse, QUDA_INVALID_PRECISION);
     P(return_clover, QUDA_INVALID_PRECISION);
     P(return_clover_inverse, QUDA_INVALID_PRECISION);
+    P(clover_rho, INVALID_DOUBLE);
 #endif
     P(clover_order, QUDA_INVALID_CLOVER_ORDER);
     P(cl_pad, INVALID_INT);

--- a/lib/clover_field.cpp
+++ b/lib/clover_field.cpp
@@ -272,21 +272,21 @@ namespace quda {
 
       pool_pinned_free(packClover);
     } else if (reorder_location() == QUDA_CUDA_FIELD_LOCATION && typeid(src) == typeid(cpuCloverField)) {
-      void *packClover = pool_device_malloc(bytes + norm_bytes);
-      void *packCloverNorm = (precision == QUDA_HALF_PRECISION) ? static_cast<char*>(packClover) + bytes : 0;
+      void *packClover = pool_device_malloc(src.Bytes() + src.NormBytes());
+      void *packCloverNorm = (precision == QUDA_HALF_PRECISION) ? static_cast<char*>(packClover) + src.Bytes() : 0;
 
       if (src.V(false)) {
-	qudaMemcpy(packClover, src.V(false), bytes, cudaMemcpyHostToDevice);
+	qudaMemcpy(packClover, src.V(false), src.Bytes(), cudaMemcpyHostToDevice);
 	if (precision == QUDA_HALF_PRECISION)
-	  qudaMemcpy(packCloverNorm, src.Norm(false), norm_bytes, cudaMemcpyHostToDevice);
+	  qudaMemcpy(packCloverNorm, src.Norm(false), src.NormBytes(), cudaMemcpyHostToDevice);
 
 	copyGenericClover(*this, src, false, QUDA_CUDA_FIELD_LOCATION, 0, packClover, 0, packCloverNorm);
       }
 
       if (src.V(true) && inverse) {
-	qudaMemcpy(packClover, src.V(true), bytes, cudaMemcpyHostToDevice);
+	qudaMemcpy(packClover, src.V(true), src.Bytes(), cudaMemcpyHostToDevice);
 	if (precision == QUDA_HALF_PRECISION)
-	  qudaMemcpy(packCloverNorm, src.Norm(true), norm_bytes, cudaMemcpyHostToDevice);
+	  qudaMemcpy(packCloverNorm, src.Norm(true), src.NormBytes(), cudaMemcpyHostToDevice);
 
 	copyGenericClover(*this, src, true, QUDA_CUDA_FIELD_LOCATION, 0, packClover, 0, packCloverNorm);
       }

--- a/lib/clover_field.cpp
+++ b/lib/clover_field.cpp
@@ -252,7 +252,7 @@ namespace quda {
     if (typeid(src) == typeid(cudaCloverField)) {
       if (src.V(false))	copyGenericClover(*this, src, false, QUDA_CUDA_FIELD_LOCATION);
       if (src.V(true)) copyGenericClover(*this, src, true, QUDA_CUDA_FIELD_LOCATION);
-    } else if (typeid(src) == typeid(cpuCloverField)) {
+    } else if (reorder_location() == QUDA_CPU_FIELD_LOCATION && typeid(src) == typeid(cpuCloverField)) {
       void *packClover = pool_pinned_malloc(bytes + norm_bytes);
       void *packCloverNorm = (precision == QUDA_HALF_PRECISION) ? static_cast<char*>(packClover) + bytes : 0;
       
@@ -271,6 +271,27 @@ namespace quda {
       }
 
       pool_pinned_free(packClover);
+    } else if (reorder_location() == QUDA_CUDA_FIELD_LOCATION && typeid(src) == typeid(cpuCloverField)) {
+      void *packClover = pool_device_malloc(bytes + norm_bytes);
+      void *packCloverNorm = (precision == QUDA_HALF_PRECISION) ? static_cast<char*>(packClover) + bytes : 0;
+
+      if (src.V(false)) {
+	qudaMemcpy(packClover, src.V(false), bytes, cudaMemcpyHostToDevice);
+	if (precision == QUDA_HALF_PRECISION)
+	  qudaMemcpy(packCloverNorm, src.Norm(false), norm_bytes, cudaMemcpyHostToDevice);
+
+	copyGenericClover(*this, src, false, QUDA_CUDA_FIELD_LOCATION, 0, packClover, 0, packCloverNorm);
+      }
+
+      if (src.V(true) && inverse) {
+	qudaMemcpy(packClover, src.V(true), bytes, cudaMemcpyHostToDevice);
+	if (precision == QUDA_HALF_PRECISION)
+	  qudaMemcpy(packCloverNorm, src.Norm(true), norm_bytes, cudaMemcpyHostToDevice);
+
+	copyGenericClover(*this, src, true, QUDA_CUDA_FIELD_LOCATION, 0, packClover, 0, packCloverNorm);
+      }
+
+      pool_device_free(packClover);
     } else {
       errorQuda("Invalid clover field type");
     }

--- a/lib/clover_rho.cu
+++ b/lib/clover_rho.cu
@@ -1,0 +1,104 @@
+#include <tune_quda.h>
+#include <clover_field_order.h>
+
+namespace quda {
+
+  using namespace clover;
+
+#ifdef GPU_CLOVER_DIRAC
+
+  template <typename real, typename Clover>
+  struct CloverRhoArg  {
+    Clover clover;
+    real rho;
+    CloverRhoArg(Clover &clover, real rho) : clover(clover), rho(rho) {}
+  };
+
+  template <typename Arg>
+  __global__ void cloverRhoKernel(Arg arg) {  
+    int x_cb = blockIdx.x*blockDim.x + threadIdx.x;
+    int parity = threadIdx.y;
+
+    if (x_cb < arg.clover.volumeCB) {
+      for (int chi=0; chi<2; chi++) {
+	decltype(arg.rho) A[36];
+	arg.clover.load(A, x_cb, parity,chi);
+	for (int i=0; i<6; i++) A[i] += arg.rho;
+	arg.clover.save(A, x_cb, parity,chi);
+      }
+    }
+  }
+
+  template <typename Arg>
+  class CloverRho : TunableLocalParity {
+    Arg arg;
+    const CloverField &meta; // used for meta data only
+
+  private:
+    bool tuneSharedBytes() const { return false; } // Don't tune the shared memory
+    unsigned int minThreads() const { return arg.clover.volumeCB; }
+
+  public:
+    CloverRho(Arg &arg, const CloverField &meta) : arg(arg), meta(meta) {
+      writeAuxString("_");
+    }
+    virtual ~CloverRho() { ; }
+  
+    void apply(const cudaStream_t &stream) {
+      TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
+      if (meta.Location() == QUDA_CUDA_FIELD_LOCATION) {
+	cloverRhoKernel<<<tp.grid,tp.block,tp.shared_bytes,stream>>>(arg);
+      } else {
+	errorQuda("Not implemented");
+      }
+    }
+
+    TuneKey tuneKey() const {
+      return TuneKey(meta.VolString(), typeid(*this).name(), aux);
+    }
+
+    long long flops() const { return 0; } 
+    long long bytes() const { return 2*2*arg.clover.volumeCB*(6*arg.clover.Bytes()/72); } 
+
+    void preTune() { arg.clover.save(); }
+    void postTune() { arg.clover.load(); }
+
+  };
+
+  template <typename Float, typename Clover>
+  void cloverRho(Clover clover, const CloverField &meta, double rho) {
+    CloverRhoArg<Float,Clover> arg(clover, rho);
+    CloverRho<CloverRhoArg<Float,Clover> > clover_rho(arg, meta);
+    clover_rho.apply(0);
+  }
+
+  template <typename Float>
+  void cloverRho(const CloverField &clover, double rho) {
+
+    if (clover.isNative()) {
+      typedef typename clover_mapper<Float>::type C;
+      cloverRho<Float>(C(clover, 0), clover, rho);
+    } else {
+      errorQuda("Clover field %d order not supported", clover.Order());
+    }
+
+  }
+
+#endif
+
+  void cloverRho(CloverField &clover, double rho) {
+
+#ifdef GPU_CLOVER_DIRAC
+    if (clover.Precision() == QUDA_DOUBLE_PRECISION) {
+      cloverRho<double>(clover, rho);
+    } else if (clover.Precision() == QUDA_SINGLE_PRECISION) {
+      cloverRho<float>(clover, rho);
+    } else {
+      errorQuda("Precision %d not supported", clover.Precision());
+    }
+#else
+    errorQuda("Clover has not been built");
+#endif
+  }
+
+} // namespace quda

--- a/lib/cuda_color_spinor_field.cu
+++ b/lib/cuda_color_spinor_field.cu
@@ -11,12 +11,6 @@
 #include <face_quda.h>
 #include <dslash_quda.h>
 
-#ifdef DEVICE_PACK
-static const QudaFieldLocation reorder_location_ = QUDA_CUDA_FIELD_LOCATION;
-#else
-static const QudaFieldLocation reorder_location_ = QUDA_CPU_FIELD_LOCATION;
-#endif
-
 int zeroCopy = 0;
 
 namespace quda {
@@ -544,7 +538,7 @@ namespace quda {
 
   void cudaColorSpinorField::loadSpinorField(const ColorSpinorField &src) {
 
-    if (reorder_location_ == QUDA_CPU_FIELD_LOCATION &&typeid(src) == typeid(cpuColorSpinorField)) {
+    if (reorder_location() == QUDA_CPU_FIELD_LOCATION &&typeid(src) == typeid(cpuColorSpinorField)) {
       void *buffer = pool_pinned_malloc(bytes + norm_bytes);
       memset(buffer, 0, bytes+norm_bytes); // FIXME (temporary?) bug fix for padding
 
@@ -585,7 +579,7 @@ namespace quda {
 
   void cudaColorSpinorField::saveSpinorField(ColorSpinorField &dest) const {
 
-    if (reorder_location_ == QUDA_CPU_FIELD_LOCATION &&	typeid(dest) == typeid(cpuColorSpinorField)) {
+    if (reorder_location() == QUDA_CPU_FIELD_LOCATION && typeid(dest) == typeid(cpuColorSpinorField)) {
       void *buffer = pool_pinned_malloc(bytes+norm_bytes);
       qudaMemcpy(buffer, v, bytes, cudaMemcpyDeviceToHost);
       qudaMemcpy(static_cast<char*>(buffer)+bytes, norm, norm_bytes, cudaMemcpyDeviceToHost);

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -858,6 +858,8 @@ void loadCloverQuda(void *h_clover, void *h_clovinv, QudaInvertParam *inv_param)
   clover_param.direct = true;
   clover_param.inverse = dynamic_clover ? false : true;
 
+  if (inv_param->clover_rho != 0.0) cloverRho(*cloverPrecise, inv_param->clover_rho);
+
   // create the mirror sloppy clover field
   if (inv_param->clover_cuda_prec != inv_param->clover_cuda_prec_sloppy) {
     profileClover.TPSTART(QUDA_PROFILE_INIT);

--- a/lib/quda_fortran.F90
+++ b/lib/quda_fortran.F90
@@ -167,6 +167,7 @@ module quda_fortran
      QudaUseInitGuess :: use_init_guess
 
      real(8) :: clover_coeff ! Coefficient of the clover term
+     real(8) :: clover_rho   ! Real number added to the clover diagonal (not to inverse)
      integer(4) :: compute_clover_trlog ! Whether to compute the trace log of the clover term
      real(8), dimension(2) :: trlogA    ! The trace log of the clover term (even/odd computed separately)
 

--- a/lib/quda_memcpy.cpp
+++ b/lib/quda_memcpy.cpp
@@ -76,7 +76,7 @@ namespace quda {
       printfQuda("%s bytes = %llu\n", __func__, (long long unsigned int)count);
 
     if (count == 0) return;
-#if 0
+#if 1
     QudaMemCopy copy(dst, src, count, kind, func, file, line);
     copy.apply(0);
 #else

--- a/make.inc.in
+++ b/make.inc.in
@@ -68,9 +68,6 @@ BUILD_QDPJIT_INTERFACE = @BUILD_QDPJIT_INTERFACE@               # build qdpjit i
 BUILD_BQCD_INTERFACE = @BUILD_BQCD_INTERFACE@                   # build bqcd interface
 BUILD_TIFR_INTERFACE = @BUILD_TIFR_INTERFACE@                   # build tifr interface
 
-# Packing option
-DEVICE_PACK = @DEVICE_PACK@	     # set to 'yes' to enable packing and unpacking on the device
-
 # GPU contractions of spinors
 BUILD_CONTRACT = @BUILD_CONTRACT@    # build code for bilinear contraction?
 
@@ -361,11 +358,6 @@ endif
 ifeq ($(strip $(BUILD_TIFR_INTERFACE)), yes)
   NVCCOPT += -DBUILD_TIFR_INTERFACE
   COPT += -DBUILD_TIFR_INTERFACE
-endif
-
-ifeq ($(strip $(DEVICE_PACK)), yes)
-  NVCCOPT += -DDEVICE_PACK
-  COPT += -DDEVICE_PACK
 endif
 
 ifeq ($(strip $(BUILD_CONTRACT)), yes)


### PR DESCRIPTION
This pull if focussed on optimization of the host-side interface for Wilson-clover solvers:
* Enables GPU reordering support for clover fields, respects `QUDA_REORDER_LOCATION` environment variable
* Enables GPU reordering support for quark field, respects `QUDA_REORDER_LOCATION` environment variable
* Adds new parameter `QudaInvertParam::clover_rho` that adds a real number `rho` to the matrix diagonal using the clover_rho kernel
* Removes legacy `DEVICE_PACK` build option since this now does nothing