### PR TITLE
Feature/ghost precision

### DIFF
--- a/include/blas_cublas.h
+++ b/include/blas_cublas.h
@@ -7,6 +7,16 @@ namespace quda {
   namespace cublas {
 
     /**
+       @brief Create the CUBLAS context
+    */
+    void init();
+
+    /**
+       @brief Destroy the CUBLAS context
+    */
+    void destroy();
+
+    /**
        Batch inversion the matrix field using an LU decomposition method.
        @param[out] Ainv Matrix field containing the inverse matrices
        @param[in] A Matrix field containing the input matrices

--- a/include/blas_cublas.h
+++ b/include/blas_cublas.h
@@ -1,5 +1,4 @@
 #include <quda_internal.h>
-#include <cublas_v2.h>
 
 #pragma once
 

--- a/include/clover_field.h
+++ b/include/clover_field.h
@@ -22,6 +22,7 @@ namespace quda {
     QudaFieldCreate create;
     void setPrecision(QudaPrecision precision) {
       this->precision = precision;
+      this->ghost_precision = precision;
       order = (precision == QUDA_DOUBLE_PRECISION) ? 
 	QUDA_FLOAT2_CLOVER_ORDER : QUDA_FLOAT4_CLOVER_ORDER;
     }

--- a/include/clover_field_order.h
+++ b/include/clover_field_order.h
@@ -222,16 +222,18 @@ namespace quda {
       }
 
       __host__ double device_absmax() const {
+	thrust_allocator alloc;
 	thrust::device_ptr<complex<Float> > ptr(reinterpret_cast<complex<Float>*>(a));
 	// just use offset_cb, since factor of two from parity is equivalent to complexity
-	return thrust::transform_reduce(thrust::retag<my_tag>(ptr), thrust::retag<my_tag>(ptr+offset_cb),
+	return thrust::transform_reduce(thrust::cuda::par(alloc), ptr, ptr+offset_cb,
 					abs_<Float>(), 0.0, thrust::maximum<Float>());
       }
 
       __host__ double device_absmin() const {
+	thrust_allocator alloc;
 	thrust::device_ptr<complex<Float> > ptr(reinterpret_cast<complex<Float>*>(a));
 	// just use offset_cb, since factor of two from parity is equivalent to complexity
-	return thrust::transform_reduce(thrust::retag<my_tag>(ptr), thrust::retag<my_tag>(ptr+offset_cb),
+	return thrust::transform_reduce(thrust::cuda::par(alloc), ptr, ptr+offset_cb,
 					abs_<Float>(), 0.0, thrust::minimum<Float>());
       }
     };

--- a/include/color_spinor_field.h
+++ b/include/color_spinor_field.h
@@ -192,9 +192,10 @@ namespace quda {
        If using CUDA native fields, this function will ensure that the
        field ordering is appropriate for the new precision setting to
        maintain this status
-       @param precision New precision value
+       @param precision_ New precision value
+       @param ghost_precision_ New ghost precision value
      */
-    void setPrecision(QudaPrecision precision) {
+    void setPrecision(QudaPrecision precision, QudaPrecision ghost_precision=QUDA_INVALID_PRECISION) {
       // is the current status in native field order?
       bool native = false;
       if ( ((this->precision == QUDA_DOUBLE_PRECISION || nSpin==1 || nSpin==2) &&
@@ -203,6 +204,7 @@ namespace quda {
 	    (nSpin==4) && fieldOrder == QUDA_FLOAT4_FIELD_ORDER) ) { native = true; }
 
       this->precision = precision;
+      this->ghost_precision = (ghost_precision == QUDA_INVALID_PRECISION) ? precision : ghost_precision;
 
       // if this is a native field order, let's preserve that status, else keep the same field order
       if (native) fieldOrder = (precision == QUDA_DOUBLE_PRECISION || nSpin == 1 || nSpin == 2) ?
@@ -216,6 +218,7 @@ namespace quda {
       printfQuda("nDim = %d\n", nDim);
       for (int d=0; d<nDim; d++) printfQuda("x[%d] = %d\n", d, x[d]);
       printfQuda("precision = %d\n", precision);
+      printfQuda("ghost_precision = %d\n", ghost_precision);
       printfQuda("pad = %d\n", pad);
       printfQuda("siteSubset = %d\n", siteSubset);
       printfQuda("siteOrder = %d\n", siteOrder);
@@ -372,9 +375,11 @@ namespace quda {
        @param[in] halo_location Destination of the halo reading buffer
        @param[in] gdr_send Are we using GDR for sending
        @param[in] gdr_recv Are we using GDR for receiving
+       @param[in] ghost_precision The precision used for the ghost exchange
      */
     virtual void exchangeGhost(QudaParity parity, int nFace, int dagger, const MemoryLocation *pack_destination=nullptr,
-			       const MemoryLocation *halo_location=nullptr, bool gdr_send=false, bool gdr_recv=false) const = 0;
+			       const MemoryLocation *halo_location=nullptr, bool gdr_send=false, bool gdr_recv=false,
+			       QudaPrecision ghost_precision=QUDA_INVALID_PRECISION) const = 0;
 
     /**
       This function returns true if the field is stored in an internal
@@ -686,9 +691,11 @@ namespace quda {
        @param[in] halo_location Destination of the halo reading buffer
        @param[in] gdr_send Are we using GDR for sending
        @param[in] gdr_recv Are we using GDR for receiving
+       @param[in] ghost_precision The precision used for the ghost exchange
      */
     void exchangeGhost(QudaParity parity, int nFace, int dagger, const MemoryLocation *pack_destination=nullptr,
-		       const MemoryLocation *halo_location=nullptr, bool gdr_send=false, bool gdr_recv=false) const;
+		       const MemoryLocation *halo_location=nullptr, bool gdr_send=false, bool gdr_recv=false,
+		       QudaPrecision ghost_precision=QUDA_INVALID_PRECISION) const;
 
 #ifdef USE_TEXTURE_OBJECTS
     const cudaTextureObject_t& Tex() const { return tex; }
@@ -786,9 +793,11 @@ namespace quda {
        @param[in] halo_location Destination of the halo reading buffer
        @param[in] gdr_send Dummy for CPU
        @param[in] gdr_recv Dummy for GPU
+       @param[in] ghost_precision The precision used for the ghost exchange
      */
     void exchangeGhost(QudaParity parity, int nFace, int dagger, const MemoryLocation *pack_destination=nullptr,
-		       const MemoryLocation *halo_location=nullptr, bool gdr_send=false, bool gdr_recv=false) const;
+		       const MemoryLocation *halo_location=nullptr, bool gdr_send=false, bool gdr_recv=false,
+		       QudaPrecision ghost_precision=QUDA_INVALID_PRECISION) const;
 
     /**
        @brief Backs up the cpuColorSpinorField

--- a/include/color_spinor_field_order.h
+++ b/include/color_spinor_field_order.h
@@ -608,9 +608,9 @@ namespace quda {
       __host__ double norm2(bool global=true) const {
 	double nrm2 = 0;
 	if (location == QUDA_CUDA_FIELD_LOCATION) {
+	  thrust_allocator alloc;
 	  thrust::device_ptr<complex<storeFloat> > ptr(v);
-	  nrm2 = thrust::transform_reduce(thrust::retag<my_tag>(ptr),
-					  thrust::retag<my_tag>(ptr+nParity*volumeCB*nSpin*nColor*nVec),
+	  nrm2 = thrust::transform_reduce(thrust::cuda::par(alloc), ptr, ptr+nParity*volumeCB*nSpin*nColor*nVec,
 					  square_<double,storeFloat>(scale_inv), 0.0, thrust::plus<double>());
 	} else {
 	  nrm2 = thrust::transform_reduce(thrust::seq, v, v+nParity*volumeCB*nSpin*nColor*nVec,
@@ -628,9 +628,9 @@ namespace quda {
       __host__ double abs_max(bool global=true) const {
 	double absmax = 0;
 	if (location == QUDA_CUDA_FIELD_LOCATION) {
+	  thrust_allocator alloc;
 	  thrust::device_ptr<complex<storeFloat> > ptr(v);
-	  absmax = thrust::transform_reduce(thrust::retag<my_tag>(ptr),
-					    thrust::retag<my_tag>(ptr+nParity*volumeCB*nSpin*nColor*nVec),
+	  absmax = thrust::transform_reduce(thrust::cuda::par(alloc), ptr, ptr+nParity*volumeCB*nSpin*nColor*nVec,
 					    abs_<double,storeFloat>(scale_inv), 0.0, thrust::maximum<double>());
 	} else {
 	  absmax = thrust::transform_reduce(thrust::seq, v, v+nParity*volumeCB*nSpin*nColor*nVec,

--- a/include/color_spinor_field_order.h
+++ b/include/color_spinor_field_order.h
@@ -213,10 +213,12 @@ namespace quda {
 
     template<typename Float, int nSpin, int nColor, int nVec>
       struct GhostAccessorCB<Float,nSpin,nColor,nVec,QUDA_SPACE_SPIN_COLOR_FIELD_ORDER> {
+      int faceVolumeCB[4];
       int ghostOffset[4];
       GhostAccessorCB(const ColorSpinorField &a, int nFace = 1) {
 	for (int d=0; d<4; d++) {
-	  ghostOffset[d] = nFace*a.SurfaceCB(d)*nColor*nSpin*nVec;
+	  faceVolumeCB[d] = nFace*a.SurfaceCB(d);
+	  ghostOffset[d] = faceVolumeCB[d]*nColor*nSpin*nVec;
 	}
       }
       __device__ __host__ inline int index(int dim, int dir, int parity, int x_cb, int s, int c, int v) const
@@ -406,6 +408,7 @@ namespace quda {
     protected:
       complex<storeFloat> *v;
       mutable complex<ghostFloat> *ghost[8];
+      mutable float *ghost_norm[8];
       mutable int x[QUDA_MAX_DIM];
       const int volumeCB;
       const int nDim;
@@ -417,7 +420,11 @@ namespace quda {
       const QudaFieldLocation location;
       Float scale;
       Float scale_inv;
+      Float ghost_scale;
+      Float ghost_scale_inv;
       static constexpr bool fixed = fixed_point<Float,storeFloat>();
+      static constexpr bool ghost_fixed = fixed_point<Float,ghostFloat>();
+      static constexpr bool block_float_ghost = !fixed && ghost_fixed;
 
     public:
       /**
@@ -431,10 +438,11 @@ namespace quda {
 	nDim(field.Ndim()), gammaBasis(field.GammaBasis()),
 	siteSubset(field.SiteSubset()), nParity(field.SiteSubset()),
         location(field.Location()), accessor(field), ghostAccessor(field,nFace),
-        scale(static_cast<Float>(1.0)), scale_inv(static_cast<Float>(1.0))
+        scale(static_cast<Float>(1.0)), scale_inv(static_cast<Float>(1.0)),
+        ghost_scale(static_cast<Float>(1.0)), ghost_scale_inv(static_cast<Float>(1.0))
       {
 	for (int d=0; d<QUDA_MAX_DIM; d++) x[d]=field.X(d);
-	resetGhost(ghost_ ? ghost_ : field.Ghost());
+	resetGhost(field, ghost_ ? ghost_ : field.Ghost());
 	resetScale(field.Scale());
       }
 
@@ -443,11 +451,15 @@ namespace quda {
        */
       virtual ~FieldOrderCB() { ; }
 
-      void resetGhost(void * const *ghost_) const
+    void resetGhost(const ColorSpinorField &a, void * const *ghost_) const
       {
-	for (int d=0; d<4; d++) {
-	  ghost[2*d+0] = static_cast<complex<ghostFloat>*>(ghost_[2*d+0]);
-	  ghost[2*d+1] = static_cast<complex<ghostFloat>*>(ghost_[2*d+1]);
+	for (int dim=0; dim<4; dim++) {
+	  for (int dir=0; dir<2; dir++) {
+	    ghost[2*dim+dir] = static_cast<complex<ghostFloat>*>(ghost_[2*dim+dir]);
+	    ghost_norm[2*dim+dir] =
+	      reinterpret_cast<float*>(static_cast<char*>(ghost_[2*dim+dir]) +
+				       a.GhostNormOffset(dim,dir)*QUDA_SINGLE_PRECISION - a.GhostOffset(dim,dir)*sizeof(ghostFloat));
+	  }
 	}
       }
 
@@ -455,6 +467,12 @@ namespace quda {
 	if (fixed) {
 	  scale = static_cast<Float>(std::numeric_limits<storeFloat>::max() / max);
 	  scale_inv = static_cast<Float>(max / std::numeric_limits<storeFloat>::max());
+	}
+	if (ghost_fixed) {
+	  if (block_float_ghost && max != static_cast<Float>(1.0))
+	      errorQuda("Block-float accessor requires max=1.0 not max=%e\n", max);
+	  ghost_scale = static_cast<Float>(std::numeric_limits<ghostFloat>::max() / max);
+	  ghost_scale_inv = static_cast<Float>(max / std::numeric_limits<ghostFloat>::max());
 	}
       }
 
@@ -500,11 +518,13 @@ namespace quda {
        */
       __device__ __host__ inline const complex<Float> Ghost(int dim, int dir, int parity, int x_cb, int s, int c, int n=0) const
       {
-	if (!fixed) {
+	if (!ghost_fixed) {
 	  return complex<Float>(ghost[2*dim+dir][ghostAccessor.index(dim,dir,parity,x_cb,s,c,n)]);
 	} else {
+	  Float scale = ghost_scale_inv;
+	  if (block_float_ghost) scale *= ghost_norm[2*dim+dir][parity*ghostAccessor.faceVolumeCB[dim] + x_cb];
 	  complex<ghostFloat> tmp = ghost[2*dim+dir][ghostAccessor.index(dim,dir,parity,x_cb,s,c,n)];
-	  return scale_inv*complex<Float>(static_cast<Float>(tmp.x), static_cast<Float>(tmp.y));
+	  return scale*complex<Float>(static_cast<Float>(tmp.x), static_cast<Float>(tmp.y));
 	}
       }
 
@@ -516,11 +536,15 @@ namespace quda {
        * @param s spin index
        * @param c color index
        * @param n vector number
+       * @param max site-element max (only when using block-float format)
        */
-      __device__ __host__ inline fieldorder_wrapper<Float,ghostFloat> Ghost(int dim, int dir, int parity, int x_cb, int s, int c, int n=0)
+	__device__ __host__ inline fieldorder_wrapper<Float,ghostFloat> Ghost(int dim, int dir, int parity, int x_cb, int s, int c, int n=0, Float max=0)
       {
+	if (block_float_ghost && s==0 && c==0 && n==0) ghost_norm[2*dim+dir][parity*ghostAccessor.faceVolumeCB[dim] + x_cb] = max;
 	const int idx = ghostAccessor.index(dim,dir,parity,x_cb,s,c,n);
-	return fieldorder_wrapper<Float,ghostFloat>(ghost[2*dim+dir], idx, scale, scale_inv);
+	return fieldorder_wrapper<Float,ghostFloat>(ghost[2*dim+dir], idx,
+						    block_float_ghost ? ghost_scale/max : ghost_scale,
+						    block_float_ghost ? ghost_scale_inv*max : ghost_scale_inv);
       }
 
       /**

--- a/include/comm_quda.h
+++ b/include/comm_quda.h
@@ -161,6 +161,14 @@ extern "C" {
   void comm_peer2peer_init(const char *hostname_recv_buf);
 
   /**
+     @brief Returns true if any peer-to-peer capability is present on
+     this system (regardless of whether it has been disabled or not.  We
+     use this, for example, to determine if we need to allocate pinned
+     device memory or not.
+  */
+  bool comm_peer2peer_present();
+
+  /**
      Query if peer-to-peer communication is enabled globally
      @return Whether peer-to-peer is enabled globally
   */

--- a/include/gauge_field.h
+++ b/include/gauge_field.h
@@ -206,8 +206,10 @@ namespace quda {
        @param[in] R Radius of the ghost zone
        @param[in] no_comms_fill If true we create a full halo
        regardless of partitioning
+       @param[in] bidir Is this a bi-directional exchange - if not
+       then we alias the fowards and backwards offsetss
     */
-    void createGhostZone(const int *R, bool no_comms_fill) const;
+    void createGhostZone(const int *R, bool no_comms_fill, bool bidir=true) const;
 
   public:
     GaugeField(const GaugeFieldParam &param);
@@ -356,19 +358,24 @@ namespace quda {
 
     /**
        @brief Create the communication handlers and buffers
-       @param R The thickness of the extended region in each dimension
-       @param no_comms_fill Do local exchange to fill out the extended
+       @param[in] R The thickness of the extended region in each dimension
+       @param[in] no_comms_fill Do local exchange to fill out the extended
        region in non-partitioned dimensions
+       @param[in] bidir Whether to allocate communication buffers to
+       allow for simultaneous bi-directional exchange.  If false, then
+       the forwards and backwards buffers will alias (saving memory).
     */
-    void createComms(const int *R, bool no_comms_fill);
+    void createComms(const int *R, bool no_comms_fill, bool bidir=true);
 
     /**
        @brief Allocate the ghost buffers
-       @param R The thickness of the extended region in each dimension
-       @param no_comms_fill Do local exchange to fill out the extended
+       @param[in] R The thickness of the extended region in each dimension
+       @param[in] no_comms_fill Do local exchange to fill out the extended
+       @param[in] bidir Is this a bi-directional exchange - if not
+       then we alias the fowards and backwards offsetss
        region in non-partitioned dimensions
     */
-    void allocateGhostBuffer(const int *R, bool no_comms_fill) const;
+    void allocateGhostBuffer(const int *R, bool no_comms_fill, bool bidir=true) const;
 
     /**
        @brief Start the receive communicators

--- a/include/gauge_field.h
+++ b/include/gauge_field.h
@@ -109,9 +109,30 @@ namespace quda {
        @param precision The precision to use 
      */
     void setPrecision(QudaPrecision precision) {
+      // is the current status in native field order?
+      bool native = false;
+      if (precision == QUDA_DOUBLE_PRECISION) {
+	if (order  == QUDA_FLOAT2_GAUGE_ORDER) native = true;
+      } else if (precision == QUDA_SINGLE_PRECISION ||
+		 precision == QUDA_HALF_PRECISION) {
+	if (reconstruct == QUDA_RECONSTRUCT_NO) {
+	  if (order == QUDA_FLOAT2_GAUGE_ORDER) native = true;
+	} else if (reconstruct == QUDA_RECONSTRUCT_12 || reconstruct == QUDA_RECONSTRUCT_13) {
+	  if (order == QUDA_FLOAT4_GAUGE_ORDER) native = true;
+	} else if (reconstruct == QUDA_RECONSTRUCT_8 || reconstruct == QUDA_RECONSTRUCT_9) {
+	  if (order == QUDA_FLOAT4_GAUGE_ORDER) native = true;
+	} else if (reconstruct == QUDA_RECONSTRUCT_10) {
+	  if (order == QUDA_FLOAT2_GAUGE_ORDER) native = true;
+	}
+      }
+
       this->precision = precision;
-      order = (precision == QUDA_DOUBLE_PRECISION || reconstruct == QUDA_RECONSTRUCT_NO) ? 
-	QUDA_FLOAT2_GAUGE_ORDER : QUDA_FLOAT4_GAUGE_ORDER; 
+      this->ghost_precision = precision;
+
+      if (native) {
+	order = (precision == QUDA_DOUBLE_PRECISION || reconstruct == QUDA_RECONSTRUCT_NO) ?
+	  QUDA_FLOAT2_GAUGE_ORDER : QUDA_FLOAT4_GAUGE_ORDER;
+      }
     }
 
   };

--- a/include/gauge_field_order.h
+++ b/include/gauge_field_order.h
@@ -524,9 +524,11 @@ namespace quda {
       }
 
       __host__ double device_norm2() const {
+	thrust_allocator alloc;
 	thrust::device_ptr<complex<storeFloat> > ptr(u);
-	return thrust::transform_reduce(thrust::retag<my_tag>(ptr+0*volumeCB*geometry*nColor*nColor),
-					thrust::retag<my_tag>(ptr+2*volumeCB*geometry*nColor*nColor),
+	return thrust::transform_reduce(thrust::cuda::par(alloc),
+					ptr+0*volumeCB*geometry*nColor*nColor,
+					ptr+2*volumeCB*geometry*nColor*nColor,
 					square_<double,storeFloat>(scale_inv), 0.0, thrust::plus<double>());
       }
 
@@ -711,72 +713,86 @@ namespace quda {
       }
 
       __host__ double device_norm2() const {
+	thrust_allocator alloc;
 	thrust::device_ptr<complex<storeFloat> > ptr(u);
-
-	double even = thrust::transform_reduce(thrust::retag<my_tag>(ptr+0*offset_cb),
-					       thrust::retag<my_tag>(ptr+0*offset_cb+geometry*stride*nColor*nColor),
+	double even = thrust::transform_reduce(thrust::cuda::par(alloc),
+					       ptr+0*offset_cb, ptr+0*offset_cb+geometry*stride*nColor*nColor,
 					       square_<double,storeFloat>(scale_inv), 0.0, thrust::plus<double>());
-	double odd  = thrust::transform_reduce(thrust::retag<my_tag>(ptr+1*offset_cb),
-					       thrust::retag<my_tag>(ptr+1*offset_cb+geometry*stride*nColor*nColor),
+	double odd  = thrust::transform_reduce(thrust::cuda::par(alloc),
+					       ptr+1*offset_cb, ptr+1*offset_cb+geometry*stride*nColor*nColor,
 					       square_<double,storeFloat>(scale_inv), 0.0, thrust::plus<double>());
 	return even + odd;
       }
 
       __host__ double device_norm2(int dim) const {
 	if (dim >= geometry) errorQuda("Request dimension %d exceeds dimensionality of the field %d", dim, geometry);
+	thrust_allocator alloc;
 	thrust::device_ptr<complex<storeFloat> > ptr(u);
-
-	double even = thrust::transform_reduce(thrust::retag<my_tag>(ptr+0*offset_cb+(dim+0)*stride*nColor*nColor),
-					       thrust::retag<my_tag>(ptr+0*offset_cb+(dim+1)*stride*nColor*nColor),
+	double even = thrust::transform_reduce(thrust::cuda::par(alloc),
+					       ptr+0*offset_cb+(dim+0)*stride*nColor*nColor,
+					       ptr+0*offset_cb+(dim+1)*stride*nColor*nColor,
 					       square_<double,storeFloat>(scale_inv), 0.0, thrust::plus<double>());
-	double odd  = thrust::transform_reduce(thrust::retag<my_tag>(ptr+1*offset_cb+(dim+0)*stride*nColor*nColor),
-					       thrust::retag<my_tag>(ptr+1*offset_cb+(dim+1)*stride*nColor*nColor),
+	double odd  = thrust::transform_reduce(thrust::cuda::par(alloc),
+					       ptr+1*offset_cb+(dim+0)*stride*nColor*nColor,
+					       ptr+1*offset_cb+(dim+1)*stride*nColor*nColor,
 					       square_<double,storeFloat>(scale_inv), 0.0, thrust::plus<double>());
 	return even + odd;
       }
 
       __host__ Float device_absmax() const {
+	thrust_allocator alloc;
 	thrust::device_ptr<complex<storeFloat> > ptr(u);
-	Float even = thrust::transform_reduce(thrust::retag<my_tag>(ptr+0*offset_cb+0*stride*nColor*nColor),
-					      thrust::retag<my_tag>(ptr+0*offset_cb+geometry*stride*nColor*nColor),
+	Float even = thrust::transform_reduce(thrust::cuda::par(alloc),
+					      ptr+0*offset_cb+0*stride*nColor*nColor,
+					      ptr+0*offset_cb+geometry*stride*nColor*nColor,
 					      abs_<Float,storeFloat>(scale_inv), static_cast<Float>(0.0), thrust::maximum<Float>());
-	Float odd  = thrust::transform_reduce(thrust::retag<my_tag>(ptr+1*offset_cb+0*stride*nColor*nColor),
-					      thrust::retag<my_tag>(ptr+1*offset_cb+geometry*stride*nColor*nColor),
+	Float odd  = thrust::transform_reduce(thrust::cuda::par(alloc),
+					      ptr+1*offset_cb+0*stride*nColor*nColor,
+					      ptr+1*offset_cb+geometry*stride*nColor*nColor,
 					      abs_<Float,storeFloat>(scale_inv), static_cast<Float>(0.0), thrust::maximum<Float>());
 	return std::max(even,odd);
       }
 
       __host__ Float device_absmax(int dim) const {
 	if (dim >= geometry) errorQuda("Request dimension %d exceeds dimensionality of the field %d", dim, geometry);
+	thrust_allocator alloc;
 	thrust::device_ptr<complex<storeFloat> > ptr(u);
-	Float even = thrust::transform_reduce(thrust::retag<my_tag>(ptr+0*offset_cb+(dim+0)*stride*nColor*nColor),
-					      thrust::retag<my_tag>(ptr+0*offset_cb+(dim+1)*stride*nColor*nColor),
+	Float even = thrust::transform_reduce(thrust::cuda::par(alloc),
+					      ptr+0*offset_cb+(dim+0)*stride*nColor*nColor,
+					      ptr+0*offset_cb+(dim+1)*stride*nColor*nColor,
 					      abs_<Float,storeFloat>(scale_inv), static_cast<Float>(0.0), thrust::maximum<Float>());
-	Float odd  = thrust::transform_reduce(thrust::retag<my_tag>(ptr+1*offset_cb+(dim+0)*stride*nColor*nColor),
-					      thrust::retag<my_tag>(ptr+1*offset_cb+(dim+1)*stride*nColor*nColor),
+	Float odd  = thrust::transform_reduce(thrust::cuda::par(alloc),
+					      ptr+1*offset_cb+(dim+0)*stride*nColor*nColor,
+					      ptr+1*offset_cb+(dim+1)*stride*nColor*nColor,
 					      abs_<Float,storeFloat>(scale_inv), static_cast<Float>(0.0), thrust::maximum<Float>());
 	return std::max(even,odd);
       }
 
       __host__ Float device_absmin() const {
+	thrust_allocator alloc;
 	thrust::device_ptr<complex<storeFloat> > ptr(u);
-	Float even = thrust::transform_reduce(thrust::retag<my_tag>(ptr+0*offset_cb+0*stride*nColor*nColor),
-					      thrust::retag<my_tag>(ptr+0*offset_cb+geometry*stride*nColor*nColor),
+	Float even = thrust::transform_reduce(thrust::cuda::par(alloc),
+					      ptr+0*offset_cb+0*stride*nColor*nColor,
+					      ptr+0*offset_cb+geometry*stride*nColor*nColor,
 					      abs_<Float,storeFloat>(scale_inv), std::numeric_limits<Float>::max(), thrust::minimum<Float>());
-	Float odd  = thrust::transform_reduce(thrust::retag<my_tag>(ptr+1*offset_cb+0*stride*nColor*nColor),
-					      thrust::retag<my_tag>(ptr+1*offset_cb+geometry*stride*nColor*nColor),
+	Float odd  = thrust::transform_reduce(thrust::cuda::par(alloc),
+					      ptr+1*offset_cb+0*stride*nColor*nColor,
+					      ptr+1*offset_cb+geometry*stride*nColor*nColor,
 					      abs_<Float,storeFloat>(scale_inv), std::numeric_limits<Float>::max(), thrust::minimum<Float>());
 	return std::min(even,odd);
       }
 
       __host__ Float device_absmin(int dim) const {
 	if (dim >= geometry) errorQuda("Request dimension %d exceeds dimensionality of the field %d", dim, geometry);
+	thrust_allocator alloc;
 	thrust::device_ptr<complex<storeFloat> > ptr(u);
-	Float even = thrust::transform_reduce(thrust::retag<my_tag>(ptr+0*offset_cb+(dim+0)*stride*nColor*nColor),
-					      thrust::retag<my_tag>(ptr+0*offset_cb+(dim+1)*stride*nColor*nColor),
+	Float even = thrust::transform_reduce(thrust::cuda::par(alloc),
+					      ptr+0*offset_cb+(dim+0)*stride*nColor*nColor,
+					      ptr+0*offset_cb+(dim+1)*stride*nColor*nColor,
 					      abs_<Float,storeFloat>(scale_inv), std::numeric_limits<Float>::max(), thrust::minimum<Float>());
-	Float odd  = thrust::transform_reduce(thrust::retag<my_tag>(ptr+1*offset_cb+(dim+0)*stride*nColor*nColor),
-					      thrust::retag<my_tag>(ptr+1*offset_cb+(dim+1)*stride*nColor*nColor),
+	Float odd  = thrust::transform_reduce(thrust::cuda::par(alloc),
+					      ptr+1*offset_cb+(dim+0)*stride*nColor*nColor,
+					      ptr+1*offset_cb+(dim+1)*stride*nColor*nColor,
 					      abs_<Float,storeFloat>(scale_inv), std::numeric_limits<Float>::max(), thrust::minimum<Float>());
 	return std::min(even,odd);
       }

--- a/include/lattice_field.h
+++ b/include/lattice_field.h
@@ -43,6 +43,20 @@ namespace quda {
 
   struct LatticeFieldParam {
 
+  protected:
+    /** Field precision */
+    QudaPrecision precision;
+
+    /** Ghost precision */
+    QudaPrecision ghost_precision;
+
+  public:
+    /** Field precision */
+    QudaPrecision Precision() const { return precision; }
+
+    /** Ghost precision */
+    QudaPrecision GhostPrecision() const { return ghost_precision; }
+
     /** Number of field dimensions */
     int nDim;
 
@@ -51,7 +65,6 @@ namespace quda {
 
     int pad;
 
-    QudaPrecision precision;
     QudaSiteSubset siteSubset;
 
     QudaMemoryType mem_type; 
@@ -69,7 +82,8 @@ namespace quda {
        @brief Default constructor for LatticeFieldParam
     */
     LatticeFieldParam()
-    : nDim(4), pad(0), precision(QUDA_INVALID_PRECISION), siteSubset(QUDA_INVALID_SITE_SUBSET), mem_type(QUDA_MEMORY_DEVICE),
+    : precision(QUDA_INVALID_PRECISION), ghost_precision(QUDA_INVALID_PRECISION), nDim(4), pad(0),
+      siteSubset(QUDA_INVALID_SITE_SUBSET), mem_type(QUDA_MEMORY_DEVICE),
       ghostExchange(QUDA_GHOST_EXCHANGE_PAD), scale(1.0)
     {
       for (int i=0; i<nDim; i++) {
@@ -88,7 +102,8 @@ namespace quda {
     */
     LatticeFieldParam(int nDim, const int *x, int pad, QudaPrecision precision,
 		      QudaGhostExchange ghostExchange=QUDA_GHOST_EXCHANGE_PAD)
-    : nDim(nDim), pad(pad), precision(precision), siteSubset(QUDA_FULL_SITE_SUBSET), mem_type(QUDA_MEMORY_DEVICE),
+    : precision(precision), ghost_precision(precision), nDim(nDim), pad(pad),
+      siteSubset(QUDA_FULL_SITE_SUBSET), mem_type(QUDA_MEMORY_DEVICE),
       ghostExchange(ghostExchange), scale(1.0)
     {
       if (nDim > QUDA_MAX_DIM) errorQuda("Number of dimensions too great");
@@ -105,7 +120,8 @@ namespace quda {
        @param[in] param Contains the metadata for filling out the LatticeFieldParam
     */
     LatticeFieldParam(const QudaGaugeParam &param) 
-    : nDim(4), pad(0), precision(param.cpu_prec), siteSubset(QUDA_FULL_SITE_SUBSET), mem_type(QUDA_MEMORY_DEVICE),
+    :  precision(param.cpu_prec), ghost_precision(param.cpu_prec), nDim(4), pad(0),
+      siteSubset(QUDA_FULL_SITE_SUBSET), mem_type(QUDA_MEMORY_DEVICE),
       ghostExchange(QUDA_GHOST_EXCHANGE_NO), scale(param.scale)
     {
       for (int i=0; i<nDim; i++) {
@@ -151,6 +167,9 @@ namespace quda {
     /** Precision of the field */
     QudaPrecision precision;
     
+    /** Precision of the ghost */
+    mutable QudaPrecision ghost_precision;
+
     /** For fixed-point fields that need a global scaling factor */
     double scale;
 
@@ -477,6 +496,11 @@ namespace quda {
        @return The field precision
     */
     QudaPrecision Precision() const { return precision; }
+
+    /**
+       @return The ghost precision
+    */
+    QudaPrecision GhostPrecision() const { return ghost_precision; }
 
     /**
        @return The global scaling factor for a fixed-point field

--- a/include/lattice_field.h
+++ b/include/lattice_field.h
@@ -231,6 +231,11 @@ namespace quda {
     mutable size_t ghost_bytes;
 
     /**
+       Size in bytes of prior ghost allocation
+    */
+    mutable size_t ghost_bytes_old;
+
+    /**
        Size in bytes of the ghost in each dimension
     */
     mutable size_t ghost_face_bytes[QUDA_MAX_DIM];
@@ -392,8 +397,11 @@ namespace quda {
        Create the communication handlers (both host and device)
        @param[in] no_comms_fill Whether to allocate halo buffers for
        dimensions that are not partitioned
+       @param[in] bidir Whether to allocate communication buffers to
+       allow for simultaneous bi-directional exchange.  If false, then
+       the forwards and backwards buffers will alias (saving memory).
     */
-    void createComms(bool no_comms_fill=false);
+    void createComms(bool no_comms_fill=false, bool bidir=true);
 
     /**
        Destroy the communication handlers

--- a/lib/blas_cublas.cu
+++ b/lib/blas_cublas.cu
@@ -1,4 +1,5 @@
 #include <blas_cublas.h>
+#include <cublas_v2.h>
 #include <malloc_quda.h>
 
 #define FMULS_GETRF(m_, n_) ( ((m_) < (n_)) \

--- a/lib/blas_cublas.cu
+++ b/lib/blas_cublas.cu
@@ -22,16 +22,22 @@ namespace quda {
 
   namespace cublas { 
 
+#ifdef CUBLAS_LIB
     static cublasHandle_t handle;
+#endif
 
     void init() {
+#ifdef CUBLAS_LIB
       cublasStatus_t error = cublasCreate(&handle);
       if (error != CUBLAS_STATUS_SUCCESS) errorQuda("cublasCreate failed with error %d", error);
+#endif
     }
 
     void destroy() {
+#ifdef CUBLAS_LIB
       cublasStatus_t error = cublasDestroy(handle);
       if (error != CUBLAS_STATUS_SUCCESS) errorQuda("\nError indestroying cublas context, error code = %d\n", error);
+#endif
     }
 
     // mini kernel to set the array of pointers needed for batched cublas

--- a/lib/clover_field.cpp
+++ b/lib/clover_field.cpp
@@ -431,7 +431,7 @@ namespace quda {
     spinor_param.nSpin = 4;
     spinor_param.nDim = a.Ndim();
     for (int d=0; d<a.Ndim(); d++) spinor_param.x[d] = a.X()[d];
-    spinor_param.precision = a.Precision();
+    spinor_param.setPrecision(a.Precision());
     spinor_param.pad = a.Pad();
     spinor_param.siteSubset = QUDA_FULL_SITE_SUBSET;
     spinor_param.siteOrder = QUDA_EVEN_ODD_SITE_ORDER;

--- a/lib/clover_field.cpp
+++ b/lib/clover_field.cpp
@@ -231,11 +231,15 @@ namespace quda {
 
   void cudaCloverField::destroyTexObject() {
     if (isNative()) {
+      cudaDestroyTextureObject(tex);
+      cudaDestroyTextureObject(invTex);
       cudaDestroyTextureObject(evenTex);
       cudaDestroyTextureObject(oddTex);
       cudaDestroyTextureObject(evenInvTex);
       cudaDestroyTextureObject(oddInvTex);
       if (precision == QUDA_HALF_PRECISION) {
+	cudaDestroyTextureObject(normTex);
+	cudaDestroyTextureObject(invNormTex);
 	cudaDestroyTextureObject(evenNormTex);
 	cudaDestroyTextureObject(oddNormTex);
 	cudaDestroyTextureObject(evenInvNormTex);

--- a/lib/coarse_op.cu
+++ b/lib/coarse_op.cu
@@ -221,7 +221,8 @@ namespace quda {
       //Create a copy of the gauge field with no reconstruction, required for fine-grained access
       GaugeFieldParam gf_param(gauge);
       gf_param.reconstruct = QUDA_RECONSTRUCT_NO;
-      gf_param.setPrecision(gf_param.precision);
+      gf_param.order = QUDA_FLOAT2_GAUGE_ORDER;
+      gf_param.setPrecision(gf_param.Precision());
       U = new cudaGaugeField(gf_param);
 
       U->copy(gauge);
@@ -230,7 +231,7 @@ namespace quda {
     CloverFieldParam cf_param;
     cf_param.nDim = 4;
     cf_param.pad = 0;
-    cf_param.precision = clover ? clover->Precision() : QUDA_SINGLE_PRECISION;
+    cf_param.setPrecision(clover ? clover->Precision() : QUDA_SINGLE_PRECISION);
 
     // if we have no clover term then create an empty clover field
     for(int i = 0; i < cf_param.nDim; i++) cf_param.x[i] = clover ? clover->X()[i] : 0;
@@ -259,7 +260,7 @@ namespace quda {
     ColorSpinorParam UVparam(T.Vectors(location));
     UVparam.create = QUDA_ZERO_FIELD_CREATE;
     UVparam.location = location;
-    UVparam.precision = T.Vectors(location).Precision();
+    UVparam.setPrecision(T.Vectors(location).Precision());
 
     ColorSpinorField *uv = ColorSpinorField::Create(UVparam);
 

--- a/lib/coarse_op.cuh
+++ b/lib/coarse_op.cuh
@@ -1559,11 +1559,11 @@ namespace quda {
 	  if (from_coarse) errorQuda("ComputeCloverInvMax should only be called from the fine grid");
 #ifdef DYNAMIC_CLOVER
 	  arg.max_d = static_cast<Float*>(pool_device_malloc(2 * arg.fineVolumeCB));
-    ComputeCloverInvMaxGPU<Float><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
-    thrust_allocator alloc;
-    thrust::device_ptr<Float> ptr(arg.max_d);
-    arg.max_h = thrust::reduce(thrust::cuda::par(alloc), ptr, ptr+2*arg.fineVolumeCB, static_cast<Float>(0.0), thrust::maximum<Float>());
-    pool_device_free(arg.max_d);
+	  ComputeCloverInvMaxGPU<Float><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+	  thrust_allocator alloc;
+	  thrust::device_ptr<Float> ptr(arg.max_d);
+	  arg.max_h = thrust::reduce(thrust::cuda::par(alloc), ptr, ptr+2*arg.fineVolumeCB, static_cast<Float>(0.0), thrust::maximum<Float>());
+	  pool_device_free(arg.max_d);
 #else
 	  errorQuda("ComputeCloverInvMax only enabled with dynamic clover");
 #endif

--- a/lib/coarse_op.cuh
+++ b/lib/coarse_op.cuh
@@ -1898,8 +1898,8 @@ namespace quda {
     // do exchange of null-space vectors
     const int nFace = 1;
     v.exchangeGhost(QUDA_INVALID_PARITY, nFace, 0);
-    arg.V.resetGhost(v.Ghost());  // point the accessor to the correct ghost buffer
-    if (&v == &av) arg.AV.resetGhost(av.Ghost());
+    arg.V.resetGhost(v, v.Ghost());  // point the accessor to the correct ghost buffer
+    if (&v == &av) arg.AV.resetGhost(av, av.Ghost());
     LatticeField::bufferIndex = (1 - LatticeField::bufferIndex); // update ghost bufferIndex for next exchange
 
     if (getVerbosity() >= QUDA_VERBOSE) printfQuda("V2 = %e\n", arg.V.norm2());
@@ -2007,7 +2007,7 @@ namespace quda {
     if ( (dirac == QUDA_CLOVERPC_DIRAC || dirac == QUDA_TWISTED_MASSPC_DIRAC || dirac == QUDA_TWISTED_CLOVERPC_DIRAC) &&
 	 (matpc == QUDA_MATPC_EVEN_EVEN || matpc == QUDA_MATPC_ODD_ODD) ) {
       av.exchangeGhost(QUDA_INVALID_PARITY, nFace, 0);
-      arg.AV.resetGhost(av.Ghost());  // make sure we point to the correct pointer in the accessor
+      arg.AV.resetGhost(av, av.Ghost());  // make sure we point to the correct pointer in the accessor
       LatticeField::bufferIndex = (1 - LatticeField::bufferIndex); // update ghost bufferIndex for next exchange
     }
 

--- a/lib/coarsecoarse_op.cu
+++ b/lib/coarsecoarse_op.cu
@@ -203,7 +203,7 @@ namespace quda {
     UVparam.create = QUDA_ZERO_FIELD_CREATE;
     UVparam.location = location;
     UVparam.nSpin *= 2; // so nSpin == 4
-    UVparam.precision = T.Vectors(location).Precision();
+    UVparam.setPrecision(T.Vectors(location).Precision());
 
     ColorSpinorField *uv = ColorSpinorField::Create(UVparam);
 

--- a/lib/color_spinor_field.cpp
+++ b/lib/color_spinor_field.cpp
@@ -9,7 +9,7 @@ namespace quda {
 
     }*/
 
-  ColorSpinorParam::ColorSpinorParam(const ColorSpinorField &field) {
+  ColorSpinorParam::ColorSpinorParam(const ColorSpinorField &field) : LatticeFieldParam()  {
     field.fill(*this);
   }
 
@@ -21,7 +21,7 @@ namespace quda {
       components(0)
   {
     create(param.nDim, param.x, param.nColor, param.nSpin, param.nVec, param.twistFlavor,
-	   param.precision, param.pad, param.siteSubset, param.siteOrder,
+	   param.Precision(), param.pad, param.siteSubset, param.siteOrder,
 	   param.fieldOrder, param.gammaBasis, param.PCtype);
   }
 
@@ -32,7 +32,7 @@ namespace quda {
      composite_descr(field.composite_descr), components(0)
   {
     create(field.nDim, field.x, field.nColor, field.nSpin, field.nVec, field.twistFlavor,
-	   field.precision, field.pad, field.siteSubset, field.siteOrder,
+	   field.Precision(), field.pad, field.siteSubset, field.siteOrder,
 	   field.fieldOrder, field.gammaBasis, field.PCtype);
   }
 
@@ -67,7 +67,7 @@ namespace quda {
       if (i==0) {
 	ghostOffset[i][0] = 0;
       } else {
-        if (precision == QUDA_HALF_PRECISION) {
+        if (ghost_precision == QUDA_HALF_PRECISION) {
           ghostOffset[i][0] = (ghostNormOffset[i-1][1] + num_norm_faces*ghostFace[i-1]/2)*sizeof(float)/sizeof(short);
           // Ensure that start of ghostOffset is aligned on four word boundaries (check if this is needed)
           ghostOffset[i][0] = 4*((ghostOffset[i][0] + 3)/4);
@@ -76,7 +76,7 @@ namespace quda {
         }
       }
 
-      if (precision == QUDA_HALF_PRECISION) {
+      if (ghost_precision == QUDA_HALF_PRECISION) {
         ghostNormOffset[i][0] = (ghostOffset[i][0] + (num_faces*ghostFace[i]*nSpin*nColor*2/2))*sizeof(short)/sizeof(float);
         ghostOffset[i][1] = (ghostNormOffset[i][0] + num_norm_faces*ghostFace[i]/2)*sizeof(float)/sizeof(short);
 	// Ensure that start of ghostOffset is aligned on four word boundaries (check if this is needed)
@@ -87,8 +87,8 @@ namespace quda {
       }
 
       int Nint = nColor * nSpin * 2 / (nSpin == 4 && spin_project ? 2 : 1); // number of internal degrees of freedom
-      ghost_face_bytes[i] = nFace*ghostFace[i]*Nint*precision;
-      if (precision == QUDA_HALF_PRECISION) ghost_face_bytes[i] += nFace*ghostFace[i]*sizeof(float);
+      ghost_face_bytes[i] = nFace*ghostFace[i]*Nint*ghost_precision;
+      if (ghost_precision == QUDA_HALF_PRECISION) ghost_face_bytes[i] += nFace*ghostFace[i]*sizeof(float);
 
     } // dim
 
@@ -96,15 +96,15 @@ namespace quda {
     ghostVolume *= num_faces;
 
     size_t ghost_length = ghostVolume*nColor*nSpin*2;
-    size_t ghost_norm_length = (precision == QUDA_HALF_PRECISION) ? ghostNormVolume : 0;
+    size_t ghost_norm_length = (ghost_precision == QUDA_HALF_PRECISION) ? ghostNormVolume : 0;
 
     if (getVerbosity() == QUDA_DEBUG_VERBOSE) {
       printfQuda("Allocated ghost volume = %d, ghost norm volume %d\n", ghostVolume, ghostNormVolume);
       printfQuda("ghost length = %lu, ghost norm length = %lu\n", ghost_length, ghost_norm_length);
     }
 
-    ghost_bytes = (size_t)ghost_length*precision;
-    if (precision == QUDA_HALF_PRECISION) ghost_bytes += ghost_norm_length*sizeof(float);
+    ghost_bytes = (size_t)ghost_length*ghost_precision;
+    if (ghost_precision == QUDA_HALF_PRECISION) ghost_bytes += ghost_norm_length*sizeof(float);
     if (isNative()) ghost_bytes = ALIGNMENT_ADJUST(ghost_bytes);
 
   } // createGhostZone
@@ -258,7 +258,7 @@ namespace quda {
 
     if (param.PCtype != QUDA_PC_INVALID) PCtype = param.PCtype;
 
-    if (param.precision != QUDA_INVALID_PRECISION)  precision = param.precision;
+    if (param.Precision() != QUDA_INVALID_PRECISION) precision = param.Precision();
     if (param.nDim != 0) nDim = param.nDim;
 
     composite_descr.is_composite     = param.is_composite;
@@ -349,7 +349,8 @@ namespace quda {
     param.nSpin = nSpin;
     param.nVec = nVec;
     param.twistFlavor = twistFlavor;
-    param.precision = precision;
+    param.fieldOrder = fieldOrder;
+    param.setPrecision(precision, ghost_precision);
     param.nDim = nDim;
 
     param.is_composite  = composite_descr.is_composite;
@@ -361,7 +362,6 @@ namespace quda {
     param.pad = pad;
     param.siteSubset = siteSubset;
     param.siteOrder = siteOrder;
-    param.fieldOrder = fieldOrder;
     param.gammaBasis = gammaBasis;
     param.PCtype = PCtype;
     param.create = QUDA_INVALID_FIELD_CREATE;
@@ -379,7 +379,7 @@ namespace quda {
     const int Ninternal = 2*nColor*nSpin;
     size_t total_bytes = 0;
     for (int i=0; i<nDimComms; i++) {
-      bytes[i] = siteSubset*nFace*surfaceCB[i]*Ninternal*precision;
+      bytes[i] = siteSubset*nFace*surfaceCB[i]*Ninternal*ghost_precision;
       if (comm_dim_partitioned(i)) total_bytes += 2*bytes[i]; // 2 for fwd/bwd
     }
 
@@ -761,7 +761,7 @@ namespace quda {
 
     // for GPU fields, always use native ordering to ensure coalescing
     if (new_location == QUDA_CUDA_FIELD_LOCATION) {
-      fineParam.fieldOrder = (fineParam.nSpin==4 && fineParam.precision!= QUDA_DOUBLE_PRECISION) ?
+      fineParam.fieldOrder = (fineParam.nSpin==4 && fineParam.Precision()!= QUDA_DOUBLE_PRECISION) ?
 	QUDA_FLOAT4_FIELD_ORDER : QUDA_FLOAT2_FIELD_ORDER;
     }
 
@@ -785,6 +785,7 @@ namespace quda {
     for (int d=0; d<a.nDim; d++) out << "x[" << d << "] = " << a.x[d] << std::endl;
     out << "volume = " << a.volume << std::endl;
     out << "precision = " << a.precision << std::endl;
+    out << "ghost_precision = " << a.ghost_precision << std::endl;
     out << "pad = " << a.pad << std::endl;
     out << "stride = " << a.stride << std::endl;
     out << "real_length = " << a.real_length << std::endl;

--- a/lib/color_spinor_field.cpp
+++ b/lib/color_spinor_field.cpp
@@ -259,6 +259,7 @@ namespace quda {
     if (param.PCtype != QUDA_PC_INVALID) PCtype = param.PCtype;
 
     if (param.Precision() != QUDA_INVALID_PRECISION) precision = param.Precision();
+    if (param.GhostPrecision() != QUDA_INVALID_PRECISION) ghost_precision = param.GhostPrecision();
     if (param.nDim != 0) nDim = param.nDim;
 
     composite_descr.is_composite     = param.is_composite;

--- a/lib/color_spinor_pack.cu
+++ b/lib/color_spinor_pack.cu
@@ -4,14 +4,47 @@
 #include <tune_quda.h>
 #include <fast_intdiv.h>
 
+/**
+   @file color_spinor_pack.cu
+
+   @brief This is the implementation of the color-spinor halo packer
+   for an arbitrary field.  This implementation uses the fine-grained
+   accessors and should support all field types reqgardless of
+   precision, number of color or spins etc.
+
+   Using a different precision of the field and of the halo is
+   supported, though only QUDA_SINGLE_PRECISION fields with
+   QUDA_HALF_PRECISION halos are instantiated.  When an integer format
+   is requested for the halos then block-float format is used.
+
+   As well as tuning basic block sizes, the autotuner also tunes for
+   the dimensions to assign to each thread.  E.g., dim_thread=1 means
+   we have one thread for all dimensions, dim_thread=4 means we have
+   four threads (e.g., one per dimension).  We always uses seperate
+   threads for forwards and backwards directions.  Dimension,
+   direction and parity are assigned to the z thread dimension.
+
+   If doing block-float format, since all spin and color components of
+   a given site have to reside in the same thread block (to allow us
+   to compute the max element) we override the autotuner to keep the z
+   thread dimensions in the grid and not the block, and allow for
+   smaller tuning increments of the thread block dimension in x to
+   ensure that we can always fit within a single thread block.  It is
+   this constraint that gives rise for the need to cap the limit for
+   block-float support, e.g., MAX_BLOCK_FLOAT_NC.
+
+   At present we launch a volume of threads (actually multiples
+   thereof for direction / dimension) and thus we have coalesced reads
+   but not coalesced writes.  A more optimal implementation will
+   launch a surface of threads for each halo giving coalesced writes.
+ */
+
 namespace quda {
 
   template <typename Field>
   struct PackGhostArg {
 
     Field field;
-    void **ghost;
-    const void *v;
     int_fastdiv X[QUDA_MAX_DIM];
     const int volumeCB;
     const int nDim;
@@ -22,10 +55,8 @@ namespace quda {
     const QudaDWFPCType pc_type;
     int commDim[4]; // whether a given dimension is partitioned or not
 
-    PackGhostArg(Field field, void **ghost, const ColorSpinorField &a, int parity, int nFace, int dagger)
+    PackGhostArg(Field field, const ColorSpinorField &a, int parity, int nFace, int dagger)
       : field(field),
-	ghost(ghost),
-	v(a.V()),
 	volumeCB(a.VolumeCB()),
 	nDim(a.Ndim()),
 	nFace(nFace),
@@ -43,76 +74,174 @@ namespace quda {
     }
   };
 
-  template <typename Float, int Ns, int Ms, int Nc, int Mc, int nDim, typename Arg>
-  __device__ __host__ inline void packGhost(Arg &arg, int cb_idx, int parity, int spinor_parity, int spin_block, int color_block) {
-    typedef typename mapper<Float>::type RegType;
+// this is the maximum number of colors for which we support block-float format
+#define MAX_BLOCK_FLOAT_NC 32
 
-    int x[5] = { };
-    if (nDim == 5) getCoords5(x, cb_idx, arg.X, parity, arg.pc_type);
-    else getCoords(x, cb_idx, arg.X, parity);
+  /**
+     Compute the max element over the spin-color components of a given site.
+   */
+  template <typename Float, int Ns, int Ms, int Nc, int Mc, typename Arg>
+  __device__ __host__ inline Float compute_site_max(Arg &arg, int x_cb, int parity, int spinor_parity, int spin_block, int color_block) {
+
+    Float thread_max = 0.0;
+    Float site_max = 0.0;
+#ifdef __CUDA_ARCH__
+    // workout how big a shared-memory allocation we need
+    // just statically compute the largest size needed to avoid templating on block size
+    constexpr int max_block_size = 1024; // all supported GPUs have 1024 as their max block size
+    constexpr int bank_width = 32; // shared memory has 32 banks
+    constexpr int color_spin_threads = Nc <= MAX_BLOCK_FLOAT_NC ? (Ns/Ms) * (Nc/Mc) : 1;
+    // this is the largest size of blockDim.x (rounded up to multiples of bank_width)
+    constexpr int thread_width_x = ( (max_block_size / color_spin_threads + bank_width-1) / bank_width) * bank_width;
+    const auto &rhs = arg.field;
+#pragma unroll
+    for (int spin_local=0; spin_local<Ms; spin_local++) {
+      int s = spin_block + spin_local;
+#pragma unroll
+      for (int color_local=0; color_local<Mc; color_local++) {
+	int c = color_block + color_local;
+	complex<Float> z = rhs(spinor_parity, x_cb, s, c);
+	thread_max = thread_max > fabs(z.real()) ? thread_max : fabs(z.real());
+	thread_max = thread_max > fabs(z.imag()) ? thread_max : fabs(z.imag());
+      }
+    }
+
+    __shared__ Float v[ (Ns/Ms) * (Nc/Mc) * thread_width_x];
+    v[ ( (spin_block/Ms) * (Nc/Mc) + (color_block/Mc)) * blockDim.x + threadIdx.x ] = thread_max;
+    __syncthreads();
 
 #pragma unroll
-    for (int dim=0; dim<4; dim++) {
-      if (arg.commDim[dim] && x[dim] < arg.nFace){
+    for (int sc=0; sc<(Ns/Ms) * (Nc/Mc); sc++) {
+      site_max = site_max > v[sc*blockDim.x + threadIdx.x] ? site_max : v[sc*blockDim.x + threadIdx.x];
+    }
+
+#else
+    errorQuda("Not supported on CPU");
+#endif
+
+    return site_max;
+  }
+
+
+  template <typename Float, bool block_float, int Ns, int Ms, int Nc, int Mc, int nDim, int dim, int dir, typename Arg>
+  __device__ __host__ inline void packGhost(Arg &arg, int x_cb, int parity, int spinor_parity, int spin_block, int color_block) {
+
+    int x[5] = { };
+    if (nDim == 5) getCoords5(x, x_cb, arg.X, parity, arg.pc_type);
+    else getCoords(x, x_cb, arg.X, parity);
+
+    const auto &rhs = arg.field;
+
+    {
+      if (dir == 0 && arg.commDim[dim] && x[dim] < arg.nFace){
+	Float max = block_float ? compute_site_max<Float,Ns,Ms,Nc,Mc>(arg, x_cb, parity, spinor_parity, spin_block, color_block) : 1.0;
+
 	for (int spin_local=0; spin_local<Ms; spin_local++) {
 	  int s = spin_block + spin_local;
 	  for (int color_local=0; color_local<Mc; color_local++) {
 	    int c = color_block + color_local;
-	    arg.field.Ghost(dim, 0, spinor_parity, ghostFaceIndex<0>(x,arg.X,dim,arg.nFace), s, c)
-	      = arg.field(spinor_parity, cb_idx, s, c);
+	    arg.field.Ghost(dim, 0, spinor_parity, ghostFaceIndex<0>(x,arg.X,dim,arg.nFace), s, c, 0, max) = rhs(spinor_parity, x_cb, s, c);
 	  }
 	}
       }
       
-      if (arg.commDim[dim] && x[dim] >= arg.X[dim] - arg.nFace){
+      if (dir == 1 && arg.commDim[dim] && x[dim] >= arg.X[dim] - arg.nFace){
+	Float max = block_float ? compute_site_max<Float,Ns,Ms,Nc,Mc>(arg, x_cb, parity, spinor_parity, spin_block, color_block) : 1.0;
+
 	for (int spin_local=0; spin_local<Ms; spin_local++) {
 	  int s = spin_block + spin_local;
 	  for (int color_local=0; color_local<Mc; color_local++) {
 	    int c = color_block + color_local;
-	    arg.field.Ghost(dim, 1, spinor_parity, ghostFaceIndex<1>(x,arg.X,dim,arg.nFace), s, c)
-	      = arg.field(spinor_parity, cb_idx, s, c);
+	    arg.field.Ghost(dim, 1, spinor_parity, ghostFaceIndex<1>(x,arg.X,dim,arg.nFace), s, c, 0, max) = rhs(spinor_parity, x_cb, s, c);
 	  }
 	}
       }
     }
   }
 
-  template <typename Float, int Ns, int Ms, int Nc, int Mc, int nDim, typename Arg>
+  template <typename Float, bool block_float, int Ns, int Ms, int Nc, int Mc, int nDim, typename Arg>
   void GenericPackGhost(Arg &arg) {
     for (int parity=0; parity<arg.nParity; parity++) {
       parity = (arg.nParity == 2) ? parity : arg.parity;
       const int spinor_parity = (arg.nParity == 2) ? parity : 0;
-      for (int i=0; i<arg.volumeCB; i++)
-	for (int spin_block=0; spin_block<Ns; spin_block+=Ms)
-	  for (int color_block=0; color_block<Nc; color_block+=Mc)
-	    packGhost<Float,Ns,Ms,Nc,Mc,nDim>(arg, i, parity, spinor_parity, spin_block, color_block);
+      for (int dim=0; dim<4; dim++)
+	for (int dir=0; dir<2; dir++)
+	  for (int x_cb=0; x_cb<arg.volumeCB; x_cb++)
+	    for (int spin_block=0; spin_block<Ns; spin_block+=Ms)
+	      for (int color_block=0; color_block<Nc; color_block+=Mc)
+		switch(dir) {
+		case 0: // backwards pack
+		  switch(dim) {
+		  case 0: packGhost<Float,block_float,Ns,Ms,Nc,Mc,nDim,0,0>(arg, x_cb, parity, spinor_parity, spin_block, color_block); break;
+		  case 1: packGhost<Float,block_float,Ns,Ms,Nc,Mc,nDim,1,0>(arg, x_cb, parity, spinor_parity, spin_block, color_block); break;
+		  case 2: packGhost<Float,block_float,Ns,Ms,Nc,Mc,nDim,2,0>(arg, x_cb, parity, spinor_parity, spin_block, color_block); break;
+		  case 3: packGhost<Float,block_float,Ns,Ms,Nc,Mc,nDim,3,0>(arg, x_cb, parity, spinor_parity, spin_block, color_block); break;
+		  }
+		  break;
+		case 1: // forwards pack
+		  switch(dim) {
+		  case 0: packGhost<Float,block_float,Ns,Ms,Nc,Mc,nDim,0,1>(arg, x_cb, parity, spinor_parity, spin_block, color_block); break;
+		  case 1: packGhost<Float,block_float,Ns,Ms,Nc,Mc,nDim,1,1>(arg, x_cb, parity, spinor_parity, spin_block, color_block); break;
+		  case 2: packGhost<Float,block_float,Ns,Ms,Nc,Mc,nDim,2,1>(arg, x_cb, parity, spinor_parity, spin_block, color_block); break;
+		  case 3: packGhost<Float,block_float,Ns,Ms,Nc,Mc,nDim,3,1>(arg, x_cb, parity, spinor_parity, spin_block, color_block); break;
+		  }
+		}
     }
   }
 
-  template <typename Float, int Ns, int Ms, int Nc, int Mc, int nDim, typename Arg>
+  template <typename Float, bool block_float, int Ns, int Ms, int Nc, int Mc, int nDim, int dim_threads, typename Arg>
   __global__ void GenericPackGhostKernel(Arg arg) {
     int x_cb = blockIdx.x*blockDim.x + threadIdx.x;
     if (x_cb >= arg.volumeCB) return;
 
-    const int parity = (arg.nParity == 2) ? blockDim.z*blockIdx.z + threadIdx.z : arg.parity;
+    const int parity_dim_dir = blockDim.z*blockIdx.z + threadIdx.z;
+    if (parity_dim_dir >= arg.nParity*2*dim_threads) return;
+
+    const int dim_dir = parity_dim_dir % (2*dim_threads);
+    const int dim0 = dim_dir / 2;
+    const int dir = dim_dir % 2;
+    const int parity = (arg.nParity == 2) ? (parity_dim_dir / (2*dim_threads) ) : arg.parity;
+
     const int spinor_parity = (arg.nParity == 2) ? parity : 0;
     const int spin_color_block = blockDim.y*blockIdx.y + threadIdx.y;
     if (spin_color_block >= (Ns/Ms)*(Nc/Mc)) return; // ensure only valid threads
     const int spin_block = (spin_color_block / (Nc / Mc)) * Ms;
     const int color_block = (spin_color_block % (Nc / Mc)) * Mc;
-    packGhost<Float,Ns,Ms,Nc,Mc,nDim>(arg, x_cb, parity, spinor_parity, spin_block, color_block);
+
+#pragma unroll
+    for (int dim=dim0; dim<4; dim+=dim_threads) {
+      switch(dir) {
+      case 0:
+	switch(dim) {
+	case 0: packGhost<Float,block_float,Ns,Ms,Nc,Mc,nDim,0,0>(arg, x_cb, parity, spinor_parity, spin_block, color_block); break;
+	case 1: packGhost<Float,block_float,Ns,Ms,Nc,Mc,nDim,1,0>(arg, x_cb, parity, spinor_parity, spin_block, color_block); break;
+	case 2: packGhost<Float,block_float,Ns,Ms,Nc,Mc,nDim,2,0>(arg, x_cb, parity, spinor_parity, spin_block, color_block); break;
+	case 3: packGhost<Float,block_float,Ns,Ms,Nc,Mc,nDim,3,0>(arg, x_cb, parity, spinor_parity, spin_block, color_block); break;
+	}
+	break;
+      case 1:
+	switch(dim) {
+	case 0: packGhost<Float,block_float,Ns,Ms,Nc,Mc,nDim,0,1>(arg, x_cb, parity, spinor_parity, spin_block, color_block); break;
+	case 1: packGhost<Float,block_float,Ns,Ms,Nc,Mc,nDim,1,1>(arg, x_cb, parity, spinor_parity, spin_block, color_block); break;
+	case 2: packGhost<Float,block_float,Ns,Ms,Nc,Mc,nDim,2,1>(arg, x_cb, parity, spinor_parity, spin_block, color_block); break;
+	case 3: packGhost<Float,block_float,Ns,Ms,Nc,Mc,nDim,3,1>(arg, x_cb, parity, spinor_parity, spin_block, color_block); break;
+	}
+	break;
+      }
+    }
   }
 
-  template <typename Float, int Ns, int Ms, int Nc, int Mc, typename Arg>
+  template <typename Float, bool block_float, int Ns, int Ms, int Nc, int Mc, typename Arg>
   class GenericPackGhostLauncher : public TunableVectorYZ {
     Arg &arg;
     const ColorSpinorField &meta;
     unsigned int minThreads() const { return arg.volumeCB; }
     bool tuneGridDim() const { return false; }
+    bool tuneAuxDim() const { return true; }
 
   public:
     inline GenericPackGhostLauncher(Arg &arg, const ColorSpinorField &meta, MemoryLocation *destination)
-      : TunableVectorYZ((Ns/Ms)*(Nc/Mc), arg.nParity), arg(arg), meta(meta) {
+      : TunableVectorYZ((Ns/Ms)*(Nc/Mc), 2*arg.nParity), arg(arg), meta(meta) {
       strcpy(aux, meta.AuxString());
       strcat(aux,comm_dim_partitioned_string());
 
@@ -135,17 +264,77 @@ namespace quda {
 
     inline void apply(const cudaStream_t &stream) {
       if (meta.Location() == QUDA_CPU_FIELD_LOCATION) {
-	if (arg.nDim == 5) GenericPackGhost<Float,Ns,Ms,Nc,Mc,5,Arg>(arg);
-	else GenericPackGhost<Float,Ns,Ms,Nc,Mc,4,Arg>(arg);
+	if (arg.nDim == 5) GenericPackGhost<Float,block_float,Ns,Ms,Nc,Mc,5,Arg>(arg);
+	else GenericPackGhost<Float,block_float,Ns,Ms,Nc,Mc,4,Arg>(arg);
       } else {
 	const TuneParam &tp = tuneLaunch(*this, getTuning(), getVerbosity());
-	if (arg.nDim == 5) GenericPackGhostKernel<Float,Ns,Ms,Nc,Mc,5,Arg> <<<tp.grid,tp.block,tp.shared_bytes,stream>>>(arg);
-	else GenericPackGhostKernel<Float,Ns,Ms,Nc,Mc,4,Arg> <<<tp.grid,tp.block,tp.shared_bytes,stream>>>(arg);
+	switch(tp.aux.x) {
+	case 1:
+	  if (arg.nDim == 5) GenericPackGhostKernel<Float,block_float,Ns,Ms,Nc,Mc,5,1,Arg> <<<tp.grid,tp.block,tp.shared_bytes,stream>>>(arg);
+	  else GenericPackGhostKernel<Float,block_float,Ns,Ms,Nc,Mc,4,1,Arg> <<<tp.grid,tp.block,tp.shared_bytes,stream>>>(arg);
+	  break;
+	case 2:
+	  if (arg.nDim == 5) GenericPackGhostKernel<Float,block_float,Ns,Ms,Nc,Mc,5,2,Arg> <<<tp.grid,tp.block,tp.shared_bytes,stream>>>(arg);
+	  else GenericPackGhostKernel<Float,block_float,Ns,Ms,Nc,Mc,4,2,Arg> <<<tp.grid,tp.block,tp.shared_bytes,stream>>>(arg);
+	  break;
+	case 4:
+	  if (arg.nDim == 5) GenericPackGhostKernel<Float,block_float,Ns,Ms,Nc,Mc,5,4,Arg> <<<tp.grid,tp.block,tp.shared_bytes,stream>>>(arg);
+	  else GenericPackGhostKernel<Float,block_float,Ns,Ms,Nc,Mc,4,4,Arg> <<<tp.grid,tp.block,tp.shared_bytes,stream>>>(arg);
+	  break;
+	}
       }
+    }
+
+    // if doing block float then all spin-color components must be within the same block
+    void setColorSpinBlock(TuneParam &param) const {
+      param.block.y = (Ns/Ms)*(Nc/Mc);
+      param.grid.y = 1;
+      param.block.z = 1;
+      param.grid.z = arg.nParity*2*param.aux.x;
+    }
+
+    bool advanceBlockDim(TuneParam &param) const {
+      if (!block_float) {
+	return TunableVectorYZ::advanceBlockDim(param);
+      } else {
+	bool advance = Tunable::advanceBlockDim(param);
+	setColorSpinBlock(param); // if doing block float then all spin-color components must be within the same block
+	return advance;
+      }
+    }
+
+    int blockStep() const { return block_float ? 2 : TunableVectorYZ::blockStep(); }
+    int blockMin() const { return block_float ? 2 : TunableVectorYZ::blockMin(); }
+
+    bool advanceAux(TuneParam &param) const {
+      if (param.aux.x < 4) {
+	param.aux.x *= 2;
+	const_cast<GenericPackGhostLauncher*>(this)->resizeVector((Ns/Ms)*(Nc/Mc), arg.nParity*2*param.aux.x);
+	TunableVectorYZ::initTuneParam(param);
+	if (block_float) setColorSpinBlock(param);
+	return true;
+      }
+      param.aux.x = 1;
+      const_cast<GenericPackGhostLauncher*>(this)->resizeVector((Ns/Ms)*(Nc/Mc), arg.nParity*2*param.aux.x);
+      TunableVectorYZ::initTuneParam(param);
+      if (block_float) setColorSpinBlock(param);
+      return false;
     }
 
     TuneKey tuneKey() const {
       return TuneKey(meta.VolString(), typeid(*this).name(), aux);
+    }
+
+    virtual void initTuneParam(TuneParam &param) const {
+      TunableVectorYZ::initTuneParam(param);
+      param.aux = make_int4(1,1,1,1);
+      if (block_float) setColorSpinBlock(param);
+    }
+
+    virtual void defaultTuneParam(TuneParam &param) const {
+      TunableVectorYZ::defaultTuneParam(param);
+      param.aux = make_int4(1,1,1,1);
+      if (block_float) setColorSpinBlock(param);
     }
 
     long long flops() const { return 0; }
@@ -153,88 +342,97 @@ namespace quda {
       size_t totalBytes = 0;
       for (int d=0; d<4; d++) {
 	if (!comm_dim_partitioned(d)) continue;
-	totalBytes += 2*arg.nFace*2*Ns*Nc*meta.SurfaceCB(d)*meta.Precision();
+	totalBytes += arg.nFace*2*Ns*Nc*meta.SurfaceCB(d)*(meta.Precision() + meta.GhostPrecision());
       }
       return totalBytes;
     }
   };
 
-  template <typename Float, QudaFieldOrder order, int Ns, int Nc>
+  template <typename Float, typename ghostFloat, QudaFieldOrder order, int Ns, int Nc>
   inline void genericPackGhost(void **ghost, const ColorSpinorField &a, QudaParity parity,
 			       int nFace, int dagger, MemoryLocation *destination) {
 
-    typedef typename colorspinor::FieldOrderCB<typename mapper<Float>::type,Ns,Nc,1,order,Float> Q;
+    typedef typename mapper<Float>::type RegFloat;
+    typedef typename colorspinor::FieldOrderCB<RegFloat,Ns,Nc,1,order,Float,ghostFloat> Q;
     Q field(a, nFace, 0, ghost);
 
-    constexpr int spins_per_thread = 1; // make this autotunable
-    constexpr int colors_per_thread = 1;
-    PackGhostArg<Q> arg(field, ghost, a, parity, nFace, dagger);
-    GenericPackGhostLauncher<Float,Ns,spins_per_thread,Nc,colors_per_thread,PackGhostArg<Q> >
+    constexpr int spins_per_thread = Ns == 1 ? 1 : 2; // make this autotunable?
+    constexpr int colors_per_thread = Nc%2 == 0 ? 2 : 1;
+    PackGhostArg<Q> arg(field, a, parity, nFace, dagger);
+
+    // if we only have short precision for the ghost then this means we have block-float
+    constexpr bool block_float = (sizeof(Float) == QUDA_SINGLE_PRECISION &&
+				  sizeof(ghostFloat) == QUDA_HALF_PRECISION && Nc <= MAX_BLOCK_FLOAT_NC) ? true : false;
+    if (sizeof(Float) == QUDA_SINGLE_PRECISION && sizeof(ghostFloat) == QUDA_HALF_PRECISION && Nc > MAX_BLOCK_FLOAT_NC)
+      errorQuda("Block-float format not supported for Nc = %d", Nc);
+
+    GenericPackGhostLauncher<RegFloat,block_float,Ns,spins_per_thread,Nc,colors_per_thread,PackGhostArg<Q> >
       launch(arg, a, destination);
+
     launch.apply(0);
   }
 
-  template <typename Float, QudaFieldOrder order, int Ns>
+  template <typename Float, typename ghostFloat, QudaFieldOrder order, int Ns>
   inline void genericPackGhost(void **ghost, const ColorSpinorField &a, QudaParity parity,
 			       int nFace, int dagger, MemoryLocation *destination) {
     
     if (a.Ncolor() == 2) {
-      genericPackGhost<Float,order,Ns,2>(ghost, a, parity, nFace, dagger, destination);
+      genericPackGhost<Float,ghostFloat,order,Ns,2>(ghost, a, parity, nFace, dagger, destination);
     } else if (a.Ncolor() == 3) {
-      genericPackGhost<Float,order,Ns,3>(ghost, a, parity, nFace, dagger, destination);
+      genericPackGhost<Float,ghostFloat,order,Ns,3>(ghost, a, parity, nFace, dagger, destination);
     } else if (a.Ncolor() == 4) {
-      genericPackGhost<Float,order,Ns,4>(ghost, a, parity, nFace, dagger, destination);
+      genericPackGhost<Float,ghostFloat,order,Ns,4>(ghost, a, parity, nFace, dagger, destination);
     } else if (a.Ncolor() == 6) {
-      genericPackGhost<Float,order,Ns,6>(ghost, a, parity, nFace, dagger, destination);
+      genericPackGhost<Float,ghostFloat,order,Ns,6>(ghost, a, parity, nFace, dagger, destination);
     } else if (a.Ncolor() == 8) {
-      genericPackGhost<Float,order,Ns,8>(ghost, a, parity, nFace, dagger, destination);
+      genericPackGhost<Float,ghostFloat,order,Ns,8>(ghost, a, parity, nFace, dagger, destination);
     } else if (a.Ncolor() == 12) {
-      genericPackGhost<Float,order,Ns,12>(ghost, a, parity, nFace, dagger, destination);
+      genericPackGhost<Float,ghostFloat,order,Ns,12>(ghost, a, parity, nFace, dagger, destination);
     } else if (a.Ncolor() == 16) {
-      genericPackGhost<Float,order,Ns,16>(ghost, a, parity, nFace, dagger, destination);
+      genericPackGhost<Float,ghostFloat,order,Ns,16>(ghost, a, parity, nFace, dagger, destination);
     } else if (a.Ncolor() == 18) { // Needed for two level free field Wilson
-      genericPackGhost<Float,order,Ns,18>(ghost, a, parity, nFace, dagger, destination);
+      genericPackGhost<Float,ghostFloat,order,Ns,18>(ghost, a, parity, nFace, dagger, destination);
     } else if (a.Ncolor() == 20) {
-      genericPackGhost<Float,order,Ns,20>(ghost, a, parity, nFace, dagger, destination);
+      genericPackGhost<Float,ghostFloat,order,Ns,20>(ghost, a, parity, nFace, dagger, destination);
     } else if (a.Ncolor() == 24) {
-      genericPackGhost<Float,order,Ns,24>(ghost, a, parity, nFace, dagger, destination);
+      genericPackGhost<Float,ghostFloat,order,Ns,24>(ghost, a, parity, nFace, dagger, destination);
     } else if (a.Ncolor() == 28) {
-      genericPackGhost<Float,order,Ns,28>(ghost, a, parity, nFace, dagger, destination);
+      genericPackGhost<Float,ghostFloat,order,Ns,28>(ghost, a, parity, nFace, dagger, destination);
     } else if (a.Ncolor() == 32) {
-      genericPackGhost<Float,order,Ns,32>(ghost, a, parity, nFace, dagger, destination);
+      genericPackGhost<Float,ghostFloat,order,Ns,32>(ghost, a, parity, nFace, dagger, destination);
     } else if (a.Ncolor() == 36) { // Needed for three level free field Wilson
-      genericPackGhost<Float,order,Ns,36>(ghost, a, parity, nFace, dagger, destination);
+      genericPackGhost<Float,ghostFloat,order,Ns,36>(ghost, a, parity, nFace, dagger, destination);
     } else if (a.Ncolor() == 48) {
-      genericPackGhost<Float,order,Ns,48>(ghost, a, parity, nFace, dagger, destination);
+      genericPackGhost<Float,ghostFloat,order,Ns,48>(ghost, a, parity, nFace, dagger, destination);
     } else if (a.Ncolor() == 72) {
-      genericPackGhost<Float,order,Ns,72>(ghost, a, parity, nFace, dagger, destination);
+      genericPackGhost<Float,ghostFloat,order,Ns,72>(ghost, a, parity, nFace, dagger, destination);
     } else if (a.Ncolor() == 96) {
-      genericPackGhost<Float,order,Ns,96>(ghost, a, parity, nFace, dagger, destination);
+      genericPackGhost<Float,ghostFloat,order,Ns,96>(ghost, a, parity, nFace, dagger, destination);
     } else if (a.Ncolor() == 256) {
-      genericPackGhost<Float,order,Ns,256>(ghost, a, parity, nFace, dagger, destination);
+      genericPackGhost<Float,ghostFloat,order,Ns,256>(ghost, a, parity, nFace, dagger, destination);
     } else if (a.Ncolor() == 576) {
-      genericPackGhost<Float,order,Ns,576>(ghost, a, parity, nFace, dagger, destination);
+      genericPackGhost<Float,ghostFloat,order,Ns,576>(ghost, a, parity, nFace, dagger, destination);
     } else if (a.Ncolor() == 768) {
-      genericPackGhost<Float,order,Ns,768>(ghost, a, parity, nFace, dagger, destination);
+      genericPackGhost<Float,ghostFloat,order,Ns,768>(ghost, a, parity, nFace, dagger, destination);
     } else if (a.Ncolor() == 1024) {
-      genericPackGhost<Float,order,Ns,1024>(ghost, a, parity, nFace, dagger, destination);
+      genericPackGhost<Float,ghostFloat,order,Ns,1024>(ghost, a, parity, nFace, dagger, destination);
     } else {
       errorQuda("Unsupported nColor = %d", a.Ncolor());
     }
 
   }
 
-  template <typename Float, QudaFieldOrder order>
+  template <typename Float, typename ghostFloat, QudaFieldOrder order>
   inline void genericPackGhost(void **ghost, const ColorSpinorField &a, QudaParity parity,
 			       int nFace, int dagger, MemoryLocation *destination) {
 
     if (a.Nspin() == 4) {
-      genericPackGhost<Float,order,4>(ghost, a, parity, nFace, dagger, destination);
+      genericPackGhost<Float,ghostFloat,order,4>(ghost, a, parity, nFace, dagger, destination);
     } else if (a.Nspin() == 2) {
-      genericPackGhost<Float,order,2>(ghost, a, parity, nFace, dagger, destination);
+      genericPackGhost<Float,ghostFloat,order,2>(ghost, a, parity, nFace, dagger, destination);
 #ifdef GPU_STAGGERED_DIRAC
     } else if (a.Nspin() == 1) {
-      genericPackGhost<Float,order,1>(ghost, a, parity, nFace, dagger, destination);
+      genericPackGhost<Float,ghostFloat,order,1>(ghost, a, parity, nFace, dagger, destination);
 #endif
     } else {
       errorQuda("Unsupported nSpin = %d", a.Nspin());
@@ -242,16 +440,16 @@ namespace quda {
 
   }
 
-  template <typename Float>
+  template <typename Float, typename ghostFloat>
   inline void genericPackGhost(void **ghost, const ColorSpinorField &a, QudaParity parity,
 			       int nFace, int dagger, MemoryLocation *destination) {
 
     if (a.FieldOrder() == QUDA_FLOAT2_FIELD_ORDER) {
-      genericPackGhost<Float,QUDA_FLOAT2_FIELD_ORDER>(ghost, a, parity, nFace, dagger, destination);
+      genericPackGhost<Float,ghostFloat,QUDA_FLOAT2_FIELD_ORDER>(ghost, a, parity, nFace, dagger, destination);
     } else if (a.FieldOrder() == QUDA_FLOAT4_FIELD_ORDER) {
-      genericPackGhost<Float,QUDA_FLOAT4_FIELD_ORDER>(ghost, a, parity, nFace, dagger, destination);
+      genericPackGhost<Float,ghostFloat,QUDA_FLOAT4_FIELD_ORDER>(ghost, a, parity, nFace, dagger, destination);
     } else if (a.FieldOrder() == QUDA_SPACE_SPIN_COLOR_FIELD_ORDER) {
-      genericPackGhost<Float,QUDA_SPACE_SPIN_COLOR_FIELD_ORDER>(ghost, a, parity, nFace, dagger, destination);
+      genericPackGhost<Float,ghostFloat,QUDA_SPACE_SPIN_COLOR_FIELD_ORDER>(ghost, a, parity, nFace, dagger, destination);
     } else {
       errorQuda("Unsupported field order = %d", a.FieldOrder());
     }
@@ -278,11 +476,25 @@ namespace quda {
     if (!partitioned) return;
 
     if (a.Precision() == QUDA_DOUBLE_PRECISION) {
-      genericPackGhost<double>(ghost, a, parity, nFace, dagger, destination);
+      if (a.GhostPrecision() == QUDA_DOUBLE_PRECISION) {
+	genericPackGhost<double,double>(ghost, a, parity, nFace, dagger, destination);
+      } else {
+	errorQuda("precision = %d and ghost precision = %d not supported", a.Precision(), a.GhostPrecision());
+      }
     } else if (a.Precision() == QUDA_SINGLE_PRECISION) {
-      genericPackGhost<float>(ghost, a, parity, nFace, dagger, destination);
+      if (a.GhostPrecision() == QUDA_SINGLE_PRECISION) {
+	genericPackGhost<float,float>(ghost, a, parity, nFace, dagger, destination);
+      } else if (a.GhostPrecision() == QUDA_HALF_PRECISION) {
+	genericPackGhost<float,short>(ghost, a, parity, nFace, dagger, destination);
+      } else {
+	errorQuda("precision = %d and ghost precision = %d not supported", a.Precision(), a.GhostPrecision());
+      }
     } else if (a.Precision() == QUDA_HALF_PRECISION) {
-      genericPackGhost<short>(ghost, a, parity, nFace, dagger, destination);
+      if (a.GhostPrecision() == QUDA_HALF_PRECISION) {
+	genericPackGhost<short,short>(ghost, a, parity, nFace, dagger, destination);
+      } else {
+	errorQuda("precision = %d and ghost precision = %d not supported", a.Precision(), a.GhostPrecision());
+      }
     } else {
       errorQuda("Unsupported precision %d", a.Precision());
     }

--- a/lib/comm_common.cpp
+++ b/lib/comm_common.cpp
@@ -149,6 +149,10 @@ static bool peer2peer_init = false;
 static bool intranode_enabled[2][4] = { {false,false,false,false},
 					{false,false,false,false} };
 
+/** this records whether there is any peer-2-peer capability
+    (regardless whether it is enabled or not) */
+static bool peer2peer_present = false;
+
 void comm_peer2peer_init(const char* hostname_recv_buf)
 {
   if (peer2peer_init) return;
@@ -233,6 +237,8 @@ void comm_peer2peer_init(const char* hostname_recv_buf)
 
   comm_barrier();
 
+  peer2peer_present = comm_peer2peer_enabled_global();
+
   // set gdr enablement
   if (comm_gdr_enabled()) {
     if (getVerbosity() > QUDA_SILENT) printfQuda("Enabling GPU-Direct RDMA access\n");
@@ -244,6 +250,8 @@ void comm_peer2peer_init(const char* hostname_recv_buf)
   checkCudaErrorNoSync();
   return;
 }
+
+bool comm_peer2peer_present() { return peer2peer_present; }
 
 static bool enable_p2p = true;
 

--- a/lib/copy_gauge_helper.cuh
+++ b/lib/copy_gauge_helper.cuh
@@ -276,7 +276,11 @@ namespace quda {
 	//else warningQuda("Cannot copy for %d geometry gauge field", geometry);
       }
 
-      // special copy that only copies the second set of links in the ghost zone for bi-directional link fields
+      // special copy that only copies the second set of links in the
+      // ghost zone for bi-directional link fields - at present this is
+      // only used in cudaGaugefield::exchangeGhost where we copy from
+      // the buffer into the field's ghost zone (padded
+      // region), so we only have the offset on the receiver
       if (type == 3) {
         if (geometry != QUDA_COARSE_GEOMETRY) errorQuda("Cannot request copy type %d on non-coarse link fields", geometry);
 	arg.out_offset = nDim;
@@ -300,7 +304,11 @@ namespace quda {
 	}
       }
 
-      // special copy that only copies the second set of links in the ghost zone for bi-directional link fields
+      // special copy that only copies the second set of links in the
+      // ghost zone for bi-directional link fields - at present this is
+      // only used in cudaGaugefield::exchangeGhost where we copy from
+      // the buffer into the field's ghost zone (padded
+      // region), so we only have the offset on the receiver
       if (type == 3) {
         if (geometry != QUDA_COARSE_GEOMETRY) errorQuda("Cannot request copy type %d on non-coarse link fields", geometry);
 	arg.out_offset = nDim;

--- a/lib/cpu_color_spinor_field.cpp
+++ b/lib/cpu_color_spinor_field.cpp
@@ -309,7 +309,7 @@ namespace quda {
   }
 
   void cpuColorSpinorField::exchangeGhost(QudaParity parity, int nFace, int dagger, const MemoryLocation *dummy1,
-					  const MemoryLocation *dummy2, bool dummy3, bool dummy4) const
+					  const MemoryLocation *dummy2, bool dummy3, bool dummy4, QudaPrecision dummy5) const
   {
     // allocate ghost buffer if not yet allocated
     allocateGhostBuffer(nFace);

--- a/lib/cuda_color_spinor_field.cu
+++ b/lib/cuda_color_spinor_field.cu
@@ -1054,7 +1054,7 @@ namespace quda {
       void *ghost_norm_dst = static_cast<char*>(ghost_remote_send_buffer_d[bufferIndex][dim][dir])
 	+ QUDA_SINGLE_PRECISION*ghostNormOffset[dim][(d+1)%2];
 
-    if (ghost_precision != precision) pushKernelPackT(true);
+      if (ghost_precision != precision) pushKernelPackT(true);
 
       if (dim != 3 || getKernelPackT()) {
 

--- a/lib/cuda_color_spinor_field.cu
+++ b/lib/cuda_color_spinor_field.cu
@@ -458,7 +458,7 @@ namespace quda {
   void cudaColorSpinorField::destroyGhostTexObject() const {
     if ( (isNative() || fieldOrder == QUDA_FLOAT2_FIELD_ORDER) && nVec == 1 && ghostTexInit) {
       for (int i=0; i<4; i++) cudaDestroyTextureObject(ghostTex[i]);
-      if (precision == QUDA_HALF_PRECISION) {
+      if (ghost_precision == QUDA_HALF_PRECISION) {
 	for (int i=0; i<4; i++) cudaDestroyTextureObject(ghostTexNorm[i]);
       }
       ghostTexInit = false;

--- a/lib/cuda_gauge_field.cu
+++ b/lib/cuda_gauge_field.cu
@@ -157,9 +157,11 @@ namespace quda {
 
   void cudaGaugeField::destroyTexObject() {
     if( isNative() && geometry != QUDA_COARSE_GEOMETRY ){
+      cudaDestroyTextureObject(tex);
       cudaDestroyTextureObject(evenTex);
       cudaDestroyTextureObject(oddTex);
       if(reconstruct == QUDA_RECONSTRUCT_9 || reconstruct == QUDA_RECONSTRUCT_13){
+        cudaDestroyTextureObject(phaseTex);
         cudaDestroyTextureObject(evenPhaseTex);
         cudaDestroyTextureObject(oddPhaseTex);
       }

--- a/lib/cuda_gauge_field.cu
+++ b/lib/cuda_gauge_field.cu
@@ -202,7 +202,8 @@ namespace quda {
     const int dir = 1; // sending forwards only
     const int R[] = {nFace, nFace, nFace, nFace};
     const bool no_comms_fill = true; // dslash kernels presently require this
-    createComms(R, true); // always need to allocate space for non-partitioned dimension for copyGenericGauge
+    const bool bidir = false; // communication is only ever done in one direction at once
+    createComms(R, true, bidir); // always need to allocate space for non-partitioned dimension for copyGenericGauge
 
     // loop over backwards and forwards links
     const QudaLinkDirection directions[] = {QUDA_LINK_BACKWARDS, QUDA_LINK_FORWARDS};
@@ -215,7 +216,7 @@ namespace quda {
       size_t offset = 0;
       for (int d=0; d<nDim; d++) {
 	// receive from backwards is first half of each ghost_recv_buffer
-	recv_d[d] = static_cast<char*>(ghost_recv_buffer_d[bufferIndex]) + offset; offset += ghost_face_bytes[d];
+	recv_d[d] = static_cast<char*>(ghost_recv_buffer_d[bufferIndex]) + offset; if (bidir) offset += ghost_face_bytes[d];
 	// send forwards is second half of each ghost_send_buffer
 	send_d[d] = static_cast<char*>(ghost_send_buffer_d[bufferIndex]) + offset; offset += ghost_face_bytes[d];
       }
@@ -286,7 +287,8 @@ namespace quda {
     const int dir = 0; // sending backwards only
     const int R[] = {nFace, nFace, nFace, nFace};
     const bool no_comms_fill = false; // injection never does no_comms_fill
-    createComms(R, true); // always need to allocate space for non-partitioned dimension for copyGenericGauge
+    const bool bidir = false; // communication is only ever done in one direction at once
+    createComms(R, true, bidir); // always need to allocate space for non-partitioned dimension for copyGenericGauge
 
     // loop over backwards and forwards links (forwards links never sent but leave here just in case)
     const QudaLinkDirection directions[] = {QUDA_LINK_BACKWARDS, QUDA_LINK_FORWARDS};
@@ -299,7 +301,7 @@ namespace quda {
       size_t offset = 0;
       for (int d=0; d<nDim; d++) {
 	// send backwards is first half of each ghost_send_buffer
-	send_d[d] = static_cast<char*>(ghost_send_buffer_d[bufferIndex]) + offset; offset += ghost_face_bytes[d];
+	send_d[d] = static_cast<char*>(ghost_send_buffer_d[bufferIndex]) + offset; if (bidir) offset += ghost_face_bytes[d];
 	// receive from forwards is the second half of each ghost_recv_buffer
 	recv_d[d] = static_cast<char*>(ghost_recv_buffer_d[bufferIndex]) + offset; offset += ghost_face_bytes[d];
       }
@@ -356,21 +358,22 @@ namespace quda {
     cudaDeviceSynchronize();
   }
 
-  void cudaGaugeField::allocateGhostBuffer(const int *R, bool no_comms_fill) const
+  void cudaGaugeField::allocateGhostBuffer(const int *R, bool no_comms_fill, bool bidir) const
   {
-    createGhostZone(R, no_comms_fill);
+    createGhostZone(R, no_comms_fill, bidir);
     LatticeField::allocateGhostBuffer(ghost_bytes);
   }
 
-  void cudaGaugeField::createComms(const int *R, bool no_comms_fill)
+  void cudaGaugeField::createComms(const int *R, bool no_comms_fill, bool bidir)
   {
-    allocateGhostBuffer(R, no_comms_fill); // allocate the ghost buffer if not yet allocated
+    allocateGhostBuffer(R, no_comms_fill, bidir); // allocate the ghost buffer if not yet allocated
 
     // ascertain if this instance needs it comms buffers to be updated
     bool comms_reset = ghost_field_reset || // FIXME add send buffer check
-      (my_face_h[0] != ghost_pinned_buffer_h[0]) || (my_face_h[1] != ghost_pinned_buffer_h[1]); // pinned buffers
+      (my_face_h[0] != ghost_pinned_buffer_h[0]) || (my_face_h[1] != ghost_pinned_buffer_h[1]) || // pinned buffers
+      ghost_bytes != ghost_bytes_old; // ghost buffer has been resized (e.g., bidir to unidir)
 
-    if (!initComms || comms_reset) LatticeField::createComms(no_comms_fill);
+    if (!initComms || comms_reset) LatticeField::createComms(no_comms_fill, bidir);
 
     if (ghost_field_reset) destroyIPCComms();
     createIPCComms();

--- a/lib/dirac_clover.cpp
+++ b/lib/dirac_clover.cpp
@@ -88,7 +88,7 @@ namespace quda {
     if (in.Location() == QUDA_CPU_FIELD_LOCATION) {
       ColorSpinorParam param(in);
       param.location = QUDA_CUDA_FIELD_LOCATION;
-      param.fieldOrder =  param.precision == QUDA_DOUBLE_PRECISION ? QUDA_FLOAT2_FIELD_ORDER :
+      param.fieldOrder =  param.Precision() == QUDA_DOUBLE_PRECISION ? QUDA_FLOAT2_FIELD_ORDER :
         (param.nSpin == 4 ? QUDA_FLOAT4_FIELD_ORDER : QUDA_FLOAT2_FIELD_ORDER);
       param.gammaBasis = QUDA_UKQCD_GAMMA_BASIS;
       In = ColorSpinorField::Create(param);
@@ -99,7 +99,7 @@ namespace quda {
     if (out.Location() == QUDA_CPU_FIELD_LOCATION) {
       ColorSpinorParam param(out);
       param.location = QUDA_CUDA_FIELD_LOCATION;
-      param.fieldOrder =  param.precision == QUDA_DOUBLE_PRECISION ? QUDA_FLOAT2_FIELD_ORDER :
+      param.fieldOrder =  param.Precision() == QUDA_DOUBLE_PRECISION ? QUDA_FLOAT2_FIELD_ORDER :
         (param.nSpin == 4 ? QUDA_FLOAT4_FIELD_ORDER : QUDA_FLOAT2_FIELD_ORDER);
       param.gammaBasis = QUDA_UKQCD_GAMMA_BASIS;
       Out = ColorSpinorField::Create(param);

--- a/lib/dirac_coarse.cpp
+++ b/lib/dirac_coarse.cpp
@@ -72,7 +72,7 @@ namespace quda {
     gParam.link_type = QUDA_COARSE_LINKS;
     gParam.t_boundary = QUDA_PERIODIC_T;
     gParam.create = QUDA_ZERO_FIELD_CREATE;
-    gParam.precision = prec;
+    gParam.setPrecision(prec);
     gParam.nDim = ndim;
     gParam.siteSubset = QUDA_FULL_SITE_SUBSET;
     gParam.ghostExchange = QUDA_GHOST_EXCHANGE_PAD;
@@ -124,12 +124,12 @@ namespace quda {
       gParam.nFace = 1;
       gParam.order = QUDA_FLOAT2_GAUGE_ORDER;
       gParam.geometry = QUDA_COARSE_GEOMETRY;
-      gParam.precision = transfer->Vectors(QUDA_CUDA_FIELD_LOCATION).Precision();
+      gParam.setPrecision(transfer->Vectors(QUDA_CUDA_FIELD_LOCATION).Precision());
       int pad = std::max( { (x[0]*x[1]*x[2])/2, (x[1]*x[2]*x[3])/2, (x[0]*x[2]*x[3])/2, (x[0]*x[1]*x[3])/2 } );
       gParam.pad = gParam.nFace * pad * 2; // factor of 2 since we have to store bi-directional ghost zone
       Yhat_d = new cudaGaugeField(gParam);
 
-      gParam.precision = prec;
+      gParam.setPrecision(prec);
       gParam.ghostExchange = QUDA_GHOST_EXCHANGE_NO;
       gParam.nFace = 0;
       gParam.pad = 0;

--- a/lib/dirac_wilson.cpp
+++ b/lib/dirac_wilson.cpp
@@ -75,7 +75,7 @@ namespace quda {
     if (in.Location() == QUDA_CPU_FIELD_LOCATION) {
       ColorSpinorParam param(in);
       param.location = QUDA_CUDA_FIELD_LOCATION;
-      param.fieldOrder =  param.precision == QUDA_DOUBLE_PRECISION ? QUDA_FLOAT2_FIELD_ORDER :
+      param.fieldOrder =  param.Precision() == QUDA_DOUBLE_PRECISION ? QUDA_FLOAT2_FIELD_ORDER :
 	(param.nSpin == 4 ? QUDA_FLOAT4_FIELD_ORDER : QUDA_FLOAT2_FIELD_ORDER);
       param.gammaBasis = QUDA_UKQCD_GAMMA_BASIS;
       In = ColorSpinorField::Create(param);
@@ -86,7 +86,7 @@ namespace quda {
     if (out.Location() == QUDA_CPU_FIELD_LOCATION) {
       ColorSpinorParam param(out);
       param.location = QUDA_CUDA_FIELD_LOCATION;
-      param.fieldOrder =  param.precision == QUDA_DOUBLE_PRECISION ? QUDA_FLOAT2_FIELD_ORDER :
+      param.fieldOrder =  param.Precision() == QUDA_DOUBLE_PRECISION ? QUDA_FLOAT2_FIELD_ORDER :
 	(param.nSpin == 4 ? QUDA_FLOAT4_FIELD_ORDER : QUDA_FLOAT2_FIELD_ORDER);
       param.gammaBasis = QUDA_UKQCD_GAMMA_BASIS;
       Out = ColorSpinorField::Create(param);

--- a/lib/dslash_coarse.cu
+++ b/lib/dslash_coarse.cu
@@ -1047,6 +1047,7 @@ namespace quda {
       i32toa(prec_str,dslash.Y.Precision());
       strcat(aux,prec_str);
       strcat(aux,comm_dim_partitioned_string());
+      strcat(aux,comm_dim_topology_string());
 
       int comm_sum = 4;
       if (dslash.commDim) for (int i=0; i<4; i++) comm_sum -= (1-dslash.commDim[i]);

--- a/lib/dslash_coarse.cu
+++ b/lib/dslash_coarse.cu
@@ -464,12 +464,7 @@ namespace quda {
     const int nParity;
     const int nSrc;
 
-#define EIGHT_WAY_WARP_SPLIT
-#ifdef EIGHT_WAY_WARP_SPLIT
     const int max_color_col_stride = 8;
-#else
-    const int max_color_col_stride = 4;
-#endif
     mutable int color_col_stride;
     mutable int dim_threads;
     char *saveOut;
@@ -695,11 +690,9 @@ namespace quda {
 	  case 4:
 	    coarseDslashKernel<Float,nDim,Ns,Nc,Mc,4,1,dslash,clover,dagger,type> <<<tp.grid,tp.block,tp.shared_bytes,stream>>>(arg);
 	    break;
-#ifdef EIGHT_WAY_WARP_SPLIT
 	  case 8:
 	    coarseDslashKernel<Float,nDim,Ns,Nc,Mc,8,1,dslash,clover,dagger,type> <<<tp.grid,tp.block,tp.shared_bytes,stream>>>(arg);
 	    break;
-#endif // EIGHT_WAY_WARP_SPLIT
 #endif // DOT_PRODUCT_SPLIT
 	  default:
 	    errorQuda("Color column stride %d not valid", tp.aux.x);
@@ -717,11 +710,9 @@ namespace quda {
 	  case 4:
 	    coarseDslashKernel<Float,nDim,Ns,Nc,Mc,4,2,dslash,clover,dagger,type> <<<tp.grid,tp.block,tp.shared_bytes,stream>>>(arg);
 	    break;
-#ifdef EIGHT_WAY_WARP_SPLIT
 	  case 8:
 	    coarseDslashKernel<Float,nDim,Ns,Nc,Mc,8,2,dslash,clover,dagger,type> <<<tp.grid,tp.block,tp.shared_bytes,stream>>>(arg);
 	    break;
-#endif // EIGHT_WAY_WARP_SPLIT
 #endif // DOT_PRODUCT_SPLIT
 	  default:
 	    errorQuda("Color column stride %d not valid", tp.aux.x);
@@ -739,11 +730,9 @@ namespace quda {
 	  case 4:
 	    coarseDslashKernel<Float,nDim,Ns,Nc,Mc,4,4,dslash,clover,dagger,type> <<<tp.grid,tp.block,tp.shared_bytes,stream>>>(arg);
 	    break;
-#ifdef EIGHT_WAY_WARP_SPLIT
 	  case 8:
 	    coarseDslashKernel<Float,nDim,Ns,Nc,Mc,8,4,dslash,clover,dagger,type> <<<tp.grid,tp.block,tp.shared_bytes,stream>>>(arg);
 	    break;
-#endif // EIGHT_WAY_WARP_SPLIT
 #endif // DOT_PRODUCT_SPLIT
 	  default:
 	    errorQuda("Color column stride %d not valid", tp.aux.x);

--- a/lib/dslash_coarse.cu
+++ b/lib/dslash_coarse.cu
@@ -25,7 +25,7 @@ namespace quda {
 
   template <typename Float, typename yFloat, int coarseSpin, int coarseColor, QudaFieldOrder csOrder, QudaGaugeFieldOrder gOrder>
   struct DslashCoarseArg {
-    typedef typename colorspinor::FieldOrderCB<Float,coarseSpin,coarseColor,1,csOrder> F;
+    typedef typename colorspinor::FieldOrderCB<Float,coarseSpin,coarseColor,1,csOrder,Float,yFloat> F;
     typedef typename gauge::FieldOrder<Float,coarseColor*coarseSpin,coarseSpin,gOrder> G;
     typedef typename gauge::FieldOrder<Float,coarseColor*coarseSpin,coarseSpin,gOrder,true,yFloat> GY;
 
@@ -975,7 +975,7 @@ namespace quda {
 
       if (dslash && comm_partitioned() && comms) {
 	const int nFace = 1;
-	inA.exchangeGhost((QudaParity)(1-parity), nFace, dagger, pack_destination, halo_location, gdr_send, gdr_recv);
+	inA.exchangeGhost((QudaParity)(1-parity), nFace, dagger, pack_destination, halo_location, gdr_send, gdr_recv, Y.Precision());
       }
 
       if (dslash::aux_worker) dslash::aux_worker->apply(0);

--- a/lib/dslash_coarse.cu
+++ b/lib/dslash_coarse.cu
@@ -464,6 +464,7 @@ namespace quda {
     const int nParity;
     const int nSrc;
 
+#define EIGHT_WAY_WARP_SPLIT
 #ifdef EIGHT_WAY_WARP_SPLIT
     const int max_color_col_stride = 8;
 #else

--- a/lib/dslash_policy.cuh
+++ b/lib/dslash_policy.cuh
@@ -1980,41 +1980,42 @@ void disable_policy(QudaDslashPolicy p){
 
        for (auto &i : policies) {
 
-	 if (i == QudaDslashPolicy::QUDA_DSLASH || 
-       i == QudaDslashPolicy::QUDA_FUSED_DSLASH ||
-	     i == QudaDslashPolicy::QUDA_DSLASH_ASYNC || 
-       i == QudaDslashPolicy::QUDA_FUSED_DSLASH_ASYNC) {
+	 if (i == QudaDslashPolicy::QUDA_DSLASH ||
+	     i == QudaDslashPolicy::QUDA_FUSED_DSLASH ||
+	     i == QudaDslashPolicy::QUDA_DSLASH_ASYNC ||
+	     i == QudaDslashPolicy::QUDA_FUSED_DSLASH_ASYNC) {
 
 	   DslashPolicyImp* dslashImp = DslashFactory::create(i);
 	   (*dslashImp)(dslash, in, regSize, parity, dagger, volume, ghostFace, profile);
 	   delete dslashImp;
 
-	 } else if (i == QudaDslashPolicy::QUDA_GDR_DSLASH || 
-              i == QudaDslashPolicy::QUDA_FUSED_GDR_DSLASH ||
-		          i == QudaDslashPolicy::QUDA_GDR_RECV_DSLASH || 
-              i == QudaDslashPolicy::QUDA_FUSED_GDR_RECV_DSLASH ||
-		          i == QudaDslashPolicy::QUDA_ZERO_COPY_PACK_DSLASH ||
-              i == QudaDslashPolicy::QUDA_FUSED_ZERO_COPY_PACK_DSLASH ||
-		          i == QudaDslashPolicy::QUDA_ZERO_COPY_PACK_GDR_RECV_DSLASH || 
-              i == QudaDslashPolicy::QUDA_FUSED_ZERO_COPY_PACK_GDR_RECV_DSLASH ||
-              i == QudaDslashPolicy::QUDA_ZERO_COPY_DSLASH || 
-              i == QudaDslashPolicy::QUDA_FUSED_ZERO_COPY_DSLASH) {
+	 } else if (i == QudaDslashPolicy::QUDA_GDR_DSLASH ||
+		    i == QudaDslashPolicy::QUDA_FUSED_GDR_DSLASH ||
+		    i == QudaDslashPolicy::QUDA_GDR_RECV_DSLASH ||
+		    i == QudaDslashPolicy::QUDA_FUSED_GDR_RECV_DSLASH ||
+		    i == QudaDslashPolicy::QUDA_ZERO_COPY_PACK_DSLASH ||
+		    i == QudaDslashPolicy::QUDA_FUSED_ZERO_COPY_PACK_DSLASH ||
+		    i == QudaDslashPolicy::QUDA_ZERO_COPY_PACK_GDR_RECV_DSLASH ||
+		    i == QudaDslashPolicy::QUDA_FUSED_ZERO_COPY_PACK_GDR_RECV_DSLASH ||
+		    i == QudaDslashPolicy::QUDA_ZERO_COPY_DSLASH ||
+		    i == QudaDslashPolicy::QUDA_FUSED_ZERO_COPY_DSLASH) {
 	   // these dslash policies all must have kernel packing enabled
 
-     // clumsy, but we call setKernelPackT a handful of times before 
-     // we restore the the current state, so this will "just work"
-     pushKernelPackT(getKernelPackT());
+	   // clumsy, but we call setKernelPackT a handful of times before
+	   // we restore the the current state, so this will "just work"
+	   pushKernelPackT(getKernelPackT());
 
 	   // if we are using GDR policies then we must tune the
 	   // non-GDR variants as well with and without kernel packing
 	   // enabled - this ensures that all GPUs will have the
 	   // required tune cache entries prior to potential process
 	   // divergence regardless of which GPUs are blacklisted
-	   if (i == QudaDslashPolicy::QUDA_GDR_DSLASH || 
-         i == QudaDslashPolicy::QUDA_FUSED_GDR_DSLASH ||
-	       i == QudaDslashPolicy::QUDA_GDR_RECV_DSLASH || 
-         i == QudaDslashPolicy::QUDA_FUSED_GDR_RECV_DSLASH) {
-	     QudaDslashPolicy policy = (i==QudaDslashPolicy::QUDA_GDR_DSLASH || i==QudaDslashPolicy::QUDA_GDR_RECV_DSLASH) ? QudaDslashPolicy::QUDA_DSLASH : QudaDslashPolicy::QUDA_FUSED_DSLASH;
+	   if (i == QudaDslashPolicy::QUDA_GDR_DSLASH ||
+	       i == QudaDslashPolicy::QUDA_FUSED_GDR_DSLASH ||
+	       i == QudaDslashPolicy::QUDA_GDR_RECV_DSLASH ||
+	       i == QudaDslashPolicy::QUDA_FUSED_GDR_RECV_DSLASH) {
+	     QudaDslashPolicy policy = (i==QudaDslashPolicy::QUDA_GDR_DSLASH || i==QudaDslashPolicy::QUDA_GDR_RECV_DSLASH) ?
+	       QudaDslashPolicy::QUDA_DSLASH : QudaDslashPolicy::QUDA_FUSED_DSLASH;
 	     DslashPolicyImp* dslashImp = DslashFactory::create(policy);
 	     setKernelPackT(false);
 	     (*dslashImp)(dslash, in, regSize, parity, dagger, volume, ghostFace, profile);
@@ -2030,7 +2031,7 @@ void disable_policy(QudaDslashPolicy p){
 	   delete dslashImp;
 
 	   // restore default kernel packing
-     popKernelPackT();
+	   popKernelPackT();
 
 	 } else if (i != QudaDslashPolicy::QUDA_DSLASH_POLICY_DISABLED){
 	   errorQuda("Unsupported dslash policy %d\n", static_cast<int>(i));
@@ -2062,7 +2063,7 @@ void disable_policy(QudaDslashPolicy p){
      auto p = static_cast<QudaDslashPolicy>(tp.aux.x);
      if ( p == QudaDslashPolicy::QUDA_GDR_DSLASH ||
           p == QudaDslashPolicy::QUDA_FUSED_GDR_DSLASH ||
-	        p == QudaDslashPolicy::QUDA_ZERO_COPY_PACK_DSLASH ||
+	  p == QudaDslashPolicy::QUDA_ZERO_COPY_PACK_DSLASH ||
           p == QudaDslashPolicy::QUDA_FUSED_ZERO_COPY_PACK_DSLASH ||
           p == QudaDslashPolicy::QUDA_ZERO_COPY_PACK_GDR_RECV_DSLASH ||
           p == QudaDslashPolicy::QUDA_FUSED_ZERO_COPY_PACK_GDR_RECV_DSLASH ||

--- a/lib/gauge_field.cpp
+++ b/lib/gauge_field.cpp
@@ -36,6 +36,8 @@ namespace quda {
     staggeredPhaseType(param.staggeredPhaseType), staggeredPhaseApplied(param.staggeredPhaseApplied), i_mu(param.i_mu),
     site_offset(param.site_offset), site_size(param.site_size)
   {
+    if (ghost_precision != precision) ghost_precision = precision; // gauge fields require matching precision
+
     if (link_type != QUDA_COARSE_LINKS && nColor != 3)
       errorQuda("nColor must be 3, not %d for this link type", nColor);
     if (nDim != 4)
@@ -100,7 +102,7 @@ namespace quda {
       ghostOffset[i][0] = (i == 0) ? 0 : ghostOffset[i-1][1] + ghostFace[i-1]*geometry*nInternal;
       ghostOffset[i][1] = ghostOffset[i][0] + ghostFace[i]*geometry*nInternal;
 
-      ghost_face_bytes[i] = ghostFace[i] * geometry * nInternal * precision;
+      ghost_face_bytes[i] = ghostFace[i] * geometry * nInternal * ghost_precision;
       ghost_bytes += 2*ghost_face_bytes[i]; // factor of two from direction
     }
 
@@ -287,7 +289,7 @@ namespace quda {
     spinor_param.nSpin = 1;
     spinor_param.nDim = a.Ndim();
     for (int d=0; d<a.Ndim(); d++) spinor_param.x[d] = a.X()[d];
-    spinor_param.precision = a.Precision();
+    spinor_param.setPrecision(a.Precision());
     spinor_param.pad = a.Pad();
     spinor_param.siteSubset = QUDA_FULL_SITE_SUBSET;
     spinor_param.siteOrder = QUDA_EVEN_ODD_SITE_ORDER;

--- a/lib/gauge_field.cpp
+++ b/lib/gauge_field.cpp
@@ -92,6 +92,8 @@ namespace quda {
   {
     if (typeid(*this) == typeid(cpuGaugeField)) return;
 
+    QudaFieldGeometry geometry_comms = geometry == QUDA_COARSE_GEOMETRY ? QUDA_VECTOR_GEOMETRY : geometry;
+
     // calculate size of ghost zone required
     ghost_bytes = 0;
     for (int i=0; i<nDim; i++) {
@@ -99,10 +101,10 @@ namespace quda {
       if ( !(comm_dim_partitioned(i) || (no_comms_fill && R[i])) ) ghostFace[i] = 0;
       else ghostFace[i] = surface[i] * R[i]; // includes the radius (unlike ColorSpinorField)
 
-      ghostOffset[i][0] = (i == 0) ? 0 : ghostOffset[i-1][1] + ghostFace[i-1]*geometry*nInternal;
-      ghostOffset[i][1] = ghostOffset[i][0] + ghostFace[i]*geometry*nInternal;
+      ghostOffset[i][0] = (i == 0) ? 0 : ghostOffset[i-1][1] + ghostFace[i-1]*geometry_comms*nInternal;
+      ghostOffset[i][1] = ghostOffset[i][0] + ghostFace[i]*geometry_comms*nInternal;
 
-      ghost_face_bytes[i] = ghostFace[i] * geometry * nInternal * ghost_precision;
+      ghost_face_bytes[i] = ghostFace[i] * geometry_comms * nInternal * ghost_precision;
       ghost_bytes += 2*ghost_face_bytes[i]; // factor of two from direction
     }
 

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -84,6 +84,8 @@ static int R[4] = {0, 0, 0, 0};
 // setting this to false prevents redundant halo exchange but isn't yet compatible with HISQ / ASQTAD kernels
 static bool redundant_comms = false;
 
+#include <blas_cublas.h>
+
 //for MAGMA lib:
 #include <blas_magma.h>
 
@@ -500,6 +502,10 @@ void initQudaMemory()
   checkCudaError();
   createDslashEvents();
   blas::init();
+
+#ifdef CUBLAS_LIB
+  cublas::init();
+#endif
 
   // initalize the memory pool allocators
   pool::init();
@@ -1263,6 +1269,10 @@ void endQuda(void)
 
   LatticeField::freeGhostBuffer();
   cpuColorSpinorField::freeGhostBuffer();
+
+#ifdef CUBLAS_LIB
+  cublas::destroy();
+#endif
 
   blas::end();
 

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -641,11 +641,11 @@ void loadGaugeQuda(void *h_gauge, QudaGaugeParam *param)
 
   // switch the parameters for creating the mirror precise cuda gauge field
   gauge_param.create = QUDA_NULL_FIELD_CREATE;
-  gauge_param.precision = param->cuda_prec;
+  gauge_param.setPrecision(param->cuda_prec);
   gauge_param.reconstruct = param->reconstruct;
   gauge_param.ghostExchange = QUDA_GHOST_EXCHANGE_PAD;
   gauge_param.pad = param->ga_pad;
-  gauge_param.order = (gauge_param.precision == QUDA_DOUBLE_PRECISION ||
+  gauge_param.order = (gauge_param.Precision() == QUDA_DOUBLE_PRECISION ||
 		       gauge_param.reconstruct == QUDA_RECONSTRUCT_NO ) ?
     QUDA_FLOAT2_GAUGE_ORDER : QUDA_FLOAT4_GAUGE_ORDER;
 
@@ -683,9 +683,9 @@ void loadGaugeQuda(void *h_gauge, QudaGaugeParam *param)
   profileGauge.TPSTART(QUDA_PROFILE_COMPUTE);
 
   // switch the parameters for creating the mirror sloppy cuda gauge field
-  gauge_param.precision = param->cuda_prec_sloppy;
+  gauge_param.setPrecision(param->cuda_prec_sloppy);
   gauge_param.reconstruct = param->reconstruct_sloppy;
-  gauge_param.order = (gauge_param.precision == QUDA_DOUBLE_PRECISION ||
+  gauge_param.order = (gauge_param.Precision() == QUDA_DOUBLE_PRECISION ||
       gauge_param.reconstruct == QUDA_RECONSTRUCT_NO ) ?
     QUDA_FLOAT2_GAUGE_ORDER : QUDA_FLOAT4_GAUGE_ORDER;
   cudaGaugeField *sloppy = NULL;
@@ -698,9 +698,9 @@ void loadGaugeQuda(void *h_gauge, QudaGaugeParam *param)
   }
 
   // switch the parameters for creating the mirror preconditioner cuda gauge field
-  gauge_param.precision = param->cuda_prec_precondition;
+  gauge_param.setPrecision(param->cuda_prec_precondition);
   gauge_param.reconstruct = param->reconstruct_precondition;
-  gauge_param.order = (gauge_param.precision == QUDA_DOUBLE_PRECISION ||
+  gauge_param.order = (gauge_param.Precision() == QUDA_DOUBLE_PRECISION ||
       gauge_param.reconstruct == QUDA_RECONSTRUCT_NO ) ?
     QUDA_FLOAT2_GAUGE_ORDER : QUDA_FLOAT4_GAUGE_ORDER;
   cudaGaugeField *precondition = NULL;
@@ -797,11 +797,11 @@ void saveGaugeQuda(void *h_gauge, QudaGaugeParam *param)
       break;
     case QUDA_SMEARED_LINKS:
       gauge_param.create = QUDA_NULL_FIELD_CREATE;
-      gauge_param.precision = param->cuda_prec;
+      gauge_param.setPrecision(param->cuda_prec);
       gauge_param.reconstruct = param->reconstruct;
       gauge_param.ghostExchange = QUDA_GHOST_EXCHANGE_PAD;
       gauge_param.pad = param->ga_pad;
-      gauge_param.order = (gauge_param.precision == QUDA_DOUBLE_PRECISION ||
+      gauge_param.order = (gauge_param.Precision() == QUDA_DOUBLE_PRECISION ||
                            gauge_param.reconstruct == QUDA_RECONSTRUCT_NO ) ?
         QUDA_FLOAT2_GAUGE_ORDER : QUDA_FLOAT4_GAUGE_ORDER;
       cudaGauge = new cudaGaugeField(gauge_param);
@@ -913,7 +913,7 @@ void loadCloverQuda(void *h_clover, void *h_clovinv, QudaInvertParam *inv_param)
     if (!device_calc || inv_param->return_clover || inv_param->return_clover_inverse) {
       // create a param for the cpu clover field
       CloverFieldParam inParam(clover_param);
-      inParam.precision = inv_param->clover_cpu_prec;
+      inParam.setPrecision(inv_param->clover_cpu_prec);
       inParam.order = inv_param->clover_order;
       inParam.direct = h_clover ? true : false;
       inParam.inverse = h_clovinv ? true : false;
@@ -1034,7 +1034,7 @@ void loadSloppyCloverQuda(QudaPrecision prec_sloppy, QudaPrecision prec_precondi
       clover_param.inverse = true;
     }
 
-    if (clover_param.precision != cloverPrecise->Precision()) {
+    if (clover_param.Precision() != cloverPrecise->Precision()) {
       cloverSloppy = new cudaCloverField(clover_param);
       cloverSloppy->copy(*cloverPrecise, clover_param.inverse);
     } else {
@@ -1045,7 +1045,7 @@ void loadSloppyCloverQuda(QudaPrecision prec_sloppy, QudaPrecision prec_precondi
     clover_param.setPrecision(prec_precondition);
 
     // create the mirror preconditioner clover field
-    if (clover_param.precision != cloverSloppy->Precision()) {
+    if (clover_param.Precision() != cloverSloppy->Precision()) {
       cloverPrecondition = new cudaCloverField(clover_param);
       cloverPrecondition->copy(*cloverSloppy, clover_param.inverse);
     } else {
@@ -1122,7 +1122,7 @@ void loadSloppyGaugeQuda(QudaPrecision prec_sloppy, QudaPrecision prec_precondit
 
     if (gaugeSloppy) errorQuda("gaugeSloppy already exists");
 
-    if (gauge_param.precision != gaugePrecise->Precision() ||
+    if (gauge_param.Precision() != gaugePrecise->Precision() ||
 	gauge_param.reconstruct != gaugePrecise->Reconstruct()) {
       gaugeSloppy = new cudaGaugeField(gauge_param);
       gaugeSloppy->copy(*gaugePrecise);
@@ -1136,7 +1136,7 @@ void loadSloppyGaugeQuda(QudaPrecision prec_sloppy, QudaPrecision prec_precondit
 
     if (gaugePrecondition) errorQuda("gaugePrecondition already exists");
 
-    if (gauge_param.precision != gaugeSloppy->Precision() ||
+    if (gauge_param.Precision() != gaugeSloppy->Precision() ||
 	gauge_param.reconstruct != gaugeSloppy->Reconstruct()) {
       gaugePrecondition = new cudaGaugeField(gauge_param);
       gaugePrecondition->copy(*gaugeSloppy);
@@ -1156,7 +1156,7 @@ void loadSloppyGaugeQuda(QudaPrecision prec_sloppy, QudaPrecision prec_precondit
       if (gaugeFatSloppy) errorQuda("gaugeFatSloppy already exists");
       if (gaugeFatSloppy != gaugeFatPrecise) delete gaugeFatSloppy;
 
-      if (gauge_param.precision != gaugeFatPrecise->Precision() ||
+      if (gauge_param.Precision() != gaugeFatPrecise->Precision() ||
 	  gauge_param.reconstruct != gaugeFatPrecise->Reconstruct()) {
 	gaugeFatSloppy = new cudaGaugeField(gauge_param);
 	gaugeFatSloppy->copy(*gaugeFatPrecise);
@@ -1172,7 +1172,7 @@ void loadSloppyGaugeQuda(QudaPrecision prec_sloppy, QudaPrecision prec_precondit
 
       if (gaugeFatPrecondition) errorQuda("gaugeFatPrecondition already exists\n");
 
-      if (gauge_param.precision != gaugeFatSloppy->Precision() ||
+      if (gauge_param.Precision() != gaugeFatSloppy->Precision() ||
 	  gauge_param.reconstruct != gaugeFatSloppy->Reconstruct()) {
 	gaugeFatPrecondition = new cudaGaugeField(gauge_param);
 	gaugeFatPrecondition->copy(*gaugeFatSloppy);
@@ -1191,7 +1191,7 @@ void loadSloppyGaugeQuda(QudaPrecision prec_sloppy, QudaPrecision prec_precondit
     if (gaugeLongSloppy) errorQuda("gaugeLongSloppy already exists");
     if (gaugeLongSloppy != gaugeLongPrecise) delete gaugeLongSloppy;
 
-    if (gauge_param.precision != gaugeLongPrecise->Precision() ||
+    if (gauge_param.Precision() != gaugeLongPrecise->Precision() ||
 	gauge_param.reconstruct != gaugeLongPrecise->Reconstruct()) {
       gaugeLongSloppy = new cudaGaugeField(gauge_param);
       gaugeLongSloppy->copy(*gaugeLongPrecise);
@@ -1205,7 +1205,7 @@ void loadSloppyGaugeQuda(QudaPrecision prec_sloppy, QudaPrecision prec_precondit
 
     if (gaugeLongPrecondition) warningQuda("gaugeLongPrecondition already exists\n");
 
-    if (gauge_param.precision != gaugeLongSloppy->Precision() ||
+    if (gauge_param.Precision() != gaugeLongSloppy->Precision() ||
 	gauge_param.reconstruct != gaugeLongSloppy->Reconstruct()) {
       gaugeLongPrecondition = new cudaGaugeField(gauge_param);
       gaugeLongPrecondition->copy(*gaugeLongSloppy);
@@ -2319,7 +2319,7 @@ multigrid_solver::multigrid_solver(QudaMultigridParam &mg_param, TimeProfile &pr
 
   ColorSpinorParam cpuParam(0, *param, cudaGauge->X(), pc_solution, QUDA_CPU_FIELD_LOCATION);
   cpuParam.create = QUDA_ZERO_FIELD_CREATE;
-  cpuParam.precision = param->cuda_prec_sloppy;
+  cpuParam.setPrecision(param->cuda_prec_sloppy);
   B.resize(mg_param.n_vec[0]);
   for (int i=0; i<mg_param.n_vec[0]; i++) B[i] = new cpuColorSpinorField(cpuParam);
 
@@ -2481,8 +2481,8 @@ deflated_solver::deflated_solver(QudaEigParam &eig_param, TimeProfile &profile)
 
   if( getVerbosity() == QUDA_DEBUG_VERBOSE ) { 
 
-    size_t byte_estimate = (size_t)ritzParam.composite_dim*(size_t)ritzVolume*(ritzParam.nColor*ritzParam.nSpin*ritzParam.precision);
-    printfQuda("allocating bytes: %lu (lattice volume %d, prec %d)" , byte_estimate, ritzVolume, ritzParam.precision);
+    size_t byte_estimate = (size_t)ritzParam.composite_dim*(size_t)ritzVolume*(ritzParam.nColor*ritzParam.nSpin*ritzParam.Precision());
+    printfQuda("allocating bytes: %lu (lattice volume %d, prec %d)" , byte_estimate, ritzVolume, ritzParam.Precision());
     if(ritzParam.mem_type == QUDA_MEMORY_DEVICE) printfQuda("Using device memory type.\n");
     else if (ritzParam.mem_type == QUDA_MEMORY_MAPPED) printfQuda("Using mapped memory type.\n"); 
   }
@@ -2593,7 +2593,7 @@ void invertQuda(void *hp_x, void *hp_b, QudaInvertParam *param)
   // now check if we need to invalidate the solutionResident vectors
   bool invalidate = false;
   for (auto v : solutionResident)
-    if (cudaParam.precision != v->Precision()) { invalidate = true; break; }
+    if (cudaParam.Precision() != v->Precision()) { invalidate = true; break; }
 
   if (invalidate) {
     for (auto v : solutionResident) if (v) delete v;
@@ -3369,7 +3369,7 @@ void invertMultiShiftQuda(void **_hp_x, void *_hp_b, QudaInvertParam *param)
   // now check if we need to invalidate the solutionResident vectors
   bool invalidate = false;
   for (auto v : solutionResident)
-    if (cudaParam.precision != v->Precision()) { invalidate = true; break; }
+    if (cudaParam.Precision() != v->Precision()) { invalidate = true; break; }
 
   if (invalidate) {
     for (auto v : solutionResident) delete v;
@@ -3746,7 +3746,7 @@ int computeGaugeForceQuda(void* mom, void* siteLink,  int*** input_path_buf, int
     gParamMom.order = QUDA_FLOAT2_GAUGE_ORDER;
     gParamMom.reconstruct = QUDA_RECONSTRUCT_10;
     gParamMom.link_type = QUDA_ASQTAD_MOM_LINKS;
-    gParamMom.precision = qudaGaugeParam->cuda_prec;
+    gParamMom.setPrecision(qudaGaugeParam->cuda_prec);
     gParamMom.create = QUDA_ZERO_FIELD_CREATE;
     cudaMom = new cudaGaugeField(gParamMom);
     profileGaugeForce.TPSTOP(QUDA_PROFILE_INIT);
@@ -3919,7 +3919,7 @@ void computeStaggeredForceQuda(void* h_mom, double dt, double delta, void *h_for
   qParam.siteSubset = QUDA_FULL_SITE_SUBSET;
   qParam.siteOrder = QUDA_EVEN_ODD_SITE_ORDER;
   qParam.nDim = 5; // 5 since staggered mrhs
-  qParam.precision = gParam.precision;
+  qParam.setPrecision(gParam.Precision());
   qParam.pad = 0;
   for(int dir=0; dir<4; ++dir) qParam.x[dir] = gParam.x[dir];
   qParam.x[4] = 1;
@@ -4258,7 +4258,7 @@ void computeAsqtadForceQuda(void* const milc_momentum,
 
   param.ghostExchange =  QUDA_GHOST_EXCHANGE_NO;
   param.link_type = QUDA_GENERAL_LINKS;
-  param.precision = gParam->cpu_prec;
+  param.setPrecision(gParam->cpu_prec);
 
   param.order = QUDA_FLOAT2_GAUGE_ORDER;
   cudaGaugeField* cudaInForce  = new cudaGaugeField(param);
@@ -4496,7 +4496,7 @@ void computeStaggeredOprodQuda(void** oprod,
   qParam.fieldOrder = QUDA_SPACE_COLOR_SPIN_FIELD_ORDER;
   qParam.siteOrder = QUDA_EVEN_ODD_SITE_ORDER;
   qParam.nDim = 4;
-  qParam.precision = oParam.precision;
+  qParam.setPrecision(oParam.Precision());
   qParam.pad = 0;
   for(int dir=0; dir<4; ++dir) qParam.x[dir] = oParam.x[dir];
 
@@ -4583,7 +4583,7 @@ void computeCloverForceQuda(void *h_mom, double dt, void **h_x, void **h_p,
   qParam.siteSubset = QUDA_FULL_SITE_SUBSET;
   qParam.siteOrder = QUDA_EVEN_ODD_SITE_ORDER;
   qParam.nDim = 4;
-  qParam.precision = fParam.precision;
+  qParam.setPrecision(fParam.Precision());
   qParam.pad = 0;
   for(int dir=0; dir<4; ++dir) qParam.x[dir] = fParam.x[dir];
 
@@ -5509,7 +5509,7 @@ int computeGaugeFixingOVRQuda(void* gauge, const unsigned int gauge_dir,  const 
   gParam.create      = QUDA_NULL_FIELD_CREATE;
   gParam.link_type   = param->type;
   gParam.reconstruct = param->reconstruct;
-  gParam.order       = (gParam.precision == QUDA_DOUBLE_PRECISION || gParam.reconstruct == QUDA_RECONSTRUCT_NO ) ?
+  gParam.order       = (gParam.Precision() == QUDA_DOUBLE_PRECISION || gParam.reconstruct == QUDA_RECONSTRUCT_NO ) ?
     QUDA_FLOAT2_GAUGE_ORDER : QUDA_FLOAT4_GAUGE_ORDER;
   cudaGaugeField *cudaInGauge = new cudaGaugeField(gParam);
 
@@ -5595,7 +5595,7 @@ int computeGaugeFixingFFTQuda(void* gauge, const unsigned int gauge_dir,  const 
   gParam.create      = QUDA_NULL_FIELD_CREATE;
   gParam.link_type   = param->type;
   gParam.reconstruct = param->reconstruct;
-  gParam.order       = (gParam.precision == QUDA_DOUBLE_PRECISION || gParam.reconstruct == QUDA_RECONSTRUCT_NO ) ?
+  gParam.order       = (gParam.Precision() == QUDA_DOUBLE_PRECISION || gParam.reconstruct == QUDA_RECONSTRUCT_NO ) ?
     QUDA_FLOAT2_GAUGE_ORDER : QUDA_FLOAT4_GAUGE_ORDER;
 
   cudaGaugeField *cudaInGauge = new cudaGaugeField(gParam);

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -502,10 +502,7 @@ void initQudaMemory()
   checkCudaError();
   createDslashEvents();
   blas::init();
-
-#ifdef CUBLAS_LIB
   cublas::init();
-#endif
 
   // initalize the memory pool allocators
   pool::init();
@@ -1270,10 +1267,7 @@ void endQuda(void)
   LatticeField::freeGhostBuffer();
   cpuColorSpinorField::freeGhostBuffer();
 
-#ifdef CUBLAS_LIB
   cublas::destroy();
-#endif
-
   blas::end();
 
   pool::flush_pinned();

--- a/lib/lattice_field.cpp
+++ b/lib/lattice_field.cpp
@@ -41,7 +41,8 @@ namespace quda {
   int LatticeField::bufferIndex = 0;
 
   LatticeFieldParam::LatticeFieldParam(const LatticeField &field)
-    : nDim(field.Ndim()), pad(field.Pad()), precision(field.Precision()),
+    : precision(field.Precision()), ghost_precision(field.Precision()),
+      nDim(field.Ndim()), pad(field.Pad()),
       siteSubset(field.SiteSubset()), mem_type(field.MemType()),
       ghostExchange(field.GhostExchange()), scale(field.Scale())
   {
@@ -52,7 +53,8 @@ namespace quda {
   }
 
   LatticeField::LatticeField(const LatticeFieldParam &param)
-    : volume(1), pad(param.pad), total_bytes(0), nDim(param.nDim), precision(param.precision),
+    : volume(1), pad(param.pad), total_bytes(0), nDim(param.nDim),
+      precision(param.Precision()), ghost_precision(param.GhostPrecision()),
       scale(param.scale), siteSubset(param.siteSubset), ghostExchange(param.ghostExchange),
       ghost_bytes(0), ghost_face_bytes{ }, ghostOffset( ), ghostNormOffset( ),
       my_face_h{ }, my_face_hd{ }, initComms(false), mem_type(param.mem_type),
@@ -94,7 +96,8 @@ namespace quda {
   }
 
   LatticeField::LatticeField(const LatticeField &field)
-    : volume(1), pad(field.pad), total_bytes(0), nDim(field.nDim), precision(field.precision),
+    : volume(1), pad(field.pad), total_bytes(0), nDim(field.nDim),
+      precision(field.precision), ghost_precision(field.ghost_precision),
       scale(field.scale), siteSubset(field.siteSubset), ghostExchange(field.ghostExchange), ghost_bytes(0),
       ghost_face_bytes{ }, ghostOffset( ), ghostNormOffset( ),
       my_face_h{ }, my_face_hd{ }, initComms(false), mem_type(field.mem_type),
@@ -215,7 +218,7 @@ namespace quda {
 	from_face_dim_dir_hd[b][i][0] = static_cast<char*>(from_face_hd[b]) + offset;
 
 	my_face_dim_dir_d[b][i][0] = static_cast<char*>(ghost_send_buffer_d[b]) + offset;
-	from_face_dim_dir_d[b][i][0] = static_cast<char*>(ghost_recv_buffer_d[b]) + ghostOffset[i][0]*precision;
+	from_face_dim_dir_d[b][i][0] = static_cast<char*>(ghost_recv_buffer_d[b]) + ghostOffset[i][0]*ghost_precision;
       } // loop over b
 
       offset += ghost_face_bytes[i];
@@ -228,7 +231,7 @@ namespace quda {
 	from_face_dim_dir_hd[b][i][1] = static_cast<char*>(from_face_hd[b]) + offset;
 
 	my_face_dim_dir_d[b][i][1] = static_cast<char*>(ghost_send_buffer_d[b]) + offset;
-	from_face_dim_dir_d[b][i][1] = static_cast<char*>(ghost_recv_buffer_d[b]) + ghostOffset[i][1]*precision;
+	from_face_dim_dir_d[b][i][1] = static_cast<char*>(ghost_recv_buffer_d[b]) + ghostOffset[i][1]*ghost_precision;
       } // loop over b
       offset += ghost_face_bytes[i];
 
@@ -575,7 +578,8 @@ namespace quda {
       output << "x[" << i << "] = " << param.x[i] << std::endl;    
     }
     output << "pad = " << param.pad << std::endl;
-    output << "precision = " << param.precision << std::endl;
+    output << "precision = " << param.Precision() << std::endl;
+    output << "ghost_precision = " << param.GhostPrecision() << std::endl;
     output << "scale = " << param.scale << std::endl;
 
     output << "ghostExchange = " << param.ghostExchange << std::endl;

--- a/lib/llfat_quda.cu
+++ b/lib/llfat_quda.cu
@@ -531,7 +531,7 @@ namespace quda {
 #ifdef GPU_FATLINK
     GaugeFieldParam gParam(u);
     gParam.reconstruct = QUDA_RECONSTRUCT_NO;
-    gParam.setPrecision(gParam.precision);
+    gParam.setPrecision(gParam.Precision());
     gParam.create = QUDA_NULL_FIELD_CREATE;
     cudaGaugeField staple(gParam);
     cudaGaugeField staple1(gParam);

--- a/lib/malloc.cpp
+++ b/lib/malloc.cpp
@@ -186,6 +186,8 @@ namespace quda {
    */
   void *device_pinned_malloc_(const char *func, const char *file, int line, size_t size)
   {
+    if (!comm_peer2peer_present()) return device_malloc_(func, file, line, size);
+
     MemAlloc a(func, file, line);
     void *ptr;
 
@@ -308,6 +310,11 @@ namespace quda {
    */
   void device_pinned_free_(const char *func, const char *file, int line, void *ptr)
   {
+    if (!comm_peer2peer_present()) {
+      device_free_(func, file, line, ptr);
+      return;
+    }
+
     if (!ptr) {
       printfQuda("ERROR: Attempt to free NULL device pointer (%s:%d in %s())\n", file, line, func);
       errorQuda("Aborting");

--- a/lib/milc_interface.cpp
+++ b/lib/milc_interface.cpp
@@ -746,7 +746,7 @@ static void setColorSpinorParams(const int dim[4],
   for(int dir=0; dir<4; ++dir) param->x[dir] = dim[dir];
   param->x[0] /= 2;
 
-  param->precision = precision;
+  param->setPrecision(precision);
   param->pad = 0;
   param->siteSubset = QUDA_PARITY_SITE_SUBSET;
   param->siteOrder = QUDA_EVEN_ODD_SITE_ORDER;

--- a/lib/transfer.cpp
+++ b/lib/transfer.cpp
@@ -108,12 +108,12 @@ namespace quda {
     }
 
     // allocate and compute the fine-to-coarse and coarse-to-fine site maps
-    fine_to_coarse_h = static_cast<int*>(safe_malloc(B[0]->Volume()*sizeof(int)));
-    coarse_to_fine_h = static_cast<int*>(safe_malloc(B[0]->Volume()*sizeof(int)));
+    fine_to_coarse_h = static_cast<int*>(pool_pinned_malloc(B[0]->Volume()*sizeof(int)));
+    coarse_to_fine_h = static_cast<int*>(pool_pinned_malloc(B[0]->Volume()*sizeof(int)));
 
     if (enable_gpu) {
-      fine_to_coarse_d = static_cast<int*>(device_malloc(B[0]->Volume()*sizeof(int)));
-      coarse_to_fine_d = static_cast<int*>(device_malloc(B[0]->Volume()*sizeof(int)));
+      fine_to_coarse_d = static_cast<int*>(pool_device_malloc(B[0]->Volume()*sizeof(int)));
+      coarse_to_fine_d = static_cast<int*>(pool_device_malloc(B[0]->Volume()*sizeof(int)));
     }
 
     createGeoMap(geo_bs);
@@ -174,10 +174,10 @@ namespace quda {
       for (int s = 0; s < nspin_fine; s++) { if (spin_map[s]) host_free(spin_map[s]); } 
       host_free(spin_map);
     }
-    if (coarse_to_fine_d) device_free(coarse_to_fine_d);
-    if (fine_to_coarse_d) device_free(fine_to_coarse_d);
-    if (coarse_to_fine_h) host_free(coarse_to_fine_h);
-    if (fine_to_coarse_h) host_free(fine_to_coarse_h);
+    if (coarse_to_fine_d) pool_device_free(coarse_to_fine_d);
+    if (fine_to_coarse_d) pool_device_free(fine_to_coarse_d);
+    if (coarse_to_fine_h) pool_pinned_free(coarse_to_fine_h);
+    if (fine_to_coarse_h) pool_pinned_free(fine_to_coarse_h);
     if (V_h) delete V_h;
     if (V_d) delete V_d;
 

--- a/tests/blas_test.cu
+++ b/tests/blas_test.cu
@@ -46,7 +46,7 @@ int Ncolor;
 
 void setPrec(ColorSpinorParam &param, const QudaPrecision precision)
 {
-  param.precision = precision;
+  param.setPrecision(precision);
   if (Nspin == 1 || Nspin == 2 || precision == QUDA_DOUBLE_PRECISION) {
     param.fieldOrder = QUDA_FLOAT2_FIELD_ORDER;
   } else {
@@ -117,7 +117,7 @@ void initFields(int prec)
 
   param.siteOrder = QUDA_EVEN_ODD_SITE_ORDER;
   param.gammaBasis = QUDA_DEGRAND_ROSSI_GAMMA_BASIS;
-  param.precision = QUDA_DOUBLE_PRECISION;
+  param.setPrecision(QUDA_DOUBLE_PRECISION);
   param.fieldOrder = QUDA_SPACE_SPIN_COLOR_FIELD_ORDER;
 
   param.create = QUDA_ZERO_FIELD_CREATE;

--- a/tests/covdev_test.cpp
+++ b/tests/covdev_test.cpp
@@ -149,7 +149,7 @@ void init()
   }
 //  csParam.x[4] = Nsrc; // number of sources becomes the fifth dimension
 
-  csParam.precision = inv_param.cpu_prec;
+  csParam.setPrecision(inv_param.cpu_prec);
   csParam.pad = 0;
   inv_param.solution_type = QUDA_MAT_SOLUTION;
   csParam.siteSubset = QUDA_FULL_SITE_SUBSET;	
@@ -213,8 +213,8 @@ void init()
   if (!transfer) {
     csParam.gammaBasis = QUDA_UKQCD_GAMMA_BASIS;
     csParam.pad = inv_param.sp_pad;
-    csParam.precision = inv_param.cuda_prec;
-    if (csParam.precision == QUDA_DOUBLE_PRECISION ) {
+    csParam.setPrecision(inv_param.cuda_prec);
+    if (csParam.Precision() == QUDA_DOUBLE_PRECISION ) {
       csParam.fieldOrder = QUDA_FLOAT2_FIELD_ORDER;
     } else {
       /* Single and half */

--- a/tests/domain_wall_dslash_reference.cpp
+++ b/tests/domain_wall_dslash_reference.cpp
@@ -517,7 +517,7 @@ void dw_dslash(void *out, void **gauge, void *in, int oddBit, int daggerBit, Qud
     csParam.nDim = 5; //for DW dslash
     for (int d=0; d<4; d++) csParam.x[d] = Z[d];
     csParam.x[4] = Ls;//5th dimention
-    csParam.precision = precision;
+    csParam.setPrecision(precision);
     csParam.pad = 0;
     csParam.siteSubset = QUDA_PARITY_SITE_SUBSET;
     csParam.x[0] /= 2;
@@ -579,7 +579,7 @@ void dslash_4_4d(void *out, void **gauge, void *in, int oddBit, int daggerBit, Q
     csParam.nDim = 5; //for DW dslash
     for (int d=0; d<4; d++) csParam.x[d] = Z[d];
     csParam.x[4] = Ls;//5th dimention
-    csParam.precision = precision;
+    csParam.setPrecision(precision);
     csParam.pad = 0;
     csParam.siteSubset = QUDA_PARITY_SITE_SUBSET;
     csParam.x[0] /= 2;

--- a/tests/dslash_test.cpp
+++ b/tests/dslash_test.cpp
@@ -276,7 +276,7 @@ void init(int argc, char **argv) {
   }
 
 
-  csParam.precision = inv_param.cpu_prec;
+  csParam.setPrecision(inv_param.cpu_prec);
   csParam.pad = 0;
 
   if(dslash_type == QUDA_DOMAIN_WALL_4D_DSLASH || dslash_type == QUDA_MOBIUS_DWF_DSLASH) {
@@ -348,8 +348,8 @@ void init(int argc, char **argv) {
   if (!transfer) {
     csParam.gammaBasis = QUDA_UKQCD_GAMMA_BASIS;
     csParam.pad = inv_param.sp_pad;
-    csParam.precision = inv_param.cuda_prec;
-    if (csParam.precision == QUDA_DOUBLE_PRECISION ) {
+    csParam.setPrecision(inv_param.cuda_prec);
+    if (csParam.Precision() == QUDA_DOUBLE_PRECISION ) {
       csParam.fieldOrder = QUDA_FLOAT2_FIELD_ORDER;
     } else {
       /* Single and half */

--- a/tests/hisq_paths_force_test.cpp
+++ b/tests/hisq_paths_force_test.cpp
@@ -334,7 +334,7 @@ hisq_force_init()
 
 #ifdef MULTI_GPU
   gParam_ex.order = QUDA_FLOAT2_GAUGE_ORDER;
-  gParam_ex.precision = prec;
+  gParam_ex.setPrecision(prec);
   gParam_ex.reconstruct = link_recon;
   //gParam_ex.pad = E1*E2*E3/2;
   gParam_ex.pad = 0;

--- a/tests/multigrid_benchmark_test.cu
+++ b/tests/multigrid_benchmark_test.cu
@@ -79,7 +79,7 @@ void initFields(QudaPrecision prec)
 
   param.siteOrder = QUDA_EVEN_ODD_SITE_ORDER;
   param.gammaBasis = QUDA_DEGRAND_ROSSI_GAMMA_BASIS;
-  param.precision = QUDA_DOUBLE_PRECISION;
+  param.setPrecision(QUDA_DOUBLE_PRECISION);
   param.fieldOrder = QUDA_SPACE_SPIN_COLOR_FIELD_ORDER;
 
   param.create = QUDA_ZERO_FIELD_CREATE;
@@ -95,7 +95,7 @@ void initFields(QudaPrecision prec)
 
   if (param.nSpin == 4) param.gammaBasis = QUDA_UKQCD_GAMMA_BASIS;
   param.create = QUDA_ZERO_FIELD_CREATE;
-  param.precision = prec;
+  param.setPrecision(prec);
   param.fieldOrder = QUDA_FLOAT2_FIELD_ORDER;
 
   xD = new cudaColorSpinorField(param);
@@ -118,7 +118,7 @@ void initFields(QudaPrecision prec)
   gParam.link_type = QUDA_COARSE_LINKS;
   gParam.t_boundary = QUDA_PERIODIC_T;
   gParam.create = QUDA_ZERO_FIELD_CREATE;
-  gParam.precision = param.precision;
+  gParam.setPrecision(param.Precision());
   gParam.nDim = 4;
   gParam.siteSubset = QUDA_FULL_SITE_SUBSET;
   gParam.ghostExchange = QUDA_GHOST_EXCHANGE_PAD;
@@ -141,13 +141,13 @@ void initFields(QudaPrecision prec)
 	(gParam.x[0]*gParam.x[2]*gParam.x[3])/2,
 	(gParam.x[0]*gParam.x[1]*gParam.x[3])/2 } );
   gParam.pad = gParam.nFace * pad * 2;
-  gParam.precision = prec_sloppy;
+  gParam.setPrecision(prec_sloppy);
   Y_d = new cudaGaugeField(gParam);
   Yhat_d = new cudaGaugeField(gParam);
   Y_d->copy(*Y_h);
   Yhat_d->copy(*Yhat_h);
 
-  gParam.precision = param.precision;
+  gParam.setPrecision(param.Precision());
   gParam.geometry = QUDA_SCALAR_GEOMETRY;
   gParam.ghostExchange = QUDA_GHOST_EXCHANGE_NO;
   gParam.nFace = 0;

--- a/tests/multigrid_evolve_test.cpp
+++ b/tests/multigrid_evolve_test.cpp
@@ -72,6 +72,7 @@ extern QudaSolveType mg_solve_type[QUDA_MAX_MG_LEVEL];
 extern int geo_block_size[QUDA_MAX_MG_LEVEL][QUDA_MAX_DIM];
 extern double mu_factor[QUDA_MAX_MG_LEVEL];
 
+extern QudaVerbosity verbosity;
 extern QudaVerbosity mg_verbosity[QUDA_MAX_MG_LEVEL];
 
 extern QudaFieldLocation solver_location[QUDA_MAX_MG_LEVEL];
@@ -330,8 +331,8 @@ void setMultigridParam(QudaMultigridParam &mg_param) {
   inv_param.reliable_delta = 1e-10;
   inv_param.gcrNkrylov = 10;
 
-  inv_param.verbosity = QUDA_SUMMARIZE;
-  inv_param.verbosity_precondition = QUDA_SUMMARIZE;
+  inv_param.verbosity = verbosity;
+  inv_param.verbosity_precondition = mg_verbosity[0];
 }
 
 void setInvertParam(QudaInvertParam &inv_param) {
@@ -395,7 +396,7 @@ void setInvertParam(QudaInvertParam &inv_param) {
 
   inv_param.inv_type = QUDA_GCR_INVERTER;
 
-  inv_param.verbosity = QUDA_VERBOSE;
+  inv_param.verbosity = verbosity;
   inv_param.verbosity_precondition = mg_verbosity[0];
 
 
@@ -653,7 +654,6 @@ int main(int argc, char **argv)
     inv_param2.inv_type_precondition = QUDA_INVALID_INVERTER;
     inv_param2.reliable_delta = 0.1;
     inv_param2.maxiter = 10000;
-    inv_param2.verbosity = QUDA_VERBOSE;
     inv_param2.chrono_use_resident = true;
     inv_param2.chrono_make_resident = true;
     inv_param2.chrono_index = 0 ;

--- a/tests/pack_test.cpp
+++ b/tests/pack_test.cpp
@@ -71,7 +71,7 @@ void init() {
   csParam.nSpin = 4;
   csParam.nDim = 4;
   for (int d=0; d<4; d++) csParam.x[d] = param.X[d];
-  csParam.precision = prec_cpu;
+  csParam.setPrecision(prec_cpu);
   csParam.pad = 0;
   csParam.siteSubset = QUDA_PARITY_SITE_SUBSET;
   csParam.siteOrder = QUDA_EVEN_ODD_SITE_ORDER;
@@ -117,10 +117,10 @@ void packTest() {
     GaugeFieldParam cpsParam(cpsCpuGauge_p, param);
     cpuGaugeField cpsCpuGauge(cpsParam);
     cpsParam.create = QUDA_NULL_FIELD_CREATE;
-    cpsParam.precision = param.cuda_prec;
+    cpsParam.setPrecision(param.cuda_prec);
     cpsParam.reconstruct = param.reconstruct;
     cpsParam.pad = param.ga_pad;
-    cpsParam.order = (cpsParam.precision == QUDA_DOUBLE_PRECISION || 
+    cpsParam.order = (cpsParam.Precision() == QUDA_DOUBLE_PRECISION ||
 		      cpsParam.reconstruct == QUDA_RECONSTRUCT_NO ) ?
       QUDA_FLOAT2_GAUGE_ORDER : QUDA_FLOAT4_GAUGE_ORDER;
     cudaGaugeField cudaCpsGauge(cpsParam);
@@ -144,10 +144,10 @@ void packTest() {
     GaugeFieldParam qdpParam(qdpCpuGauge_p, param);
     cpuGaugeField qdpCpuGauge(qdpParam);
     qdpParam.create = QUDA_NULL_FIELD_CREATE;
-    qdpParam.precision = param.cuda_prec;
+    qdpParam.setPrecision(param.cuda_prec);
     qdpParam.reconstruct = param.reconstruct;
     qdpParam.pad = param.ga_pad;
-    qdpParam.order = (qdpParam.precision == QUDA_DOUBLE_PRECISION || 
+    qdpParam.order = (qdpParam.Precision() == QUDA_DOUBLE_PRECISION ||
 		      qdpParam.reconstruct == QUDA_RECONSTRUCT_NO ) ?
       QUDA_FLOAT2_GAUGE_ORDER : QUDA_FLOAT4_GAUGE_ORDER;
     cudaGaugeField cudaQdpGauge(qdpParam);

--- a/tests/staggered_dslash_test.cpp
+++ b/tests/staggered_dslash_test.cpp
@@ -147,7 +147,7 @@ void init()
   }
   csParam.x[4] = Nsrc; // number of sources becomes the fifth dimension
 
-  csParam.precision = inv_param.cpu_prec;
+  csParam.setPrecision(inv_param.cpu_prec);
   csParam.pad = 0;
   if (test_type < 2) {
     inv_param.solution_type = QUDA_MATPC_SOLUTION;
@@ -242,7 +242,7 @@ void init()
 
     csParam.fieldOrder = QUDA_FLOAT2_FIELD_ORDER;
     csParam.pad = inv_param.sp_pad;
-    csParam.precision = inv_param.cuda_prec;
+    csParam.setPrecision(inv_param.cuda_prec);
     if (test_type < 2){
       csParam.siteSubset = QUDA_PARITY_SITE_SUBSET;
       csParam.x[0] /=2;

--- a/tests/staggered_invert_test.cpp
+++ b/tests/staggered_invert_test.cpp
@@ -239,7 +239,7 @@ invert_test(void)
   if (pc) csParam.x[0] /= 2;
   csParam.x[4] = Nsrc;
 
-  csParam.precision = inv_param.cpu_prec;
+  csParam.setPrecision(inv_param.cpu_prec);
   csParam.pad = 0;
   csParam.siteSubset = pc ? QUDA_PARITY_SITE_SUBSET : QUDA_FULL_SITE_SUBSET;
   csParam.siteOrder = QUDA_EVEN_ODD_SITE_ORDER;

--- a/tests/wilson_dslash_reference.cpp
+++ b/tests/wilson_dslash_reference.cpp
@@ -195,7 +195,7 @@ void wil_dslash(void *out, void **gauge, void *in, int oddBit, int daggerBit,
   csParam.nSpin = 4;
   csParam.nDim = 4;
   for (int d=0; d<4; d++) csParam.x[d] = Z[d];
-  csParam.precision = precision;
+  csParam.setPrecision(precision);
   csParam.pad = 0;
   csParam.siteSubset = QUDA_PARITY_SITE_SUBSET;
   csParam.x[0] /= 2;


### PR DESCRIPTION
* Add new members `LatticeField::ghost_precision` `LatticeFieldParam::ghost_precision` for separate halo precision and field precision specification
* Both `LatticeFieldParam::precision` is now protected forcing the use of `setPrecision` and `Precision` methods for setting and getting the precision (this ensures consistent setting of `ghost_precision`)
* Dimension and direction parallelization in `genericPackGhost` (with the former autotuned)
* Optionally specify the halo precision in `ColorspinorField::exchangeGhost` 
* Add support for block-float format to fine-grained colorspinor accessor (enabled if field is floating point but halo precision is fixed point)
* Add support for block-float 16-bit halos from single-precision fields in `genericPackGhost` function through cooperative computation of the site max
* Dslash coarse now uses the precision of the link field to specify its halo precision (with the result that 16-bit link fields result in 16-bit halo exchange)