### PR TITLE
Saving gauge fields + standalone heatbath

### DIFF
--- a/include/qio_field.h
+++ b/include/qio_field.h
@@ -4,12 +4,19 @@
 #ifdef HAVE_QIO
 void read_gauge_field(const char *filename, void *gauge[], QudaPrecision prec, const int *X,
 		      int argc, char *argv[]);
+void write_gauge_field(const char *filename, void* gauge[], QudaPrecision prec, const int *X,
+          int argc, char* argv[]);
 void read_spinor_field(const char *filename, void *V[], QudaPrecision precision, const int *X,
 		       int nColor, int nSpin, int Nvec, int argc, char *argv[]);
 void write_spinor_field(const char *filename, void *V[], QudaPrecision precision, const int *X,
 			int nColor, int nSpin, int Nvec, int argc, char *argv[]);
 #else
 inline void read_gauge_field(const char *filename, void *gauge[], QudaPrecision prec,
+		      const int *X, int argc, char *argv[]) {
+  printf("QIO support has not been enabled\n");
+  exit(-1);
+}
+inline void write_gauge_field(const char *filename, void *gauge[], QudaPrecision prec,
 		      const int *X, int argc, char *argv[]) {
   printf("QIO support has not been enabled\n");
   exit(-1);

--- a/include/quda.h
+++ b/include/quda.h
@@ -1062,6 +1062,13 @@ extern "C" {
    */
   void plaqQuda(double plaq[3]);
 
+  /*
+   * Performs a deep copy to the internal extendedGaugeResident field.
+   * @param Pointer to externalGaugeResident cudaGaugeField
+   * @param Location of gauge field
+   */
+  void copyResidentGauge(void* resident_gauge, QudaFieldLocation loc);
+
   /**
    * Performs Wuppertal smearing on a given spinor using the gauge field 
    * gaugeSmeared, if it exist, or gaugePrecise if no smeared field is present.

--- a/include/quda.h
+++ b/include/quda.h
@@ -1063,11 +1063,11 @@ extern "C" {
   void plaqQuda(double plaq[3]);
 
   /*
-   * Performs a deep copy to the internal extendedGaugeResident field.
+   * Performs a deep copy from the internal extendedGaugeResident field.
    * @param Pointer to externalGaugeResident cudaGaugeField
    * @param Location of gauge field
    */
-  void copyResidentGauge(void* resident_gauge, QudaFieldLocation loc);
+  void copyExtendedResidentGaugeQuda(void* resident_gauge, QudaFieldLocation loc);
 
   /**
    * Performs Wuppertal smearing on a given spinor using the gauge field 

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -5457,6 +5457,26 @@ void plaqQuda (double plq[3])
   return;
 }
 
+/*
+ * Performs a deep copy to the internal extendedGaugeResident field.
+ */
+void copyResidentGauge(void* resident_gauge, QudaFieldLocation loc)
+{
+  //profilePlaq.TPSTART(QUDA_PROFILE_TOTAL);
+
+  if (!gaugePrecise) errorQuda("Cannot perform deep copy of resident gauge field as there is no resident gauge field");
+
+  cudaGaugeField *data = extendedGaugeResident ? extendedGaugeResident : createExtendedGauge(*gaugePrecise, R, profilePlaq);
+  extendedGaugeResident = data;
+
+  cudaGaugeField* io_gauge = (cudaGaugeField*)resident_gauge;
+
+  copyExtendedGauge(*io_gauge, *extendedGaugeResident, loc);
+
+  //profilePlaq.TPSTOP(QUDA_PROFILE_TOTAL);
+  return;
+}
+
 void performWuppertalnStep(void *h_out, void *h_in, QudaInvertParam *inv_param, 
                            unsigned int nSteps, double alpha)
 {

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -5458,9 +5458,9 @@ void plaqQuda (double plq[3])
 }
 
 /*
- * Performs a deep copy to the internal extendedGaugeResident field.
+ * Performs a deep copy from the internal extendedGaugeResident field.
  */
-void copyResidentGauge(void* resident_gauge, QudaFieldLocation loc)
+void copyExtendedResidentGaugeQuda(void* resident_gauge, QudaFieldLocation loc)
 {
   //profilePlaq.TPSTART(QUDA_PROFILE_TOTAL);
 

--- a/lib/qio_field.cpp
+++ b/lib/qio_field.cpp
@@ -279,6 +279,38 @@ int write_field(QIO_Writer *outfile, int count, void *field_out[], QudaPrecision
   return 0;
 }
 
+int write_su3_field(QIO_Writer *outfile, int count, void *field_out[],
+    QudaPrecision file_prec, QudaPrecision cpu_prec, const char* type)
+{
+  return write_field<18>(outfile, count, field_out, file_prec, cpu_prec, 1, 9, type); 
+}
+
+void write_gauge_field(const char *filename, void* gauge[], QudaPrecision precision, const int *X,
+    int argc, char* argv[]) {
+  this_node = mynode();
+
+  set_layout(X);
+
+  QudaPrecision file_prec = precision;
+
+  char type[128];
+  sprintf(type, "QUDA_%sNc%d_GaugeField", (file_prec == QUDA_DOUBLE_PRECISION) ? "D" : "F", 3);
+
+  /* Open the test file for writing */
+  QIO_Writer *outfile = open_test_output(filename, QIO_SINGLEFILE, QIO_PARALLEL, QIO_ILDGNO);
+  if (outfile == NULL) { printfQuda("Open file failed\n"); exit(0); }
+
+  /* Write the gauge field record */
+  printfQuda("%s: writing the gauge field\n", __func__); fflush(stdout);
+  int status = write_su3_field(outfile, 4, gauge, precision, precision, type);
+  if (status) { errorQuda("write_gauge_field failed %d\n", status); }
+
+  /* Close the file */
+  QIO_close_write(outfile);
+  printfQuda("%s: Closed file for writing\n", __func__);
+}
+
+
 // count is the number of vectors
 // Ninternal is the size of the "inner struct" (24 for Wilson spinor)
 int write_field(QIO_Writer *outfile, int Ninternal, int count, void *field_out[],

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -122,6 +122,10 @@ if(QUDA_GAUGE_ALG)
   cuda_add_executable(gauge_alg_test gauge_alg_test.cpp)
   target_link_libraries(gauge_alg_test ${TEST_LIBS})
   QUDA_CHECKBUILDTEST(gauge_alg_test QUDA_BUILD_ALL_TESTS)
+
+  cuda_add_executable(heatbath_test heatbath_test.cpp)
+  target_link_libraries(heatbath_test ${TEST_LIBS})
+  QUDA_CHECKBUILDTEST(heatbath_test QUDA_BUILD_ALL_TESTS)
 endif()
 
 if(QUDA_FORCE_HISQ)

--- a/tests/gauge_alg_test.cpp
+++ b/tests/gauge_alg_test.cpp
@@ -39,7 +39,6 @@ extern QudaReconstructType link_recon;
 extern QudaReconstructType link_recon_sloppy;
 extern double anisotropy;
 extern char latfile[];
-extern char gauge_outfile[];
 
 int num_failures=0;
 int *num_failures_dev;
@@ -199,11 +198,11 @@ class GaugeAlgTest : public ::testing::Test {
     randstates = new RNG(halfvolume, 1234, param.X);
     randstates->Init();
 
-    nsteps = 100;
+    nsteps = 10;
     nhbsteps = 4;
     novrsteps = 4;
     coldstart = false;
-    beta_value = 6.5;
+    beta_value = 6.2;
 
 
 
@@ -233,29 +232,6 @@ class GaugeAlgTest : public ::testing::Test {
     printfQuda("Time Monte -> %.6f s\n", a1.Last());
     plaq = plaquette( *cudaInGauge, QUDA_CUDA_FIELD_LOCATION) ;
     printfQuda("Plaq: %.16e , %.16e, %.16e\n", plaq.x, plaq.y, plaq.z);
-
-    // Save if output string is specified
-    if (strcmp(gauge_outfile,"")) {
-
-      // Create cpu gauge field
-      QudaGaugeParam gauge_param;
-      cpuSetGaugeParam(gauge_param);
-
-      size_t gSize = (gauge_param.cpu_prec == QUDA_DOUBLE_PRECISION) ? sizeof(double) : sizeof(float);
-      void *cpu_gauge[4];
-      for (int dir = 0; dir < 4; dir++) {
-        cpu_gauge[dir] = malloc(V*gaugeSiteSize*gSize);
-      }
-
-      
-
-      saveGaugeFieldQuda((void*)cpu_gauge, (void*)cudaInGauge, &gauge_param);
-
-      write_gauge_field(gauge_outfile, cpu_gauge, gauge_param.cpu_prec, param.X, 0, (char**)0);
-
-
-      for (int dir = 0; dir<4; dir++) free(cpu_gauge[dir]);
-    }
   }
 
   virtual void TearDown() {

--- a/tests/heatbath_test.cpp
+++ b/tests/heatbath_test.cpp
@@ -249,7 +249,7 @@ int main(int argc, char **argv)
       loadGaugeQuda(load_gauge, &gauge_param);
       // Get pointer to internal resident gauge field
       cudaGaugeField* extendedGaugeResident = new cudaGaugeField(gParamEx);
-      copyResidentGauge((void*)extendedGaugeResident, QUDA_CUDA_FIELD_LOCATION);
+      copyExtendedResidentGaugeQuda((void*)extendedGaugeResident, QUDA_CUDA_FIELD_LOCATION);
       InitGaugeField( *gaugeEx);
       copyExtendedGauge(*gaugeEx, *extendedGaugeResident, QUDA_CUDA_FIELD_LOCATION);
       delete extendedGaugeResident;

--- a/tests/heatbath_test.cpp
+++ b/tests/heatbath_test.cpp
@@ -239,13 +239,20 @@ int main(int argc, char **argv)
 
       printfQuda("Loading the gauge field in %s\n", latfile);
 
+      loadGaugeQuda(load_gauge, &gauge_param);
+      // Get pointer to internal resident gauge field
+      cudaGaugeField* extendedGaugeResident = new cudaGaugeField(gParamEx);
+      copyResidentGauge((void*)extendedGaugeResident, QUDA_CUDA_FIELD_LOCATION);
+      copyExtendedGauge(*gaugeEx, *extendedGaugeResident, QUDA_CUDA_FIELD_LOCATION);
+      delete extendedGaugeResident;
+      /*
       QudaGaugeParam gauge_param = newQudaGaugeParam();
       setGaugeParam(gauge_param);
       GaugeFieldParam gParam(load_gauge, gauge_param, QUDA_WILSON_LINKS);
       gParam.geometry = QUDA_VECTOR_GEOMETRY;
       cpuGaugeField *cpuGauge = new cpuGaugeField(gParam);
       gaugeEx->loadCPUField(*cpuGauge);
-      delete cpuGauge;
+      delete cpuGauge;*/
     }
 
     // copy into regular field
@@ -259,7 +266,7 @@ int main(int argc, char **argv)
     loadGaugeQuda(gauge->Gauge_p(), &gauge_param);
     double3 plaq = plaquette( *gaugeEx, QUDA_CUDA_FIELD_LOCATION) ;
     double charge = qChargeCuda();
-    printfQuda("starting plaquette = %e topological charge = %e\n", plaq.x, charge);
+    printfQuda("Initial gauge field plaquette = %e topological charge = %e\n", plaq.x, charge);
 
     // Reunitarization setup
     setReunitarizationConsts();

--- a/tests/heatbath_test.cpp
+++ b/tests/heatbath_test.cpp
@@ -1,0 +1,360 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <quda.h>
+#include <quda_internal.h>
+#include <gauge_field.h>
+
+#include <comm_quda.h>
+#include <test_util.h>
+#include <gauge_tools.h>
+#include "misc.h"
+
+#include <pgauge_monte.h>
+#include <random_quda.h>
+#include <unitarization_links.h>
+
+#include <qio_field.h>
+
+#if defined(QMP_COMMS)
+#include <qmp.h>
+#elif defined(MPI_COMMS)
+#include <mpi.h>
+#endif
+
+
+
+#define MAX(a,b) ((a)>(b)?(a):(b))
+#define DABS(a) ((a)<(0.)?(-(a)):(a))
+
+// Wilson, clover-improved Wilson, twisted mass, and domain wall are supported.
+extern int device;
+extern int xdim;
+extern int ydim;
+extern int zdim;
+extern int tdim;
+extern int Lsdim;
+extern int gridsize_from_cmdline[];
+extern QudaReconstructType link_recon;
+extern QudaPrecision prec;
+extern QudaPrecision prec_sloppy;
+extern QudaReconstructType link_recon_sloppy;
+extern double anisotropy;
+extern char latfile[];
+extern char gauge_outfile[];
+
+extern void usage(char** );
+
+
+namespace quda {
+  extern void setTransferGPU(bool);
+}
+
+void
+display_test_info()
+{
+  printfQuda("running the following test:\n");
+    
+  printfQuda("prec    sloppy_prec    link_recon  sloppy_link_recon S_dimension T_dimension Ls_dimension\n");
+  printfQuda("%s   %s             %s            %s            %d/%d/%d          %d         %d\n",
+	     get_prec_str(prec),get_prec_str(prec_sloppy),
+	     get_recon_str(link_recon), 
+	     get_recon_str(link_recon_sloppy),  xdim, ydim, zdim, tdim, Lsdim);     
+
+  printfQuda("Grid partition info:     X  Y  Z  T\n"); 
+  printfQuda("                         %d  %d  %d  %d\n", 
+	     dimPartitioned(0),
+	     dimPartitioned(1),
+	     dimPartitioned(2),
+	     dimPartitioned(3)); 
+  
+  return ;
+  
+}
+
+QudaPrecision &cpu_prec = prec;
+QudaPrecision &cuda_prec = prec;
+QudaPrecision &cuda_prec_sloppy = prec_sloppy;
+
+void setGaugeParam(QudaGaugeParam &gauge_param) {
+  gauge_param.X[0] = xdim;
+  gauge_param.X[1] = ydim;
+  gauge_param.X[2] = zdim;
+  gauge_param.X[3] = tdim;
+
+  gauge_param.anisotropy = anisotropy;
+  gauge_param.tadpole_coeff = 1.0;
+  gauge_param.type = QUDA_WILSON_LINKS;
+  gauge_param.gauge_order = QUDA_QDP_GAUGE_ORDER;
+  gauge_param.t_boundary = QUDA_PERIODIC_T;
+  
+  gauge_param.cpu_prec = cpu_prec;
+
+  gauge_param.cuda_prec = cuda_prec;
+  gauge_param.reconstruct = link_recon;
+
+  gauge_param.cuda_prec_sloppy = cuda_prec_sloppy;
+  gauge_param.reconstruct_sloppy = link_recon_sloppy;
+
+  gauge_param.gauge_fix = QUDA_GAUGE_FIXED_NO;
+
+  gauge_param.ga_pad = 0;
+  // For multi-GPU, ga_pad must be large enough to store a time-slice
+#ifdef MULTI_GPU
+  int x_face_size = gauge_param.X[1]*gauge_param.X[2]*gauge_param.X[3]/2;
+  int y_face_size = gauge_param.X[0]*gauge_param.X[2]*gauge_param.X[3]/2;
+  int z_face_size = gauge_param.X[0]*gauge_param.X[1]*gauge_param.X[3]/2;
+  int t_face_size = gauge_param.X[0]*gauge_param.X[1]*gauge_param.X[2]/2;
+  int pad_size =MAX(x_face_size, y_face_size);
+  pad_size = MAX(pad_size, z_face_size);
+  pad_size = MAX(pad_size, t_face_size);
+  gauge_param.ga_pad = pad_size;    
+#endif
+}
+
+ void setReunitarizationConsts(){
+   using namespace quda;
+    const double unitarize_eps = 1e-14;
+    const double max_error = 1e-10;
+    const int reunit_allow_svd = 1;
+    const int reunit_svd_only  = 0;
+    const double svd_rel_error = 1e-6;
+    const double svd_abs_error = 1e-6;
+    setUnitarizeLinksConstants(unitarize_eps, max_error,
+                               reunit_allow_svd, reunit_svd_only,
+                               svd_rel_error, svd_abs_error);
+
+  }
+
+void CallUnitarizeLinks(quda::cudaGaugeField *cudaInGauge){
+   using namespace quda;
+   int *num_failures_dev = (int*)device_malloc(sizeof(int));
+   int num_failures;
+   cudaMemset(num_failures_dev, 0, sizeof(int));
+   unitarizeLinks(*cudaInGauge, num_failures_dev);
+
+   cudaMemcpy(&num_failures, num_failures_dev, sizeof(int), cudaMemcpyDeviceToHost);
+   if(num_failures>0) errorQuda("Error in the unitarization\n");
+   device_free(num_failures_dev);
+  }
+
+int main(int argc, char **argv)
+{
+
+  for (int i = 1; i < argc; i++){
+    if(process_command_line_option(argc, argv, &i) == 0){
+      continue;
+    }
+    printf("ERROR: Invalid option:%s\n", argv[i]);
+    usage(argv);
+  }
+
+  if (prec_sloppy == QUDA_INVALID_PRECISION) prec_sloppy = prec;
+  if (link_recon_sloppy == QUDA_RECONSTRUCT_INVALID) link_recon_sloppy = link_recon;
+
+  // initialize QMP/MPI, QUDA comms grid and RNG (test_util.cpp)
+  initComms(argc, argv, gridsize_from_cmdline);
+
+  // call srand() with a rank-dependent seed
+  initRand();
+
+  display_test_info();
+
+  // *** QUDA parameters begin here.
+
+  QudaGaugeParam gauge_param = newQudaGaugeParam();
+  setGaugeParam(gauge_param);
+
+  // *** Everything between here and the call to initQuda() is
+  // *** application-specific.
+
+  setDims(gauge_param.X);
+
+  setSpinorSiteSize(24);
+
+  size_t gSize = (gauge_param.cpu_prec == QUDA_DOUBLE_PRECISION) ? sizeof(double) : sizeof(float);
+
+  void *load_gauge[4];
+
+  for (int dir = 0; dir < 4; dir++) {
+    load_gauge[dir] = malloc(V*gaugeSiteSize*gSize);
+  }
+
+  if (strcmp(latfile,"")) {  // load in the command line supplied gauge field
+    read_gauge_field(latfile, load_gauge, gauge_param.cpu_prec, gauge_param.X, argc, argv);
+    construct_gauge_field(load_gauge, 2, gauge_param.cpu_prec, &gauge_param);
+  }
+
+  // start the timer
+  double time0 = -((double)clock());
+
+  // initialize the QUDA library
+  initQuda(device);
+
+  {
+    using namespace quda;
+    GaugeFieldParam gParam(0, gauge_param);
+    gParam.pad = 0;
+    gParam.ghostExchange = QUDA_GHOST_EXCHANGE_NO;
+    gParam.create      = QUDA_NULL_FIELD_CREATE;
+    gParam.link_type   = gauge_param.type;
+    gParam.reconstruct = gauge_param.reconstruct;
+    gParam.order       = (gauge_param.cuda_prec == QUDA_DOUBLE_PRECISION || gauge_param.reconstruct == QUDA_RECONSTRUCT_NO )
+      ? QUDA_FLOAT2_GAUGE_ORDER : QUDA_FLOAT4_GAUGE_ORDER;
+    cudaGaugeField *gauge = new cudaGaugeField(gParam);
+
+    int pad = 0;
+    int y[4];
+    int R[4] = {0,0,0,0};
+    for(int dir=0; dir<4; ++dir) if(comm_dim_partitioned(dir)) R[dir] = 2;
+    for(int dir=0; dir<4; ++dir) y[dir] = gauge_param.X[dir] + 2 * R[dir];
+    GaugeFieldParam gParamEx(y, prec, link_recon,
+			     pad, QUDA_VECTOR_GEOMETRY, QUDA_GHOST_EXCHANGE_EXTENDED);
+    gParamEx.create = QUDA_ZERO_FIELD_CREATE;
+    gParamEx.order = gParam.order;
+    gParamEx.siteSubset = QUDA_FULL_SITE_SUBSET;
+    gParamEx.t_boundary = gParam.t_boundary;
+    gParamEx.nFace = 1;
+    for(int dir=0; dir<4; ++dir) gParamEx.r[dir] = R[dir];
+    cudaGaugeField *gaugeEx = new cudaGaugeField(gParamEx);
+    int halfvolume = xdim*ydim*zdim*tdim >> 1;
+    // CURAND random generator initialization
+    RNG *randstates = new RNG(halfvolume, 1234, gauge_param.X);
+    randstates->Init();
+
+    int nsteps = 10;
+    int nhbsteps = 5;
+    int novrsteps = 5;
+    bool  coldstart = false;
+    double beta_value = 6.2;
+
+    if(link_recon != QUDA_RECONSTRUCT_8 && coldstart) InitGaugeField( *gaugeEx);
+    else{
+      InitGaugeField( *gaugeEx, *randstates );
+    }
+
+    // Copy in loaded gauge field
+    if (strcmp(latfile,"")) { 
+
+      printfQuda("Loading the gauge field in %s\n", latfile);
+
+      QudaGaugeParam gauge_param = newQudaGaugeParam();
+      setGaugeParam(gauge_param);
+      GaugeFieldParam gParam(load_gauge, gauge_param, QUDA_WILSON_LINKS);
+      gParam.geometry = QUDA_VECTOR_GEOMETRY;
+      cpuGaugeField *cpuGauge = new cpuGaugeField(gParam);
+      gaugeEx->loadCPUField(*cpuGauge);
+      delete cpuGauge;
+    }
+
+    // copy into regular field
+    copyExtendedGauge(*gauge, *gaugeEx, QUDA_CUDA_FIELD_LOCATION);
+
+    // load the gauge field from gauge
+    gauge_param.gauge_order = (gauge_param.cuda_prec == QUDA_DOUBLE_PRECISION || gauge_param.reconstruct == QUDA_RECONSTRUCT_NO )
+      ? QUDA_FLOAT2_GAUGE_ORDER : QUDA_FLOAT4_GAUGE_ORDER;
+    gauge_param.location = QUDA_CUDA_FIELD_LOCATION;
+
+    loadGaugeQuda(gauge->Gauge_p(), &gauge_param);
+    double3 plaq = plaquette( *gaugeEx, QUDA_CUDA_FIELD_LOCATION) ;
+    double charge = qChargeCuda();
+    printfQuda("starting plaquette = %e topological charge = %e\n", plaq.x, charge);
+
+    // Reunitarization setup
+    setReunitarizationConsts();
+    plaquette( *gaugeEx, QUDA_CUDA_FIELD_LOCATION) ;
+
+    Monte( *gaugeEx, *randstates, beta_value, 100*nhbsteps, 100*novrsteps);
+
+    // copy into regular field
+    copyExtendedGauge(*gauge, *gaugeEx, QUDA_CUDA_FIELD_LOCATION);
+
+    // load the gauge field from gauge
+    gauge_param.gauge_order = (gauge_param.cuda_prec == QUDA_DOUBLE_PRECISION || gauge_param.reconstruct == QUDA_RECONSTRUCT_NO )
+      ? QUDA_FLOAT2_GAUGE_ORDER : QUDA_FLOAT4_GAUGE_ORDER;
+    gauge_param.location = QUDA_CUDA_FIELD_LOCATION;
+
+    loadGaugeQuda(gauge->Gauge_p(), &gauge_param);
+    plaq = plaquette( *gaugeEx, QUDA_CUDA_FIELD_LOCATION) ;
+    charge = qChargeCuda();
+    printfQuda("step=0 plaquette = %e topological charge = %e\n", plaq.x, charge);
+
+
+    freeGaugeQuda();
+
+    for(int step=1; step<=nsteps; ++step){
+      printfQuda("Step %d\n", step);
+      Monte( *gaugeEx, *randstates, beta_value, nhbsteps, novrsteps);
+
+      //Reunitarize gauge links...
+      CallUnitarizeLinks(gaugeEx);
+
+      // copy into regular field
+      copyExtendedGauge(*gauge, *gaugeEx, QUDA_CUDA_FIELD_LOCATION);
+
+      loadGaugeQuda(gauge->Gauge_p(), &gauge_param);
+      plaq = plaquette( *gaugeEx, QUDA_CUDA_FIELD_LOCATION) ;
+      charge = qChargeCuda();
+      printfQuda("step=%d plaquette = %e topological charge = %e\n", step, plaq.x, charge);
+
+      freeGaugeQuda();
+    }
+
+    // Save if output string is specified
+    if (strcmp(gauge_outfile,"")) {
+
+      printfQuda("Saving the gauge field to file %s\n", gauge_outfile);
+
+      QudaGaugeParam gauge_param = newQudaGaugeParam();
+      setGaugeParam(gauge_param);
+
+      size_t gSize = (gauge_param.cpu_prec == QUDA_DOUBLE_PRECISION) ? sizeof(double) : sizeof(float);
+      void *cpu_gauge[4];
+      for (int dir = 0; dir < 4; dir++) {
+        cpu_gauge[dir] = malloc(V*gaugeSiteSize*gSize);
+      }
+
+      // copy into regular field
+      copyExtendedGauge(*gauge, *gaugeEx, QUDA_CUDA_FIELD_LOCATION);
+
+      saveGaugeFieldQuda((void*)cpu_gauge, (void*)gauge, &gauge_param);
+
+      write_gauge_field(gauge_outfile, cpu_gauge, gauge_param.cpu_prec, gauge_param.X, 0, (char**)0);
+
+
+      for (int dir = 0; dir<4; dir++) free(cpu_gauge[dir]);
+    } else {
+      printfQuda("No output file specified.\n");
+    }
+
+    delete gauge;
+    delete gaugeEx;
+    //Release all temporary memory used for data exchange between GPUs in multi-GPU mode
+    PGaugeExchangeFree();
+ 
+    randstates->Release();
+    delete randstates;
+  }
+
+  // stop the timer
+  time0 += clock();
+  time0 /= CLOCKS_PER_SEC;
+    
+  //printfQuda("\nDone: %i iter / %g secs = %g Gflops, total time = %g secs\n", 
+  //inv_param.iter, inv_param.secs, inv_param.gflops/inv_param.secs, time0);
+  printfQuda("\nDone, total time = %g secs\n", 
+	 time0);
+
+  freeGaugeQuda();
+  
+  // finalize the QUDA library
+  endQuda();
+
+  // finalize the communications layer
+  finalizeComms();
+
+  for (int dir = 0; dir<4; dir++) free(load_gauge[dir]);
+
+  return 0;
+}

--- a/tests/test_util.cpp
+++ b/tests/test_util.cpp
@@ -1694,6 +1694,14 @@ QudaExtLibType deflation_ext_lib  = QUDA_EIGEN_EXTLIB;
 QudaFieldLocation location_ritz   = QUDA_CUDA_FIELD_LOCATION;
 QudaMemoryType    mem_type_ritz   = QUDA_MEMORY_DEVICE;
 
+double heatbath_beta_value = 6.2;
+int heatbath_warmup_steps = 10;
+int heatbath_num_steps = 10;
+int heatbath_num_heatbath_per_step = 5;
+int heatbath_num_overrelax_per_step = 5;
+bool heatbath_coldstart = false;
+
+
 static int dim_partitioned[4] = {0,0,0,0};
 
 int dimPartitioned(int dim)
@@ -1810,6 +1818,12 @@ void usage(char** argv )
   printf("    --nsrc <n>                                # How many spinors to apply the dslash to simultaneusly (experimental for staggered only)\n");
 
   printf("    --msrc <n>                                # Used for testing non-square block blas routines where nsrc defines the other dimension\n");
+  printf("    --heatbath-beta <beta>                    # Beta value used in heatbath test (default 6.2)\n");
+  printf("    --heatbath-warmup-steps <n>               # Number of warmup steps in heatbath test (default 10)\n");
+  printf("    --heatbath-num-steps <n>                  # Number of measurement steps in heatbath test (default 10)\n");
+  printf("    --heatbath-num-hb-per-step <n>            # Number of heatbath hits per heatbath step (default 5)\n");
+  printf("    --heatbath-num-or-per-step <n>            # Number of overrelaxation hits per heatbath step (default 5)\n");
+  printf("    --heatbath-coldstart <true/false>         # Whether to use a cold or hot start in heatbath test (default false)\n");
   printf("    --help                                    # Print out this message\n");
 
   usage_extra(argv); 
@@ -3202,6 +3216,95 @@ int process_command_line_option(int argc, char** argv, int* idx)
       printf("ERROR: invalid solution pipeline length (%d)\n", solution_accumulator_pipeline);
       usage(argv);
     }
+    i++;
+    ret = 0;
+    goto out;
+  }
+
+  if( strcmp(argv[i], "--heatbath-beta") == 0){
+    if (i+1 >= argc){
+      usage(argv);
+    }
+    heatbath_beta_value = atof(argv[i+1]);
+    if (heatbath_beta_value <= 0.0){
+      printf("ERROR: invalid beta (%f)\n", heatbath_beta_value);
+      usage(argv);
+    }
+    i++;
+    ret = 0;
+    goto out;
+  }
+
+  if( strcmp(argv[i], "--heatbath-warmup-steps") == 0){
+    if (i+1 >= argc){
+      usage(argv);
+    }
+    heatbath_warmup_steps = atoi(argv[i+1]);
+    if (heatbath_warmup_steps < 0){
+      printf("ERROR: invalid number of warmup steps (%d)\n", heatbath_warmup_steps);
+      usage(argv);
+    }
+    i++;
+    ret = 0;
+    goto out;
+  }
+
+  if( strcmp(argv[i], "--heatbath-num-steps") == 0){
+    if (i+1 >= argc){
+      usage(argv);
+    }
+    heatbath_num_steps = atoi(argv[i+1]);
+    if (heatbath_num_steps < 0){
+      printf("ERROR: invalid number of heatbath steps (%d)\n", heatbath_num_steps);
+      usage(argv);
+    }
+    i++;
+    ret = 0;
+    goto out;
+  }
+
+  if( strcmp(argv[i], "--heatbath-num-hb-per-step") == 0){
+    if (i+1 >= argc){
+      usage(argv);
+    }
+    heatbath_num_heatbath_per_step = atoi(argv[i+1]);
+    if (heatbath_num_heatbath_per_step <= 0){
+      printf("ERROR: invalid number of heatbath hits per step (%d)\n", heatbath_num_heatbath_per_step);
+      usage(argv);
+    }
+    i++;
+    ret = 0;
+    goto out;
+  }
+
+  if( strcmp(argv[i], "--heatbath-num-or-per-step") == 0){
+    if (i+1 >= argc){
+      usage(argv);
+    }
+    heatbath_num_overrelax_per_step = atoi(argv[i+1]);
+    if (heatbath_num_overrelax_per_step <= 0){
+      printf("ERROR: invalid number of overrelaxation hits per step (%d)\n", heatbath_num_overrelax_per_step);
+      usage(argv);
+    }
+    i++;
+    ret = 0;
+    goto out;
+  }
+
+  if( strcmp(argv[i], "--heatbath-coldstart") == 0){
+    if (i+1 >= argc){
+      usage(argv);
+    }
+
+    if (strcmp(argv[i+1], "true") == 0){
+      heatbath_coldstart = true;
+    }else if (strcmp(argv[i+1], "false") == 0){
+      heatbath_coldstart = false;
+    }else{
+      fprintf(stderr, "ERROR: invalid value for heatbath_coldstart type\n");
+      usage(argv);
+    }
+
     i++;
     ret = 0;
     goto out;

--- a/tests/test_util.cpp
+++ b/tests/test_util.cpp
@@ -1619,6 +1619,7 @@ int Lsdim = 16;
 QudaDagType dagger = QUDA_DAG_NO;
 QudaDslashType dslash_type = QUDA_WILSON_DSLASH;
 char latfile[256] = "";
+char gauge_outfile[256] = "";
 int Nsrc = 1;
 int Msrc = 1;
 int niter = 100;
@@ -1738,6 +1739,7 @@ void usage(char** argv )
          "                                                  /asqtad/domain-wall/domain-wall-4d/mobius/laplace\n");
   printf("    --flavor <type>                           # Set the twisted mass flavor type (singlet (default), deg-doublet, nondeg-doublet)\n");
   printf("    --load-gauge file                         # Load gauge field \"file\" for the test (requires QIO)\n");
+  printf("    --save-gauge file                         # Save gauge field \"file\" for the test (requires QIO, heatbath test only)\n");
   printf("    --niter <n>                               # The number of iterations to perform (default 10)\n");
   printf("    --ngcrkrylov <n>                          # The number of inner iterations to use for GCR, BiCGstab-l (default 10)\n");
   printf("    --pipeline <n>                            # The pipeline length for fused operations in GCR, BiCGstab-l (default 0, no pipelining)\n");
@@ -2417,6 +2419,16 @@ int process_command_line_option(int argc, char** argv, int* idx)
       usage(argv);
     }     
     strcpy(latfile, argv[i+1]);
+    i++;
+    ret = 0;
+    goto out;
+  }
+
+  if( strcmp(argv[i], "--save-gauge") == 0){
+    if (i+1 >= argc){
+      usage(argv);
+    }     
+    strcpy(gauge_outfile, argv[i+1]);
     i++;
     ret = 0;
     goto out;


### PR DESCRIPTION
This pull request adds in routines to save gauge fields in single or double position. It additionally adds a standalone heatbath executable in the test directory which can optionally load and, more importantly, save generated gauge fields. 

The following heatbath parameters are exposed on the command line: the value of beta; the number of thermalization and measurement (plaquette+topology) steps; the number of heatbath and overrelaxation hits per step; and whether to use a cold or hot start, or load from a file.

I'll work on documenting the new flags on the wiki momentarily.
