### PR TITLE
Feature/milc site optimize

### DIFF
--- a/include/clover_field_order.h
+++ b/include/clover_field_order.h
@@ -521,7 +521,7 @@ namespace quda {
 	      for (int j=0; j<N; j++) copy(reinterpret_cast<Float*>(&vecTmp)[j], v[i*N+j]);
 
 	    // second do vectorized copy into memory
-	    reinterpret_cast<Vector*>(clover + parity*offset)[x + stride*(chirality*M+i)] = vecTmp;
+	    vector_store(clover + parity*offset, x + stride*(chirality*M+i), vecTmp);
 	  }
 	}
 

--- a/include/color_spinor_field_order.h
+++ b/include/color_spinor_field_order.h
@@ -545,7 +545,7 @@ namespace quda {
 	    // first do vectorized copy converting into storage type
 	    copy(vecTmp, reinterpret_cast<RegVector*>(tmp)[i]);
 	    // second do vectorized copy into memory
-	    reinterpret_cast< Vector* >(field + parity*offset)[x + stride*i] = vecTmp;
+	    vector_store(field + parity*offset, x + stride*i, vecTmp);
 	  }
 	}
 
@@ -600,8 +600,7 @@ namespace quda {
 	    // first do vectorized copy converting into storage type
 	    copy(vecTmp, reinterpret_cast< RegVector* >(v)[i]);
 	    // second do vectorized copy into memory
-	    reinterpret_cast< Vector*>
-	      (ghost[2*dim+dir]+parity*faceVolumeCB[dim]*M*N)[i*faceVolumeCB[dim]+x] = vecTmp;
+	    vector_store(ghost[2*dim+dir]+parity*faceVolumeCB[dim]*M*N, i*faceVolumeCB[dim]+x, vecTmp);
           }
 	}
 

--- a/include/enum_quda.h
+++ b/include/enum_quda.h
@@ -42,6 +42,7 @@ extern "C" {
     QUDA_QDPJIT_GAUGE_ORDER, // expect *gauge[mu], even-odd, complex-column-row-spacetime
     QUDA_CPS_WILSON_GAUGE_ORDER, // expect *gauge, even-odd, mu, spacetime, column-row color
     QUDA_MILC_GAUGE_ORDER, // expect *gauge, even-odd, mu, spacetime, row-column order
+    QUDA_MILC_SITE_GAUGE_ORDER, // packed into MILC site AoS [even-odd][spacetime] array, and [dir][row][col] inside
     QUDA_BQCD_GAUGE_ORDER, // expect *gauge, mu, even-odd, spacetime+halos, column-row order
     QUDA_TIFR_GAUGE_ORDER, // expect *gauge, mu, even-odd, spacetime, column-row order
     QUDA_TIFR_PADDED_GAUGE_ORDER, // expect *gauge, mu, parity, t, z+halo, y, x/2, column-row order

--- a/include/enum_quda_fortran.h
+++ b/include/enum_quda_fortran.h
@@ -49,9 +49,10 @@
 #define QUDA_QDPJIT_GAUGE_ORDER 6 //expect *gauge[4] even-odd spacetime row-column color
 #define QUDA_CPS_WILSON_GAUGE_ORDER 7 //expect *gauge even-odd spacetime column-row color
 #define QUDA_MILC_GAUGE_ORDER 8 //expect *gauge even-odd mu spacetime row-column order
-#define QUDA_BQCD_GAUGE_ORDER 9 //expect *gauge mu even-odd spacetime+halos row-column order
-#define QUDA_TIFR_GAUGE_ORDER 10
-#define QUDA_TIFR_PADDED_GAUGE_ORDER 11
+#define QUDA_MILC_SITE_GAUGE_ORDER 9 // packed into MILC site AoS [even-odd][spacetime] array, and [dir][row][col] inside
+#define QUDA_BQCD_GAUGE_ORDER 10 //expect *gauge mu even-odd spacetime+halos row-column order
+#define QUDA_TIFR_GAUGE_ORDER 11
+#define QUDA_TIFR_PADDED_GAUGE_ORDER 12
 #define QUDA_INVALID_GAUGE_ORDER QUDA_INVALID_ENUM
 
 #define QudaTboundary integer(4)

--- a/include/gauge_field.h
+++ b/include/gauge_field.h
@@ -40,6 +40,12 @@ namespace quda {
     /** Imaginary chemical potential */
     double i_mu;
 
+    /** Offset into MILC site struct to the desired matrix field (only if gauge_order=MILC_SITE_GAUGE_ORDER) */
+    size_t site_offset;
+
+    /** Size of MILC site struct (only if gauge_order=MILC_SITE_GAUGE_ORDER) */
+    size_t site_size;
+
     // Default constructor
   GaugeFieldParam(void* const h_gauge=NULL) : LatticeFieldParam(),
       nColor(3),
@@ -58,7 +64,9 @@ namespace quda {
       compute_fat_link_max(false),
       staggeredPhaseType(QUDA_STAGGERED_PHASE_NO),
       staggeredPhaseApplied(false),
-      i_mu(0.0)
+      i_mu(0.0),
+      site_offset(0),
+      site_size(0)
 	{ }
 
     GaugeFieldParam(const GaugeField &u);
@@ -71,7 +79,7 @@ namespace quda {
       link_type(QUDA_WILSON_LINKS), t_boundary(QUDA_INVALID_T_BOUNDARY), anisotropy(1.0),
       tadpole(1.0), scale(1.0), gauge(0), create(QUDA_NULL_FIELD_CREATE), geometry(geometry),
       compute_fat_link_max(false), staggeredPhaseType(QUDA_STAGGERED_PHASE_NO),
-      staggeredPhaseApplied(false), i_mu(0.0)
+      staggeredPhaseApplied(false), i_mu(0.0), site_offset(0), site_size(0)
       { }
 
   GaugeFieldParam(void *h_gauge, const QudaGaugeParam &param, QudaLinkType link_type_=QUDA_INVALID_LINKS)
@@ -81,7 +89,8 @@ namespace quda {
       anisotropy(param.anisotropy), tadpole(param.tadpole_coeff), scale(param.scale), gauge(h_gauge),
       create(QUDA_REFERENCE_FIELD_CREATE), geometry(QUDA_VECTOR_GEOMETRY),
       compute_fat_link_max(false), staggeredPhaseType(param.staggered_phase_type),
-      staggeredPhaseApplied(param.staggered_phase_applied), i_mu(param.i_mu)
+      staggeredPhaseApplied(param.staggered_phase_applied), i_mu(param.i_mu),
+      site_offset(param.gauge_offset), site_size(param.site_size)
 	{
 	  switch(link_type) {
 	  case QUDA_SU3_LINKS:
@@ -165,6 +174,16 @@ namespace quda {
     double i_mu;
 
     /**
+       Offset into MILC site struct to the desired matrix field (only if gauge_order=MILC_SITE_GAUGE_ORDER)
+    */
+    size_t site_offset;
+
+    /**
+       Size of MILC site struct (only if gauge_order=MILC_SITE_GAUGE_ORDER)
+    */
+    size_t site_size;
+
+    /**
        Compute the required extended ghost zone sizes and offsets
        @param[in] R Radius of the ghost zone
        @param[in] no_comms_fill If true we create a full halo
@@ -241,6 +260,18 @@ namespace quda {
       if ( isNative() ) errorQuda("No ghost zone pointer for quda-native gauge fields");
       return ghost;
     }
+
+    /**
+       @return The offset into the struct to the start of the gauge
+       field (only for order = QUDA_MILC_SITE_GAUGE_ORDER)
+     */
+    size_t SiteOffset() const { return site_offset; }
+
+    /**
+       @return The size of the struct into which the gauge
+       field is packed (only for order = QUDA_MILC_SITE_GAUGE_ORDER)
+     */
+    size_t SiteSize() const { return site_size; }
 
     /**
        Set all field elements to zero (virtual)

--- a/include/gauge_field_order.h
+++ b/include/gauge_field_order.h
@@ -1486,6 +1486,74 @@ namespace quda {
     size_t Bytes() const { return length * sizeof(Float); }
   };
 
+  /**
+     @brief struct to define gauge fields packed into an opaque MILC site struct:
+
+     struct {
+       char padding[offset];
+       Float [dim][row][col];
+     } site;
+
+     site lattice [parity][volumecb];
+
+     We are just passed the size of the struct and the offset to the
+     required matrix elements.  Typically, it is expected that this
+     accessor will be used with zero-copy memory to the original
+     allocation in MILC.
+  */
+  template <typename Float, int length> struct MILCSiteOrder : public LegacyOrder<Float,length> {
+    typedef typename mapper<Float>::type RegType;
+    Float *gauge;
+    const int volumeCB;
+    const int geometry;
+    const size_t offset;
+    const size_t size;
+  MILCSiteOrder(const GaugeField &u, Float *gauge_=0, Float **ghost_=0) :
+    LegacyOrder<Float,length>(u, ghost_), gauge(gauge_ ? gauge_ : (Float*)u.Gauge_p()),
+      volumeCB(u.VolumeCB()), geometry(u.Geometry()),
+      offset(u.SiteOffset()), size(u.SiteSize()) { ; }
+  MILCSiteOrder(const MILCSiteOrder &order) : LegacyOrder<Float,length>(order),
+      gauge(order.gauge), volumeCB(order.volumeCB), geometry(order.geometry),
+      offset(order.offset), size(order.size)
+      { ; }
+    virtual ~MILCSiteOrder() { ; }
+
+    __device__ __host__ inline void load(RegType v[length], int x, int dir, int parity) const {
+      // get base pointer
+      const Float *gauge0 = reinterpret_cast<const Float*>(reinterpret_cast<const char*>(gauge) + (parity*volumeCB+x)*size + offset);
+
+#if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
+      typedef S<Float,length> structure;
+      trove::coalesced_ptr<structure> gauge_((structure*)gauge0);
+      structure v_ = gauge_[dir];
+      for (int i=0; i<length; i++) v[i] = (RegType)v_.v[i];
+#else
+      for (int i=0; i<length; i++) {
+	v[i] = (RegType)gauge0[dir*length + i];
+      }
+#endif
+    }
+
+    __device__ __host__ inline void save(const RegType v[length], int x, int dir, int parity) {
+      // get base pointer
+      Float *gauge0 = reinterpret_cast<Float*>(reinterpret_cast<char*>(gauge) + (parity*volumeCB+x)*size + offset);
+
+#if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
+      typedef S<Float,length> structure;
+      trove::coalesced_ptr<structure> gauge_((structure*)gauge0);
+      structure v_;
+      for (int i=0; i<length; i++) v_.v[i] = (Float)v[i];
+      gauge_[dir] = v_;
+#else
+      for (int i=0; i<length; i++) {
+	gauge0[dir*length + i] = (Float)v[i];
+      }
+#endif
+    }
+
+    size_t Bytes() const { return length * sizeof(Float); }
+  };
+
 
   /**
      struct to define CPS ordered gauge fields:

--- a/include/gauge_field_order.h
+++ b/include/gauge_field_order.h
@@ -376,7 +376,6 @@ namespace quda {
   template <typename Float, int nColor, int nSpinCoarse, QudaGaugeFieldOrder order, bool native_ghost=true>
       struct FieldOrder {
 
-      protected:
 	/** An internal reference to the actual field we are accessing */
 	const int volumeCB;
 	const int nDim;
@@ -1070,7 +1069,7 @@ namespace quda {
 #pragma unroll
 	  for (int j=0; j<N; j++) copy(reinterpret_cast<Float*>(&vecTmp)[j], tmp[i*N+j]);
 	  // second do vectorized copy into memory
-	  reinterpret_cast< Vector* >(gauge + parity*offset)[x + dir*stride*M + stride*i] = vecTmp;
+	  vector_store(gauge + parity*offset, x + dir*stride*M + stride*i, vecTmp);
         }
         if(hasPhase){
           RegType phase = reconstruct.getPhase(v);
@@ -1147,8 +1146,7 @@ namespace quda {
 #pragma unroll
 	    for (int j=0; j<N; j++) copy(reinterpret_cast<Float*>(&vecTmp)[j], tmp[i*N+j]);
 	    // second do vectorized copy into memory
-	    reinterpret_cast< Vector*>
-	      (ghost[dir]+parity*faceVolumeCB[dir]*(M*N + hasPhase))[i*faceVolumeCB[dir]+x] = vecTmp;
+	    vector_store(ghost[dir]+parity*faceVolumeCB[dir]*(M*N + hasPhase), i*faceVolumeCB[dir]+x, vecTmp);
           }
 
 	  if (hasPhase) {
@@ -1225,9 +1223,8 @@ namespace quda {
 #pragma unroll
 	    for (int j=0; j<N; j++) copy(reinterpret_cast<Float*>(&vecTmp)[j], tmp[i*N+j]);
 	    // second do vectorized copy to memory
-	    reinterpret_cast< Vector* >
-	      (ghost[dim] + ((dir*2+parity)*geometry+g)*R[dim]*faceVolumeCB[dim]*(M*N + hasPhase))
-	      [i*R[dim]*faceVolumeCB[dim]+buff_idx] = vecTmp;
+	    vector_store(ghost[dim] + ((dir*2+parity)*geometry+g)*R[dim]*faceVolumeCB[dim]*(M*N + hasPhase),
+			 i*R[dim]*faceVolumeCB[dim]+buff_idx, vecTmp);
 	  }
 	  if (hasPhase) {
 	    RegType phase = reconstruct.getPhase(v);

--- a/include/inline_ptx.h
+++ b/include/inline_ptx.h
@@ -1,3 +1,5 @@
+#pragma once
+
 /*
   Inline ptx instructions for low-level control of code generation.
   Primarily these are for doing stores avoiding L1 cache and minimal

--- a/include/quda.h
+++ b/include/quda.h
@@ -75,6 +75,10 @@ extern "C" {
     int return_result_gauge; /**< Return the result gauge field */
     int return_result_mom;   /**< Return the result momentum field */
 
+    size_t gauge_offset; /**< Offset into MILC site struct to the gauge field (only if gauge_order=MILC_SITE_GAUGE_ORDER) */
+    size_t mom_offset; /**< Offset into MILC site struct to the momentum field (only if gauge_order=MILC_SITE_GAUGE_ORDER) */
+    size_t site_size; /**< Size of MILC site struct (only if gauge_order=MILC_SITE_GAUGE_ORDER) */
+
   } QudaGaugeParam;
 
 

--- a/include/quda_milc_interface.h
+++ b/include/quda_milc_interface.h
@@ -18,6 +18,18 @@ extern "C" {
 #endif
 
   /**
+   * Parameters related to MILC site struct
+   */
+  typedef struct {
+    void *site; /** Pointer to beginning of site array */
+    void *link; /** Pointer to link field (only used if site is not set) */
+    size_t link_offset; /** Offset to link entry in site struct (bytes) */
+    void *mom; /** Pointer to link field (only used if site is not set) */
+    size_t mom_offset; /** Offset to mom entry in site struct (bytes) */
+    size_t size; /** Size of site struct (bytes) */
+  } QudaMILCSiteArg_t;
+
+  /**
    * Parameters related to linear solvers.
    */
   typedef struct {
@@ -638,18 +650,16 @@ extern "C" {
    * match.
    *
    * @param precision The precision of the field (2 - double, 1 - single)
-   * @param dummy Not presently used
+   * @param num_loop_types 1, 2 or 3
    * @param milc_loop_coeff Coefficients of the different loops in the Symanzik action
    * @param eb3 The integration step size (for MILC this is dt*beta/3)
-   * @param milc_sitelink The gauge field from which we compute the force
-   * @param milc_momentum The momentum field to be updated
+   * @param arg Metadata for MILC's internal site struct array
    */
   void qudaGaugeForce(int precision,
-		      int dummy,
+		      int num_loop_types,
 		      double milc_loop_coeff[3],
 		      double eb3,
-		      void* milc_sitelink,
-		      void* milc_momentum);
+		      QudaMILCSiteArg_t *arg);
 
   /**
    * Compute the staggered quark-field outer product needed for gauge generation
@@ -673,13 +683,11 @@ extern "C" {
    *
    * @param precision Precision of the field (2 - double, 1 - single)
    * @param dt The integration step size step
-   * @param momentum The momentum field
-   * @param The gauge field to be updated
+   * @param arg Metadata for MILC's internal site struct array
    */
   void qudaUpdateU(int precision,
 		   double eps,
-		   void* momentum,
-		   void* link);
+		   QudaMILCSiteArg_t *arg);
 
   /**
    * Evaluate the momentum contribution to the Hybrid Monte Carlo
@@ -712,10 +720,10 @@ extern "C" {
    * tolerance is not met, this routine will give a runtime error.
    *
    * @param prec Precision of the gauge field
-   * @param gauge_h The gauge field to be updated
    * @param tol The tolerance to which we iterate
+   * @param arg Metadata for MILC's internal site struct array
    */
-  void qudaUnitarizeSU3(int prec, void *gauge, double tol);
+  void qudaUnitarizeSU3(int prec, double tol, QudaMILCSiteArg_t *arg);
 
   /**
    * Compute the clover force contributions in each dimension mu given

--- a/include/tune_quda.h
+++ b/include/tune_quda.h
@@ -186,13 +186,12 @@ namespace quda {
 
     char aux[TuneKey::aux_n];
 
-    void writeAuxString(const char *format, ...) {
+    int writeAuxString(const char *format, ...) {
       va_list arguments;
       va_start(arguments, format);
       int n = vsnprintf(aux, TuneKey::aux_n, format, arguments);
-      //int n = snprintf(aux, QUDA_TUNE_AUX_STR_LENGTH, "threads=%d,prec=%lu,stride=%d,geometery=%d",
-      //	       arg.volumeCB,sizeof(Complex)/2,arg.forceOffset);
       if (n < 0 || n >=TuneKey::aux_n) errorQuda("Error writing auxiliary string");
+      return n;
     }
 
   public:

--- a/lib/check_params.h
+++ b/lib/check_params.h
@@ -116,6 +116,9 @@ void printQudaGaugeParam(QudaGaugeParam *param) {
   P(make_resident_mom, 0);
   P(return_result_gauge, 1);
   P(return_result_mom, 1);
+  P(gauge_offset, 0);
+  P(mom_offset, 0);
+  P(site_size, 0);
 #else
   P(overwrite_mom, INVALID_INT);
   P(use_resident_gauge, INVALID_INT);

--- a/lib/clover_field.cpp
+++ b/lib/clover_field.cpp
@@ -177,7 +177,8 @@ namespace quda {
       desc.y = (precision == QUDA_DOUBLE_PRECISION) ? 8*sizeof(int) : 8*precision;
       desc.z = (precision == QUDA_DOUBLE_PRECISION) ? 8*sizeof(int) : 8*precision;
       desc.w = (precision == QUDA_DOUBLE_PRECISION) ? 8*sizeof(int) : 8*precision;
-      
+      int texel_size = 4 * (precision == QUDA_DOUBLE_PRECISION ? sizeof(int) : precision);
+
       cudaResourceDesc resDesc;
       memset(&resDesc, 0, sizeof(resDesc));
       resDesc.resType = cudaResourceTypeLinear;
@@ -185,6 +186,11 @@ namespace quda {
       resDesc.res.linear.desc = desc;
       resDesc.res.linear.sizeInBytes = bytes/(!full ? 2 : 1);
       
+      unsigned long texels = resDesc.res.linear.sizeInBytes / texel_size;
+      if (texels > (unsigned)deviceProp.maxTexture1DLinear) {
+	errorQuda("Attempting to bind too large a texture %lu > %d", texels, deviceProp.maxTexture1DLinear);
+      }
+
       cudaTextureDesc texDesc;
       memset(&texDesc, 0, sizeof(texDesc));
       if (precision == QUDA_HALF_PRECISION) texDesc.readMode = cudaReadModeNormalizedFloat;

--- a/lib/copy_gauge.cu
+++ b/lib/copy_gauge.cu
@@ -26,6 +26,9 @@ namespace quda {
     } else if (u.Order() == QUDA_MILC_GAUGE_ORDER) {
       if (u.Reconstruct() != QUDA_RECONSTRUCT_10)
 	errorQuda("Unsuported order %d and reconstruct %d combination", u.Order(), u.Reconstruct());
+    } else if (u.Order() == QUDA_MILC_SITE_GAUGE_ORDER) {
+      if (u.Reconstruct() != QUDA_RECONSTRUCT_10)
+	errorQuda("Unsuported order %d and reconstruct %d combination", u.Order(), u.Reconstruct());
     } else {
       errorQuda("Unsupported gauge field order %d", u.Order());
     }

--- a/lib/cpu_gauge_field.cpp
+++ b/lib/cpu_gauge_field.cpp
@@ -18,7 +18,7 @@ namespace quda {
     if (reconstruct != QUDA_RECONSTRUCT_NO && reconstruct != QUDA_RECONSTRUCT_10) {
       errorQuda("Reconstruction type %d not supported", reconstruct);
     }
-    if (reconstruct == QUDA_RECONSTRUCT_10 && order != QUDA_MILC_GAUGE_ORDER) {
+    if (reconstruct == QUDA_RECONSTRUCT_10 && order != QUDA_MILC_GAUGE_ORDER && order != QUDA_MILC_SITE_GAUGE_ORDER) {
       errorQuda("10-reconstruction only supported with MILC gauge order");
     }
 
@@ -34,6 +34,8 @@ namespace quda {
       bytes = siteDim * (x[0]*x[1]*(x[2]+4)*x[3]) * nInternal * precision;
     } else if (order == QUDA_BQCD_GAUGE_ORDER) {
       bytes = siteDim * (x[0]+4)*(x[1]+2)*(x[2]+2)*(x[3]+2) * nInternal * precision;
+    } else if (order == QUDA_MILC_SITE_GAUGE_ORDER) {
+      bytes = volume * site_size;
     }
 
     if (order == QUDA_QDP_GAUGE_ORDER) {
@@ -51,9 +53,13 @@ namespace quda {
 	}
       }
     
-    } else if (order == QUDA_CPS_WILSON_GAUGE_ORDER || order == QUDA_MILC_GAUGE_ORDER  || 
+    } else if (order == QUDA_CPS_WILSON_GAUGE_ORDER || order == QUDA_MILC_GAUGE_ORDER  ||
 	       order == QUDA_BQCD_GAUGE_ORDER || order == QUDA_TIFR_GAUGE_ORDER ||
-	       order == QUDA_TIFR_PADDED_GAUGE_ORDER) {
+	       order == QUDA_TIFR_PADDED_GAUGE_ORDER || order == QUDA_MILC_SITE_GAUGE_ORDER) {
+
+      if (order == QUDA_MILC_SITE_GAUGE_ORDER && create != QUDA_REFERENCE_FIELD_CREATE) {
+	errorQuda("MILC site gauge order only supported for reference fields");
+      }
 
       if (create == QUDA_NULL_FIELD_CREATE || create == QUDA_ZERO_FIELD_CREATE) {
 	gauge = (void **) safe_malloc(bytes);

--- a/lib/cuda_color_spinor_field.cu
+++ b/lib/cuda_color_spinor_field.cu
@@ -291,16 +291,19 @@ namespace quda {
       else desc.f = cudaChannelFormatKindSigned; // half is short, double is int2
       
       // staggered and coarse fields in half and single are always two component
+      int texel_size = 1;
       if ( (nSpin == 1 || nSpin == 2) && (precision == QUDA_HALF_PRECISION || precision == QUDA_SINGLE_PRECISION)) {
 	desc.x = 8*precision;
 	desc.y = 8*precision;
 	desc.z = 0;
 	desc.w = 0;
+	texel_size = 2*precision;
       } else { // all others are four component (double2 is spread across int4)
-	desc.x = (precision == QUDA_DOUBLE_PRECISION) ? 32 : 8*precision;
-	desc.y = (precision == QUDA_DOUBLE_PRECISION) ? 32 : 8*precision;
-	desc.z = (precision == QUDA_DOUBLE_PRECISION) ? 32 : 8*precision;
-	desc.w = (precision == QUDA_DOUBLE_PRECISION) ? 32 : 8*precision;
+	desc.x = (precision == QUDA_DOUBLE_PRECISION) ? 8*sizeof(int) : 8*precision;
+	desc.y = (precision == QUDA_DOUBLE_PRECISION) ? 8*sizeof(int) : 8*precision;
+	desc.z = (precision == QUDA_DOUBLE_PRECISION) ? 8*sizeof(int) : 8*precision;
+	desc.w = (precision == QUDA_DOUBLE_PRECISION) ? 8*sizeof(int) : 8*precision;
+	texel_size = 4 * (precision == QUDA_DOUBLE_PRECISION ? sizeof(int) : precision);
       }
       
       cudaResourceDesc resDesc;
@@ -314,7 +317,12 @@ namespace quda {
       memset(&texDesc, 0, sizeof(texDesc));
       if (precision == QUDA_HALF_PRECISION) texDesc.readMode = cudaReadModeNormalizedFloat;
       else texDesc.readMode = cudaReadModeElementType;
-      
+
+      unsigned long texels = resDesc.res.linear.sizeInBytes / texel_size;
+      if (texels > (unsigned)deviceProp.maxTexture1DLinear) {
+	errorQuda("Attempting to bind too large a texture %lu > %d", texels, deviceProp.maxTexture1DLinear);
+      }
+
       cudaCreateTextureObject(&tex, &resDesc, &texDesc, NULL);
 
       // create the texture for the norm components

--- a/lib/cuda_gauge_field.cu
+++ b/lib/cuda_gauge_field.cu
@@ -525,33 +525,47 @@ namespace quda {
 	qudaMemcpy(gauge, buffer, bytes, cudaMemcpyHostToDevice);
 	pool_pinned_free(buffer);
       } else { // else on the GPU
-	void *buffer = create_gauge_buffer(src.Bytes(), src.Order(), src.Geometry());
-	size_t ghost_bytes[8];
-	int srcNinternal = src.Reconstruct() != QUDA_RECONSTRUCT_NO ? src.Reconstruct() : 2*nColor*nColor;
-	for (int d=0; d<geometry; d++) ghost_bytes[d] = nFace * surface[d%4] * srcNinternal * src.Precision();
-	void **ghost_buffer = (nFace > 0) ? create_ghost_buffer(ghost_bytes, src.Order(), geometry) : nullptr;
 
-	if (src.Order() == QUDA_QDP_GAUGE_ORDER) {
-	  for (int d=0; d<geometry; d++) {
-	    qudaMemcpy(((void**)buffer)[d], ((void**)src.Gauge_p())[d], src.Bytes()/geometry, cudaMemcpyHostToDevice);
+	if (src.Order() == QUDA_MILC_SITE_GAUGE_ORDER) {
+	  // special case where we use zero-copy memory to read/write directly from MILC's data
+	  void *src_d;
+	  cudaHostGetDevicePointer(&src_d, const_cast<void*>(src.Gauge_p()), 0);
+
+	  if (src.GhostExchange() == QUDA_GHOST_EXCHANGE_NO) {
+	    copyGenericGauge(*this, src, QUDA_CUDA_FIELD_LOCATION, gauge, src_d);
+	  } else {
+	    errorQuda("Ghost copy not supported here");
 	  }
-	} else {
-	  qudaMemcpy(buffer, src.Gauge_p(), src.Bytes(), cudaMemcpyHostToDevice);
-	}
 
-	if (src.Order() > 4 && GhostExchange() == QUDA_GHOST_EXCHANGE_PAD &&
-	    src.GhostExchange() == QUDA_GHOST_EXCHANGE_PAD && nFace)
-	  for (int d=0; d<geometry; d++)
-	    qudaMemcpy(ghost_buffer[d], src.Ghost()[d], ghost_bytes[d], cudaMemcpyHostToDevice);
-
-	if (src.GhostExchange() != QUDA_GHOST_EXCHANGE_EXTENDED) {
-	  copyGenericGauge(*this, src, QUDA_CUDA_FIELD_LOCATION, gauge, buffer, 0, ghost_buffer);
-	  if (geometry == QUDA_COARSE_GEOMETRY) copyGenericGauge(*this, src, QUDA_CUDA_FIELD_LOCATION, gauge, buffer, 0, ghost_buffer, 3);
 	} else {
-	  copyExtendedGauge(*this, src, QUDA_CUDA_FIELD_LOCATION, gauge, buffer);
+	  void *buffer = create_gauge_buffer(src.Bytes(), src.Order(), src.Geometry());
+	  size_t ghost_bytes[8];
+	  int srcNinternal = src.Reconstruct() != QUDA_RECONSTRUCT_NO ? src.Reconstruct() : 2*nColor*nColor;
+	  for (int d=0; d<geometry; d++) ghost_bytes[d] = nFace * surface[d%4] * srcNinternal * src.Precision();
+	  void **ghost_buffer = (nFace > 0) ? create_ghost_buffer(ghost_bytes, src.Order(), geometry) : nullptr;
+
+	  if (src.Order() == QUDA_QDP_GAUGE_ORDER) {
+	    for (int d=0; d<geometry; d++) {
+	      qudaMemcpy(((void**)buffer)[d], ((void**)src.Gauge_p())[d], src.Bytes()/geometry, cudaMemcpyHostToDevice);
+	    }
+	  } else {
+	    qudaMemcpy(buffer, src.Gauge_p(), src.Bytes(), cudaMemcpyHostToDevice);
+	  }
+
+	  if (src.Order() > 4 && GhostExchange() == QUDA_GHOST_EXCHANGE_PAD &&
+	      src.GhostExchange() == QUDA_GHOST_EXCHANGE_PAD && nFace)
+	    for (int d=0; d<geometry; d++)
+	      qudaMemcpy(ghost_buffer[d], src.Ghost()[d], ghost_bytes[d], cudaMemcpyHostToDevice);
+
+	  if (src.GhostExchange() != QUDA_GHOST_EXCHANGE_EXTENDED) {
+	    copyGenericGauge(*this, src, QUDA_CUDA_FIELD_LOCATION, gauge, buffer, 0, ghost_buffer);
+	    if (geometry == QUDA_COARSE_GEOMETRY) copyGenericGauge(*this, src, QUDA_CUDA_FIELD_LOCATION, gauge, buffer, 0, ghost_buffer, 3);
+	  } else {
+	    copyExtendedGauge(*this, src, QUDA_CUDA_FIELD_LOCATION, gauge, buffer);
+	  }
+	  free_gauge_buffer(buffer, src.Order(), src.Geometry());
+	  if (nFace > 0) free_ghost_buffer(ghost_buffer, src.Order(), geometry);
 	}
-	free_gauge_buffer(buffer, src.Order(), src.Geometry());
-	if (nFace > 0) free_ghost_buffer(ghost_buffer, src.Order(), geometry);
       } // reorder_location
     } else {
       errorQuda("Invalid gauge field type");
@@ -579,35 +593,46 @@ namespace quda {
 
     if (reorder_location() == QUDA_CUDA_FIELD_LOCATION) {
 
-      void *buffer = create_gauge_buffer(cpu.Bytes(), cpu.Order(), cpu.Geometry());
+      if (cpu.Order() == QUDA_MILC_SITE_GAUGE_ORDER) {
+	// special case where we use zero-copy memory to read/write directly from MILC's data
+	void *cpu_d;
+	cudaHostGetDevicePointer(&cpu_d, const_cast<void*>(cpu.Gauge_p()), 0);
 
-      // Allocate space for ghost zone if required
-      size_t ghost_bytes[8];
-      int cpuNinternal = cpu.Reconstruct() != QUDA_RECONSTRUCT_NO ? cpu.Reconstruct() : 2*nColor*nColor;
-      for (int d=0; d<geometry; d++) ghost_bytes[d] = nFace * surface[d%4] * cpuNinternal * cpu.Precision();
-      void **ghost_buffer = (nFace > 0) ? create_ghost_buffer(ghost_bytes, cpu.Order(), geometry) : nullptr;
-
-      if (cpu.GhostExchange() != QUDA_GHOST_EXCHANGE_EXTENDED) {
-	copyGenericGauge(cpu, *this, QUDA_CUDA_FIELD_LOCATION, buffer, gauge, ghost_buffer, 0);
-	if (geometry == QUDA_COARSE_GEOMETRY) copyGenericGauge(cpu, *this, QUDA_CUDA_FIELD_LOCATION, buffer, gauge, ghost_buffer, 0, 3);
+	if (cpu.GhostExchange() == QUDA_GHOST_EXCHANGE_NO) {
+	  copyGenericGauge(cpu, *this, QUDA_CUDA_FIELD_LOCATION, cpu_d, gauge);
+	} else {
+	  errorQuda("Ghost copy not supported here");
+	}
       } else {
-	copyExtendedGauge(cpu, *this, QUDA_CUDA_FIELD_LOCATION, buffer, gauge);
+	void *buffer = create_gauge_buffer(cpu.Bytes(), cpu.Order(), cpu.Geometry());
+
+	// Allocate space for ghost zone if required
+	size_t ghost_bytes[8];
+	int cpuNinternal = cpu.Reconstruct() != QUDA_RECONSTRUCT_NO ? cpu.Reconstruct() : 2*nColor*nColor;
+	for (int d=0; d<geometry; d++) ghost_bytes[d] = nFace * surface[d%4] * cpuNinternal * cpu.Precision();
+	void **ghost_buffer = (nFace > 0) ? create_ghost_buffer(ghost_bytes, cpu.Order(), geometry) : nullptr;
+
+	if (cpu.GhostExchange() != QUDA_GHOST_EXCHANGE_EXTENDED) {
+	  copyGenericGauge(cpu, *this, QUDA_CUDA_FIELD_LOCATION, buffer, gauge, ghost_buffer, 0);
+	  if (geometry == QUDA_COARSE_GEOMETRY) copyGenericGauge(cpu, *this, QUDA_CUDA_FIELD_LOCATION, buffer, gauge, ghost_buffer, 0, 3);
+	} else {
+	  copyExtendedGauge(cpu, *this, QUDA_CUDA_FIELD_LOCATION, buffer, gauge);
+	}
+
+	if (cpu.Order() == QUDA_QDP_GAUGE_ORDER) {
+	  for (int d=0; d<geometry; d++) qudaMemcpy(((void**)cpu.gauge)[d], ((void**)buffer)[d], cpu.Bytes()/geometry, cudaMemcpyDeviceToHost);
+	} else {
+	  qudaMemcpy(cpu.gauge, buffer, cpu.Bytes(), cudaMemcpyDeviceToHost);
+	}
+
+	if (cpu.Order() > 4 && GhostExchange() == QUDA_GHOST_EXCHANGE_PAD &&
+	    cpu.GhostExchange() == QUDA_GHOST_EXCHANGE_PAD && nFace)
+	  for (int d=0; d<geometry; d++)
+	    qudaMemcpy(cpu.Ghost()[d], ghost_buffer[d], ghost_bytes[d], cudaMemcpyDeviceToHost);
+
+	free_gauge_buffer(buffer, cpu.Order(), cpu.Geometry());
+	if (nFace > 0) free_ghost_buffer(ghost_buffer, cpu.Order(), geometry);
       }
-
-      if (cpu.Order() == QUDA_QDP_GAUGE_ORDER) {
-	for (int d=0; d<geometry; d++) qudaMemcpy(((void**)cpu.gauge)[d], ((void**)buffer)[d], cpu.Bytes()/geometry, cudaMemcpyDeviceToHost);
-      } else {
-	qudaMemcpy(cpu.gauge, buffer, cpu.Bytes(), cudaMemcpyDeviceToHost);
-      }
-
-      if (cpu.Order() > 4 && GhostExchange() == QUDA_GHOST_EXCHANGE_PAD &&
-	  cpu.GhostExchange() == QUDA_GHOST_EXCHANGE_PAD && nFace)
-	for (int d=0; d<geometry; d++)
-	  qudaMemcpy(cpu.Ghost()[d], ghost_buffer[d], ghost_bytes[d], cudaMemcpyDeviceToHost);
-
-      free_gauge_buffer(buffer, cpu.Order(), cpu.Geometry());
-      if (nFace > 0) free_ghost_buffer(ghost_buffer, cpu.Order(), geometry);
-
     } else if (reorder_location() == QUDA_CPU_FIELD_LOCATION) { // do copy then host-side reorder
 
       void *buffer = pool_pinned_malloc(bytes);

--- a/lib/cuda_gauge_field.cu
+++ b/lib/cuda_gauge_field.cu
@@ -539,7 +539,8 @@ namespace quda {
 	if (src.Order() == QUDA_MILC_SITE_GAUGE_ORDER) {
 	  // special case where we use zero-copy memory to read/write directly from MILC's data
 	  void *src_d;
-	  cudaHostGetDevicePointer(&src_d, const_cast<void*>(src.Gauge_p()), 0);
+	  cudaError_t error = cudaHostGetDevicePointer(&src_d, const_cast<void*>(src.Gauge_p()), 0);
+	  if (error != cudaSuccess) errorQuda("Failed to get device pointer for MILC site array");
 
 	  if (src.GhostExchange() == QUDA_GHOST_EXCHANGE_NO) {
 	    copyGenericGauge(*this, src, QUDA_CUDA_FIELD_LOCATION, gauge, src_d);

--- a/lib/cuda_gauge_field.cu
+++ b/lib/cuda_gauge_field.cu
@@ -607,8 +607,8 @@ namespace quda {
       if (cpu.Order() == QUDA_MILC_SITE_GAUGE_ORDER) {
 	// special case where we use zero-copy memory to read/write directly from MILC's data
 	void *cpu_d;
-	cudaHostGetDevicePointer(&cpu_d, const_cast<void*>(cpu.Gauge_p()), 0);
-
+  cudaError_t error = cudaHostGetDevicePointer(&cpu_d, const_cast<void*>(cpu.Gauge_p()), 0);
+  if (error != cudaSuccess) errorQuda("Failed to get device pointer for MILC site array");
 	if (cpu.GhostExchange() == QUDA_GHOST_EXCHANGE_NO) {
 	  copyGenericGauge(cpu, *this, QUDA_CUDA_FIELD_LOCATION, cpu_d, gauge);
 	} else {

--- a/lib/gauge_field.cpp
+++ b/lib/gauge_field.cpp
@@ -21,7 +21,10 @@ namespace quda {
     compute_fat_link_max(false),
     staggeredPhaseType(u.StaggeredPhase()),
     staggeredPhaseApplied(u.StaggeredPhaseApplied()),
-    i_mu(u.iMu()) { }
+    i_mu(u.iMu()),
+    site_offset(u.SiteOffset()),
+    site_size(u.SiteSize())
+  { }
 
 
   GaugeField::GaugeField(const GaugeFieldParam &param) :
@@ -31,7 +34,8 @@ namespace quda {
     order(param.order), fixed(param.fixed), link_type(param.link_type), t_boundary(param.t_boundary), 
     anisotropy(param.anisotropy), tadpole(param.tadpole), fat_link_max(0.0), scale(param.scale),  
     create(param.create),
-    staggeredPhaseType(param.staggeredPhaseType), staggeredPhaseApplied(param.staggeredPhaseApplied), i_mu(param.i_mu)
+    staggeredPhaseType(param.staggeredPhaseType), staggeredPhaseApplied(param.staggeredPhaseApplied), i_mu(param.i_mu),
+    site_offset(param.site_offset), site_size(param.site_size)
   {
     if (link_type != QUDA_COARSE_LINKS && nColor != 3)
       errorQuda("nColor must be 3, not %d for this link type", nColor);

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -3643,6 +3643,8 @@ int computeGaugeForceQuda(void* mom, void* siteLink,  int*** input_path_buf, int
   checkGaugeParam(qudaGaugeParam);
 
   GaugeFieldParam gParam(siteLink, *qudaGaugeParam);
+  gParam.site_offset = qudaGaugeParam->gauge_offset;
+  gParam.site_size = qudaGaugeParam->site_size;
   cpuGaugeField *cpuSiteLink = (!qudaGaugeParam->use_resident_gauge) ? new cpuGaugeField(gParam) : NULL;
 
   cudaGaugeField* cudaSiteLink = NULL;
@@ -3674,6 +3676,8 @@ int computeGaugeForceQuda(void* mom, void* siteLink,  int*** input_path_buf, int
   if (gParamMom.order == QUDA_TIFR_GAUGE_ORDER || gParamMom.order == QUDA_TIFR_PADDED_GAUGE_ORDER) gParamMom.reconstruct = QUDA_RECONSTRUCT_NO;
   else gParamMom.reconstruct = QUDA_RECONSTRUCT_10;
 
+  gParamMom.site_offset = qudaGaugeParam->mom_offset;
+  gParamMom.site_size = qudaGaugeParam->site_size;
   cpuGaugeField* cpuMom = (!qudaGaugeParam->use_resident_mom) ? new cpuGaugeField(gParamMom) : NULL;
 
   cudaGaugeField* cudaMom = NULL;
@@ -4688,6 +4692,8 @@ void updateGaugeFieldQuda(void* gauge,
 
   // create the host fields
   GaugeFieldParam gParam(gauge, *param, QUDA_SU3_LINKS);
+  gParam.site_offset = param->gauge_offset;
+  gParam.site_size = param->site_size;
   bool need_cpu = !param->use_resident_gauge || param->return_result_gauge;
   cpuGaugeField *cpuGauge = need_cpu ? new cpuGaugeField(gParam) : NULL;
 
@@ -4695,6 +4701,8 @@ void updateGaugeFieldQuda(void* gauge,
   gParamMom.reconstruct = (gParamMom.order == QUDA_TIFR_GAUGE_ORDER || gParamMom.order == QUDA_TIFR_PADDED_GAUGE_ORDER) ?
    QUDA_RECONSTRUCT_NO : QUDA_RECONSTRUCT_10;
   gParamMom.link_type = QUDA_ASQTAD_MOM_LINKS;
+  gParamMom.site_offset = param->mom_offset;
+  gParamMom.site_size = param->site_size;
   cpuGaugeField *cpuMom = !param->use_resident_mom ? new cpuGaugeField(gParamMom) : NULL;
 
   // create the device fields
@@ -4779,6 +4787,8 @@ void updateGaugeFieldQuda(void* gauge,
 
    // create the gauge field
    GaugeFieldParam gParam(gauge_h, *param, QUDA_GENERAL_LINKS);
+   gParam.site_offset = param->gauge_offset;
+   gParam.site_size = param->site_size;
    bool need_cpu = !param->use_resident_gauge || param->return_result_gauge;
    cpuGaugeField *cpuGauge = need_cpu ? new cpuGaugeField(gParam) : NULL;
 

--- a/lib/quda_fortran.F90
+++ b/lib/quda_fortran.F90
@@ -71,7 +71,11 @@ module quda_fortran
      integer(4) :: return_result_gauge ! Return the result gauge field
      integer(4) :: return_result_mom   ! Return the result momentum field
 
-  end type quda_gauge_param
+     integer(8) :: gauge_offset ! Offset into MILC site struct to the gauge field (only if gauge_order=MILC_SITE_GAUGE_ORDER)
+     integer(8) :: mom_offset   ! Offset into MILC site struct to the momentum field (only if gauge_order=MILC_SITE_GAUGE_ORDER)
+     integer(8) :: site_size    ! Size of MILC site struct (only if gauge_order=MILC_SITE_GAUGE_ORDER)
+
+ end type quda_gauge_param
 
   ! This module corresponds to the QudaInvertParam struct in quda.h
   type quda_invert_param


### PR DESCRIPTION
This pull request is focussed upon reducing the overhead of the MILC-QUDA interface and fixes some other issues
* Introduce a new gauge field ordering type `QUDA_MILC_SITE_GAUGE_ORDER` which corresponds to the `gauge::MILCSiteOrder` field accessor.  This is for mapping directly to MILC's internal array of sites and facilitates QUDA being able to read and write directly from this array.
* Updates the `qudaUpdate`, `qudaGaugeForce` and `qudaUnitarizeSU3` interface functions to use the direct site mapping for greatly improved throughput.
* Introduce a new `vector_store` helper that does streaming stores for generic vector types.  This ensures that all stores from `gauge::FloatNOrder`, `clover::FloatNOrder` and `colorspinor::FloatNOrder` are vectorized.
* Adds an explicit check for all texture sizes, to ensure that we don't attempt to bind a texture larger than supported by the device 

This should not be merged until we have confirmed that the partner pull request for MILC will also be merged.