### PR TITLE
Hotfix/cuda 9.1

### DIFF
--- a/include/thrust_helper.cuh
+++ b/include/thrust_helper.cuh
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <malloc_quda.h>
+
+#undef device_malloc
+#undef device_free
+
+#include <thrust/system/cuda/vector.h>
+#include <thrust/system/cuda/execution_policy.h>
+#include <thrust/transform_reduce.h>
+#include <thrust/device_ptr.h>
+#include <thrust/device_vector.h>
+#include <thrust/sort.h>
+
+#define device_malloc(size) quda::device_malloc_(__func__, quda::file_name(__FILE__), __LINE__, size)
+#define device_free(ptr) quda::device_free_(__func__, quda::file_name(__FILE__), __LINE__, ptr)
+
+/**
+   Allocator helper class which allows us to redirect thrust temporary
+   alocations to use QUDA's pool memory
+ */
+class thrust_allocator
+{
+public:
+  // just allocate bytes
+  typedef char value_type;
+
+  thrust_allocator() {}
+  ~thrust_allocator() { }
+
+  char *allocate(std::ptrdiff_t num_bytes) { return reinterpret_cast<char*>(pool_device_malloc(num_bytes)); }
+  void deallocate(char *ptr, size_t n) { pool_device_free(ptr); }
+
+};

--- a/lib/coarse_op.cu
+++ b/lib/coarse_op.cu
@@ -12,6 +12,8 @@
 
 namespace quda {
 
+#ifdef GPU_MULTIGRID
+
   template <typename Float, int fineColor, int fineSpin, int coarseColor, int coarseSpin>
   void calculateY(GaugeField &Y, GaugeField &X, GaugeField &Xinv, GaugeField &Yhat, ColorSpinorField &uv, ColorSpinorField &av, const Transfer &T,
 		  const GaugeField &g, const CloverField &c, double kappa, double mu, double mu_factor, QudaDiracType dirac, QudaMatPCType matpc) {
@@ -161,12 +163,15 @@ namespace quda {
     printfQuda("....done computing Y field\n");
   }
 
+#endif // GPU_MULTIGRID
+
   //Calculates the coarse color matrix and puts the result in Y.
   //N.B. Assumes Y, X have been allocated.
   void CoarseOp(GaugeField &Y, GaugeField &X, GaugeField &Xinv, GaugeField &Yhat, const Transfer &T,
 		const cudaGaugeField &gauge, const cudaCloverField *clover,
 		double kappa, double mu, double mu_factor, QudaDiracType dirac, QudaMatPCType matpc) {
 
+#ifdef GPU_MULTIGRID
     QudaPrecision precision = Y.Precision();
     QudaFieldLocation location = checkLocation(Y, X, Xinv, Yhat);
 
@@ -249,6 +254,9 @@ namespace quda {
 
     if (C != clover) delete C;
     if (U != &gauge) delete U;
+#else
+    errorQuda("Multigrid has not been built");
+#endif // GPU_MULTIGRID
   }
 
 } //namespace quda

--- a/lib/coarsecoarse_op.cu
+++ b/lib/coarsecoarse_op.cu
@@ -11,6 +11,8 @@
 
 namespace quda {
 
+#ifdef GPU_MULTIGRID
+
   template <typename Float, int fineColor, int fineSpin, int coarseColor, int coarseSpin>
   void calculateYcoarse(GaugeField &Y, GaugeField &X, GaugeField &Xinv, GaugeField &Yhat,
 			ColorSpinorField &uv, const Transfer &T, const GaugeField &g, const GaugeField &clover,
@@ -160,12 +162,15 @@ namespace quda {
     printfQuda("....done computing Y field\n");
   }
 
+#endif // GPU_MULTIGRID
+
   //Calculates the coarse color matrix and puts the result in Y.
   //N.B. Assumes Y, X have been allocated.
   void CoarseCoarseOp(GaugeField &Y, GaugeField &X, GaugeField &Xinv, GaugeField &Yhat, const Transfer &T,
 		      const GaugeField &gauge, const GaugeField &clover, const GaugeField &cloverInv,
 		      double kappa, double mu, double mu_factor, QudaDiracType dirac, QudaMatPCType matpc) {
 
+#ifdef GPU_MULTIGRID
     QudaPrecision precision = Y.Precision();
     QudaFieldLocation location = checkLocation(X, Y, Xinv, Yhat, gauge, clover, cloverInv);
 
@@ -183,6 +188,9 @@ namespace quda {
     calculateYcoarse(Y, X, Xinv, Yhat, *uv, T, gauge, clover, cloverInv, kappa, mu, mu_factor, dirac, matpc);
 
     delete uv;
+#else
+    errorQuda("Multigrid has not been built");
+#endif // GPU_MULTIGRID
   }
   
 } //namespace quda

--- a/lib/gauge_fix_fft.cu
+++ b/lib/gauge_fix_fft.cu
@@ -1087,18 +1087,16 @@ namespace quda {
                                reunit_allow_svd, reunit_svd_only,
                                svd_rel_error, svd_abs_error);
     int num_failures = 0;
-    int* num_failures_dev;
-    cudaMalloc((void**)&num_failures_dev, sizeof(int));
+    int* num_failures_dev = static_cast<int*>(pool_device_malloc(sizeof(int)));
     cudaMemset(num_failures_dev, 0, sizeof(int));
-    if ( num_failures_dev == NULL ) errorQuda("cudaMalloc failed for dev_pointer\n");
     unitarizeLinks(data, data, num_failures_dev);
     qudaMemcpy(&num_failures, num_failures_dev, sizeof(int), cudaMemcpyDeviceToHost);
+
+    pool_device_free(num_failures_dev);
     if ( num_failures > 0 ) {
-      cudaFree(num_failures_dev);
       errorQuda("Error in the unitarization\n");
       exit(1);
     }
-    cudaFree(num_failures_dev);
     // end reunitarize
 
 

--- a/lib/pgauge_init.cu
+++ b/lib/pgauge_init.cu
@@ -425,30 +425,6 @@ namespace quda {
     cudaDeviceSynchronize();
 
     data.exchangeExtendedGhost(data.R(),false);
-    /*cudaDeviceSynchronize();
-       const double unitarize_eps = 1e-14;
-       const double max_error = 1e-10;
-       const int reunit_allow_svd = 1;
-       const int reunit_svd_only  = 0;
-       const double svd_rel_error = 1e-6;
-       const double svd_abs_error = 1e-6;
-       setUnitarizeLinksConstants(unitarize_eps, max_error,
-        reunit_allow_svd, reunit_svd_only,
-        svd_rel_error, svd_abs_error);
-       int num_failures=0;
-       int* num_failures_dev;
-       cudaMalloc((void**)&num_failures_dev, sizeof(int));
-       cudaMemset(num_failures_dev, 0, sizeof(int));
-       if(num_failures_dev == NULL) errorQuda("cudaMalloc failed for dev_pointer\n");
-
-       unitarizeLinksQuda(data, num_failures_dev);
-       cudaMemcpy(&num_failures, num_failures_dev, sizeof(int), cudaMemcpyDeviceToHost);
-       if(num_failures>0){
-       cudaFree(num_failures_dev);
-       errorQuda("Error in the unitarization\n");
-       exit(1);
-       }
-       cudaFree(num_failures_dev);*/
   }
 
 

--- a/lib/transfer_util.cu
+++ b/lib/transfer_util.cu
@@ -7,6 +7,8 @@
 
 namespace quda {
 
+#ifdef GPU_MULTIGRID
+
   using namespace quda::colorspinor;
 
   template<typename real, int nSpin, int nColor, int nVec, QudaFieldOrder order>
@@ -165,7 +167,11 @@ namespace quda {
     }
   }
 
+#endif // GPU_MULTIGRID
+
   void FillV(ColorSpinorField &V, const std::vector<ColorSpinorField*> &B, int Nvec) {
+
+#ifdef GPU_MULTIGRID
     if (V.Precision() == QUDA_DOUBLE_PRECISION) {
 #ifdef GPU_MULTIGRID_DOUBLE
       FillV<double>(V,B,Nvec);
@@ -177,7 +183,12 @@ namespace quda {
     } else {
       errorQuda("Unsupported precision %d", V.Precision());
     }
+#else
+    errorQuda("Multigrid has not been built");
+#endif
   }
+
+#ifdef GPU_MULTIGRID
 
   // Creates a block-ordered version of a ColorSpinorField
   // N.B.: Only works for the V field, as we need to block spin.
@@ -648,8 +659,11 @@ namespace quda {
     }
   }
 
+#endif // GPU_MULTIGRID
+
   void BlockOrthogonalize(ColorSpinorField &V, int Nvec, 
 			  const int *geo_bs, const int *geo_map, int spin_bs) {
+#ifdef GPU_MULTIGRID
     if (V.Precision() == QUDA_DOUBLE_PRECISION) {
 #ifdef GPU_MULTIGRID_DOUBLE
       BlockOrthogonalize<double>(V, Nvec, geo_bs, geo_map, spin_bs);
@@ -661,6 +675,9 @@ namespace quda {
     } else {
       errorQuda("Unsupported precision %d\n", V.Precision());
     }
+#else
+    errorQuda("Multigrid has not been built");
+#endif // GPU_MULTIGRID
   }
 
 } // namespace quda


### PR DESCRIPTION
* Fix thrust compilation with CUDA 9.1
* Gauge fixing routines now use pool memory allocations
* Don't compile multigrid components unless multigrid is enabled (reduces compilation time)