### PR TITLE
Feature/tifr dec2018

### DIFF
--- a/include/color_spinor.h
+++ b/include/color_spinor.h
@@ -101,6 +101,13 @@ namespace quda {
       */
       __device__ __host__ inline const complex<Float>& operator()(int idx) const { return data[idx]; }
 
+      __device__ __host__ void print() {
+        for (int s=0; s<Ns; s++) {
+          for (int c=0; c<Nc; c++) {
+            printf("s=%d c=%d %e %e\n", s, c, data[s*Nc+c].real(), data[s*Nc+c].imag());
+          }
+        }
+      }
     };
 
   /**
@@ -614,7 +621,7 @@ namespace quda {
       *this = a;
     }
 
-  __device__ __host__ void print() {
+    __device__ __host__ void print() {
       for (int s=0; s<Ns; s++) {
 	for (int c=0; c<Nc; c++) {
 	  printf("s=%d c=%d %e %e\n", s, c, data[s*Nc+c].real(), data[s*Nc+c].imag());

--- a/include/color_spinor_field.h
+++ b/include/color_spinor_field.h
@@ -767,7 +767,7 @@ namespace quda {
       if (bufferIndex < 2) {
         return ghost_recv_buffer_d[bufferIndex];
       } else {
-        return static_cast<char*>(ghost_pinned_buffer_hd[bufferIndex%2])+ghost_bytes;
+        return ghost_pinned_recv_buffer_hd[bufferIndex%2];
       }
     }
 

--- a/include/color_spinor_field_order.h
+++ b/include/color_spinor_field_order.h
@@ -1269,7 +1269,7 @@ namespace quda {
     dim[0] *= (nParity == 1) ? 2 : 1; // need to full dimensions
     exDim[0] *= (nParity == 1) ? 2 : 1; // need to full dimensions
 
-    offset = (exVolumeCB*Ns*Nc*2) / 2; // compute manually since Bytes is likely wrong due to z-padding
+    offset = exVolumeCB*Ns*Nc*2; // compute manually since Bytes is likely wrong due to z-padding
   }
   virtual ~PaddedSpaceSpinorColorOrder() { ; }
 

--- a/include/gauge_field.h
+++ b/include/gauge_field.h
@@ -246,8 +246,11 @@ namespace quda {
 
     /**
        Apply the staggered phase factors to the gauge field.
+       @param[in] phase The phase we will apply to the field.  If this
+       is QUDA_STAGGERED_PHASE_INVALID, the default value, then apply
+       the phase set internal to the field.
     */
-    void applyStaggeredPhase();
+    void applyStaggeredPhase(QudaStaggeredPhase phase=QUDA_STAGGERED_PHASE_INVALID);
 
     /**
        Remove the staggered phase factors from the gauge field.

--- a/include/lattice_field.h
+++ b/include/lattice_field.h
@@ -201,14 +201,24 @@ namespace quda {
     static void *ghost_recv_buffer_d[2];
 
     /**
-       Double buffered static pinned send/recv buffers
+       Double buffered static pinned send buffers
     */
-    static void *ghost_pinned_buffer_h[2];
+    static void *ghost_pinned_send_buffer_h[2];
 
     /**
-       Mapped version of ghost_pinned
+       Double buffered static pinned recv buffers
     */
-    static void *ghost_pinned_buffer_hd[2];
+    static void *ghost_pinned_recv_buffer_h[2];
+
+    /**
+       Mapped version of pinned send buffers
+    */
+    static void *ghost_pinned_send_buffer_hd[2];
+
+    /**
+       Mapped version of pinned recv buffers
+    */
+    static void *ghost_pinned_recv_buffer_hd[2];
 
     /**
        Remove ghost pointer for sending to
@@ -250,9 +260,14 @@ namespace quda {
     */
     mutable int ghostNormOffset[QUDA_MAX_DIM][2];
 
-    /** Pinned memory buffer used for sending all messages */
+    /**
+       Pinned memory buffer used for sending all messages
+    */
     void *my_face_h[2];
-    /** Mapped version of my_face_h */
+
+    /**
+       Mapped version of my_face_h
+    */
     void *my_face_hd[2];
 
     /** Local pointers to the pinned my_face buffer */

--- a/lib/blas_core.cuh
+++ b/lib/blas_core.cuh
@@ -232,7 +232,7 @@ template <typename Float, typename yFloat, int nSpin, QudaFieldOrder order,
   } else if (x.Ncolor() == 32) {
     genericBlas<Float,yFloat,nSpin,32,order,writeX,writeY,writeZ,writeW,Functor>(x, y, z, w, f);
   } else {
-    errorQuda("nColor = %d not implemeneted",x.Ncolor());
+    errorQuda("nColor = %d not implemented",x.Ncolor());
   }
 }
 
@@ -247,7 +247,7 @@ template <typename Float, typename yFloat, QudaFieldOrder order, int writeX, int
     genericBlas<Float,yFloat,1,order,writeX,writeY,writeZ,writeW,Functor>(x, y, z, w, f);
 #endif
   } else {
-    errorQuda("nSpin = %d not implemeneted",x.Nspin());
+    errorQuda("nSpin = %d not implemented",x.Nspin());
   }
 }
 
@@ -257,6 +257,6 @@ template <typename Float, typename yFloat, int writeX, int writeY, int writeZ, i
     genericBlas<Float,yFloat,QUDA_SPACE_SPIN_COLOR_FIELD_ORDER,writeX,writeY,writeZ,writeW,Functor>
       (x, y, z, w, f);
   } else {
-    errorQuda("Not implemeneted");
+    errorQuda("Not implemented");
   }
 }

--- a/lib/color_spinor_pack.cu
+++ b/lib/color_spinor_pack.cu
@@ -60,9 +60,10 @@ namespace quda {
 #endif
       }
 
-      strcpy(aux, compile_type_str(meta));
-      strcat(aux, meta.AuxString());
+      strcpy(aux,compile_type_str(meta));
+      strcat(aux,meta.AuxString());
       strcat(aux,comm_dim_partitioned_string());
+      strcat(aux,comm_dim_topology_string());
 
       // record the location of where each pack buffer is in [2*dim+dir] ordering
       // 0 - no packing

--- a/lib/comm_qmp.cpp
+++ b/lib/comm_qmp.cpp
@@ -17,7 +17,7 @@ struct MsgHandle_s {
 static int gpuid = -1;
 
 static char partition_string[16];
-static char topology_string[16];
+static char topology_string[128];
 
 // While we can emulate an all-gather using QMP reductions, this
 // scales horribly as the number of nodes increases, so for
@@ -122,7 +122,37 @@ void comm_init(int ndim, const int *dims, QudaCommsMap rank_from_coords, void *m
   host_free(hostname_recv_buf);
 
   snprintf(partition_string, 16, ",comm=%d%d%d%d", comm_dim_partitioned(0), comm_dim_partitioned(1), comm_dim_partitioned(2), comm_dim_partitioned(3));
-  snprintf(topology_string, 16, ",topo=%d%d%d%d", comm_dim(0), comm_dim(1), comm_dim(2), comm_dim(3));
+
+  // if CUDA_VISIBLE_DEVICES is set, we include this information in the topology_string
+  char *device_order_env = getenv("CUDA_VISIBLE_DEVICES");
+  if (device_order_env) {
+
+    // to ensure we have process consistency define using rank 0
+    if (comm_rank() == 0) {
+      std::stringstream device_list_raw(device_order_env); // raw input
+      std::stringstream device_list;                       // formatted (no commas)
+
+      int device;
+      int deviceCount;
+      cudaGetDeviceCount(&deviceCount);
+      while (device_list_raw >> device) {
+        // check this is a valid policy choice
+        if ( device < 0 || device >= device_count) {
+          errorQuda("Invalid CUDA_VISIBLE_DEVICE ordinal %d", device);
+        }
+
+        device_list << device;
+        if (device_list_raw.peek() == ',') device_list_raw.ignore();
+      }
+      snprintf(topology_string, 128, ",topo=%d%d%d%d,order=%s",
+               comm_dim(0), comm_dim(1), comm_dim(2), comm_dim(3), device_list.str().c_str());
+    }
+
+    comm_broadcast(topology_string, 128);
+  } else {
+    snprintf(topology_string, 128, ",topo=%d%d%d%d", comm_dim(0), comm_dim(1), comm_dim(2), comm_dim(3));
+  }
+
 }
 
 int comm_rank(void)

--- a/lib/cuda_color_spinor_field.cu
+++ b/lib/cuda_color_spinor_field.cu
@@ -410,7 +410,7 @@ namespace quda {
 	cudaCreateTextureObject(&ghostTex[b], &resDesc, &texDesc, NULL);
 
 	// second set of ghost texture map to the host-mapped pinned receive buffers
-	resDesc.res.linear.devPtr = static_cast<char*>(ghost_pinned_buffer_hd[b])+ghost_bytes;
+	resDesc.res.linear.devPtr = ghost_pinned_recv_buffer_hd[b];
 	cudaCreateTextureObject(&ghostTex[2+b], &resDesc, &texDesc, NULL);
 
 	if (ghost_precision == QUDA_HALF_PRECISION || ghost_precision == QUDA_QUARTER_PRECISION) {
@@ -432,12 +432,12 @@ namespace quda {
 
 	  cudaCreateTextureObject(&ghostTexNorm[b], &resDesc, &texDesc, NULL);
 
-	  resDesc.res.linear.devPtr = static_cast<char*>(ghost_pinned_buffer_hd[b])+ghost_bytes;
+	  resDesc.res.linear.devPtr = ghost_pinned_recv_buffer_hd[b];
 	  cudaCreateTextureObject(&ghostTexNorm[2+b], &resDesc, &texDesc, NULL);
 	}
 
 	ghost_field_tex[b] = ghost_recv_buffer_d[b];
-	ghost_field_tex[2+b] = static_cast<char*>(ghost_pinned_buffer_hd[b])+ghost_bytes;
+	ghost_field_tex[2+b] = ghost_pinned_recv_buffer_hd[b];
       } // buffer index
 
       ghostTexInit = true;
@@ -925,7 +925,8 @@ namespace quda {
 
     // ascertain if this instance needs its comms buffers to be updated
     bool comms_reset = ghost_field_reset || // FIXME add send buffer check
-      (my_face_h[0] != ghost_pinned_buffer_h[0]) || (my_face_h[1] != ghost_pinned_buffer_h[1]) || // pinned buffers
+      (my_face_h[0] != ghost_pinned_send_buffer_h[0]) || (my_face_h[1] != ghost_pinned_send_buffer_h[1]) ||
+      (from_face_h[0] != ghost_pinned_recv_buffer_h[0]) || (from_face_h[1] != ghost_pinned_recv_buffer_h[1]) ||
       (ghost_field_tex[0] != ghost_recv_buffer_d[0]) || (ghost_field_tex[1] != ghost_recv_buffer_d[1]) || // receive buffers
       ghost_precision_reset; // ghost_precision has changed
 

--- a/lib/cuda_gauge_field.cu
+++ b/lib/cuda_gauge_field.cu
@@ -391,7 +391,8 @@ namespace quda {
 
     // ascertain if this instance needs it comms buffers to be updated
     bool comms_reset = ghost_field_reset || // FIXME add send buffer check
-      (my_face_h[0] != ghost_pinned_buffer_h[0]) || (my_face_h[1] != ghost_pinned_buffer_h[1]) || // pinned buffers
+      (my_face_h[0] != ghost_pinned_send_buffer_h[0]) || (my_face_h[1] != ghost_pinned_send_buffer_h[1]) ||
+      (from_face_h[0] != ghost_pinned_recv_buffer_h[0]) || (from_face_h[1] != ghost_pinned_recv_buffer_h[1]) ||
       ghost_bytes != ghost_bytes_old; // ghost buffer has been resized (e.g., bidir to unidir)
 
     if (!initComms || comms_reset) LatticeField::createComms(no_comms_fill, bidir);

--- a/lib/dslash_core/staggered_dslash_core.h
+++ b/lib/dslash_core/staggered_dslash_core.h
@@ -414,7 +414,11 @@ if (threadId.z & 1)
 
 
 #if (DD_FAT_RECON == 12 || DD_FAT_RECON == 8)
+#ifndef TIFR
   int fat_sign = (y[3]%2 == 1) ? -1 : 1;
+#else
+  int fat_sign = (y[3]+y[2]+y[1])%2 == 0 ? -1 : 1;
+#endif
 #endif
 #if ((DD_LONG_RECON == 12 || DD_LONG_RECON == 8) && DD_IMPROVED==1)
   int long_sign = (y[3]%2 == 1) ? -1 : 1;
@@ -514,7 +518,11 @@ if (!(threadIdx.z & 1))
 {
   // direction: -X
 #if (DD_FAT_RECON == 12 || DD_FAT_RECON == 8)
+#ifndef TIFR
   int fat_sign = (y[3]%2 == 1) ? -1 : 1;
+#else
+  int fat_sign = (y[3]+y[2]+y[1])%2 == 0 ? -1 : 1;
+#endif
 #endif
 #if ((DD_LONG_RECON == 12 || DD_LONG_RECON == 8) && DD_IMPROVED==1)
   int long_sign = (y[3]%2 == 1) ? -1 : 1;
@@ -625,7 +633,11 @@ if (threadIdx.z & 1)
 {
   //direction: +Y
 #if (DD_FAT_RECON == 12 || DD_FAT_RECON == 8)
+#ifndef TIFR
   int fat_sign = ((y[3]+y[0])%2 == 1) ? -1 : 1;
+#else
+  int fat_sign = ((y[3]+y[2])%2 == 1) ? -1 : 1;
+#endif
 #endif
 #if ((DD_LONG_RECON == 12 || DD_LONG_RECON == 8) && DD_IMPROVED==1)
   int long_sign = ((y[3]+y[0])%2 == 1) ? -1 : 1;
@@ -724,7 +736,11 @@ if (!(threadIdx.z & 1))
   //direction: -Y
 
 #if (DD_FAT_RECON == 12 || DD_FAT_RECON == 8)
+#ifndef TIFR
   int fat_sign = ((y[3]+y[0])%2 == 1) ? -1 : 1;
+#else
+  int fat_sign = ((y[3]+y[2])%2 == 1) ? -1 : 1;
+#endif
 #endif
 #if ((DD_LONG_RECON == 12 || DD_LONG_RECON == 8) && DD_IMPROVED==1)
   int long_sign = ((y[3]+y[0])%2 == 1) ? -1 : 1;
@@ -833,7 +849,11 @@ if (threadIdx.z&1)
   //direction: +Z
 
 #if (DD_FAT_RECON == 12 || DD_FAT_RECON == 8)
+#ifndef TIFR
   int fat_sign = ((y[3]+y[0]+y[1])%2 == 1) ? -1 : 1;
+#else
+  int fat_sign = (y[3]%2 == 0) ? -1 : 1;
+#endif
 #endif
 #if ((DD_LONG_RECON == 12 || DD_LONG_RECON == 8) && DD_IMPROVED==1)
   int long_sign = ((y[3]+y[0]+y[1])%2 == 1) ? -1 : 1;
@@ -933,7 +953,11 @@ if (!(threadIdx.z & 1))
   //direction: -Z
 
 #if (DD_FAT_RECON == 12 || DD_FAT_RECON == 8)
+#ifndef TIFR
   int fat_sign = ((y[3]+y[0]+y[1])%2 == 1) ? -1 : 1;
+#else
+  int fat_sign = (y[3]%2 == 0) ? -1 : 1;
+#endif
 #endif
 #if ((DD_LONG_RECON == 12 || DD_LONG_RECON == 8) && DD_IMPROVED==1)
   int long_sign = ((y[3]+y[0]+y[1])%2 == 1) ? -1 : 1;

--- a/lib/dslash_core/staggered_dslash_core.h
+++ b/lib/dslash_core/staggered_dslash_core.h
@@ -441,7 +441,7 @@ if (threadId.z & 1)
 #if (DD_PREC == 2) //half precision
       norm_idx1 = param.ghostNormOffset[0][1] + src_idx*NFACE*param.dc.ghostFace[0] + (y[0]-(X[0]-1))*param.dc.ghostFace[0]+ space_con;
 #endif
-      READ_1ST_NBR_SPINOR_GHOST(GHOSTSPINORTEX, nbr_idx1, stride1, 1);
+      READ_1ST_NBR_SPINOR_GHOST(GHOSTSPINORTEX, nbr_idx1, stride1, 0);
       RECONSTRUCT_FAT_GAUGE_MATRIX(0, fat, sp_idx_1st_nbr, fat_sign);
       MAT_MUL_V(A, fat, i);    
       o00_re += A0_re;
@@ -487,7 +487,7 @@ if (threadId.z & 1)
 #if (DD_PREC == 2) //half precision
       norm_idx3 = param.ghostNormOffset[0][1] + src_idx*NFACE*param.dc.ghostFace[0] + (y[0]-(X[0]-3))*param.dc.ghostFace[0]+ space_con;
 #endif	
-      READ_3RD_NBR_SPINOR_GHOST(T, GHOSTSPINORTEX, nbr_idx3, stride3, 1);
+      READ_3RD_NBR_SPINOR_GHOST(T, GHOSTSPINORTEX, nbr_idx3, stride3, 0);
     } else
 #endif
     {
@@ -546,7 +546,7 @@ if (!(threadIdx.z & 1))
 #if (DD_PREC == 2) //half precision
       norm_idx1 = param.ghostNormOffset[0][0] + src_idx*NFACE*param.dc.ghostFace[0] + (y[0]+NFACE-1)*param.dc.ghostFace[0]+ space_con;
 #endif	
-      READ_1ST_NBR_SPINOR_GHOST(GHOSTSPINORTEX, nbr_idx1, stride1, 0);
+      READ_1ST_NBR_SPINOR_GHOST(GHOSTSPINORTEX, nbr_idx1, stride1, 1);
       RECONSTRUCT_FAT_GAUGE_MATRIX(1, fat, sp_idx_1st_nbr, fat_sign);
       ADJ_MAT_MUL_V(A, fat, i);       
       o00_re -= A0_re;
@@ -598,7 +598,7 @@ if (!(threadIdx.z & 1))
 #if (DD_PREC == 2) //half precision
       norm_idx3 = param.ghostNormOffset[0][0] + src_idx*NFACE*param.dc.ghostFace[0] + y[0]*param.dc.ghostFace[0]+ space_con;
 #endif
-      READ_3RD_NBR_SPINOR_GHOST(T, GHOSTSPINORTEX, nbr_idx3, stride3, 0);
+      READ_3RD_NBR_SPINOR_GHOST(T, GHOSTSPINORTEX, nbr_idx3, stride3, 1);
     } else
 #endif
     {
@@ -652,7 +652,7 @@ if (threadIdx.z & 1)
 #if (DD_PREC == 2) //half precision
       norm_idx1 = param.ghostNormOffset[1][1] + src_idx*NFACE*param.dc.ghostFace[1] + (y[1]-(X[1]-1))*param.dc.ghostFace[1]+ space_con;
 #endif		    
-      READ_1ST_NBR_SPINOR_GHOST(GHOSTSPINORTEX, nbr_idx1, stride1, 3);
+      READ_1ST_NBR_SPINOR_GHOST(GHOSTSPINORTEX, nbr_idx1, stride1, 2);
       RECONSTRUCT_FAT_GAUGE_MATRIX(2, fat, sp_idx_1st_nbr, fat_sign);
       MAT_MUL_V(A, fat, i);
       o00_re += A0_re;
@@ -698,7 +698,7 @@ if (threadIdx.z & 1)
 #if (DD_PREC == 2) //half precision
       norm_idx3 = param.ghostNormOffset[1][1] + src_idx*NFACE*param.dc.ghostFace[1] + (y[1]-(X[1]-3))*param.dc.ghostFace[1]+ space_con;
 #endif		    
-      READ_3RD_NBR_SPINOR_GHOST(T, GHOSTSPINORTEX, nbr_idx3, stride3, 3);
+      READ_3RD_NBR_SPINOR_GHOST(T, GHOSTSPINORTEX, nbr_idx3, stride3, 2);
     } else
 #endif    
     {
@@ -756,7 +756,7 @@ if (!(threadIdx.z & 1))
 #if (DD_PREC == 2) //half precision
       norm_idx1 = param.ghostNormOffset[1][0] + src_idx*NFACE*param.dc.ghostFace[1] + (y[1]+NFACE-1)*param.dc.ghostFace[1]+ space_con;
 #endif	
-      READ_1ST_NBR_SPINOR_GHOST(GHOSTSPINORTEX, nbr_idx1, stride1, 2);
+      READ_1ST_NBR_SPINOR_GHOST(GHOSTSPINORTEX, nbr_idx1, stride1, 3);
       RECONSTRUCT_FAT_GAUGE_MATRIX(3, fat, sp_idx_1st_nbr, fat_sign);
       ADJ_MAT_MUL_V(A, fat, i);
       o00_re -= A0_re;
@@ -808,7 +808,7 @@ if (!(threadIdx.z & 1))
 #if (DD_PREC == 2) //half precision
       norm_idx3 = param.ghostNormOffset[1][0] + src_idx*NFACE*param.dc.ghostFace[1] + y[1]*param.dc.ghostFace[1]+ space_con;
 #endif
-      READ_3RD_NBR_SPINOR_GHOST(T, GHOSTSPINORTEX, nbr_idx3, stride3, 2);
+      READ_3RD_NBR_SPINOR_GHOST(T, GHOSTSPINORTEX, nbr_idx3, stride3, 3);
     } else
 #endif
     {
@@ -860,7 +860,7 @@ if (threadIdx.z&1)
 #if (DD_PREC == 2) //half precision
       norm_idx1 = param.ghostNormOffset[2][1] + src_idx*NFACE*param.dc.ghostFace[2] + (y[2]-(X[2]-1))*param.dc.ghostFace[2]+ space_con;
 #endif		
-      READ_1ST_NBR_SPINOR_GHOST(GHOSTSPINORTEX, nbr_idx1, stride1, 5);
+      READ_1ST_NBR_SPINOR_GHOST(GHOSTSPINORTEX, nbr_idx1, stride1, 4);
       RECONSTRUCT_FAT_GAUGE_MATRIX(4, fat, sp_idx_1st_nbr, fat_sign);
       MAT_MUL_V(A, fat, i);	 
       o00_re += A0_re;
@@ -906,7 +906,7 @@ if (threadIdx.z&1)
 #if (DD_PREC == 2) //half precision
       norm_idx3 = param.ghostNormOffset[2][1] + src_idx*NFACE*param.dc.ghostFace[2] + (y[2]-(X[2]-3))*param.dc.ghostFace[2]+ space_con;
 #endif
-      READ_3RD_NBR_SPINOR_GHOST(T, GHOSTSPINORTEX, nbr_idx3, stride3, 5);
+      READ_3RD_NBR_SPINOR_GHOST(T, GHOSTSPINORTEX, nbr_idx3, stride3, 4);
     } else
 #endif
     {
@@ -966,7 +966,7 @@ if (!(threadIdx.z & 1))
 #if (DD_PREC == 2) //half precision
       norm_idx1 = param.ghostNormOffset[2][0] + src_idx*NFACE*param.dc.ghostFace[2] + (y[2]+NFACE-1)*param.dc.ghostFace[2]+ space_con;
 #endif			    
-      READ_1ST_NBR_SPINOR_GHOST(GHOSTSPINORTEX, nbr_idx1, stride1, 4);
+      READ_1ST_NBR_SPINOR_GHOST(GHOSTSPINORTEX, nbr_idx1, stride1, 5);
       RECONSTRUCT_FAT_GAUGE_MATRIX(5, fat, sp_idx_1st_nbr, fat_sign);
       ADJ_MAT_MUL_V(A, fat, i);
       o00_re -= A0_re;
@@ -1018,7 +1018,7 @@ if (!(threadIdx.z & 1))
 #if (DD_PREC == 2) //half precision
       norm_idx3 = param.ghostNormOffset[2][0] + src_idx*NFACE*param.dc.ghostFace[2] + y[2]*param.dc.ghostFace[2]+ space_con;
 #endif			    
-      READ_3RD_NBR_SPINOR_GHOST(T, GHOSTSPINORTEX, nbr_idx3, stride3, 4);
+      READ_3RD_NBR_SPINOR_GHOST(T, GHOSTSPINORTEX, nbr_idx3, stride3, 5);
     } else
 #endif
     {
@@ -1070,7 +1070,7 @@ if (threadIdx.z & 1)
 #if (DD_PREC == 2) //half precision
       norm_idx1 = param.ghostNormOffset[3][1] + src_idx*NFACE*param.dc.ghostFace[3] + (y[3]-(X[3]-1))*param.dc.ghostFace[3]+ space_con;
 #endif
-      READ_1ST_NBR_SPINOR_GHOST( GHOSTSPINORTEX, nbr_idx1, stride1, 7);
+      READ_1ST_NBR_SPINOR_GHOST( GHOSTSPINORTEX, nbr_idx1, stride1, 6);
       RECONSTRUCT_FAT_GAUGE_MATRIX(6, fat, sp_idx_1st_nbr, fat_sign);
       MAT_MUL_V(A, fat, i);
       o00_re += A0_re;
@@ -1117,7 +1117,7 @@ if (threadIdx.z & 1)
 #if (DD_PREC == 2) //half precision
       norm_idx3 = param.ghostNormOffset[3][1] + src_idx*NFACE*param.dc.ghostFace[3] + (y[3]-(X[3]-3))*param.dc.ghostFace[3]+ space_con;
 #endif
-      READ_3RD_NBR_SPINOR_GHOST(T, GHOSTSPINORTEX, nbr_idx3, stride3, 7); 
+      READ_3RD_NBR_SPINOR_GHOST(T, GHOSTSPINORTEX, nbr_idx3, stride3, 6);
     } else
 #endif
     {
@@ -1172,7 +1172,7 @@ if (!(threadIdx.z & 1))
 #if (DD_PREC == 2) //half precision
       norm_idx1 = param.ghostNormOffset[3][0] + src_idx*NFACE*param.dc.ghostFace[3] + (y[3]+NFACE-1)*param.dc.ghostFace[3]+ space_con;
 #endif		    
-      READ_1ST_NBR_SPINOR_GHOST(GHOSTSPINORTEX, nbr_idx1, stride1, 6);
+      READ_1ST_NBR_SPINOR_GHOST(GHOSTSPINORTEX, nbr_idx1, stride1, 7);
       READ_FAT_MATRIX(FATLINK1TEX, dir, fat_idx, fat_stride);
       RECONSTRUCT_FAT_GAUGE_MATRIX(7, fat, sp_idx_1st_nbr, fat_sign);
       ADJ_MAT_MUL_V(A, fat, i);
@@ -1222,7 +1222,7 @@ if (!(threadIdx.z & 1))
 #if (DD_PREC == 2) //half precision
       norm_idx3 = param.ghostNormOffset[3][0] + src_idx*NFACE*param.dc.ghostFace[3] + y[3]*param.dc.ghostFace[3]+ space_con;
 #endif		    
-      READ_3RD_NBR_SPINOR_GHOST(T, GHOSTSPINORTEX, nbr_idx3, stride3, 6);
+      READ_3RD_NBR_SPINOR_GHOST(T, GHOSTSPINORTEX, nbr_idx3, stride3, 7);
     } else
 #endif	  
     {  

--- a/lib/dslash_core/staggered_fused_exterior_dslash_core.h
+++ b/lib/dslash_core/staggered_fused_exterior_dslash_core.h
@@ -412,7 +412,11 @@ if (threadId.z & 1)
   //direction: +X
 
 #if (DD_FAT_RECON == 12 || DD_FAT_RECON == 8)
+#ifndef TIFR
   int fat_sign = (y[3]%2 == 1) ? -1 : 1;
+#else
+  int fat_sign = (y[3]+y[2]+y[1])%2 == 0 ? -1 : 1;
+#endif
 #endif
 #if ((DD_LONG_RECON == 12 || DD_LONG_RECON == 8) && DD_IMPROVED==1)
   int long_sign = (y[3]%2 == 1) ? -1 : 1;
@@ -497,7 +501,11 @@ if (!(threadIdx.z & 1))
 {
   // direction: -X
 #if (DD_FAT_RECON == 12 || DD_FAT_RECON == 8)
+#ifndef TIFR
   int fat_sign = (y[3]%2 == 1) ? -1 : 1;
+#else
+  int fat_sign = (y[3]+y[2]+y[1])%2 == 0 ? -1 : 1;
+#endif
 #endif
 #if ((DD_LONG_RECON == 12 || DD_LONG_RECON == 8) && DD_IMPROVED==1)
   int long_sign = (y[3]%2 == 1) ? -1 : 1;
@@ -592,7 +600,11 @@ if (threadId.z & 1)
 {
   //direction: +Y
 #if (DD_FAT_RECON == 12 || DD_FAT_RECON == 8)
+#ifndef TIFR
   int fat_sign = ((y[3]+y[0])%2 == 1) ? -1 : 1;
+#else
+  int fat_sign = ((y[3]+y[2])%2 == 1) ? -1 : 1;
+#endif
 #endif
 #if ((DD_LONG_RECON == 12 || DD_LONG_RECON == 8) && DD_IMPROVED==1)
   int long_sign = ((y[3]+y[0])%2 == 1) ? -1 : 1;
@@ -676,7 +688,11 @@ if (!(threadIdx.z & 1))
   //direction: -Y
 
 #if (DD_FAT_RECON == 12 || DD_FAT_RECON == 8)
+#ifndef TIFR
   int fat_sign = ((y[3]+y[0])%2 == 1) ? -1 : 1;
+#else
+  int fat_sign = ((y[3]+y[2])%2 == 1) ? -1 : 1;
+#endif
 #endif
 #if ((DD_LONG_RECON == 12 || DD_LONG_RECON == 8) && DD_IMPROVED==1)
   int long_sign = ((y[3]+y[0])%2 == 1) ? -1 : 1;
@@ -772,7 +788,11 @@ if (threadId.z & 1)
   //direction: +Z
 
 #if (DD_FAT_RECON == 12 || DD_FAT_RECON == 8)
+#ifndef TIFR
   int fat_sign = ((y[3]+y[0]+y[1])%2 == 1) ? -1 : 1;
+#else
+  int fat_sign = (y[3]%2 == 0) ? -1 : 1;
+#endif
 #endif
 #if ((DD_LONG_RECON == 12 || DD_LONG_RECON == 8) && DD_IMPROVED==1)
   int long_sign = ((y[3]+y[0]+y[1])%2 == 1) ? -1 : 1;
@@ -857,7 +877,11 @@ if (!(threadIdx.z & 1))
   //direction: -Z
 
 #if (DD_FAT_RECON == 12 || DD_FAT_RECON == 8)
+#ifndef TIFR
   int fat_sign = ((y[3]+y[0]+y[1])%2 == 1) ? -1 : 1;
+#else
+  int fat_sign = (y[3]%2 == 0) ? -1 : 1;
+#endif
 #endif
 #if ((DD_LONG_RECON == 12 || DD_LONG_RECON == 8) && DD_IMPROVED==1)
   int long_sign = ((y[3]+y[0]+y[1])%2 == 1) ? -1 : 1;

--- a/lib/dslash_core/staggered_fused_exterior_dslash_core.h
+++ b/lib/dslash_core/staggered_fused_exterior_dslash_core.h
@@ -440,7 +440,7 @@ if (threadId.z & 1)
     norm_idx1 = param.ghostNormOffset[0][1] + src_idx*NFACE*param.dc.ghostFace[0] + (y[0]-(X[0]-1))*param.dc.ghostFace[0] + space_con;
 #endif		    
 #endif
-    READ_1ST_NBR_SPINOR_GHOST( GHOSTSPINORTEX, nbr_idx1, stride1, 1);
+    READ_1ST_NBR_SPINOR_GHOST( GHOSTSPINORTEX, nbr_idx1, stride1, 0);
     RECONSTRUCT_FAT_GAUGE_MATRIX(0, fat, ga_idx, fat_sign);
     MAT_MUL_V(A, fat, i);    
     o00_re += A0_re;
@@ -474,7 +474,7 @@ if (threadId.z & 1)
 #endif	
 #endif
     spinorFloat2 T0, T1, T2;
-    READ_3RD_NBR_SPINOR_GHOST(T, GHOSTSPINORTEX, nbr_idx3, stride3, 1);
+    READ_3RD_NBR_SPINOR_GHOST(T, GHOSTSPINORTEX, nbr_idx3, stride3, 0);
 
     RECONSTRUCT_LONG_GAUGE_MATRIX(0, long, ga_idx, long_sign);
     MAT_MUL_V(B, long, t);        
@@ -530,7 +530,7 @@ if (!(threadIdx.z & 1))
     norm_idx1 = param.ghostNormOffset[0][0] + src_idx*NFACE*param.dc.ghostFace[0] + (y[0]+NFACE-1)*param.dc.ghostFace[0] + space_con;
 #endif	
 #endif
-    READ_1ST_NBR_SPINOR_GHOST( GHOSTSPINORTEX, nbr_idx1, stride1, 0);
+    READ_1ST_NBR_SPINOR_GHOST( GHOSTSPINORTEX, nbr_idx1, stride1, 1);
     RECONSTRUCT_FAT_GAUGE_MATRIX(1, fat, ga_idx, fat_sign);
     ADJ_MAT_MUL_V(A, fat, i);       
     o00_re -= A0_re;
@@ -571,7 +571,7 @@ if (!(threadIdx.z & 1))
 #endif
 
     spinorFloat2 T0, T1, T2;
-    READ_3RD_NBR_SPINOR_GHOST(T, GHOSTSPINORTEX, nbr_idx3, stride3, 0);
+    READ_3RD_NBR_SPINOR_GHOST(T, GHOSTSPINORTEX, nbr_idx3, stride3, 1);
     RECONSTRUCT_LONG_GAUGE_MATRIX(1, long, sp_idx_3rd_nbr, long_sign);
     ADJ_MAT_MUL_V(B, long, t);    
     o00_re -= B0_re;
@@ -620,7 +620,7 @@ if (threadId.z & 1)
     norm_idx1 = param.ghostNormOffset[1][1] + src_idx*NFACE*param.dc.ghostFace[1] + (y[1]-(X[1]-1))*param.dc.ghostFace[1] + space_con;
 #endif		    
 #endif 
-    READ_1ST_NBR_SPINOR_GHOST( GHOSTSPINORTEX, nbr_idx1, stride1, 3);
+    READ_1ST_NBR_SPINOR_GHOST( GHOSTSPINORTEX, nbr_idx1, stride1, 2);
     RECONSTRUCT_FAT_GAUGE_MATRIX(2, fat, ga_idx, fat_sign);
     MAT_MUL_V(A, fat, i);
     o00_re += A0_re;
@@ -654,7 +654,7 @@ if (threadId.z & 1)
 #endif		    
 #endif    
     spinorFloat2 T0, T1, T2;
-    READ_3RD_NBR_SPINOR_GHOST(T, GHOSTSPINORTEX, nbr_idx3, stride3, 3);
+    READ_3RD_NBR_SPINOR_GHOST(T, GHOSTSPINORTEX, nbr_idx3, stride3, 2);
 
     RECONSTRUCT_LONG_GAUGE_MATRIX(2, long, ga_idx, long_sign);
     MAT_MUL_V(B, long, t);            
@@ -709,7 +709,7 @@ if (!(threadIdx.z & 1))
     norm_idx1 = param.ghostNormOffset[1][0] + src_idx*NFACE*param.dc.ghostFace[1] + (y[1]+NFACE-1)*param.dc.ghostFace[1] + space_con;
 #endif	
 #endif
-    READ_1ST_NBR_SPINOR_GHOST( GHOSTSPINORTEX, nbr_idx1, stride1, 2);
+    READ_1ST_NBR_SPINOR_GHOST( GHOSTSPINORTEX, nbr_idx1, stride1, 3);
     RECONSTRUCT_FAT_GAUGE_MATRIX(3, fat, ga_idx, fat_sign);
     ADJ_MAT_MUL_V(A, fat, i);
     o00_re -= A0_re;
@@ -749,7 +749,7 @@ if (!(threadIdx.z & 1))
 #endif
 #endif
     spinorFloat2 T0, T1, T2;
-    READ_3RD_NBR_SPINOR_GHOST(T, GHOSTSPINORTEX, nbr_idx3, stride3, 2);
+    READ_3RD_NBR_SPINOR_GHOST(T, GHOSTSPINORTEX, nbr_idx3, stride3, 3);
 
     RECONSTRUCT_LONG_GAUGE_MATRIX(3, long, sp_idx_3rd_nbr,long_sign);
     ADJ_MAT_MUL_V(B, long, t);    
@@ -800,7 +800,7 @@ if (threadId.z & 1)
     norm_idx1 = param.ghostNormOffset[2][1] + src_idx*NFACE*param.dc.ghostFace[2] + (y[2]-(X[2]-1))*param.dc.ghostFace[2] + space_con;
 #endif		
 #endif
-    READ_1ST_NBR_SPINOR_GHOST( GHOSTSPINORTEX, nbr_idx1, stride1, 5);
+    READ_1ST_NBR_SPINOR_GHOST( GHOSTSPINORTEX, nbr_idx1, stride1, 4);
     RECONSTRUCT_FAT_GAUGE_MATRIX(4, fat, ga_idx, fat_sign);
     MAT_MUL_V(A, fat, i);	 
     o00_re += A0_re;
@@ -834,7 +834,7 @@ if (threadId.z & 1)
 #endif
 #endif
     spinorFloat2 T0, T1, T2;
-    READ_3RD_NBR_SPINOR_GHOST(T, GHOSTSPINORTEX, nbr_idx3, stride3, 5);
+    READ_3RD_NBR_SPINOR_GHOST(T, GHOSTSPINORTEX, nbr_idx3, stride3, 4);
 
     RECONSTRUCT_LONG_GAUGE_MATRIX(4, long, ga_idx, long_sign);
     MAT_MUL_V(B, long, t);        
@@ -891,7 +891,7 @@ if (!(threadIdx.z & 1))
     norm_idx1 = param.ghostNormOffset[2][0] + src_idx*NFACE*param.dc.ghostFace[2] + (y[2]+NFACE-1)*param.dc.ghostFace[2] + space_con;
 #endif			    
 #endif
-    READ_1ST_NBR_SPINOR_GHOST( GHOSTSPINORTEX, nbr_idx1, stride1, 4);
+    READ_1ST_NBR_SPINOR_GHOST( GHOSTSPINORTEX, nbr_idx1, stride1, 5);
     RECONSTRUCT_FAT_GAUGE_MATRIX(5, fat, ga_idx, fat_sign);
     ADJ_MAT_MUL_V(A, fat, i);
     o00_re -= A0_re;
@@ -931,7 +931,7 @@ if (!(threadIdx.z & 1))
 #endif			    
 #endif
     spinorFloat2 T0, T1, T2;
-    READ_3RD_NBR_SPINOR_GHOST(T, GHOSTSPINORTEX, nbr_idx3, stride3, 4);
+    READ_3RD_NBR_SPINOR_GHOST(T, GHOSTSPINORTEX, nbr_idx3, stride3, 5);
 
     RECONSTRUCT_LONG_GAUGE_MATRIX(5, long, sp_idx_3rd_nbr,long_sign);
     ADJ_MAT_MUL_V(B, long, t);    	    
@@ -981,7 +981,7 @@ if (threadId.z & 1)
     norm_idx1 = param.ghostNormOffset[3][1] + src_idx*NFACE*param.dc.ghostFace[3] + (y[3]-(X[3]-1))*param.dc.ghostFace[3] + space_con;
 #endif
 #endif
-    READ_1ST_NBR_SPINOR_GHOST( GHOSTSPINORTEX, nbr_idx1, stride1, 7);
+    READ_1ST_NBR_SPINOR_GHOST( GHOSTSPINORTEX, nbr_idx1, stride1, 6);
     RECONSTRUCT_FAT_GAUGE_MATRIX(6, fat, ga_idx, fat_sign);
     MAT_MUL_V(A, fat, i);
     o00_re += A0_re;
@@ -1017,7 +1017,7 @@ if (threadId.z & 1)
 #endif
 
     spinorFloat2 T0, T1, T2;
-    READ_3RD_NBR_SPINOR_GHOST(T, GHOSTSPINORTEX, nbr_idx3, stride3, 7);
+    READ_3RD_NBR_SPINOR_GHOST(T, GHOSTSPINORTEX, nbr_idx3, stride3, 6);
 
     RECONSTRUCT_LONG_GAUGE_MATRIX(6, long, ga_idx, long_sign);
     MAT_MUL_V(B, long, t);    
@@ -1069,7 +1069,7 @@ if (!(threadIdx.z & 1))
 #endif		    
 #endif
     READ_FAT_MATRIX(FATLINK1TEX, dir, fat_idx, fat_stride);
-    READ_1ST_NBR_SPINOR_GHOST( GHOSTSPINORTEX, nbr_idx1, stride1, 6);
+    READ_1ST_NBR_SPINOR_GHOST( GHOSTSPINORTEX, nbr_idx1, stride1, 7);
     RECONSTRUCT_FAT_GAUGE_MATRIX(7, fat, ga_idx, fat_sign);
     ADJ_MAT_MUL_V(A, fat, i);
     o00_re -= A0_re;
@@ -1106,7 +1106,7 @@ if (!(threadIdx.z & 1))
     READ_LONG_PHASE(LONGPHASE1TEX, dir, long_idx, long_stride);
 
     spinorFloat2 T0, T1, T2;
-    READ_3RD_NBR_SPINOR_GHOST(T, GHOSTSPINORTEX, nbr_idx3, stride3, 6);
+    READ_3RD_NBR_SPINOR_GHOST(T, GHOSTSPINORTEX, nbr_idx3, stride3, 7);
 
     RECONSTRUCT_LONG_GAUGE_MATRIX(7, long, sp_idx_3rd_nbr, long_sign);
     ADJ_MAT_MUL_V(B, long, t);    

--- a/lib/dslash_quda.cuh
+++ b/lib/dslash_quda.cuh
@@ -442,10 +442,11 @@ protected:
 
     // update the ghosts for the non-p2p directions
     for (int dim=0; dim<4; dim++) {
+      if (!dslashParam.commDim[dim]) continue;
 
       for (int dir=0; dir<2; dir++) {
         /* if doing interior kernel, then this is the initial call, so
-        we must all ghost pointers else if doing exterior kernel, then
+        we must set all ghost pointers else if doing exterior kernel, then
         we only have to update the non-p2p ghosts, since these may
         have been assigned to zero-copy memory */
         if (!comm_peer2peer_enabled(1-dir, dim) || dslashParam.kernel_type == INTERIOR_KERNEL) {

--- a/lib/dslash_quda.cuh
+++ b/lib/dslash_quda.cuh
@@ -181,6 +181,14 @@
     GENERIC_DSLASH(staggeredDslash, Dagger, Axpy, gridDim, blockDim, shared, stream, param) \
       }
 
+// macro used for staggered dslash
+#define STAGGERED_DSLASH_TIFR(gridDim, blockDim, shared, stream, param)	\
+  if (!dagger) {                                                        \
+    GENERIC_DSLASH(staggeredDslashTIFR, , Axpy, gridDim, blockDim, shared, stream, param) \
+      } else {                                                          \
+    GENERIC_DSLASH(staggeredDslashTIFR, Dagger, Axpy, gridDim, blockDim, shared, stream, param) \
+      }
+
 #define IMPROVED_STAGGERED_DSLASH(gridDim, blockDim, shared, stream, param) \
   if (!dagger) {                                                        \
     GENERIC_STAGGERED_DSLASH(improvedStaggeredDslash, , Axpy, gridDim, blockDim, shared, stream, param) \

--- a/lib/dslash_staggered.cu
+++ b/lib/dslash_staggered.cu
@@ -49,6 +49,16 @@ namespace quda {
 #undef DD_DAG
 #define DD_DAG 1
 #include <staggered_dslash_def.h> // staggered Dslash dagger kernels
+#undef DD_DAG
+
+#define TIFR
+#define DD_DAG 0
+#include <staggered_dslash_def.h> // staggered Dslash kernels
+#undef DD_DAG
+#define DD_DAG 1
+#include <staggered_dslash_def.h> // staggered Dslash dagger kernels
+#undef DD_DAG
+#undef TIFR
 
 #undef DD_IMPROVED
 
@@ -91,6 +101,20 @@ namespace quda {
       dslashParam.a = a;
       dslashParam.a_f = a;
       dslashParam.fat_link_max = gauge.LinkMax();
+
+      if (gauge.StaggeredPhase() == QUDA_STAGGERED_PHASE_TIFR) {
+#ifdef MULTI_GPU
+        strcat(aux[INTERIOR_KERNEL],",TIFR");
+        strcat(aux[EXTERIOR_KERNEL_ALL],",TIFR");
+        strcat(aux[EXTERIOR_KERNEL_X],",TIFR");
+        strcat(aux[EXTERIOR_KERNEL_Y],",TIFR");
+        strcat(aux[EXTERIOR_KERNEL_Z],",TIFR");
+        strcat(aux[EXTERIOR_KERNEL_T],",TIFR");
+#else
+        strcat(aux[INTERIOR_KERNEL],",TIFR");
+#endif // MULTI_GPU
+        strcat(aux[KERNEL_POLICY],",TIFR");
+      }
     }
 
     virtual ~StaggeredDslashCuda() { unbindSpinorTex<sFloat>(in, out, x); }
@@ -103,7 +127,15 @@ namespace quda {
       TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
       setParam();
       dslashParam.swizzle = tp.aux.x;
-      STAGGERED_DSLASH(tp.grid, tp.block, tp.shared_bytes, stream, dslashParam);
+      if (gauge.StaggeredPhase() == QUDA_STAGGERED_PHASE_TIFR) {
+#ifdef BUILD_TIFR_INTERFACE
+        STAGGERED_DSLASH_TIFR(tp.grid, tp.block, tp.shared_bytes, stream, dslashParam);
+#else
+        errorQuda("TIFR interface has not been built");
+#endif
+      } else {
+        STAGGERED_DSLASH(tp.grid, tp.block, tp.shared_bytes, stream, dslashParam);
+      }
     }
 
     bool advanceBlockDim(TuneParam &param) const

--- a/lib/gauge_field.cpp
+++ b/lib/gauge_field.cpp
@@ -124,8 +124,10 @@ namespace quda {
     if (isNative()) ghost_bytes = ALIGNMENT_ADJUST(ghost_bytes);
   } // createGhostZone
 
-  void GaugeField::applyStaggeredPhase() {
+  void GaugeField::applyStaggeredPhase(QudaStaggeredPhase phase) {
     if (staggeredPhaseApplied) errorQuda("Staggered phases already applied");
+
+    if (phase != QUDA_STAGGERED_PHASE_INVALID) staggeredPhaseType = phase;
     applyGaugePhase(*this);
     if (ghostExchange==QUDA_GHOST_EXCHANGE_PAD) {
       if (typeid(*this)==typeid(cudaGaugeField)) {

--- a/lib/gauge_phase.cu
+++ b/lib/gauge_phase.cu
@@ -14,8 +14,9 @@ namespace quda {
 
 #ifdef GPU_GAUGE_TOOLS
 
-  template <typename Float, typename Order>
+  template <typename Float, int Nc, typename Order>
   struct GaugePhaseArg {
+    static constexpr int nColor = Nc;
     Order order;
     int X[4];
     int threads;
@@ -65,7 +66,7 @@ namespace quda {
       } else if (dim == 3) { // also apply boundary condition
 	phase = (t == arg.X[3]-1) ? arg.tBoundary : 1.0;
       }
-    } if (phaseType == QUDA_STAGGERED_PHASE_TIFR) {
+    } else if (phaseType == QUDA_STAGGERED_PHASE_TIFR) {
       if (dim==0) {
 	phase = (1.0 - 2.0 * ((3 + t + z + y) % 2) );		
       } else if (dim == 1) {
@@ -90,38 +91,34 @@ namespace quda {
     return phase;
   }
 
-  template <typename Float, int length, QudaStaggeredPhase phaseType, int dim, typename Arg>
+  template <typename Float, QudaStaggeredPhase phaseType, int dim, typename Arg>
   __device__ __host__ void gaugePhase(int indexCB, int parity, Arg &arg) {
-    typedef typename mapper<Float>::type RegType;
+    typedef typename mapper<Float>::type real;
 
     int x[4];
     getCoords(x, indexCB, arg.X, parity);
 
-    RegType phase = getPhase<dim,Float,phaseType>(x[0], x[1], x[2], x[3], arg);
-    RegType u[length];
-    arg.order.load(u, indexCB, dim, parity);
-    for (int i=0; i<length; i++) u[i] *= phase;
+    real phase = getPhase<dim,Float,phaseType>(x[0], x[1], x[2], x[3], arg);
+    Matrix<complex<real>,Arg::nColor> u = arg.order(dim, indexCB, parity);
+    u *= phase;
 
     // apply imaginary chemical potential if needed
-    if (dim==3 && arg.i_mu != 0.0) {
-      complex<RegType>* v = reinterpret_cast<complex<RegType>*>(u);
-      for (int i=0; i<length/2; i++) v[i] *= arg.i_mu_phase;
-    }
+    if (dim==3 && arg.i_mu != 0.0) u *= arg.i_mu_phase;
 
-    arg.order.save(u, indexCB, dim, parity);
+    arg.order(dim, indexCB, parity) = u;
   }
 
   /**
      Generic CPU staggered phase application
   */
-  template <typename Float, int length, QudaStaggeredPhase phaseType, typename Arg>
-  void gaugePhase(Arg &arg) {  
+  template <typename Float, QudaStaggeredPhase phaseType, typename Arg>
+  void gaugePhase(Arg &arg) {
     for (int parity=0; parity<2; parity++) {
       for (int indexCB=0; indexCB < arg.threads; indexCB++) {
-	gaugePhase<Float,length,phaseType,0>(indexCB, parity, arg);
-	gaugePhase<Float,length,phaseType,1>(indexCB, parity, arg);
-	gaugePhase<Float,length,phaseType,2>(indexCB, parity, arg);
-	gaugePhase<Float,length,phaseType,3>(indexCB, parity, arg);
+	gaugePhase<Float,phaseType,0>(indexCB, parity, arg);
+	gaugePhase<Float,phaseType,1>(indexCB, parity, arg);
+	gaugePhase<Float,phaseType,2>(indexCB, parity, arg);
+	gaugePhase<Float,phaseType,3>(indexCB, parity, arg);
       }
     }
   }
@@ -129,57 +126,40 @@ namespace quda {
   /**
      Generic GPU staggered phase application
   */
-  template <typename Float, int length, QudaStaggeredPhase phaseType, typename Arg>
-  __global__ void gaugePhaseKernel(Arg arg) {  
+  template <typename Float, QudaStaggeredPhase phaseType, typename Arg>
+  __global__ void gaugePhaseKernel(Arg arg) {
     int indexCB = blockIdx.x * blockDim.x + threadIdx.x; 	
     if (indexCB >= arg.threads) return;
-    int parity = blockIdx.y;
-
-    gaugePhase<Float,length,phaseType,0>(indexCB, parity, arg);
-    gaugePhase<Float,length,phaseType,1>(indexCB, parity, arg);
-    gaugePhase<Float,length,phaseType,2>(indexCB, parity, arg);
-    gaugePhase<Float,length,phaseType,3>(indexCB, parity, arg);
+    int parity = blockIdx.y * blockDim.y + threadIdx.y;
+    gaugePhase<Float,phaseType,0>(indexCB, parity, arg);
+    gaugePhase<Float,phaseType,1>(indexCB, parity, arg);
+    gaugePhase<Float,phaseType,2>(indexCB, parity, arg);
+    gaugePhase<Float,phaseType,3>(indexCB, parity, arg);
   }
 
-  template <typename Float, int length, QudaStaggeredPhase phaseType, typename Arg>
-  class GaugePhase : Tunable {
+  template <typename Float, QudaStaggeredPhase phaseType, typename Arg>
+  class GaugePhase : TunableVectorY {
     Arg &arg;
     const GaugeField &meta; // used for meta data only
-    QudaFieldLocation location;
 
   private:
-    unsigned int sharedBytesPerThread() const { return 0; }
-    unsigned int sharedBytesPerBlock(const TuneParam &param) const { return 0 ;}
-
     bool tuneGridDim() const { return false; } // Don't tune the grid dimensions.
     unsigned int minThreads() const { return arg.threads; }
 
   public:
-    GaugePhase(Arg &arg, const GaugeField &meta, QudaFieldLocation location) 
-      : arg(arg), meta(meta), location(location) { 
+    GaugePhase(Arg &arg, const GaugeField &meta)
+      : TunableVectorY(2), arg(arg), meta(meta) {
       writeAuxString("stride=%d,prec=%lu",arg.order.stride,sizeof(Float));
     }
     virtual ~GaugePhase() { ; }
   
-    bool advanceBlockDim(TuneParam &param) const {
-      bool rtn = Tunable::advanceBlockDim(param);
-      param.grid.y = 2;
-      return rtn;
-    }
-    
-    void initTuneParam(TuneParam &param) const {
-      Tunable::initTuneParam(param);
-      param.grid.y = 2;
-    }
-
     void apply(const cudaStream_t &stream) {
-      if (location == QUDA_CUDA_FIELD_LOCATION) {
+      if (meta.Location() == QUDA_CUDA_FIELD_LOCATION) {
 	TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
-	tp.grid.y = 2; // parity is the y grid dimension
-	gaugePhaseKernel<Float, length, phaseType, Arg> 
+	gaugePhaseKernel<Float, phaseType, Arg>
 	  <<<tp.grid, tp.block, tp.shared_bytes, stream>>>(arg);
       } else {
-	gaugePhase<Float, length, phaseType, Arg>(arg);
+	gaugePhase<Float, phaseType, Arg>(arg);
       }
     }
 
@@ -195,42 +175,40 @@ namespace quda {
   };
 
 
-  template <typename Float, int length, typename Order>
-  void gaugePhase(Order order, const GaugeField &u,  QudaFieldLocation location) {
+  template <typename Float, int Nc, typename Order>
+  void gaugePhase(Order order, const GaugeField &u) {
     if (u.StaggeredPhase() == QUDA_STAGGERED_PHASE_MILC) {
-      GaugePhaseArg<Float,Order> arg(order, u);
-      GaugePhase<Float,length,QUDA_STAGGERED_PHASE_MILC,
-		 GaugePhaseArg<Float,Order> > phase(arg, u, location);
+      GaugePhaseArg<Float,Nc,Order> arg(order, u);
+      GaugePhase<Float,QUDA_STAGGERED_PHASE_MILC,
+		 GaugePhaseArg<Float,Nc,Order> > phase(arg, u);
       phase.apply(0);
     } else if (u.StaggeredPhase() == QUDA_STAGGERED_PHASE_CPS) {
-      GaugePhaseArg<Float,Order> arg(order, u);
-      GaugePhase<Float,length,QUDA_STAGGERED_PHASE_CPS,
-		 GaugePhaseArg<Float,Order> > phase(arg, u, location);
+      GaugePhaseArg<Float,Nc,Order> arg(order, u);
+      GaugePhase<Float,QUDA_STAGGERED_PHASE_CPS,
+		 GaugePhaseArg<Float,Nc,Order> > phase(arg, u);
       phase.apply(0);
     } else if (u.StaggeredPhase() == QUDA_STAGGERED_PHASE_TIFR) {
-      GaugePhaseArg<Float,Order> arg(order, u);
-      GaugePhase<Float,length,QUDA_STAGGERED_PHASE_TIFR,
-		 GaugePhaseArg<Float,Order> > phase(arg, u, location);
+      GaugePhaseArg<Float,Nc,Order> arg(order, u);
+      GaugePhase<Float,QUDA_STAGGERED_PHASE_TIFR,
+		 GaugePhaseArg<Float,Nc,Order> > phase(arg, u);
       phase.apply(0);
     } else {
       errorQuda("Undefined phase type");
     }
 
-    if (location == QUDA_CUDA_FIELD_LOCATION) checkCudaError();
+    if (u.Location() == QUDA_CUDA_FIELD_LOCATION) checkCudaError();
   }
 
   /** This is the template driver for gaugePhase */
   template <typename Float>
   void gaugePhase(GaugeField &u) {
-    const int length = 18;
-
-    QudaFieldLocation location = 
-      (typeid(u)==typeid(cudaGaugeField)) ? QUDA_CUDA_FIELD_LOCATION : QUDA_CPU_FIELD_LOCATION;
+    if (u.Ncolor() != 3) errorQuda("Unsupported number of colors %d", u.Ncolor());
+    constexpr int Nc = 3;
 
     if (u.isNative()) {
       if (u.Reconstruct() == QUDA_RECONSTRUCT_NO) {
 	typedef typename gauge_mapper<Float,QUDA_RECONSTRUCT_NO>::type G;
-	gaugePhase<Float,length>(G(u), u, location);
+	gaugePhase<Float,Nc>(G(u), u);
       } else {
 	errorQuda("Unsupported reconstruction type");
       }
@@ -255,6 +233,11 @@ namespace quda {
 #else
     errorQuda("Gauge tools are not build");
 #endif
+
+    if (u.GhostExchange() == QUDA_GHOST_EXCHANGE_PAD) {
+      // ensure that ghosts are updated if needed
+      u.exchangeGhost();
+    }
 
   }
 

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -3098,9 +3098,11 @@ void invertQuda(void *hp_x, void *hp_b, QudaInvertParam *param)
   delete h_x;
   delete b;
 
-  if (!param->make_resident_solution) {
+  if (param->use_resident_solution && !param->make_resident_solution) {
     for (auto v: solutionResident) if (v) delete v;
     solutionResident.clear();
+  } else if (!param->make_resident_solution) {
+    delete x;
   }
 
   delete d;

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -2798,19 +2798,24 @@ void invertQuda(void *hp_x, void *hp_b, QudaInvertParam *param)
 
   // now check if we need to invalidate the solutionResident vectors
   bool invalidate = false;
-  for (auto v : solutionResident)
-    if (cudaParam.Precision() != v->Precision()) { invalidate = true; break; }
+  if (param->use_resident_solution == 1) {
+    for (auto v : solutionResident)
+      if (b->Precision() != v->Precision() || b->SiteSubset() != v->SiteSubset()) { invalidate = true; break; }
 
-  if (invalidate) {
-    for (auto v : solutionResident) if (v) delete v;
-    solutionResident.clear();
-  }
+    if (invalidate) {
+      for (auto v : solutionResident) if (v) delete v;
+      solutionResident.clear();
+    }
 
-  if (!solutionResident.size()) {
+    if (!solutionResident.size()) {
+      cudaParam.create = QUDA_NULL_FIELD_CREATE;
+      solutionResident.push_back(new cudaColorSpinorField(cudaParam)); // solution
+    }
+    x = solutionResident[0];
+  } else {
     cudaParam.create = QUDA_NULL_FIELD_CREATE;
-    solutionResident.push_back(new cudaColorSpinorField(cudaParam)); // solution
+    x = new cudaColorSpinorField(cudaParam);
   }
-  x = solutionResident[0];
 
   if (param->use_init_guess == QUDA_USE_INIT_GUESS_YES) { // download initial guess
     // initial guess only supported for single-pass solvers

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -42,11 +42,6 @@
 
 #include <cuda.h>
 
-#ifdef MULTI_GPU
-extern void exchange_cpu_sitelink_ex(int* X, int *R, void** sitelink, QudaGaugeFieldOrder cpu_order,
-    QudaPrecision gPrecision, int optflag, int geom);
-#endif // MULTI_GPU
-
 #include <ks_force_quda.h>
 
 #ifdef GPU_GAUGE_FORCE

--- a/lib/inv_multi_cg_quda.cpp
+++ b/lib/inv_multi_cg_quda.cpp
@@ -192,7 +192,7 @@ namespace quda {
 
     prec_tol[0] = mixed ? sloppy_tol : fine_tol;
     for (int i=1; i<num_offset; i++) {
-       prec_tol[i] = std::max(fine_tol,sqrt(param.tol_offset[i]*sloppy_tol));
+      prec_tol[i] = std::min(sloppy_tol,std::max(fine_tol,sqrt(param.tol_offset[i]*sloppy_tol)));
     }
 
     double zeta[QUDA_MAX_MULTI_SHIFT];

--- a/lib/lattice_field.cpp
+++ b/lib/lattice_field.cpp
@@ -22,8 +22,11 @@ namespace quda {
   cudaEvent_t LatticeField::ipcCopyEvent[2][2][QUDA_MAX_DIM];
   cudaEvent_t LatticeField::ipcRemoteCopyEvent[2][2][QUDA_MAX_DIM];
 
-  void *LatticeField::ghost_pinned_buffer_h[2] = {nullptr, nullptr};
-  void *LatticeField::ghost_pinned_buffer_hd[2] = {nullptr, nullptr};
+  void *LatticeField::ghost_pinned_send_buffer_h[2] = {nullptr, nullptr};
+  void *LatticeField::ghost_pinned_send_buffer_hd[2] = {nullptr, nullptr};
+
+  void *LatticeField::ghost_pinned_recv_buffer_h[2] = {nullptr, nullptr};
+  void *LatticeField::ghost_pinned_recv_buffer_hd[2] = {nullptr, nullptr};
 
   // gpu ghost receive buffer
   void *LatticeField::ghost_recv_buffer_d[2] = {nullptr, nullptr};
@@ -143,7 +146,8 @@ namespace quda {
 	  for (int b=0; b<2; b++) {
 	    device_pinned_free(ghost_recv_buffer_d[b]);
 	    device_pinned_free(ghost_send_buffer_d[b]);
-	    host_free(ghost_pinned_buffer_h[b]);
+	    host_free(ghost_pinned_send_buffer_h[b]);
+	    host_free(ghost_pinned_recv_buffer_h[b]);
 	  }
 	}
       }
@@ -156,11 +160,17 @@ namespace quda {
 	  // gpu send buffer (use pinned allocator to avoid this being redirected, e.g., by QDPJIT)
 	  ghost_send_buffer_d[b] = device_pinned_malloc(ghost_bytes);
 
-	  // pinned buffer used for sending and receiving
-	  ghost_pinned_buffer_h[b] = mapped_malloc(2*ghost_bytes);
+	  // pinned buffer used for sending
+	  ghost_pinned_send_buffer_h[b] = mapped_malloc(ghost_bytes);
 
-	  // set the matching device-mapper pointer
-	  cudaHostGetDevicePointer(&ghost_pinned_buffer_hd[b], ghost_pinned_buffer_h[b], 0);
+	  // set the matching device-mapped pointer
+	  cudaHostGetDevicePointer(&ghost_pinned_send_buffer_hd[b], ghost_pinned_send_buffer_h[b], 0);
+
+	  // pinned buffer used for receiving
+	  ghost_pinned_recv_buffer_h[b] = mapped_malloc(ghost_bytes);
+
+	  // set the matching device-mapped pointer
+	  cudaHostGetDevicePointer(&ghost_pinned_recv_buffer_hd[b], ghost_pinned_recv_buffer_h[b], 0);
 	}
 
 	initGhostFaceBuffer = true;
@@ -187,10 +197,16 @@ namespace quda {
       if (ghost_send_buffer_d[b]) device_pinned_free(ghost_send_buffer_d[b]);
       ghost_send_buffer_d[b] = nullptr;
 
-      // free pinned memory buffers
-      if (ghost_pinned_buffer_h[b]) host_free(ghost_pinned_buffer_h[b]);
-      ghost_pinned_buffer_h[b] = nullptr;
-      ghost_pinned_buffer_hd[b] = nullptr;
+      // free pinned send memory buffer
+      if (ghost_pinned_recv_buffer_h[b]) host_free(ghost_pinned_recv_buffer_h[b]);
+
+      // free pinned send memory buffer
+      if (ghost_pinned_send_buffer_h[b]) host_free(ghost_pinned_send_buffer_h[b]);
+
+      ghost_pinned_recv_buffer_h[b] = nullptr;
+      ghost_pinned_recv_buffer_hd[b] = nullptr;
+      ghost_pinned_send_buffer_h[b] = nullptr;
+      ghost_pinned_send_buffer_hd[b] = nullptr;
     }
     initGhostFaceBuffer = false;
   }
@@ -201,10 +217,10 @@ namespace quda {
 
     // initialize the ghost pinned buffers
     for (int b=0; b<2; b++) {
-      my_face_h[b] = ghost_pinned_buffer_h[b];
-      my_face_hd[b] = ghost_pinned_buffer_hd[b];
-      from_face_h[b] = static_cast<char*>(my_face_h[b]) + ghost_bytes;
-      from_face_hd[b] = static_cast<char*>(my_face_hd[b]) + ghost_bytes;
+      my_face_h[b] = ghost_pinned_send_buffer_h[b];
+      my_face_hd[b] = ghost_pinned_send_buffer_hd[b];
+      from_face_h[b] = ghost_pinned_recv_buffer_h[b];
+      from_face_hd[b] = ghost_pinned_recv_buffer_hd[b];
     }
 
     // initialize ghost send pointers

--- a/lib/reduce_core.cuh
+++ b/lib/reduce_core.cuh
@@ -351,7 +351,7 @@ template <typename ReduceType, typename Float, typename zFloat, int nSpin, QudaF
     value = genericReduce<ReduceType,Float,zFloat,nSpin,576,order,writeX,writeY,writeZ,writeW,writeV,R>(x, y, z, w, v, r);
   } else {
     ::quda::zero(value);
-    errorQuda("nColor = %d not implemeneted",x.Ncolor());
+    errorQuda("nColor = %d not implemented",x.Ncolor());
   }
   return value;
 }
@@ -370,7 +370,7 @@ template <typename ReduceType, typename Float, typename zFloat, QudaFieldOrder o
     value = genericReduce<ReduceType,Float,zFloat,1,order,writeX,writeY,writeZ,writeW,writeV,R>(x, y, z, w, v, r);
 #endif
   } else {
-    errorQuda("nSpin = %d not implemeneted",x.Nspin());
+    errorQuda("nSpin = %d not implemented",x.Nspin());
   }
   return value;
 }
@@ -385,7 +385,7 @@ doubleN genericReduce(ColorSpinorField &x, ColorSpinorField &y, ColorSpinorField
     value = genericReduce<ReduceType,Float,zFloat,QUDA_SPACE_SPIN_COLOR_FIELD_ORDER,writeX,writeY,writeZ,writeW,writeV,R>
       (x, y, z, w, v, r);
   } else {
-    warningQuda("CPU reductions not implemeneted for %d field order", x.FieldOrder());
+    warningQuda("CPU reductions not implemented for %d field order", x.FieldOrder());
   }
   return set(value);
 }

--- a/lib/staggered_dslash_def.h
+++ b/lib/staggered_dslash_def.h
@@ -17,7 +17,11 @@
 #if (DD_IMPROVED==1)
 #define DD_FNAME improvedStaggeredDslash
 #else
+#ifndef TIFR
 #define DD_FNAME staggeredDslash
+#else
+#define DD_FNAME staggeredDslashTIFR
+#endif
 #endif
 
 #if (DD_DAG==0) // no dagger

--- a/tests/face_gauge.cpp
+++ b/tests/face_gauge.cpp
@@ -18,8 +18,6 @@ extern cudaStream_t *stream;
  * used in fat link computation
  ***************************************************************/
 
-#if defined(MULTI_GPU) && (defined(GPU_FATLINK) || defined(GPU_GAUGE_FORCE)|| defined(GPU_FERMION_FORCE) || defined(GPU_HISQ_FORCE) || defined(CLOVER_FORCE)) || defined(GPU_CLOVER_DIRAC)
-
 enum {
   XUP = 0,
   YUP = 1,
@@ -1028,5 +1026,3 @@ void exchange_llfat_cleanup(void)
 }
 
 #undef gaugeSiteSize
-
-#endif


### PR DESCRIPTION
This pull request does the following:
* If the TIFR interface is built, compile staggered fermions with direct support for the TIFR phase convention to allow for native gauge reconstruct support 
* Include the `CUDA_VISIBLE_DEVICES` information in the `comm_topology_string` to ensure that unique policy tunings are found if the device order is changed
* In multi-shift solver, ensure that prec_tol is set to be no looser than the expected precision limit
* Logic clean up of resident solutions in `invertQuda`: only use a resident solution if explicitly requested
* Clean up of host-side ghost field allocation - use seperate arrays for the send and receive buffers
* Clean up of gauge_phase.cu
* Fix bug in staggered dslash when host-mapped ghosts are used in combination with peer-to-peer communication
* Fix link error when compiling staggered fermions without `GAUGE_TOOLS` enabled
* Fix bug in padded color spinor accessor when using full fields  