### PR TITLE
Feature/trace

### DIFF
--- a/include/malloc_quda.h
+++ b/include/malloc_quda.h
@@ -8,6 +8,26 @@ namespace quda {
   void printPeakMemUsage();
   void assertAllMemFree();
 
+  /**
+     @return peak device memory allocated
+   */
+  long device_allocated_peak();
+
+  /**
+     @return peak pinned memory allocated
+   */
+  long pinned_allocated_peak();
+
+  /**
+     @return peak mapped memory allocated
+   */
+  long mapped_allocated_peak();
+
+  /**
+     @return peak host memory allocated
+   */
+  long host_allocated_peak();
+
   /*
    * The following functions should not be called directly.  Use the
    * macros below instead.

--- a/lib/dslash_coarse.cu
+++ b/lib/dslash_coarse.cu
@@ -624,7 +624,8 @@ namespace quda {
       : out(out), inA(inA), inB(inB), Y(Y), X(X), kappa(kappa), parity(parity),
       nParity(out.SiteSubset()), nSrc(out.Ndim()==5 ? out.X(4) : 1)
     {
-      strcpy(aux, out.AuxString());
+      strcpy(aux, "policy_kernel,");
+      strcat(aux, out.AuxString());
       strcat(aux, comm_dim_partitioned_string());
 
       // record the location of where each pack buffer is in [2*dim+dir] ordering

--- a/lib/dslash_pack.cu
+++ b/lib/dslash_pack.cu
@@ -854,7 +854,8 @@ namespace quda {
     unsigned int minThreads() const { return threads(); }
 
     void fillAux() {
-      strcpy(aux, in->AuxString());
+      strcpy(aux,"policy_kernel,");
+      strcat(aux, in->AuxString());
       char comm[5];
       comm[0] = (commDim[0] ? '1' : '0');
       comm[1] = (commDim[1] ? '1' : '0');

--- a/lib/dslash_quda.cuh
+++ b/lib/dslash_quda.cuh
@@ -536,14 +536,14 @@ public:
 
     fillAuxBase();
 #ifdef MULTI_GPU
-    fillAux(INTERIOR_KERNEL, "type=interior");
-    fillAux(EXTERIOR_KERNEL_ALL, "type=exterior_all");
-    fillAux(EXTERIOR_KERNEL_X, "type=exterior_x");
-    fillAux(EXTERIOR_KERNEL_Y, "type=exterior_y");
-    fillAux(EXTERIOR_KERNEL_Z, "type=exterior_z");
-    fillAux(EXTERIOR_KERNEL_T, "type=exterior_t");
+    fillAux(INTERIOR_KERNEL, "policy_kernel=interior");
+    fillAux(EXTERIOR_KERNEL_ALL, "policy_kernel=exterior_all");
+    fillAux(EXTERIOR_KERNEL_X, "policy_kernel=exterior_x");
+    fillAux(EXTERIOR_KERNEL_Y, "policy_kernel=exterior_y");
+    fillAux(EXTERIOR_KERNEL_Z, "policy_kernel=exterior_z");
+    fillAux(EXTERIOR_KERNEL_T, "policy_kernel=exterior_t");
 #else
-    fillAux(INTERIOR_KERNEL, "type=single-GPU");
+    fillAux(INTERIOR_KERNEL, "policy_kernel=single-GPU");
 #endif // MULTI_GPU
     fillAux(KERNEL_POLICY, "policy");
 

--- a/lib/malloc.cpp
+++ b/lib/malloc.cpp
@@ -54,6 +54,14 @@ namespace quda {
   static long total_host_bytes, max_total_host_bytes;
   static long total_pinned_bytes, max_total_pinned_bytes;
 
+  long device_allocated_peak() { return max_total_bytes[DEVICE]; }
+
+  long pinned_allocated_peak() { return max_total_bytes[PINNED]; }
+
+  long mapped_allocated_peak() { return max_total_bytes[MAPPED]; }
+
+  long host_allocated_peak() { return max_total_bytes[HOST]; }
+
   static void print_trace (void) {
     void *array[10];
     size_t size;

--- a/lib/multi_reduce_core.cuh
+++ b/lib/multi_reduce_core.cuh
@@ -213,7 +213,7 @@ template<typename doubleN, typename ReduceType, typename FloatN, int M, int NXZ,
   for (int i=0; i<NXZ; i++) {
     for (int j=0; j<arg.NYW; j++) {
       result[i*arg.NYW+j] = set(((ReduceType*)getHostReduceBuffer())[j*NXZ+i]);
-      if (tp.grid.z==2) result[i*arg.NYW+j] = set(((ReduceType*)getHostReduceBuffer())[NXZ*arg.NYW+j*NXZ+i]);
+      if (tp.grid.z==2) sum(result[i*arg.NYW+j], ((ReduceType*)getHostReduceBuffer())[NXZ*arg.NYW+j*NXZ+i]);
     }
   }
 }

--- a/lib/multi_reduce_core.cuh
+++ b/lib/multi_reduce_core.cuh
@@ -278,7 +278,10 @@ public:
     strcpy(name, num_to_string<NXZ>::value);
     strcat(name, std::to_string(NYW).c_str());
     strcat(name, typeid(arg.r).name());
-    return TuneKey(blasStrings.vol_str, name, blasStrings.aux_tmp);
+    char aux[TuneKey::aux_n];
+    strcpy(aux, "policy_kernel,");
+    strcat(aux,blasStrings.aux_tmp);
+    return TuneKey(blasStrings.vol_str, name, aux);
   }
 
   void apply(const cudaStream_t &stream){

--- a/lib/tune.cpp
+++ b/lib/tune.cpp
@@ -244,12 +244,21 @@ namespace quda {
 
       TuneKey &key = it->key;
 
+      // special case kernel members of a policy
+      char tmp[14] = { };
+      strncpy(tmp, key.aux, 13);
+      bool is_policy_kernel = strcmp(tmp, "policy_kernel") == 0 ? true : false;
+
       out << std::setw(12) << it->time << "\t";
       out << std::setw(12) << it->device_bytes << "\t";
       out << std::setw(12) << it->pinned_bytes << "\t";
       out << std::setw(12) << it->mapped_bytes << "\t";
       out << std::setw(12) << it->host_bytes << "\t";
-      out << std::setw(16) << key.volume << "\t" << key.name << "\t" << key.aux << std::endl;
+      out << std::setw(16) << key.volume << "\t";
+      if (is_policy_kernel) out << "\t";
+      out << key.name << "\t";
+      if (!is_policy_kernel) out << "\t";
+      out << key.aux << std::endl;
 
     }
   }
@@ -557,7 +566,7 @@ namespace quda {
       async_profile_file.close();
 
       if (traceEnabled()) {
-        trace_file << Label << "\t" << quda_version;
+        trace_file << "trace" << "\t" << quda_version;
 #ifdef GITVERSION
         trace_file << "\t" << gitversion;
 #else

--- a/lib/tune.cpp
+++ b/lib/tune.cpp
@@ -8,6 +8,7 @@
 #include <fstream>
 #include <typeinfo>
 #include <map>
+#include <list>
 #include <unistd.h>
 
 #include <deque>
@@ -28,12 +29,67 @@ quda::TuneKey getLastTuneKey() { return quda::last_key; }
 namespace quda {
   typedef std::map<TuneKey, TuneParam> map;
 
+  struct TraceKey {
+
+    TuneKey key;
+    float time;
+
+    long device_bytes;
+    long pinned_bytes;
+    long mapped_bytes;
+    long host_bytes;
+
+    TraceKey() { }
+
+    TraceKey(const TuneKey &key, float time)
+      : key(key), time(time),
+        device_bytes(device_allocated_peak()),
+        pinned_bytes(pinned_allocated_peak()),
+        mapped_bytes(mapped_allocated_peak()),
+        host_bytes(host_allocated_peak()) { }
+
+    TraceKey(const TraceKey &trace)
+      : key(trace.key), time(trace.time),
+        device_bytes(trace.device_bytes),
+        pinned_bytes(trace.pinned_bytes),
+        mapped_bytes(trace.mapped_bytes),
+        host_bytes(trace.host_bytes) { }
+
+    TraceKey& operator=(const TraceKey &trace) {
+      if (&trace != this) {
+        key = trace.key;
+        time = trace.time;
+        device_bytes = trace.device_bytes;
+        pinned_bytes = trace.pinned_bytes;
+        mapped_bytes = trace.mapped_bytes;
+        host_bytes = trace.host_bytes;
+      }
+      return *this;
+    }
+  };
+
+  // linked list that is augmented each time we call a kernel
+  static std::list<TraceKey> trace_list;
+  static bool enable_trace = false;
+
+  bool traceEnabled() {
+    static bool init = false;
+
+    if (!init) {
+      char *enable_trace_env = getenv("QUDA_ENABLE_TRACE");
+      if (enable_trace_env && strcmp(enable_trace_env, "1") == 0) {
+        enable_trace = true;
+      }
+      init = true;
+    }
+    return enable_trace;
+  }
+
   static const std::string quda_hash = QUDA_HASH; // defined in lib/Makefile
   static std::string resource_path;
   static map tunecache;
   static map::iterator it;
   static size_t initial_cache_size = 0;
-
 
 #define STR_(x) #x
 #define STR(x) STR_(x)
@@ -177,6 +233,25 @@ namespace quda {
 
     out << std::endl << "# Total time spent in kernels = " << total_time << " seconds" << std::endl;
     async_out << std::endl << "# Total time spent in asynchronous execution = " << async_total_time << " seconds" << std::endl;
+  }
+
+  /**
+   * Serialize trace to an ostream, useful for writing to a file or sending to other nodes.
+   */
+  static void serializeTrace(std::ostream &out)
+  {
+    for (auto it = trace_list.begin(); it != trace_list.end(); it++) {
+
+      TuneKey &key = it->key;
+
+      out << std::setw(12) << it->time << "\t";
+      out << std::setw(12) << it->device_bytes << "\t";
+      out << std::setw(12) << it->pinned_bytes << "\t";
+      out << std::setw(12) << it->mapped_bytes << "\t";
+      out << std::setw(12) << it->host_bytes << "\t";
+      out << std::setw(16) << key.volume << "\t" << key.name << "\t" << key.aux << std::endl;
+
+    }
   }
 
 
@@ -389,8 +464,8 @@ namespace quda {
   {
     time_t now;
     int lock_handle;
-    std::string lock_path, profile_path, async_profile_path;
-    std::ofstream profile_file, async_profile_file;
+    std::string lock_path, profile_path, async_profile_path, trace_path;
+    std::ofstream profile_file, async_profile_file, trace_file;
 
     if (resource_path.empty()) return;
 
@@ -419,18 +494,21 @@ namespace quda {
       char *profile_fname = getenv("QUDA_PROFILE_OUTPUT_BASE");
 
       if (!profile_fname) {
-	warningQuda("Environment variable QUDA_PROFILE_OUTPUT_BASE is not set; writing to profile.tsv and profile_async.tsv");
+        warningQuda("Environment variable QUDA_PROFILE_OUTPUT_BASE not set; writing to profile.tsv and profile_async.tsv");
 	profile_path = resource_path + "/profile_" + std::to_string(count) + ".tsv";
 	async_profile_path = resource_path + "/profile_async_" + std::to_string(count) + ".tsv";
+        if (traceEnabled()) trace_path = resource_path + "/trace_" + std::to_string(count) + ".tsv";
       } else {
 	profile_path = resource_path + "/" + profile_fname + "_" + std::to_string(count) + ".tsv";
 	async_profile_path = resource_path + "/" + profile_fname + "_" + std::to_string(count) + "_async.tsv";
+	if (traceEnabled()) trace_path = resource_path + "/" + profile_fname + "_trace_" + std::to_string(count) + ".tsv";
       }
 
       count++;
 
       profile_file.open(profile_path.c_str());
       async_profile_file.open(async_profile_path.c_str());
+      if (traceEnabled()) trace_file.open(trace_path.c_str());
 
       if (getVerbosity() >= QUDA_SUMMARIZE) {
 	// compute number of non-zero entries that will be output in the profile
@@ -448,6 +526,7 @@ namespace quda {
 
 	printfQuda("Saving %d sets of cached parameters to %s\n", n_entry, profile_path.c_str());
 	printfQuda("Saving %d sets of cached profiles to %s\n", n_policy, async_profile_path.c_str());
+	if (traceEnabled()) printfQuda("Saving trace list with %lu entries to %s\n", trace_list.size(), trace_path.c_str());
       }
 
       time(&now);
@@ -477,6 +556,24 @@ namespace quda {
       profile_file.close();
       async_profile_file.close();
 
+      if (traceEnabled()) {
+        trace_file << Label << "\t" << quda_version;
+#ifdef GITVERSION
+        trace_file << "\t" << gitversion;
+#else
+        trace_file << "\t" << quda_version;
+#endif
+        trace_file << "\t" << quda_hash << "\t# Last updated " << ctime(&now) << std::endl;
+
+        trace_file << std::setw(12) << "time\t" << std::setw(12) << "device-mem\t" << std::setw(12) << "pinned-mem\t";
+        trace_file << std::setw(12) << "mapped-mem\t" << std::setw(12) << "host-mem\t";
+        trace_file << std::setw(16) << "volume" << "\tname\taux" << std::endl;
+
+        serializeTrace(trace_file);
+
+        trace_file.close();
+      }
+
       // Release lock.
       close(lock_handle);
       remove(lock_path.c_str());
@@ -485,7 +582,6 @@ namespace quda {
     }
 #endif
   }
-
 
   static TimeProfile launchTimer("tuneLaunch");
 
@@ -550,6 +646,12 @@ namespace quda {
       launchTimer.TPSTOP(QUDA_PROFILE_EPILOGUE);
       launchTimer.TPSTOP(QUDA_PROFILE_TOTAL);
 #endif
+
+      if (traceEnabled()) {
+        TraceKey trace_entry(key, param.time);
+        trace_list.push_back(trace_entry);
+      }
+
       return param;
     }
 
@@ -662,6 +764,11 @@ namespace quda {
 	errorQuda("Failed to find key entry (%s:%s:%s)", key.name, key.volume, key.aux);
       }
       param = tunecache[key]; // read this now for all processes
+
+      if (traceEnabled()) {
+        TraceKey trace_entry(key, param.time);
+        trace_list.push_back(trace_entry);
+      }
 
     } else if (&tunable != active_tunable) {
       errorQuda("Unexpected call to tuneLaunch() in %s::apply()", typeid(tunable).name());

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -137,7 +137,9 @@ endif()
 
 
 ## BLAS test
-add_test(NAME blas_test COMMAND blas_test --sdim 16 --tdim 16 --gtest_output=xml:blas_test.xml)
+
+add_test(NAME blas_test_parity COMMAND blas_test --sdim 16 --tdim 16 --solve-type direct-pc --gtest_output=xml:blas_test_parity.xml)
+add_test(NAME blas_test_full COMMAND blas_test --sdim 16 --tdim 16 --solve-type direct --gtest_output=xml:blas_test_full.xml)
 
 
 # loop over Dslash policies

--- a/tests/blas_test.cu
+++ b/tests/blas_test.cu
@@ -29,6 +29,7 @@ extern int niter;
 extern bool verify_results;
 extern int Nsrc;
 extern int Msrc;
+extern QudaSolveType solve_type;
 
 extern void usage(char** );
 
@@ -108,7 +109,15 @@ void initFields(int prec)
   param.nDim = 4; // number of spacetime dimensions
 
   param.pad = 0; // padding must be zero for cpu fields
-  param.siteSubset = QUDA_PARITY_SITE_SUBSET;
+
+  if (solve_type == QUDA_DIRECT_PC_SOLVE) {
+    param.siteSubset = QUDA_PARITY_SITE_SUBSET;
+  } else if (solve_type == QUDA_DIRECT_SOLVE) {
+    param.siteSubset = QUDA_FULL_SITE_SUBSET;
+  } else {
+    errorQuda("Unexpected solve_type=%d\n", solve_type);
+  }
+
   if (param.siteSubset == QUDA_PARITY_SITE_SUBSET) param.x[0] = xdim/2;
   else param.x[0] = xdim;
   param.x[1] = ydim;


### PR DESCRIPTION
This pull adds automated tracing to QUDA, dumping out a trace file if `QUDA_ENABLE_TRACE=1` is set.  This records each kernel call in sequence, together with the time taken for each, and the peak memory allocated at the time the kernel is called.

For example, here are the first few lines from running `invert_test --partition 12`
```
trace	0.9.0	v0.9.0a1-with_v.0.8_milc_interface-293-g445cb6b-dirty-sm_60	cpu_arch=x86_64,gpu_arch=sm_60,cuda_version=9020	# Last updated Fri Jul  6 00:02:13 2018

       time	 device-mem	 pinned-mem	 mapped-mem	   host-mem	          volume	name	aux
  0.00445587	   302779904	           0	     4202496	     7968060	  bytes=47775744	cudaMemcpyHostToDevice	copy,cuda_gauge_field.cu,654
  0.00445587	   302779904	           0	     4202496	     7968060	  bytes=47775744	cudaMemcpyHostToDevice	copy,cuda_gauge_field.cu,654
  0.00445587	   302779904	           0	     4202496	     7968060	  bytes=47775744	cudaMemcpyHostToDevice	copy,cuda_gauge_field.cu,654
  0.00445587	   302779904	           0	     4202496	     7968060	  bytes=47775744	cudaMemcpyHostToDevice	copy,cuda_gauge_field.cu,654
 0.000522752	   302779904	           0	     4202496	     7968060	     24x24x24x24	N4quda9CopyGaugeIfdLi18ENS_5gauge11FloatNOrderIfLi18ELi2ELi18EL20QudaStaggeredPhase_s0ELb1EEENS1_8QDPOrderIdLi18EEELb0EEE	out_stride=172800,in_stride=165888,geome
try=4
  3.0368e-05	   430181888	           0	   131604480	     7968252	     24x24x24x24	N4quda12ExtractGhostIfLi18ELi4ENS_5gauge11FloatNOrderIfLi18ELi2ELi18EL20QudaStaggeredPhase_s0ELb1EEEEE	stride=172800
  2.9824e-05	   430181888	           0	   131604480	     7968252	   bytes=3981312	cudaMemcpyDeviceToDevice	exchangeGhost,cuda_gauge_field.cu,243
  2.9824e-05	   430181888	           0	   131604480	     7968252	   bytes=3981312	cudaMemcpyDeviceToDevice	exchangeGhost,cuda_gauge_field.cu,243
  2.3296e-05	   430181888	           0	   131604480	     7968252	     24x24x24x24	N4quda9CopyGaugeIffLi18ENS_5gauge11FloatNOrderIfLi18ELi2ELi18EL20QudaStaggeredPhase_s0ELb1EEES4_Lb1EEE	out_stride=172800,in_stride=172800,geometry=4
   0.0030496	   430181888	           0	   131604480	     7968252	  bytes=31850496	cudaMemcpyHostToDevice	loadSpinorField,cuda_color_spinor_field.cu,586
   9.728e-05	   430181888	           0	   131604480	     7968252	     12x24x24x24	N4quda15CopyColorSpinorIfdLi4ELi3ENS_18CopyColorSpinorArgINS_11colorspinor11FloatNOrderIfLi4ELi3ELi4ELb0EEENS2_21SpaceSpinorColorOrderIdLi4ELi3EEEEEEE	out_stride=16588
8,in_stride=165888,NonRelBasis
 3.67787e-05	   430181888	           0	   131604480	     7968252	     12x24x24x24	N4quda4blas5Norm2Id6float26float4EE	vol=165888,stride=165888,precision=4,Ns=4,Nc=3
 3.67787e-05	   430181888	           0	   131604480	     7968252	     12x24x24x24	N4quda4blas5Norm2Id6float26float4EE	vol=165888,stride=165888,precision=4,Ns=4,Nc=3
 3.67787e-05	   430181888	           0	   131604480	     7968252	     12x24x24x24	N4quda4blas5Norm2Id6float26float4EE	vol=165888,stride=165888,precision=4,Ns=4,Nc=3
 3.67787e-05	   430181888	           0	   131604480	     7968252	     12x24x24x24	N4quda4blas5Norm2Id6float26float4EE	vol=165888,stride=165888,precision=4,Ns=4,Nc=3
 3.67787e-05	   430181888	           0	   131604480	     7968252	     12x24x24x24	N4quda4blas5Norm2Id6float26float4EE	vol=165888,stride=165888,precision=4,Ns=4,Nc=3
  7.4208e-05	   430181888	           0	   131604480	     7968252	  bytes=15925248	cudaMemcpyDeviceToDevice	copy,copy_quda.cu,133
 4.77867e-06	   430181888	           0	   131604480	     7968252	     12x24x24x24	N4quda14PackFaceWilsonI6float4fEE	vol=165888,stride=165888,precision=4,Ns=4,Nc=3,comm=0011,topo=1111,nFace=1,device-device
  0.00027088	   430181888	           0	   131604480	     7968252	     12x24x24x24	N4quda16WilsonDslashCudaI6float4S1_EE	type=interior,ghost=0011,comm=0011,reconstruct=18,dagger
   8.672e-06	   430181888	           0	   131604480	     7968252	     12x24x24x24	N4quda16WilsonDslashCudaI6float4S1_EE	type=exterior_t,comm=0011,reconstruct=18,dagger
    8.48e-06	   430181888	           0	   131604480	     7968252	     12x24x24x24	N4quda16WilsonDslashCudaI6float4S1_EE	type=exterior_z,comm=0011,reconstruct=18,dagger
``` 

As well as being able to follow the program flow, one additional very useful feature of this trace will be to track where most of the memory is being allocated to allow for more efficient memory optimization.

By design we do not include the calls to all kernels when autotuning, but we do include the various kernels calls that occur when policy tuning.  As a result the trace produced when autotuning and post tuning will be different. 

Lastly, I have left this as opt-in, since the `std::list` containing the trace could get rather large for long running jobs.  Hence this should be used for development only.

Edit: a couple of other additions I've put in the pull
* All kernels called as members of a given policy are now indented to more easily see what kernels are part of a policy  (All policy constituent kernels are now labelled with `policy_kernel,` at the beginning of their `aux` string to identify these.)
* Fix bug in multi-reductions on full fields
* Extend ctest coverage for blas_test to cover full fields as well as single parity fields