### PR TITLE
Don't print true res=inf in multishift

### DIFF
--- a/lib/inv_multi_cg_quda.cpp
+++ b/lib/inv_multi_cg_quda.cpp
@@ -532,8 +532,13 @@ namespace quda {
       if (getVerbosity() >= QUDA_SUMMARIZE) {
         printfQuda("MultiShift CG: Converged after %d iterations\n", k);
         for (int i = 0; i < num_offset; i++) {
-          printfQuda(" shift=%d, %d iterations, relative residual: iterated = %e, true = %e\n",
-                     i, iter[i], param.iter_res_offset[i], param.true_res_offset[i]);
+          if(std::isinf(param.true_res_offset[i])){
+            printfQuda(" shift=%d, %d iterations, relative residual: iterated = %e\n",
+                       i, iter[i], param.iter_res_offset[i]);
+          } else {
+            printfQuda(" shift=%d, %d iterations, relative residual: iterated = %e, true = %e\n",
+                       i, iter[i], param.iter_res_offset[i], param.true_res_offset[i]);
+          }
         }
       }
 


### PR DESCRIPTION
While setting true res to inf is a nice way to trigger a refinement step printing inf might confuse users. So don't print it.

Thanks for pointing that out, @bjoo !