### PR TITLE
Remove spurious print statements, plus bug fixes and feature additions to test files.

### DIFF
--- a/lib/dirac_staggered.cpp
+++ b/lib/dirac_staggered.cpp
@@ -200,8 +200,6 @@ namespace quda {
 				 ColorSpinorField &x, ColorSpinorField &b, 
 				 const QudaSolutionType solType) const
   {
-    printfQuda("Enter prepare.\n");
-
     // we desire solution to preconditioned system
     if (solType == QUDA_MATPC_SOLUTION || solType == QUDA_MATPCDAG_MATPC_SOLUTION) {
       src = &b;
@@ -212,7 +210,6 @@ namespace quda {
     // we desire solution to full system.
     // See sign convention comment in DiracStaggeredPC::M().
     if (matpcType == QUDA_MATPC_EVEN_EVEN) {
-      printfQuda("Prepare for even-even.\n");
       // With the convention given in DiracStaggered::M(),
       // the source is src = 2m b_e + D_eo b_o
       // But remember, DslashXpay actually applies
@@ -240,7 +237,6 @@ namespace quda {
   void DiracStaggeredPC::reconstruct(ColorSpinorField &x, const ColorSpinorField &b,
 				     const QudaSolutionType solType) const
   {
-    printfQuda("Enter reconstruct.\n");
 
     if (solType == QUDA_MATPC_SOLUTION || solType == QUDA_MATPCDAG_MATPC_SOLUTION) {
       return;
@@ -251,7 +247,6 @@ namespace quda {
     // create full solution
     // See sign convention comment in DiracStaggeredPC::M()
     if (matpcType == QUDA_MATPC_EVEN_EVEN) {
-      printfQuda("Reconstruct even-even.\n");
       
       // With the convention given in DiracStaggered::M(),
       // the reconstruct is x_o = 1/(2m) (b_o + D_oe x_e)

--- a/tests/staggered_dslash_ctest.cpp
+++ b/tests/staggered_dslash_ctest.cpp
@@ -1076,8 +1076,13 @@ TEST_P(StaggeredDslashTest, benchmark) {
     // Set n_naiks to 2 if eps_naik != 0.0
     if (dslash_type == QUDA_ASQTAD_DSLASH) {
       if (eps_naik != 0.0) {
-        n_naiks = 2;
-        printfQuda("Note: epsilon-naik != 0, testing epsilon correction links.\n");
+        if (compute_fatlong) {
+          n_naiks = 2;
+          printfQuda("Note: epsilon-naik != 0, testing epsilon correction links.\n");
+        } else {
+          eps_naik = 0.0;
+          printfQuda("Not computing fat-long, ignoring epsilon correction.\n");
+        }
       } else {
         printfQuda("Note: epsilon-naik = 0, testing original HISQ links.\n");
       }

--- a/tests/staggered_dslash_test.cpp
+++ b/tests/staggered_dslash_test.cpp
@@ -930,8 +930,13 @@ int main(int argc, char **argv)
   // Set n_naiks to 2 if eps_naik != 0.0
   if (dslash_type == QUDA_ASQTAD_DSLASH) {
     if (eps_naik != 0.0) {
-      n_naiks = 2;
-      printfQuda("Note: epsilon-naik != 0, testing epsilon correction links.\n");
+      if (compute_fatlong) {
+        n_naiks = 2;
+        printfQuda("Note: epsilon-naik != 0, testing epsilon correction links.\n");
+      } else {
+        eps_naik = 0.0;
+        printfQuda("Not computing fat-long, ignoring epsilon correction.\n");
+      }
     } else {
       printfQuda("Note: epsilon-naik = 0, testing original HISQ links.\n");
     }

--- a/tests/staggered_invert_test.cpp
+++ b/tests/staggered_invert_test.cpp
@@ -492,7 +492,7 @@ invert_test(void)
       computeHISQLinksGPU(qdp_fatlink, qdp_longlink,
                           (n_naiks == 2) ? qdp_fatlink_naik_temp : nullptr,
                           (n_naiks == 2) ? qdp_longlink_naik_temp : nullptr,
-                          qdp_inlink, &gaugeParam, act_paths, 0.0 /* eps_naik */);
+                          qdp_inlink, &gaugeParam, act_paths, eps_naik);
 
       
       if (n_naiks == 2) {
@@ -607,8 +607,8 @@ invert_test(void)
   if (dslash_type == QUDA_ASQTAD_DSLASH) {
     gaugeParam.type = QUDA_ASQTAD_LONG_LINKS;
     gaugeParam.ga_pad = link_pad;
-    gaugeParam.reconstruct= link_recon;
-    gaugeParam.reconstruct_sloppy = link_recon_sloppy;
+    gaugeParam.reconstruct= (link_recon == QUDA_RECONSTRUCT_12 || link_recon == QUDA_RECONSTRUCT_8) ? QUDA_RECONSTRUCT_13 : link_recon;
+    gaugeParam.reconstruct_sloppy = (link_recon_sloppy == QUDA_RECONSTRUCT_12 || link_recon_sloppy == QUDA_RECONSTRUCT_8) ? QUDA_RECONSTRUCT_13 : link_recon_sloppy;
     gaugeParam.cuda_prec_precondition = gaugeParam.cuda_prec_sloppy;
     gaugeParam.reconstruct_precondition = gaugeParam.reconstruct_sloppy;
     loadGaugeQuda(milc_longlink, &gaugeParam);
@@ -998,8 +998,13 @@ int main(int argc, char** argv)
   // Set n_naiks to 2 if eps_naik != 0.0
   if (dslash_type == QUDA_ASQTAD_DSLASH) {
     if (eps_naik != 0.0) {
-      n_naiks = 2;
-      printfQuda("Note: epsilon-naik != 0, testing epsilon correction links.\n");
+      if (compute_fatlong) {
+        n_naiks = 2;
+        printfQuda("Note: epsilon-naik != 0, testing epsilon correction links.\n");
+      } else {
+        eps_naik = 0.0;
+        printfQuda("Not computing fat-long, ignoring epsilon correction.\n");
+      }
     } else {
       printfQuda("Note: epsilon-naik = 0, testing original HISQ links.\n");
     }


### PR DESCRIPTION
NOTE: _None_ of these issues effect the correctness of the QUDA library. It just adds spurious print statements and fixes bugs in the test executables.

* Removed remnant debugging print statements when prepare/reconstruct is called for improved staggered fermions.
* Found that eps_naik was commented out in the GPU link build in `staggered_invert_test`. This inconsistency causes an issue if reconstruct 13 is used since the GPU and CPU fields end up with a different scale.
* In the process, I discovered `staggered_invert_test` never actually tests reconstruct 13. Fixed this by adding the behavior that, if reconstruct 12 is specified, reconstruct 13 gets used for the long links. Reconstruct 13 cannot be passed in directly because the code will also try to use it for building fat and long links, and it'll throw an error. `staggered_dslash_(c)test` doesn't have this issue because it explicitly tests reconstruct 8 and 12 for link building, and then correctly checks and uses reconstruct 13 instead for the dslash application.
* Discovered a bug when `--epsilon-naik` is set on the command line but `--compute-fat-long` is not set _and_ reconstruct 13 is used. This gets triggered because `gauge_param.scale` still gets set with the epsilon corrections, but gauge links that use a correct epsilon scaling never actually get created, only links with |det(U)| = 1. This is addressed by catching this scenario and setting `eps_naik` to 1 before the gauge scaling is set. _Remark:_ this is irrelevant for the tadpole correction.

This branch can be deleted after merging.