### PR TITLE
bump required cmake version to 3.8 for multigrid

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # basic setup for cmake
-cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_INCLUDE_DIRECTORIES_PROJECT_BEFORE ON)
 set(CMAKE_COLOR_MAKEFILE ON)


### PR DESCRIPTION
I guess since we switched to building as a shared lib more often I think having cmake 3.8 as minimum version should be fine.
Or are there any systems where this would be an issue?
 (I'd argue that you can always easily get your own cmake installed in your home)