### PR TITLE
[DONOTMERGE] Add a QudaEnv singleton class to manage all the environment variables in one place

### DIFF
--- a/include/dslash_quda.h
+++ b/include/dslash_quda.h
@@ -2,6 +2,7 @@
 #define _DSLASH_QUDA_H
 
 #include <quda_internal.h>
+#include <quda_env.h>
 #include <tune_quda.h>
 #include <gauge_field.h>
 

--- a/include/quda_env.h
+++ b/include/quda_env.h
@@ -28,30 +28,52 @@ namespace quda {
 			return env ? atoi(env) : defaultvalue;
 		}
 
+   	bool getenvBool(const char* envname, const int defaultvalue){
+			const char* env = std::getenv(envname);
+
+			return env ? atoi(env)==1 : defaultvalue==1;
+		}
+
+   	char* getenvChar(const char* envname){
+			char* env = std::getenv(envname);
+			return env ? env : nullptr;
+		}
+
+		// MPI related
 		int enable_p2p;
-		int enable_gdr;
+		bool enable_gdr;
+		char* gdr_blacklist;
+		bool enable_mps;
+
+		// dslash policy
+		char* dslash_policy;
+		bool dslash_policy;
+		bool dslash_pack;
+		bool dslash_interior;
+		bool dslash_exterior;
+		bool dslash_copy;
+		bool dslash_comms;
 
 
     QudaEnv() {
+
+    	//
     	enable_p2p = getenvInt("QUDA_ENABLE_P2P",3);
-    	enable_gdr = getenvInt("QUDA_ENABLE_GDR",0);
+    	enable_gdr = (getenvInt("QUDA_ENABLE_GDR",0)==1);
+    	blacklist_env = getenvChar("QUDA_ENABLE_GDR_BLACKLIST");
+    	enable_mps = (getenvInt("QUDA_ENABLE_MPS",0)==1);
 
-
+    	dslash_policy = getenvChar("QUDA_ENABLE_DSLASH_POLICY");
+			dslash_pack = getenvBool("QUDA_ENABLE_DSLASH_PACK");
+			dslash_interior = getenvBool("QUDA_ENABLE_DSLASH_INTERIOR")
+			dslash_exterior = getenvBool("QUDA_ENABLE_DSLASH_EXTERIOR")
+			dslash_copy = getenvBool("QUDA_ENABLE_DSLASH_COPY")
+			dslash_comms = getenvBool("QUDA_ENABLE_DSLASH_COMMS")
     }                    // Constructor? (the {} brackets) are needed here.
 
 
     
-    // comm_common
-		// char *enable_peer_to_peer_env = getenv("QUDA_ENABLE_P2P");
-		// char *enable_gdr_env = getenv("QUDA_ENABLE_GDR");
-		// char *blacklist_env = getenv("QUDA_ENABLE_GDR_BLACKLIST");
-		
-		// // comm_mpi
-		// char *enable_mps_env = getenv("QUDA_ENABLE_MPS");
-		// // comm_qmp
-		// char *enable_mps_env = getenv("QUDA_ENABLE_MPS");
-		// //dslash_coarse.cu
-		// static char *dslash_policy_env = getenv("QUDA_ENABLE_DSLASH_COARSE_POLICY");
+
 
 		// //dslash_policy.cuh
 		// static char *dslash_policy_env = getenv("QUDA_ENABLE_DSLASH_POLICY");
@@ -88,13 +110,20 @@ namespace quda {
    public:
     QudaEnv(QudaEnv const &)               = delete;
     void operator=(QudaEnv const &)  = delete;
-
     int get_enable_p2p() const{
     	return enable_p2p;
     }
 
-    int get_enable_gdr() const{
+    bool get_enable_gdr() const{
     	return enable_gdr;
+    }
+
+    bool get_enable_mps() const{
+    	return enable_mps;
+    }
+
+    char* get_enable_gdr_blacklist() const{
+    	return blacklist_env;
     }
 
 

--- a/include/quda_env.h
+++ b/include/quda_env.h
@@ -5,89 +5,83 @@
 
 namespace quda {
   // forward declaration of class TestEnv for later use
-  class TestEnv;
+	class TestEnv;
 
   /**
   * Singleton
   */
 
-  class QudaEnv {
-    friend class TestEnv;
+	class QudaEnv {
+		friend class TestEnv;
 
-   public:
-    static QudaEnv &getInstance() {
+	public:
+		static QudaEnv &getInstance() {
       static QudaEnv    instance; // Guaranteed to be destroyed.
       // Instantiated on first use.
       return instance;
     }
 
-   private:
-   	int getenvInt(const char* envname, const int defaultvalue){
-			const char* env = std::getenv(envname);
+  private:
+  	int getenvInt(const char* envname, const int defaultvalue){
+  		const char* env = std::getenv(envname);
 
-			return env ? atoi(env) : defaultvalue;
-		}
+  		return env ? atoi(env) : defaultvalue;
+  	}
 
-   	bool getenvBool(const char* envname, const int defaultvalue){
-			const char* env = std::getenv(envname);
+  	bool getenvBool(const char* envname, const int defaultvalue){
+  		const char* env = std::getenv(envname);
 
-			return env ? atoi(env)==1 : defaultvalue==1;
-		}
+  		return env ? atoi(env)==1 : defaultvalue==1;
+  	}
 
-   	char* getenvChar(const char* envname){
-			char* env = std::getenv(envname);
-			return env ? env : nullptr;
-		}
+  	char* getenvChar(const char* envname){
+  		char* env = std::getenv(envname);
+  		return env ? env : nullptr;
+  	}
 
 		// MPI related
-		int enable_p2p;
-		bool enable_gdr;
-		char* gdr_blacklist;
-		bool enable_mps;
+  	int enable_p2p;
+  	bool enable_gdr;
+  	char* gdr_blacklist;
+  	bool enable_mps;
 
 		// dslash policy
-		char* dslash_policy;
-		bool dslash_policy;
-		bool dslash_pack;
-		bool dslash_interior;
-		bool dslash_exterior;
-		bool dslash_copy;
-		bool dslash_comms;
+  	char* dslash_policy;
+  	bool dslash_pack;
+  	bool dslash_interior;
+  	bool dslash_exterior;
+  	bool dslash_copy;
+  	bool dslash_comms;
+
+  	// interface
+  	bool allow_jit;
+  	bool enable_numa;
+  	char* reorder_location;
+  	bool device_reset;
 
 
-    QudaEnv() {
+  	QudaEnv() {
 
-    	//
-    	enable_p2p = getenvInt("QUDA_ENABLE_P2P",3);
-    	enable_gdr = (getenvInt("QUDA_ENABLE_GDR",0)==1);
-    	blacklist_env = getenvChar("QUDA_ENABLE_GDR_BLACKLIST");
-    	enable_mps = (getenvInt("QUDA_ENABLE_MPS",0)==1);
+  		enable_p2p = getenvInt("QUDA_ENABLE_P2P",3);
+  		enable_gdr = (getenvInt("QUDA_ENABLE_GDR",0)==1);
+  		gdr_blacklist = getenvChar("QUDA_ENABLE_GDR_BLACKLIST");
+  		enable_mps = (getenvInt("QUDA_ENABLE_MPS",0)==1);
 
-    	dslash_policy = getenvChar("QUDA_ENABLE_DSLASH_POLICY");
-			dslash_pack = getenvBool("QUDA_ENABLE_DSLASH_PACK");
-			dslash_interior = getenvBool("QUDA_ENABLE_DSLASH_INTERIOR")
-			dslash_exterior = getenvBool("QUDA_ENABLE_DSLASH_EXTERIOR")
-			dslash_copy = getenvBool("QUDA_ENABLE_DSLASH_COPY")
-			dslash_comms = getenvBool("QUDA_ENABLE_DSLASH_COMMS")
-    }                    // Constructor? (the {} brackets) are needed here.
+  		dslash_policy = getenvChar("QUDA_ENABLE_DSLASH_POLICY");
+  		dslash_pack = getenvBool("QUDA_ENABLE_DSLASH_PACK",1);
+  		dslash_interior = getenvBool("QUDA_ENABLE_DSLASH_INTERIOR",1);
+  		dslash_exterior = getenvBool("QUDA_ENABLE_DSLASH_EXTERIOR",1);
+  		dslash_copy = getenvBool("QUDA_ENABLE_DSLASH_COPY",1);
+  		dslash_comms = getenvBool("QUDA_ENABLE_DSLASH_COMMS",1);
+
+  		allow_jit = getenvBool("QUDA_ALLOW_JIT",0);
+  		enable_numa =getenvBool("QUDA_ENABLE_NUMA",0);
+  		reorder_location=getenvChar("QUDA_REORDER_LOCATION");
+  		device_reset=getenvBool("QUDA_DEVICE_RESET",0);
+
+    } 
 
 
-    
-
-
-		// //dslash_policy.cuh
-		// static char *dslash_policy_env = getenv("QUDA_ENABLE_DSLASH_POLICY");
-		// static char *dslash_pack_env = getenv("QUDA_ENABLE_DSLASH_PACK");
-		// static char *dslash_interior_env = getenv("QUDA_ENABLE_DSLASH_INTERIOR");
-		// static char *dslash_exterior_env = getenv("QUDA_ENABLE_DSLASH_EXTERIOR");
-		// static char *dslash_copy_env = getenv("QUDA_ENABLE_DSLASH_COPY");
-		// static char *dslash_comms_env = getenv("QUDA_ENABLE_DSLASH_COMMS");
-
-		// //interface_quda.cpp:  
-		// char *cni_str = getenv("CUDA_NIC_INTEROP");
-		// char *allow_jit_env = getenv("QUDA_ALLOW_JIT");
-		// char *enable_numa_env = getenv("QUDA_ENABLE_NUMA");
-		// char *reorder_str = getenv("QUDA_REORDER_LOCATION");
 		// char *device_reset_env = getenv("QUDA_DEVICE_RESET");
 
 
@@ -98,40 +92,77 @@ namespace quda {
 		// //milc_interface.cpp
 		// char *quda_reconstruct = getenv("QUDA_MILC_HISQ_RECONSTRUCT");
 		// char *quda_solver = getenv("QUDA_MILC_CLOVER_SOLVER");
-		
+
 		// //tune.cpp
 		// char *path = getenv("QUDA_RESOURCE_PATH");
 		// char *profile_fname = getenv("QUDA_PROFILE_OUTPUT_BASE");
-		
+
 		// //util_quda
 		// static char *rank_verbosity_env = getenv("QUDA_RANK_VERBOSITY");
 		// char *enable_tuning = getenv("QUDA_ENABLE_TUNING");
 
-   public:
-    QudaEnv(QudaEnv const &)               = delete;
-    void operator=(QudaEnv const &)  = delete;
-    int get_enable_p2p() const{
-    	return enable_p2p;
-    }
+  public:
+  	QudaEnv(QudaEnv const &)         = delete;
+  	void operator=(QudaEnv const &)  = delete;
 
-    bool get_enable_gdr() const{
-    	return enable_gdr;
-    }
+  	int get_enable_p2p() const{
+  		return enable_p2p;
+  	}
 
-    bool get_enable_mps() const{
-    	return enable_mps;
-    }
+  	bool get_enable_gdr() const{
+  		return enable_gdr;
+  	}
 
-    char* get_enable_gdr_blacklist() const{
-    	return blacklist_env;
-    }
+  	bool get_enable_mps() const{
+  		return enable_mps;
+  	}
 
+  	char* get_enable_gdr_blacklist() const{
+  		return gdr_blacklist;
+  	}
 
-   protected:
-//    void setx(int _x) {
-//      x = _x;
-//    }
+  	char* get_enable_dslash_policy() const{
+  		return dslash_policy;
+  	}
 
+  	bool get_enable_dslash_pack() const{
+  		return dslash_pack;
+  	}
+
+  	bool get_enable_dslash_interior() const{
+  		return dslash_interior;
+  	}
+
+  	bool get_enable_dslash_exterior()const {
+  		return dslash_exterior;
+  	}
+
+  	bool get_enable_dslash_copy()const {
+  		return dslash_copy;
+  	}
+
+  	bool get_enable_dslash_comms()const {
+  		return dslash_comms;
+  	}
+
+  	bool get_allow_jit() const {
+  		return allow_jit;
+  	}
+
+  	bool get_enable_numa() const{
+  		return enable_numa;
+  	}
+
+  	char* get_reorder_location() const{
+  		return reorder_location;
+  	}
+
+  	bool get_device_reset() const{
+  		return device_reset;
+  	}
+
+  protected:
+  	// may add setters here
 
   };
 

--- a/include/quda_env.h
+++ b/include/quda_env.h
@@ -1,0 +1,109 @@
+#pragma once
+
+#include <cstdlib>
+#include <quda_internal.h>
+
+namespace quda {
+  // forward declaration
+  class TestEnv;
+
+  /**
+  * Singleton
+  */
+
+  class QudaEnv {
+    friend class TestEnv;
+
+   public:
+    static QudaEnv &getInstance() {
+      static QudaEnv    instance; // Guaranteed to be destroyed.
+      // Instantiated on first use.
+      return instance;
+    }
+
+   private:
+   	int getenvInt(const char* envname, const int defaultvalue){
+			const char* env = std::getenv(envname);
+
+			return env ? atoi(env) : defaultvalue;
+		}
+
+		int enable_p2p;
+		int enable_gdr;
+
+
+    QudaEnv() {
+    	enable_p2p = getenvInt("QUDA_ENABLE_P2P",3);
+    	enable_gdr = getenvInt("QUDA_ENABLE_GDR",0);
+
+
+    }                    // Constructor? (the {} brackets) are needed here.
+
+
+    
+    // comm_common
+		// char *enable_peer_to_peer_env = getenv("QUDA_ENABLE_P2P");
+		// char *enable_gdr_env = getenv("QUDA_ENABLE_GDR");
+		// char *blacklist_env = getenv("QUDA_ENABLE_GDR_BLACKLIST");
+		
+		// // comm_mpi
+		// char *enable_mps_env = getenv("QUDA_ENABLE_MPS");
+		// // comm_qmp
+		// char *enable_mps_env = getenv("QUDA_ENABLE_MPS");
+		// //dslash_coarse.cu
+		// static char *dslash_policy_env = getenv("QUDA_ENABLE_DSLASH_COARSE_POLICY");
+
+		// //dslash_policy.cuh
+		// static char *dslash_policy_env = getenv("QUDA_ENABLE_DSLASH_POLICY");
+		// static char *dslash_pack_env = getenv("QUDA_ENABLE_DSLASH_PACK");
+		// static char *dslash_interior_env = getenv("QUDA_ENABLE_DSLASH_INTERIOR");
+		// static char *dslash_exterior_env = getenv("QUDA_ENABLE_DSLASH_EXTERIOR");
+		// static char *dslash_copy_env = getenv("QUDA_ENABLE_DSLASH_COPY");
+		// static char *dslash_comms_env = getenv("QUDA_ENABLE_DSLASH_COMMS");
+
+		// //interface_quda.cpp:  
+		// char *cni_str = getenv("CUDA_NIC_INTEROP");
+		// char *allow_jit_env = getenv("QUDA_ALLOW_JIT");
+		// char *enable_numa_env = getenv("QUDA_ENABLE_NUMA");
+		// char *reorder_str = getenv("QUDA_REORDER_LOCATION");
+		// char *device_reset_env = getenv("QUDA_DEVICE_RESET");
+
+
+		// //malloc.cpp:	c
+		// char *enable_device_pool = getenv("QUDA_ENABLE_DEVICE_MEMORY_POOL");
+		// char *enable_pinned_pool = getenv("QUDA_ENABLE_PINNED_MEMORY_POOL");
+
+		// //milc_interface.cpp
+		// char *quda_reconstruct = getenv("QUDA_MILC_HISQ_RECONSTRUCT");
+		// char *quda_solver = getenv("QUDA_MILC_CLOVER_SOLVER");
+		
+		// //tune.cpp
+		// char *path = getenv("QUDA_RESOURCE_PATH");
+		// char *profile_fname = getenv("QUDA_PROFILE_OUTPUT_BASE");
+		
+		// //util_quda
+		// static char *rank_verbosity_env = getenv("QUDA_RANK_VERBOSITY");
+		// char *enable_tuning = getenv("QUDA_ENABLE_TUNING");
+
+   public:
+    QudaEnv(QudaEnv const &)               = delete;
+    void operator=(QudaEnv const &)  = delete;
+
+    int get_enable_p2p() const{
+    	return enable_p2p;
+    }
+
+    int get_enable_gdr() const{
+    	return enable_gdr;
+    }
+
+
+   protected:
+//    void setx(int _x) {
+//      x = _x;
+//    }
+
+
+  };
+
+} // namespace quda

--- a/include/quda_env.h
+++ b/include/quda_env.h
@@ -5,164 +5,307 @@
 
 namespace quda {
   // forward declaration of class TestEnv for later use
-	class TestEnv;
+  class TestEnv;
+
 
   /**
-  * Singleton
-  */
+   * @brief Singleton class to hold global quda configuration variables ususally set through environement variables
+   * @details See https://github.com/lattice/quda/wiki/QUDA-Environment-Variables for a list of environment variables.
+   */
+  class QudaEnv {
+    friend class TestEnv;
 
-	class QudaEnv {
-		friend class TestEnv;
-
-	public:
-		static QudaEnv &getInstance() {
+   public:
+    static QudaEnv &getInstance() {
       static QudaEnv    instance; // Guaranteed to be destroyed.
       // Instantiated on first use.
       return instance;
     }
 
-  private:
-  	int getenvInt(const char* envname, const int defaultvalue){
-  		const char* env = std::getenv(envname);
+   private:
+    /**
+    * try to read an integer value from an environement variable
+    * @param envname
+    * @param defaultValue
+    */
+    int getenvInt(const char *envname, const int defaultvalue) {
+      const char *env = std::getenv(envname);
 
-  		return env ? atoi(env) : defaultvalue;
-  	}
+      return env ? atoi(env) : defaultvalue;
+    }
 
-  	bool getenvBool(const char* envname, const int defaultvalue){
-  		const char* env = std::getenv(envname);
+    /**
+     * @brief [brief description]
+     * @details [long description]
+     *
+     * @param envname [description]
+     * @param defaultvalue [description]
+     *
+     * @return [description]
+     */
+    bool getenvBool(const char *envname, const int defaultvalue) {
+      const char *env = std::getenv(envname);
 
-  		return env ? atoi(env)==1 : defaultvalue==1;
-  	}
+      return env ? atoi(env) == 1 : defaultvalue == 1;
+    }
 
-  	char* getenvChar(const char* envname){
-  		char* env = std::getenv(envname);
-  		return env ? env : nullptr;
-  	}
+    /**
+     * @brief [brief description]
+     * @details [long description]
+     *
+     * @param envname [description]
+     * @return [description]
+     */
+    char *getenvChar(const char *envname) {
+      char *env = std::getenv(envname);
+      return env ? env : nullptr;
+    }
 
-		// MPI related
-  	int enable_p2p;
-  	bool enable_gdr;
-  	char* gdr_blacklist;
-  	bool enable_mps;
+    // MPI related
+    int enable_p2p;
+    bool enable_gdr;
+    char *gdr_blacklist;
+    bool enable_mps;
 
-		// dslash policy
-  	char* dslash_policy;
-  	bool dslash_pack;
-  	bool dslash_interior;
-  	bool dslash_exterior;
-  	bool dslash_copy;
-  	bool dslash_comms;
+    // dslash policy
+    char *dslash_policy;
+    bool dslash_pack;
+    bool dslash_interior;
+    bool dslash_exterior;
+    bool dslash_copy;
+    bool dslash_comms;
 
-  	// interface
-  	bool allow_jit;
-  	bool enable_numa;
-  	char* reorder_location;
-  	bool device_reset;
+    // interface
+    bool allow_jit;
+    bool enable_numa;
+    char *reorder_location;
+    bool device_reset;
+
+    // malloc
+    bool device_memory_pool;
+    bool pinned_memory_pool;
+
+    char *resource_path;
+    char *profile_output_base;
+
+    char *rank_verbosity;
+    bool enable_tuning;
+
+    QudaEnv() {
+
+      enable_p2p = getenvInt("QUDA_ENABLE_P2P", 3);
+      enable_gdr = (getenvInt("QUDA_ENABLE_GDR", 0) == 1);
+      gdr_blacklist = getenvChar("QUDA_ENABLE_GDR_BLACKLIST");
+      enable_mps = (getenvInt("QUDA_ENABLE_MPS", 0) == 1);
+
+      dslash_policy = getenvChar("QUDA_ENABLE_DSLASH_POLICY");
+      dslash_pack = getenvBool("QUDA_ENABLE_DSLASH_PACK", 1);
+      dslash_interior = getenvBool("QUDA_ENABLE_DSLASH_INTERIOR", 1);
+      dslash_exterior = getenvBool("QUDA_ENABLE_DSLASH_EXTERIOR", 1);
+      dslash_copy = getenvBool("QUDA_ENABLE_DSLASH_COPY", 1);
+      dslash_comms = getenvBool("QUDA_ENABLE_DSLASH_COMMS", 1);
+
+      allow_jit = getenvBool("QUDA_ALLOW_JIT", 0);
+      enable_numa = getenvBool("QUDA_ENABLE_NUMA", 0);
+      reorder_location = getenvChar("QUDA_REORDER_LOCATION");
+      device_reset = getenvBool("QUDA_DEVICE_RESET", 0);
+
+      device_memory_pool = getenvBool("QUDA_ENABLE_DEVICE_MEMORY_POOL", 1);
+      pinned_memory_pool = getenvBool("QUDA_ENABLE_PINNED_MEMORY_POOL", 1);
+
+      resource_path = getenvChar("QUDA_RESOURCE_PATH");
+      profile_output_base = getenvChar("QUDA_PROFILE_OUTPUT_BASE");
+
+      rank_verbosity = getenvChar("QUDA_RANK_VERBOSITY");
+      enable_tuning = getenvBool("QUDA_ENABLE_TUNING", 1);
+
+    }
+
+   public:
+    QudaEnv(QudaEnv const &)         = delete;
+    void operator=(QudaEnv const &)  = delete;
+
+    /**
+     * @brief [brief description]
+     * @details [long description]
+     * @return [description]
+     */
+    int get_enable_p2p() const {
+      return enable_p2p;
+    }
+
+    /**
+     * @brief [brief description]
+     * @details [long description]
+     * @return [description]
+     */
+    bool get_enable_gdr() const {
+      return enable_gdr;
+    }
+
+    /**
+     * @brief [brief description]
+     * @details [long description]
+     * @return [description]
+     */
+    bool get_enable_mps() const {
+      return enable_mps;
+    }
+
+    /**
+     * @brief [brief description]
+     * @details [long description]
+     * @return [description]
+     */char *get_enable_gdr_blacklist() const {
+      return gdr_blacklist;
+    }
+
+    /**
+     * @brief [brief description]
+     * @details [long description]
+     * @return [description]
+     */
+    char *get_enable_dslash_policy() const {
+      return dslash_policy;
+    }
+
+    /**
+     * @brief [brief description]
+     * @details [long description]
+     * @return [description]
+     */
+    bool get_enable_dslash_pack() const {
+      return dslash_pack;
+    }
+    /**
+     * @brief [brief description]
+     * @details [long description]
+     * @return [description]
+     */
+    bool get_enable_dslash_interior() const {
+      return dslash_interior;
+    }
+
+    /**
+     * @brief [brief description]
+     * @details [long description]
+     * @return [description]
+     */
+    bool get_enable_dslash_exterior()const {
+      return dslash_exterior;
+    }
+
+    /**
+     * @brief [brief description]
+     * @details [long description]
+     * @return [description]
+     */
+    bool get_enable_dslash_copy()const {
+      return dslash_copy;
+    }
+
+    /**
+     * @brief [brief description]
+     * @details [long description]
+     * @return [description]
+     */
+    bool get_enable_dslash_comms()const {
+      return dslash_comms;
+    }
+
+    /**
+     * @brief [brief description]
+     * @details [long description]
+     * @return [description]
+     */
+    bool get_allow_jit() const {
+      return allow_jit;
+    }
+
+    /**
+     * @brief [brief description]
+     * @details [long description]
+     * @return [description]
+     */
+    bool get_enable_numa() const {
+      return enable_numa;
+    }
+
+    /**
+     * @brief [brief description]
+     * @details [long description]
+     * @return [description]
+     */
+    char *get_reorder_location() const {
+      return reorder_location;
+    }
+
+    /**
+     * @brief [brief description]
+     * @details [long description]
+     * @return [description]
+     */
+    bool get_device_reset() const {
+      return device_reset;
+    }
+
+    /**
+     * @brief [brief description]
+     * @details [long description]
+     * @return [description]
+     */
+    bool get_enable_device_memory_pool() const {
+      return device_memory_pool;
+    }
+
+    /**
+     * @brief [brief description]
+     * @details [long description]
+     * @return [description]
+     */
+    bool get_enable_pinned_memory_pool() const {
+      return pinned_memory_pool;
+    }
+
+    /**
+     * @brief [brief description]
+     * @details [long description]
+     * @return [description]
+     */
+    char *get_resource_path() const {
+      return resource_path;
+    }
+
+    /**
+     * @brief
+     *
+     * @details [long description]
+     * @return [description]
+     */
+    char *get_profile_output_base() const {
+      return profile_output_base;
+    }
 
 
-  	QudaEnv() {
+    /**
+     * @brief [brief description]
+     * @details [long description]
+     * @return [description]
+     */
+    char *get_rank_verbosity() const {
+      return rank_verbosity;
+    };
 
-  		enable_p2p = getenvInt("QUDA_ENABLE_P2P",3);
-  		enable_gdr = (getenvInt("QUDA_ENABLE_GDR",0)==1);
-  		gdr_blacklist = getenvChar("QUDA_ENABLE_GDR_BLACKLIST");
-  		enable_mps = (getenvInt("QUDA_ENABLE_MPS",0)==1);
-
-  		dslash_policy = getenvChar("QUDA_ENABLE_DSLASH_POLICY");
-  		dslash_pack = getenvBool("QUDA_ENABLE_DSLASH_PACK",1);
-  		dslash_interior = getenvBool("QUDA_ENABLE_DSLASH_INTERIOR",1);
-  		dslash_exterior = getenvBool("QUDA_ENABLE_DSLASH_EXTERIOR",1);
-  		dslash_copy = getenvBool("QUDA_ENABLE_DSLASH_COPY",1);
-  		dslash_comms = getenvBool("QUDA_ENABLE_DSLASH_COMMS",1);
-
-  		allow_jit = getenvBool("QUDA_ALLOW_JIT",0);
-  		enable_numa =getenvBool("QUDA_ENABLE_NUMA",0);
-  		reorder_location=getenvChar("QUDA_REORDER_LOCATION");
-  		device_reset=getenvBool("QUDA_DEVICE_RESET",0);
-
-    } 
-
-
-		// char *device_reset_env = getenv("QUDA_DEVICE_RESET");
-
-
-		// //malloc.cpp:	c
-		// char *enable_device_pool = getenv("QUDA_ENABLE_DEVICE_MEMORY_POOL");
-		// char *enable_pinned_pool = getenv("QUDA_ENABLE_PINNED_MEMORY_POOL");
-
-		// //milc_interface.cpp
-		// char *quda_reconstruct = getenv("QUDA_MILC_HISQ_RECONSTRUCT");
-		// char *quda_solver = getenv("QUDA_MILC_CLOVER_SOLVER");
-
-		// //tune.cpp
-		// char *path = getenv("QUDA_RESOURCE_PATH");
-		// char *profile_fname = getenv("QUDA_PROFILE_OUTPUT_BASE");
-
-		// //util_quda
-		// static char *rank_verbosity_env = getenv("QUDA_RANK_VERBOSITY");
-		// char *enable_tuning = getenv("QUDA_ENABLE_TUNING");
-
-  public:
-  	QudaEnv(QudaEnv const &)         = delete;
-  	void operator=(QudaEnv const &)  = delete;
-
-  	int get_enable_p2p() const{
-  		return enable_p2p;
-  	}
-
-  	bool get_enable_gdr() const{
-  		return enable_gdr;
-  	}
-
-  	bool get_enable_mps() const{
-  		return enable_mps;
-  	}
-
-  	char* get_enable_gdr_blacklist() const{
-  		return gdr_blacklist;
-  	}
-
-  	char* get_enable_dslash_policy() const{
-  		return dslash_policy;
-  	}
-
-  	bool get_enable_dslash_pack() const{
-  		return dslash_pack;
-  	}
-
-  	bool get_enable_dslash_interior() const{
-  		return dslash_interior;
-  	}
-
-  	bool get_enable_dslash_exterior()const {
-  		return dslash_exterior;
-  	}
-
-  	bool get_enable_dslash_copy()const {
-  		return dslash_copy;
-  	}
-
-  	bool get_enable_dslash_comms()const {
-  		return dslash_comms;
-  	}
-
-  	bool get_allow_jit() const {
-  		return allow_jit;
-  	}
-
-  	bool get_enable_numa() const{
-  		return enable_numa;
-  	}
-
-  	char* get_reorder_location() const{
-  		return reorder_location;
-  	}
-
-  	bool get_device_reset() const{
-  		return device_reset;
-  	}
-
-  protected:
-  	// may add setters here
+    /**
+     * @brief [brief description]
+     * @details [long description]
+     * @return [description]
+     */
+    bool get_enable_tuning() const {
+      return enable_tuning;
+    }
+   protected:
+    // may add setters here
 
   };
 

--- a/include/quda_env.h
+++ b/include/quda_env.h
@@ -4,7 +4,7 @@
 #include <quda_internal.h>
 
 namespace quda {
-  // forward declaration
+  // forward declaration of class TestEnv for later use
   class TestEnv;
 
   /**

--- a/lib/comm_common.cpp
+++ b/lib/comm_common.cpp
@@ -606,7 +606,7 @@ int comm_partitioned()
 }
 
 bool comm_gdr_enabled() {
-    return static_cast<bool>(quda::QudaEnv::getInstance().get_enable_gdr());
+    return quda::QudaEnv::getInstance().get_enable_gdr();
 }
 
 bool comm_gdr_blacklist() {
@@ -614,7 +614,7 @@ bool comm_gdr_blacklist() {
   static bool blacklist_init = false;
 
   if (!blacklist_init) {
-    char *blacklist_env = getenv("QUDA_ENABLE_GDR_BLACKLIST");
+    char *blacklist_env = quda::QudaEnv::getInstance().get_enable_gdr_blacklist();
 
     if (blacklist_env) { // set the policies to tune for explicitly
       std::stringstream blacklist_list(blacklist_env);

--- a/lib/comm_mpi.cpp
+++ b/lib/comm_mpi.cpp
@@ -4,6 +4,7 @@
 #include <mpi.h>
 #include <csignal>
 #include <quda_internal.h>
+#include "quda_env.h"
 #include <comm_quda.h>
 
 
@@ -100,8 +101,7 @@ void comm_init(int ndim, const int *dims, QudaCommsMap rank_from_coords, void *m
     errorQuda("No CUDA devices found");
   }
   if (gpuid >= device_count) {
-    char *enable_mps_env = getenv("QUDA_ENABLE_MPS");
-    if (enable_mps_env && strcmp(enable_mps_env,"1") == 0) {
+    if (quda::QudaEnv::getInstance().get_enable_mps()) {
       gpuid = gpuid%device_count;
       printf("MPS enabled, rank=%d -> gpu=%d\n", comm_rank(), gpuid);
     } else {

--- a/lib/comm_qmp.cpp
+++ b/lib/comm_qmp.cpp
@@ -1,6 +1,7 @@
 #include <qmp.h>
 #include <csignal>
 #include <quda_internal.h>
+#include "quda_env.h"
 #include <comm_quda.h>
 
 #define QMP_CHECK(qmp_call) do {                     \
@@ -108,8 +109,8 @@ void comm_init(int ndim, const int *dims, QudaCommsMap rank_from_coords, void *m
     errorQuda("No CUDA devices found");
   }
   if (gpuid >= device_count) {
-    char *enable_mps_env = getenv("QUDA_ENABLE_MPS");
-    if (enable_mps_env && strcmp(enable_mps_env,"1") == 0) {
+
+if (quda::QudaEnv::getInstance().get_enable_mps()) {
       gpuid = gpuid%device_count;
       printf("MPS enabled, rank=%d -> gpu=%d\n", comm_rank(), gpuid);
     } else {

--- a/lib/dslash_policy.cuh
+++ b/lib/dslash_policy.cuh
@@ -1927,9 +1927,9 @@ struct DslashFactory {
        p2p_policies[static_cast<std::size_t>(QudaP2PPolicy::QUDA_P2P_DEFAULT)] = QudaP2PPolicy::QUDA_P2P_DEFAULT;
        first_active_p2p_policy = static_cast<int>(QudaP2PPolicy::QUDA_P2P_DEFAULT); // first active policy is presently always the default
 
-       static char *dslash_policy_env = getenv("QUDA_ENABLE_DSLASH_POLICY");
-       if (dslash_policy_env) { // set the policies to tune for explicitly
-	 std::stringstream policy_list(dslash_policy_env);
+       
+       if (quda::QudaEnv::getInstance().get_enable_dslash_policy()) { // set the policies to tune for explicitly
+	 std::stringstream policy_list(quda::QudaEnv::getInstance().get_enable_dslash_policy());
 
 	 int policy_;
 	 while (policy_list >> policy_) {
@@ -1994,32 +1994,28 @@ struct DslashFactory {
 #endif
        }
 
-       static char *dslash_pack_env = getenv("QUDA_ENABLE_DSLASH_PACK");
-       if (dslash_pack_env && strcmp(dslash_pack_env, "0") == 0) {
+       
+       if (!quda::QudaEnv::getInstance().get_enable_dslash_pack()) {
 	 if (getVerbosity() > QUDA_SILENT) warningQuda("Disabling Dslash halo packing");
 	 dslash_pack_compute = false;
        }
 
-       static char *dslash_interior_env = getenv("QUDA_ENABLE_DSLASH_INTERIOR");
-       if (dslash_interior_env && strcmp(dslash_interior_env, "0") == 0) {
+       if (!quda::QudaEnv::getInstance().get_enable_dslash_interior()) {
 	 if (getVerbosity() > QUDA_SILENT) warningQuda("Disabling Dslash interior computation");
 	 dslash_interior_compute = false;
        }
 
-       static char *dslash_exterior_env = getenv("QUDA_ENABLE_DSLASH_EXTERIOR");
-       if (dslash_exterior_env && strcmp(dslash_exterior_env, "0") == 0) {
+       if (!quda::QudaEnv::getInstance().get_enable_dslash_exterior()) {
 	 if (getVerbosity() > QUDA_SILENT) warningQuda("Disabling Dslash exterior computation");
 	 dslash_exterior_compute = false;
        }
 
-       static char *dslash_copy_env = getenv("QUDA_ENABLE_DSLASH_COPY");
-       if (dslash_copy_env && strcmp(dslash_copy_env, "0") == 0) {
+       if (!quda::QudaEnv::getInstance().get_enable_dslash_copy()) {
 	 if (getVerbosity() > QUDA_SILENT) warningQuda("Disabling Dslash host-device copying");
 	 dslash_copy = false;
        }
 
-       static char *dslash_comms_env = getenv("QUDA_ENABLE_DSLASH_COMMS");
-       if (dslash_comms_env && strcmp(dslash_comms_env, "0") == 0) {
+       if (!quda::QudaEnv::getInstance().get_enable_dslash_comms()) {
 	 if (getVerbosity() > QUDA_SILENT) warningQuda("Disabling Dslash communication");
 	 dslash_comms = false;
        }

--- a/lib/malloc.cpp
+++ b/lib/malloc.cpp
@@ -5,6 +5,7 @@
 #include <unistd.h> // for getpagesize()
 #include <execinfo.h> // for backtrace
 #include <quda_internal.h>
+#include <quda_env.h>
 
 #ifdef USE_QDPJIT
 #include "qdp_quda.h"
@@ -416,8 +417,8 @@ namespace quda {
     void init() {
       if (!pool_init) {
 	// device memory pool
-	char *enable_device_pool = getenv("QUDA_ENABLE_DEVICE_MEMORY_POOL");
-	if (!enable_device_pool || strcmp(enable_device_pool,"0")!=0) {
+
+	if (quda::QudaEnv::getInstance().get_enable_device_memory_pool()) {
 	  warningQuda("Using device memory pool allocator");
 	  device_memory_pool = true;
 	} else {
@@ -426,8 +427,7 @@ namespace quda {
 	}
 
 	// pinned memory pool
-	char *enable_pinned_pool = getenv("QUDA_ENABLE_PINNED_MEMORY_POOL");
-	if (!enable_pinned_pool || strcmp(enable_pinned_pool,"0")!=0) {
+  if (quda::QudaEnv::getInstance().get_enable_pinned_memory_pool()) {
 	  warningQuda("Using pinned memory pool allocator");
 	  pinned_memory_pool = true;
 	} else {

--- a/lib/timer.cpp
+++ b/lib/timer.cpp
@@ -44,7 +44,7 @@ namespace quda {
                                        "memcpy h2d async", "comms start", "comms query", "constant", "total" };
 
 #ifdef INTERFACE_NVTX
-  const uint32_t TimeProfile::nvtx_colors[] = { 0x0000ff00, 0x000000ff, 0x00ffff00, 0x00ff00ff, 0x0000ffff, 0x00ff0000, 0x00ffffff };
+  const uint32_t TimeProfile::nvtx_colors[] = { 0xff00ff00, 0xff0000ff, 0xffffff00, 0xffff00ff, 0xff00ffff, 0xffff0000, 0xffffffff };
   const int TimeProfile::nvtx_num_colors = sizeof(nvtx_colors)/sizeof(uint32_t);
 #endif
 

--- a/lib/tune.cpp
+++ b/lib/tune.cpp
@@ -9,6 +9,7 @@
 #include <typeinfo>
 #include <map>
 #include <unistd.h>
+#include <quda_env.h>
 
 #include <deque>
 #include <queue>
@@ -228,7 +229,7 @@ namespace quda {
     std::ifstream cache_file;
     std::stringstream ls;
 
-    path = getenv("QUDA_RESOURCE_PATH");
+    path = quda::QudaEnv::getInstance().get_resource_path();
 
     if (!path) {
       warningQuda("Environment variable QUDA_RESOURCE_PATH is not set.");
@@ -416,7 +417,7 @@ namespace quda {
       // profile counter for writing out unique profiles
       static int count = 0;
 
-      char *profile_fname = getenv("QUDA_PROFILE_OUTPUT_BASE");
+      char *profile_fname = quda::QudaEnv::getInstance().get_profile_output_base();
 
       if (!profile_fname) {
 	warningQuda("Environment variable QUDA_PROFILE_OUTPUT_BASE is not set; writing to profile.tsv and profile_async.tsv");

--- a/lib/util_quda.cpp
+++ b/lib/util_quda.cpp
@@ -7,6 +7,7 @@
 #include <enum_quda.h>
 #include <util_quda.h>
 #include <sstream>
+#include <quda_env.h>
 
 static const size_t MAX_PREFIX_SIZE = 100;
 
@@ -29,10 +30,9 @@ void setVerbosity(QudaVerbosity verbosity)
 bool getRankVerbosity() {
   static bool init = false;
   static bool rank_verbosity = false;
-  static char *rank_verbosity_env = getenv("QUDA_RANK_VERBOSITY");
 
-  if (!init && rank_verbosity_env) { // set the policies to tune for explicitly
-    std::stringstream rank_list(rank_verbosity_env);
+  if (!init && quda::QudaEnv::getInstance().get_rank_verbosity()) { // set the policies to tune for explicitly
+    std::stringstream rank_list(quda::QudaEnv::getInstance().get_rank_verbosity());
 
     int rank_;
     while (rank_list >> rank_) {
@@ -53,8 +53,7 @@ QudaTune getTuning() {
   static QudaTune tune = QUDA_TUNE_YES;
 
   if (!init) {
-    char *enable_tuning = getenv("QUDA_ENABLE_TUNING");
-    if (!enable_tuning || strcmp(enable_tuning,"0")!=0) {
+    if (quda::QudaEnv::getInstance().get_enable_tuning()) {
       tune = QUDA_TUNE_YES;
     } else {
       tune = QUDA_TUNE_NO;


### PR DESCRIPTION
Motivation is:
* have a central place for all environment variable
* allow to control the features from within code (e.g. set different dslash policies for the unit tests) without needing to hack that with run scripts

This is not ready for merge but I put it out for suggestions 