### PR TITLE
Hotfix/twisted clover gdr

### DIFF
--- a/lib/dslash_core/tmc_fused_exterior_dslash_fermi_core.h
+++ b/lib/dslash_core/tmc_fused_exterior_dslash_fermi_core.h
@@ -1657,26 +1657,17 @@ if (isActive(dim,3,+1,coord,param.commDim,param.X) && coord[3]==X4m1 )
     
     
     const int sp_stride_pad = ghostFace[3];
-    //const int t_proj_scale = TPROJSCALE;
+    const int t_proj_scale = TPROJSCALE;
     
     // read half spinor from device memory
     READ_HALF_SPINOR(GHOSTSPINORTEX, sp_stride_pad, sp_idx, sp_norm_idx);
     
-#ifdef CLOVER_TWIST_INV_DSLASH
-    a0_re = i00_re;  a0_im = i00_im;
-    a1_re = i01_re;  a1_im = i01_im;
-    a2_re = i02_re;  a2_im = i02_im;
-    b0_re = i10_re;  b0_im = i10_im;
-    b1_re = i11_re;  b1_im = i11_im;
-    b2_re = i12_re;  b2_im = i12_im;
-#else  
-    a0_re = 2*i00_re;  a0_im = 2*i00_im;
-    a1_re = 2*i01_re;  a1_im = 2*i01_im;
-    a2_re = 2*i02_re;  a2_im = 2*i02_im;
-    b0_re = 2*i10_re;  b0_im = 2*i10_im;
-    b1_re = 2*i11_re;  b1_im = 2*i11_im;
-    b2_re = 2*i12_re;  b2_im = 2*i12_im;
-#endif 
+    a0_re = t_proj_scale*i00_re;  a0_im = t_proj_scale*i00_im;
+    a1_re = t_proj_scale*i01_re;  a1_im = t_proj_scale*i01_im;
+    a2_re = t_proj_scale*i02_re;  a2_im = t_proj_scale*i02_im;
+    b0_re = t_proj_scale*i10_re;  b0_im = t_proj_scale*i10_im;
+    b1_re = t_proj_scale*i11_re;  b1_im = t_proj_scale*i11_im;
+    b2_re = t_proj_scale*i12_re;  b2_im = t_proj_scale*i12_im;
     
     // identity gauge matrix
     spinorFloat A0_re = a0_re; spinorFloat A0_im = a0_im;
@@ -1711,26 +1702,17 @@ if (isActive(dim,3,+1,coord,param.commDim,param.X) && coord[3]==X4m1 )
     
     
     const int sp_stride_pad = ghostFace[3];
-    //const int t_proj_scale = TPROJSCALE;
+    const int t_proj_scale = TPROJSCALE;
     
     // read half spinor from device memory
     READ_HALF_SPINOR(GHOSTSPINORTEX, sp_stride_pad, sp_idx, sp_norm_idx);
     
-#ifdef CLOVER_TWIST_INV_DSLASH
-    a0_re = i00_re;  a0_im = i00_im;
-    a1_re = i01_re;  a1_im = i01_im;
-    a2_re = i02_re;  a2_im = i02_im;
-    b0_re = i10_re;  b0_im = i10_im;
-    b1_re = i11_re;  b1_im = i11_im;
-    b2_re = i12_re;  b2_im = i12_im;
-#else  
-    a0_re = 2*i00_re;  a0_im = 2*i00_im;
-    a1_re = 2*i01_re;  a1_im = 2*i01_im;
-    a2_re = 2*i02_re;  a2_im = 2*i02_im;
-    b0_re = 2*i10_re;  b0_im = 2*i10_im;
-    b1_re = 2*i11_re;  b1_im = 2*i11_im;
-    b2_re = 2*i12_re;  b2_im = 2*i12_im;
-#endif 
+    a0_re = t_proj_scale*i00_re;  a0_im = t_proj_scale*i00_im;
+    a1_re = t_proj_scale*i01_re;  a1_im = t_proj_scale*i01_im;
+    a2_re = t_proj_scale*i02_re;  a2_im = t_proj_scale*i02_im;
+    b0_re = t_proj_scale*i10_re;  b0_im = t_proj_scale*i10_im;
+    b1_re = t_proj_scale*i11_re;  b1_im = t_proj_scale*i11_im;
+    b2_re = t_proj_scale*i12_re;  b2_im = t_proj_scale*i12_im;
     
     // read gauge matrix from device memory
     READ_GAUGE_MATRIX(G, GAUGE0TEX, 6, ga_idx, ga_stride);
@@ -1873,26 +1855,17 @@ if (isActive(dim,3,-1,coord,param.commDim,param.X) && coord[3]==0 )
     
     
     const int sp_stride_pad = ghostFace[3];
-    //const int t_proj_scale = TPROJSCALE;
+    const int t_proj_scale = TPROJSCALE;
     
     // read half spinor from device memory
     READ_HALF_SPINOR(GHOSTSPINORTEX, sp_stride_pad, sp_idx, sp_norm_idx);
     
-#ifdef CLOVER_TWIST_INV_DSLASH
-    a0_re = i00_re;  a0_im = i00_im;
-    a1_re = i01_re;  a1_im = i01_im;
-    a2_re = i02_re;  a2_im = i02_im;
-    b0_re = i10_re;  b0_im = i10_im;
-    b1_re = i11_re;  b1_im = i11_im;
-    b2_re = i12_re;  b2_im = i12_im;
-#else  
-    a0_re = 2*i00_re;  a0_im = 2*i00_im;
-    a1_re = 2*i01_re;  a1_im = 2*i01_im;
-    a2_re = 2*i02_re;  a2_im = 2*i02_im;
-    b0_re = 2*i10_re;  b0_im = 2*i10_im;
-    b1_re = 2*i11_re;  b1_im = 2*i11_im;
-    b2_re = 2*i12_re;  b2_im = 2*i12_im;
-#endif 
+    a0_re = t_proj_scale*i00_re;  a0_im = t_proj_scale*i00_im;
+    a1_re = t_proj_scale*i01_re;  a1_im = t_proj_scale*i01_im;
+    a2_re = t_proj_scale*i02_re;  a2_im = t_proj_scale*i02_im;
+    b0_re = t_proj_scale*i10_re;  b0_im = t_proj_scale*i10_im;
+    b1_re = t_proj_scale*i11_re;  b1_im = t_proj_scale*i11_im;
+    b2_re = t_proj_scale*i12_re;  b2_im = t_proj_scale*i12_im;
     
     // identity gauge matrix
     spinorFloat A0_re = a0_re; spinorFloat A0_im = a0_im;
@@ -1927,26 +1900,17 @@ if (isActive(dim,3,-1,coord,param.commDim,param.X) && coord[3]==0 )
     
     
     const int sp_stride_pad = ghostFace[3];
-    //const int t_proj_scale = TPROJSCALE;
+    const int t_proj_scale = TPROJSCALE;
     
     // read half spinor from device memory
     READ_HALF_SPINOR(GHOSTSPINORTEX, sp_stride_pad, sp_idx, sp_norm_idx);
     
-#ifdef CLOVER_TWIST_INV_DSLASH
-    a0_re = i00_re;  a0_im = i00_im;
-    a1_re = i01_re;  a1_im = i01_im;
-    a2_re = i02_re;  a2_im = i02_im;
-    b0_re = i10_re;  b0_im = i10_im;
-    b1_re = i11_re;  b1_im = i11_im;
-    b2_re = i12_re;  b2_im = i12_im;
-#else  
-    a0_re = 2*i00_re;  a0_im = 2*i00_im;
-    a1_re = 2*i01_re;  a1_im = 2*i01_im;
-    a2_re = 2*i02_re;  a2_im = 2*i02_im;
-    b0_re = 2*i10_re;  b0_im = 2*i10_im;
-    b1_re = 2*i11_re;  b1_im = 2*i11_im;
-    b2_re = 2*i12_re;  b2_im = 2*i12_im;
-#endif 
+    a0_re = t_proj_scale*i00_re;  a0_im = t_proj_scale*i00_im;
+    a1_re = t_proj_scale*i01_re;  a1_im = t_proj_scale*i01_im;
+    a2_re = t_proj_scale*i02_re;  a2_im = t_proj_scale*i02_im;
+    b0_re = t_proj_scale*i10_re;  b0_im = t_proj_scale*i10_im;
+    b1_re = t_proj_scale*i11_re;  b1_im = t_proj_scale*i11_im;
+    b2_re = t_proj_scale*i12_re;  b2_im = t_proj_scale*i12_im;
     
     // read gauge matrix from device memory
     READ_GAUGE_MATRIX(G, GAUGE1TEX, 7, ga_idx, ga_stride);

--- a/lib/dslash_core/tmc_fused_exterior_dslash_gt200_core.h
+++ b/lib/dslash_core/tmc_fused_exterior_dslash_gt200_core.h
@@ -1647,26 +1647,17 @@ if (isActive(dim,3,+1,coord,param.commDim,param.X) && coord[3]==X4m1 )
     
     
     const int sp_stride_pad = ghostFace[3];
-    //const int t_proj_scale = TPROJSCALE;
+    const int t_proj_scale = TPROJSCALE;
     
     // read half spinor from device memory
     READ_HALF_SPINOR(GHOSTSPINORTEX, sp_stride_pad, sp_idx, sp_norm_idx);
     
-#ifdef CLOVER_TWIST_INV_DSLASH
-    a0_re = i00_re;  a0_im = i00_im;
-    a1_re = i01_re;  a1_im = i01_im;
-    a2_re = i02_re;  a2_im = i02_im;
-    b0_re = i10_re;  b0_im = i10_im;
-    b1_re = i11_re;  b1_im = i11_im;
-    b2_re = i12_re;  b2_im = i12_im;
-#else  
-    a0_re = 2*i00_re;  a0_im = 2*i00_im;
-    a1_re = 2*i01_re;  a1_im = 2*i01_im;
-    a2_re = 2*i02_re;  a2_im = 2*i02_im;
-    b0_re = 2*i10_re;  b0_im = 2*i10_im;
-    b1_re = 2*i11_re;  b1_im = 2*i11_im;
-    b2_re = 2*i12_re;  b2_im = 2*i12_im;
-#endif 
+    a0_re = t_proj_scale*i00_re;  a0_im = t_proj_scale*i00_im;
+    a1_re = t_proj_scale*i01_re;  a1_im = t_proj_scale*i01_im;
+    a2_re = t_proj_scale*i02_re;  a2_im = t_proj_scale*i02_im;
+    b0_re = t_proj_scale*i10_re;  b0_im = t_proj_scale*i10_im;
+    b1_re = t_proj_scale*i11_re;  b1_im = t_proj_scale*i11_im;
+    b2_re = t_proj_scale*i12_re;  b2_im = t_proj_scale*i12_im;
     
     // identity gauge matrix
     spinorFloat A0_re = a0_re; spinorFloat A0_im = a0_im;
@@ -1701,26 +1692,17 @@ if (isActive(dim,3,+1,coord,param.commDim,param.X) && coord[3]==X4m1 )
     
     
     const int sp_stride_pad = ghostFace[3];
-    //const int t_proj_scale = TPROJSCALE;
+    const int t_proj_scale = TPROJSCALE;
     
     // read half spinor from device memory
     READ_HALF_SPINOR(GHOSTSPINORTEX, sp_stride_pad, sp_idx, sp_norm_idx);
     
-#ifdef CLOVER_TWIST_INV_DSLASH
-    a0_re = i00_re;  a0_im = i00_im;
-    a1_re = i01_re;  a1_im = i01_im;
-    a2_re = i02_re;  a2_im = i02_im;
-    b0_re = i10_re;  b0_im = i10_im;
-    b1_re = i11_re;  b1_im = i11_im;
-    b2_re = i12_re;  b2_im = i12_im;
-#else  
-    a0_re = 2*i00_re;  a0_im = 2*i00_im;
-    a1_re = 2*i01_re;  a1_im = 2*i01_im;
-    a2_re = 2*i02_re;  a2_im = 2*i02_im;
-    b0_re = 2*i10_re;  b0_im = 2*i10_im;
-    b1_re = 2*i11_re;  b1_im = 2*i11_im;
-    b2_re = 2*i12_re;  b2_im = 2*i12_im;
-#endif 
+    a0_re = t_proj_scale*i00_re;  a0_im = t_proj_scale*i00_im;
+    a1_re = t_proj_scale*i01_re;  a1_im = t_proj_scale*i01_im;
+    a2_re = t_proj_scale*i02_re;  a2_im = t_proj_scale*i02_im;
+    b0_re = t_proj_scale*i10_re;  b0_im = t_proj_scale*i10_im;
+    b1_re = t_proj_scale*i11_re;  b1_im = t_proj_scale*i11_im;
+    b2_re = t_proj_scale*i12_re;  b2_im = t_proj_scale*i12_im;
     
     // read gauge matrix from device memory
     READ_GAUGE_MATRIX(G, GAUGE0TEX, 6, ga_idx, ga_stride);
@@ -1863,26 +1845,17 @@ if (isActive(dim,3,-1,coord,param.commDim,param.X) && coord[3]==0 )
     
     
     const int sp_stride_pad = ghostFace[3];
-    //const int t_proj_scale = TPROJSCALE;
+    const int t_proj_scale = TPROJSCALE;
     
     // read half spinor from device memory
     READ_HALF_SPINOR(GHOSTSPINORTEX, sp_stride_pad, sp_idx, sp_norm_idx);
     
-#ifdef CLOVER_TWIST_INV_DSLASH
-    a0_re = i00_re;  a0_im = i00_im;
-    a1_re = i01_re;  a1_im = i01_im;
-    a2_re = i02_re;  a2_im = i02_im;
-    b0_re = i10_re;  b0_im = i10_im;
-    b1_re = i11_re;  b1_im = i11_im;
-    b2_re = i12_re;  b2_im = i12_im;
-#else  
-    a0_re = 2*i00_re;  a0_im = 2*i00_im;
-    a1_re = 2*i01_re;  a1_im = 2*i01_im;
-    a2_re = 2*i02_re;  a2_im = 2*i02_im;
-    b0_re = 2*i10_re;  b0_im = 2*i10_im;
-    b1_re = 2*i11_re;  b1_im = 2*i11_im;
-    b2_re = 2*i12_re;  b2_im = 2*i12_im;
-#endif 
+    a0_re = t_proj_scale*i00_re;  a0_im = t_proj_scale*i00_im;
+    a1_re = t_proj_scale*i01_re;  a1_im = t_proj_scale*i01_im;
+    a2_re = t_proj_scale*i02_re;  a2_im = t_proj_scale*i02_im;
+    b0_re = t_proj_scale*i10_re;  b0_im = t_proj_scale*i10_im;
+    b1_re = t_proj_scale*i11_re;  b1_im = t_proj_scale*i11_im;
+    b2_re = t_proj_scale*i12_re;  b2_im = t_proj_scale*i12_im;
     
     // identity gauge matrix
     spinorFloat A0_re = a0_re; spinorFloat A0_im = a0_im;
@@ -1917,26 +1890,17 @@ if (isActive(dim,3,-1,coord,param.commDim,param.X) && coord[3]==0 )
     
     
     const int sp_stride_pad = ghostFace[3];
-    //const int t_proj_scale = TPROJSCALE;
+    const int t_proj_scale = TPROJSCALE;
     
     // read half spinor from device memory
     READ_HALF_SPINOR(GHOSTSPINORTEX, sp_stride_pad, sp_idx, sp_norm_idx);
     
-#ifdef CLOVER_TWIST_INV_DSLASH
-    a0_re = i00_re;  a0_im = i00_im;
-    a1_re = i01_re;  a1_im = i01_im;
-    a2_re = i02_re;  a2_im = i02_im;
-    b0_re = i10_re;  b0_im = i10_im;
-    b1_re = i11_re;  b1_im = i11_im;
-    b2_re = i12_re;  b2_im = i12_im;
-#else  
-    a0_re = 2*i00_re;  a0_im = 2*i00_im;
-    a1_re = 2*i01_re;  a1_im = 2*i01_im;
-    a2_re = 2*i02_re;  a2_im = 2*i02_im;
-    b0_re = 2*i10_re;  b0_im = 2*i10_im;
-    b1_re = 2*i11_re;  b1_im = 2*i11_im;
-    b2_re = 2*i12_re;  b2_im = 2*i12_im;
-#endif 
+    a0_re = t_proj_scale*i00_re;  a0_im = t_proj_scale*i00_im;
+    a1_re = t_proj_scale*i01_re;  a1_im = t_proj_scale*i01_im;
+    a2_re = t_proj_scale*i02_re;  a2_im = t_proj_scale*i02_im;
+    b0_re = t_proj_scale*i10_re;  b0_im = t_proj_scale*i10_im;
+    b1_re = t_proj_scale*i11_re;  b1_im = t_proj_scale*i11_im;
+    b2_re = t_proj_scale*i12_re;  b2_im = t_proj_scale*i12_im;
     
     // read gauge matrix from device memory
     READ_GAUGE_MATRIX(G, GAUGE1TEX, 7, ga_idx, ga_stride);

--- a/lib/generate/deg_tm_dslash_cuda_gen.py
+++ b/lib/generate/deg_tm_dslash_cuda_gen.py
@@ -9,13 +9,13 @@ def complexToStr(c):
     def fltToString(a):
         if a == int(a): return `int(a)`
         else: return `a`
-    
+
     def imToString(a):
         if a == 0: return "0i"
         elif a == -1: return "-i"
         elif a == 1: return "i"
         else: return fltToString(a)+"i"
-    
+
     re = c.real
     im = c.imag
     if re == 0 and im == 0: return "0"
@@ -133,7 +133,7 @@ def acc_im(s, c): return "acc"+`s`+`c`+"_im"
 def tmp_re(s, c): return "tmp"+`s`+`c`+"_re"
 def tmp_im(s, c): return "tmp"+`s`+`c`+"_im"
 
-def spinor(name, s, c, z): 
+def spinor(name, s, c, z):
     if z==0: return name+`s`+`c`+"_re"
     else: return name+`s`+`c`+"_im"
 
@@ -142,7 +142,7 @@ def def_input_spinor():
     str += "// input spinor\n"
     str += "#ifdef SPINOR_DOUBLE\n"
     str += "#define spinorFloat double\n"
-    if sharedDslash: 
+    if sharedDslash:
         str += "#define WRITE_SPINOR_SHARED WRITE_SPINOR_SHARED_DOUBLE2\n"
         str += "#define READ_SPINOR_SHARED READ_SPINOR_SHARED_DOUBLE2\n"
 
@@ -159,7 +159,7 @@ def def_input_spinor():
                 str += "#define "+acc_im(s,c)+" accum"+nthFloat2(2*i+1)+"\n"
     str += "#else\n"
     str += "#define spinorFloat float\n"
-    if sharedDslash: 
+    if sharedDslash:
         str += "#define WRITE_SPINOR_SHARED WRITE_SPINOR_SHARED_FLOAT4\n"
         str += "#define READ_SPINOR_SHARED READ_SPINOR_SHARED_FLOAT4\n"
     for s in range(0,4):
@@ -197,7 +197,7 @@ def def_gauge():
 
     str += "\n"
     str += "#endif // GAUGE_DOUBLE\n\n"
-            
+
     str += "// conjugated gauge link\n"
     for m in range(0,3):
         for n in range(0,3):
@@ -274,7 +274,7 @@ def prolog():
 
 
     # set the pointer if using shared memory for pseudo registers
-    if sharedFloats > 0 and not sharedDslash: 
+    if sharedFloats > 0 and not sharedDslash:
         prolog_str += (
 """
 extern __shared__ char s_data[];
@@ -377,7 +377,7 @@ def gen(dir, pack_only=False):
     projStr = projectorToStr(projectors[projIdx])
     def proj(i,j):
         return projectors[projIdx][4*i+j]
-    
+
     # if row(i) = (j, c), then the i'th row of the projector can be represented
     # as a multiple of the j'th row: row(i) = c row(j)
     def row(i):
@@ -405,7 +405,7 @@ def gen(dir, pack_only=False):
     cond += "#endif\n"
 
     str = ""
-    
+
     projName = "P"+`dir/2`+["-","+"][projIdx%2]
     str += "// Projector "+projName+"\n"
     for l in projStr.splitlines():
@@ -546,7 +546,7 @@ def gen(dir, pack_only=False):
                     elif re==0:
                         strRe += sign(-im)+in_im(s,c)
                         strIm += sign(im)+in_re(s,c)
-                
+
             project += h1_re(h,c)+" = "+strRe+";\n"
             project += h1_im(h,c)+" = "+strIm+";\n"
 
@@ -620,7 +620,7 @@ READ_SPINOR_SHARED(tx, threadIdx.y, tz);\n
     if sharedDslash:
         if dir == 0:
             prep_half += indent(load_spinor)
-            prep_half += indent(write_shared)            
+            prep_half += indent(write_shared)
             prep_half += indent(project)
         elif dir == 1:
             prep_half += indent(load_shared_1)
@@ -628,7 +628,7 @@ READ_SPINOR_SHARED(tx, threadIdx.y, tz);\n
         elif dir == 2:
             prep_half += indent("if (threadIdx.y == blockDim.y-1 && blockDim.y < X2 ) {\n")
             prep_half += indent(load_spinor)
-            prep_half += indent(project)            
+            prep_half += indent(project)
             prep_half += indent("} else {")
             prep_half += indent(load_shared_2)
             prep_half += indent(project)
@@ -636,7 +636,7 @@ READ_SPINOR_SHARED(tx, threadIdx.y, tz);\n
         elif dir == 3:
             prep_half += indent("if (threadIdx.y == 0 && blockDim.y < X2) {\n")
             prep_half += indent(load_spinor)
-            prep_half += indent(project)            
+            prep_half += indent(project)
             prep_half += indent("} else {")
             prep_half += indent(load_shared_3)
             prep_half += indent(project)
@@ -644,7 +644,7 @@ READ_SPINOR_SHARED(tx, threadIdx.y, tz);\n
         elif dir == 4:
             prep_half += indent("if (threadIdx.z == blockDim.z-1 && blockDim.z < X3) {\n")
             prep_half += indent(load_spinor)
-            prep_half += indent(project)            
+            prep_half += indent(project)
             prep_half += indent("} else {")
             prep_half += indent(load_shared_4)
             prep_half += indent(project)
@@ -652,7 +652,7 @@ READ_SPINOR_SHARED(tx, threadIdx.y, tz);\n
         elif dir == 5:
             prep_half += indent("if (threadIdx.z == 0 && blockDim.z < X3) {\n")
             prep_half += indent(load_spinor)
-            prep_half += indent(project)            
+            prep_half += indent(project)
             prep_half += indent("} else {")
             prep_half += indent(load_shared_5)
             prep_half += indent(project)
@@ -673,14 +673,14 @@ READ_SPINOR_SHARED(tx, threadIdx.y, tz);\n
     prep_half += "}\n"
     prep_half += "#endif // MULTI_GPU\n"
     prep_half += "\n"
-    
+
     ident = "// identity gauge matrix\n"
     for m in range(0,3):
         for h in range(0,2):
             ident += "spinorFloat "+h2_re(h,m)+" = " + h1_re(h,m) + "; "
             ident += "spinorFloat "+h2_im(h,m)+" = " + h1_im(h,m) + ";\n"
     ident += "\n"
-    
+
     mult = ""
     for m in range(0,3):
         mult += "// multiply row "+`m`+"\n"
@@ -694,7 +694,7 @@ READ_SPINOR_SHARED(tx, threadIdx.y, tz);\n
                 im += h2_im(h,m) + " += " + g_im(dir,m,c) + " * "+h1_re(h,c)+";\n"
             mult += re + im
         mult += "\n"
-    
+
     reconstruct = ""
     for m in range(0,3):
 
@@ -705,7 +705,7 @@ READ_SPINOR_SHARED(tx, threadIdx.y, tz);\n
 
             reconstruct += out_re(h_out, m) + " += " + h2_re(h,m) + ";\n"
             reconstruct += out_im(h_out, m) + " += " + h2_im(h,m) + ";\n"
-    
+
         for s in range(2,4):
             (h,c) = row(s)
             re = c.real
@@ -717,7 +717,7 @@ READ_SPINOR_SHARED(tx, threadIdx.y, tz);\n
             elif re == 0:
                     reconstruct += out_re(s, m) + " " + sign(-im) + "= " + h2_im(h,m) + ";\n"
                     reconstruct += out_im(s, m) + " " + sign(+im) + "= " + h2_re(h,m) + ";\n"
-        
+
         reconstruct += "\n"
 
     if dir >= 6:
@@ -727,7 +727,7 @@ READ_SPINOR_SHARED(tx, threadIdx.y, tz);\n
         str += block(decl_half + prep_half + load_gauge + reconstruct_gauge + mult + reconstruct)
     else:
         str += decl_half + prep_half + load_gauge + reconstruct_gauge + mult + reconstruct
-    
+
     if pack_only:
         out = load_spinor + decl_half + project
         out = out.replace("sp_idx", "idx")
@@ -803,7 +803,7 @@ def epilog():
         if twist:
             str += "#ifdef MULTI_GPU\n"
         else:
-            str += "#if defined MULTI_GPU && (defined DSLASH_XPAY || defined DSLASH_CLOVER)\n"        
+            str += "#if defined MULTI_GPU && (defined DSLASH_XPAY || defined DSLASH_CLOVER)\n"
         str += (
 """
 int incomplete = 0; // Have all 8 contributions been computed for this site?
@@ -819,21 +819,21 @@ case EXTERIOR_KERNEL_Y:
   incomplete = incomplete || (param.commDim[0] && (coord[0]==0 || coord[0]==X1m1));
 }
 
-""")    
+""")
         str += "if (!incomplete)\n"
         str += "#endif // MULTI_GPU\n"
 
     block_str = ""
     block_str += twisted_xpay()
     str += block( block_str )
-    
+
     str += "\n\n"
     str += "// write spinor field back to device memory\n"
     str += "WRITE_SPINOR(param.sp_stride);\n\n"
 
     str += "// undefine to prevent warning when precision is changed\n"
     str += "#undef spinorFloat\n"
-    if sharedDslash: 
+    if sharedDslash:
         str += "#undef WRITE_SPINOR_SHARED\n"
         str += "#undef READ_SPINOR_SHARED\n"
     if sharedFloats > 0: str += "#undef SHARED_STRIDE\n\n"
@@ -872,7 +872,7 @@ case EXTERIOR_KERNEL_Y:
                     str += "#undef "+out_im(s,c)+"\n"
     str += "\n"
 
-    str += "#undef VOLATILE\n" 
+    str += "#undef VOLATILE\n"
 
     return str
 # end def epilog
@@ -936,7 +936,7 @@ def generate_dslash_kernels(arch):
     sharedFloats = 0
     if arch >= 200:
         sharedFloats = 24
-        sharedDslash = True    
+        sharedDslash = True
         name = "fermi"
     elif arch >= 120:
         sharedFloats = 0

--- a/lib/generate/deg_tmc_dslash_cuda_gen.py
+++ b/lib/generate/deg_tmc_dslash_cuda_gen.py
@@ -9,13 +9,13 @@ def complexToStr(c):
     def fltToString(a):
         if a == int(a): return `int(a)`
         else: return `a`
-    
+
     def imToString(a):
         if a == 0: return "0i"
         elif a == -1: return "-i"
         elif a == 1: return "i"
         else: return fltToString(a)+"i"
-    
+
     re = c.real
     im = c.imag
     if re == 0 and im == 0: return "0"
@@ -137,7 +137,7 @@ def acc_im(s, c): return "acc"+`s`+`c`+"_im"
 def tmp_re(s, c): return "tmp"+`s`+`c`+"_re"
 def tmp_im(s, c): return "tmp"+`s`+`c`+"_im"
 
-def spinor(name, s, c, z): 
+def spinor(name, s, c, z):
     if z==0: return name+`s`+`c`+"_re"
     else: return name+`s`+`c`+"_im"
 
@@ -146,7 +146,7 @@ def def_input_spinor():
     str += "// input spinor\n"
     str += "#ifdef SPINOR_DOUBLE\n"
     str += "#define spinorFloat double\n"
-    if sharedDslash: 
+    if sharedDslash:
         str += "#define WRITE_SPINOR_SHARED WRITE_SPINOR_SHARED_DOUBLE2\n"
         str += "#define READ_SPINOR_SHARED READ_SPINOR_SHARED_DOUBLE2\n"
 
@@ -163,7 +163,7 @@ def def_input_spinor():
                 str += "#define "+acc_im(s,c)+" accum"+nthFloat2(2*i+1)+"\n"
     str += "#else\n"
     str += "#define spinorFloat float\n"
-    if sharedDslash: 
+    if sharedDslash:
         str += "#define WRITE_SPINOR_SHARED WRITE_SPINOR_SHARED_FLOAT4\n"
         str += "#define READ_SPINOR_SHARED READ_SPINOR_SHARED_FLOAT4\n"
     for s in range(0,4):
@@ -201,7 +201,7 @@ def def_gauge():
 
     str += "\n"
     str += "#endif // GAUGE_DOUBLE\n\n"
-            
+
     str += "// conjugated gauge link\n"
     for m in range(0,3):
         for n in range(0,3):
@@ -439,7 +439,7 @@ def prolog():
 
 
     # set the pointer if using shared memory for pseudo registers
-    if sharedFloats > 0 and not sharedDslash: 
+    if sharedFloats > 0 and not sharedDslash:
         prolog_str += (
 """
 extern __shared__ char s_data[];
@@ -544,7 +544,7 @@ def gen(dir, pack_only=False):
     projStr = projectorToStr(projectors[projIdx])
     def proj(i,j):
         return projectors[projIdx][4*i+j]
-    
+
     # if row(i) = (j, c), then the i'th row of the projector can be represented
     # as a multiple of the j'th row: row(i) = c row(j)
     def row(i):
@@ -572,7 +572,7 @@ def gen(dir, pack_only=False):
     cond += "#endif\n"
 
     str = ""
-    
+
     projName = "P"+`dir/2`+["-","+"][projIdx%2]
     str += "// Projector "+projName+"\n"
     for l in projStr.splitlines():
@@ -677,7 +677,7 @@ def gen(dir, pack_only=False):
                     elif re==0:
                         strRe += sign(-im)+in_im(s,c)
                         strIm += sign(im)+in_re(s,c)
-                
+
             project += h1_re(h,c)+" = "+strRe+";\n"
             project += h1_im(h,c)+" = "+strIm+";\n"
 
@@ -744,7 +744,7 @@ READ_SPINOR_SHARED(tx, threadIdx.y, tz);\n
     if sharedDslash:
         if dir == 0:
             prep_half += indent(load_spinor)
-            prep_half += indent(write_shared)            
+            prep_half += indent(write_shared)
             prep_half += indent(project)
         elif dir == 1:
             prep_half += indent(load_shared_1)
@@ -752,7 +752,7 @@ READ_SPINOR_SHARED(tx, threadIdx.y, tz);\n
         elif dir == 2:
             prep_half += indent("if (threadIdx.y == blockDim.y-1 && blockDim.y < X2 ) {\n")
             prep_half += indent(load_spinor)
-            prep_half += indent(project)            
+            prep_half += indent(project)
             prep_half += indent("} else {")
             prep_half += indent(load_shared_2)
             prep_half += indent(project)
@@ -760,7 +760,7 @@ READ_SPINOR_SHARED(tx, threadIdx.y, tz);\n
         elif dir == 3:
             prep_half += indent("if (threadIdx.y == 0 && blockDim.y < X2) {\n")
             prep_half += indent(load_spinor)
-            prep_half += indent(project)            
+            prep_half += indent(project)
             prep_half += indent("} else {")
             prep_half += indent(load_shared_3)
             prep_half += indent(project)
@@ -768,7 +768,7 @@ READ_SPINOR_SHARED(tx, threadIdx.y, tz);\n
         elif dir == 4:
             prep_half += indent("if (threadIdx.z == blockDim.z-1 && blockDim.z < X3) {\n")
             prep_half += indent(load_spinor)
-            prep_half += indent(project)            
+            prep_half += indent(project)
             prep_half += indent("} else {")
             prep_half += indent(load_shared_4)
             prep_half += indent(project)
@@ -776,7 +776,7 @@ READ_SPINOR_SHARED(tx, threadIdx.y, tz);\n
         elif dir == 5:
             prep_half += indent("if (threadIdx.z == 0 && blockDim.z < X3) {\n")
             prep_half += indent(load_spinor)
-            prep_half += indent(project)            
+            prep_half += indent(project)
             prep_half += indent("} else {")
             prep_half += indent(load_shared_5)
             prep_half += indent(project)
@@ -797,14 +797,14 @@ READ_SPINOR_SHARED(tx, threadIdx.y, tz);\n
     prep_half += "}\n"
     prep_half += "#endif // MULTI_GPU\n"
     prep_half += "\n"
-    
+
     ident = "// identity gauge matrix\n"
     for m in range(0,3):
         for h in range(0,2):
             ident += "spinorFloat "+h2_re(h,m)+" = " + h1_re(h,m) + "; "
             ident += "spinorFloat "+h2_im(h,m)+" = " + h1_im(h,m) + ";\n"
     ident += "\n"
-    
+
     mult = ""
     for m in range(0,3):
         mult += "// multiply row "+`m`+"\n"
@@ -818,7 +818,7 @@ READ_SPINOR_SHARED(tx, threadIdx.y, tz);\n
                 im += h2_im(h,m) + " += " + g_im(dir,m,c) + " * "+h1_re(h,c)+";\n"
             mult += re + im
         mult += "\n"
-    
+
     reconstruct = ""
     for m in range(0,3):
 
@@ -829,7 +829,7 @@ READ_SPINOR_SHARED(tx, threadIdx.y, tz);\n
 
             reconstruct += out_re(h_out, m) + " += " + h2_re(h,m) + ";\n"
             reconstruct += out_im(h_out, m) + " += " + h2_im(h,m) + ";\n"
-    
+
         for s in range(2,4):
             (h,c) = row(s)
             re = c.real
@@ -841,7 +841,7 @@ READ_SPINOR_SHARED(tx, threadIdx.y, tz);\n
             elif re == 0:
                     reconstruct += out_re(s, m) + " " + sign(-im) + "= " + h2_im(h,m) + ";\n"
                     reconstruct += out_im(s, m) + " " + sign(+im) + "= " + h2_re(h,m) + ";\n"
-        
+
         reconstruct += "\n"
 
     if dir >= 6:
@@ -851,7 +851,7 @@ READ_SPINOR_SHARED(tx, threadIdx.y, tz);\n
         str += block(decl_half + prep_half + load_gauge + reconstruct_gauge + mult + reconstruct)
     else:
         str += decl_half + prep_half + load_gauge + reconstruct_gauge + mult + reconstruct
-    
+
     return cond + block(str)+"\n\n"
 # end def gen
 
@@ -952,7 +952,7 @@ def epilog():
         if twist:
             str += "#ifdef MULTI_GPU\n"
         else:
-            str += "#if defined MULTI_GPU && (defined DSLASH_XPAY || defined DSLASH_CLOVER)\n"        
+            str += "#if defined MULTI_GPU && (defined DSLASH_XPAY || defined DSLASH_CLOVER)\n"
         str += (
 """
 int incomplete = 0; // Have all 8 contributions been computed for this site?
@@ -969,21 +969,21 @@ case EXTERIOR_KERNEL_Y:
   incomplete = incomplete || (param.commDim[0] && (coord[0]==0 || coord[0]==X1m1));
 }
 
-""")    
+""")
         str += "if (!incomplete)\n"
         str += "#endif // MULTI_GPU\n"
 
     block_str = ""
     block_str += clover_twisted_xpay()
     str += block( block_str )
-    
+
     str += "\n\n"
     str += "// write spinor field back to device memory\n"
     str += "WRITE_SPINOR(param.sp_stride);\n\n"
 
     str += "// undefine to prevent warning when precision is changed\n"
     str += "#undef spinorFloat\n"
-    if sharedDslash: 
+    if sharedDslash:
         str += "#undef WRITE_SPINOR_SHARED\n"
         str += "#undef READ_SPINOR_SHARED\n"
     if sharedFloats > 0: str += "#undef SHARED_STRIDE\n\n"
@@ -1050,7 +1050,7 @@ case EXTERIOR_KERNEL_Y:
                     str += "#undef "+out_im(s,c)+"\n"
     str += "\n"
 
-    str += "#undef VOLATILE\n" 
+    str += "#undef VOLATILE\n"
 
     return str
 # end def epilog
@@ -1073,7 +1073,7 @@ def generate_dslash_kernels(arch):
     sharedFloats = 0
     if arch >= 200:
         sharedFloats = 24
-        sharedDslash = True    
+        sharedDslash = True
         name = "fermi"
     elif arch >= 120:
         sharedFloats = 0

--- a/lib/generate/fused_exterior_deg_tmc_dslash_cuda_gen.py
+++ b/lib/generate/fused_exterior_deg_tmc_dslash_cuda_gen.py
@@ -681,10 +681,8 @@ def gen(dir, pack_only=False):
     #load_half += "#endif\n"
 
     if dir >= 6:
-	if not dagger: load_half += "//const int t_proj_scale = TPROJSCALE;\n"
-	else: load_half += "const int t_proj_scale = TPROJSCALE;\n"
+	load_half += "const int t_proj_scale = TPROJSCALE;\n"
 
-    #if dir >= 6: load_half += "const int t_proj_scale = 2;//set this manually\n"
     load_half += "\n"
     load_half += "// read half spinor from device memory\n"
 
@@ -777,23 +775,10 @@ READ_SPINOR_SHARED(tx, threadIdx.y, tz);\n
                 copy_half += h1_re(h,c)+" = "+in_re(h,c)+";  "
                 copy_half += h1_im(h,c)+" = "+in_im(h,c)+";\n"
     else:
-	if dagger:
-	    for h in range(0, 2):
-		for c in range(0, 3):
-		    copy_half += h1_re(h,c)+" = t_proj_scale*"+in_re(h,c)+";  "
-		    copy_half += h1_im(h,c)+" = t_proj_scale*"+in_im(h,c)+";\n"
-	else:
-	    copy_half += "#ifdef CLOVER_TWIST_INV_DSLASH\n"
-	    for h in range(0, 2):
-		for c in range(0, 3):
-		    copy_half += h1_re(h,c)+" = "+in_re(h,c)+";  "
-		    copy_half += h1_im(h,c)+" = "+in_im(h,c)+";\n"
-	    copy_half += "#else  \n"
-	    for h in range(0, 2):
-		for c in range(0, 3):
-		    copy_half += h1_re(h,c)+" = "+"2*"+in_re(h,c)+";  "
-		    copy_half += h1_im(h,c)+" = "+"2*"+in_im(h,c)+";\n"
-	    copy_half += "#endif \n"
+        for h in range(0, 2):
+            for c in range(0, 3):
+                copy_half += h1_re(h,c)+" = t_proj_scale*"+in_re(h,c)+";  "
+                copy_half += h1_im(h,c)+" = t_proj_scale*"+in_im(h,c)+";\n"
     copy_half += "\n"
 
     prep_half = ""

--- a/lib/generate/ndeg_tm_dslash_cuda_gen.py
+++ b/lib/generate/ndeg_tm_dslash_cuda_gen.py
@@ -10,13 +10,13 @@ def complexToStr(c):
     def fltToString(a):
         if a == int(a): return `int(a)`
         else: return `a`
-    
+
     def imToString(a):
         if a == 0: return "0i"
         elif a == -1: return "-i"
         elif a == 1: return "i"
         else: return fltToString(a)+"i"
-    
+
     re = c.real
     im = c.imag
     if re == 0 and im == 0: return "0"
@@ -146,7 +146,7 @@ def def_input_spinor():
     str += "// input spinor\n"
     str += "#ifdef SPINOR_DOUBLE\n"
     str += "#define spinorFloat double\n"
-    if sharedDslash: 
+    if sharedDslash:
         str += "#define WRITE_SPINOR_SHARED WRITE_SPINOR_SHARED_DOUBLE2\n"
         str += "#define READ_SPINOR_SHARED READ_SPINOR_SHARED_DOUBLE2\n"
 
@@ -157,7 +157,7 @@ def def_input_spinor():
             str += "#define "+in_im(s,c)+" I"+nthFloat2(2*i+1)+"\n"
     str += "#else\n"
     str += "#define spinorFloat float\n"
-    if sharedDslash: 
+    if sharedDslash:
         str += "#define WRITE_SPINOR_SHARED WRITE_SPINOR_SHARED_FLOAT4\n"
         str += "#define READ_SPINOR_SHARED READ_SPINOR_SHARED_FLOAT4\n"
     for s in range(0,4):
@@ -189,7 +189,7 @@ def def_gauge():
 
     str += "\n"
     str += "#endif // GAUGE_DOUBLE\n\n"
-            
+
     str += "// conjugated gauge link\n"
     for m in range(0,3):
         for n in range(0,3):
@@ -282,7 +282,7 @@ def prolog():
 
 
     # set the pointer if using shared memory for pseudo registers
-#    if sharedFloatsPerFlavor > 0 and not sharedDslash: 
+#    if sharedFloatsPerFlavor > 0 and not sharedDslash:
     if sharedFloatsPerFlavor > 0:
         prolog_str += (
 """
@@ -321,7 +321,7 @@ if (kernel_type == INTERIOR_KERNEL) {
 
   // only need to check Y and Z dims currently since X and T set to match exactly
   if (coord[1] >= param.X[1]) return;
-  if (coord[2] >= param.X[2]) return; 
+  if (coord[2] >= param.X[2]) return;
 
 """)
         else:
@@ -418,7 +418,7 @@ if (sid >= param.threads) return;
 
 // read spinor from device memory
 READ_SPINOR(SPINORTEX, param.sp_stride, sid, sid);
-""")            
+""")
     return prolog_str
 # end def prolog
 
@@ -428,7 +428,7 @@ def gen(dir, pack_only=False):
     projStr = projectorToStr(projectors[projIdx])
     def proj(i,j):
         return projectors[projIdx][4*i+j]
-    
+
     # if row(i) = (j, c), then the i'th row of the projector can be represented
     # as a multiple of the j'th row: row(i) = c row(j)
     def row(i):
@@ -456,7 +456,7 @@ def gen(dir, pack_only=False):
     cond += "#endif\n"
 
     str = ""
-    
+
     projName = "P"+`dir/2`+["-","+"][projIdx%2]
     str += "// Projector "+projName+"\n"
     for l in projStr.splitlines():
@@ -543,21 +543,21 @@ def gen(dir, pack_only=False):
 
 # we have to use the same volume index for backwards and forwards gathers
 # instead of using READ_UP_SPINOR and READ_DOWN_SPINOR, just use READ_HALF_SPINOR with the appropriate shift
-#if (dir+1) % 2 == 0: 
+#if (dir+1) % 2 == 0:
  #         load_half_flv1 += "READ_HALF_SPINOR(SPINORTEX, sp_stride_pad, sp_idx, sp_norm_idx);\n\n"
-  #  else: 
+  #  else:
 #flavor offset: extra ghostFace[static_cast<int>(kernel_type)]
    #       load_half_flv1 += "READ_HALF_SPINOR(SPINORTEX, sp_stride_pad, sp_idx + (SPINOR_HOP/2)*sp_stride_pad, sp_norm_idx);\n\n"
 
     load_half_flv1 += "READ_HALF_SPINOR(GHOSTSPINORTEX, sp_stride_pad, sp_idx, sp_norm_idx);\n\n"
-    
+
     load_half_flv2 = "// read half spinor for the second flavor from device memory\n"
     load_half_flv2 += "const int fl_idx = sp_idx + ghostFace[static_cast<int>(kernel_type)];\n"
 # we have to use the same volume index for backwards and forwards gathers
 # instead of using READ_UP_SPINOR and READ_DOWN_SPINOR, just use READ_HALF_SPINOR with the appropriate shift
-    #if (dir+1) % 2 == 0: 
+    #if (dir+1) % 2 == 0:
      #     load_half_flv2 += "READ_HALF_SPINOR(SPINORTEX, sp_stride_pad, fl_idx, sp_norm_idx+ghostFace[static_cast<int>(kernel_type)]);\n\n"
-    #else: 
+    #else:
 #flavor offset: extra ghostFace[static_cast<int>(kernel_type)]
      #     load_half_flv2 += "READ_HALF_SPINOR(SPINORTEX, sp_stride_pad, fl_idx + (SPINOR_HOP/2)*sp_stride_pad, sp_norm_idx+ghostFace[static_cast<int>(kernel_type)]);\n\n"
 
@@ -589,7 +589,7 @@ def gen(dir, pack_only=False):
                     elif re==0:
                         strRe += sign(-im)+in_im(s,c)
                         strIm += sign(im)+in_re(s,c)
-                
+
             project += h1_re(h,c)+" = "+strRe+";\n"
             project += h1_im(h,c)+" = "+strIm+";\n"
 
@@ -673,14 +673,14 @@ READ_SPINOR_SHARED(tx, threadIdx.y, tz);\n
     prep_half_cond3 = "}\n"
     prep_half_cond3 += "#endif // MULTI_GPU\n"
     prep_half_cond3 += "\n"
-    
+
     ident = "// identity gauge matrix\n"
     for m in range(0,3):
         for h in range(0,2):
             ident += "spinorFloat "+h2_re(h,m)+" = " + h1_re(h,m) + "; "
             ident += "spinorFloat "+h2_im(h,m)+" = " + h1_im(h,m) + ";\n"
     ident += "\n"
-    
+
     mult = ""
     for m in range(0,3):
         mult += "// multiply row "+`m`+"\n"
@@ -694,7 +694,7 @@ READ_SPINOR_SHARED(tx, threadIdx.y, tz);\n
                 im += h2_im(h,m) + " += " + g_im(dir,m,c) + " * "+h1_re(h,c)+";\n"
             mult += re + im
         mult += "\n"
-    
+
     reconstruct_flv1 = ""
     for m in range(0,3):
 
@@ -704,7 +704,7 @@ READ_SPINOR_SHARED(tx, threadIdx.y, tz);\n
                 h_out = h+2
             reconstruct_flv1 += out1_re(h_out, m) + " += " + h2_re(h,m) + ";\n"
             reconstruct_flv1 += out1_im(h_out, m) + " += " + h2_im(h,m) + ";\n"
-    
+
         for s in range(2,4):
             (h,c) = row(s)
             re = c.real
@@ -717,7 +717,7 @@ READ_SPINOR_SHARED(tx, threadIdx.y, tz);\n
             elif re == 0:
                 reconstruct_flv1 += out1_re(s, m) + " " + sign(-im) + "= " + h2_im(h,m) + ";\n"
                 reconstruct_flv1 += out1_im(s, m) + " " + sign(+im) + "= " + h2_re(h,m) + ";\n"
-        
+
         reconstruct_flv1 += "\n"
 
     reconstruct_flv2 = ""
@@ -729,7 +729,7 @@ READ_SPINOR_SHARED(tx, threadIdx.y, tz);\n
                 h_out = h+2
             reconstruct_flv2 += out2_re(h_out, m) + " += " + h2_re(h,m) + ";\n"
             reconstruct_flv2 += out2_im(h_out, m) + " += " + h2_im(h,m) + ";\n"
-    
+
         for s in range(2,4):
             (h,c) = row(s)
             re = c.real
@@ -742,7 +742,7 @@ READ_SPINOR_SHARED(tx, threadIdx.y, tz);\n
             elif re == 0:
                 reconstruct_flv2 += out2_re(s, m) + " " + sign(-im) + "= " + h2_im(h,m) + ";\n"
                 reconstruct_flv2 += out2_im(s, m) + " " + sign(+im) + "= " + h2_re(h,m) + ";\n"
-        
+
         reconstruct_flv2 += "\n"
 
 
@@ -753,9 +753,9 @@ READ_SPINOR_SHARED(tx, threadIdx.y, tz);\n
         str += " else "
         str += block(load_gauge + reconstruct_gauge + "{\n"+ prep_half_cond1 + prep_half_flv1 + prep_half_cond2 + load_half_cond + prep_face_flv1 + prep_half + prep_half_cond3 + mult + reconstruct_flv1 + "}\n" + "{\n"+ prep_half_cond1 + prep_half_flv2 + prep_half_cond2 + load_half_cond + prep_face_flv2 + prep_half + prep_half_cond3 + mult + reconstruct_flv2 +"}\n")
     else:
-        str += decl_half + load_gauge + reconstruct_gauge 
-        str +="{\n" + prep_half_cond1 + prep_half_flv1 + prep_half_cond2 + load_half_cond + prep_face_flv1 + prep_half + prep_half_cond3 + mult + reconstruct_flv1 + "}\n" 
-        str +="{\n" + prep_half_cond1 + prep_half_flv2 + prep_half_cond2 + load_half_cond + prep_face_flv2 + prep_half + prep_half_cond3 + mult + reconstruct_flv2 + "}\n"     
+        str += decl_half + load_gauge + reconstruct_gauge
+        str +="{\n" + prep_half_cond1 + prep_half_flv1 + prep_half_cond2 + load_half_cond + prep_face_flv1 + prep_half + prep_half_cond3 + mult + reconstruct_flv1 + "}\n"
+        str +="{\n" + prep_half_cond1 + prep_half_flv2 + prep_half_cond2 + load_half_cond + prep_face_flv2 + prep_half + prep_half_cond3 + mult + reconstruct_flv2 + "}\n"
 
     if pack_only:
         out = load_spinor + decl_half + project
@@ -797,7 +797,7 @@ def twisted():
     if dagger :
        a1 += " - a *"
        a2 += " + a *"
-    else:     
+    else:
        a1 += " + a *"
        a2 += " - a *"
 
@@ -968,7 +968,7 @@ def xpay():
     if dagger :
        a1 += " - a *"
        a2 += " + a *"
-    else:     
+    else:
        a1 += " + a *"
        a2 += " - a *"
 
@@ -1062,20 +1062,20 @@ case EXTERIOR_KERNEL_Y:
   incomplete = incomplete || (param.commDim[0] && (coord[0]==0 || coord[0]==X1m1));
 }
 
-""")    
+""")
     str += "\n"
     str += "if (!incomplete)\n"
     str += "#endif // MULTI_GPU\n"
     str += "// apply twisted mass rotation\n"
     str += block( "\n" + twisted() + xpay() )
-    
+
     str += "\n\n"
     str += "// write spinor field back to device memory\n"
     str += "WRITE_FLAVOR_SPINOR();\n\n"
 
     str += "// undefine to prevent warning when precision is changed\n"
     str += "#undef spinorFloat\n"
-    if sharedDslash: 
+    if sharedDslash:
         str += "#undef WRITE_SPINOR_SHARED\n"
         str += "#undef READ_SPINOR_SHARED\n"
     if sharedFloatsPerFlavor > 0: str += "#undef SHARED_STRIDE\n\n"
@@ -1104,7 +1104,7 @@ case EXTERIOR_KERNEL_Y:
                     str += "#undef "+out1_im(s,c)+"\n"
     str += "\n"
 
-    str += "#undef VOLATILE\n" 
+    str += "#undef VOLATILE\n"
 
     return str
 # end def epilog
@@ -1130,7 +1130,7 @@ def generate_dslash_kernels(arch):
     if arch >= 200:
         sharedFloatsPerFlavor = 0
         #sharedDslash = True
-        sharedDslash = False    
+        sharedDslash = False
         name = "fermi"
     elif arch >= 120:
         sharedFloatsPerFlavor = 0


### PR DESCRIPTION
This hotfix fixes a bug in the twisted-clover dslash that appears to have been present for a long time.  The required scaling was not being applied when using a packing kernel kernel (vs a memcpy) to form the T-dimension halo buffers when using a fused-halo-update kernel.  This situation only generally arises when GDR is enabled, and was only apparent when the policy autotuner picked the `DslashFusedGPUComms` policy.

This pull also removes the ^M characters that had polluted some of the twisted-mass dslash generator files.