### PR TITLE
Hotfix/force monitor

### DIFF
--- a/include/tune_quda.h
+++ b/include/tune_quda.h
@@ -46,11 +46,10 @@ namespace quda {
     }
 
     friend std::ostream& operator<<(std::ostream& output, const TuneParam& param) {
-      output << "block = (" << param.block.x << ", " << param.block.y << ", " << param.block.z << ")" << std::endl;
-      output << "grid = (" << param.grid.x << ", " << param.grid.y << ", " << param.grid.z << ")" << std::endl;
-      output << "shared_bytes = " << param.shared_bytes << std::endl;
-      output << "aux = (" << param.aux.x << ", " << param.aux.y << ", " << param.aux.z << ", " << param.aux.w << ")" << std::endl;
-      output << param.comment << std::endl;
+      output << "block=(" << param.block.x << "," << param.block.y << "," << param.block.z << "), ";
+      output << "grid=(" << param.grid.x << "," << param.grid.y << "," << param.grid.z << "), ";
+      output << "shared_bytes=" << param.shared_bytes;
+      output << ", aux=(" << param.aux.x << "," << param.aux.y << "," << param.aux.z << "," << param.aux.w << ")";
       return output;
     }
   };
@@ -219,12 +218,7 @@ namespace quda {
     virtual std::string paramString(const TuneParam &param) const
       {
 	std::stringstream ps;
-	ps << "block=(" << param.block.x << "," << param.block.y << "," << param.block.z << "), ";
-	if (tuneGridDim()) ps << "grid=(" << param.grid.x << "," << param.grid.y << "," << param.grid.z << "), ";
-	ps << "shared=" << param.shared_bytes << ", ";
-
-	// determine if we are tuning the auxiliary dimension
-	if (tuneAuxDim()) ps << "aux=(" << param.aux.x << "," << param.aux.y << "," << param.aux.z << "," << param.aux.w << ")";
+	ps << param;
 	return ps.str();
       }
 

--- a/lib/color_spinor_field.cpp
+++ b/lib/color_spinor_field.cpp
@@ -101,11 +101,6 @@ namespace quda {
     size_t ghost_length = ghostVolume*nColor*nSpin*2;
     size_t ghost_norm_length = (ghost_precision == QUDA_HALF_PRECISION || ghost_precision == QUDA_QUARTER_PRECISION) ? ghostNormVolume : 0;
 
-    if (getVerbosity() == QUDA_DEBUG_VERBOSE) {
-      printfQuda("Allocated ghost volume = %d, ghost norm volume %d\n", ghostVolume, ghostNormVolume);
-      printfQuda("ghost length = %lu, ghost norm length = %lu\n", ghost_length, ghost_norm_length);
-    }
-
     ghost_bytes = (size_t)ghost_length*ghost_precision;
     if (ghost_precision == QUDA_HALF_PRECISION || ghost_precision == QUDA_QUARTER_PRECISION) ghost_bytes += ghost_norm_length*sizeof(float);
     if (isNative()) ghost_bytes = ALIGNMENT_ADJUST(ghost_bytes);
@@ -396,12 +391,6 @@ namespace quda {
     }
 
     if (!init) errorQuda("Shouldn't be resetting a non-inited field\n");
-
-    if (getVerbosity() >= QUDA_DEBUG_VERBOSE) {
-      printfQuda("\nPrinting out reset field\n");
-      std::cout << *this << std::endl;
-      printfQuda("\n");
-    }
 
     setTuningString();
   }

--- a/lib/comm_common.cpp
+++ b/lib/comm_common.cpp
@@ -428,6 +428,14 @@ int comm_coord(int dim)
 }
 
 
+inline bool isHost(const cudaPointerAttributes &attributes) {
+#if CUDA_VERSION >= 10000
+  return (attributes.type == cudaMemoryTypeHost);
+#else
+  return (attributes.memoryType == cudaMemoryTypeHost);
+#endif
+}
+
 /**
  * Send to the "dir" direction in the "dim" dimension
  */
@@ -438,7 +446,7 @@ MsgHandle *comm_declare_send_relative_(const char *func, const char *file, int l
   checkCudaError(); // check and clear error state first
   cudaPointerAttributes attributes;
   cudaError_t err = cudaPointerGetAttributes(&attributes, buffer);
-  if (err != cudaSuccess || attributes.memoryType == cudaMemoryTypeHost) {
+  if (err != cudaSuccess || isHost(attributes)) {
     // test this memory allocation is ok by doing a memcpy from it
     void *tmp = safe_malloc(nbytes);
     try {
@@ -477,7 +485,7 @@ MsgHandle *comm_declare_receive_relative_(const char *func, const char *file, in
   checkCudaError(); // check and clear error state first
   cudaPointerAttributes attributes;
   cudaError_t err = cudaPointerGetAttributes(&attributes, buffer);
-  if (err != cudaSuccess || attributes.memoryType == cudaMemoryTypeHost) {
+  if (err != cudaSuccess || isHost(attributes)) {
     // test this memory allocation is ok by filling it
     try {
       std::fill(static_cast<char*>(buffer), static_cast<char*>(buffer)+nbytes, 0);
@@ -512,7 +520,7 @@ MsgHandle *comm_declare_strided_send_relative_(const char *func, const char *fil
   checkCudaError(); // check and clear error state first
   cudaPointerAttributes attributes;
   cudaError_t err = cudaPointerGetAttributes(&attributes, buffer);
-  if (err != cudaSuccess || attributes.memoryType == cudaMemoryTypeHost) {
+  if (err != cudaSuccess || isHost(attributes)) {
     // test this memory allocation is ok by doing a memcpy from it
     void *tmp = safe_malloc(blksize*nblocks);
     try {
@@ -555,7 +563,7 @@ MsgHandle *comm_declare_strided_receive_relative_(const char *func, const char *
   checkCudaError(); // check and clear error state first
   cudaPointerAttributes attributes;
   cudaError_t err = cudaPointerGetAttributes(&attributes, buffer);
-  if (err != cudaSuccess || attributes.memoryType == cudaMemoryTypeHost) {
+  if (err != cudaSuccess || isHost(attributes)) {
     // test this memory allocation is ok by filling it
     try {
       for (int i=0; i<nblocks; i++)

--- a/lib/dslash_coarse.cu
+++ b/lib/dslash_coarse.cu
@@ -698,7 +698,7 @@ namespace quda {
    virtual ~DslashCoarsePolicyTune() { setPolicyTuning(false); }
 
    inline void apply(const cudaStream_t &stream) {
-     TuneParam tp = tuneLaunch(*this, getTuning(), QUDA_DEBUG_VERBOSE /*getVerbosity()*/);
+     TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
 
      if (config != tp.aux.y && comm_size() > 1) {
        errorQuda("Machine configuration (P2P/GDR=%d) changed since tunecache was created (P2P/GDR=%d).  Please delete "

--- a/lib/dslash_policy.cuh
+++ b/lib/dslash_policy.cuh
@@ -2123,7 +2123,7 @@ struct DslashFactory {
    virtual ~DslashPolicyTune() { setPolicyTuning(false); }
 
    void apply(const cudaStream_t &stream) {
-     TuneParam tp = tuneLaunch(*this, getTuning(), QUDA_DEBUG_VERBOSE /*getVerbosity()*/);
+     TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
 
      if (config != tp.aux.w && comm_size() > 1) {
        errorQuda("Machine configuration (P2P/GDR=%d) changed since tunecache was created (P2P/GDR=%d).  Please delete "

--- a/lib/gauge_fix_ovr.cu
+++ b/lib/gauge_fix_ovr.cu
@@ -321,12 +321,7 @@ namespace quda {
       return TuneKey(vol.str().c_str(), typeid(*this).name(), aux_string);
 
     }
-    std::string paramString(const TuneParam &param) const {
-      std::stringstream ps;
-      ps << "block=(" << param.block.x << "," << param.block.y << "," << param.block.z << ")";
-      ps << "shared=" << param.shared_bytes;
-      return ps.str();
-    }
+
     long long flops() const {
       return (36LL * gauge_dir + 65LL) * 2 * argQ.threads;
     }                                                                   // Only correct if there is no link reconstruction, no cub reduction accounted also

--- a/lib/momentum.cu
+++ b/lib/momentum.cu
@@ -296,7 +296,7 @@ using namespace gauge;
     UpdateMom<Float,decltype(arg)> update(arg, force);
     update.apply(0);
 
-    if (forceMonitor()) forceRecord(*((double2*)arg.array_h), arg.coeff, fname);
+    if (forceMonitor()) forceRecord(*((double2*)arg.result_h), arg.coeff, fname);
   }
   
   template <typename Float>

--- a/lib/momentum.cu
+++ b/lib/momentum.cu
@@ -10,6 +10,62 @@ namespace quda {
 
 using namespace gauge;
 
+  bool forceMonitor() {
+    static bool init = false;
+    static bool monitor = false;
+    if (!init) {
+      char *path = getenv("QUDA_RESOURCE_PATH");
+      char *enable_force_monitor = getenv("QUDA_ENABLE_FORCE_MONITOR");
+      if (path && enable_force_monitor && strcmp(enable_force_monitor, "1") == 0) monitor = true;
+      init = true;
+    }
+    return monitor;
+  }
+
+  static std::stringstream force_stream;
+  static long long force_count = 0;
+  static long long force_flush = 1000; // how many force samples we accumulate before flushing
+
+  void flushForceMonitor() {
+    if (!forceMonitor() || comm_rank() != 0) return;
+
+    static std::string path = std::string(getenv("QUDA_RESOURCE_PATH"));
+    static char *profile_fname = getenv("QUDA_PROFILE_OUTPUT_BASE");
+
+    std::ofstream force_file;
+    static long long count = 0;
+    if (count == 0) {
+      path += (profile_fname ? std::string("/") + profile_fname + "_force.tsv" : std::string("/force.tsv"));
+      force_file.open(path.c_str());
+      force_file << "Force\tL1\tL2\tdt" << std::endl;
+    } else {
+      force_file.open(path.c_str(), std::ios_base::app);
+    }
+    if (getVerbosity() >= QUDA_VERBOSE) printfQuda("Flushing force monitor data to %s\n", path.c_str());
+    force_file << force_stream.str();
+
+    force_file.flush();
+    force_file.close();
+
+    // empty the stream buffer
+    force_stream.clear();
+    force_stream.str(std::string());
+
+    count++;
+  }
+
+  void forceRecord(double2 &force, double dt, const char *fname) {
+    qudaDeviceSynchronize();
+    comm_allreduce_max_array((double*)&force, 2);
+
+    if (comm_rank()==0) {
+      force_stream << fname << "\t" << std::setprecision(5) << force.x << "\t"
+                   << std::setprecision(5) << force.y << "\t"
+                   << std::setprecision(5) << dt << std::endl;
+      if (++force_count % force_flush == 0) flushForceMonitor();
+    }
+  }
+
 #ifdef GPU_GAUGE_TOOLS
 
   template <typename Mom>
@@ -234,67 +290,13 @@ using namespace gauge;
     long long bytes() const { return 4*2*arg.threads*(2*arg.mom.Bytes()+arg.force.Bytes()); }
   };
 
-  bool forceMonitor() {
-    static bool init = false;
-    static bool monitor = false;
-    if (!init) {
-      char *path = getenv("QUDA_RESOURCE_PATH");
-      char *enable_force_monitor = getenv("QUDA_ENABLE_FORCE_MONITOR");
-      if (path && enable_force_monitor && strcmp(enable_force_monitor, "1") == 0) monitor = true;
-      init = true;
-    }
-    return monitor;
-  }
-
-  static std::stringstream force_stream;
-  static long long force_count = 0;
-  static long long force_flush = 1000; // how many force samples we accumulate before flushing
-
-  void flushForceMonitor() {
-    if (!forceMonitor() || comm_rank() != 0) return;
-
-    static std::string path = std::string(getenv("QUDA_RESOURCE_PATH"));
-    static char *profile_fname = getenv("QUDA_PROFILE_OUTPUT_BASE");
-
-    std::ofstream force_file;
-    static long long count = 0;
-    if (count == 0) {
-      path += (profile_fname ? std::string("/") + profile_fname + "_force.tsv" : std::string("/force.tsv"));
-      force_file.open(path.c_str());
-      force_file << "Force\tL1\tL2\tdt" << std::endl;
-    } else {
-      force_file.open(path.c_str(), std::ios_base::app);
-    }
-    if (getVerbosity() >= QUDA_VERBOSE) printfQuda("Flushing force monitor data to %s\n", path.c_str());
-    force_file << force_stream.str();
-
-    force_file.flush();
-    force_file.close();
-
-    // empty the stream buffer
-    force_stream.clear();
-    force_stream.str(std::string());
-
-    count++;
-  }
-
   template<typename Float, QudaReconstructType reconstruct>
   void updateMomentum(GaugeField &mom, Float coeff, GaugeField &force, const char *fname) {
     UpdateMomArg<Float,reconstruct> arg(mom, coeff, force);
     UpdateMom<Float,decltype(arg)> update(arg, force);
     update.apply(0);
 
-    if (forceMonitor()) {
-      qudaDeviceSynchronize();
-      comm_allreduce_array((double*)arg.result_h, 2);
-
-      if (comm_rank()==0) {
-        force_stream << fname << "\t" << std::setprecision(5) << arg.result_h[0].x << "\t"
-                     << std::setprecision(5) << arg.result_h[0].y << "\t"
-                     << std::setprecision(5) << abs(arg.coeff) << std::endl;
-        if (++force_count % force_flush == 0) flushForceMonitor();
-      }
-    }
+    if (forceMonitor()) forceRecord(*((double2*)arg.array_h), arg.coeff, fname);
   }
   
   template <typename Float>

--- a/lib/tune.cpp
+++ b/lib/tune.cpp
@@ -649,11 +649,9 @@ namespace quda {
 #endif
 
     static const Tunable *active_tunable; // for error checking
+    it = tunecache.find(key);
 
     // first check if we have the tuned value and return if we have it
-    //if (enabled == QUDA_TUNE_YES && tunecache.count(key)) {
-
-    it = tunecache.find(key);
     if (enabled == QUDA_TUNE_YES && it != tunecache.end()) {
 
 #ifdef LAUNCH_TIMER
@@ -662,6 +660,11 @@ namespace quda {
 #endif
 
       TuneParam &param = it->second;
+
+      if (verbosity >= QUDA_DEBUG_VERBOSE) {
+        printfQuda("Launching %s with %s at vol=%s with %s\n",
+                   key.name, key.aux, key.volume, tunable.paramString(param).c_str());
+      }
 
 #ifdef LAUNCH_TIMER
       launchTimer.TPSTOP(QUDA_PROFILE_COMPUTE);
@@ -696,10 +699,14 @@ namespace quda {
     launchTimer.TPSTOP(QUDA_PROFILE_TOTAL);
 #endif
 
-
     if (enabled == QUDA_TUNE_NO) {
       tunable.defaultTuneParam(param);
       tunable.checkLaunchParam(param);
+
+      if (verbosity >= QUDA_DEBUG_VERBOSE) {
+        printfQuda("Launching %s with %s at vol=%s with %s (untuned)\n",
+                   key.name, key.aux, key.volume, tunable.paramString(param).c_str());
+      }
     } else if (!tuning) {
 
       /* As long as global reductions are not disabled, only do the


### PR DESCRIPTION
Hotfix pull:
* Fix linking with force monitoring when gauge fools is disabled
* Clean up of `Tunable::paramString`
* Fix warning in CUDA 10 compilation with respect to deprecated `memoryType` attribute
* Clean up of verbosity handling: debug verbosity now prints the kernel name and launch parameters whenever a kernel is launched