### PR TITLE
Hotfix/profile naik epsilon

### DIFF
--- a/include/quda_constants.h
+++ b/include/quda_constants.h
@@ -1,6 +1,6 @@
 #define QUDA_VERSION_MAJOR     0
 #define QUDA_VERSION_MINOR     9
-#define QUDA_VERSION_SUBMINOR  0
+#define QUDA_VERSION_SUBMINOR  1
 
 /**
  * @def   QUDA_VERSION

--- a/include/quda_milc_interface.h
+++ b/include/quda_milc_interface.h
@@ -40,6 +40,8 @@ extern "C" {
     int make_resident_solution; /** Make the solution resident and don't copy back */
     int use_resident_solution; /** Use the resident solution */
     QudaInverterType solver_type; /** Type of solver to use */
+    double tadpole; /** Tadpole improvement factor */
+    double naik_epsilon; /** Naik epsilon parameter (HISQ fermions only).*/
   } QudaInvertArgs_t;
 
   /**
@@ -197,7 +199,6 @@ extern "C" {
    * @param inv_args Struct setting some solver metadata
    * @param milc_fatlink Fat-link field on the host
    * @param milc_longlink Long-link field on the host
-   * @param tadpole Tadpole improvement facter
    * @param source Right-hand side source field
    * @param solution Solution spinor field
    */
@@ -206,7 +207,6 @@ extern "C" {
 		  QudaInvertArgs_t inv_args,
 		  const void* const milc_fatlink,
 		  const void* const milc_longlink,
-		  const double tadpole,
 		  void* source,
 		  void* solution,
 		  int* num_iters);
@@ -264,7 +264,6 @@ extern "C" {
    * @param target_relative_residual Target Fermilab residual
    * @param milc_fatlink Fat-link field on the host
    * @param milc_longlink Long-link field on the host
-   * @param tadpole Tadpole improvement facter
    * @param source Right-hand side source field
    * @param solution Solution spinor field
    * @param final_residual True residual
@@ -279,7 +278,6 @@ extern "C" {
 		  double target_fermilab_residual,
 		  const void* const milc_fatlink,
 		  const void* const milc_longlink,
-		  const double tadpole,
 		  void* source,
 		  void* solution,
 		  double* const final_resid,
@@ -300,7 +298,6 @@ extern "C" {
    * @param target_relative_residual Target Fermilab residual
    * @param milc_fatlink Fat-link field on the host
    * @param milc_longlink Long-link field on the host
-   * @param tadpole Tadpole improvement facter
    * @param source array of right-hand side source fields
    * @param solution array of solution spinor fields
    * @param final_residual True residual
@@ -316,7 +313,6 @@ extern "C" {
                       double target_fermilab_residual,
                       const void* const fatlink,
                       const void* const longlink,
-                      const double tadpole,
                       void** sourceArray,
                       void** solutionArray,
                       double* const final_residual,
@@ -342,7 +338,6 @@ extern "C" {
    * @param target_relative_residual Array of target Fermilab residuals per shift
    * @param milc_fatlink Fat-link field on the host
    * @param milc_longlink Long-link field on the host
-   * @param tadpole Tadpole improvement factor
    * @param source Right-hand side source field
    * @param solutionArray Array of solution spinor fields
    * @param final_residual Array of true residuals
@@ -359,7 +354,6 @@ extern "C" {
       const double* target_fermilab_residual,
       const void* const milc_fatlink,
       const void* const milc_longlink,
-      const double tadpole,
       void* source,
       void** solutionArray,
       double* const final_residual,
@@ -385,7 +379,6 @@ extern "C" {
    * @param target_relative_residual Array of target Fermilab residuals per shift
    * @param milc_fatlink Fat-link field on the host
    * @param milc_longlink Long-link field on the host
-   * @param tadpole Tadpole improvement factor
    * @param source Right-hand side source field
    * @param solution Array of solution spinor fields
    * @param eig_args contains info about deflation space
@@ -404,7 +397,6 @@ extern "C" {
       double target_fermilab_residual,
       const void* const fatlink,
       const void* const longlink,
-      const double tadpole,
       void* source,
       void* solution,
       QudaEigArgs_t eig_args,

--- a/include/quda_milc_interface.h
+++ b/include/quda_milc_interface.h
@@ -40,7 +40,9 @@ extern "C" {
     int make_resident_solution; /** Make the solution resident and don't copy back */
     int use_resident_solution; /** Use the resident solution */
     QudaInverterType solver_type; /** Type of solver to use */
-    double tadpole; /** Tadpole improvement factor */
+    double tadpole; /** Tadpole improvement factor - set to 1.0 for
+                        HISQ fermions since the tadpole factor is
+                        baked into the links during their construction */
     double naik_epsilon; /** Naik epsilon parameter (HISQ fermions only).*/
   } QudaInvertArgs_t;
 

--- a/lib/tune.cpp
+++ b/lib/tune.cpp
@@ -194,9 +194,10 @@ namespace quda {
       TuneKey key = entry->first;
       TuneParam param = entry->second;
 
-      char tmp[7] = { };
-      strncpy(tmp, key.aux, 6);
-      bool is_policy = strcmp(tmp, "policy") == 0 ? true : false;
+      char tmp[14] = { };
+      strncpy(tmp, key.aux, 13);
+      bool is_policy_kernel = strncmp(tmp, "policy_kernel", 13) == 0 ? true : false;
+      bool is_policy = (strncmp(tmp, "policy", 6) == 0 && !is_policy_kernel) ? true : false;
       if (param.n_calls > 0 && !is_policy) total_time += param.n_calls * param.time;
       if (param.n_calls > 0 && is_policy) async_total_time += param.n_calls * param.time;
     }

--- a/lib/tune.cpp
+++ b/lib/tune.cpp
@@ -207,9 +207,10 @@ namespace quda {
       TuneKey key = q.top().first;
       TuneParam param = q.top().second;
 
-      char tmp[7] = { };
-      strncpy(tmp, key.aux, 6);
-      bool is_policy = strcmp(tmp, "policy") == 0 ? true : false;
+      char tmp[14] = { };
+      strncpy(tmp, key.aux, 13);
+      bool is_policy_kernel = strncmp(tmp, "policy_kernel", 13) == 0 ? true : false;
+      bool is_policy = (strncmp(tmp, "policy", 6) == 0 && !is_policy_kernel) ? true : false;
 
       // synchronous profile
       if (param.n_calls > 0 && !is_policy) {


### PR DESCRIPTION
A couple of bugs and minor additions that need to be fixed sooner rather than later
* Fixes long-link reconstruction with HISQ fermions with non-zero Naik epsilon relativistic correction
* In the MILC interface, the environment variable `QUDA_MILC_HISQ_RECONSTRUCT` is now supported by `qudaDslash`, `qudaInvert`, `qudaInvertMsrc` and `qudaEigCGInvert`
* Fixes an issue where some kernels were wrongly being counted as policies in profile_async.tsv instead of kernels in profile.tsv
* I've also updated the QUDA_VERSION for 0.9.1, which is appropriate here since the MILC interface functions have changed (in case there is a desire to maintain compatibility from 0.9.0 to 0.9.1) from within MILC.

This pull request will require an update to MILC (I'll file a pull request for that shortly) since the interface functions need to be changed to accomodate the passing of the naik_epsilon factor. 