### PR TITLE
remove legacy CUDA_TOOLKIT_ROOTDIR dependency from FindCUDALibs.

### DIFF
--- a/cmake/FindCUDALibs.cmake
+++ b/cmake/FindCUDALibs.cmake
@@ -51,6 +51,7 @@
 #   CUDA_nvcuvid_LIBRARY  -- CUDA Video Decoder library.
 #                            Only available for CUDA version 3.2+.
 #                            Windows only.
+#  CUDA_cuda_LIBRARY      
 #
 
 #   James Bigler, NVIDIA Corp (nvidia.com - jbigler)
@@ -99,40 +100,10 @@ endif()
 
 # Always set this convenience variable
 set(CUDA_VERSION_STRING "${CUDA_VERSION}")
+
+
 get_filename_component(cuda_dir "${CMAKE_CUDA_COMPILER}" DIRECTORY)
 
-macro(cuda_unset_libraries)
-  unset(CUDA_cublas_LIBRARY CACHE)
-  unset(CUDA_cublas_device_LIBRARY CACHE)
-  unset(CUDA_cufft_LIBRARY CACHE)
-  unset(CUDA_cupti_LIBRARY CACHE)
-  unset(CUDA_curand_LIBRARY CACHE)
-  unset(CUDA_cusolver_LIBRARY CACHE)
-  unset(CUDA_cusparse_LIBRARY CACHE)
-  unset(CUDA_npp_LIBRARY CACHE)
-  unset(CUDA_nppc_LIBRARY CACHE)
-  unset(CUDA_nppi_LIBRARY CACHE)
-  unset(CUDA_npps_LIBRARY CACHE)
-  unset(CUDA_nvcuvenc_LIBRARY CACHE)
-  unset(CUDA_nvcuvid_LIBRARY CACHE)
-endmacro()
-
-if(NOT "${QUDA_CUDA_DIR_INTERNAL}" STREQUAL "${cuda_dir}")
-  cuda_unset_libraries()
-endif()
-
-
-# # Check to see if the CUDA_TOOLKIT_ROOT_DIR and CUDA_SDK_ROOT_DIR have changed,
-# # if they have then clear the cache variables, so that will be detected again.
-# if(NOT "${CUDA_TOOLKIT_ROOT_DIR}" STREQUAL "${CUDA_TOOLKIT_ROOT_DIR_INTERNAL}")
-#   unset(CUDA_TOOLKIT_TARGET_DIR CACHE)
-#   unset(CUDA_NVCC_EXECUTABLE CACHE)
-#   cuda_unset_include_and_libraries()
-# endif()
-
-# if(NOT "${CUDA_TOOLKIT_TARGET_DIR}" STREQUAL "${CUDA_TOOLKIT_TARGET_DIR_INTERNAL}")
-#   cuda_unset_include_and_libraries()
-# endif()
 
 macro(cuda_find_library_local_first_with_path_ext _var _names _doc _path_ext )
   if(CMAKE_SIZEOF_VOID_P EQUAL 8)
@@ -146,9 +117,6 @@ macro(cuda_find_library_local_first_with_path_ext _var _names _doc _path_ext )
   find_library(${_var}
     NAMES ${_names}
     PATHS  ${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES} "${cuda_dir}/.."
-    # PATHS "${CUDA_TOOLKIT_TARGET_DIR}" "${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES}"
-    #ENV CUDA_PATH
-    #ENV CUDA_LIB_PATH
     PATH_SUFFIXES ${_cuda_64bit_lib_dir}  "lib" "lib64" "${_path_ext}lib/Win32" "${_path_ext}lib" "${_path_ext}libWin32"
     DOC ${_doc}
     NO_DEFAULT_PATH
@@ -175,67 +143,6 @@ macro(find_cuda_helper_libs _name)
   mark_as_advanced(CUDA_${_name}_LIBRARY)
 endmacro()
 
-# # Search for the cuda distribution.
-# if(NOT CUDA_TOOLKIT_ROOT_DIR AND NOT CMAKE_CROSSCOMPILING)
-#   # Search in the CUDA_BIN_PATH first.
-
-#   
-
-
-#   find_path(CUDA_TOOLKIT_ROOT_DIR
-#     NAMES nvcc nvcc.exe
-#     PATHS "${cuda_dir}"
-#       ENV CUDA_TOOLKIT_ROOT
-#       ENV CUDA_PATH
-#       ENV CUDA_BIN_PATH
-#     PATH_SUFFIXES bin bin64
-#     DOC "CUDA Toolkit location."
-#     NO_DEFAULT_PATH
-#     )
-
-#    if (CUDA_TOOLKIT_ROOT_DIR)
-#     string(REGEX REPLACE "[/\\\\]?bin[64]*[/\\\\]?$" "" CUDA_TOOLKIT_ROOT_DIR ${CUDA_TOOLKIT_ROOT_DIR})
-#     # We need to force this back into the cache.
-#     set(CUDA_TOOLKIT_ROOT_DIR ${CUDA_TOOLKIT_ROOT_DIR} CACHE PATH "Toolkit location." FORCE)
-#     set(CUDA_TOOLKIT_TARGET_DIR ${CUDA_TOOLKIT_ROOT_DIR})
-#     set(CUDA_TOOLKIT_ROOT_DIR_INTERNAL "${CUDA_TOOLKIT_ROOT_DIR}" CACHE INTERNAL
-#   "This is the value of the last time CUDA_TOOLKIT_ROOT_DIR was set successfully." FORCE)
-# set(CUDA_TOOLKIT_TARGET_DIR_INTERNAL "${CUDA_TOOLKIT_TARGET_DIR}" CACHE INTERNAL
-#   "This is the value of the last time CUDA_TOOLKIT_TARGET_DIR was set successfully." FORCE)
-#   endif()
-
-#   if (NOT EXISTS ${CUDA_TOOLKIT_ROOT_DIR})
-#     if(CUDA_FIND_REQUIRED)
-#       message(FATAL_ERROR "Specify CUDA_TOOLKIT_ROOT_DIR")
-#     elseif(NOT CUDA_FIND_QUIETLY)
-#       message("CUDA_TOOLKIT_ROOT_DIR not found or specified")
-#     endif()
-#   endif ()
-# endif()
-
-# if(CMAKE_CROSSCOMPILING)
-#   SET (CUDA_TOOLKIT_ROOT $ENV{CUDA_TOOLKIT_ROOT})
-#   if(CMAKE_SYSTEM_PROCESSOR STREQUAL "armv7-a")
-#     # Support for NVPACK
-#     set (CUDA_TOOLKIT_TARGET_NAME "armv7-linux-androideabi")
-#   elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "arm")
-#     # Support for arm cross compilation
-#     set(CUDA_TOOLKIT_TARGET_NAME "armv7-linux-gnueabihf")
-#   elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
-#     # Support for aarch64 cross compilation
-#     if (ANDROID_ARCH_NAME STREQUAL "arm64")
-#       set(CUDA_TOOLKIT_TARGET_NAME "aarch64-linux-androideabi")
-#     else()
-#       set(CUDA_TOOLKIT_TARGET_NAME "aarch64-linux")
-#     endif (ANDROID_ARCH_NAME STREQUAL "arm64")
-#   endif()
-
-#   if (EXISTS "${CUDA_TOOLKIT_ROOT}/targets/${CUDA_TOOLKIT_TARGET_NAME}")
-#     set(CUDA_TOOLKIT_TARGET_DIR "${CUDA_TOOLKIT_ROOT}/targets/${CUDA_TOOLKIT_TARGET_NAME}" CACHE PATH "CUDA Toolkit target location.")
-#     SET (CUDA_TOOLKIT_ROOT_DIR ${CUDA_TOOLKIT_ROOT})
-#     mark_as_advanced(CUDA_TOOLKIT_TARGET_DIR)
-#   endif()
-# endif()
 
 # CUPTI library showed up in cuda toolkit 4.0
 if(NOT CUDA_VERSION VERSION_LESS "4.0")
@@ -269,5 +176,6 @@ if(NOT CUDA_VERSION VERSION_LESS "7.0")
   find_cuda_helper_libs(cusolver)
 endif()
 
-set(QUDA_CUDA_DIR_INTERNAL "${cuda_dir}" CACHE INTERNAL
-  "This is the value of the last time cuda_dir was set successfully." FORCE)
+
+find_cuda_helper_libs(cuda)
+

--- a/cmake/FindCUDALibs.cmake
+++ b/cmake/FindCUDALibs.cmake
@@ -99,7 +99,7 @@ endif()
 
 # Always set this convenience variable
 set(CUDA_VERSION_STRING "${CUDA_VERSION}")
-
+get_filename_component(cuda_dir "${CMAKE_CUDA_COMPILER}" DIRECTORY)
 
 macro(cuda_unset_include_and_libraries)
   unset(CUDA_cublas_LIBRARY CACHE)
@@ -117,17 +117,17 @@ macro(cuda_unset_include_and_libraries)
   unset(CUDA_nvcuvid_LIBRARY CACHE)
 endmacro()
 
-# Check to see if the CUDA_TOOLKIT_ROOT_DIR and CUDA_SDK_ROOT_DIR have changed,
-# if they have then clear the cache variables, so that will be detected again.
-if(NOT "${CUDA_TOOLKIT_ROOT_DIR}" STREQUAL "${CUDA_TOOLKIT_ROOT_DIR_INTERNAL}")
-  unset(CUDA_TOOLKIT_TARGET_DIR CACHE)
-  unset(CUDA_NVCC_EXECUTABLE CACHE)
-  cuda_unset_include_and_libraries()
-endif()
+# # Check to see if the CUDA_TOOLKIT_ROOT_DIR and CUDA_SDK_ROOT_DIR have changed,
+# # if they have then clear the cache variables, so that will be detected again.
+# if(NOT "${CUDA_TOOLKIT_ROOT_DIR}" STREQUAL "${CUDA_TOOLKIT_ROOT_DIR_INTERNAL}")
+#   unset(CUDA_TOOLKIT_TARGET_DIR CACHE)
+#   unset(CUDA_NVCC_EXECUTABLE CACHE)
+#   cuda_unset_include_and_libraries()
+# endif()
 
-if(NOT "${CUDA_TOOLKIT_TARGET_DIR}" STREQUAL "${CUDA_TOOLKIT_TARGET_DIR_INTERNAL}")
-  cuda_unset_include_and_libraries()
-endif()
+# if(NOT "${CUDA_TOOLKIT_TARGET_DIR}" STREQUAL "${CUDA_TOOLKIT_TARGET_DIR_INTERNAL}")
+#   cuda_unset_include_and_libraries()
+# endif()
 
 macro(cuda_find_library_local_first_with_path_ext _var _names _doc _path_ext )
   if(CMAKE_SIZEOF_VOID_P EQUAL 8)
@@ -140,13 +140,15 @@ macro(cuda_find_library_local_first_with_path_ext _var _names _doc _path_ext )
   # (lib/Win32) and the old path (lib).
   find_library(${_var}
     NAMES ${_names}
-    PATHS "${CUDA_TOOLKIT_TARGET_DIR}" "${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES}"
-    ENV CUDA_PATH
-    ENV CUDA_LIB_PATH
-    PATH_SUFFIXES ${_cuda_64bit_lib_dir} "lib" "lib64" "${_path_ext}lib/Win32" "${_path_ext}lib" "${_path_ext}libWin32"
+    PATHS  ${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES} "${cuda_dir}/.."
+    # PATHS "${CUDA_TOOLKIT_TARGET_DIR}" "${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES}"
+    #ENV CUDA_PATH
+    #ENV CUDA_LIB_PATH
+    PATH_SUFFIXES ${_cuda_64bit_lib_dir}  "lib" "lib64" "${_path_ext}lib/Win32" "${_path_ext}lib" "${_path_ext}libWin32"
     DOC ${_doc}
     NO_DEFAULT_PATH
     )
+  message(${${_var}})
   if (NOT CMAKE_CROSSCOMPILING)
     # Search default search paths, after we search our own set of paths.
     find_library(${_var}
@@ -168,67 +170,67 @@ macro(find_cuda_helper_libs _name)
   mark_as_advanced(CUDA_${_name}_LIBRARY)
 endmacro()
 
-# Search for the cuda distribution.
-if(NOT CUDA_TOOLKIT_ROOT_DIR AND NOT CMAKE_CROSSCOMPILING)
-  # Search in the CUDA_BIN_PATH first.
+# # Search for the cuda distribution.
+# if(NOT CUDA_TOOLKIT_ROOT_DIR AND NOT CMAKE_CROSSCOMPILING)
+#   # Search in the CUDA_BIN_PATH first.
 
-  get_filename_component(cuda_dir "${CMAKE_CUDA_COMPILER}" DIRECTORY)
+#   
 
 
-  find_path(CUDA_TOOLKIT_ROOT_DIR
-    NAMES nvcc nvcc.exe
-    PATHS "${cuda_dir}"
-      ENV CUDA_TOOLKIT_ROOT
-      ENV CUDA_PATH
-      ENV CUDA_BIN_PATH
-    PATH_SUFFIXES bin bin64
-    DOC "CUDA Toolkit location."
-    NO_DEFAULT_PATH
-    )
+#   find_path(CUDA_TOOLKIT_ROOT_DIR
+#     NAMES nvcc nvcc.exe
+#     PATHS "${cuda_dir}"
+#       ENV CUDA_TOOLKIT_ROOT
+#       ENV CUDA_PATH
+#       ENV CUDA_BIN_PATH
+#     PATH_SUFFIXES bin bin64
+#     DOC "CUDA Toolkit location."
+#     NO_DEFAULT_PATH
+#     )
 
-   if (CUDA_TOOLKIT_ROOT_DIR)
-    string(REGEX REPLACE "[/\\\\]?bin[64]*[/\\\\]?$" "" CUDA_TOOLKIT_ROOT_DIR ${CUDA_TOOLKIT_ROOT_DIR})
-    # We need to force this back into the cache.
-    set(CUDA_TOOLKIT_ROOT_DIR ${CUDA_TOOLKIT_ROOT_DIR} CACHE PATH "Toolkit location." FORCE)
-    set(CUDA_TOOLKIT_TARGET_DIR ${CUDA_TOOLKIT_ROOT_DIR})
-    set(CUDA_TOOLKIT_ROOT_DIR_INTERNAL "${CUDA_TOOLKIT_ROOT_DIR}" CACHE INTERNAL
-  "This is the value of the last time CUDA_TOOLKIT_ROOT_DIR was set successfully." FORCE)
-set(CUDA_TOOLKIT_TARGET_DIR_INTERNAL "${CUDA_TOOLKIT_TARGET_DIR}" CACHE INTERNAL
-  "This is the value of the last time CUDA_TOOLKIT_TARGET_DIR was set successfully." FORCE)
-  endif()
+#    if (CUDA_TOOLKIT_ROOT_DIR)
+#     string(REGEX REPLACE "[/\\\\]?bin[64]*[/\\\\]?$" "" CUDA_TOOLKIT_ROOT_DIR ${CUDA_TOOLKIT_ROOT_DIR})
+#     # We need to force this back into the cache.
+#     set(CUDA_TOOLKIT_ROOT_DIR ${CUDA_TOOLKIT_ROOT_DIR} CACHE PATH "Toolkit location." FORCE)
+#     set(CUDA_TOOLKIT_TARGET_DIR ${CUDA_TOOLKIT_ROOT_DIR})
+#     set(CUDA_TOOLKIT_ROOT_DIR_INTERNAL "${CUDA_TOOLKIT_ROOT_DIR}" CACHE INTERNAL
+#   "This is the value of the last time CUDA_TOOLKIT_ROOT_DIR was set successfully." FORCE)
+# set(CUDA_TOOLKIT_TARGET_DIR_INTERNAL "${CUDA_TOOLKIT_TARGET_DIR}" CACHE INTERNAL
+#   "This is the value of the last time CUDA_TOOLKIT_TARGET_DIR was set successfully." FORCE)
+#   endif()
 
-  if (NOT EXISTS ${CUDA_TOOLKIT_ROOT_DIR})
-    if(CUDA_FIND_REQUIRED)
-      message(FATAL_ERROR "Specify CUDA_TOOLKIT_ROOT_DIR")
-    elseif(NOT CUDA_FIND_QUIETLY)
-      message("CUDA_TOOLKIT_ROOT_DIR not found or specified")
-    endif()
-  endif ()
-endif()
+#   if (NOT EXISTS ${CUDA_TOOLKIT_ROOT_DIR})
+#     if(CUDA_FIND_REQUIRED)
+#       message(FATAL_ERROR "Specify CUDA_TOOLKIT_ROOT_DIR")
+#     elseif(NOT CUDA_FIND_QUIETLY)
+#       message("CUDA_TOOLKIT_ROOT_DIR not found or specified")
+#     endif()
+#   endif ()
+# endif()
 
-if(CMAKE_CROSSCOMPILING)
-  SET (CUDA_TOOLKIT_ROOT $ENV{CUDA_TOOLKIT_ROOT})
-  if(CMAKE_SYSTEM_PROCESSOR STREQUAL "armv7-a")
-    # Support for NVPACK
-    set (CUDA_TOOLKIT_TARGET_NAME "armv7-linux-androideabi")
-  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "arm")
-    # Support for arm cross compilation
-    set(CUDA_TOOLKIT_TARGET_NAME "armv7-linux-gnueabihf")
-  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
-    # Support for aarch64 cross compilation
-    if (ANDROID_ARCH_NAME STREQUAL "arm64")
-      set(CUDA_TOOLKIT_TARGET_NAME "aarch64-linux-androideabi")
-    else()
-      set(CUDA_TOOLKIT_TARGET_NAME "aarch64-linux")
-    endif (ANDROID_ARCH_NAME STREQUAL "arm64")
-  endif()
+# if(CMAKE_CROSSCOMPILING)
+#   SET (CUDA_TOOLKIT_ROOT $ENV{CUDA_TOOLKIT_ROOT})
+#   if(CMAKE_SYSTEM_PROCESSOR STREQUAL "armv7-a")
+#     # Support for NVPACK
+#     set (CUDA_TOOLKIT_TARGET_NAME "armv7-linux-androideabi")
+#   elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "arm")
+#     # Support for arm cross compilation
+#     set(CUDA_TOOLKIT_TARGET_NAME "armv7-linux-gnueabihf")
+#   elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+#     # Support for aarch64 cross compilation
+#     if (ANDROID_ARCH_NAME STREQUAL "arm64")
+#       set(CUDA_TOOLKIT_TARGET_NAME "aarch64-linux-androideabi")
+#     else()
+#       set(CUDA_TOOLKIT_TARGET_NAME "aarch64-linux")
+#     endif (ANDROID_ARCH_NAME STREQUAL "arm64")
+#   endif()
 
-  if (EXISTS "${CUDA_TOOLKIT_ROOT}/targets/${CUDA_TOOLKIT_TARGET_NAME}")
-    set(CUDA_TOOLKIT_TARGET_DIR "${CUDA_TOOLKIT_ROOT}/targets/${CUDA_TOOLKIT_TARGET_NAME}" CACHE PATH "CUDA Toolkit target location.")
-    SET (CUDA_TOOLKIT_ROOT_DIR ${CUDA_TOOLKIT_ROOT})
-    mark_as_advanced(CUDA_TOOLKIT_TARGET_DIR)
-  endif()
-endif()
+#   if (EXISTS "${CUDA_TOOLKIT_ROOT}/targets/${CUDA_TOOLKIT_TARGET_NAME}")
+#     set(CUDA_TOOLKIT_TARGET_DIR "${CUDA_TOOLKIT_ROOT}/targets/${CUDA_TOOLKIT_TARGET_NAME}" CACHE PATH "CUDA Toolkit target location.")
+#     SET (CUDA_TOOLKIT_ROOT_DIR ${CUDA_TOOLKIT_ROOT})
+#     mark_as_advanced(CUDA_TOOLKIT_TARGET_DIR)
+#   endif()
+# endif()
 
 # CUPTI library showed up in cuda toolkit 4.0
 if(NOT CUDA_VERSION VERSION_LESS "4.0")

--- a/cmake/FindCUDALibs.cmake
+++ b/cmake/FindCUDALibs.cmake
@@ -101,7 +101,7 @@ endif()
 set(CUDA_VERSION_STRING "${CUDA_VERSION}")
 get_filename_component(cuda_dir "${CMAKE_CUDA_COMPILER}" DIRECTORY)
 
-macro(cuda_unset_include_and_libraries)
+macro(cuda_unset_libraries)
   unset(CUDA_cublas_LIBRARY CACHE)
   unset(CUDA_cublas_device_LIBRARY CACHE)
   unset(CUDA_cufft_LIBRARY CACHE)
@@ -116,6 +116,11 @@ macro(cuda_unset_include_and_libraries)
   unset(CUDA_nvcuvenc_LIBRARY CACHE)
   unset(CUDA_nvcuvid_LIBRARY CACHE)
 endmacro()
+
+if(NOT "${QUDA_CUDA_DIR_INTERNAL}" STREQUAL "${cuda_dir}")
+  cuda_unset_libraries()
+endif()
+
 
 # # Check to see if the CUDA_TOOLKIT_ROOT_DIR and CUDA_SDK_ROOT_DIR have changed,
 # # if they have then clear the cache variables, so that will be detected again.
@@ -263,3 +268,6 @@ if(NOT CUDA_VERSION VERSION_LESS "7.0")
   # cusolver showed up in version 7.0
   find_cuda_helper_libs(cusolver)
 endif()
+
+set(QUDA_CUDA_DIR_INTERNAL "${cuda_dir}" CACHE INTERNAL
+  "This is the value of the last time cuda_dir was set successfully." FORCE)

--- a/cmake/FindCUDALibs.cmake
+++ b/cmake/FindCUDALibs.cmake
@@ -148,7 +148,7 @@ macro(cuda_find_library_local_first_with_path_ext _var _names _doc _path_ext )
     DOC ${_doc}
     NO_DEFAULT_PATH
     )
-  message(${${_var}})
+
   if (NOT CMAKE_CROSSCOMPILING)
     # Search default search paths, after we search our own set of paths.
     find_library(${_var}

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -133,7 +133,10 @@ endif()
 
 # malloc.cpp uses both the driver and runtime api
 # So we need to find the CUDA_CUDA_LIBRARY (driver api) or the stub version
-find_library(CUDA_CUDA_LIBRARY cuda HINTS ${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES} ${CUDA_TOOLKIT_ROOT_DIR}/lib ${CUDA_TOOLKIT_ROOT_DIR}/lib64 PATH_SUFFIXES stubs )
+# for cmake 3.8 and later this has been integrated into  FindCUDALibs.cmake 
+if(${CMAKE_VERSION} VERSION_LESS 3.8)
+  find_library(CUDA_CUDA_LIBRARY cuda HINTS ${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES} ${CUDA_TOOLKIT_ROOT_DIR}/lib ${CUDA_TOOLKIT_ROOT_DIR}/lib64 PATH_SUFFIXES stubs )
+endif()
 target_link_libraries(quda ${CUDA_CUDA_LIBRARY})
 
 # if we did not find Eigen but downloaded it we need to add it as dependency so the download is done first

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -135,9 +135,9 @@ endif()
 # So we need to find the CUDA_CUDA_LIBRARY (driver api) or the stub version
 # for cmake 3.8 and later this has been integrated into  FindCUDALibs.cmake 
 if(${CMAKE_VERSION} VERSION_LESS 3.8)
-  find_library(CUDA_CUDA_LIBRARY cuda HINTS ${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES} ${CUDA_TOOLKIT_ROOT_DIR}/lib ${CUDA_TOOLKIT_ROOT_DIR}/lib64 PATH_SUFFIXES stubs )
+  find_library(CUDA_cuda_LIBRARY cuda HINTS ${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES} ${CUDA_TOOLKIT_ROOT_DIR}/lib ${CUDA_TOOLKIT_ROOT_DIR}/lib64 PATH_SUFFIXES stubs )
 endif()
-target_link_libraries(quda ${CUDA_CUDA_LIBRARY})
+target_link_libraries(quda ${CUDA_cuda_LIBRARY})
 
 # if we did not find Eigen but downloaded it we need to add it as dependency so the download is done first
 if (QUDA_DOWNLOAD_EIGEN)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -133,7 +133,7 @@ endif()
 
 # malloc.cpp uses both the driver and runtime api
 # So we need to find the CUDA_CUDA_LIBRARY (driver api) or the stub version
-find_library(CUDA_CUDA_LIBRARY cuda HINTS ${CUDA_TOOLKIT_ROOT_DIR}/lib ${CUDA_TOOLKIT_ROOT_DIR}/lib64 PATH_SUFFIXES stubs )
+find_library(CUDA_CUDA_LIBRARY cuda HINTS ${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES} ${CUDA_TOOLKIT_ROOT_DIR}/lib ${CUDA_TOOLKIT_ROOT_DIR}/lib64 PATH_SUFFIXES stubs )
 target_link_libraries(quda ${CUDA_CUDA_LIBRARY})
 
 # if we did not find Eigen but downloaded it we need to add it as dependency so the download is done first


### PR DESCRIPTION
CUDA_TOOLKIT_ROOT_DIR was used by FindCUDA.cmake. When using native cuda support in cmake we use FindCUDAlibs.cmake which is based on FindCUDA to detect the cuda libraries.

We now detect libraries based on the values of `${CMAKE_CUDA_COMPILER}` _(path to nvcc)_ and cmake's `${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES}` (same mechanism used to also detect implicit link directories for other languages).

