### PR TITLE
Hotfix/improve eigen download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ profile.tsv
 config.log
 CMakeCache.txt
 CMakeFiles
+externals
+.tags*
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,9 +194,10 @@ endif()
 ## QUDA depends on Eigen
 ## this part makes sure we can download eigen if it is not found
 if (QUDA_DOWNLOAD_EIGEN)
+  FILE(DOWNLOAD http://bitbucket.org/eigen/eigen/get/3.3.4.tar.bz2 ${CMAKE_SOURCE_DIR}/externals/3.3.4.tar.bz2 SHOW_PROGRESS EXPECTED_HASH SHA256=dd254beb0bafc695d0f62ae1a222ff85b52dbaa3a16f76e781dce22d0d20a4a6 STATUS EIGEN_DOWNLOADED)
   include(ExternalProject)
   ExternalProject_Add(Eigen
-    URL http://bitbucket.org/eigen/eigen/get/3.3.4.tar.bz2
+    URL ${CMAKE_SOURCE_DIR}/externals/3.3.4.tar.bz2
     URL_HASH SHA256=dd254beb0bafc695d0f62ae1a222ff85b52dbaa3a16f76e781dce22d0d20a4a6
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/eigen/
     CONFIGURE_COMMAND ""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,12 +194,24 @@ endif()
 ## QUDA depends on Eigen
 ## this part makes sure we can download eigen if it is not found
 if (QUDA_DOWNLOAD_EIGEN)
-  FILE(DOWNLOAD http://bitbucket.org/eigen/eigen/get/3.3.4.tar.bz2 ${CMAKE_SOURCE_DIR}/externals/3.3.4.tar.bz2 SHOW_PROGRESS EXPECTED_HASH SHA256=dd254beb0bafc695d0f62ae1a222ff85b52dbaa3a16f76e781dce22d0d20a4a6 STATUS EIGEN_DOWNLOADED)
+  set(EIGEN_DOWNLOAD_LOCATION ${CMAKE_SOURCE_DIR}/externals/eigen/3.3.4.tar.bz2)
+  set(EIGEN_URL http://bitbucket.org/eigen/eigen/get/3.3.4.tar.bz2)
+  set(EIGEN_SHA dd254beb0bafc695d0f62ae1a222ff85b52dbaa3a16f76e781dce22d0d20a4a6)
+  if(NOT EXISTS ${EIGEN_DOWNLOAD_LOCATION} )
+    message(STATUS "Checking for Eigen tarball and downloading if necessary.")
+  endif()
+  FILE(DOWNLOAD ${EIGEN_URL} ${EIGEN_DOWNLOAD_LOCATION} EXPECTED_HASH SHA256=${EIGEN_SHA} STATUS EIGEN_DOWNLOADED)
+  list(GET EIGEN_DOWNLOADED 0 EIGEN_DOWNLOADED_CODE)
+  list(GET EIGEN_DOWNLOADED 1 EIGEN_DOWNLOADED_MSG)
+  if(${EIGEN_DOWNLOADED_CODE})
+    message(SEND_ERROR "Could not download Eigen automatically (${EIGEN_DOWNLOADED_MSG}). Please download eigen from ${EIGEN_URL} and save it to ${EIGEN_DOWNLOAD_LOCATION} and try running cmake again.")
+  endif()
+
   include(ExternalProject)
   ExternalProject_Add(Eigen
-    URL ${CMAKE_SOURCE_DIR}/externals/3.3.4.tar.bz2
-    URL_HASH SHA256=dd254beb0bafc695d0f62ae1a222ff85b52dbaa3a16f76e781dce22d0d20a4a6
-    PREFIX ${CMAKE_CURRENT_BINARY_DIR}/eigen/
+    URL ${CMAKE_SOURCE_DIR}/externals/eigen/3.3.4.tar.bz2
+    URL_HASH SHA256=${EIGEN_SHA}
+    PREFIX ${CMAKE_CURRENT_BINARY_DIR}/externals/eigen/
     CONFIGURE_COMMAND ""
     BUILD_COMMAND COMMAND ""
     INSTALL_COMMAND ""
@@ -207,13 +219,14 @@ if (QUDA_DOWNLOAD_EIGEN)
   ExternalProject_Get_Property(Eigen source_dir)
   set(EIGEN_INCLUDE_DIRS ${source_dir}/EIGEN)
 else()
+  # fall back to using find_package
   find_package(Eigen QUIET)
   if(NOT EIGEN_FOUND)
     message(FATAL_ERROR "QUDA requires Eigen (http://eigen.tuxfamily.org). Please either set EIGEN_INCLUDE_DIRS to path to eigen3 include directory, e.g. /usr/local/include/eigen3 or set QUDA_DOWNLOAD_EIGEN to ON to enable automatic download of the necessary components.")
   endif()
 endif()
 include_directories(${EIGEN_INCLUDE_DIRS})
-
+## Now we hopefully found some way to get eigen to work
 
 # We need threads
 find_package(Threads REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -521,6 +521,10 @@ STRING(STRIP CUDA_VERSIONLONG ${CUDA_VERSIONLONG} )
 set(HASH cpu_arch=${CPU_ARCH},gpu_arch=${QUDA_GPU_ARCH},cuda_version=${CUDA_VERSIONLONG})
 
 
+# this allows simplified running of clang-tidy 
+if(${CMAKE_BUILD_TYPE} STREQUAL "DEVEL")
+   set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+endif()
 string(REGEX MATCH [Dd][Ee][Bb][Uu][Gg] DEBUG_BUILD ${CMAKE_BUILD_TYPE})
 
 # build up git version


### PR DESCRIPTION
Download Eigen already during cmake.

Note this currently downloads the eigen tarball into the source directory. Extraction is done into the build directory. 

Pro:
* Download eigen only once for multiple build dirs.
* If the automatic download fails users can copy the tarball into the right location into the source directory. (If the file is present and the SHA sum matches the download is skipped)
* error if download not possible already during cmake run - not during build.

Con:
* Doesn't keep the source dir clean (but externals is ignored in git)
