### PR TITLE
Added passing the mass to "createCoarseOp" to the base Dirac op in di…

### DIFF
--- a/include/dirac_quda.h
+++ b/include/dirac_quda.h
@@ -161,11 +161,12 @@ namespace quda {
      * @param X[out] Coarse clover field
      * @param T[in] Transfer operator defining the coarse grid
      * @param kappa Kappa parameter for the coarse operator
+     * @param mass Mass parameter for the coarse operator (gets explicitly built into clover, hard coded to zero for non-staggered ops)
      * @param mu TM mu parameter for the coarse operator
      * @param mu_factor multiplicative factor for the mu parameter
      */
     virtual void createCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T,
-				double kappa, double mu=0., double mu_factor=0.) const
+				double kappa, double mass=0., double mu=0., double mu_factor=0.) const
     {errorQuda("Not implemented");}
 
   };
@@ -203,10 +204,11 @@ namespace quda {
      * @param Y[out] Coarse link field
      * @param X[out] Coarse clover field
      * @param T[in] Transfer operator defining the coarse grid
+     * @param mass Mass parameter for the coarse operator (hard coded to 0 when CoarseOp is called)
      * @param kappa Kappa parameter for the coarse operator
      */
     virtual void createCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T,
-				double kappa, double mu=0., double mu_factor=0.) const;
+				double kappa, double mass=0.,double mu=0., double mu_factor=0.) const;
   };
 
   // Even-odd preconditioned Wilson
@@ -263,9 +265,10 @@ namespace quda {
      * @param Y[out] Coarse link field
      * @param X[out] Coarse clover field
      * @param kappa Kappa parameter for the coarse operator
+     * @param mass Mass parameter for the coarse operator (hard coded to 0 when CoarseOp is called)
      */
     void createCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T,
-			double kappa, double mu=0., double mu_factor=0.) const;
+			double kappa, double mass=0., double mu=0., double mu_factor=0.) const;
   };
 
   // Even-odd preconditioned clover
@@ -302,9 +305,10 @@ namespace quda {
      * @param Y[out] Coarse link field
      * @param X[out] Coarse clover field
      * @param kappa Kappa parameter for the coarse operator
+     * @param mass Mass parameter for the coarse operator (set to zero)
      */
     void createCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T,
-			double kappa, double mu=0., double mu_factor=0.) const;
+			double kappa, double mass=0., double mu=0., double mu_factor=0.) const;
   };
 
 
@@ -499,11 +503,12 @@ namespace quda {
      * @param Y[out] Coarse link field
      * @param X[out] Coarse clover field
      * @param kappa Kappa parameter for the coarse operator
+     * @param mass Mass parameter for the coarse operator (gets explicitly built into clover, hard coded to zero for non-staggered ops)
      * @param mu TM mu parameter for the coarse operator
      * @param mu_factor multiplicative factor for the mu parameter
      */
     void createCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T,
-			double kappa, double mu, double mu_factor=0.) const;
+			double kappa, double mass, double mu, double mu_factor=0.) const;
   };
 
   // Even-odd preconditioned twisted mass
@@ -537,11 +542,12 @@ namespace quda {
      * @param Y[out] Coarse link field
      * @param X[out] Coarse clover field
      * @param kappa Kappa parameter for the coarse operator
+     * @param mass Mass parameter for the coarse operator (gets explicitly built into clover, hard coded to zero for non-staggered ops)
      * @param mu TM mu parameter for the coarse operator
      * @param mu_factor multiplicative factor for the mu parameter
      */
     void createCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T,
-			double kappa, double mu, double mu_factor=0.) const;
+			double kappa, double mass, double mu, double mu_factor=0.) const;
   };
 
   // Full twisted mass with a clover term
@@ -581,11 +587,12 @@ namespace quda {
      * @param Y[out] Coarse link field
      * @param X[out] Coarse clover field
      * @param kappa Kappa parameter for the coarse operator
+     * @param mass Mass parameter for the coarse operator (gets explicitly built into clover, hard coded to zero for non-staggered ops)
      * @param mu TM mu parameter for the coarse operator
      * @param mu_factor multiplicative factor for the mu parameter
      */
     void createCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T,
-			double kappa, double mu, double mu_factor=0.) const;
+			double kappa, double mass, double mu, double mu_factor=0.) const;
   };
 
   // Even-odd preconditioned twisted mass with a clover term
@@ -623,11 +630,12 @@ namespace quda {
      * @param Y[out] Coarse link field
      * @param X[out] Coarse clover field
      * @param kappa Kappa parameter for the coarse operator
+     * @param mass Mass parameter for the coarse operator (gets explicitly built into clover, hard coded to zero for non-staggered ops)
      * @param mu TM mu parameter for the coarse operator
      * @param mu_factor multiplicative factor for the mu parameter
      */
     void createCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T,
-			double kappa, double mu, double mu_factor=0.) const;
+			double kappa, double mass, double mu, double mu_factor=0.) const;
   };
 
   // Full staggered
@@ -655,6 +663,20 @@ namespace quda {
 			 const QudaSolutionType) const;
     virtual void reconstruct(ColorSpinorField &x, const ColorSpinorField &b,
 			     const QudaSolutionType) const;
+
+    /**
+     * @brief Create the coarse staggered operator.  Unlike the Wilson operator,
+     *        we assume a mass normalization, not a kappa normalization. Thus kappa
+     *        gets ignored. 
+     *
+     * @param T[in] Transfer operator defining the coarse grid
+     * @param Y[out] Coarse link field
+     * @param X[out] Coarse clover field
+     * @param kappa Kappa parameter for the coarse operator (ignored, set to 1.0)
+     * @param mass Mass parameter for the coarse operator (gets explicitly built into clover)
+     */
+    void createCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T,
+      double kappa, double mass, double mu=0., double mu_factor=0.) const;
   };
 
   // Even-odd preconditioned staggered
@@ -842,11 +864,12 @@ namespace quda {
      * @param Y[out] Coarse link field
      * @param X[out] Coarse clover field
      * @param kappa Kappa parameter for the coarse operator
+     * @param mass Mass parameter (assumed to be zero, staggered mass gets built into clover)
      * @param mu TM mu parameter for the coarse operator
      * @param mu_factor multiplicative factor for the mu parameter
      */
     void createCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T,
-			double kappa, double mu, double mu_factor=0.) const;
+			double kappa, double mass, double mu, double mu_factor=0.) const;
 
 
     /**
@@ -890,11 +913,12 @@ namespace quda {
      * @param Y[out] Coarse link field
      * @param X[out] Coarse clover field
      * @param kappa Kappa parameter for the coarse operator
+     * @param mass Mass parameter for the coarse operator, assumed to be zero
      * @param mu TM mu parameter for the coarse operator
      * @param mu_factor multiplicative factor for the mu parameter
      */
     void createCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T,
-			double kappa, double mu, double mu_factor=0.) const;
+			double kappa, double mass, double mu, double mu_factor=0.) const;
   };
 
 

--- a/lib/dirac_clover.cpp
+++ b/lib/dirac_clover.cpp
@@ -156,7 +156,7 @@ namespace quda {
   }
 
   void DiracClover::createCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T,
-				   double kappa, double mu, double mu_factor) const {
+				   double kappa, double mass, double mu, double mu_factor) const {
     double a = 2.0 * kappa * mu * T.Vectors().TwistFlavor();
     CoarseOp(Y, X, T, *gauge, &clover, kappa, a, mu_factor, QUDA_CLOVER_DIRAC, QUDA_MATPC_INVALID);
   }
@@ -374,7 +374,7 @@ namespace quda {
   }
 
   void DiracCloverPC::createCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T,
-				     double kappa, double mu, double mu_factor) const {
+				     double kappa, double mass, double mu, double mu_factor) const {
     double a = - 2.0 * kappa * mu * T.Vectors().TwistFlavor();
     CoarseOp(Y, X, T, *gauge, &clover, kappa, a, -mu_factor, QUDA_CLOVERPC_DIRAC, matpcType);
   }

--- a/lib/dirac_coarse.cpp
+++ b/lib/dirac_coarse.cpp
@@ -104,8 +104,8 @@ namespace quda {
 
     bool gpu_setup = true;
 
-    if (enable_gpu && gpu_setup) dirac->createCoarseOp(*Y_d,*X_d,*transfer,kappa,Mu(),MuFactor());
-    else dirac->createCoarseOp(*Y_h,*X_h,*transfer,kappa,Mu(),MuFactor());
+    if (enable_gpu && gpu_setup) dirac->createCoarseOp(*Y_d,*X_d,*transfer,kappa,mass,Mu(),MuFactor());
+    else dirac->createCoarseOp(*Y_h,*X_h,*transfer,kappa,mass,Mu(),MuFactor());
 
     gParam.order = QUDA_QDP_GAUGE_ORDER;
     gParam.ghostExchange = QUDA_GHOST_EXCHANGE_PAD;
@@ -257,7 +257,7 @@ namespace quda {
   }
 
   //Make the coarse operator one level down.  Pass both the coarse gauge field and coarse clover field.
-  void DiracCoarse::createCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T, double kappa, double mu, double mu_factor) const
+  void DiracCoarse::createCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T, double kappa, double mass, double mu, double mu_factor) const
   {
     double a = 2.0 * kappa * mu * T.Vectors().TwistFlavor();
     if (checkLocation(Y, X) == QUDA_CPU_FIELD_LOCATION) {
@@ -434,7 +434,7 @@ namespace quda {
   //Make the coarse operator one level down.  For the preconditioned
   //operator we are coarsening the Yhat links, not the Y links.  We
   //pass the fine clover fields, though they are actually ignored.
-  void DiracCoarsePC::createCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T, double kappa, double mu, double mu_factor) const
+  void DiracCoarsePC::createCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T, double kappa, double mass, double mu, double mu_factor) const
   {
     double a = -2.0 * kappa * mu * T.Vectors().TwistFlavor();
     if (checkLocation(Y, X) == QUDA_CPU_FIELD_LOCATION) {

--- a/lib/dirac_staggered.cpp
+++ b/lib/dirac_staggered.cpp
@@ -127,6 +127,12 @@ namespace quda {
     // do nothing
   }
 
+  void DiracStaggered::createCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T,
+           double kappa, double mass, double mu, double mu_factor) const {
+    errorQuda("Cannot coarsen a staggered operator (yet!), we're just getting the functions in place.");
+    //CoarseStaggeredOp(Y, X, T, *gauge, mass, QUDA_STAGGERED_DIRAC, QUDA_MATPC_INVALID);
+  }
+
 
   DiracStaggeredPC::DiracStaggeredPC(const DiracParam &param)
     : DiracStaggered(param)
@@ -193,5 +199,7 @@ namespace quda {
   {
     // do nothing
   }
+
+
 
 } // namespace quda

--- a/lib/dirac_twisted_clover.cpp
+++ b/lib/dirac_twisted_clover.cpp
@@ -156,7 +156,7 @@ namespace quda {
   }
 
   void DiracTwistedClover::createCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T,
-					  double kappa, double mu, double mu_factor) const {
+					  double kappa, double mass, double mu, double mu_factor) const {
     double a = 2.0 * kappa * mu * T.Vectors().TwistFlavor();
     CoarseOp(Y, X, T, *gauge, &clover, kappa, a, mu_factor, QUDA_TWISTED_CLOVER_DIRAC, QUDA_MATPC_INVALID);
   }
@@ -415,7 +415,7 @@ namespace quda {
   }
 
   void DiracTwistedCloverPC::createCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T,
-					    double kappa, double mu, double mu_factor) const {
+					    double kappa, double mass, double mu, double mu_factor) const {
     double a = -2.0 * kappa * mu * T.Vectors().TwistFlavor();
     CoarseOp(Y, X, T, *gauge, &clover, kappa, a, -mu_factor, QUDA_TWISTED_CLOVERPC_DIRAC, matpcType);
   }

--- a/lib/dirac_twisted_mass.cpp
+++ b/lib/dirac_twisted_mass.cpp
@@ -183,7 +183,7 @@ namespace quda {
   }
 
   void DiracTwistedMass::createCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T,
-					double kappa, double mu, double mu_factor) const {
+					double kappa, double mass, double mu, double mu_factor) const {
     double a = 2.0 * kappa * mu;
     cudaCloverField *c = NULL;
     CoarseOp(Y, X, T, *gauge, c, kappa, a, mu_factor, QUDA_TWISTED_MASS_DIRAC, QUDA_MATPC_INVALID);
@@ -535,7 +535,7 @@ namespace quda {
   }
 
   void DiracTwistedMassPC::createCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T,
-					  double kappa, double mu, double mu_factor) const {
+					  double kappa, double mass, double mu, double mu_factor) const {
     double a = -2.0 * kappa * mu;
     cudaCloverField *c = NULL;
     CoarseOp(Y, X, T, *gauge, c, kappa, a, -mu_factor, QUDA_TWISTED_MASSPC_DIRAC, matpcType);

--- a/lib/dirac_wilson.cpp
+++ b/lib/dirac_wilson.cpp
@@ -147,7 +147,7 @@ namespace quda {
   grid
   */
   void DiracWilson::createCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T,
-				   double kappa, double mu, double mu_factor) const {
+				   double kappa, double mass, double mu, double mu_factor) const {
     double a = 2.0 * kappa * mu * T.Vectors().TwistFlavor();
     cudaCloverField *c = NULL;
     CoarseOp(Y, X, T, *gauge, c, kappa, a, mu_factor, QUDA_WILSON_DIRAC, QUDA_MATPC_INVALID);


### PR DESCRIPTION
At the end of the day, this is a very trivial change: it just added "mass" as a parameter that gets carried around everywhere and is ignored for Wilson-type fermions, but it'll be needed for staggered. This isn't intended to add support for both kappa and mass normalizations for Wilson-type fermions, nor for being able to add a mass-like term to the coarse op (though that could be done).

That said, it involves tiny changes, but for every Wilson-type fermion, so it required a lot of testing just to be thorough, so I think it's best to get this merged sooner as opposed to later. It'd probably be safer to explicitly build the mass into a coarse clover, though.

Tests I performed:

`./multigrid_invert_test --prec double --prec-sloppy single`
`./multigrid_invert_test --prec double --prec-sloppy single --mg-levels 3 --mg-block-size 0 3 3 3 2 --mg-block-size 1 2 2 2 2 --solve-type direct-pc --dslash-type clover`
`./multigrid_invert_test --prec double --prec-sloppy single --mg-levels 3 --mg-block-size 0 3 3 3 2 --mg-block-size 1 2 2 2 2 --solve-type direct-pc --dslash-type twisted-mass`
`./multigrid_invert_test --prec double --prec-sloppy single --mg-levels 2 --mg-block-size 0 3 3 3 2 --solve-type direct-pc --dslash-type twisted-clover`