### PR TITLE
Hotfix/twist mass pack

### DIFF
--- a/lib/comm_qmp.cpp
+++ b/lib/comm_qmp.cpp
@@ -277,7 +277,7 @@ void comm_allreduce_int(int* data)
 void comm_allreduce_xor(uint64_t *data)
 {
   if (sizeof(uint64_t) != sizeof(unsigned long)) errorQuda("unsigned long is not 64-bit");
-  QMP_CHECK( QMP_xor_ulong( reinterpret_cast<unsigned long*>(data) );
+  QMP_CHECK( QMP_xor_ulong( reinterpret_cast<unsigned long*>(data) ));
 }
 
 void comm_broadcast(void *data, size_t nbytes)

--- a/lib/dslash_core/tm_dslash_dagger_fermi_core.h
+++ b/lib/dslash_core/tm_dslash_dagger_fermi_core.h
@@ -1673,26 +1673,17 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]<X4m1)) |
     } else {
     
       const int sp_stride_pad = ghostFace[static_cast<int>(kernel_type)];
-      //const int t_proj_scale = TPROJSCALE;
+      const int t_proj_scale = TPROJSCALE;
       
       // read half spinor from device memory
       READ_HALF_SPINOR(GHOSTSPINORTEX, sp_stride_pad, sp_idx, sp_norm_idx);
       
-#ifdef TWIST_INV_DSLASH
-      a0_re = i00_re;  a0_im = i00_im;
-      a1_re = i01_re;  a1_im = i01_im;
-      a2_re = i02_re;  a2_im = i02_im;
-      b0_re = i10_re;  b0_im = i10_im;
-      b1_re = i11_re;  b1_im = i11_im;
-      b2_re = i12_re;  b2_im = i12_im;
-#else  
-      a0_re = 2*i00_re;  a0_im = 2*i00_im;
-      a1_re = 2*i01_re;  a1_im = 2*i01_im;
-      a2_re = 2*i02_re;  a2_im = 2*i02_im;
-      b0_re = 2*i10_re;  b0_im = 2*i10_im;
-      b1_re = 2*i11_re;  b1_im = 2*i11_im;
-      b2_re = 2*i12_re;  b2_im = 2*i12_im;
-#endif 
+      a0_re = t_proj_scale*i00_re;  a0_im = t_proj_scale*i00_im;
+      a1_re = t_proj_scale*i01_re;  a1_im = t_proj_scale*i01_im;
+      a2_re = t_proj_scale*i02_re;  a2_im = t_proj_scale*i02_im;
+      b0_re = t_proj_scale*i10_re;  b0_im = t_proj_scale*i10_im;
+      b1_re = t_proj_scale*i11_re;  b1_im = t_proj_scale*i11_im;
+      b2_re = t_proj_scale*i12_re;  b2_im = t_proj_scale*i12_im;
       
     }
 #endif // MULTI_GPU
@@ -1767,26 +1758,17 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]<X4m1)) |
     } else {
     
       const int sp_stride_pad = ghostFace[static_cast<int>(kernel_type)];
-      //const int t_proj_scale = TPROJSCALE;
+      const int t_proj_scale = TPROJSCALE;
       
       // read half spinor from device memory
       READ_HALF_SPINOR(GHOSTSPINORTEX, sp_stride_pad, sp_idx, sp_norm_idx);
       
-#ifdef TWIST_INV_DSLASH
-      a0_re = i00_re;  a0_im = i00_im;
-      a1_re = i01_re;  a1_im = i01_im;
-      a2_re = i02_re;  a2_im = i02_im;
-      b0_re = i10_re;  b0_im = i10_im;
-      b1_re = i11_re;  b1_im = i11_im;
-      b2_re = i12_re;  b2_im = i12_im;
-#else  
-      a0_re = 2*i00_re;  a0_im = 2*i00_im;
-      a1_re = 2*i01_re;  a1_im = 2*i01_im;
-      a2_re = 2*i02_re;  a2_im = 2*i02_im;
-      b0_re = 2*i10_re;  b0_im = 2*i10_im;
-      b1_re = 2*i11_re;  b1_im = 2*i11_im;
-      b2_re = 2*i12_re;  b2_im = 2*i12_im;
-#endif 
+      a0_re = t_proj_scale*i00_re;  a0_im = t_proj_scale*i00_im;
+      a1_re = t_proj_scale*i01_re;  a1_im = t_proj_scale*i01_im;
+      a2_re = t_proj_scale*i02_re;  a2_im = t_proj_scale*i02_im;
+      b0_re = t_proj_scale*i10_re;  b0_im = t_proj_scale*i10_im;
+      b1_re = t_proj_scale*i11_re;  b1_im = t_proj_scale*i11_im;
+      b2_re = t_proj_scale*i12_re;  b2_im = t_proj_scale*i12_im;
       
     }
 #endif // MULTI_GPU
@@ -1980,26 +1962,17 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]>0)) ||
     } else {
     
       const int sp_stride_pad = ghostFace[static_cast<int>(kernel_type)];
-      //const int t_proj_scale = TPROJSCALE;
+      const int t_proj_scale = TPROJSCALE;
       
       // read half spinor from device memory
       READ_HALF_SPINOR(GHOSTSPINORTEX, sp_stride_pad, sp_idx, sp_norm_idx);
       
-#ifdef TWIST_INV_DSLASH
-      a0_re = i00_re;  a0_im = i00_im;
-      a1_re = i01_re;  a1_im = i01_im;
-      a2_re = i02_re;  a2_im = i02_im;
-      b0_re = i10_re;  b0_im = i10_im;
-      b1_re = i11_re;  b1_im = i11_im;
-      b2_re = i12_re;  b2_im = i12_im;
-#else  
-      a0_re = 2*i00_re;  a0_im = 2*i00_im;
-      a1_re = 2*i01_re;  a1_im = 2*i01_im;
-      a2_re = 2*i02_re;  a2_im = 2*i02_im;
-      b0_re = 2*i10_re;  b0_im = 2*i10_im;
-      b1_re = 2*i11_re;  b1_im = 2*i11_im;
-      b2_re = 2*i12_re;  b2_im = 2*i12_im;
-#endif 
+      a0_re = t_proj_scale*i00_re;  a0_im = t_proj_scale*i00_im;
+      a1_re = t_proj_scale*i01_re;  a1_im = t_proj_scale*i01_im;
+      a2_re = t_proj_scale*i02_re;  a2_im = t_proj_scale*i02_im;
+      b0_re = t_proj_scale*i10_re;  b0_im = t_proj_scale*i10_im;
+      b1_re = t_proj_scale*i11_re;  b1_im = t_proj_scale*i11_im;
+      b2_re = t_proj_scale*i12_re;  b2_im = t_proj_scale*i12_im;
       
     }
 #endif // MULTI_GPU
@@ -2074,26 +2047,17 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]>0)) ||
     } else {
     
       const int sp_stride_pad = ghostFace[static_cast<int>(kernel_type)];
-      //const int t_proj_scale = TPROJSCALE;
+      const int t_proj_scale = TPROJSCALE;
       
       // read half spinor from device memory
       READ_HALF_SPINOR(GHOSTSPINORTEX, sp_stride_pad, sp_idx, sp_norm_idx);
       
-#ifdef TWIST_INV_DSLASH
-      a0_re = i00_re;  a0_im = i00_im;
-      a1_re = i01_re;  a1_im = i01_im;
-      a2_re = i02_re;  a2_im = i02_im;
-      b0_re = i10_re;  b0_im = i10_im;
-      b1_re = i11_re;  b1_im = i11_im;
-      b2_re = i12_re;  b2_im = i12_im;
-#else  
-      a0_re = 2*i00_re;  a0_im = 2*i00_im;
-      a1_re = 2*i01_re;  a1_im = 2*i01_im;
-      a2_re = 2*i02_re;  a2_im = 2*i02_im;
-      b0_re = 2*i10_re;  b0_im = 2*i10_im;
-      b1_re = 2*i11_re;  b1_im = 2*i11_im;
-      b2_re = 2*i12_re;  b2_im = 2*i12_im;
-#endif 
+      a0_re = t_proj_scale*i00_re;  a0_im = t_proj_scale*i00_im;
+      a1_re = t_proj_scale*i01_re;  a1_im = t_proj_scale*i01_im;
+      a2_re = t_proj_scale*i02_re;  a2_im = t_proj_scale*i02_im;
+      b0_re = t_proj_scale*i10_re;  b0_im = t_proj_scale*i10_im;
+      b1_re = t_proj_scale*i11_re;  b1_im = t_proj_scale*i11_im;
+      b2_re = t_proj_scale*i12_re;  b2_im = t_proj_scale*i12_im;
       
     }
 #endif // MULTI_GPU

--- a/lib/dslash_core/tm_dslash_dagger_gt200_core.h
+++ b/lib/dslash_core/tm_dslash_dagger_gt200_core.h
@@ -1585,26 +1585,17 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]<X4m1)) |
     } else {
     
       const int sp_stride_pad = ghostFace[static_cast<int>(kernel_type)];
-      //const int t_proj_scale = TPROJSCALE;
+      const int t_proj_scale = TPROJSCALE;
       
       // read half spinor from device memory
       READ_HALF_SPINOR(GHOSTSPINORTEX, sp_stride_pad, sp_idx, sp_norm_idx);
       
-#ifdef TWIST_INV_DSLASH
-      a0_re = i00_re;  a0_im = i00_im;
-      a1_re = i01_re;  a1_im = i01_im;
-      a2_re = i02_re;  a2_im = i02_im;
-      b0_re = i10_re;  b0_im = i10_im;
-      b1_re = i11_re;  b1_im = i11_im;
-      b2_re = i12_re;  b2_im = i12_im;
-#else  
-      a0_re = 2*i00_re;  a0_im = 2*i00_im;
-      a1_re = 2*i01_re;  a1_im = 2*i01_im;
-      a2_re = 2*i02_re;  a2_im = 2*i02_im;
-      b0_re = 2*i10_re;  b0_im = 2*i10_im;
-      b1_re = 2*i11_re;  b1_im = 2*i11_im;
-      b2_re = 2*i12_re;  b2_im = 2*i12_im;
-#endif 
+      a0_re = t_proj_scale*i00_re;  a0_im = t_proj_scale*i00_im;
+      a1_re = t_proj_scale*i01_re;  a1_im = t_proj_scale*i01_im;
+      a2_re = t_proj_scale*i02_re;  a2_im = t_proj_scale*i02_im;
+      b0_re = t_proj_scale*i10_re;  b0_im = t_proj_scale*i10_im;
+      b1_re = t_proj_scale*i11_re;  b1_im = t_proj_scale*i11_im;
+      b2_re = t_proj_scale*i12_re;  b2_im = t_proj_scale*i12_im;
       
     }
 #endif // MULTI_GPU
@@ -1679,26 +1670,17 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]<X4m1)) |
     } else {
     
       const int sp_stride_pad = ghostFace[static_cast<int>(kernel_type)];
-      //const int t_proj_scale = TPROJSCALE;
+      const int t_proj_scale = TPROJSCALE;
       
       // read half spinor from device memory
       READ_HALF_SPINOR(GHOSTSPINORTEX, sp_stride_pad, sp_idx, sp_norm_idx);
       
-#ifdef TWIST_INV_DSLASH
-      a0_re = i00_re;  a0_im = i00_im;
-      a1_re = i01_re;  a1_im = i01_im;
-      a2_re = i02_re;  a2_im = i02_im;
-      b0_re = i10_re;  b0_im = i10_im;
-      b1_re = i11_re;  b1_im = i11_im;
-      b2_re = i12_re;  b2_im = i12_im;
-#else  
-      a0_re = 2*i00_re;  a0_im = 2*i00_im;
-      a1_re = 2*i01_re;  a1_im = 2*i01_im;
-      a2_re = 2*i02_re;  a2_im = 2*i02_im;
-      b0_re = 2*i10_re;  b0_im = 2*i10_im;
-      b1_re = 2*i11_re;  b1_im = 2*i11_im;
-      b2_re = 2*i12_re;  b2_im = 2*i12_im;
-#endif 
+      a0_re = t_proj_scale*i00_re;  a0_im = t_proj_scale*i00_im;
+      a1_re = t_proj_scale*i01_re;  a1_im = t_proj_scale*i01_im;
+      a2_re = t_proj_scale*i02_re;  a2_im = t_proj_scale*i02_im;
+      b0_re = t_proj_scale*i10_re;  b0_im = t_proj_scale*i10_im;
+      b1_re = t_proj_scale*i11_re;  b1_im = t_proj_scale*i11_im;
+      b2_re = t_proj_scale*i12_re;  b2_im = t_proj_scale*i12_im;
       
     }
 #endif // MULTI_GPU
@@ -1892,26 +1874,17 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]>0)) ||
     } else {
     
       const int sp_stride_pad = ghostFace[static_cast<int>(kernel_type)];
-      //const int t_proj_scale = TPROJSCALE;
+      const int t_proj_scale = TPROJSCALE;
       
       // read half spinor from device memory
       READ_HALF_SPINOR(GHOSTSPINORTEX, sp_stride_pad, sp_idx, sp_norm_idx);
       
-#ifdef TWIST_INV_DSLASH
-      a0_re = i00_re;  a0_im = i00_im;
-      a1_re = i01_re;  a1_im = i01_im;
-      a2_re = i02_re;  a2_im = i02_im;
-      b0_re = i10_re;  b0_im = i10_im;
-      b1_re = i11_re;  b1_im = i11_im;
-      b2_re = i12_re;  b2_im = i12_im;
-#else  
-      a0_re = 2*i00_re;  a0_im = 2*i00_im;
-      a1_re = 2*i01_re;  a1_im = 2*i01_im;
-      a2_re = 2*i02_re;  a2_im = 2*i02_im;
-      b0_re = 2*i10_re;  b0_im = 2*i10_im;
-      b1_re = 2*i11_re;  b1_im = 2*i11_im;
-      b2_re = 2*i12_re;  b2_im = 2*i12_im;
-#endif 
+      a0_re = t_proj_scale*i00_re;  a0_im = t_proj_scale*i00_im;
+      a1_re = t_proj_scale*i01_re;  a1_im = t_proj_scale*i01_im;
+      a2_re = t_proj_scale*i02_re;  a2_im = t_proj_scale*i02_im;
+      b0_re = t_proj_scale*i10_re;  b0_im = t_proj_scale*i10_im;
+      b1_re = t_proj_scale*i11_re;  b1_im = t_proj_scale*i11_im;
+      b2_re = t_proj_scale*i12_re;  b2_im = t_proj_scale*i12_im;
       
     }
 #endif // MULTI_GPU
@@ -1986,26 +1959,17 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]>0)) ||
     } else {
     
       const int sp_stride_pad = ghostFace[static_cast<int>(kernel_type)];
-      //const int t_proj_scale = TPROJSCALE;
+      const int t_proj_scale = TPROJSCALE;
       
       // read half spinor from device memory
       READ_HALF_SPINOR(GHOSTSPINORTEX, sp_stride_pad, sp_idx, sp_norm_idx);
       
-#ifdef TWIST_INV_DSLASH
-      a0_re = i00_re;  a0_im = i00_im;
-      a1_re = i01_re;  a1_im = i01_im;
-      a2_re = i02_re;  a2_im = i02_im;
-      b0_re = i10_re;  b0_im = i10_im;
-      b1_re = i11_re;  b1_im = i11_im;
-      b2_re = i12_re;  b2_im = i12_im;
-#else  
-      a0_re = 2*i00_re;  a0_im = 2*i00_im;
-      a1_re = 2*i01_re;  a1_im = 2*i01_im;
-      a2_re = 2*i02_re;  a2_im = 2*i02_im;
-      b0_re = 2*i10_re;  b0_im = 2*i10_im;
-      b1_re = 2*i11_re;  b1_im = 2*i11_im;
-      b2_re = 2*i12_re;  b2_im = 2*i12_im;
-#endif 
+      a0_re = t_proj_scale*i00_re;  a0_im = t_proj_scale*i00_im;
+      a1_re = t_proj_scale*i01_re;  a1_im = t_proj_scale*i01_im;
+      a2_re = t_proj_scale*i02_re;  a2_im = t_proj_scale*i02_im;
+      b0_re = t_proj_scale*i10_re;  b0_im = t_proj_scale*i10_im;
+      b1_re = t_proj_scale*i11_re;  b1_im = t_proj_scale*i11_im;
+      b2_re = t_proj_scale*i12_re;  b2_im = t_proj_scale*i12_im;
       
     }
 #endif // MULTI_GPU

--- a/lib/dslash_core/tm_dslash_fermi_core.h
+++ b/lib/dslash_core/tm_dslash_fermi_core.h
@@ -1673,26 +1673,17 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]<X4m1)) |
     } else {
     
       const int sp_stride_pad = ghostFace[static_cast<int>(kernel_type)];
-      //const int t_proj_scale = TPROJSCALE;
+      const int t_proj_scale = TPROJSCALE;
       
       // read half spinor from device memory
       READ_HALF_SPINOR(GHOSTSPINORTEX, sp_stride_pad, sp_idx, sp_norm_idx);
       
-#ifdef TWIST_INV_DSLASH
-      a0_re = i00_re;  a0_im = i00_im;
-      a1_re = i01_re;  a1_im = i01_im;
-      a2_re = i02_re;  a2_im = i02_im;
-      b0_re = i10_re;  b0_im = i10_im;
-      b1_re = i11_re;  b1_im = i11_im;
-      b2_re = i12_re;  b2_im = i12_im;
-#else  
-      a0_re = 2*i00_re;  a0_im = 2*i00_im;
-      a1_re = 2*i01_re;  a1_im = 2*i01_im;
-      a2_re = 2*i02_re;  a2_im = 2*i02_im;
-      b0_re = 2*i10_re;  b0_im = 2*i10_im;
-      b1_re = 2*i11_re;  b1_im = 2*i11_im;
-      b2_re = 2*i12_re;  b2_im = 2*i12_im;
-#endif 
+      a0_re = t_proj_scale*i00_re;  a0_im = t_proj_scale*i00_im;
+      a1_re = t_proj_scale*i01_re;  a1_im = t_proj_scale*i01_im;
+      a2_re = t_proj_scale*i02_re;  a2_im = t_proj_scale*i02_im;
+      b0_re = t_proj_scale*i10_re;  b0_im = t_proj_scale*i10_im;
+      b1_re = t_proj_scale*i11_re;  b1_im = t_proj_scale*i11_im;
+      b2_re = t_proj_scale*i12_re;  b2_im = t_proj_scale*i12_im;
       
     }
 #endif // MULTI_GPU
@@ -1767,26 +1758,17 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]<X4m1)) |
     } else {
     
       const int sp_stride_pad = ghostFace[static_cast<int>(kernel_type)];
-      //const int t_proj_scale = TPROJSCALE;
+      const int t_proj_scale = TPROJSCALE;
       
       // read half spinor from device memory
       READ_HALF_SPINOR(GHOSTSPINORTEX, sp_stride_pad, sp_idx, sp_norm_idx);
       
-#ifdef TWIST_INV_DSLASH
-      a0_re = i00_re;  a0_im = i00_im;
-      a1_re = i01_re;  a1_im = i01_im;
-      a2_re = i02_re;  a2_im = i02_im;
-      b0_re = i10_re;  b0_im = i10_im;
-      b1_re = i11_re;  b1_im = i11_im;
-      b2_re = i12_re;  b2_im = i12_im;
-#else  
-      a0_re = 2*i00_re;  a0_im = 2*i00_im;
-      a1_re = 2*i01_re;  a1_im = 2*i01_im;
-      a2_re = 2*i02_re;  a2_im = 2*i02_im;
-      b0_re = 2*i10_re;  b0_im = 2*i10_im;
-      b1_re = 2*i11_re;  b1_im = 2*i11_im;
-      b2_re = 2*i12_re;  b2_im = 2*i12_im;
-#endif 
+      a0_re = t_proj_scale*i00_re;  a0_im = t_proj_scale*i00_im;
+      a1_re = t_proj_scale*i01_re;  a1_im = t_proj_scale*i01_im;
+      a2_re = t_proj_scale*i02_re;  a2_im = t_proj_scale*i02_im;
+      b0_re = t_proj_scale*i10_re;  b0_im = t_proj_scale*i10_im;
+      b1_re = t_proj_scale*i11_re;  b1_im = t_proj_scale*i11_im;
+      b2_re = t_proj_scale*i12_re;  b2_im = t_proj_scale*i12_im;
       
     }
 #endif // MULTI_GPU
@@ -1980,26 +1962,17 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]>0)) ||
     } else {
     
       const int sp_stride_pad = ghostFace[static_cast<int>(kernel_type)];
-      //const int t_proj_scale = TPROJSCALE;
+      const int t_proj_scale = TPROJSCALE;
       
       // read half spinor from device memory
       READ_HALF_SPINOR(GHOSTSPINORTEX, sp_stride_pad, sp_idx, sp_norm_idx);
       
-#ifdef TWIST_INV_DSLASH
-      a0_re = i00_re;  a0_im = i00_im;
-      a1_re = i01_re;  a1_im = i01_im;
-      a2_re = i02_re;  a2_im = i02_im;
-      b0_re = i10_re;  b0_im = i10_im;
-      b1_re = i11_re;  b1_im = i11_im;
-      b2_re = i12_re;  b2_im = i12_im;
-#else  
-      a0_re = 2*i00_re;  a0_im = 2*i00_im;
-      a1_re = 2*i01_re;  a1_im = 2*i01_im;
-      a2_re = 2*i02_re;  a2_im = 2*i02_im;
-      b0_re = 2*i10_re;  b0_im = 2*i10_im;
-      b1_re = 2*i11_re;  b1_im = 2*i11_im;
-      b2_re = 2*i12_re;  b2_im = 2*i12_im;
-#endif 
+      a0_re = t_proj_scale*i00_re;  a0_im = t_proj_scale*i00_im;
+      a1_re = t_proj_scale*i01_re;  a1_im = t_proj_scale*i01_im;
+      a2_re = t_proj_scale*i02_re;  a2_im = t_proj_scale*i02_im;
+      b0_re = t_proj_scale*i10_re;  b0_im = t_proj_scale*i10_im;
+      b1_re = t_proj_scale*i11_re;  b1_im = t_proj_scale*i11_im;
+      b2_re = t_proj_scale*i12_re;  b2_im = t_proj_scale*i12_im;
       
     }
 #endif // MULTI_GPU
@@ -2074,26 +2047,17 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]>0)) ||
     } else {
     
       const int sp_stride_pad = ghostFace[static_cast<int>(kernel_type)];
-      //const int t_proj_scale = TPROJSCALE;
+      const int t_proj_scale = TPROJSCALE;
       
       // read half spinor from device memory
       READ_HALF_SPINOR(GHOSTSPINORTEX, sp_stride_pad, sp_idx, sp_norm_idx);
       
-#ifdef TWIST_INV_DSLASH
-      a0_re = i00_re;  a0_im = i00_im;
-      a1_re = i01_re;  a1_im = i01_im;
-      a2_re = i02_re;  a2_im = i02_im;
-      b0_re = i10_re;  b0_im = i10_im;
-      b1_re = i11_re;  b1_im = i11_im;
-      b2_re = i12_re;  b2_im = i12_im;
-#else  
-      a0_re = 2*i00_re;  a0_im = 2*i00_im;
-      a1_re = 2*i01_re;  a1_im = 2*i01_im;
-      a2_re = 2*i02_re;  a2_im = 2*i02_im;
-      b0_re = 2*i10_re;  b0_im = 2*i10_im;
-      b1_re = 2*i11_re;  b1_im = 2*i11_im;
-      b2_re = 2*i12_re;  b2_im = 2*i12_im;
-#endif 
+      a0_re = t_proj_scale*i00_re;  a0_im = t_proj_scale*i00_im;
+      a1_re = t_proj_scale*i01_re;  a1_im = t_proj_scale*i01_im;
+      a2_re = t_proj_scale*i02_re;  a2_im = t_proj_scale*i02_im;
+      b0_re = t_proj_scale*i10_re;  b0_im = t_proj_scale*i10_im;
+      b1_re = t_proj_scale*i11_re;  b1_im = t_proj_scale*i11_im;
+      b2_re = t_proj_scale*i12_re;  b2_im = t_proj_scale*i12_im;
       
     }
 #endif // MULTI_GPU

--- a/lib/dslash_core/tm_dslash_gt200_core.h
+++ b/lib/dslash_core/tm_dslash_gt200_core.h
@@ -1585,26 +1585,17 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]<X4m1)) |
     } else {
     
       const int sp_stride_pad = ghostFace[static_cast<int>(kernel_type)];
-      //const int t_proj_scale = TPROJSCALE;
+      const int t_proj_scale = TPROJSCALE;
       
       // read half spinor from device memory
       READ_HALF_SPINOR(GHOSTSPINORTEX, sp_stride_pad, sp_idx, sp_norm_idx);
       
-#ifdef TWIST_INV_DSLASH
-      a0_re = i00_re;  a0_im = i00_im;
-      a1_re = i01_re;  a1_im = i01_im;
-      a2_re = i02_re;  a2_im = i02_im;
-      b0_re = i10_re;  b0_im = i10_im;
-      b1_re = i11_re;  b1_im = i11_im;
-      b2_re = i12_re;  b2_im = i12_im;
-#else  
-      a0_re = 2*i00_re;  a0_im = 2*i00_im;
-      a1_re = 2*i01_re;  a1_im = 2*i01_im;
-      a2_re = 2*i02_re;  a2_im = 2*i02_im;
-      b0_re = 2*i10_re;  b0_im = 2*i10_im;
-      b1_re = 2*i11_re;  b1_im = 2*i11_im;
-      b2_re = 2*i12_re;  b2_im = 2*i12_im;
-#endif 
+      a0_re = t_proj_scale*i00_re;  a0_im = t_proj_scale*i00_im;
+      a1_re = t_proj_scale*i01_re;  a1_im = t_proj_scale*i01_im;
+      a2_re = t_proj_scale*i02_re;  a2_im = t_proj_scale*i02_im;
+      b0_re = t_proj_scale*i10_re;  b0_im = t_proj_scale*i10_im;
+      b1_re = t_proj_scale*i11_re;  b1_im = t_proj_scale*i11_im;
+      b2_re = t_proj_scale*i12_re;  b2_im = t_proj_scale*i12_im;
       
     }
 #endif // MULTI_GPU
@@ -1679,26 +1670,17 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]<X4m1)) |
     } else {
     
       const int sp_stride_pad = ghostFace[static_cast<int>(kernel_type)];
-      //const int t_proj_scale = TPROJSCALE;
+      const int t_proj_scale = TPROJSCALE;
       
       // read half spinor from device memory
       READ_HALF_SPINOR(GHOSTSPINORTEX, sp_stride_pad, sp_idx, sp_norm_idx);
       
-#ifdef TWIST_INV_DSLASH
-      a0_re = i00_re;  a0_im = i00_im;
-      a1_re = i01_re;  a1_im = i01_im;
-      a2_re = i02_re;  a2_im = i02_im;
-      b0_re = i10_re;  b0_im = i10_im;
-      b1_re = i11_re;  b1_im = i11_im;
-      b2_re = i12_re;  b2_im = i12_im;
-#else  
-      a0_re = 2*i00_re;  a0_im = 2*i00_im;
-      a1_re = 2*i01_re;  a1_im = 2*i01_im;
-      a2_re = 2*i02_re;  a2_im = 2*i02_im;
-      b0_re = 2*i10_re;  b0_im = 2*i10_im;
-      b1_re = 2*i11_re;  b1_im = 2*i11_im;
-      b2_re = 2*i12_re;  b2_im = 2*i12_im;
-#endif 
+      a0_re = t_proj_scale*i00_re;  a0_im = t_proj_scale*i00_im;
+      a1_re = t_proj_scale*i01_re;  a1_im = t_proj_scale*i01_im;
+      a2_re = t_proj_scale*i02_re;  a2_im = t_proj_scale*i02_im;
+      b0_re = t_proj_scale*i10_re;  b0_im = t_proj_scale*i10_im;
+      b1_re = t_proj_scale*i11_re;  b1_im = t_proj_scale*i11_im;
+      b2_re = t_proj_scale*i12_re;  b2_im = t_proj_scale*i12_im;
       
     }
 #endif // MULTI_GPU
@@ -1892,26 +1874,17 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]>0)) ||
     } else {
     
       const int sp_stride_pad = ghostFace[static_cast<int>(kernel_type)];
-      //const int t_proj_scale = TPROJSCALE;
+      const int t_proj_scale = TPROJSCALE;
       
       // read half spinor from device memory
       READ_HALF_SPINOR(GHOSTSPINORTEX, sp_stride_pad, sp_idx, sp_norm_idx);
       
-#ifdef TWIST_INV_DSLASH
-      a0_re = i00_re;  a0_im = i00_im;
-      a1_re = i01_re;  a1_im = i01_im;
-      a2_re = i02_re;  a2_im = i02_im;
-      b0_re = i10_re;  b0_im = i10_im;
-      b1_re = i11_re;  b1_im = i11_im;
-      b2_re = i12_re;  b2_im = i12_im;
-#else  
-      a0_re = 2*i00_re;  a0_im = 2*i00_im;
-      a1_re = 2*i01_re;  a1_im = 2*i01_im;
-      a2_re = 2*i02_re;  a2_im = 2*i02_im;
-      b0_re = 2*i10_re;  b0_im = 2*i10_im;
-      b1_re = 2*i11_re;  b1_im = 2*i11_im;
-      b2_re = 2*i12_re;  b2_im = 2*i12_im;
-#endif 
+      a0_re = t_proj_scale*i00_re;  a0_im = t_proj_scale*i00_im;
+      a1_re = t_proj_scale*i01_re;  a1_im = t_proj_scale*i01_im;
+      a2_re = t_proj_scale*i02_re;  a2_im = t_proj_scale*i02_im;
+      b0_re = t_proj_scale*i10_re;  b0_im = t_proj_scale*i10_im;
+      b1_re = t_proj_scale*i11_re;  b1_im = t_proj_scale*i11_im;
+      b2_re = t_proj_scale*i12_re;  b2_im = t_proj_scale*i12_im;
       
     }
 #endif // MULTI_GPU
@@ -1986,26 +1959,17 @@ if ( (kernel_type == INTERIOR_KERNEL && (!param.ghostDim[3] || coord[3]>0)) ||
     } else {
     
       const int sp_stride_pad = ghostFace[static_cast<int>(kernel_type)];
-      //const int t_proj_scale = TPROJSCALE;
+      const int t_proj_scale = TPROJSCALE;
       
       // read half spinor from device memory
       READ_HALF_SPINOR(GHOSTSPINORTEX, sp_stride_pad, sp_idx, sp_norm_idx);
       
-#ifdef TWIST_INV_DSLASH
-      a0_re = i00_re;  a0_im = i00_im;
-      a1_re = i01_re;  a1_im = i01_im;
-      a2_re = i02_re;  a2_im = i02_im;
-      b0_re = i10_re;  b0_im = i10_im;
-      b1_re = i11_re;  b1_im = i11_im;
-      b2_re = i12_re;  b2_im = i12_im;
-#else  
-      a0_re = 2*i00_re;  a0_im = 2*i00_im;
-      a1_re = 2*i01_re;  a1_im = 2*i01_im;
-      a2_re = 2*i02_re;  a2_im = 2*i02_im;
-      b0_re = 2*i10_re;  b0_im = 2*i10_im;
-      b1_re = 2*i11_re;  b1_im = 2*i11_im;
-      b2_re = 2*i12_re;  b2_im = 2*i12_im;
-#endif 
+      a0_re = t_proj_scale*i00_re;  a0_im = t_proj_scale*i00_im;
+      a1_re = t_proj_scale*i01_re;  a1_im = t_proj_scale*i01_im;
+      a2_re = t_proj_scale*i02_re;  a2_im = t_proj_scale*i02_im;
+      b0_re = t_proj_scale*i10_re;  b0_im = t_proj_scale*i10_im;
+      b1_re = t_proj_scale*i11_re;  b1_im = t_proj_scale*i11_im;
+      b2_re = t_proj_scale*i12_re;  b2_im = t_proj_scale*i12_im;
       
     }
 #endif // MULTI_GPU

--- a/lib/dslash_core/tm_fused_exterior_dslash_dagger_fermi_core.h
+++ b/lib/dslash_core/tm_fused_exterior_dslash_dagger_fermi_core.h
@@ -1264,26 +1264,17 @@ if (isActive(dim,3,+1,coord,param.commDim,param.X) && coord[3]==X4m1 )
     
     
     const int sp_stride_pad = ghostFace[3];
-    //const int t_proj_scale = TPROJSCALE;
+    const int t_proj_scale = TPROJSCALE;
     
     // read half spinor from device memory
     READ_HALF_SPINOR(GHOSTSPINORTEX, sp_stride_pad, sp_idx, sp_norm_idx);
     
-#ifdef TWIST_INV_DSLASH
-    a0_re = i00_re;  a0_im = i00_im;
-    a1_re = i01_re;  a1_im = i01_im;
-    a2_re = i02_re;  a2_im = i02_im;
-    b0_re = i10_re;  b0_im = i10_im;
-    b1_re = i11_re;  b1_im = i11_im;
-    b2_re = i12_re;  b2_im = i12_im;
-#else  
-    a0_re = 2*i00_re;  a0_im = 2*i00_im;
-    a1_re = 2*i01_re;  a1_im = 2*i01_im;
-    a2_re = 2*i02_re;  a2_im = 2*i02_im;
-    b0_re = 2*i10_re;  b0_im = 2*i10_im;
-    b1_re = 2*i11_re;  b1_im = 2*i11_im;
-    b2_re = 2*i12_re;  b2_im = 2*i12_im;
-#endif 
+    a0_re = t_proj_scale*i00_re;  a0_im = t_proj_scale*i00_im;
+    a1_re = t_proj_scale*i01_re;  a1_im = t_proj_scale*i01_im;
+    a2_re = t_proj_scale*i02_re;  a2_im = t_proj_scale*i02_im;
+    b0_re = t_proj_scale*i10_re;  b0_im = t_proj_scale*i10_im;
+    b1_re = t_proj_scale*i11_re;  b1_im = t_proj_scale*i11_im;
+    b2_re = t_proj_scale*i12_re;  b2_im = t_proj_scale*i12_im;
     
     // identity gauge matrix
     spinorFloat A0_re = a0_re; spinorFloat A0_im = a0_im;
@@ -1318,26 +1309,17 @@ if (isActive(dim,3,+1,coord,param.commDim,param.X) && coord[3]==X4m1 )
     
     
     const int sp_stride_pad = ghostFace[3];
-    //const int t_proj_scale = TPROJSCALE;
+    const int t_proj_scale = TPROJSCALE;
     
     // read half spinor from device memory
     READ_HALF_SPINOR(GHOSTSPINORTEX, sp_stride_pad, sp_idx, sp_norm_idx);
     
-#ifdef TWIST_INV_DSLASH
-    a0_re = i00_re;  a0_im = i00_im;
-    a1_re = i01_re;  a1_im = i01_im;
-    a2_re = i02_re;  a2_im = i02_im;
-    b0_re = i10_re;  b0_im = i10_im;
-    b1_re = i11_re;  b1_im = i11_im;
-    b2_re = i12_re;  b2_im = i12_im;
-#else  
-    a0_re = 2*i00_re;  a0_im = 2*i00_im;
-    a1_re = 2*i01_re;  a1_im = 2*i01_im;
-    a2_re = 2*i02_re;  a2_im = 2*i02_im;
-    b0_re = 2*i10_re;  b0_im = 2*i10_im;
-    b1_re = 2*i11_re;  b1_im = 2*i11_im;
-    b2_re = 2*i12_re;  b2_im = 2*i12_im;
-#endif 
+    a0_re = t_proj_scale*i00_re;  a0_im = t_proj_scale*i00_im;
+    a1_re = t_proj_scale*i01_re;  a1_im = t_proj_scale*i01_im;
+    a2_re = t_proj_scale*i02_re;  a2_im = t_proj_scale*i02_im;
+    b0_re = t_proj_scale*i10_re;  b0_im = t_proj_scale*i10_im;
+    b1_re = t_proj_scale*i11_re;  b1_im = t_proj_scale*i11_im;
+    b2_re = t_proj_scale*i12_re;  b2_im = t_proj_scale*i12_im;
     
     // read gauge matrix from device memory
     READ_GAUGE_MATRIX(G, GAUGE0TEX, 6, ga_idx, ga_stride);
@@ -1480,26 +1462,17 @@ if (isActive(dim,3,-1,coord,param.commDim,param.X) && coord[3]==0 )
     
     
     const int sp_stride_pad = ghostFace[3];
-    //const int t_proj_scale = TPROJSCALE;
+    const int t_proj_scale = TPROJSCALE;
     
     // read half spinor from device memory
     READ_HALF_SPINOR(GHOSTSPINORTEX, sp_stride_pad, sp_idx, sp_norm_idx);
     
-#ifdef TWIST_INV_DSLASH
-    a0_re = i00_re;  a0_im = i00_im;
-    a1_re = i01_re;  a1_im = i01_im;
-    a2_re = i02_re;  a2_im = i02_im;
-    b0_re = i10_re;  b0_im = i10_im;
-    b1_re = i11_re;  b1_im = i11_im;
-    b2_re = i12_re;  b2_im = i12_im;
-#else  
-    a0_re = 2*i00_re;  a0_im = 2*i00_im;
-    a1_re = 2*i01_re;  a1_im = 2*i01_im;
-    a2_re = 2*i02_re;  a2_im = 2*i02_im;
-    b0_re = 2*i10_re;  b0_im = 2*i10_im;
-    b1_re = 2*i11_re;  b1_im = 2*i11_im;
-    b2_re = 2*i12_re;  b2_im = 2*i12_im;
-#endif 
+    a0_re = t_proj_scale*i00_re;  a0_im = t_proj_scale*i00_im;
+    a1_re = t_proj_scale*i01_re;  a1_im = t_proj_scale*i01_im;
+    a2_re = t_proj_scale*i02_re;  a2_im = t_proj_scale*i02_im;
+    b0_re = t_proj_scale*i10_re;  b0_im = t_proj_scale*i10_im;
+    b1_re = t_proj_scale*i11_re;  b1_im = t_proj_scale*i11_im;
+    b2_re = t_proj_scale*i12_re;  b2_im = t_proj_scale*i12_im;
     
     // identity gauge matrix
     spinorFloat A0_re = a0_re; spinorFloat A0_im = a0_im;
@@ -1534,26 +1507,17 @@ if (isActive(dim,3,-1,coord,param.commDim,param.X) && coord[3]==0 )
     
     
     const int sp_stride_pad = ghostFace[3];
-    //const int t_proj_scale = TPROJSCALE;
+    const int t_proj_scale = TPROJSCALE;
     
     // read half spinor from device memory
     READ_HALF_SPINOR(GHOSTSPINORTEX, sp_stride_pad, sp_idx, sp_norm_idx);
     
-#ifdef TWIST_INV_DSLASH
-    a0_re = i00_re;  a0_im = i00_im;
-    a1_re = i01_re;  a1_im = i01_im;
-    a2_re = i02_re;  a2_im = i02_im;
-    b0_re = i10_re;  b0_im = i10_im;
-    b1_re = i11_re;  b1_im = i11_im;
-    b2_re = i12_re;  b2_im = i12_im;
-#else  
-    a0_re = 2*i00_re;  a0_im = 2*i00_im;
-    a1_re = 2*i01_re;  a1_im = 2*i01_im;
-    a2_re = 2*i02_re;  a2_im = 2*i02_im;
-    b0_re = 2*i10_re;  b0_im = 2*i10_im;
-    b1_re = 2*i11_re;  b1_im = 2*i11_im;
-    b2_re = 2*i12_re;  b2_im = 2*i12_im;
-#endif 
+    a0_re = t_proj_scale*i00_re;  a0_im = t_proj_scale*i00_im;
+    a1_re = t_proj_scale*i01_re;  a1_im = t_proj_scale*i01_im;
+    a2_re = t_proj_scale*i02_re;  a2_im = t_proj_scale*i02_im;
+    b0_re = t_proj_scale*i10_re;  b0_im = t_proj_scale*i10_im;
+    b1_re = t_proj_scale*i11_re;  b1_im = t_proj_scale*i11_im;
+    b2_re = t_proj_scale*i12_re;  b2_im = t_proj_scale*i12_im;
     
     // read gauge matrix from device memory
     READ_GAUGE_MATRIX(G, GAUGE1TEX, 7, ga_idx, ga_stride);

--- a/lib/dslash_core/tm_fused_exterior_dslash_dagger_gt200_core.h
+++ b/lib/dslash_core/tm_fused_exterior_dslash_dagger_gt200_core.h
@@ -1254,26 +1254,17 @@ if (isActive(dim,3,+1,coord,param.commDim,param.X) && coord[3]==X4m1 )
     
     
     const int sp_stride_pad = ghostFace[3];
-    //const int t_proj_scale = TPROJSCALE;
+    const int t_proj_scale = TPROJSCALE;
     
     // read half spinor from device memory
     READ_HALF_SPINOR(GHOSTSPINORTEX, sp_stride_pad, sp_idx, sp_norm_idx);
     
-#ifdef TWIST_INV_DSLASH
-    a0_re = i00_re;  a0_im = i00_im;
-    a1_re = i01_re;  a1_im = i01_im;
-    a2_re = i02_re;  a2_im = i02_im;
-    b0_re = i10_re;  b0_im = i10_im;
-    b1_re = i11_re;  b1_im = i11_im;
-    b2_re = i12_re;  b2_im = i12_im;
-#else  
-    a0_re = 2*i00_re;  a0_im = 2*i00_im;
-    a1_re = 2*i01_re;  a1_im = 2*i01_im;
-    a2_re = 2*i02_re;  a2_im = 2*i02_im;
-    b0_re = 2*i10_re;  b0_im = 2*i10_im;
-    b1_re = 2*i11_re;  b1_im = 2*i11_im;
-    b2_re = 2*i12_re;  b2_im = 2*i12_im;
-#endif 
+    a0_re = t_proj_scale*i00_re;  a0_im = t_proj_scale*i00_im;
+    a1_re = t_proj_scale*i01_re;  a1_im = t_proj_scale*i01_im;
+    a2_re = t_proj_scale*i02_re;  a2_im = t_proj_scale*i02_im;
+    b0_re = t_proj_scale*i10_re;  b0_im = t_proj_scale*i10_im;
+    b1_re = t_proj_scale*i11_re;  b1_im = t_proj_scale*i11_im;
+    b2_re = t_proj_scale*i12_re;  b2_im = t_proj_scale*i12_im;
     
     // identity gauge matrix
     spinorFloat A0_re = a0_re; spinorFloat A0_im = a0_im;
@@ -1308,26 +1299,17 @@ if (isActive(dim,3,+1,coord,param.commDim,param.X) && coord[3]==X4m1 )
     
     
     const int sp_stride_pad = ghostFace[3];
-    //const int t_proj_scale = TPROJSCALE;
+    const int t_proj_scale = TPROJSCALE;
     
     // read half spinor from device memory
     READ_HALF_SPINOR(GHOSTSPINORTEX, sp_stride_pad, sp_idx, sp_norm_idx);
     
-#ifdef TWIST_INV_DSLASH
-    a0_re = i00_re;  a0_im = i00_im;
-    a1_re = i01_re;  a1_im = i01_im;
-    a2_re = i02_re;  a2_im = i02_im;
-    b0_re = i10_re;  b0_im = i10_im;
-    b1_re = i11_re;  b1_im = i11_im;
-    b2_re = i12_re;  b2_im = i12_im;
-#else  
-    a0_re = 2*i00_re;  a0_im = 2*i00_im;
-    a1_re = 2*i01_re;  a1_im = 2*i01_im;
-    a2_re = 2*i02_re;  a2_im = 2*i02_im;
-    b0_re = 2*i10_re;  b0_im = 2*i10_im;
-    b1_re = 2*i11_re;  b1_im = 2*i11_im;
-    b2_re = 2*i12_re;  b2_im = 2*i12_im;
-#endif 
+    a0_re = t_proj_scale*i00_re;  a0_im = t_proj_scale*i00_im;
+    a1_re = t_proj_scale*i01_re;  a1_im = t_proj_scale*i01_im;
+    a2_re = t_proj_scale*i02_re;  a2_im = t_proj_scale*i02_im;
+    b0_re = t_proj_scale*i10_re;  b0_im = t_proj_scale*i10_im;
+    b1_re = t_proj_scale*i11_re;  b1_im = t_proj_scale*i11_im;
+    b2_re = t_proj_scale*i12_re;  b2_im = t_proj_scale*i12_im;
     
     // read gauge matrix from device memory
     READ_GAUGE_MATRIX(G, GAUGE0TEX, 6, ga_idx, ga_stride);
@@ -1470,26 +1452,17 @@ if (isActive(dim,3,-1,coord,param.commDim,param.X) && coord[3]==0 )
     
     
     const int sp_stride_pad = ghostFace[3];
-    //const int t_proj_scale = TPROJSCALE;
+    const int t_proj_scale = TPROJSCALE;
     
     // read half spinor from device memory
     READ_HALF_SPINOR(GHOSTSPINORTEX, sp_stride_pad, sp_idx, sp_norm_idx);
     
-#ifdef TWIST_INV_DSLASH
-    a0_re = i00_re;  a0_im = i00_im;
-    a1_re = i01_re;  a1_im = i01_im;
-    a2_re = i02_re;  a2_im = i02_im;
-    b0_re = i10_re;  b0_im = i10_im;
-    b1_re = i11_re;  b1_im = i11_im;
-    b2_re = i12_re;  b2_im = i12_im;
-#else  
-    a0_re = 2*i00_re;  a0_im = 2*i00_im;
-    a1_re = 2*i01_re;  a1_im = 2*i01_im;
-    a2_re = 2*i02_re;  a2_im = 2*i02_im;
-    b0_re = 2*i10_re;  b0_im = 2*i10_im;
-    b1_re = 2*i11_re;  b1_im = 2*i11_im;
-    b2_re = 2*i12_re;  b2_im = 2*i12_im;
-#endif 
+    a0_re = t_proj_scale*i00_re;  a0_im = t_proj_scale*i00_im;
+    a1_re = t_proj_scale*i01_re;  a1_im = t_proj_scale*i01_im;
+    a2_re = t_proj_scale*i02_re;  a2_im = t_proj_scale*i02_im;
+    b0_re = t_proj_scale*i10_re;  b0_im = t_proj_scale*i10_im;
+    b1_re = t_proj_scale*i11_re;  b1_im = t_proj_scale*i11_im;
+    b2_re = t_proj_scale*i12_re;  b2_im = t_proj_scale*i12_im;
     
     // identity gauge matrix
     spinorFloat A0_re = a0_re; spinorFloat A0_im = a0_im;
@@ -1524,26 +1497,17 @@ if (isActive(dim,3,-1,coord,param.commDim,param.X) && coord[3]==0 )
     
     
     const int sp_stride_pad = ghostFace[3];
-    //const int t_proj_scale = TPROJSCALE;
+    const int t_proj_scale = TPROJSCALE;
     
     // read half spinor from device memory
     READ_HALF_SPINOR(GHOSTSPINORTEX, sp_stride_pad, sp_idx, sp_norm_idx);
     
-#ifdef TWIST_INV_DSLASH
-    a0_re = i00_re;  a0_im = i00_im;
-    a1_re = i01_re;  a1_im = i01_im;
-    a2_re = i02_re;  a2_im = i02_im;
-    b0_re = i10_re;  b0_im = i10_im;
-    b1_re = i11_re;  b1_im = i11_im;
-    b2_re = i12_re;  b2_im = i12_im;
-#else  
-    a0_re = 2*i00_re;  a0_im = 2*i00_im;
-    a1_re = 2*i01_re;  a1_im = 2*i01_im;
-    a2_re = 2*i02_re;  a2_im = 2*i02_im;
-    b0_re = 2*i10_re;  b0_im = 2*i10_im;
-    b1_re = 2*i11_re;  b1_im = 2*i11_im;
-    b2_re = 2*i12_re;  b2_im = 2*i12_im;
-#endif 
+    a0_re = t_proj_scale*i00_re;  a0_im = t_proj_scale*i00_im;
+    a1_re = t_proj_scale*i01_re;  a1_im = t_proj_scale*i01_im;
+    a2_re = t_proj_scale*i02_re;  a2_im = t_proj_scale*i02_im;
+    b0_re = t_proj_scale*i10_re;  b0_im = t_proj_scale*i10_im;
+    b1_re = t_proj_scale*i11_re;  b1_im = t_proj_scale*i11_im;
+    b2_re = t_proj_scale*i12_re;  b2_im = t_proj_scale*i12_im;
     
     // read gauge matrix from device memory
     READ_GAUGE_MATRIX(G, GAUGE1TEX, 7, ga_idx, ga_stride);

--- a/lib/dslash_core/tm_fused_exterior_dslash_fermi_core.h
+++ b/lib/dslash_core/tm_fused_exterior_dslash_fermi_core.h
@@ -1264,26 +1264,17 @@ if (isActive(dim,3,+1,coord,param.commDim,param.X) && coord[3]==X4m1 )
     
     
     const int sp_stride_pad = ghostFace[3];
-    //const int t_proj_scale = TPROJSCALE;
+    const int t_proj_scale = TPROJSCALE;
     
     // read half spinor from device memory
     READ_HALF_SPINOR(GHOSTSPINORTEX, sp_stride_pad, sp_idx, sp_norm_idx);
     
-#ifdef TWIST_INV_DSLASH
-    a0_re = i00_re;  a0_im = i00_im;
-    a1_re = i01_re;  a1_im = i01_im;
-    a2_re = i02_re;  a2_im = i02_im;
-    b0_re = i10_re;  b0_im = i10_im;
-    b1_re = i11_re;  b1_im = i11_im;
-    b2_re = i12_re;  b2_im = i12_im;
-#else  
-    a0_re = 2*i00_re;  a0_im = 2*i00_im;
-    a1_re = 2*i01_re;  a1_im = 2*i01_im;
-    a2_re = 2*i02_re;  a2_im = 2*i02_im;
-    b0_re = 2*i10_re;  b0_im = 2*i10_im;
-    b1_re = 2*i11_re;  b1_im = 2*i11_im;
-    b2_re = 2*i12_re;  b2_im = 2*i12_im;
-#endif 
+    a0_re = t_proj_scale*i00_re;  a0_im = t_proj_scale*i00_im;
+    a1_re = t_proj_scale*i01_re;  a1_im = t_proj_scale*i01_im;
+    a2_re = t_proj_scale*i02_re;  a2_im = t_proj_scale*i02_im;
+    b0_re = t_proj_scale*i10_re;  b0_im = t_proj_scale*i10_im;
+    b1_re = t_proj_scale*i11_re;  b1_im = t_proj_scale*i11_im;
+    b2_re = t_proj_scale*i12_re;  b2_im = t_proj_scale*i12_im;
     
     // identity gauge matrix
     spinorFloat A0_re = a0_re; spinorFloat A0_im = a0_im;
@@ -1318,26 +1309,17 @@ if (isActive(dim,3,+1,coord,param.commDim,param.X) && coord[3]==X4m1 )
     
     
     const int sp_stride_pad = ghostFace[3];
-    //const int t_proj_scale = TPROJSCALE;
+    const int t_proj_scale = TPROJSCALE;
     
     // read half spinor from device memory
     READ_HALF_SPINOR(GHOSTSPINORTEX, sp_stride_pad, sp_idx, sp_norm_idx);
     
-#ifdef TWIST_INV_DSLASH
-    a0_re = i00_re;  a0_im = i00_im;
-    a1_re = i01_re;  a1_im = i01_im;
-    a2_re = i02_re;  a2_im = i02_im;
-    b0_re = i10_re;  b0_im = i10_im;
-    b1_re = i11_re;  b1_im = i11_im;
-    b2_re = i12_re;  b2_im = i12_im;
-#else  
-    a0_re = 2*i00_re;  a0_im = 2*i00_im;
-    a1_re = 2*i01_re;  a1_im = 2*i01_im;
-    a2_re = 2*i02_re;  a2_im = 2*i02_im;
-    b0_re = 2*i10_re;  b0_im = 2*i10_im;
-    b1_re = 2*i11_re;  b1_im = 2*i11_im;
-    b2_re = 2*i12_re;  b2_im = 2*i12_im;
-#endif 
+    a0_re = t_proj_scale*i00_re;  a0_im = t_proj_scale*i00_im;
+    a1_re = t_proj_scale*i01_re;  a1_im = t_proj_scale*i01_im;
+    a2_re = t_proj_scale*i02_re;  a2_im = t_proj_scale*i02_im;
+    b0_re = t_proj_scale*i10_re;  b0_im = t_proj_scale*i10_im;
+    b1_re = t_proj_scale*i11_re;  b1_im = t_proj_scale*i11_im;
+    b2_re = t_proj_scale*i12_re;  b2_im = t_proj_scale*i12_im;
     
     // read gauge matrix from device memory
     READ_GAUGE_MATRIX(G, GAUGE0TEX, 6, ga_idx, ga_stride);
@@ -1480,26 +1462,17 @@ if (isActive(dim,3,-1,coord,param.commDim,param.X) && coord[3]==0 )
     
     
     const int sp_stride_pad = ghostFace[3];
-    //const int t_proj_scale = TPROJSCALE;
+    const int t_proj_scale = TPROJSCALE;
     
     // read half spinor from device memory
     READ_HALF_SPINOR(GHOSTSPINORTEX, sp_stride_pad, sp_idx, sp_norm_idx);
     
-#ifdef TWIST_INV_DSLASH
-    a0_re = i00_re;  a0_im = i00_im;
-    a1_re = i01_re;  a1_im = i01_im;
-    a2_re = i02_re;  a2_im = i02_im;
-    b0_re = i10_re;  b0_im = i10_im;
-    b1_re = i11_re;  b1_im = i11_im;
-    b2_re = i12_re;  b2_im = i12_im;
-#else  
-    a0_re = 2*i00_re;  a0_im = 2*i00_im;
-    a1_re = 2*i01_re;  a1_im = 2*i01_im;
-    a2_re = 2*i02_re;  a2_im = 2*i02_im;
-    b0_re = 2*i10_re;  b0_im = 2*i10_im;
-    b1_re = 2*i11_re;  b1_im = 2*i11_im;
-    b2_re = 2*i12_re;  b2_im = 2*i12_im;
-#endif 
+    a0_re = t_proj_scale*i00_re;  a0_im = t_proj_scale*i00_im;
+    a1_re = t_proj_scale*i01_re;  a1_im = t_proj_scale*i01_im;
+    a2_re = t_proj_scale*i02_re;  a2_im = t_proj_scale*i02_im;
+    b0_re = t_proj_scale*i10_re;  b0_im = t_proj_scale*i10_im;
+    b1_re = t_proj_scale*i11_re;  b1_im = t_proj_scale*i11_im;
+    b2_re = t_proj_scale*i12_re;  b2_im = t_proj_scale*i12_im;
     
     // identity gauge matrix
     spinorFloat A0_re = a0_re; spinorFloat A0_im = a0_im;
@@ -1534,26 +1507,17 @@ if (isActive(dim,3,-1,coord,param.commDim,param.X) && coord[3]==0 )
     
     
     const int sp_stride_pad = ghostFace[3];
-    //const int t_proj_scale = TPROJSCALE;
+    const int t_proj_scale = TPROJSCALE;
     
     // read half spinor from device memory
     READ_HALF_SPINOR(GHOSTSPINORTEX, sp_stride_pad, sp_idx, sp_norm_idx);
     
-#ifdef TWIST_INV_DSLASH
-    a0_re = i00_re;  a0_im = i00_im;
-    a1_re = i01_re;  a1_im = i01_im;
-    a2_re = i02_re;  a2_im = i02_im;
-    b0_re = i10_re;  b0_im = i10_im;
-    b1_re = i11_re;  b1_im = i11_im;
-    b2_re = i12_re;  b2_im = i12_im;
-#else  
-    a0_re = 2*i00_re;  a0_im = 2*i00_im;
-    a1_re = 2*i01_re;  a1_im = 2*i01_im;
-    a2_re = 2*i02_re;  a2_im = 2*i02_im;
-    b0_re = 2*i10_re;  b0_im = 2*i10_im;
-    b1_re = 2*i11_re;  b1_im = 2*i11_im;
-    b2_re = 2*i12_re;  b2_im = 2*i12_im;
-#endif 
+    a0_re = t_proj_scale*i00_re;  a0_im = t_proj_scale*i00_im;
+    a1_re = t_proj_scale*i01_re;  a1_im = t_proj_scale*i01_im;
+    a2_re = t_proj_scale*i02_re;  a2_im = t_proj_scale*i02_im;
+    b0_re = t_proj_scale*i10_re;  b0_im = t_proj_scale*i10_im;
+    b1_re = t_proj_scale*i11_re;  b1_im = t_proj_scale*i11_im;
+    b2_re = t_proj_scale*i12_re;  b2_im = t_proj_scale*i12_im;
     
     // read gauge matrix from device memory
     READ_GAUGE_MATRIX(G, GAUGE1TEX, 7, ga_idx, ga_stride);

--- a/lib/dslash_core/tm_fused_exterior_dslash_gt200_core.h
+++ b/lib/dslash_core/tm_fused_exterior_dslash_gt200_core.h
@@ -1254,26 +1254,17 @@ if (isActive(dim,3,+1,coord,param.commDim,param.X) && coord[3]==X4m1 )
     
     
     const int sp_stride_pad = ghostFace[3];
-    //const int t_proj_scale = TPROJSCALE;
+    const int t_proj_scale = TPROJSCALE;
     
     // read half spinor from device memory
     READ_HALF_SPINOR(GHOSTSPINORTEX, sp_stride_pad, sp_idx, sp_norm_idx);
     
-#ifdef TWIST_INV_DSLASH
-    a0_re = i00_re;  a0_im = i00_im;
-    a1_re = i01_re;  a1_im = i01_im;
-    a2_re = i02_re;  a2_im = i02_im;
-    b0_re = i10_re;  b0_im = i10_im;
-    b1_re = i11_re;  b1_im = i11_im;
-    b2_re = i12_re;  b2_im = i12_im;
-#else  
-    a0_re = 2*i00_re;  a0_im = 2*i00_im;
-    a1_re = 2*i01_re;  a1_im = 2*i01_im;
-    a2_re = 2*i02_re;  a2_im = 2*i02_im;
-    b0_re = 2*i10_re;  b0_im = 2*i10_im;
-    b1_re = 2*i11_re;  b1_im = 2*i11_im;
-    b2_re = 2*i12_re;  b2_im = 2*i12_im;
-#endif 
+    a0_re = t_proj_scale*i00_re;  a0_im = t_proj_scale*i00_im;
+    a1_re = t_proj_scale*i01_re;  a1_im = t_proj_scale*i01_im;
+    a2_re = t_proj_scale*i02_re;  a2_im = t_proj_scale*i02_im;
+    b0_re = t_proj_scale*i10_re;  b0_im = t_proj_scale*i10_im;
+    b1_re = t_proj_scale*i11_re;  b1_im = t_proj_scale*i11_im;
+    b2_re = t_proj_scale*i12_re;  b2_im = t_proj_scale*i12_im;
     
     // identity gauge matrix
     spinorFloat A0_re = a0_re; spinorFloat A0_im = a0_im;
@@ -1308,26 +1299,17 @@ if (isActive(dim,3,+1,coord,param.commDim,param.X) && coord[3]==X4m1 )
     
     
     const int sp_stride_pad = ghostFace[3];
-    //const int t_proj_scale = TPROJSCALE;
+    const int t_proj_scale = TPROJSCALE;
     
     // read half spinor from device memory
     READ_HALF_SPINOR(GHOSTSPINORTEX, sp_stride_pad, sp_idx, sp_norm_idx);
     
-#ifdef TWIST_INV_DSLASH
-    a0_re = i00_re;  a0_im = i00_im;
-    a1_re = i01_re;  a1_im = i01_im;
-    a2_re = i02_re;  a2_im = i02_im;
-    b0_re = i10_re;  b0_im = i10_im;
-    b1_re = i11_re;  b1_im = i11_im;
-    b2_re = i12_re;  b2_im = i12_im;
-#else  
-    a0_re = 2*i00_re;  a0_im = 2*i00_im;
-    a1_re = 2*i01_re;  a1_im = 2*i01_im;
-    a2_re = 2*i02_re;  a2_im = 2*i02_im;
-    b0_re = 2*i10_re;  b0_im = 2*i10_im;
-    b1_re = 2*i11_re;  b1_im = 2*i11_im;
-    b2_re = 2*i12_re;  b2_im = 2*i12_im;
-#endif 
+    a0_re = t_proj_scale*i00_re;  a0_im = t_proj_scale*i00_im;
+    a1_re = t_proj_scale*i01_re;  a1_im = t_proj_scale*i01_im;
+    a2_re = t_proj_scale*i02_re;  a2_im = t_proj_scale*i02_im;
+    b0_re = t_proj_scale*i10_re;  b0_im = t_proj_scale*i10_im;
+    b1_re = t_proj_scale*i11_re;  b1_im = t_proj_scale*i11_im;
+    b2_re = t_proj_scale*i12_re;  b2_im = t_proj_scale*i12_im;
     
     // read gauge matrix from device memory
     READ_GAUGE_MATRIX(G, GAUGE0TEX, 6, ga_idx, ga_stride);
@@ -1470,26 +1452,17 @@ if (isActive(dim,3,-1,coord,param.commDim,param.X) && coord[3]==0 )
     
     
     const int sp_stride_pad = ghostFace[3];
-    //const int t_proj_scale = TPROJSCALE;
+    const int t_proj_scale = TPROJSCALE;
     
     // read half spinor from device memory
     READ_HALF_SPINOR(GHOSTSPINORTEX, sp_stride_pad, sp_idx, sp_norm_idx);
     
-#ifdef TWIST_INV_DSLASH
-    a0_re = i00_re;  a0_im = i00_im;
-    a1_re = i01_re;  a1_im = i01_im;
-    a2_re = i02_re;  a2_im = i02_im;
-    b0_re = i10_re;  b0_im = i10_im;
-    b1_re = i11_re;  b1_im = i11_im;
-    b2_re = i12_re;  b2_im = i12_im;
-#else  
-    a0_re = 2*i00_re;  a0_im = 2*i00_im;
-    a1_re = 2*i01_re;  a1_im = 2*i01_im;
-    a2_re = 2*i02_re;  a2_im = 2*i02_im;
-    b0_re = 2*i10_re;  b0_im = 2*i10_im;
-    b1_re = 2*i11_re;  b1_im = 2*i11_im;
-    b2_re = 2*i12_re;  b2_im = 2*i12_im;
-#endif 
+    a0_re = t_proj_scale*i00_re;  a0_im = t_proj_scale*i00_im;
+    a1_re = t_proj_scale*i01_re;  a1_im = t_proj_scale*i01_im;
+    a2_re = t_proj_scale*i02_re;  a2_im = t_proj_scale*i02_im;
+    b0_re = t_proj_scale*i10_re;  b0_im = t_proj_scale*i10_im;
+    b1_re = t_proj_scale*i11_re;  b1_im = t_proj_scale*i11_im;
+    b2_re = t_proj_scale*i12_re;  b2_im = t_proj_scale*i12_im;
     
     // identity gauge matrix
     spinorFloat A0_re = a0_re; spinorFloat A0_im = a0_im;
@@ -1524,26 +1497,17 @@ if (isActive(dim,3,-1,coord,param.commDim,param.X) && coord[3]==0 )
     
     
     const int sp_stride_pad = ghostFace[3];
-    //const int t_proj_scale = TPROJSCALE;
+    const int t_proj_scale = TPROJSCALE;
     
     // read half spinor from device memory
     READ_HALF_SPINOR(GHOSTSPINORTEX, sp_stride_pad, sp_idx, sp_norm_idx);
     
-#ifdef TWIST_INV_DSLASH
-    a0_re = i00_re;  a0_im = i00_im;
-    a1_re = i01_re;  a1_im = i01_im;
-    a2_re = i02_re;  a2_im = i02_im;
-    b0_re = i10_re;  b0_im = i10_im;
-    b1_re = i11_re;  b1_im = i11_im;
-    b2_re = i12_re;  b2_im = i12_im;
-#else  
-    a0_re = 2*i00_re;  a0_im = 2*i00_im;
-    a1_re = 2*i01_re;  a1_im = 2*i01_im;
-    a2_re = 2*i02_re;  a2_im = 2*i02_im;
-    b0_re = 2*i10_re;  b0_im = 2*i10_im;
-    b1_re = 2*i11_re;  b1_im = 2*i11_im;
-    b2_re = 2*i12_re;  b2_im = 2*i12_im;
-#endif 
+    a0_re = t_proj_scale*i00_re;  a0_im = t_proj_scale*i00_im;
+    a1_re = t_proj_scale*i01_re;  a1_im = t_proj_scale*i01_im;
+    a2_re = t_proj_scale*i02_re;  a2_im = t_proj_scale*i02_im;
+    b0_re = t_proj_scale*i10_re;  b0_im = t_proj_scale*i10_im;
+    b1_re = t_proj_scale*i11_re;  b1_im = t_proj_scale*i11_im;
+    b2_re = t_proj_scale*i12_re;  b2_im = t_proj_scale*i12_im;
     
     // read gauge matrix from device memory
     READ_GAUGE_MATRIX(G, GAUGE1TEX, 7, ga_idx, ga_stride);

--- a/lib/generate/deg_tm_dslash_cuda_gen.py
+++ b/lib/generate/deg_tm_dslash_cuda_gen.py
@@ -504,8 +504,7 @@ def gen(dir, pack_only=False):
     #load_half += "const int sp_norm_idx = sid + param.ghostNormOffset[static_cast<int>(kernel_type)];\n"
     #load_half += "#endif\n"
 
-    if dir >= 6: load_half += "//const int t_proj_scale = TPROJSCALE;\n"
-    #if dir >= 6: load_half += "const int t_proj_scale = 2;//set this manually\n"
+    if dir >= 6: load_half += "const int t_proj_scale = TPROJSCALE;\n"
     load_half += "\n"
     load_half += "// read half spinor from device memory\n"
 
@@ -592,23 +591,10 @@ READ_SPINOR_SHARED(tx, threadIdx.y, tz);\n
 
 
     copy_half = ""
-    if dir < 6:
-        for h in range(0, 2):
-            for c in range(0, 3):
-                copy_half += h1_re(h,c)+" = "+in_re(h,c)+";  "
-                copy_half += h1_im(h,c)+" = "+in_im(h,c)+";\n"
-    else:
-        copy_half += "#ifdef TWIST_INV_DSLASH\n"
-        for h in range(0, 2):
-            for c in range(0, 3):
-                copy_half += h1_re(h,c)+" = "+in_re(h,c)+";  "
-                copy_half += h1_im(h,c)+" = "+in_im(h,c)+";\n"
-        copy_half += "#else  \n"
-        for h in range(0, 2):
-            for c in range(0, 3):
-                copy_half += h1_re(h,c)+" = "+"2*"+in_re(h,c)+";  "
-                copy_half += h1_im(h,c)+" = "+"2*"+in_im(h,c)+";\n"
-        copy_half += "#endif \n"
+    for h in range(0, 2):
+        for c in range(0, 3):
+            copy_half += h1_re(h,c)+" = "+("t_proj_scale*" if (dir >= 6) else "")+in_re(h,c)+";  "
+            copy_half += h1_im(h,c)+" = "+("t_proj_scale*" if (dir >= 6) else "")+in_im(h,c)+";\n"
     copy_half += "\n"
 
     prep_half = ""

--- a/lib/generate/fused_exterior_deg_tm_dslash_cuda_gen.py
+++ b/lib/generate/fused_exterior_deg_tm_dslash_cuda_gen.py
@@ -487,7 +487,7 @@ def gen(dir, pack_only=False):
     #load_half += "const int sp_norm_idx = sid + param.ghostNormOffset[static_cast<int>(kernel_type)];\n"
     #load_half += "#endif\n"
 
-    if dir >= 6: load_half += "//const int t_proj_scale = TPROJSCALE;\n"
+    if dir >= 6: load_half += "const int t_proj_scale = TPROJSCALE;\n"
     #if dir >= 6: load_half += "const int t_proj_scale = 2;//set this manually\n"
     load_half += "\n"
     load_half += "// read half spinor from device memory\n"
@@ -575,23 +575,10 @@ READ_SPINOR_SHARED(tx, threadIdx.y, tz);\n
 
 
     copy_half = ""
-    if dir < 6:
-        for h in range(0, 2):
-            for c in range(0, 3):
-                copy_half += h1_re(h,c)+" = "+in_re(h,c)+";  "
-                copy_half += h1_im(h,c)+" = "+in_im(h,c)+";\n"
-    else:
-        copy_half += "#ifdef TWIST_INV_DSLASH\n"
-        for h in range(0, 2):
-            for c in range(0, 3):
-                copy_half += h1_re(h,c)+" = "+in_re(h,c)+";  "
-                copy_half += h1_im(h,c)+" = "+in_im(h,c)+";\n"
-        copy_half += "#else  \n"
-        for h in range(0, 2):
-            for c in range(0, 3):
-                copy_half += h1_re(h,c)+" = "+"2*"+in_re(h,c)+";  "
-                copy_half += h1_im(h,c)+" = "+"2*"+in_im(h,c)+";\n"
-        copy_half += "#endif \n"
+    for h in range(0, 2):
+        for c in range(0, 3):
+            copy_half += h1_re(h,c)+" = "+("t_proj_scale*" if (dir >= 6) else "")+in_re(h,c)+";  "
+            copy_half += h1_im(h,c)+" = "+("t_proj_scale*" if (dir >= 6) else "")+in_im(h,c)+";\n"
     copy_half += "\n"
 
     prep_half = ""

--- a/lib/tm_dslash_def.h
+++ b/lib/tm_dslash_def.h
@@ -156,7 +156,7 @@
 
 #if (DD_PREC==0) // double-precision fields
 
-//#define TPROJSCALE tProjScale
+#define TPROJSCALE param.tProjScale
 
 // double-precision gauge field
 #if (defined DIRECT_ACCESS_LINK) || (defined FERMI_NO_DBLE_TEX)
@@ -224,7 +224,7 @@
 
 #elif (DD_PREC==1) // single-precision fields
 
-//#define TPROJSCALE tProjScale_f
+#define TPROJSCALE param.tProjScale_f
 
 // single-precision gauge field
 #ifdef DIRECT_ACCESS_LINK
@@ -294,7 +294,7 @@
 
 #else             // half-precision fields
 
-//#define TPROJSCALE tProjScale_f
+#define TPROJSCALE param.tProjScale_f
 
 // half-precision gauge field
 #ifdef DIRECT_ACCESS_LINK
@@ -550,7 +550,7 @@ __global__ void	DD_FUNC(DD_NAME_F, DD_PREC_F, DD_RECON_F, DD_DAG_F, DD_XPAY_F)(c
 
 #undef SPINOR_HOP
 
-//#undef TPROJSCALE
+#undef TPROJSCALE
 
 // prepare next set of options, or clean up after final iteration
 


### PR DESCRIPTION
This fixes a bug in twisted-mass fermions with the dslash policies where we enable/disable kernel packing the T dimension depending on the chosen policy. Previously the non-preconditioned dslash assumed no kernel packing with the result that the scaling was wrong if we forced kernel packing.