### PR TITLE
Fixes for Fermi multi-GPU with texture references

### DIFF
--- a/include/color_spinor_field.h
+++ b/include/color_spinor_field.h
@@ -669,7 +669,13 @@ namespace quda {
 
     void scatterExtended(int nFace, int parity, int dagger, int dir);
 
-    const void* Ghost2() const { return ghost_field_tex[bufferIndex]; }
+    const void* Ghost2() const {
+      if (bufferIndex < 2) {
+        return ghost_recv_buffer_d[bufferIndex];
+      } else {
+        return static_cast<char*>(ghost_pinned_buffer_hd[bufferIndex%2])+ghost_bytes;
+      }
+    }
 
     /**
        @brief This is a unified ghost exchange function for doing a complete

--- a/include/quda_internal.h
+++ b/include/quda_internal.h
@@ -44,6 +44,11 @@
 #define USE_TEXTURE_OBJECTS
 #endif
 
+// if not using texture objects then we need to disable multi-blas support since these don't work with texture references
+#ifndef USE_TEXTURE_OBJECTS
+#undef MAX_MULTI_BLAS_N
+#define MAX_MULTI_BLAS_N 1
+#endif
 
 
 #ifdef INTERFACE_NVTX

--- a/lib/dslash_clover.cu
+++ b/lib/dslash_clover.cu
@@ -81,7 +81,6 @@ namespace quda {
 		     const cudaColorSpinorField *x, const double a, const int dagger)
       : SharedDslashCuda(out, in, x, reconstruct, dagger)
     { 
-      bindSpinorTex<sFloat>(in, out, x);
       dslashParam.gauge0 = (void*)gauge0;
       dslashParam.gauge1 = (void*)gauge1;
       dslashParam.clover = (void*)clover;
@@ -100,6 +99,8 @@ namespace quda {
 #ifdef USE_TEXTURE_OBJECTS
       dslashParam.ghostTex = in->GhostTex();
       dslashParam.ghostTexNorm = in->GhostTexNorm();
+#else
+      bindSpinorTex<sFloat>(in, out, x);
 #endif // USE_TEXTURE_OBJECTS
 
 #ifdef SHARED_WILSON_DSLASH

--- a/lib/dslash_clover_asym.cu
+++ b/lib/dslash_clover_asym.cu
@@ -77,7 +77,6 @@ namespace quda {
 			 const cudaColorSpinorField *x, const double a, const double rho, const int dagger)
       : SharedDslashCuda(out, in, x, reconstruct, dagger)
     { 
-      bindSpinorTex<sFloat>(in, out, x);
       dslashParam.gauge0 = (void*)gauge0;
       dslashParam.gauge1 = (void*)gauge1;
       dslashParam.clover = (void*)clover;
@@ -101,6 +100,8 @@ namespace quda {
 #ifdef USE_TEXTURE_OBJECTS
       dslashParam.ghostTex = in->GhostTex();
       dslashParam.ghostTexNorm = in->GhostTexNorm();
+#else
+      bindSpinorTex<sFloat>(in, out, x);
 #endif // USE_TEXTURE_OBJECTS
 
 #ifdef SHARED_WILSON_DSLASH

--- a/lib/dslash_domain_wall.cu
+++ b/lib/dslash_domain_wall.cu
@@ -118,7 +118,6 @@ namespace quda {
 			 const double a, const int dagger)
       : DslashCuda(out, in, x, reconstruct, dagger)
     { 
-      bindSpinorTex<sFloat>(in, out, x);
       dslashParam.gauge0 = (void*)gauge0;
       dslashParam.gauge1 = (void*)gauge1;
       dslashParam.a = a;
@@ -159,6 +158,8 @@ namespace quda {
 #ifdef USE_TEXTURE_OBJECTS
       dslashParam.ghostTex = in->GhostTex();
       dslashParam.ghostTexNorm = in->GhostTexNorm();
+#else
+      bindSpinorTex<sFloat>(in, out, x);
 #endif // USE_TEXTURE_OBJECTS
 
       TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());

--- a/lib/dslash_domain_wall_4d.cu
+++ b/lib/dslash_domain_wall_4d.cu
@@ -122,7 +122,6 @@ namespace quda {
 			     const double a, const double b, const int dagger, const int DS_type)
       : DslashCuda(out, in, x, reconstruct, dagger), DS_type(DS_type)
     { 
-      bindSpinorTex<sFloat>(in, out, x);
       dslashParam.gauge0 = (void*)gauge0;
       dslashParam.gauge1 = (void*)gauge1;
       dslashParam.a = a;
@@ -180,6 +179,8 @@ namespace quda {
 #ifdef USE_TEXTURE_OBJECTS
       dslashParam.ghostTex = in->GhostTex();
       dslashParam.ghostTexNorm = in->GhostTexNorm();
+#else
+      bindSpinorTex<sFloat>(in, out, x);
 #endif // USE_TEXTURE_OBJECTS
 
       TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());

--- a/lib/dslash_improved_staggered.cu
+++ b/lib/dslash_improved_staggered.cu
@@ -81,7 +81,6 @@ namespace quda {
 			const cudaColorSpinorField *x, const double a, const int dagger)
       : DslashCuda(out, in, x, reconstruct, dagger), nSrc(in->X(4))
     { 
-      bindSpinorTex<sFloat>(in, out, x);
       dslashParam.gauge0 = (void*)fat0;
       dslashParam.gauge1 = (void*)fat1;
       dslashParam.longGauge0 = (void*)long0;
@@ -99,6 +98,8 @@ namespace quda {
 #ifdef USE_TEXTURE_OBJECTS
       dslashParam.ghostTex = in->GhostTex();
       dslashParam.ghostTexNorm = in->GhostTexNorm();
+#else
+      bindSpinorTex<sFloat>(in, out, x);
 #endif // USE_TEXTURE_OBJECTS
 
       TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());

--- a/lib/dslash_mobius.cu
+++ b/lib/dslash_mobius.cu
@@ -124,7 +124,6 @@ namespace quda {
 		     const double a, const int dagger, const int DS_type)
       : DslashCuda(out, in, x, reconstruct, dagger), DS_type(DS_type)
     { 
-      bindSpinorTex<sFloat>(in, out, x);
       dslashParam.gauge0 = (void*)gauge0;
       dslashParam.gauge1 = (void*)gauge1;
       dslashParam.a = a;
@@ -183,6 +182,8 @@ namespace quda {
 #ifdef USE_TEXTURE_OBJECTS
       dslashParam.ghostTex = in->GhostTex();
       dslashParam.ghostTexNorm = in->GhostTexNorm();
+#else
+      bindSpinorTex<sFloat>(in, out, x);
 #endif // USE_TEXTURE_OBJECTS
 
       TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());

--- a/lib/dslash_ndeg_twisted_mass.cu
+++ b/lib/dslash_ndeg_twisted_mass.cu
@@ -80,7 +80,6 @@ namespace quda {
 		      const double epsilon, const double k, const int dagger)
       : SharedDslashCuda(out, in, x, reconstruct, dagger), gauge0(gauge0), gauge1(gauge1), dslashType(dslashType)
     { 
-      bindSpinorTex<sFloat>(in, out, x); 
       a = kappa;
       b = mu;
       c = epsilon;
@@ -116,6 +115,8 @@ namespace quda {
 #ifdef USE_TEXTURE_OBJECTS
       dslashParam.ghostTex = in->GhostTex();
       dslashParam.ghostTexNorm = in->GhostTexNorm();
+#else
+      bindSpinorTex<sFloat>(in, out, x);
 #endif // USE_TEXTURE_OBJECTS
 
 #ifdef SHARED_WILSON_DSLASH

--- a/lib/dslash_staggered.cu
+++ b/lib/dslash_staggered.cu
@@ -79,7 +79,6 @@ namespace quda {
 			const cudaColorSpinorField *x, const double a, const int dagger)
       : DslashCuda(out, in, x, reconstruct, dagger), nSrc(in->X(4))
     { 
-      bindSpinorTex<sFloat>(in, out, x);
       dslashParam.gauge0 = (void*)gauge0;
       dslashParam.gauge1 = (void*)gauge1;
       dslashParam.a = a;
@@ -93,6 +92,8 @@ namespace quda {
 #ifdef USE_TEXTURE_OBJECTS
       dslashParam.ghostTex = in->GhostTex();
       dslashParam.ghostTexNorm = in->GhostTexNorm();
+#else
+      bindSpinorTex<sFloat>(in, out, x);
 #endif // USE_TEXTURE_OBJECTS
 
       TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());

--- a/lib/dslash_twisted_clover.cu
+++ b/lib/dslash_twisted_clover.cu
@@ -85,7 +85,6 @@ namespace quda {
       : SharedDslashCuda(out, in, x, reconstruct,dagger),gauge0(gauge0), gauge1(gauge1), clover(clover),
 	cNorm(cNorm), cloverInv(cloverInv), cNrm2(cNrm2), dslashType(dslashType)
     { 
-      bindSpinorTex<sFloat>(in, out, x); 
       a = kappa;
       b = mu;
       c = epsilon;
@@ -197,6 +196,8 @@ namespace quda {
 #ifdef USE_TEXTURE_OBJECTS
       dslashParam.ghostTex = in->GhostTex();
       dslashParam.ghostTexNorm = in->GhostTexNorm();
+#else
+      bindSpinorTex<sFloat>(in, out, x);
 #endif // USE_TEXTURE_OBJECTS
 
 #ifdef SHARED_WILSON_DSLASH

--- a/lib/dslash_twisted_mass.cu
+++ b/lib/dslash_twisted_mass.cu
@@ -81,7 +81,6 @@ namespace quda {
 		      const double epsilon, const double k, const int dagger)
       : SharedDslashCuda(out, in, x, reconstruct, dagger), gauge0(gauge0), gauge1(gauge1), dslashType(dslashType)
     { 
-      bindSpinorTex<sFloat>(in, out, x); 
       a = kappa;
       b = mu;
       c = epsilon;
@@ -125,6 +124,8 @@ namespace quda {
 #ifdef USE_TEXTURE_OBJECTS
       dslashParam.ghostTex = in->GhostTex();
       dslashParam.ghostTexNorm = in->GhostTexNorm();
+#else
+      bindSpinorTex<sFloat>(in, out, x);
 #endif // USE_TEXTURE_OBJECTS
 
 #ifdef SHARED_WILSON_DSLASH

--- a/lib/dslash_wilson.cu
+++ b/lib/dslash_wilson.cu
@@ -76,7 +76,6 @@ namespace quda {
 		     const cudaColorSpinorField *x, const double a, const int dagger)
       : SharedDslashCuda(out, in, x, reconstruct, dagger)
     { 
-      bindSpinorTex<sFloat>(in, out, x); 
       dslashParam.gauge0 = (void*)gauge0;
       dslashParam.gauge1 = (void*)gauge1;
       dslashParam.a = a;
@@ -93,6 +92,8 @@ namespace quda {
 #ifdef USE_TEXTURE_OBJECTS
       dslashParam.ghostTex = in->GhostTex();
       dslashParam.ghostTexNorm = in->GhostTexNorm();
+#else
+      bindSpinorTex<sFloat>(in, out, x);
 #endif // USE_TEXTURE_OBJECTS
 
 #ifdef SHARED_WILSON_DSLASH

--- a/lib/multi_blas_quda.cu
+++ b/lib/multi_blas_quda.cu
@@ -701,7 +701,8 @@ namespace quda {
       const int NYW;
       real a[MAX_MULTI_BLAS_N], b[MAX_MULTI_BLAS_N], c[MAX_MULTI_BLAS_N];
 
-      multi_axpyBzpcx_(const coeff_array<double> &a, const coeff_array<double> &b, const coeff_array<double> &c, int NYW) : NYW(NYW){
+      multi_axpyBzpcx_(const coeff_array<double> &a, const coeff_array<double> &b, const coeff_array<double> &c, int NYW)
+        : NYW(NYW) , a{ }, b{ }, c{ } {
 	// copy arguments into the functor
 	for (int i=0; i<NYW; i++) { this->a[i] = a.data[i]; this->b[i] = b.data[i]; this->c[i] = c.data[i]; }
       }


### PR DESCRIPTION
Two fixes for multi-GPU Fermi (lazy ghost allocation and zero-copy textures broke with texture references)
* `cudaColorSpinorField::Ghost2()` directly returns required pointers, since `createGhostTextureObject` is not called on Fermi which sets `ghost_field_tex` pointers
* Always rebind spinor textures to ensure correct ghost pointers are used
* Closes #685
 