### PR TITLE
Hotfix/gcc 5.5

### DIFF
--- a/include/quda_arpack_interface.h
+++ b/include/quda_arpack_interface.h
@@ -7,7 +7,6 @@
 #include <color_spinor_field.h>
 #include <dirac_quda.h>
 #include <vector>
-#include <algorithm>
 
 //#ifdef PRIMME_LIB
 //#include "primme.h"

--- a/lib/blas_magma.cu
+++ b/lib/blas_magma.cu
@@ -1,9 +1,6 @@
 #include <blas_magma.h>
 #include <string.h>
 
-#include <vector>
-#include <algorithm>
-
 #include <util_quda.h>
 #include <quda_internal.h>
 

--- a/lib/blas_magma_nopiv.cu
+++ b/lib/blas_magma_nopiv.cu
@@ -1,9 +1,6 @@
 #include <blas_magma.h>
 #include <string.h>
 
-#include <vector>
-#include <algorithm>
-
 #include <util_quda.h>
 #include <quda_internal.h>
 

--- a/lib/copy_color_spinor.cuh
+++ b/lib/copy_color_spinor.cuh
@@ -11,7 +11,7 @@
 #include <color_spinor_field.h>
 #include <color_spinor_field_order.h>
 #include <tune_quda.h>
-#include <algorithm> // for std::swap
+#include <utility> // for std::swap
 
 #define PRESERVE_SPINOR_NORM
 

--- a/lib/copy_color_spinor_mg.cuh
+++ b/lib/copy_color_spinor_mg.cuh
@@ -11,7 +11,7 @@
 #include <color_spinor_field.h>
 #include <color_spinor_field_order.h>
 #include <tune_quda.h>
-#include <algorithm> // for std::swap
+#include <utility> // for std::swap
 
 namespace quda {
 

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -3679,7 +3679,6 @@ int computeGaugeForceQuda(void* mom, void* siteLink,  int*** input_path_buf, int
   if (qudaGaugeParam->use_resident_gauge) {
     if (!gaugePrecise) errorQuda("No resident gauge field to use");
     cudaSiteLink = gaugePrecise;
-    profileGaugeForce.TPSTOP(QUDA_PROFILE_INIT);
   } else {
     gParam.create = QUDA_NULL_FIELD_CREATE;
     gParam.reconstruct = qudaGaugeParam->reconstruct;

--- a/lib/quda_arpack_interface.cpp
+++ b/lib/quda_arpack_interface.cpp
@@ -1,4 +1,5 @@
 #include <quda_arpack_interface.h>
+#include <thrust/sort.h>
 
 #if (defined (QMP_COMMS) || defined (MPI_COMMS))
 #include <mpi.h>
@@ -241,8 +242,8 @@ namespace quda{
       errorQuda("\nSorting option is not supported.\n");
     }
 
-    if(SortEvals::small_values) std::stable_sort(sorted_evals.begin(), sorted_evals.end(), SortEvals::SelectSmall );
-    else                        std::stable_sort(sorted_evals.begin(), sorted_evals.end(), SortEvals::SelectLarge );
+    if(SortEvals::small_values) thrust::stable_sort(sorted_evals.begin(), sorted_evals.end(), SortEvals::SelectSmall );
+    else                        thrust::stable_sort(sorted_evals.begin(), sorted_evals.end(), SortEvals::SelectLarge );
 
     cpuColorSpinorField *cpu_tmp = nullptr;
     int ev_id = 0;

--- a/lib/quda_fortran.F90
+++ b/lib/quda_fortran.F90
@@ -240,10 +240,7 @@ module quda_fortran
      integer(4)::max_search_dim ! for magma library this parameter must be multiple 16?
      integer(4)::rhs_idx
      integer(4)::deflation_grid !total deflation space is nev*deflation_grid
-     integer(4)::use_reduced_vector_set ! eigCG: specifies whether to use reduced eigenvector set
      real(8):: eigenval_tol ! eigCG: selection criterion for the reduced eigenvector set
-     integer(4)::use_cg_updates ! mixed precision eigCG:whether to use cg refinement corrections in the incremental stage
-     real(8)::cg_iterref_tol ! mixed precision eigCG:  tolerance for cg refinement corrections in the incremental stage
      integer(4)::eigcg_max_restarts ! mixed precision eigCG tuning parameter:  minimum search vector space restarts
      integer(4)::max_restart_num     ! initCG tuning parameter:  maximum restarts
      real(8)::inc_tol     ! initCG tuning parameter:  decrease in absolute value of the residual within each restart cycle

--- a/lib/reduce_quda.cu
+++ b/lib/reduce_quda.cu
@@ -9,7 +9,6 @@
 #endif
 
 #include <cub_helper.cuh>
-#include <algorithm>
 
 template<typename> struct ScalarType { };
 template<> struct ScalarType<double> { typedef double type; };
@@ -103,8 +102,9 @@ namespace quda {
       const int max_generic_blocks = 65336; // FIXME - this isn't quite right
       const int max_generic_reduce = 2 * MAX_MULTI_BLAS_N * max_generic_blocks * 4 * sizeof(QudaSumFloat);
 
-      // reduction buffer size 
-      size_t bytes = std::max(std::max(max_reduce, max_multi_reduce), max_generic_reduce);
+      // reduction buffer size
+      size_t bytes = max_reduce > max_multi_reduce ? max_reduce : max_multi_reduce;
+      bytes = bytes > max_generic_reduce ? bytes : max_generic_reduce;
 
       if (!d_reduce) d_reduce = (QudaSumFloat *) device_malloc(bytes);
 

--- a/lib/spinor_gauss.cu
+++ b/lib/spinor_gauss.cu
@@ -11,7 +11,7 @@
 #include <color_spinor_field.h>
 #include <color_spinor_field_order.h>
 #include <tune_quda.h>
-#include <algorithm> // for std::swap
+#include <utility> // for std::swap
 #include <random_quda.h>
 
 namespace quda {

--- a/tests/gtest.h
+++ b/tests/gtest.h
@@ -367,7 +367,10 @@
 # include <TargetConditionals.h>
 #endif
 
+#if 0
+// algorithm doesn't seem to be actually used by gtest - disable since causes incompatibility between CUDA 9.x and GCC 5.5
 #include <algorithm>  // NOLINT
+#endif
 #include <iostream>  // NOLINT
 #include <sstream>  // NOLINT
 #include <string>  // NOLINT

--- a/tests/multigrid_benchmark_test.cu
+++ b/tests/multigrid_benchmark_test.cu
@@ -11,7 +11,6 @@
 // include because of nasty globals used in the tests
 #include <dslash_util.h>
 #include <dirac_quda.h>
-#include <algorithm>
 
 extern QudaDslashType dslash_type;
 extern QudaInverterType inv_type;
@@ -135,11 +134,16 @@ void initFields(QudaPrecision prec)
   gParam.order = QUDA_FLOAT2_GAUGE_ORDER;
   gParam.geometry = QUDA_COARSE_GEOMETRY;
   gParam.nFace = 1;
-  int pad = std::max( { (gParam.x[0]*gParam.x[1]*gParam.x[2])/2,
-	(gParam.x[1]*gParam.x[2]*gParam.x[3])/2,
-	(gParam.x[0]*gParam.x[2]*gParam.x[3])/2,
-	(gParam.x[0]*gParam.x[1]*gParam.x[3])/2 } );
+
+  int x_face_size = gParam.x[1]*gParam.x[2]*gParam.x[3]/2;
+  int y_face_size = gParam.x[0]*gParam.x[2]*gParam.x[3]/2;
+  int z_face_size = gParam.x[0]*gParam.x[1]*gParam.x[3]/2;
+  int t_face_size = gParam.x[0]*gParam.x[1]*gParam.x[2]/2;
+  int pad = MAX(x_face_size, y_face_size);
+  pad = MAX(pad_size, z_face_size);
+  pad = MAX(pad_size, t_face_size);
   gParam.pad = gParam.nFace * pad * 2;
+
   Y_d = new cudaGaugeField(gParam);
   Yhat_d = new cudaGaugeField(gParam);
   Y_d->copy(*Y_h);


### PR DESCRIPTION
This pull request fixes compilation with GCC 5.5 with CUDA 9.x.  There is an incompatibility due to AVX header changes in GCC 5.5 versus prior versions of GCC 5.x (this does not affect GCC 6.x or 7.x at all).  The only place these headers are included is when the `<algorithm>` header is included in a CUDA source code file - hence this PR removes all use of `<algorithm>` from such files
* For `std::swap` we can get this with `<utility>` instead of `<algorithm>`
* Replace `std::stable_sort` with `thrust::stable_sort`
* Replace use of `std::max` with hand-coded variant
* gtest.h included `<algorithm>` but doesn't seem to use it at all so I've just commented this inclusion out

With these changes made, we can now compile with GCC 5.5 without issues.

I've also fixed  a couple of other issue:
* Fortran interface was broken in 3820720 (changes made to quda.h not propagated to quda_fortran.F90)
* Remove stray profile stop command