### PR TITLE
Hotfix/multi gpu p2p bugfix

### DIFF
--- a/include/comm_quda.h
+++ b/include/comm_quda.h
@@ -140,6 +140,21 @@ extern "C" {
   int comm_gpuid(void);
 
   /**
+     @brief Gather all hostnames
+     @param[out] hostname_recv_buf char array of length
+     128*comm_size() that will be filled in GPU ids for all processes.
+     Each hostname is in rank order, with 128 bytes for each.
+   */
+  void comm_gather_hostname(char *hostname_recv_buf);
+
+  /**
+     @brief Gather all GPU ids
+     @param[out] gpuid_recv_buf int array of length comm_size() that
+     will be filled in GPU ids for all processes (in rank order).
+   */
+  void comm_gather_gpuid(int *gpuid_recv_buf);
+
+  /**
      Enabled peer-to-peer communication.
      @param hostname_buf Array that holds all process hostnames
    */

--- a/lib/comm_common.cpp
+++ b/lib/comm_common.cpp
@@ -142,6 +142,101 @@ void comm_destroy_topology(Topology *topo)
 }
 
 
+static bool peer2peer_enabled[2][4] = { {false,false,false,false},
+                                        {false,false,false,false} };
+static bool peer2peer_init = false;
+void comm_peer2peer_init(const char* hostname_recv_buf)
+{
+  if (peer2peer_init) return;
+
+  bool disable_peer_to_peer = false;
+  char *enable_peer_to_peer_env = getenv("QUDA_ENABLE_P2P");
+  if (enable_peer_to_peer_env && strcmp(enable_peer_to_peer_env, "0") == 0) {
+    if (getVerbosity() > QUDA_SILENT) printfQuda("Disabling peer-to-peer access\n");
+    disable_peer_to_peer = true;
+  }
+
+  // disable peer-to-peer comms in one direction if QUDA_ENABLE_P2P=-1
+  // and comm_dim(dim) == 2 (used for perf benchmarking)
+  bool disable_peer_to_peer_bidir = false;
+  if (enable_peer_to_peer_env && strcmp(enable_peer_to_peer_env, "-1") == 0) {
+    if (getVerbosity() > QUDA_SILENT) printfQuda("Disabling bi-directional peer-to-peer access\n");
+    disable_peer_to_peer_bidir = true;
+  }
+
+  if (!peer2peer_init && !disable_peer_to_peer) {
+
+    // first check that the local GPU supports UVA
+    const int gpuid = comm_gpuid();
+    cudaDeviceProp prop;
+    cudaGetDeviceProperties(&prop, gpuid);
+    if(!prop.unifiedAddressing) return;
+
+    comm_set_neighbor_ranks();
+
+    char *hostname = comm_hostname();
+    int *gpuid_recv_buf = (int *)safe_malloc(sizeof(int)*comm_size());
+
+    comm_gather_gpuid(gpuid_recv_buf);
+
+    for(int dir=0; dir<2; ++dir){ // forward/backward directions
+      for(int dim=0; dim<4; ++dim){
+	int neighbor_rank = comm_neighbor_rank(dir,dim);
+	if(neighbor_rank == comm_rank()) continue;
+
+	// disable peer-to-peer comms in one direction
+	if ( ((comm_rank() > neighbor_rank && dir == 0) || (comm_rank() < neighbor_rank && dir == 1)) &&
+	     disable_peer_to_peer_bidir && comm_dim(dim) == 2 ) continue;
+
+	// if the neighbors are on the same
+	if (!strncmp(hostname, &hostname_recv_buf[128*neighbor_rank], 128)) {
+	  int neighbor_gpuid = gpuid_recv_buf[neighbor_rank];
+	  int canAccessPeer[2];
+	  cudaDeviceCanAccessPeer(&canAccessPeer[0], gpuid, neighbor_gpuid);
+	  cudaDeviceCanAccessPeer(&canAccessPeer[1], neighbor_gpuid, gpuid);
+
+	  int accessRank[2] = { };
+#if CUDA_VERSION >= 8000  // this was introduced with CUDA 8
+	  if (canAccessPeer[0]*canAccessPeer[1]) {
+	    cudaDeviceGetP2PAttribute(&accessRank[0], cudaDevP2PAttrPerformanceRank, gpuid, neighbor_gpuid);
+	    cudaDeviceGetP2PAttribute(&accessRank[1], cudaDevP2PAttrPerformanceRank, neighbor_gpuid, gpuid);
+	  }
+#endif
+
+	  // enable P2P if we can access the peer or if peer is self
+	  if (canAccessPeer[0]*canAccessPeer[1] || gpuid == neighbor_gpuid) {
+	    peer2peer_enabled[dir][dim] = true;
+	    if (getVerbosity() > QUDA_SILENT) {
+	      printf("Peer-to-peer enabled for rank %d (gpu=%d) with neighbor %d (gpu=%d) dir=%d, dim=%d, performance rank = (%d, %d)\n",
+		     comm_rank(), gpuid, neighbor_rank, neighbor_gpuid, dir, dim, accessRank[0], accessRank[1]);
+	    }
+	  }
+
+	} // on the same node
+      } // different dimensions - x, y, z, t
+    } // different directions - forward/backward
+
+    host_free(gpuid_recv_buf);
+  }
+
+  peer2peer_init = true;
+
+  // set gdr enablement
+  if (comm_gdr_enabled()) {
+    printfQuda("Enabling GPU-Direct RDMA access\n");
+  } else {
+    printfQuda("Disabling GPU-Direct RDMA access\n");
+  }
+
+  checkCudaErrorNoSync();
+  return;
+}
+
+bool comm_peer2peer_enabled(int dir, int dim){
+  return peer2peer_enabled[dir][dim];
+}
+
+
 int comm_ndim(const Topology *topo)
 {
   return topo->ndim;

--- a/lib/comm_mpi.cpp
+++ b/lib/comm_mpi.cpp
@@ -42,12 +42,21 @@ struct MsgHandle_s {
 static int rank = -1;
 static int size = -1;
 static int gpuid = -1;
-static bool peer2peer_enabled[2][4] = { {false,false,false,false},
-                                        {false,false,false,false} };
-static bool peer2peer_init = false;
 
 static char partition_string[16];
 static char topology_string[16];
+
+
+void comm_gather_hostname(char *hostname_recv_buf) {
+  // determine which GPU this rank will use
+  char *hostname = comm_hostname();
+  MPI_CHECK( MPI_Allgather(hostname, 128, MPI_CHAR, hostname_recv_buf, 128, MPI_CHAR, MPI_COMM_WORLD) );
+}
+
+void comm_gather_gpuid(int *gpuid_recv_buf) {
+  MPI_CHECK(MPI_Allgather(&gpuid, 1, MPI_INT, gpuid_recv_buf, 1, MPI_INT, MPI_COMM_WORLD));
+}
+
 
 void comm_init(int ndim, const int *dims, QudaCommsMap rank_from_coords, void *map_data)
 {
@@ -74,14 +83,13 @@ void comm_init(int ndim, const int *dims, QudaCommsMap rank_from_coords, void *m
   comm_set_default_topology(topo);
 
   // determine which GPU this MPI rank will use
-  char *hostname = comm_hostname();
   char *hostname_recv_buf = (char *)safe_malloc(128*size);
 
-  MPI_CHECK( MPI_Allgather(hostname, 128, MPI_CHAR, hostname_recv_buf, 128, MPI_CHAR, MPI_COMM_WORLD) );
+  comm_gather_hostname(hostname_recv_buf);
 
   gpuid = 0;
   for (int i = 0; i < rank; i++) {
-    if (!strncmp(hostname, &hostname_recv_buf[128*i], 128)) {
+    if (!strncmp(comm_hostname(), &hostname_recv_buf[128*i], 128)) {
       gpuid++;
     }
   }
@@ -108,103 +116,6 @@ void comm_init(int ndim, const int *dims, QudaCommsMap rank_from_coords, void *m
   snprintf(partition_string, 16, ",comm=%d%d%d%d", comm_dim_partitioned(0), comm_dim_partitioned(1), comm_dim_partitioned(2), comm_dim_partitioned(3));
   snprintf(topology_string, 16, ",topo=%d%d%d%d", comm_dim(0), comm_dim(1), comm_dim(2), comm_dim(3));
 }
-
-void comm_peer2peer_init(const char* hostname_recv_buf)
-{
-  if (peer2peer_init) return;
-
-  bool disable_peer_to_peer = false;
-  char *enable_peer_to_peer_env = getenv("QUDA_ENABLE_P2P");
-  if (enable_peer_to_peer_env && strcmp(enable_peer_to_peer_env, "0") == 0) {
-    if (getVerbosity() > QUDA_SILENT) printfQuda("Disabling peer-to-peer access\n");
-    disable_peer_to_peer = true;
-  }
-
-  // disable peer-to-peer comms in one direction if QUDA_ENABLE_P2P=-1
-  // and comm_dim(dim) == 2 (used for perf benchmarking)
-  bool disable_peer_to_peer_bidir = false;
-  if (enable_peer_to_peer_env && strcmp(enable_peer_to_peer_env, "-1") == 0) {
-    if (getVerbosity() > QUDA_SILENT) printfQuda("Disabling bi-directional peer-to-peer access\n");
-    disable_peer_to_peer_bidir = true;
-  }
-
-  if (!peer2peer_init && !disable_peer_to_peer) {
-
-    // first check that the local GPU supports UVA
-    cudaDeviceProp prop;
-    cudaGetDeviceProperties(&prop,gpuid);
-    if(!prop.unifiedAddressing) return;
-
-    comm_set_neighbor_ranks();
-
-    char *hostname = comm_hostname();
-
-    int *gpuid_recv_buf = (int *)safe_malloc(sizeof(int)*size);
-
-    // There are more efficient ways to do the following,
-    // but it doesn't really matter since this function should be
-    // called just once.
-    MPI_CHECK( MPI_Allgather(&gpuid, 1, MPI_INT, gpuid_recv_buf, 1, MPI_INT, MPI_COMM_WORLD) );
-
-    for(int dir=0; dir<2; ++dir){ // backward/forward directions
-      for(int dim=0; dim<4; ++dim){
-	int neighbor_rank = comm_neighbor_rank(dir,dim);
-	if(neighbor_rank == rank) continue;
-
-	// disable peer-to-peer comms in one direction
-	if ( ((rank > neighbor_rank && dir == 0) || (rank < neighbor_rank && dir == 1)) &&
-	     disable_peer_to_peer_bidir && comm_dim(dim) == 2 ) continue;
-
-	// if the neighbors are on the same
-	if (!strncmp(hostname, &hostname_recv_buf[128*neighbor_rank], 128)) {
-	  int neighbor_gpuid = gpuid_recv_buf[neighbor_rank];
-	  int canAccessPeer[2];
-	  cudaDeviceCanAccessPeer(&canAccessPeer[0], gpuid, neighbor_gpuid);
-	  cudaDeviceCanAccessPeer(&canAccessPeer[1], neighbor_gpuid, gpuid);
-
-      // this was introduced with CUDA 8
-#if CUDA_VERSION >= 8000
-      int accessRank[2];
-      cudaDeviceGetP2PAttribute(&accessRank[0], cudaDevP2PAttrPerformanceRank, gpuid, neighbor_gpuid);
-      cudaDeviceGetP2PAttribute(&accessRank[1], cudaDevP2PAttrPerformanceRank, neighbor_gpuid, gpuid);
-#endif
-
-	  if(canAccessPeer[0]*canAccessPeer[1]){
-	    peer2peer_enabled[dir][dim] = true;
-	    if (getVerbosity() > QUDA_SILENT)
-	      printf("Peer-to-peer enabled for rank %d (gpu=%d) with neighbor %d (gpu=%d) dir=%d, dim=%d, performance rank = (%d, %d)\n",
-#if CUDA_VERSION >= 8000
-                  comm_rank(), gpuid, neighbor_rank, neighbor_gpuid, dir, dim, accessRank[0], accessRank[1]);
-#else
-                  // default to 0 for CUDA < 8
-                  comm_rank(), gpuid, neighbor_rank, neighbor_gpuid, dir, dim, 0, 0);
-#endif
-	  }
-	} // on the same node
-      } // different dimensions - x, y, z, t
-    } // different directions - forward/backward
-
-    host_free(gpuid_recv_buf);
-  }
-
-  peer2peer_init = true;
-
-  // set gdr enablement
-  if (comm_gdr_enabled()) {
-    printfQuda("Enabling GPU-Direct RDMA access\n");
-  } else {
-    printfQuda("Disabling GPU-Direct RDMA access\n");
-  }
-
-  checkCudaErrorNoSync();
-  return;
-}
-
-
-bool comm_peer2peer_enabled(int dir, int dim){
-  return peer2peer_enabled[dir][dim];
-}
-
 
 int comm_rank(void)
 {

--- a/lib/comm_qmp.cpp
+++ b/lib/comm_qmp.cpp
@@ -134,6 +134,14 @@ void comm_peer2peer_init(const char* hostname_recv_buf)
     disable_peer_to_peer = true;
   }
 
+  // disable peer-to-peer comms in one direction if QUDA_ENABLE_P2P=-1
+  // and comm_dim(dim) == 2 (used for perf benchmarking)
+  bool disable_peer_to_peer_bidir = false;
+  if (enable_peer_to_peer_env && strcmp(enable_peer_to_peer_env, "-1") == 0) {
+    if (getVerbosity() > QUDA_SILENT) printfQuda("Disabling bi-directional peer-to-peer access\n");
+    disable_peer_to_peer_bidir = true;
+  }
+
   if (!peer2peer_init && !disable_peer_to_peer) {
 
     // first check that the local GPU supports UVA
@@ -152,6 +160,10 @@ void comm_peer2peer_init(const char* hostname_recv_buf)
       for(int dim=0; dim<4; ++dim){
 	int neighbor_rank = comm_neighbor_rank(dir,dim);
 	if(neighbor_rank == comm_rank()) continue;
+
+	// disable peer-to-peer comms in one direction
+	if ( ((rank > neighbor_rank && dir == 0) || (rank < neighbor_rank && dir == 1)) &&
+	     disable_peer_to_peer_bidir && comm_dim(dim) == 2 ) continue;
 
 	// if the neighbors are on the same
 	if (!strncmp(hostname, &hostname_recv_buf[128*neighbor_rank], 128)) {

--- a/lib/comm_qmp.cpp
+++ b/lib/comm_qmp.cpp
@@ -15,9 +15,6 @@ struct MsgHandle_s {
 };
 
 static int gpuid = -1;
-static bool peer2peer_enabled[2][4] = { {false,false,false,false},
-                                        {false,false,false,false} };
-static bool peer2peer_init = false;
 
 static char partition_string[16];
 static char topology_string[16];
@@ -31,7 +28,10 @@ static char topology_string[16];
 #include <mpi.h>
 #endif
 
-void get_hostnames(char *hostname_recv_buf) {
+// There are more efficient ways to do the following,
+// but it doesn't really matter since this function should be
+// called just once.
+void comm_gather_hostname(char *hostname_recv_buf) {
   // determine which GPU this rank will use
   char *hostname = comm_hostname();
 
@@ -54,13 +54,16 @@ void get_hostnames(char *hostname_recv_buf) {
 }
 
 
-void get_gpuid(int *gpuid_recv_buf) {
+// There are more efficient ways to do the following,
+// but it doesn't really matter since this function should be
+// called just once.
+void comm_gather_gpuid(int *gpuid_recv_buf) {
 
 #ifdef USE_MPI_GATHER
   MPI_Allgather(&gpuid, 1, MPI_INT, gpuid_recv_buf, 1, MPI_INT, MPI_COMM_WORLD);
 #else
   // Abuse reductions to emulate all-gather.  We need to copy the
-  // local hostname to all other nodes
+  // local gpu to all other nodes
   for (int i=0; i<comm_size(); i++) {
     int data = (i == comm_rank()) ? gpuid : 0;
     QMP_sum_int(&data);
@@ -90,7 +93,7 @@ void comm_init(int ndim, const int *dims, QudaCommsMap rank_from_coords, void *m
 
   // determine which GPU this rank will use
   char *hostname_recv_buf = (char *)safe_malloc(128*comm_size());
-  get_hostnames(hostname_recv_buf);
+  comm_gather_hostname(hostname_recv_buf);
 
   gpuid = 0;
   for (int i = 0; i < comm_rank(); i++) {
@@ -121,87 +124,6 @@ void comm_init(int ndim, const int *dims, QudaCommsMap rank_from_coords, void *m
   snprintf(partition_string, 16, ",comm=%d%d%d%d", comm_dim_partitioned(0), comm_dim_partitioned(1), comm_dim_partitioned(2), comm_dim_partitioned(3));
   snprintf(topology_string, 16, ",topo=%d%d%d%d", comm_dim(0), comm_dim(1), comm_dim(2), comm_dim(3));
 }
-
-void comm_peer2peer_init(const char* hostname_recv_buf)
-{
-  if (peer2peer_init) return;
-
-  bool disable_peer_to_peer = false;
-  char *enable_peer_to_peer_env = getenv("QUDA_ENABLE_P2P");
-  if (enable_peer_to_peer_env && strcmp(enable_peer_to_peer_env, "0") == 0) {
-    if (getVerbosity() > QUDA_SILENT)
-      printfQuda("Disabling peer-to-peer access\n");
-    disable_peer_to_peer = true;
-  }
-
-  // disable peer-to-peer comms in one direction if QUDA_ENABLE_P2P=-1
-  // and comm_dim(dim) == 2 (used for perf benchmarking)
-  bool disable_peer_to_peer_bidir = false;
-  if (enable_peer_to_peer_env && strcmp(enable_peer_to_peer_env, "-1") == 0) {
-    if (getVerbosity() > QUDA_SILENT) printfQuda("Disabling bi-directional peer-to-peer access\n");
-    disable_peer_to_peer_bidir = true;
-  }
-
-  if (!peer2peer_init && !disable_peer_to_peer) {
-
-    // first check that the local GPU supports UVA
-    cudaDeviceProp prop;
-    cudaGetDeviceProperties(&prop,gpuid);
-    if(!prop.unifiedAddressing) return;
-
-    comm_set_neighbor_ranks();
-
-    char *hostname = comm_hostname();
-    int *gpuid_recv_buf = (int *)safe_malloc(sizeof(int)*comm_size());
-
-    get_gpuid(gpuid_recv_buf);
-
-    for(int dir=0; dir<2; ++dir){ // forward/backward directions
-      for(int dim=0; dim<4; ++dim){
-	int neighbor_rank = comm_neighbor_rank(dir,dim);
-	if(neighbor_rank == comm_rank()) continue;
-
-	// disable peer-to-peer comms in one direction
-	if ( ((rank > neighbor_rank && dir == 0) || (rank < neighbor_rank && dir == 1)) &&
-	     disable_peer_to_peer_bidir && comm_dim(dim) == 2 ) continue;
-
-	// if the neighbors are on the same
-	if (!strncmp(hostname, &hostname_recv_buf[128*neighbor_rank], 128)) {
-	  int neighbor_gpuid = gpuid_recv_buf[neighbor_rank];
-	  int canAccessPeer[2];
-	  cudaDeviceCanAccessPeer(&canAccessPeer[0], gpuid, neighbor_gpuid);
-	  cudaDeviceCanAccessPeer(&canAccessPeer[1], neighbor_gpuid, gpuid);
-	  if(canAccessPeer[0]*canAccessPeer[1]){
-	    peer2peer_enabled[dir][dim] = true;
-	    if (getVerbosity() > QUDA_SILENT)
-	      printf("Peer-to-peer enabled for rank %d gpu=%d with neighbor %d gpu=%d dir=%d, dim=%d\n",
-		     comm_rank(), gpuid, neighbor_rank, neighbor_gpuid, dir, dim);
-	  }
-	} // on the same node
-      } // different dimensions - x, y, z, t
-    } // different directions - forward/backward
-
-    host_free(gpuid_recv_buf);
-  }
-
-  peer2peer_init = true;
-
-  // set gdr enablement
-  if (comm_gdr_enabled()) {
-    printfQuda("Enabling GPU-Direct RDMA access\n");
-  } else {
-    printfQuda("Disabling GPU-Direct RDMA access\n");
-  }
-
-  checkCudaErrorNoSync();
-  return;
-}
-
-
-bool comm_peer2peer_enabled(int dir, int dim){
-  return peer2peer_enabled[dir][dim];
-}
-
 
 int comm_rank(void)
 {

--- a/lib/comm_single.cpp
+++ b/lib/comm_single.cpp
@@ -3,6 +3,7 @@
  */
 
 #include <stdlib.h>
+#include <string.h>
 #include <csignal>
 #include <comm_quda.h>
 
@@ -15,15 +16,19 @@ void comm_init(int ndim, const int *dims, QudaCommsMap rank_from_coords, void *m
   comm_set_default_topology(topo);
 }
 
-void comm_peer2peer_init(const char *hostname_buf) {}
-
-bool comm_peer2peer_enabled(int die, int dim) { return false; }
-
 int comm_rank(void) { return 0; }
 
 int comm_size(void) { return 1; }
 
 int comm_gpuid(void) { return 0; }
+
+void comm_gather_hostname(char *hostname_recv_buf) {
+  strncpy(hostname_recv_buf, comm_hostname(), 128);
+}
+
+void comm_gather_gpuid(int *gpuid_recv_buf) {
+  gpuid_recv_buf[0] = comm_gpuid();
+}
 
 MsgHandle *comm_declare_send_displaced(void *buffer, const int displacement[], size_t nbytes)
 { return NULL; }

--- a/lib/cuda_color_spinor_field.cu
+++ b/lib/cuda_color_spinor_field.cu
@@ -962,7 +962,7 @@ namespace quda {
 
     int dim = dir/2;
     if (!commDimPartitioned(dim)) return;
-    if (gdr && !comm_gdr_enabled()) errorQuda("Requesting GDR comms but not GDR is not enabled");
+    if (gdr && !comm_gdr_enabled()) errorQuda("Requesting GDR comms but GDR is not enabled");
 
     if (dir%2 == 0) { // sending backwards
       if (comm_peer2peer_enabled(1,dim)) {
@@ -993,7 +993,7 @@ namespace quda {
     int dim = d/2;
     int dir = d%2;
     if (!commDimPartitioned(dim)) return;
-    if (gdr && !comm_gdr_enabled()) errorQuda("Requesting GDR comms but not GDR is not enabled");
+    if (gdr && !comm_gdr_enabled()) errorQuda("Requesting GDR comms but GDR is not enabled");
 
     int Nvec = (nSpin == 1 || precision == QUDA_DOUBLE_PRECISION) ? 2 : 4;
     int Nint = (nColor * nSpin * 2)/(nSpin == 4 ? 2 : 1); // (spin proj.) degrees of freedom
@@ -1133,52 +1133,42 @@ namespace quda {
 
     int dim = dir/2;
     if (!commDimPartitioned(dim)) return 0;
-    if (gdr && !comm_gdr_enabled()) errorQuda("Requesting GDR comms but not GDR is not enabled");
+    if (gdr && !comm_gdr_enabled()) errorQuda("Requesting GDR comms but GDR is not enabled");
 
     if (dir%2==0) {
 
-      if (comm_peer2peer_enabled(1,dim)) {
-	if (!complete_recv_fwd[dim]) complete_recv_fwd[dim] = comm_query(mh_recv_p2p_fwd[bufferIndex][dim]);
-      } else if (gdr) {
-	if (!complete_recv_fwd[dim]) complete_recv_fwd[dim] = comm_query(mh_recv_rdma_fwd[bufferIndex][dim]);
-      } else {
-	if (!complete_recv_fwd[dim]) complete_recv_fwd[dim] = comm_query(mh_recv_fwd[bufferIndex][dim]);
-      }
-
       if (comm_peer2peer_enabled(0,dim)) {
 	if (!complete_send_back[dim]) complete_send_back[dim] = comm_query(mh_send_p2p_back[bufferIndex][dim]);
+	if (!complete_recv_back[dim]) complete_recv_back[dim] = comm_query(mh_recv_p2p_back[bufferIndex][dim]);
       } else if (gdr) {
 	if (!complete_send_back[dim]) complete_send_back[dim] = comm_query(mh_send_rdma_back[bufferIndex][dim]);
+	if (!complete_recv_back[dim]) complete_recv_back[dim] = comm_query(mh_recv_rdma_back[bufferIndex][dim]);
       } else {
 	if (!complete_send_back[dim]) complete_send_back[dim] = comm_query(mh_send_back[bufferIndex][dim]);
+	if (!complete_recv_back[dim]) complete_recv_back[dim] = comm_query(mh_recv_back[bufferIndex][dim]);
       }
 
-      if (complete_recv_fwd[dim] && complete_send_back[dim]) {
-	complete_recv_fwd[dim] = false;
+      if (complete_recv_back[dim] && complete_send_back[dim]) {
+	complete_recv_back[dim] = false;
 	complete_send_back[dim] = false;
 	return 1;
       }
 
     } else { // dir%2 == 1
 
-      if (comm_peer2peer_enabled(0,dim)) {
-	if (!complete_recv_back[dim]) complete_recv_back[dim] = comm_query(mh_recv_p2p_back[bufferIndex][dim]);
-      } else if (gdr) {
-	if (!complete_recv_back[dim]) complete_recv_back[dim] = comm_query(mh_recv_rdma_back[bufferIndex][dim]);
-      } else {
-	if (!complete_recv_back[dim]) complete_recv_back[dim] = comm_query(mh_recv_back[bufferIndex][dim]);
-      }
-
       if (comm_peer2peer_enabled(1,dim)) {
 	if (!complete_send_fwd[dim]) complete_send_fwd[dim] = comm_query(mh_send_p2p_fwd[bufferIndex][dim]);
+	if (!complete_recv_fwd[dim]) complete_recv_fwd[dim] = comm_query(mh_recv_p2p_fwd[bufferIndex][dim]);
       } else if (gdr) {
 	if (!complete_send_fwd[dim]) complete_send_fwd[dim] = comm_query(mh_send_rdma_fwd[bufferIndex][dim]);
+	if (!complete_recv_fwd[dim]) complete_recv_fwd[dim] = comm_query(mh_recv_rdma_fwd[bufferIndex][dim]);
       } else {
 	if (!complete_send_fwd[dim]) complete_send_fwd[dim] = comm_query(mh_send_fwd[bufferIndex][dim]);
+	if (!complete_recv_fwd[dim]) complete_recv_fwd[dim] = comm_query(mh_recv_fwd[bufferIndex][dim]);
       }
 
-      if (complete_recv_back[dim] && complete_send_fwd[dim]) {
-	complete_recv_back[dim] = false;
+      if (complete_recv_fwd[dim] && complete_send_fwd[dim]) {
+	complete_recv_fwd[dim] = false;
 	complete_send_fwd[dim] = false;
 	return 1;
       }
@@ -1191,45 +1181,38 @@ namespace quda {
   void cudaColorSpinorField::commsWait(int nFace, int dir, int dagger, cudaStream_t *stream_p, bool gdr) {
     int dim = dir / 2;
     if (!commDimPartitioned(dim)) return;
-    if (gdr && !comm_gdr_enabled()) errorQuda("Requesting GDR comms but not GDR is not enabled");
+    if (gdr && !comm_gdr_enabled()) errorQuda("Requesting GDR comms but GDR is not enabled");
 
     if (dir%2==0) {
+
+      if (comm_peer2peer_enabled(0,dim)) {
+	comm_wait(mh_recv_p2p_back[bufferIndex][dim]);
+	cudaEventSynchronize(ipcRemoteCopyEvent[bufferIndex][0][dim]);
+	comm_wait(mh_send_p2p_back[bufferIndex][dim]);
+	cudaEventSynchronize(ipcCopyEvent[bufferIndex][0][dim]);
+      } else if (gdr) {
+	comm_wait(mh_recv_rdma_back[bufferIndex][dim]);
+	comm_wait(mh_send_rdma_back[bufferIndex][dim]);
+      } else {
+	comm_wait(mh_recv_back[bufferIndex][dim]);
+	comm_wait(mh_send_back[bufferIndex][dim]);
+      }
+
+    } else {
 
       if (comm_peer2peer_enabled(1,dim)) {
 	comm_wait(mh_recv_p2p_fwd[bufferIndex][dim]);
 	cudaEventSynchronize(ipcRemoteCopyEvent[bufferIndex][1][dim]);
-      } else if (gdr) {
-	comm_wait(mh_recv_rdma_fwd[bufferIndex][dim]);
-      } else {
-	comm_wait(mh_recv_fwd[bufferIndex][dim]);
-      }
-
-      if (comm_peer2peer_enabled(0,dim)) {
-	comm_wait(mh_send_p2p_back[bufferIndex][dim]);
-	cudaEventSynchronize(ipcCopyEvent[bufferIndex][0][dim]);
-      } else if (gdr) {
-	comm_wait(mh_send_rdma_back[bufferIndex][dim]);
-      } else {
-	comm_wait(mh_send_back[bufferIndex][dim]);
-      }
-    } else {
-      if (comm_peer2peer_enabled(0,dim)) {
-	comm_wait(mh_recv_p2p_back[bufferIndex][dim]);
-	cudaEventSynchronize(ipcRemoteCopyEvent[bufferIndex][0][dim]);
-      } else if (gdr) {
-	comm_wait(mh_recv_rdma_back[bufferIndex][dim]);
-      } else {
-	comm_wait(mh_recv_back[bufferIndex][dim]);
-      }
-
-      if (comm_peer2peer_enabled(1,dim)) {
 	comm_wait(mh_send_p2p_fwd[bufferIndex][dim]);
 	cudaEventSynchronize(ipcCopyEvent[bufferIndex][1][dim]);
       } else if (gdr) {
+	comm_wait(mh_recv_rdma_fwd[bufferIndex][dim]);
 	comm_wait(mh_send_rdma_fwd[bufferIndex][dim]);
       } else {
+	comm_wait(mh_recv_fwd[bufferIndex][dim]);
 	comm_wait(mh_send_fwd[bufferIndex][dim]);
       }
+
     }
 
     return;
@@ -1266,7 +1249,7 @@ namespace quda {
  
   void cudaColorSpinorField::exchangeGhost(QudaParity parity, int nFace, int dagger, const MemoryLocation *pack_destination_,
 					   const MemoryLocation *halo_location_, bool gdr_send, bool gdr_recv)  const {
-    if ((gdr_send || gdr_recv) && !comm_gdr_enabled()) errorQuda("Requesting GDR comms but not GDR is not enabled");
+    if ((gdr_send || gdr_recv) && !comm_gdr_enabled()) errorQuda("Requesting GDR comms but GDR is not enabled");
     const_cast<cudaColorSpinorField&>(*this).createComms(nFace, false);
 
     // first set default values to device if needed

--- a/lib/dslash_policy.cuh
+++ b/lib/dslash_policy.cuh
@@ -253,7 +253,7 @@ struct DslashBasic : DslashPolicyImp {
 
 	// if peer-2-peer in a given direction then we need only wait on that copy event to finish
 	// else we post an event in the scatter stream and wait on that
-        if (!pattern.dslashCompleted[2*i] && pattern.commsCompleted[2*i] && pattern.commsCompleted[2*i+1] ) {
+        if ( (i==3 || pattern.dslashCompleted[2*(i+1)]) && !pattern.dslashCompleted[2*i] && pattern.commsCompleted[2*i] && pattern.commsCompleted[2*i+1] ) {
 	  if (comm_peer2peer_enabled(0,i)) {
 	    PROFILE(cudaStreamWaitEvent(streams[Nstream-1], inputSpinor->getIPCRemoteCopyEvent(0,i), 0),
 		    profile, QUDA_PROFILE_STREAM_WAIT_EVENT);
@@ -549,7 +549,7 @@ struct DslashGPUComms : DslashPolicyImp {
 
         } // dir=0,1
 
-        if (!pattern.dslashCompleted[2*i] && pattern.commsCompleted[2*i] && pattern.commsCompleted[2*i+1] ) {
+	if ( (i==3 || pattern.dslashCompleted[2*(i+1)]) && !pattern.dslashCompleted[2*i] && pattern.commsCompleted[2*i] && pattern.commsCompleted[2*i+1] ) {
 	  dslashParam.kernel_type = static_cast<KernelType>(i);
 	  dslashParam.threads = dslash.Nface()*faceVolumeCB[i]; // updating 2 or 6 faces
 
@@ -950,7 +950,7 @@ struct DslashAsync : DslashPolicyImp {
 
 	// if peer-2-peer in a given direction then we need only wait on that copy event to finish
 	// else we post an event in the scatter stream and wait on that
-        if (!pattern.dslashCompleted[2*i] && pattern.commsCompleted[2*i] && pattern.commsCompleted[2*i+1] ) {
+	if ( (i==3 || pattern.dslashCompleted[2*(i+1)]) && !pattern.dslashCompleted[2*i] && pattern.commsCompleted[2*i] && pattern.commsCompleted[2*i+1] ) {
 	  if (comm_peer2peer_enabled(0,i)) {
 	    PROFILE(cudaStreamWaitEvent(streams[Nstream-1], inputSpinor->getIPCRemoteCopyEvent(0,i), 0),
 		    profile, QUDA_PROFILE_STREAM_WAIT_EVENT);
@@ -1260,7 +1260,7 @@ struct DslashZeroCopyPack : DslashPolicyImp {
 
 	// if peer-2-peer in a given direction then we need only wait on that copy event to finish
 	// else we post an event in the scatter stream and wait on that
-        if (!pattern.dslashCompleted[2*i] && pattern.commsCompleted[2*i] && pattern.commsCompleted[2*i+1] ) {
+	if ( (i==3 || pattern.dslashCompleted[2*(i+1)]) && !pattern.dslashCompleted[2*i] && pattern.commsCompleted[2*i] && pattern.commsCompleted[2*i+1] ) {
 	  if (comm_peer2peer_enabled(0,i)) {
 	    PROFILE(cudaStreamWaitEvent(streams[Nstream-1], inputSpinor->getIPCRemoteCopyEvent(0,i), 0),
 		    profile, QUDA_PROFILE_STREAM_WAIT_EVENT);
@@ -1537,7 +1537,7 @@ struct DslashZeroCopy : DslashPolicyImp {
 
 	// FIXME - will not work with P2P until we can split where the halos originate
 	// enqueue the boundary dslash kernel as soon as the scatters have been enqueued
-	if (!pattern.dslashCompleted[2*i] && pattern.commsCompleted[2*i] && pattern.commsCompleted[2*i+1] ) {
+	if ( (i==3 || pattern.dslashCompleted[2*(i+1)]) && !pattern.dslashCompleted[2*i] && pattern.commsCompleted[2*i] && pattern.commsCompleted[2*i+1] ) {
 	  dslashParam.kernel_type = static_cast<KernelType>(i);
 	  dslashParam.threads = dslash.Nface()*faceVolumeCB[i]; // updating 2 or 6 faces
 

--- a/lib/lattice_field.cpp
+++ b/lib/lattice_field.cpp
@@ -328,7 +328,8 @@ namespace quda {
       // open the remote memory handles and set the send ghost pointers
       for (int dim=0; dim<4; ++dim) {
 	if (comm_dim(dim)==1) continue;
-	const int num_dir = (comm_dim(dim) == 2) ? 1 : 2;
+	// even if comm_dim(2) == 2, we not have p2p enabled in both directions, so check this
+	const int num_dir = (comm_dim(dim) == 2 && comm_peer2peer_enabled(0,dim) && comm_peer2peer_enabled(1,dim)) ? 1 : 2;
 	for (int dir=0; dir<num_dir; ++dir) {
 	  if (!comm_peer2peer_enabled(dir,dim)) continue;
 	  void **ghostDest = &(ghost_remote_send_buffer_d[b][dim][dir]);
@@ -431,7 +432,7 @@ namespace quda {
     for (int dim=0; dim<4; ++dim) {
 
       if (comm_dim(dim)==1) continue;
-      const int num_dir = (comm_dim(dim) == 2) ? 1 : 2;
+      const int num_dir = (comm_dim(dim) == 2 && comm_peer2peer_enabled(0,dim) && comm_peer2peer_enabled(1,dim)) ? 1 : 2;
 
       for (int b=0; b<2; b++) {
 	if (comm_peer2peer_enabled(1,dim)) {

--- a/tests/blas_test.cu
+++ b/tests/blas_test.cu
@@ -13,6 +13,8 @@
 // google test
 #include <gtest.h>
 
+extern int test_type;
+extern QudaPrecision prec;
 extern QudaDslashType dslash_type;
 extern QudaInverterType inv_type;
 extern int nvec;
@@ -70,6 +72,13 @@ display_test_info()
 int Nprec = 3;
 
 bool skip_kernel(int precision, int kernel) {
+  // if we've selected a given kernel then make sure we only run that
+  if (test_type != -1 && kernel != test_type) return true;
+
+  // if we've selected a given precision then make sure we only run that
+  QudaPrecision this_prec = precision == 2 ? QUDA_DOUBLE_PRECISION : precision  == 1 ? QUDA_SINGLE_PRECISION : QUDA_HALF_PRECISION;
+  if (prec != QUDA_INVALID_PRECISION && this_prec != prec) return true;
+
   if ( Nspin == 2 && precision == 0) {
     // avoid half precision tests if doing coarse fields
     return true;
@@ -948,6 +957,9 @@ const char *names[] = {
 
 int main(int argc, char** argv)
 {
+  prec = QUDA_INVALID_PRECISION;
+  test_type = -1;
+
   for (int i = 1; i < argc; i++){
     if(process_command_line_option(argc, argv, &i) == 0){
       continue;

--- a/tests/dslash_test.cpp
+++ b/tests/dslash_test.cpp
@@ -447,15 +447,32 @@ void end() {
 
 }
 
+struct DslashTime {
+  double event_time;
+  double cpu_time;
+  double cpu_min;
+  double cpu_max;
+
+  DslashTime() : event_time(0.0), cpu_time(0.0), cpu_min(DBL_MAX), cpu_max(0.0) {}
+};
+
 // execute kernel
-double dslashCUDA(int niter) {
+DslashTime dslashCUDA(int niter) {
+
+  DslashTime dslash_time;
+  timeval tstart, tstop;
 
   cudaEvent_t start, end;
   cudaEventCreate(&start);
   cudaEventCreate(&end);
+
+  comm_barrier();
   cudaEventRecord(start, 0);
 
   for (int i = 0; i < niter; i++) {
+
+    gettimeofday(&tstart, NULL);
+
     if (dslash_type == QUDA_DOMAIN_WALL_4D_DSLASH){
       switch (test_type) {
         case 0:
@@ -592,6 +609,18 @@ double dslashCUDA(int niter) {
           break;
       }
     }
+
+    gettimeofday(&tstop, NULL);
+    long ds = tstop.tv_sec - tstart.tv_sec;
+    long dus = tstop.tv_usec - tstart.tv_usec;
+    double elapsed = ds + 0.000001*dus;
+
+    dslash_time.cpu_time += elapsed;
+    // skip first and last iterations since they may skew these metrics if comms are not synchronous
+    if (i>0 && i<niter) {
+      if (elapsed < dslash_time.cpu_min) dslash_time.cpu_min = elapsed;
+      if (elapsed > dslash_time.cpu_max) dslash_time.cpu_max = elapsed;
+    }
   }
     
   cudaEventRecord(end, 0);
@@ -601,14 +630,14 @@ double dslashCUDA(int niter) {
   cudaEventDestroy(start);
   cudaEventDestroy(end);
 
-  double secs = runTime / 1000; //stopwatchReadSeconds();
+  dslash_time.event_time = runTime / 1000;
 
   // check for errors
   cudaError_t stat = cudaGetLastError();
   if (stat != cudaSuccess)
     printfQuda("with ERROR: %s\n", cudaGetErrorString(stat));
 
-  return secs;
+  return dslash_time;
 }
 
 void dslashRef() {
@@ -977,19 +1006,22 @@ int main(int argc, char **argv)
     }
     printfQuda("Executing %d kernel loops...\n", niter);
     if (!transfer) dirac->Flops();
-    double secs = dslashCUDA(niter);
+    DslashTime dslash_time = dslashCUDA(niter);
     printfQuda("done.\n\n");
 
     if (!transfer) *spinorOut = *cudaSpinorOut;
 
     // print timing information
-    printfQuda("%fus per kernel call\n", 1e6*secs / niter);
+    printfQuda("%fus per kernel call\n", 1e6*dslash_time.event_time / niter);
     //FIXME No flops count for twisted-clover yet
     unsigned long long flops = 0;
     if (!transfer) flops = dirac->Flops();
-    printfQuda("GFLOPS = %f\n", 1.0e-9*flops/secs);
-    printfQuda("Effective halo bi-directional bandwidth = %f for aggregate message size %lu bytes\n",
-	       1.0e-9*2*cudaSpinor->GhostBytes()*niter/secs, 2*cudaSpinor->GhostBytes());
+    printfQuda("GFLOPS = %f\n", 1.0e-9*flops/dslash_time.event_time);
+
+    printfQuda("Effective halo bi-directional bandwidth (GB/s) GPU = %f ( CPU = %f, min = %f , max = %f ) for aggregate message size %lu bytes\n",
+	       1.0e-9*2*cudaSpinor->GhostBytes()*niter/dslash_time.event_time, 1.0e-9*2*cudaSpinor->GhostBytes()*niter/dslash_time.cpu_time,
+	       1.0e-9*2*cudaSpinor->GhostBytes()/dslash_time.cpu_max, 1.0e-9*2*cudaSpinor->GhostBytes()/dslash_time.cpu_min,
+	       2*cudaSpinor->GhostBytes());
 
     double norm2_cpu = blas::norm2(*spinorRef);
     double norm2_cpu_cuda= blas::norm2(*spinorOut);

--- a/tests/staggered_dslash_test.cpp
+++ b/tests/staggered_dslash_test.cpp
@@ -321,6 +321,9 @@ struct DslashTime {
 
 DslashTime dslashCUDA(int niter) {
 
+  DslashTime dslash_time;
+  timeval tstart, tstop;
+
   cudaEvent_t start, end;
   cudaEventCreate(&start);
   cudaEventRecord(start, 0);
@@ -453,11 +456,11 @@ static int dslashTest()
 
     if (!transfer) *spinorOut = *cudaSpinorOut;
 
-    printfQuda("\n%fms per loop\n", 1000*secs);
+    printfQuda("%fus per kernel call\n", 1e6*dslash_time.event_time / niter);
     staggeredDslashRef();
 
     unsigned long long flops = dirac->Flops();
-    printfQuda("GFLOPS = %f\n", 1.0e-9*flops/secs);
+    printfQuda("GFLOPS = %f\n", 1.0e-9*flops/dslash_time.event_time);
 
     printfQuda("Effective halo bi-directional bandwidth (GB/s) GPU = %f ( CPU = %f, min = %f , max = %f ) for aggregate message size %lu bytes\n",
 	       1.0e-9*2*cudaSpinor->GhostBytes()*niter/dslash_time.event_time, 1.0e-9*2*cudaSpinor->GhostBytes()*niter/dslash_time.cpu_time,

--- a/tests/staggered_dslash_test.cpp
+++ b/tests/staggered_dslash_test.cpp
@@ -310,14 +310,29 @@ void end(void)
   endQuda();
 }
 
-double dslashCUDA(int niter) {
+struct DslashTime {
+  double event_time;
+  double cpu_time;
+  double cpu_min;
+  double cpu_max;
+
+  DslashTime() : event_time(0.0), cpu_time(0.0), cpu_min(DBL_MAX), cpu_max(0.0) {}
+};
+
+DslashTime dslashCUDA(int niter) {
 
   cudaEvent_t start, end;
   cudaEventCreate(&start);
   cudaEventRecord(start, 0);
   cudaEventSynchronize(start);
 
+  comm_barrier();
+  cudaEventRecord(start, 0);
+
   for (int i = 0; i < niter; i++) {
+
+    gettimeofday(&tstart, NULL);
+
     switch (test_type) {
       case 0:
         if (transfer){
@@ -341,6 +356,18 @@ double dslashCUDA(int niter) {
           dirac->M(*cudaSpinorOut, *cudaSpinor);
         }
     }
+
+    gettimeofday(&tstop, NULL);
+    long ds = tstop.tv_sec - tstart.tv_sec;
+    long dus = tstop.tv_usec - tstart.tv_usec;
+    double elapsed = ds + 0.000001*dus;
+
+    dslash_time.cpu_time += elapsed;
+    // skip first and last iterations since they may skew these metrics if comms are not synchronous
+    if (i>0 && i<niter) {
+      if (elapsed < dslash_time.cpu_min) dslash_time.cpu_min = elapsed;
+      if (elapsed > dslash_time.cpu_max) dslash_time.cpu_max = elapsed;
+    }
   }
 
   cudaEventCreate(&end);
@@ -351,14 +378,14 @@ double dslashCUDA(int niter) {
   cudaEventDestroy(start);
   cudaEventDestroy(end);
 
-  double secs = runTime / 1000; //stopwatchReadSeconds();
+  dslash_time.event_time = runTime / 1000;
 
   // check for errors
   cudaError_t stat = cudaGetLastError();
   if (stat != cudaSuccess)
     errorQuda("with ERROR: %s\n", cudaGetErrorString(stat));
 
-  return secs;
+  return dslash_time;
 }
 
 void staggeredDslashRef()
@@ -422,7 +449,7 @@ static int dslashTest()
     // reset flop counter
     dirac->Flops();
 
-    double secs = dslashCUDA(niter);
+    DslashTime dslash_time = dslashCUDA(niter);
 
     if (!transfer) *spinorOut = *cudaSpinorOut;
 
@@ -431,8 +458,11 @@ static int dslashTest()
 
     unsigned long long flops = dirac->Flops();
     printfQuda("GFLOPS = %f\n", 1.0e-9*flops/secs);
-    printfQuda("Effective halo bi-directional bandwidth = %f for aggregate message size %lu bytes\n",
-	       1.0e-9*2*cudaSpinor->GhostBytes()*niter/secs, 2*cudaSpinor->GhostBytes());
+
+    printfQuda("Effective halo bi-directional bandwidth (GB/s) GPU = %f ( CPU = %f, min = %f , max = %f ) for aggregate message size %lu bytes\n",
+	       1.0e-9*2*cudaSpinor->GhostBytes()*niter/dslash_time.event_time, 1.0e-9*2*cudaSpinor->GhostBytes()*niter/dslash_time.cpu_time,
+	       1.0e-9*2*cudaSpinor->GhostBytes()/dslash_time.cpu_max, 1.0e-9*2*cudaSpinor->GhostBytes()/dslash_time.cpu_min,
+	       2*cudaSpinor->GhostBytes());
 
     double spinor_ref_norm2 = blas::norm2(*spinorRef);
     double spinor_out_norm2 =  blas::norm2(*spinorOut);


### PR DESCRIPTION
* Important bug fix for a latent race condition in the dslash: was triggered if in a given dimension, the MPI communication in a given direction completed before the local peer-to-peer communication  completed in the other direction in the same dimension.  This scenario only really applies to systems with first-class GPU RDMA support where MPI could complete in comparable time as peer-to-peer.
* Ensure that split kernel dslash halo kernels run in order T->X to prevent any possible race conditions if lower dimensions complete before high dimensions.  This ensures reproducibility of dslash computation. 
* Added option to environment variable `QUDA_ENABLE_P2P=-1`: if the process topology is length 2, then enabling this will only allow half of the network traffic to traverse peer-to-peer and force the other half to traverse MPI.  Useful to extrapolating performance at high node counts. 
* Improved reporting statistics for bi-directional bandwidth of dslash_test
* Targeted kernel and precision testing of blas_test, since this now respects `--test` and `--prec` flags to overwrite default behaviour