### PR TITLE
Hotfix/qmp rank order

### DIFF
--- a/lib/dslash_policy.cuh
+++ b/lib/dslash_policy.cuh
@@ -296,7 +296,7 @@ namespace {
 	if (!gdr_recv && !zero_copy_recv) { // Issue CPU->GPU copy if not GDR
 
 	  if (async) {
-#if (CUDA_VERSION >= 8000)
+#if (CUDA_VERSION >= 8000) && 0
 	    // this will trigger the copy asynchronously
 	    *((volatile cuuint32_t*)(commsEnd_h+2*dim+dir2)) = 1;
 #else
@@ -1035,7 +1035,7 @@ struct DslashFusedGDRRecv : DslashPolicyImp {
  */
 struct DslashAsync : DslashPolicyImp {
 
-#if (CUDA_VERSION >= 8000)
+#if (CUDA_VERSION >= 8000) && 0
 
   void operator()(DslashCuda &dslash, cudaColorSpinorField* in, const int volume, const int *faceVolumeCB, TimeProfile &profile) {
 
@@ -1143,7 +1143,7 @@ struct DslashAsync : DslashPolicyImp {
  */
 struct DslashFusedExteriorAsync : DslashPolicyImp {
 
-#if (CUDA_VERSION >= 8000)
+#if (CUDA_VERSION >= 8000) && 0
 
   void operator()(DslashCuda &dslash, cudaColorSpinorField* in, const int volume, const int *faceVolumeCB, TimeProfile &profile) {
 

--- a/lib/gauge_plaq.cu
+++ b/lib/gauge_plaq.cu
@@ -10,8 +10,6 @@
 
 namespace quda {
 
-#ifdef GPU_GAUGE_TOOLS
-
   template <typename Gauge>
   struct GaugePlaqArg : public ReduceArg<double2> {
     int threads; // number of active threads required
@@ -133,19 +131,11 @@ namespace quda {
   void plaquette(const GaugeField& data, double2 &plq, QudaFieldLocation location) {
     INSTANTIATE_RECONSTRUCT(plaquette<Float>, data, plq, location);
   }
-#endif
 
   double3 plaquette(const GaugeField& data, QudaFieldLocation location) {
-
-#ifdef GPU_GAUGE_TOOLS
     double2 plq;
     INSTANTIATE_PRECISION(plaquette, data, plq, location);
-    double3 plaq = make_double3(0.5*(plq.x + plq.y), plq.x, plq.y);
-#else
-    errorQuda("Gauge tools are not build");
-    double3 plaq = make_double3(0., 0., 0.);
-#endif
-    return plaq;
+    return make_double3(0.5*(plq.x + plq.y), plq.x, plq.y);
   }
 
 } // namespace quda

--- a/lib/pgauge_exchange.cu
+++ b/lib/pgauge_exchange.cu
@@ -5,9 +5,6 @@
 #include <gauge_field_order.h>
 #include <cub/cub.cuh>
 #include <launch_kernel.cuh>
-
-#include <device_functions.h>
-
 #include <comm_quda.h>
 
 

--- a/tests/invert_test.cpp
+++ b/tests/invert_test.cpp
@@ -381,6 +381,10 @@ int main(int argc, char **argv)
   // load the gauge field
   loadGaugeQuda((void*)gauge, &gauge_param);
 
+  double plaq[3];
+  plaqQuda(plaq);
+  printfQuda("Computed plaquette is %e (spatial = %e, temporal = %e)\n", plaq[0], plaq[1], plaq[2]);
+
   // load the clover term, if desired
   if (dslash_type == QUDA_CLOVER_WILSON_DSLASH || dslash_type == QUDA_TWISTED_CLOVER_DSLASH)
     loadCloverQuda(clover, clover_inv, &inv_param);

--- a/tests/multigrid_benchmark_test.cu
+++ b/tests/multigrid_benchmark_test.cu
@@ -44,6 +44,8 @@ cudaGaugeField *Y_d, *X_d, *Xinv_d, *Yhat_d;
 int Nspin;
 int Ncolor;
 
+#define MAX(a,b) ((a)>(b)?(a):(b))
+
 void
 display_test_info()
 {
@@ -140,8 +142,8 @@ void initFields(QudaPrecision prec)
   int z_face_size = gParam.x[0]*gParam.x[1]*gParam.x[3]/2;
   int t_face_size = gParam.x[0]*gParam.x[1]*gParam.x[2]/2;
   int pad = MAX(x_face_size, y_face_size);
-  pad = MAX(pad_size, z_face_size);
-  pad = MAX(pad_size, t_face_size);
+  pad = MAX(pad, z_face_size);
+  pad = MAX(pad, t_face_size);
   gParam.pad = gParam.nFace * pad * 2;
 
   Y_d = new cudaGaugeField(gParam);

--- a/tests/su3_test.cpp
+++ b/tests/su3_test.cpp
@@ -33,6 +33,8 @@ extern QudaPrecision prec;
 extern QudaPrecision prec_sloppy;
 extern double anisotropy;
 
+extern bool verify_results;
+
 extern char latfile[];
 
 #define MAX(a,b) ((a)>(b)?(a):(b))
@@ -122,19 +124,19 @@ void SU3test(int argc, char **argv) {
     construct_gauge_field(gauge, 2, gauge_param.cpu_prec, &gauge_param);
   } else { 
     // generate a random SU(3) field
-    printf("Randomizing fields...");
+    printfQuda("Randomizing fields...");
     construct_gauge_field(gauge, 1, gauge_param.cpu_prec, &gauge_param);
-    printf("done.\n");
+    printfQuda("done.\n");
   }
 
   loadGaugeQuda(gauge, &gauge_param);
   saveGaugeQuda(new_gauge, &gauge_param);
 
-#ifdef GPU_GAUGE_TOOLS
   double plaq[3];
   plaqQuda(plaq);
-  printf("Computed plaquette is %e (spatial = %e, temporal = %e)\n", plaq[0], plaq[1], plaq[2]);
+  printfQuda("Computed plaquette is %e (spatial = %e, temporal = %e)\n", plaq[0], plaq[1], plaq[2]);
 
+#ifdef GPU_GAUGE_TOOLS
   // Topological charge
   double qCharge;
   // start the timer
@@ -143,7 +145,7 @@ void SU3test(int argc, char **argv) {
   // stop the timer
   time0 += clock();
   time0 /= CLOCKS_PER_SEC;
-  printf("Computed topological charge is %.16e Done in %g secs\n", qCharge, time0);
+  printfQuda("Computed topological charge is %.16e Done in %g secs\n", qCharge, time0);
 
   // Stout smearing should be equivalent to APE smearing
   // on D dimensional lattices for rho = alpha/2*(D-1). 
@@ -163,7 +165,7 @@ void SU3test(int argc, char **argv) {
   time0 /= CLOCKS_PER_SEC;
   printfQuda("Total time for STOUT = %g secs\n", time0);
   qCharge = qChargeCuda();
-  printf("Computed topological charge after is %.16e \n", qCharge);
+  printfQuda("Computed topological charge after is %.16e \n", qCharge);
 
   //APE
   // start the timer
@@ -188,13 +190,13 @@ void SU3test(int argc, char **argv) {
   time0 /= CLOCKS_PER_SEC;
   printfQuda("Total time for Over Improved STOUT = %g secs\n", time0);
   qCharge = qChargeCuda();
-  printf("Computed topological charge after is %.16e \n", qCharge);
+  printfQuda("Computed topological charge after is %.16e \n", qCharge);
 
 #else
-  printf("Skipping plaquette tests since gauge tools have not been compiled\n");
+  printfQuda("Skipping other gauge tests since gauge tools have not been compiled\n");
 #endif
   
-  check_gauge(gauge, new_gauge, 1e-3, gauge_param.cpu_prec);
+  if (verify_results) check_gauge(gauge, new_gauge, 1e-3, gauge_param.cpu_prec);
   freeGaugeQuda();
   endQuda();
 


### PR DESCRIPTION
Fixes issue when using QMP with QUDA's internal tests.  Issue was that logical topology was declared using `QMP_declare_logical_topology` which is ignorant of the ordering QUDA is using.  Instead use `QMP_declare_logical_topology_map` and pass in the appropriate map.

Closes #712 