### PR TITLE
Feature/reduce cleanup

### DIFF
--- a/include/clover_field.h
+++ b/include/clover_field.h
@@ -308,9 +308,8 @@ namespace quda {
 
      @param clover The clover field (contains both the field itself and its inverse)
      @param computeTraceLog Whether to compute the trace logarithm of the clover term
-     @param location The location of the field
   */
-  void cloverInvert(CloverField &clover, bool computeTraceLog, QudaFieldLocation location);
+  void cloverInvert(CloverField &clover, bool computeTraceLog);
 
   /**
      @brief This function adds a real scalar onto the clover diagonal (only to the direct field not the inverse)

--- a/include/kernels/gauge_plaq.cuh
+++ b/include/kernels/gauge_plaq.cuh
@@ -52,7 +52,7 @@ namespace quda {
 
     double2 plaq = make_double2(0.0,0.0);
 
-    if(idx < arg.threads) {
+    while (idx < arg.threads) {
       int x[4];
       getCoords(x, idx, arg.X, parity);
       for (int dr=0; dr<4; ++dr) x[dr] += arg.border[dr]; // extended grid coordinates
@@ -64,6 +64,8 @@ namespace quda {
 
 	plaq.y += plaquette<Float>(arg, x, parity, mu, 3);
       }
+
+      idx += blockDim.x*gridDim.x;
     }
 
     // perform final inter-block reduction and write out result

--- a/include/tune_quda.h
+++ b/include/tune_quda.h
@@ -321,7 +321,7 @@ namespace quda {
     unsigned int sharedBytesPerBlock(const TuneParam &param) const { return 0; }
 
     // don't tune the grid dimension
-    bool tuneGridDim() const { return false; }
+    virtual bool tuneGridDim() const { return false; }
 
     /**
        The maximum block size in the x dimension is the total number

--- a/lib/clover_invert.cu
+++ b/lib/clover_invert.cu
@@ -77,11 +77,12 @@ namespace quda {
   __global__ void cloverInvertKernel(Arg arg) {
     int idx = blockIdx.x*blockDim.x + threadIdx.x;
     int parity = threadIdx.y;
-    double2 trlogA = 0.0;
+    double2 trlogA = make_double2(0.0,0.0);
     double trlogA_parity = 0.0;
     while (idx < arg.clover.volumeCB) {
       trlogA_parity = cloverInvertCompute<Float,Arg,computeTrLog,twist>(arg, idx, parity);
       trlogA = parity ? make_double2(0.0,trlogA.y+trlogA_parity) : make_double2(trlogA.x+trlogA_parity, 0.0);
+      idx += blockDim.x*gridDim.x;
     }
     if (computeTrLog) reduce2d<blockSize,2>(arg, trlogA);
   }

--- a/lib/gauge_fix_fft.cu
+++ b/lib/gauge_fix_fft.cu
@@ -254,7 +254,7 @@ namespace quda {
     int parity = threadIdx.y;
 
     double2 data = make_double2(0.0,0.0);
-    if ( idx < argQ.threads ) {
+    while ( idx < argQ.threads ) {
       typedef complex<Float> Cmplx;
 
       int x[4];
@@ -292,6 +292,8 @@ namespace quda {
       data.y = getRealTraceUVdagger(delta, delta);
       //35
       //T=36*gauge_dir+65
+
+      idx += blockDim.x*gridDim.x
     }
 
     reduce2d<blockSize,2>(argQ, data);
@@ -303,11 +305,11 @@ namespace quda {
   class GaugeFixQuality : TunableLocalParity {
     GaugeFixQualityArg<Float, Gauge> argQ;
     mutable char aux_string[128];     // used as a label in the autotuner
-    private:
 
-    unsigned int minThreads() const { return argQ.threads; }
+  private:
+    bool tuneGridDim() const { return true; }
 
-    public:
+  public:
     GaugeFixQuality(GaugeFixQualityArg<Float, Gauge> &argQ)
       : argQ(argQ) {
     }

--- a/lib/gauge_fix_ovr.cu
+++ b/lib/gauge_fix_ovr.cu
@@ -241,7 +241,7 @@ namespace quda {
     int parity = threadIdx.y;
 
     double2 data = make_double2(0.0,0.0);
-    if ( idx < argQ.threads ) {
+    while ( idx < argQ.threads ) {
       int X[4];
     #pragma unroll
       for ( int dr = 0; dr < 4; ++dr ) X[dr] = argQ.X[dr];
@@ -281,6 +281,8 @@ namespace quda {
       data.y = getRealTraceUVdagger(delta, delta);
       //35
       //T=36*gauge_dir+65
+
+      idx += blockDim.x*gridDim.x;
     }
     reduce2d<blockSize,2>(argQ, data);
   }
@@ -293,11 +295,11 @@ namespace quda {
   class GaugeFixQuality : TunableLocalParity {
     GaugeFixQualityArg<Gauge> argQ;
     mutable char aux_string[128]; // used as a label in the autotuner
-    private:
 
-    unsigned int minThreads() const { return argQ.threads; }
+  private:
+    bool tuneGridDim() const { return true; }
 
-    public:
+  public:
     GaugeFixQuality(GaugeFixQualityArg<Gauge> &argQ) : argQ(argQ) { }
     ~GaugeFixQuality () { }
 

--- a/lib/gauge_plaq.cu
+++ b/lib/gauge_plaq.cu
@@ -12,8 +12,7 @@ namespace quda {
     const GaugeField &meta;
 
   private:
-    bool tuneGridDim() const { return false; }
-    unsigned int minThreads() const { return arg.threads; }
+    bool tuneGridDim() const { return true; }
 
   public:
     GaugePlaq(GaugePlaqArg<Gauge> &arg, const GaugeField &meta)

--- a/lib/gauge_stout.cu
+++ b/lib/gauge_stout.cu
@@ -163,7 +163,7 @@ namespace quda {
 	Q = i_2 * Q;
 	//Q is now defined.
 	
-#ifdef HOST_DEBUG
+#if 0
 	//Test for Tracless:
 	//reuse OmegaDiffTr
 	OmegaDiffTr = getTrace(Q);
@@ -183,14 +183,14 @@ namespace quda {
 
 	exponentiate_iQ(Q,&exp_iQ);
 
-#ifdef HOST_DEBUG
+#if 0
 	//Test for expiQ unitarity:
 	error = ErrorSU3(exp_iQ);
 	printf("expiQ test %d %d %.15e\n", idx, dir, error);
 #endif
 
 	U = exp_iQ * U;
-#ifdef HOST_DEBUG
+#if 0
 	//Test for expiQ*U unitarity:
 	error = ErrorSU3(U);
 	printf("expiQ*u test %d %d %.15e\n", idx, dir, error);
@@ -230,6 +230,9 @@ namespace quda {
         aux << "threads=" << arg.threads << ",prec="  << sizeof(Float);
         return TuneKey(meta.VolString(), typeid(*this).name(), aux.str().c_str());
       }
+
+      void preTune() { arg.dest.save(); } // defensive measure in case they alias
+      void postTune() { arg.dest.load(); }
 
       long long flops() const { return 3*(2+2*4)*198ll*arg.threads; } // just counts matrix multiplication
       long long bytes() const { return 3*((1+2*6)*arg.origin.Bytes()+arg.dest.Bytes())*arg.threads; }
@@ -662,7 +665,7 @@ namespace quda {
 	Q = i_2 * Q;
 	//Q is now defined.
 
-#ifdef HOST_DEBUG
+#if 0
 	//Test for Tracless:
 	//reuse OmegaDiffTr
 	OmegaDiffTr = getTrace(Q);
@@ -682,14 +685,14 @@ namespace quda {
 
 	exponentiate_iQ(Q,&exp_iQ);
 
-#ifdef HOST_DEBUG
+#if 0
 	//Test for expiQ unitarity:
 	error = ErrorSU3(exp_iQ);
 	printf("expiQ test %d %d %.15e\n", idx, dir, error);
 #endif
 
 	U = exp_iQ * U;
-#ifdef HOST_DEBUG
+#if 0
 	//Test for expiQ*U unitarity:
 	error = ErrorSU3(U);
 	printf("expiQ*u test %d %d %.15e\n", idx, dir, error);
@@ -730,7 +733,10 @@ namespace quda {
         aux << "threads=" << arg.threads << ",prec="  << sizeof(Float);
         return TuneKey(meta.VolString(), typeid(*this).name(), aux.str().c_str());
       }
-    
+
+    void preTune() { arg.dest.save(); } // defensive measure in case they alias
+    void postTune() { arg.dest.load(); }
+
     long long flops() const { return 4*(18+2+2*4)*198ll*arg.threads; } // just counts matrix multiplication
     long long bytes() const { return 4*((1+2*12)*arg.origin.Bytes()+arg.dest.Bytes())*arg.threads; }
   }; // GaugeSTOUT

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -1075,7 +1075,7 @@ void loadCloverQuda(void *h_clover, void *h_clovinv, QudaInvertParam *inv_param)
     if ((!h_clovinv || inv_param->compute_clover_inverse) && pc_solve) {
       profileClover.TPSTART(QUDA_PROFILE_COMPUTE);
       if (!dynamic_clover) {
-	cloverInvert(*cloverPrecise, inv_param->compute_clover_trlog, QUDA_CUDA_FIELD_LOCATION);
+	cloverInvert(*cloverPrecise, inv_param->compute_clover_trlog);
 	if (inv_param->compute_clover_trlog) {
 	  inv_param->trlogA[0] = cloverPrecise->TrLog()[0];
 	  inv_param->trlogA[1] = cloverPrecise->TrLog()[1];
@@ -1113,7 +1113,7 @@ void loadCloverQuda(void *h_clover, void *h_clovinv, QudaInvertParam *inv_param)
     } else {
       auto *hackOfTheHack = new cudaCloverField(clover_param);	// Hack of the hack
       hackOfTheHack->copy(*cloverPrecise, false);
-      cloverInvert(*hackOfTheHack, inv_param->compute_clover_trlog, QUDA_CUDA_FIELD_LOCATION);
+      cloverInvert(*hackOfTheHack, inv_param->compute_clover_trlog);
       if (inv_param->compute_clover_trlog) {
 	inv_param->trlogA[0] = cloverPrecise->TrLog()[0];
 	inv_param->trlogA[1] = cloverPrecise->TrLog()[1];

--- a/lib/momentum.cu
+++ b/lib/momentum.cu
@@ -87,7 +87,7 @@ using namespace gauge;
     int parity = threadIdx.y;
     double action = 0.0;
     
-    if(x < arg.threads) {  
+    while (x < arg.threads) {
       // loop over direction
       for (int mu=0; mu<4; mu++) {
 	Float v[10];
@@ -99,6 +99,8 @@ using namespace gauge;
 	local_sum -= 4.0;
 	action += local_sum;
       }
+
+      x += blockDim.x*gridDim.x;
     }
     
     // perform final inter-block reduction and write out result
@@ -111,7 +113,7 @@ using namespace gauge;
     const GaugeField &meta;
 
   private:
-    unsigned int minThreads() const { return arg.threads; }
+    bool tuneGridDim() const { return true; }
 
   public:
     MomAction(MomActionArg<Mom> &arg, const GaugeField &meta) : arg(arg), meta(meta) {}
@@ -263,7 +265,7 @@ using namespace gauge;
     const GaugeField &meta;
 
   private:
-    unsigned int minThreads() const { return arg.threads; }
+    bool tuneGridDim() const { return true; }
 
   public:
     UpdateMom(Arg &arg, const GaugeField &meta) : arg(arg), meta(meta) {}

--- a/lib/pgauge_det_trace.cu
+++ b/lib/pgauge_det_trace.cu
@@ -46,7 +46,7 @@ __global__ void compute_Value(KernelArg<Gauge> arg){
   int parity = threadIdx.y;
 
   complex<double> val(0.0, 0.0);
-  if(idx < arg.threads) {
+  while (idx < arg.threads) {
     int X[4]; 
     #pragma unroll
     for(int dr=0; dr<4; ++dr) X[dr] = arg.X[dr];
@@ -68,6 +68,8 @@ __global__ void compute_Value(KernelArg<Gauge> arg){
       if(functiontype == 0) val += getDeterminant(U);
       if(functiontype == 1) val += getTrace(U);
     }
+
+    idx += blockDim.x*gridDim.x;
   }
 
   double2 sum = make_double2(val.real(), val.imag());
@@ -82,7 +84,7 @@ class CalcFunc : TunableLocalParity {
   TuneParam tp;
   mutable char aux_string[128]; // used as a label in the autotuner
   private:
-  unsigned int minThreads() const { return arg.threads; }
+  bool tuneGridDim() const { return true; }
 
   public:
   CalcFunc(KernelArg<Gauge> &arg) : arg(arg) {}

--- a/lib/qcharge_quda.cu
+++ b/lib/qcharge_quda.cu
@@ -33,7 +33,7 @@ namespace quda {
 
       double tmpQ1 = 0.;
 
-      if(idx < arg.threads) {
+      while (idx < arg.threads) {
         int parity = 0;  
         if(idx >= arg.threads/2) {
           parity = 1;
@@ -56,6 +56,8 @@ namespace quda {
         tmpQ3 = (getTrace(temp3)).x;
         tmpQ1 += (tmpQ3 - tmpQ2);
         tmpQ1 /= (Pi2*Pi2);
+
+        idx += blockDim.x*gridDim.x;
       }
 
       double Q = tmpQ1;
@@ -68,15 +70,11 @@ namespace quda {
       const QudaFieldLocation location;
       GaugeField *vol;
 
-      private: 
+    private:
       unsigned int sharedBytesPerThread() const { return 0; };
       unsigned int sharedBytesPerBlock(const TuneParam &param) const { return 0; }
 
-//      bool tuneSharedBytes() const { return false; } // Don't tune the shared memory.
-      bool tuneGridDim() const { return false; } // Don't tune the grid dimensions.
-      unsigned int minThreads() const { return arg.threads; }
-
-      public:
+    public:
       QChargeCompute(QChargeArg<Float,Gauge> &arg, GaugeField *vol, QudaFieldLocation location) 
         : arg(arg), vol(vol), location(location) {
 	writeAuxString("threads=%d,prec=%lu",arg.threads,sizeof(Float));

--- a/lib/qcharge_quda.cu
+++ b/lib/qcharge_quda.cu
@@ -11,7 +11,7 @@
 #include <index_helper.cuh>
 
 #ifndef Pi2
-#define Pi2   6.2831853071795864769252867665590
+#define Pi2 6.2831853071795864769252867665590
 #endif
 
 namespace quda {
@@ -22,57 +22,42 @@ namespace quda {
     int threads; // number of active threads required
     Gauge data;
     QChargeArg(const Gauge &data, GaugeField& Fmunu)
-      : ReduceArg<double>(), data(data), threads(Fmunu.Volume()) {}
+      : ReduceArg<double>(), data(data), threads(Fmunu.VolumeCB()) {}
   };
 
   // Core routine for computing the topological charge from the field strength
   template<int blockSize, typename Float, typename Gauge>
-    __global__
-    void qChargeComputeKernel(QChargeArg<Float,Gauge> arg) {
-      int idx = threadIdx.x + blockIdx.x*blockDim.x;
+  __global__ void qChargeComputeKernel(QChargeArg<Float,Gauge> arg) {
+    int idx = threadIdx.x + blockIdx.x*blockDim.x;
+    int parity = threadIdx.y;
 
-      double tmpQ1 = 0.;
+    double Q = 0.0;
 
-      while (idx < arg.threads) {
-        int parity = 0;  
-        if(idx >= arg.threads/2) {
-          parity = 1;
-          idx -= arg.threads/2;
-        }
+    while (idx < arg.threads) {
+      // Load the field-strength tensor from global memory
+      Matrix<complex<Float>,3> F[6];
+      for (int i=0; i<6; ++i) F[i] = arg.data(i, idx, parity);
 
-        // Load the field-strength tensor from global memory
-        Matrix<complex<Float>,3> F[6], temp1, temp2, temp3;
-        double tmpQ2, tmpQ3;
-        for(int i=0; i<6; ++i){
-          arg.data.load((Float*)(F[i].data), idx, i, parity);
-        }
+      double Q1 = getTrace(F[0]*F[5]).real();
+      double Q2 = getTrace(F[1]*F[4]).real();
+      double Q3 = getTrace(F[3]*F[2]).real();
+      Q += (Q1 + Q3 - Q2);
 
-        temp1 = F[0]*F[5];
-        temp2 = F[1]*F[4];
-        temp3 = F[3]*F[2];
-
-        tmpQ1 = (getTrace(temp1)).x;
-        tmpQ2 = (getTrace(temp2)).x;
-        tmpQ3 = (getTrace(temp3)).x;
-        tmpQ1 += (tmpQ3 - tmpQ2);
-        tmpQ1 /= (Pi2*Pi2);
-
-        idx += blockDim.x*gridDim.x;
-      }
-
-      double Q = tmpQ1;
-      reduce<blockSize>(arg, Q);
+      idx += blockDim.x*gridDim.x;
     }
+    Q /= (Pi2*Pi2);
+
+    reduce2d<blockSize,2>(arg, Q);
+  }
 
   template<typename Float, typename Gauge>
-    class QChargeCompute : Tunable {
+    class QChargeCompute : TunableLocalParity {
       QChargeArg<Float,Gauge> arg;
       const QudaFieldLocation location;
       GaugeField *vol;
 
     private:
-      unsigned int sharedBytesPerThread() const { return 0; };
-      unsigned int sharedBytesPerBlock(const TuneParam &param) const { return 0; }
+      bool tuneGridDim() const { return true; }
 
     public:
       QChargeCompute(QChargeArg<Float,Gauge> &arg, GaugeField *vol, QudaFieldLocation location) 
@@ -83,14 +68,13 @@ namespace quda {
       virtual ~QChargeCompute() { }
 
       void apply(const cudaStream_t &stream) {
-        if(location == QUDA_CUDA_FIELD_LOCATION){
+        if (location == QUDA_CUDA_FIELD_LOCATION) {
           arg.result_h[0] = 0.;
           TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
           LAUNCH_KERNEL(qChargeComputeKernel, tp, stream, arg, Float);
           qudaDeviceSynchronize();
-        }else{ // run the CPU code
+        } else { // run the CPU code
 	  errorQuda("qChargeComputeKernel not supported on CPU");
-//          qChargeComputeCPU(arg);
         }
       }
 
@@ -98,11 +82,9 @@ namespace quda {
 	return TuneKey(vol->VolString(), typeid(*this).name(), aux);
       }
 
-      long long flops() const { return arg.threads*(3*198+9); }
-      long long bytes() const { return arg.threads*(6*18)*sizeof(Float); }
+      long long flops() const { return 2*arg.threads*(3*198+9); }
+      long long bytes() const { return 2*arg.threads*(6*18)*sizeof(Float); }
     };
-
-
 
   template<typename Float, typename Gauge>
     void computeQCharge(const Gauge data, GaugeField& Fmunu, QudaFieldLocation location, Float &qChg){

--- a/lib/reduce_quda.cu
+++ b/lib/reduce_quda.cu
@@ -89,24 +89,16 @@ namespace quda {
 	   of size MAX_MULTI_BLAS_N^2 of vectors (max length 4), with
 	   possible parity dimension, and a grid-stride loop with
 	   maximum number of blocks = 2 x SM count
-
-	- inline reductions in kernels where we cannot assume a grid
-           stride loop - hence max blocks is given by the architecture
-           limit
-
       */
 
-      const int max_reduce_blocks = 2*deviceProp.multiProcessorCount; // FIXME - should set this according to what's used in tune_quda.h
+      const int reduce_size = 4 * sizeof(QudaSumFloat);
+      const int max_reduce_blocks = 2*deviceProp.multiProcessorCount;
 
-      const int max_reduce = 2 * max_reduce_blocks * 4 * sizeof(QudaSumFloat);
-      const int max_multi_reduce = 2 * MAX_MULTI_BLAS_N * MAX_MULTI_BLAS_N * max_reduce_blocks * 4 * sizeof(QudaSumFloat);
-
-      const int max_generic_blocks = 65336; // FIXME - this isn't quite right
-      const int max_generic_reduce = 2 * MAX_MULTI_BLAS_N * max_generic_blocks * 4 * sizeof(QudaSumFloat);
+      const int max_reduce = 2 * max_reduce_blocks * reduce_size;
+      const int max_multi_reduce = 2 * MAX_MULTI_BLAS_N * MAX_MULTI_BLAS_N * max_reduce_blocks * reduce_size;
 
       // reduction buffer size
       size_t bytes = max_reduce > max_multi_reduce ? max_reduce : max_multi_reduce;
-      bytes = bytes > max_generic_reduce ? bytes : max_generic_reduce;
 
       if (!d_reduce) d_reduce = (QudaSumFloat *) device_malloc(bytes);
 

--- a/tests/invert_test.cpp
+++ b/tests/invert_test.cpp
@@ -62,6 +62,9 @@ extern QudaMatPCType matpc_type; // preconditioning type
 extern double clover_coeff;
 extern bool compute_clover;
 
+extern QudaVerbosity verbosity;
+extern QudaVerbosity mg_verbosity[QUDA_MAX_MG_LEVEL]; // use this for preconditioner verbosity
+
 extern int Nsrc; // number of spinors to apply to simultaneously
 extern int niter; // max solver iterations
 extern int gcrNkrylov; // number of inner iterations for GCR, or l for BiCGstab-l
@@ -100,6 +103,8 @@ display_test_info()
 
 int main(int argc, char **argv)
 {
+
+  mg_verbosity[0] = QUDA_SILENT; // set default preconditioner verbosity
 
   for (int i = 1; i < argc; i++){
     if(process_command_line_option(argc, argv, &i) == 0){
@@ -270,7 +275,7 @@ int main(int argc, char **argv)
   inv_param.precondition_cycle = 1;
   inv_param.tol_precondition = 1e-1;
   inv_param.maxiter_precondition = 10;
-  inv_param.verbosity_precondition = QUDA_SILENT;
+  inv_param.verbosity_precondition = mg_verbosity[0];
   inv_param.cuda_prec_precondition = cuda_prec_precondition;
   inv_param.omega = 1.0;
 
@@ -310,7 +315,7 @@ int main(int argc, char **argv)
     inv_param.clover_coeff = clover_coeff;
   }
 
-  inv_param.verbosity = QUDA_VERBOSE;
+  inv_param.verbosity = verbosity;
 
   // *** Everything between here and the call to initQuda() is
   // *** application-specific.

--- a/tests/su3_test.cpp
+++ b/tests/su3_test.cpp
@@ -36,7 +36,8 @@ extern double anisotropy;
 extern bool verify_results;
 
 extern char latfile[];
-extern bool verify_results;
+
+extern QudaVerbosity verbosity;
 
 #define MAX(a,b) ((a)>(b)?(a):(b))
 
@@ -116,6 +117,8 @@ void SU3test(int argc, char **argv) {
 
   initQuda(device);
 
+  setVerbosity(verbosity);
+
   // call srand() with a rank-dependent seed
   initRand();
 
@@ -154,8 +157,6 @@ void SU3test(int argc, char **argv) {
   unsigned int nSteps = 50;
   double coeff_APE = 0.6;
   double coeff_STOUT = coeff_APE/(2*(4-1));
-  QudaVerbosity verbosity = QUDA_VERBOSE;
-  setVerbosity(verbosity);
   
   //STOUT
   // start the timer


### PR DESCRIPTION
This pull cleans up some of the reductions:
* Always use grid-stride loops for kernels with reductions (clover invert, topological charge, etc.)
* Since we always use grid-stride loops for reductions, we can reduce the reduction buffer sizes required (memory saving)
* Fixes a bug in stout smearing to ensure correct answer when tuning
* Some miscellaneous optimizations and clean up