### PR TITLE
Feature/force monitor

### DIFF
--- a/include/comm_quda.h
+++ b/include/comm_quda.h
@@ -264,6 +264,7 @@ extern "C" {
   void comm_allreduce_max(double* data);
   void comm_allreduce_min(double* data);
   void comm_allreduce_array(double* data, size_t size);
+  void comm_allreduce_max_array(double* data, size_t size);
   void comm_allreduce_int(int* data);
   void comm_allreduce_xor(uint64_t *data);
   void comm_broadcast(void *data, size_t nbytes);

--- a/include/cub_helper.cuh
+++ b/include/cub_helper.cuh
@@ -23,47 +23,6 @@ using namespace quda;
 namespace quda {
 
   /**
-     Helper functor for generic addition reduction.
-  */
-  template <typename T>
-  struct Summ {
-    __host__ __device__ __forceinline__ T operator() (const T &a, const T &b){
-      return a + b;
-    }
-  };
-
-  /**
-     Helper functor for double2 addition reduction.
-  */
-  template <>
-  struct Summ<double2>{
-    __host__ __device__ __forceinline__ double2 operator() (const double2 &a, const double2 &b){
-      return make_double2(a.x + b.x, a.y + b.y);
-    }
-  };
-
-  /**
-     Helper functor for double3 addition reduction.
-  */
-  template <>
-  struct Summ<double3>{
-    __host__ __device__ __forceinline__ double3 operator() (const double3 &a, const double3 &b){
-      return make_double3(a.x + b.x, a.y + b.y, a.z + b.z);
-    }
-  };
-
-  /**
-     Helper functor for doubledouble4 addition reduction.
-  */
-  template <>
-  struct Summ<double4>{
-    __host__ __device__ __forceinline__ double4 operator() (const double4 &a, const double4 &b){
-      return make_double4(a.x + b.x, a.y + b.y, a.z + b.z, a.w + b.w);
-    }
-  };
-
-
-  /**
      struct which acts as a wrapper to a vector of data.
    */
   template <typename scalar, int n>
@@ -126,13 +85,14 @@ namespace quda {
   __device__ unsigned int count[QUDA_MAX_MULTI_REDUCE] = { };
   __shared__ bool isLastBlockDone;
 
-  template <int block_size_x, int block_size_y, typename T>
+  template <int block_size_x, int block_size_y, typename T, bool do_sum=true, typename Reducer=cub::Sum>
   __device__ inline void reduce2d(ReduceArg<T> arg, const T &in, const int idx=0) {
 
     typedef cub::BlockReduce<T, block_size_x, cub::BLOCK_REDUCE_WARP_REDUCTIONS, block_size_y> BlockReduce;
     __shared__ typename BlockReduce::TempStorage cub_tmp;
 
-    T aggregate = BlockReduce(cub_tmp).Sum(in);
+    Reducer r;
+    T aggregate = (do_sum ? BlockReduce(cub_tmp).Sum(in) : BlockReduce(cub_tmp).Reduce(in, r));
 
     if (threadIdx.x == 0 && threadIdx.y == 0) {
       arg.partial[idx*gridDim.x + blockIdx.x] = aggregate;
@@ -153,11 +113,12 @@ namespace quda {
       T sum;
       zero(sum);
       while (i<gridDim.x) {
-	sum += arg.partial[idx*gridDim.x + i];
+        sum = r(sum, arg.partial[idx*gridDim.x + i]);
+	//sum += arg.partial[idx*gridDim.x + i];
 	i += block_size_x*block_size_y;
       }
 
-      sum = BlockReduce(cub_tmp).Sum(sum);
+      sum = (do_sum ? BlockReduce(cub_tmp).Sum(sum) : BlockReduce(cub_tmp).Reduce(sum,r));
 
       // write out the final reduced value
       if (threadIdx.y*block_size_x + threadIdx.x == 0) {
@@ -167,8 +128,8 @@ namespace quda {
     }
   }
 
-  template <int block_size, typename T>
-  __device__ inline void reduce(ReduceArg<T> arg, const T &in, const int idx=0) { reduce2d<block_size, 1, T>(arg, in, idx); }
+  template <int block_size, typename T, bool do_sum = true, typename Reducer = cub::Sum>
+  __device__ inline void reduce(ReduceArg<T> arg, const T &in, const int idx=0) { reduce2d<block_size, 1, T, do_sum, Reducer>(arg, in, idx); }
 
 
   __shared__ volatile bool isLastWarpDone[16];

--- a/include/ks_improved_force.h
+++ b/include/ks_improved_force.h
@@ -13,13 +13,11 @@ namespace quda {
        @param[in] oprod The previously computed input force
        @param[in] link Thin-link gauge field
        @param[in] path_coeff Coefficients of the contributions to the operator
-       @param[out] flops number of flops performed
     */
     void hisqStaplesForce(GaugeField &newOprod,
                           const GaugeField& oprod,
                           const GaugeField& link,
-                          const double path_coeff[6],
-                          long long* flops = nullptr);
+                          const double path_coeff[6]);
 
     /**
        @brief Compute the long-link contribution to the fermion force
@@ -27,26 +25,21 @@ namespace quda {
        @param[in] oprod The previously computed input force
        @param[in] link Thin-link gauge field
        @param[in] coeff Long-link Coefficient
-       @param[out] flops number of flops performed
     */
     void hisqLongLinkForce(GaugeField &newOprod,
                            const GaugeField &oprod,
                            const GaugeField &link,
-                           double coeff,
-                           long long* flops = nullptr);
+                           double coeff);
 
     /**
        @brief Multiply the computed the force matrix by the gauge
        field and perform traceless anti-hermitian projection
-       @param[out] momentum The computed momentum
-       @param[in] oprod The previously computed force
+       @param[in,out] oprod The previously computed force, overwritten
+       with new projection
        @param[in] link Thin-link gauge field
-       @param[out] flops number of flops performed
     */
-    void hisqCompleteForce(GaugeField &momentum,
-                           const GaugeField &oprod,
-                           const GaugeField &link,
-                           long long* flops = nullptr);
+    void hisqCompleteForce(GaugeField &oprod,
+                           const GaugeField &link);
 
     /**
        @brief Set the constant parameters for the force unitarization
@@ -62,13 +55,11 @@ namespace quda {
        @param[in] oldForce Input force
        @param[in] gauge Gauge field
        @param[out] unitarization_failed Whether the unitarization failed (number of failures)
-       @param[out] flops number of flops performed
     */
     void unitarizeForce(cudaGaugeField &newForce,
                         const cudaGaugeField &oldForce,
                         const cudaGaugeField &gauge,
-                        int* unitarization_failed,
-                        long long* flops = NULL);
+                        int* unitarization_failed);
 
     /**
        @brief Unitarize the fermion force on CPU

--- a/include/momentum.h
+++ b/include/momentum.h
@@ -18,9 +18,11 @@ namespace quda {
      where [A]_TA means the traceless anti-hermitian projection of A
 
      @param mom Momentum field
+     @param coeff Integration stepsize
      @param force Force field
+     @param func The function calling this (fname will be printed if force monitoring is enabled)
    */
-  void updateMomentum(GaugeField &mom, double coeff, GaugeField &force);
+  void updateMomentum(GaugeField &mom, double coeff, GaugeField &force, const char *fname);
 
   /**
      Left multiply the force field by the gauge field
@@ -31,5 +33,16 @@ namespace quda {
      @param U Gauge field
    */
   void applyU(GaugeField &force, GaugeField &U);
+
+  /**
+     @brief Whether we are monitoring the force or not
+     @return Boolean whether we are monitoring the force
+  */
+  bool forceMonitor();
+
+  /**
+     @brief Flush any outstanding force monitoring information
+  */
+  void flushForceMonitor();
 
 } // namespace quda

--- a/include/quda.h
+++ b/include/quda.h
@@ -1017,8 +1017,9 @@ extern "C" {
 				 QudaGaugeParam *gauge_param, QudaInvertParam *invert_param);
 
   /**
-   * Compute the fermion force for the HISQ quark action.
-   * @param momentum        The momentum contribution from the quark action.
+   * Compute the fermion force for the HISQ quark action and integrate the momentum.
+   * @param momentum        The momentum field we are integrating
+   * @param dt              The stepsize used to integrate the momentum
    * @param level2_coeff    The coefficients for the second level of smearing in the quark action.
    * @param fat7_coeff      The coefficients for the first level of smearing (fat7) in the quark action.
    * @param w_link          Unitarized link variables obtained by applying fat7 smearing and unitarization to the original links.
@@ -1031,7 +1032,7 @@ extern "C" {
    * @param param.          The field parameters.
    */
   void computeHISQForceQuda(void* momentum,
-                            long long* flops,
+                            double dt,
                             const double level2_coeff[6],
                             const double fat7_coeff[6],
                             const void* const w_link,

--- a/include/quda_matrix.h
+++ b/include/quda_matrix.h
@@ -63,7 +63,9 @@ namespace quda {
   template<class T, int N>
     class Matrix
     {
-      private:
+      typedef typename RealType<T>::type real;
+
+    private:
         __device__ __host__ inline int index(int i, int j) const { return i*N + j; }
 
       public:
@@ -86,7 +88,7 @@ namespace quda {
 	  for (int i=0; i<N*N; i++) data[i] = data_[i];
 	}
 
-	__device__ __host__ inline Matrix(const HMatrix<typename RealType<T>::type,N> &a);
+	__device__ __host__ inline Matrix(const HMatrix<real,N> &a);
 
         __device__ __host__ inline T const & operator()(int i, int j) const {
           return data[index(i,j)];
@@ -115,18 +117,73 @@ namespace quda {
 	}
 
 	template<typename S>
-	  __device__ __host__ inline Matrix(const gauge_wrapper<typename RealType<T>::type, S> &s);
+	  __device__ __host__ inline Matrix(const gauge_wrapper<real, S> &s);
 
 	template<typename S>
-	  __device__ __host__ inline void operator=(const gauge_wrapper<typename RealType<T>::type, S> &s);
+	  __device__ __host__ inline void operator=(const gauge_wrapper<real, S> &s);
 
 	template<typename S>
-	  __device__ __host__ inline Matrix(const gauge_ghost_wrapper<typename RealType<T>::type, S> &s);
+	  __device__ __host__ inline Matrix(const gauge_ghost_wrapper<real, S> &s);
 
 	template<typename S>
-	  __device__ __host__ inline void operator=(const gauge_ghost_wrapper<typename RealType<T>::type, S> &s);
+	  __device__ __host__ inline void operator=(const gauge_ghost_wrapper<real, S> &s);
 
-	/**
+        /**
+           @brief Compute the matrix L1 norm - this is the maximum of
+           the absolute column sums.
+           @return Compute L1 norm
+        */
+        __device__ __host__ inline real L1() {
+          real l1 = 0;
+#pragma unroll
+          for (int j=0; j<N; j++) {
+            real col_sum = 0;
+#pragma unroll
+            for (int i=0; i<N; i++) {
+              col_sum += abs(data[i*N + j]);
+            }
+            l1 = col_sum > l1 ? col_sum : l1;
+          }
+          return l1;
+        }
+
+        /**
+           @brief Compute the matrix L2 norm.  We actually compute the
+           Frobenius norm which is an upper bound on the L2 norm.
+           @return Computed L2 norm
+        */
+        __device__ __host__ inline real L2() {
+          real l2 = 0;
+#pragma unroll
+          for (int j=0; j<N; j++) {
+#pragma unroll
+            for (int i=0; i<N; i++) {
+              l2 += norm(data[i*N + j]);
+            }
+          }
+          return sqrt(l2);
+        }
+
+        /**
+           @brief Compute the matrix L1 norm - this is the maximum of
+           the absolute row sums.
+           @return Computed Linfinity norm
+        */
+        __device__ __host__ inline real Linf() {
+          real linf = 0;
+#pragma unroll
+          for (int i=0; i<N; i++) {
+            real row_sum = 0;
+#pragma unroll
+            for (int j=0; j<N; j++) {
+              row_sum += abs(data[i*N + j]);
+            }
+            linf = row_sum > linf ? row_sum : linf;
+          }
+          return linf;
+        }
+
+        /**
 	   Return 64-bit XOR checksum computed from the
 	   elements of the matrix.  Compute the checksum on each
 	   64-bit word that constitutes the Matrix

--- a/include/quda_milc_interface.h
+++ b/include/quda_milc_interface.h
@@ -598,6 +598,7 @@ extern "C" {
    * @param precision       The precision of the fields
    * @param num_terms The number of quark fields
    * @param num_naik_terms The number of naik contributions
+   * @param dt Integrating step size
    * @param coeff The coefficients multiplying the fermion fields in the outer product
    * @param quark_field The input fermion field.
    * @param level2_coeff    The coefficients for the second level of smearing in the quark action.
@@ -610,6 +611,7 @@ extern "C" {
   void qudaHisqForce(int precision,
                      int num_terms,
                      int num_naik_terms,
+                     double dt,
                      double** coeff,
                      void** quark_field,
 		     const double level2_coeff[6],

--- a/lib/comm_mpi.cpp
+++ b/lib/comm_mpi.cpp
@@ -308,6 +308,13 @@ void comm_allreduce_array(double* data, size_t size)
   delete []recvbuf;
 }
 
+void comm_allreduce_max_array(double* data, size_t size)
+{
+  double *recvbuf = new double[size];
+  MPI_CHECK( MPI_Allreduce(data, recvbuf, size, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD) );
+  memcpy(data, recvbuf, size*sizeof(double));
+  delete []recvbuf;
+}
 
 void comm_allreduce_int(int* data)
 {

--- a/lib/comm_qmp.cpp
+++ b/lib/comm_qmp.cpp
@@ -273,6 +273,12 @@ void comm_allreduce_array(double* data, size_t size)
   QMP_CHECK( QMP_sum_double_array(data, size) );
 }
 
+void comm_allreduce_max_array(double* data, size_t size)
+{
+  for (int i=0; i<size; i++) {
+    QMP_CHECK( QMP_max_double(data+i) );
+  }
+}
 
 void comm_allreduce_int(int* data)
 {

--- a/lib/comm_single.cpp
+++ b/lib/comm_single.cpp
@@ -60,6 +60,8 @@ void comm_allreduce_min(double* data) {}
 
 void comm_allreduce_array(double* data, size_t size) {}
 
+void comm_allreduce_max_array(double* data, size_t size) {}
+
 void comm_allreduce_int(int* data) {}
 
 void comm_allreduce_xor(uint64_t *data) {}

--- a/lib/gauge_field.cpp
+++ b/lib/gauge_field.cpp
@@ -4,7 +4,9 @@
 
 namespace quda {
 
-  GaugeFieldParam::GaugeFieldParam(const GaugeField &u) : LatticeFieldParam(u),
+  GaugeFieldParam::GaugeFieldParam(const GaugeField &u) :
+    LatticeFieldParam(u),
+    location(u.Location()),
     nColor(u.Ncolor()),
     nFace(u.Nface()),
     reconstruct(u.Reconstruct()),

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -1443,6 +1443,9 @@ void endQuda(void)
   saveTuneCache();
   saveProfile();
 
+  // flush any outstanding force monitoring (if enabled)
+  flushForceMonitor();
+
   initialized = false;
 
   comm_finalize();
@@ -4049,7 +4052,17 @@ int computeGaugeForceQuda(void* mom, void* siteLink,  int*** input_path_buf, int
 
   // actually do the computation
   profileGaugeForce.TPSTART(QUDA_PROFILE_COMPUTE);
-  gaugeForce(*cudaMom, *cudaGauge, eb3, input_path_buf,  path_length, loop_coeff, num_paths, max_length);
+  if (!forceMonitor()) {
+    gaugeForce(*cudaMom, *cudaGauge, eb3, input_path_buf,  path_length, loop_coeff, num_paths, max_length);
+  } else {
+    // if we are monitoring the force, separate the force computation from the momentum update
+    GaugeFieldParam gParam(*cudaMom);
+    gParam.create = QUDA_ZERO_FIELD_CREATE;
+    GaugeField *force = GaugeField::Create(gParam);
+    gaugeForce(*force, *cudaGauge, 1.0, input_path_buf,  path_length, loop_coeff, num_paths, max_length);
+    updateMomentum(*cudaMom, eb3, *force, "gauge");
+    delete force;
+  }
   profileGaugeForce.TPSTOP(QUDA_PROFILE_COMPUTE);
 
   if (qudaGaugeParam->return_result_mom) {
@@ -4283,7 +4296,7 @@ void computeStaggeredForceQuda(void* h_mom, double dt, double delta, void *h_for
   for (int i=0; i<nvector; i++) {
     ColorSpinorField &x = *(X[i]);
     // second component is zero since we have no three hop term
-    double coeff[2] = {dt * inv_param->residue[i], 0.0};
+    double coeff[2] = {inv_param->residue[i], 0.0};
 
     // Operate on even-parity sites
     computeStaggeredOprod(cudaForce_, x, coeff, 1);
@@ -4291,7 +4304,7 @@ void computeStaggeredForceQuda(void* h_mom, double dt, double delta, void *h_for
 
   // mom += delta * [U * force]TA
   applyU(cudaForce, *gaugePrecise);
-  updateMomentum(*cudaMom, delta, cudaForce);
+  updateMomentum(*cudaMom, dt * delta, cudaForce, "staggered");
   qudaDeviceSynchronize();
 
   profileStaggeredForce.TPSTOP(QUDA_PROFILE_COMPUTE);
@@ -4322,7 +4335,7 @@ void computeStaggeredForceQuda(void* h_mom, double dt, double delta, void *h_for
 }
 
 void computeHISQForceQuda(void* const milc_momentum,
-                          long long *flops,
+                          double dt,
                           const double level2_coeff[6],
                           const double fat7_coeff[6],
                           const void* const w_link,
@@ -4496,7 +4509,7 @@ void computeHISQForceQuda(void* const milc_momentum,
   cudaOutForce->exchangeExtendedGhost(R,profileHISQForce,true);
 
   profileHISQForce.TPSTART(QUDA_PROFILE_COMPUTE);
-  hisqStaplesForce(*cudaOutForce, *cudaInForce, *cudaGauge, act_path_coeff, flops);
+  hisqStaplesForce(*cudaOutForce, *cudaInForce, *cudaGauge, act_path_coeff);
   profileHISQForce.TPSTOP(QUDA_PROFILE_COMPUTE);
 
   // Load naik outer product
@@ -4506,7 +4519,7 @@ void computeHISQForceQuda(void* const milc_momentum,
 
   // Compute Naik three-link term
   profileHISQForce.TPSTART(QUDA_PROFILE_COMPUTE);
-  hisqLongLinkForce(*cudaOutForce, *cudaInForce, *cudaGauge, act_path_coeff[1], flops);
+  hisqLongLinkForce(*cudaOutForce, *cudaInForce, *cudaGauge, act_path_coeff[1]);
   profileHISQForce.TPSTOP(QUDA_PROFILE_COMPUTE);
 
   cudaOutForce->exchangeExtendedGhost(R,profileHISQForce,true);
@@ -4517,7 +4530,7 @@ void computeHISQForceQuda(void* const milc_momentum,
 
   profileHISQForce.TPSTART(QUDA_PROFILE_COMPUTE);
   *num_failures_h = 0;
-  unitarizeForce(*cudaInForce, *cudaOutForce, *cudaGauge, num_failures_d, flops);
+  unitarizeForce(*cudaInForce, *cudaOutForce, *cudaGauge, num_failures_d);
   profileHISQForce.TPSTOP(QUDA_PROFILE_COMPUTE);
 
   if (*num_failures_h>0) errorQuda("Error in the unitarization component of the hisq fermion force: %d failures\n", *num_failures_h);
@@ -4530,19 +4543,21 @@ void computeHISQForceQuda(void* const milc_momentum,
 
   // Compute Fat7-staple term
   profileHISQForce.TPSTART(QUDA_PROFILE_COMPUTE);
-  hisqStaplesForce(*cudaOutForce, *cudaInForce, *cudaGauge, fat7_coeff, flops);
+  hisqStaplesForce(*cudaOutForce, *cudaInForce, *cudaGauge, fat7_coeff);
   profileHISQForce.TPSTOP(QUDA_PROFILE_COMPUTE);
 
   delete cudaInForce;
   cudaGaugeField* cudaMom = new cudaGaugeField(momParam);
 
   profileHISQForce.TPSTART(QUDA_PROFILE_COMPUTE);
-  hisqCompleteForce(*cudaMom, *cudaOutForce, *cudaGauge, flops);
+  hisqCompleteForce(*cudaOutForce, *cudaGauge);
   profileHISQForce.TPSTOP(QUDA_PROFILE_COMPUTE);
 
   if (gParam->use_resident_mom) {
     if (!momResident) errorQuda("No resident momentum field to use");
-    updateMomentum(*momResident, 1.0, *cudaMom);
+    updateMomentum(*momResident, dt, *cudaOutForce, "hisq");
+  } else {
+    updateMomentum(*cudaMom, dt, *cudaOutForce, "hisq");
   }
 
   if (gParam->return_result_mom) {
@@ -4575,7 +4590,6 @@ void computeCloverForceQuda(void *h_mom, double dt, void **h_x, void **h_p,
 			    double *coeff, double kappa2, double ck,
 			    int nvector, double multiplicity, void *gauge,
 			    QudaGaugeParam *gauge_param, QudaInvertParam *inv_param) {
-
 
   using namespace quda;
   profileCloverForce.TPSTART(QUDA_PROFILE_TOTAL);
@@ -4727,7 +4741,7 @@ void computeCloverForceQuda(void *h_mom, double dt, void **h_x, void **h_p,
 
   if (u != &gaugeEx) delete u;
 
-  updateMomentum(cudaMom, -1.0, cudaForce);
+  updateMomentum(cudaMom, -1.0, cudaForce, "clover");
   profileCloverForce.TPSTOP(QUDA_PROFILE_COMPUTE);
 
   // copy the outer product field back to the host

--- a/lib/milc_interface.cpp
+++ b/lib/milc_interface.cpp
@@ -272,7 +272,7 @@ void qudaLoadUnitarizedLink(int prec, QudaFatLinkArgs_t fatlink_args,
 }
 
 
-void qudaHisqForce(int prec, int num_terms, int num_naik_terms, double** coeff, void** quark_field,
+void qudaHisqForce(int prec, int num_terms, int num_naik_terms, double dt, double** coeff, void** quark_field,
                    const double level2_coeff[6], const double fat7_coeff[6],
                    const void* const w_link, const void* const v_link, const void* const u_link,
                    void* const milc_momentum)
@@ -291,8 +291,7 @@ void qudaHisqForce(int prec, int num_terms, int num_naik_terms, double** coeff, 
     gParam.return_result_mom = true;
   }
 
-  long long flops;
-  computeHISQForceQuda(milc_momentum, &flops, level2_coeff, fat7_coeff,
+  computeHISQForceQuda(milc_momentum, dt, level2_coeff, fat7_coeff,
                        w_link, v_link, u_link,
                        quark_field, num_terms, num_naik_terms, coeff,
                        &gParam);

--- a/lib/momentum.cu
+++ b/lib/momentum.cu
@@ -4,6 +4,7 @@
 #include <gauge_field_order.h>
 #include <launch_kernel.cuh>
 #include <cub_helper.cuh>
+#include <fstream>
 
 namespace quda {
 
@@ -128,57 +129,90 @@ using namespace gauge;
 
 
 #ifdef GPU_GAUGE_TOOLS
-  template<typename Float, typename Mom, typename Force>
-  struct UpdateMomArg {
+  template<typename Float, QudaReconstructType reconstruct_>
+  struct UpdateMomArg : public ReduceArg<double3> {
     int threads;
-    Mom mom;
+    static constexpr int force_recon = (reconstruct_ == QUDA_RECONSTRUCT_10 ? 11 : 18);
+    FloatNOrder<Float,18,2,11> mom;
+    FloatNOrder<Float,18,2,force_recon> force;
     Float coeff;
-    Force force;
-    int X[4]; // grid dimensions
-    UpdateMomArg(Mom &mom, const Float &coeff, Force &force, GaugeField &meta)
-      : threads(meta.VolumeCB()), mom(mom), coeff(coeff), force(force) {
-      for (int dir=0; dir<4; ++dir) X[dir] = meta.X()[dir];
+    int X[4]; // grid dimensions on mom
+    int E[4]; // grid dimensions on force (possibly extended)
+    int border[4]; //
+    UpdateMomArg(GaugeField &mom, const Float &coeff, GaugeField &force)
+      : threads(mom.VolumeCB()), mom(mom), coeff(coeff), force(force) {
+      for (int dir=0; dir<4; ++dir) {
+        X[dir] = mom.X()[dir];
+        E[dir] = force.X()[dir];
+        border[dir] = force.R()[dir];
+      }
     }
   };
 
-  template<typename Float, typename Mom, typename Force>
-  __global__ void UpdateMomKernel(UpdateMomArg<Float, Mom, Force> arg) {
-    int x = blockIdx.x*blockDim.x + threadIdx.x;
+  /**
+     @brief Functor for finding the maximum over a double3 field.
+     Each lane of the double3 is evaluated separately.  This functor
+     is passed to the reduce helper.
+   */
+  struct max_reducer3 {
+    __device__ __host__ inline double3 operator()(const double3 &a, const double3 &b) {
+      return make_double3(a.x > b.x ? a.x : b.x, a.y > b.y ? a.y : b.y, a.z > b.z ? a.z : b.z);
+    }
+  };
+
+  template <int blockSize, typename Float, typename Arg>
+  __global__ void UpdateMomKernel(Arg arg) {
+    int x_cb = blockIdx.x*blockDim.x + threadIdx.x;
     int parity = threadIdx.y;
-    Matrix<complex<Float>,3> m, f;
-    while(x<arg.threads){
+    double3 norm3 = make_double3(0.0,0.0,0.0);
+    max_reducer3 r;
+
+    while (x_cb<arg.threads) {
+      int x[4];
+      getCoords(x, x_cb, arg.X, parity);
+      for (int d=0; d<4; d++) x[d] += arg.border[d];
+      int e_cb = linkIndex(x,arg.E);
+
+#pragma unroll
       for (int d=0; d<4; d++) {
-	arg.mom.load(reinterpret_cast<Float*>(m.data), x, d, parity);
-	arg.force.load(reinterpret_cast<Float*>(f.data), x, d, parity);
+	Matrix<complex<Float>,3> m = arg.mom(d, x_cb, parity);
+        Matrix<complex<Float>,3> f = arg.force(d, e_cb, parity);
 
-	m = m + arg.coeff * f;
+	makeAntiHerm(f);
+
+        // compute force norms
+        norm3 = r(make_double3(f.L1(), f.L2(), f.Linf()), norm3);
+
+        m = m + arg.coeff * f;
+
 	makeAntiHerm(m);
-
-	arg.mom.save(reinterpret_cast<Float*>(m.data), x, d, parity); 
+	arg.mom(d, x_cb, parity) = m;
       }
       
-      x += gridDim.x*blockDim.x;
+      x_cb += gridDim.x*blockDim.x;
     }
-    return;
+
+    // perform final inter-block reduction and write out result
+    reduce2d<blockSize,2,double3,false,max_reducer3>(arg, norm3, 0);
   } // UpdateMom
 
   
-  template<typename Float, typename Mom, typename Force>
+  template<typename Float, typename Arg>
   class UpdateMom : TunableLocalParity {
-    UpdateMomArg<Float, Mom, Force> &arg;
+    Arg &arg;
     const GaugeField &meta;
 
   private:
     unsigned int minThreads() const { return arg.threads; }
 
   public:
-    UpdateMom(UpdateMomArg<Float,Mom,Force> &arg, const GaugeField &meta) : arg(arg), meta(meta) {}
+    UpdateMom(Arg &arg, const GaugeField &meta) : arg(arg), meta(meta) {}
     virtual ~UpdateMom () { }
 
     void apply(const cudaStream_t &stream){
-      if(meta.Location() == QUDA_CUDA_FIELD_LOCATION){
+      if (meta.Location() == QUDA_CUDA_FIELD_LOCATION) {
 	TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
-	UpdateMomKernel<Float,Mom,Force><<<tp.grid,tp.block,tp.shared_bytes,stream>>>(arg);
+	LAUNCH_KERNEL_LOCAL_PARITY(UpdateMomKernel, tp, stream, arg, Float);
       } else {
 	errorQuda("CPU not supported yet\n");
       }
@@ -196,24 +230,81 @@ using namespace gauge;
     long long bytes() const { return 4*2*arg.threads*(2*arg.mom.Bytes()+arg.force.Bytes()); }
   };
 
-  template<typename Float, typename Mom, typename Force>
-  void updateMomentum(Mom mom, Float coeff, Force force, GaugeField &meta) {
-    UpdateMomArg<Float,Mom,Force> arg(mom, coeff, force, meta);
-    UpdateMom<Float,Mom,Force> update(arg, meta);
+  bool forceMonitor() {
+    static bool init = false;
+    static bool monitor = false;
+    if (!init) {
+      char *path = getenv("QUDA_RESOURCE_PATH");
+      char *enable_force_monitor = getenv("QUDA_ENABLE_FORCE_MONITOR");
+      if (path && enable_force_monitor && strcmp(enable_force_monitor, "1") == 0) monitor = true;
+      init = true;
+    }
+    return monitor;
+  }
+
+  static std::stringstream force_stream;
+  static long long force_count = 0;
+  static long long force_flush = 1000; // how many force samples we accumulate before flushing
+
+  void flushForceMonitor() {
+    if (!forceMonitor() || comm_rank() != 0) return;
+
+    static std::string path = std::string(getenv("QUDA_RESOURCE_PATH"));
+    static char *profile_fname = getenv("QUDA_PROFILE_OUTPUT_BASE");
+
+    std::ofstream force_file;
+    static long long count = 0;
+    if (count == 0) {
+      path += (profile_fname ? std::string("/") + profile_fname + "_force.tsv" : std::string("/force.tsv"));
+      force_file.open(path.c_str());
+      force_file << "Force\tL1\tL2\tLinf\tdt" << std::endl;
+    } else {
+      force_file.open(path.c_str(), std::ios_base::app);
+    }
+    if (getVerbosity() >= QUDA_VERBOSE) printfQuda("Flushing force monitor data to %s\n", path.c_str());
+    force_file << force_stream.str();
+
+    force_file.flush();
+    force_file.close();
+
+    // empty the stream buffer
+    force_stream.clear();
+    force_stream.str(std::string());
+
+    count++;
+  }
+
+  template<typename Float, QudaReconstructType reconstruct>
+  void updateMomentum(GaugeField &mom, Float coeff, GaugeField &force, const char *fname) {
+    UpdateMomArg<Float,reconstruct> arg(mom, coeff, force);
+    UpdateMom<Float,decltype(arg)> update(arg, force);
     update.apply(0);
+
+    if (forceMonitor()) {
+      qudaDeviceSynchronize();
+      comm_allreduce_array((double*)arg.result_h, 3);
+
+      if (comm_rank()==0) {
+        force_stream << fname << "\t" << std::setprecision(5) << arg.result_h[0].x << "\t"
+                     << std::setprecision(5) << arg.result_h[0].y << "\t"
+                     << std::setprecision(5) << arg.result_h[0].z << "\t"
+                     << std::setprecision(5) << abs(arg.coeff) << std::endl;
+        if (++force_count % force_flush == 0) flushForceMonitor();
+      }
+    }
   }
   
   template <typename Float>
-  void updateMomentum(GaugeField &mom, double coeff, GaugeField &force) {
+  void updateMomentum(GaugeField &mom, double coeff, GaugeField &force, const char *fname) {
     if (mom.Reconstruct() != QUDA_RECONSTRUCT_10)
       errorQuda("Momentum field with reconstruct %d not supported", mom.Reconstruct());
+    if (force.Order() != QUDA_FLOAT2_GAUGE_ORDER)
+      errorQuda("Force field with order %d not supported", force.Order());
 
     if (force.Reconstruct() == QUDA_RECONSTRUCT_10) {
-      updateMomentum<Float>(FloatNOrder<Float, 18, 2, 11>(mom), static_cast<Float>(coeff),
-			      FloatNOrder<Float, 18, 2, 11>(force), force);
+      updateMomentum<Float,QUDA_RECONSTRUCT_10>(mom, coeff, force, fname);
     } else if (force.Reconstruct() == QUDA_RECONSTRUCT_NO) {
-      updateMomentum<Float>(FloatNOrder<Float, 18, 2, 11>(mom), static_cast<Float>(coeff),
-			      FloatNOrder<Float, 18, 2, 18>(force), force);
+      updateMomentum<Float,QUDA_RECONSTRUCT_NO>(mom, coeff, force, fname);
     } else {
       errorQuda("Unsupported force reconstruction: %d", force.Reconstruct());
     }
@@ -221,7 +312,7 @@ using namespace gauge;
   }
 #endif // GPU_GAUGE_TOOLS
 
-  void updateMomentum(GaugeField &mom, double coeff, GaugeField &force) {
+  void updateMomentum(GaugeField &mom, double coeff, GaugeField &force, const char *fname) {
 #ifdef GPU_GAUGE_TOOLS
     if(mom.Order() != QUDA_FLOAT2_GAUGE_ORDER)
       errorQuda("Unsupported output ordering: %d\n", mom.Order());
@@ -230,7 +321,9 @@ using namespace gauge;
       errorQuda("Mixed precision not supported: %d %d\n", mom.Precision(), force.Precision());
 
     if (mom.Precision() == QUDA_DOUBLE_PRECISION) {
-      updateMomentum<double>(mom, coeff, force);
+      updateMomentum<double>(mom, coeff, force, fname);
+    } else if (mom.Precision() == QUDA_SINGLE_PRECISION) {
+      updateMomentum<float>(mom, coeff, force, fname);
     } else {
       errorQuda("Unsupported precision: %d", mom.Precision());
     }      

--- a/lib/unitarize_force_quda.cu
+++ b/lib/unitarize_force_quda.cu
@@ -600,19 +600,18 @@ namespace quda{
 
     template<typename Float, typename Gauge>
     void unitarizeForce(Gauge newForce, const Gauge oldForce, const Gauge gauge,
-			const GaugeField &meta, int* fails, long long *flops) {
+			const GaugeField &meta, int* fails) {
 
       UnitarizeForceArg<Gauge,Gauge> arg(newForce, oldForce, gauge, meta, fails, unitarize_eps, force_filter,
 					 max_det_error, allow_svd, svd_only, svd_rel_error, svd_abs_error);
       UnitarizeForce<Float,UnitarizeForceArg<Gauge,Gauge> > unitarizeForce(arg, meta);
       unitarizeForce.apply(0);
       qudaDeviceSynchronize(); // need to synchronize to ensure failure write has completed
-      if (flops) *flops += unitarizeForce.flops();
       checkCudaError();
     }
 
     void unitarizeForce(cudaGaugeField &newForce, const cudaGaugeField &oldForce, const cudaGaugeField &gauge,
-			int* fails, long long *flops) {
+			int* fails) {
 
       if (oldForce.Reconstruct() != QUDA_RECONSTRUCT_NO)
 	errorQuda("Force field should not use reconstruct %d", oldForce.Reconstruct());
@@ -632,10 +631,10 @@ namespace quda{
       if (gauge.Order() == QUDA_FLOAT2_GAUGE_ORDER) {
 	if (gauge.Precision() == QUDA_DOUBLE_PRECISION) {
 	  typedef typename gauge_mapper<double,QUDA_RECONSTRUCT_NO>::type G;
-	  unitarizeForce<double>(G(newForce), G(oldForce), G(gauge), gauge, fails, flops);
+	  unitarizeForce<double>(G(newForce), G(oldForce), G(gauge), gauge, fails);
 	} else if (gauge.Precision() == QUDA_SINGLE_PRECISION) {
 	  typedef typename gauge_mapper<float,QUDA_RECONSTRUCT_NO>::type G;
-	  unitarizeForce<float>(G(newForce), G(oldForce), G(gauge), gauge, fails, flops);
+	  unitarizeForce<float>(G(newForce), G(oldForce), G(gauge), gauge, fails);
 	}
       } else {
 	errorQuda("Data order %d not supported", gauge.Order());

--- a/tests/hisq_paths_force_test.cpp
+++ b/tests/hisq_paths_force_test.cpp
@@ -8,6 +8,7 @@
 #include "misc.h"
 #include "hisq_force_reference.h"
 #include "ks_improved_force.h"
+#include "momentum.h"
 #include <dslash_quda.h> 
 #include <sys/time.h>
 
@@ -363,17 +364,18 @@ static int hisq_force_test(void)
 
   gettimeofday(&t2, NULL);
 
-  gParam.create = QUDA_NULL_FIELD_CREATE;
+  gParam.create = QUDA_ZERO_FIELD_CREATE; // initialize to zero
   gParam.reconstruct = QUDA_RECONSTRUCT_10;
   gParam.link_type = QUDA_ASQTAD_MOM_LINKS;
   gParam.pad = 0; //X1*X2*X3/2;
   gParam.order = QUDA_FLOAT2_GAUGE_ORDER;
-  cudaMom = new cudaGaugeField(gParam); // Are the elements initialised to zero? - No!
+  cudaMom = new cudaGaugeField(gParam);
 
   //record the mom pad
   qudaGaugeParam.mom_ga_pad = gParam.pad;
 
-  fermion_force::hisqCompleteForce(*cudaMom, *cudaForce_ex, *cudaGauge_ex);
+  fermion_force::hisqCompleteForce(*cudaForce_ex, *cudaGauge_ex);
+  updateMomentum(*cudaMom, 1.0, *cudaForce_ex, __func__);
 
   cudaDeviceSynchronize();
   gettimeofday(&t3, NULL);


### PR DESCRIPTION
Adds support for automated force monitoring, e.g., over the course of an HMC trajectory.  Only enabled when `QUDA_ENABLE_FORCE_MONITOR=1` is set and `QUDA_RESOURCE_PATH` is set, whence the the force will be periodically flushed to `force.tsv` (filename respects `QUDA_PROFILE_OUTPUT_BASE`).  The L1, L2 and Linfinity norms are recorded for each force computation.

To enable this, thus pull makes some auxiliary changes
* adds support for arbitrary reducers to be passed to the cub reduction helpers
* all force computations now use `updateMomentum` to update the momentum, since this is where the force measurement and recording takes place
* pass the stepsize separately from other coefficients in the MILC HISQ force interface 