### PR TITLE
Hotfix/p9 milc

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ or specify e.g. -DQUDA_GPU_ARCH=sm_60 for a Pascal GPU in step 2.
 
 ### Multi-GPU support
 
-QUDA supports using multiple GPUs through MPI and QUDA.
+QUDA supports using multiple GPUs through MPI and QMP.
 To enable multi-GPU support either set `QUDA_MPI` or `QUDA_QMP` to ON when configuring QUDA through cmake. 
 
 Note that in any case cmake will automatically try to detect your MPI installation. If you need to specify a particular MPI please set `MPI_C_COMPILER` and `MPI_CXX_COMPILER` in cmake. 

--- a/include/double_single.h
+++ b/include/double_single.h
@@ -1,6 +1,6 @@
 #pragma once
 
-__host__ __device__ inline void dsadd(volatile float2 &c, const volatile float2 &a, const volatile float2 &b) {
+__host__ __device__ inline void dsadd(float2 &c, const float2 &a, const float2 &b) {
   float t1 = a.x + b.x;
   float e = t1 - a.x;
   float t2 = ((b.x - e) + (a.x - (t1 - e))) + a.y + b.y;
@@ -11,12 +11,11 @@ __host__ __device__ inline void dsadd(volatile float2 &c, const volatile float2 
 
 struct doublesingle {
   float2 a;
-  __host__ __device__ inline doublesingle() : a(make_float2(0.0f,0.0f)) { ; } 
-  __host__ __device__ inline doublesingle(const volatile doublesingle &b) : a(make_float2(b.a.x, b.a.y)) { ; } 
+  __host__ __device__ inline doublesingle() : a(make_float2(0.0f,0.0f)) { ; }
+  __host__ __device__ inline doublesingle(const doublesingle &b) : a(make_float2(b.a.x, b.a.y)) { ; }
   __host__ __device__ inline doublesingle(const float a) : a(make_float2(a, 0.0)) { ; }
 
   __host__ __device__ inline void operator+=(const doublesingle &b) { dsadd(this->a, this->a, b.a); }
-  __host__ __device__ inline void operator+=(const volatile doublesingle &b) { dsadd(this->a, this->a, b.a); }
   __host__ __device__ inline void operator+=(const float &b) { 
     float2 b2 = make_float2(b, 0.0); 
     dsadd(this->a, this->a, b2); }
@@ -24,11 +23,11 @@ struct doublesingle {
   __host__ __device__ inline doublesingle& operator=(const doublesingle &b)
     { a.x = b.a.x; a.y = b.a.y; return *this; }
     
-  __host__ __device__ inline doublesingle& operator=(const float &b) 
+  __host__ __device__ inline doublesingle& operator=(const float &b)
   { a.x = b; a.y = 0.0f; return *this; }
 };
 
-__host__ __device__ inline volatile doublesingle operator+=(volatile doublesingle &a, const volatile doublesingle &b) 
+__host__ __device__ inline doublesingle operator+=(doublesingle &a, const doublesingle &b)
 { dsadd(a.a, a.a, b.a); return a;}
 
 __host__ __device__ double operator+=(double& a, doublesingle &b) { a += b.a.x; a += b.a.y; return a; }

--- a/include/quda_matrix.h
+++ b/include/quda_matrix.h
@@ -69,7 +69,9 @@ namespace quda {
       public:
         T data[N*N];
 
-	__device__ __host__ inline Matrix() {
+        __device__ __host__ constexpr int size() const { return N; }
+
+        __device__ __host__ inline Matrix() {
 #pragma unroll
 	  for (int i=0; i<N*N; i++) zero(data[i]);
 	}
@@ -496,42 +498,42 @@ namespace quda {
 
   template<class T>
     __device__  __host__ inline
-    void computeMatrixInverse(const Matrix<T,3>& u, Matrix<T,3>* uinv)
+    Matrix<T,3> inverse(const Matrix<T,3> &u)
     {
-
-      const T & det = getDeterminant(u);
-      const T & det_inv = static_cast<typename T::value_type>(1.0)/det;
+      const T det = getDeterminant(u);
+      const T det_inv = static_cast<typename T::value_type>(1.0)/det;
+      Matrix<T,3> uinv;
 
       T temp;
 
       temp = u(1,1)*u(2,2) - u(1,2)*u(2,1);
-      (*uinv)(0,0) = (det_inv*temp);
+      uinv(0,0) = (det_inv*temp);
 
       temp = u(0,2)*u(2,1) - u(0,1)*u(2,2);
-      (*uinv)(0,1) = (temp*det_inv);
+      uinv(0,1) = (temp*det_inv);
 
       temp = u(0,1)*u(1,2)  - u(0,2)*u(1,1);
-      (*uinv)(0,2) = (temp*det_inv);
+      uinv(0,2) = (temp*det_inv);
 
       temp = u(1,2)*u(2,0) - u(1,0)*u(2,2);
-      (*uinv)(1,0) = (det_inv*temp);
+      uinv(1,0) = (det_inv*temp);
 
       temp = u(0,0)*u(2,2) - u(0,2)*u(2,0);
-      (*uinv)(1,1) = (temp*det_inv);
+      uinv(1,1) = (temp*det_inv);
 
       temp = u(0,2)*u(1,0) - u(0,0)*u(1,2);
-      (*uinv)(1,2) = (temp*det_inv);
+      uinv(1,2) = (temp*det_inv);
 
       temp = u(1,0)*u(2,1) - u(1,1)*u(2,0);
-      (*uinv)(2,0) = (det_inv*temp);
+      uinv(2,0) = (det_inv*temp);
 
       temp = u(0,1)*u(2,0) - u(0,0)*u(2,1);
-      (*uinv)(2,1) = (temp*det_inv);
+      uinv(2,1) = (temp*det_inv);
 
       temp = u(0,0)*u(1,1) - u(0,1)*u(1,0);
-      (*uinv)(2,2) = (temp*det_inv);
+      uinv(2,2) = (temp*det_inv);
 
-      return;
+      return uinv;
     }
 
 

--- a/include/su3_project.cuh
+++ b/include/su3_project.cuh
@@ -77,50 +77,22 @@ namespace quda {
 
     // iterate until matrix is unitary
     do {
-      out = out + conj(inv);
-      out = out*0.5;
+      out = 0.5*(out + conj(inv));
     } while(checkUnitary(inv, out, tol));
-
 
     // now project onto special unitary group
     complex<Float> det = getDeterminant(out);
-    double mod = det.x*det.x + det.y*det.y;
+    double mod = norm(det);
     mod = pow(mod, (1./6.));
     double angle = atan2(det.y, det.x);
     angle /= -3.;
     
     complex<Float> cTemp;
 
-    cTemp.x = cos(angle)/mod;
-    cTemp.y = sin(angle)/mod;
+    sincos(angle, &cTemp.y, &cTemp.x);
+    cTemp /= mod;
 
     in = out*cTemp;
-/*    if (checkUnitary(inv, out))
-    {
-    	cTemp = getDeterminant(out);
-	printf ("DetX: %+.3lf  %+.3lfi, %.3lf %.3lf\nDetN: %+.3lf  %+.3lfi", det.x, det.y, mod, angle, cTemp.x, cTemp.y);
-        cudaDeviceSynchronize();
-	checkUnitaryPrint(out, &inv);
-	setIdentity(in);
-        *in = *in * 0.5;
-    }
-    else
-    {
-      cTemp = getDeterminant(out);
-//      printf("Det: %+.3lf %+.3lf\n", cTemp.x, cTemp.y);
-      cudaDeviceSynchronize();
-
-      if (fabs(cTemp.x - 1.0) > 1e-8)
-	setIdentity(in);
-      else if (fabs(cTemp.y) > 1e-8)
-      {
-	setIdentity(in);
-        printf("DadadaUnitary failed\n");
-        *in = *in * 0.1;
-      }
-      else
-        *in = out;
-    }*/
   }
 
   

--- a/include/su3_project.cuh
+++ b/include/su3_project.cuh
@@ -20,79 +20,93 @@ namespace quda {
    * @param in The input matrix to which we're reporting its unitarity
    * @param tol Tolerance to which this check is applied
    */
-  template <typename Float2, typename Float>
-  __host__ __device__ int checkUnitary(Matrix<Float2,3> &inv,  Matrix<Float2,3> in, const Float tol)
+  template <typename Matrix, typename Float>
+  __host__ __device__ inline bool checkUnitary(const Matrix &inv, const Matrix &in, const Float tol)
   {
-    computeMatrixInverse(in, &inv);
 
-    for (int i=0;i<3;i++)
-      for (int j=0;j<3;j++)
-      {
-        if (fabs(in(i,j).x - inv(j,i).x) > tol)
-          return 1;
-        if (fabs(in(i,j).y + inv(j,i).y) > tol)
-          return 1;
+    // first check U - U^{-1} = 0
+#pragma unroll
+    for (int i=0; i<in.size(); i++) {
+#pragma unroll
+      for (int j=0; j<in.size(); j++) {
+        if (fabs(in(i,j).real() - inv(j,i).real()) > tol ||
+            fabs(in(i,j).imag() + inv(j,i).imag()) > tol) return false;
       }
-    return 0;
+    }
+
+    // now check 1 - U^dag * U = 0
+    // this check is more expensive so delay until we have passed first check
+    const Matrix identity = conj(in)*in;
+#pragma unroll
+    for (int i=0; i<in.size(); i++) {
+      if (fabs(identity(i,i).real() - static_cast<Float>(1.0)) > tol ||
+          fabs(identity(i,i).imag()) > tol)
+        return false;
+#pragma unroll
+      for (int j=0; j<in.size(); j++) {
+        if (i>j) { // off-diagonal identity check
+        if (fabs(identity(i,j).real()) > tol || fabs(identity(i,j).imag()) > tol ||
+            fabs(identity(j,i).real()) > tol || fabs(identity(j,i).imag()) > tol )
+          return false;
+        }
+      }
+    }
+
+    return true;
   }
 
   /**
-   * @brief Check the unitarity of the input matrix to a given
-   * tolerance (1e-14) and print out deviation for each component (used for
+   * @brief Print out deviation for each component (used for
    * debugging only).
    *
    * @param inv The inverse of the input matrix
    * @param in The input matrix to which we're reporting its unitarity
-   */  template <typename Float2>
-  __host__ __device__ int checkUnitaryPrint(Matrix<Float2,3> &inv, Matrix<Float2,3> in)
+   */
+  template <typename Matrix>
+  __host__ __device__ void checkUnitaryPrint(const Matrix &inv, const Matrix &in)
   {
-    computeMatrixInverse(in, &inv);
-    for (int i=0;i<3;i++)
-      for (int j=0;j<3;j++)
-      {
-        printf("TESTR: %+.3le %+.3le %+.3le\n", in(i,j).x, (*inv)(j,i).x, fabs(in(i,j).x - (*inv)(j,i).x));
-	printf("TESTI: %+.3le %+.3le %+.3le\n", in(i,j).y, (*inv)(j,i).y, fabs(in(i,j).y + (*inv)(j,i).y));
-        cudaDeviceSynchronize();
-        if (fabs(in(i,j).x - inv(j,i).x) > 1e-14)
-          return 1;
-        if (fabs(in(i,j).y + inv(j,i).y) > 1e-14)
-          return 1;
+    for (int i=0; i<in.size(); i++) {
+      for (int j=0; j<in.size(); j++) {
+        printf("TESTR: %+.13le %+.13le %+.13le\n",
+               in(i,j).real(), inv(j,i).real(), fabs(in(i,j).real() - inv(j,i).real()));
+	printf("TESTI: %+.13le %+.13le %+.13le\n",
+               in(i,j).imag(), inv(j,i).imag(), fabs(in(i,j).imag() + inv(j,i).imag()));
       }
-    return 0;  
+    }
   }
 
   /**
-   * @brief Project the input matrix on the SU(3) group.  First unitarize the matrix and then project onto the special unitary group.
+   * @brief Project the input matrix on the SU(3) group.  First
+   * unitarize the matrix and then project onto the special unitary
+   * group.
    *
    * @param in The input matrix to which we're projecting
    * @param tol Tolerance to which this check is applied
    */
   template <typename Float>
-  __host__ __device__ void polarSu3(Matrix<complex<Float>,3> &in, Float tol)
+  __host__ __device__ inline void polarSu3(Matrix<complex<Float>,3> &in, Float tol)
   {
-    Matrix<complex<Float>,3> inv, out;
+    constexpr Float negative_third = -1.0/3.0;
+    constexpr Float negative_sixth = -1.0/6.0;
+    Matrix<complex<Float>,3> out = in;
+    Matrix<complex<Float>,3> inv = inverse(in);
 
-    out = in;
-    computeMatrixInverse(out, &inv);
-
-    // iterate until matrix is unitary
-    do {
+    constexpr int max_iter = 100;
+    int i = 0;
+    do { // iterate until matrix is unitary
       out = 0.5*(out + conj(inv));
-    } while(checkUnitary(inv, out, tol));
+      inv = inverse(out);
+    } while (!checkUnitary(inv, out, tol) && ++i < max_iter);
 
     // now project onto special unitary group
     complex<Float> det = getDeterminant(out);
-    double mod = norm(det);
-    mod = pow(mod, (1./6.));
-    double angle = atan2(det.y, det.x);
-    angle /= -3.;
-    
+    Float mod = pow(norm(det), negative_sixth);
+    Float angle = arg(det);
+
     complex<Float> cTemp;
+    sincos(negative_third * angle, &cTemp.y, &cTemp.x);
 
-    sincos(angle, &cTemp.y, &cTemp.x);
-    cTemp /= mod;
-
-    in = out*cTemp;
+    in = (mod*cTemp)*out;
   }
 
   

--- a/lib/gauge_stout.cu
+++ b/lib/gauge_stout.cu
@@ -142,7 +142,7 @@ namespace quda {
 	//Compute Omega_{mu}=[Sum_{mu neq nu}rho_{mu,nu}C_{mu,nu}]*U_{mu}^dag
 
 	//Get U^{\dagger}
-	computeMatrixInverse(U,&UDag);
+	UDag = inverse(U);
 	
 	//Compute \Omega = \rho * S * U^{\dagger}
 	Omega = (arg.rho * Stap) * UDag;
@@ -637,7 +637,7 @@ namespace quda {
 	//-------------------------------------------------------------------
 
 	//Get U^{\dagger}
-	computeMatrixInverse(U,&UDag);
+	UDag = inverse(U);
 	
 	//Compute \rho * staple_coeff * S
 	Omega = (arg.rho*staple_coeff)*(Stap);

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -4471,7 +4471,7 @@ void computeHISQForceQuda(void* const milc_momentum,
         profileHISQForce.TPSTOP(QUDA_PROFILE_H2D);
 
         profileHISQForce.TPSTART(QUDA_PROFILE_COMPUTE);
-        computeStaggeredOprod(oprod, cudaQuark, coeff[i], 3);
+        computeStaggeredOprod(oprod, cudaQuark, coeff[i + num_terms], 3);
         profileHISQForce.TPSTOP(QUDA_PROFILE_COMPUTE);
       }
     }

--- a/lib/malloc.cpp
+++ b/lib/malloc.cpp
@@ -278,13 +278,22 @@ namespace quda {
   void *mapped_malloc_(const char *func, const char *file, int line, size_t size)
   {
     MemAlloc a(func, file, line);
+
+#if 1
+    void *ptr;
+    cudaError_t err = cudaHostAlloc(&ptr, size, cudaHostRegisterMapped | cudaHostRegisterPortable);
+    if (err != cudaSuccess) {
+      printfQuda("ERROR: cudaHostAlloc failed of size %zu (%s:%d in %s())\n", size, file, line, func);
+      errorQuda("Aborting");
+    }
+#else
     void *ptr = aligned_malloc(a, size);
-    
     cudaError_t err = cudaHostRegister(ptr, a.base_size, cudaHostRegisterMapped);
     if (err != cudaSuccess) {
       printfQuda("ERROR: Failed to register host-mapped memory of size %zu (%s:%d in %s())\n", size, file, line, func);
       errorQuda("Aborting");
     }
+#endif
     track_malloc(MAPPED, a, ptr);
 #ifdef HOST_DEBUG
     memset(ptr, 0xff, a.base_size);
@@ -363,6 +372,7 @@ namespace quda {
     }
     if (alloc[HOST].count(ptr)) {
       track_free(HOST, ptr);
+      free(ptr);
     } else if (alloc[PINNED].count(ptr)) {
       cudaError_t err = cudaHostUnregister(ptr);
       if (err != cudaSuccess) {
@@ -370,19 +380,27 @@ namespace quda {
 	errorQuda("Aborting");
       }
       track_free(PINNED, ptr);
+      free(ptr);
     } else if (alloc[MAPPED].count(ptr)) {
+#if 1
+      cudaError_t err = cudaFreeHost(ptr);
+      if (err != cudaSuccess) {
+	printfQuda("ERROR: Failed to free host memory (%s:%d in %s())\n", file, line, func);
+	errorQuda("Aborting");
+      }
+#else
       cudaError_t err = cudaHostUnregister(ptr);
       if (err != cudaSuccess) {
 	printfQuda("ERROR: Failed to unregister host-mapped memory (%s:%d in %s())\n", file, line, func);
 	errorQuda("Aborting");
       }
+#endif
       track_free(MAPPED, ptr);
     } else {
       printfQuda("ERROR: Attempt to free invalid host pointer (%s:%d in %s())\n", file, line, func);
       print_trace();
       errorQuda("Aborting");
     }
-    free(ptr);
   }
 
 

--- a/lib/malloc.cpp
+++ b/lib/malloc.cpp
@@ -395,6 +395,7 @@ namespace quda {
 	printfQuda("ERROR: Failed to unregister host-mapped memory (%s:%d in %s())\n", file, line, func);
 	errorQuda("Aborting");
       }
+      free(ptr);
 #endif
       track_free(MAPPED, ptr);
     } else {

--- a/lib/malloc.cpp
+++ b/lib/malloc.cpp
@@ -269,6 +269,7 @@ namespace quda {
     return ptr;
   }
 
+#define HOST_ALLOC // this needs to be set presently on P9
 
   /**
    * Allocate page-locked ("pinned") host memory, and map it into the
@@ -279,7 +280,7 @@ namespace quda {
   {
     MemAlloc a(func, file, line);
 
-#if 1
+#ifdef HOST_ALLOC
     void *ptr;
     cudaError_t err = cudaHostAlloc(&ptr, size, cudaHostRegisterMapped | cudaHostRegisterPortable);
     if (err != cudaSuccess) {
@@ -382,7 +383,7 @@ namespace quda {
       track_free(PINNED, ptr);
       free(ptr);
     } else if (alloc[MAPPED].count(ptr)) {
-#if 1
+#ifdef HOST_ALLOC
       cudaError_t err = cudaFreeHost(ptr);
       if (err != cudaSuccess) {
 	printfQuda("ERROR: Failed to free host memory (%s:%d in %s())\n", file, line, func);

--- a/lib/milc_interface.cpp
+++ b/lib/milc_interface.cpp
@@ -101,7 +101,7 @@ void qudaFinalize()
   endQuda();
   qudamilc_called<false>(__func__);
 }
-#ifdef MULTI_GPU
+#if defined(MULTI_GPU) && !defined(QMP_COMMS)
 /**
  *  Implements a lexicographical mapping of node coordinates to ranks,
  *  with t varying fastest.

--- a/lib/milc_interface.cpp
+++ b/lib/milc_interface.cpp
@@ -136,7 +136,11 @@ void qudaSetLayout(QudaLayout_t input)
 
 #ifdef MULTI_GPU
   for(int dir=0; dir<4; ++dir)  gridDim[dir] = input.machsize[dir];
+#ifdef QMP_COMMS
+  initCommsGridQuda(4, gridDim, nullptr, nullptr);
+#else
   initCommsGridQuda(4, gridDim, rankFromCoords, (void *)(gridDim));
+#endif
   static int device = -1;
 #else
   for(int dir=0; dir<4; ++dir)  gridDim[dir] = 1;

--- a/lib/unitarize_links_quda.cu
+++ b/lib/unitarize_links_quda.cu
@@ -58,13 +58,12 @@ namespace{
 		      int max_iter, double unitarize_eps, double max_error,
 		      int reunit_allow_svd, int reunit_svd_only, double svd_rel_error,
 		      double svd_abs_error)
-      : output(output), input(input), fails(fails), unitarize_eps(unitarize_eps),
+      : threads(data.VolumeCB()), output(output), input(input), fails(fails), unitarize_eps(unitarize_eps),
 	max_iter(max_iter), max_error(max_error), reunit_allow_svd(reunit_allow_svd),
 	reunit_svd_only(reunit_svd_only), svd_rel_error(svd_rel_error),
 	svd_abs_error(svd_abs_error)
     {
-      for(int dir=0; dir<4; ++dir) X[dir] = data.X()[dir];
-      threads = X[0]*X[1]*X[2]*X[3];
+      for (int dir=0; dir<4; ++dir) X[dir] = data.X()[dir];
     }
   };
 
@@ -281,7 +280,7 @@ namespace{
     u = in;
 
     for(int i=0; i<max_iter; ++i){
-      computeMatrixInverse(u, &uinv);
+      uinv = inverse(u);
       u = 0.5*(u + conj(uinv));
     }
 
@@ -364,56 +363,46 @@ namespace{
   template<typename Float, typename Out, typename In>
   __global__ void DoUnitarizedLink(UnitarizeLinksArg<Out,In> arg){
     int idx = threadIdx.x + blockIdx.x*blockDim.x;
-    if(idx >= arg.threads) return;
-    int parity = 0;
-    if(idx >= arg.threads/2) {
-      parity = 1;
-      idx -= arg.threads/2;
-    }
-    int X[4]; 
-    for(int dr=0; dr<4; ++dr) X[dr] = arg.X[dr];
-    int x[4];
-    getCoords(x, idx, X, parity);
-    
-    idx = linkIndex(x,X);
+    int parity = threadIdx.y + blockIdx.y*blockDim.y;
+    int mu = threadIdx.z + blockIdx.z*blockDim.z;
+    if (idx >= arg.threads) return;
+    if (mu >= 4) return;
+
     // result is always in double precision
     Matrix<complex<double>,3> v, result;
-    Matrix<complex<Float>,3> tmp;
-    for (int mu = 0; mu < 4; mu++) { 
-      arg.input.load((Float*)(tmp.data),idx, mu, parity);
+    Matrix<complex<Float>,3> tmp = arg.input(mu, idx, parity);
 
-      v = tmp;
-      unitarizeLinkMILC(v, &result, arg);
-      if (arg.check_unitarization) {
-        if (isUnitary(result,arg.max_error) == false) atomicAdd(arg.fails, 1);
-      }
-      //WRITE BACK IF FAIL??????????
-      tmp = result;
-
-      arg.output.save((Float*)(tmp.data),idx, mu, parity); 
+    v = tmp;
+    unitarizeLinkMILC(v, &result, arg);
+    if (arg.check_unitarization) {
+      if (isUnitary(result,arg.max_error) == false) atomicAdd(arg.fails, 1);
     }
+    tmp = result;
+
+    arg.output(mu, idx, parity) = tmp;
   }
 
 
 
   template<typename Float, typename Out, typename In>
-  class UnitarizeLinks : Tunable {
+  class UnitarizeLinks : TunableVectorYZ {
     UnitarizeLinksArg<Out,In> arg;
-    
+    const GaugeField &meta;
+
     unsigned int sharedBytesPerThread() const { return 0; }
     unsigned int sharedBytesPerBlock(const TuneParam &) const { return 0; }
-    
+
     // don't tune the grid dimension
     bool tuneGridDim() const { return false; }
     unsigned int minThreads() const { return arg.threads; }
-    
+
   public:
-    UnitarizeLinks(UnitarizeLinksArg<Out,In> &arg) : arg(arg) { }
-    
+    UnitarizeLinks(UnitarizeLinksArg<Out,In> &arg, const GaugeField &meta)
+      : TunableVectorYZ(2,4), arg(arg), meta(meta) { }
     
     void apply(const cudaStream_t &stream){
       TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
-      DoUnitarizedLink<Float,Out,In><<<tp.grid, tp.block, 0, stream>>>(arg);
+      DoUnitarizedLink<Float,Out,In><<<tp.grid, tp.block, tp.shared_bytes, stream>>>(arg);
     }
     void preTune() { if (arg.input.gauge == arg.output.gauge) arg.output.save(); }
     void postTune() {
@@ -423,27 +412,23 @@ namespace{
     
     long long flops() const { 
       // Accounted only the minimum flops for the case reunitarize_svd_only=0
-      return 4588LL*arg.threads; 
+      return 4ll * 2 * arg.threads * 1147;
     }
-    long long bytes() const { return 4ll * arg.threads * (arg.input.Bytes() + arg.output.Bytes()); }
+    long long bytes() const { return 4ll * 2 * arg.threads * (arg.input.Bytes() + arg.output.Bytes()); }
     
     TuneKey tuneKey() const {
-      std::stringstream vol, aux;
-      vol << arg.X[0] << "x";
-      vol << arg.X[1] << "x";
-      vol << arg.X[2] << "x";
-      vol << arg.X[3];
+      std::stringstream aux;
       aux << "threads=" << arg.threads << ",prec=" << sizeof(Float);
-      return TuneKey(vol.str().c_str(), typeid(*this).name(), aux.str().c_str());
+      return TuneKey(meta.VolString(), typeid(*this).name(), aux.str().c_str());
     }  
   }; 
   
   
   template<typename Float, typename Out, typename In>
-  void unitarizeLinks(Out output,  const In input, const cudaGaugeField& meta, int* fails) {
+  void unitarizeLinks(Out output, const In input, const cudaGaugeField& meta, int* fails) {
     UnitarizeLinksArg<Out,In> arg(output, input, meta, fails, max_iter, unitarize_eps, max_error,
-				      reunit_allow_svd, reunit_svd_only, svd_rel_error, svd_abs_error);
-    UnitarizeLinks<Float, Out, In> unitlinks(arg) ;
+                                  reunit_allow_svd, reunit_svd_only, svd_rel_error, svd_abs_error);
+    UnitarizeLinks<Float, Out, In> unitlinks(arg, meta);
     unitlinks.apply(0);
     qudaDeviceSynchronize(); // need to synchronize to ensure failure write has completed
   }
@@ -540,37 +525,35 @@ void unitarizeLinks(cudaGaugeField& output, const cudaGaugeField &input, int* fa
     G u;
     Float tol;
     int *fails;
-    int X[4];
     ProjectSU3Arg(G u, const GaugeField &meta, Float tol, int *fails) 
-      : u(u), tol(tol), fails(fails) {
-      for(int dir=0; dir<4; ++dir) X[dir] = meta.X()[dir];
-      threads = meta.VolumeCB();
-    }
+      : threads(meta.VolumeCB()), u(u), tol(tol), fails(fails) { }
   };
 
   template<typename Float, typename G>
   __global__ void ProjectSU3kernel(ProjectSU3Arg<Float,G> arg){
     int idx = threadIdx.x + blockIdx.x*blockDim.x;
-    int parity = blockIdx.y;
-    if(idx >= arg.threads) return;
-    
-    Matrix<complex<Float>,3> u;
+    int parity = threadIdx.y + blockIdx.y*blockDim.y;
+    int mu = threadIdx.z + blockIdx.z*blockDim.z;
+    if (idx >= arg.threads) return;
+    if (mu >= 4) return;
 
-    for (int mu = 0; mu < 4; mu++) { 
-      arg.u.load((Float*)(u.data),idx, mu, parity);
-      polarSu3<Float>(u, arg.tol);
+    Matrix<complex<Float>,3> u = arg.u(mu, idx, parity);
 
-      // count number of failures
-      if(isUnitary(u, arg.tol) == false) atomicAdd(arg.fails, 1);
+    polarSu3<Float>(u, arg.tol);
 
-      arg.u.save((Float*)(u.data),idx, mu, parity); 
+    // count number of failures
+    if (isUnitary(u, arg.tol) == false) {
+      atomicAdd(arg.fails, 1);
     }
+
+    arg.u(mu, idx, parity) = u;
   }
 
   template<typename Float, typename G>
-  class ProjectSU3 : Tunable {    
+  class ProjectSU3 : TunableVectorYZ {
     ProjectSU3Arg<Float,G> arg;
-    
+    const GaugeField &meta;
+
     unsigned int sharedBytesPerThread() const { return 0; }
     unsigned int sharedBytesPerBlock(const TuneParam &) const { return 0; }
     
@@ -579,23 +562,26 @@ void unitarizeLinks(cudaGaugeField& output, const cudaGaugeField &input, int* fa
     unsigned int minThreads() const { return arg.threads; }
     
   public:
-    ProjectSU3(ProjectSU3Arg<Float,G> &arg) : arg(arg) { }
+    ProjectSU3(ProjectSU3Arg<Float,G> &arg, const GaugeField &meta)
+      : TunableVectorYZ(2, 4), arg(arg), meta(meta) { }
     
     void apply(const cudaStream_t &stream){
-      TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
-      ProjectSU3kernel<Float,G><<<tp.grid, tp.block, 0, stream>>>(arg);
+      TuneParam tp = tuneLaunch(*this, getTuning(), QUDA_VERBOSE); //getVerbosity());
+      ProjectSU3kernel<Float,G><<<tp.grid, tp.block, tp.shared_bytes, stream>>>(arg);
     }
     void preTune() { arg.u.save(); }
-    void postTune() { arg.u.load(); }
+    void postTune() {
+      arg.u.load();
+      cudaMemset(arg.fails, 0, sizeof(int)); // reset fails counter
+    }
   
     long long flops() const { return 0; } // depends on number of iterations
-    long long bytes() const { return 4ll * arg.threads * arg.u.Bytes(); }
+    long long bytes() const { return 4ll * 2 * arg.threads * arg.u.Bytes(); }
     
     TuneKey tuneKey() const {
-      std::stringstream vol, aux;
-      vol << arg.X[0] << "x" << arg.X[1] << "x" << arg.X[2] << "x" << arg.X[3];
+      std::stringstream aux;
       aux << "threads=" << arg.threads << ",prec=" << sizeof(Float);
-      return TuneKey(vol.str().c_str(), typeid(*this).name(), aux.str().c_str());
+      return TuneKey(meta.VolString(), typeid(*this).name(), aux.str().c_str());
     }
   };
   
@@ -605,7 +591,7 @@ void unitarizeLinks(cudaGaugeField& output, const cudaGaugeField &input, int* fa
     if (u.Reconstruct() == QUDA_RECONSTRUCT_NO) {
       typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_NO>::type G;
       ProjectSU3Arg<Float,G> arg(G(u), u, static_cast<Float>(tol), fails);
-      ProjectSU3<Float,G> project(arg);
+      ProjectSU3<Float,G> project(arg, u);
       project.apply(0);
       qudaDeviceSynchronize();
       checkCudaError();
@@ -615,6 +601,7 @@ void unitarizeLinks(cudaGaugeField& output, const cudaGaugeField &input, int* fa
   }
   
   void projectSU3(cudaGaugeField &u, double tol, int *fails) {
+
 #ifdef GPU_UNITARIZE
     // check the the field doesn't have staggered phases applied
     if (u.StaggeredPhaseApplied()) 
@@ -630,6 +617,7 @@ void unitarizeLinks(cudaGaugeField& output, const cudaGaugeField &input, int* fa
 #else
     errorQuda("Unitarization has not been built");
 #endif
+
   }
 
 } // namespace quda

--- a/lib/unitarize_links_quda.cu
+++ b/lib/unitarize_links_quda.cu
@@ -576,7 +576,7 @@ void unitarizeLinks(cudaGaugeField& output, const cudaGaugeField &input, int* fa
     }
   
     long long flops() const { return 0; } // depends on number of iterations
-    long long bytes() const { return 4ll * 2 * arg.threads * arg.u.Bytes(); }
+    long long bytes() const { return 4ll * 2 * arg.threads * 2 * arg.u.Bytes(); }
     
     TuneKey tuneKey() const {
       std::stringstream aux;

--- a/tests/unitarize_link_test.cpp
+++ b/tests/unitarize_link_test.cpp
@@ -164,7 +164,7 @@ static int unitarize_link_test(int &test_rc)
   gParam.pad         = 0;
   gParam.create      = QUDA_NULL_FIELD_CREATE;
   gParam.reconstruct = QUDA_RECONSTRUCT_NO;
-  gParam.setPrecision(prec);
+  gParam.setPrecision(prec, true);
   cudaFatLink = new cudaGaugeField(gParam);
   cudaULink   = new cudaGaugeField(gParam);
 


### PR DESCRIPTION
Some fixes and cleanup in this pull
* When allocating mapped memory, use `cudaAllocHost` instead of `malloc` and `cudaHostRegister` (work around for issue on POWER9 systems)
* Improved test coverage of `unitarizeLinkTest` to use mapped memory matching what the actual interface does
* Fixed bug in link unitarization (only first parity was being unitarized) and some performance optimization
* Fix bug in HISQ force outer product when including a non-zero Naik term in the action
* In MILC interface, when using QMP communication, do not supply a rank-to-coordinate functor, allowing QMP to specify the logical topology
* Remove legacy some `volatile` declarations