### PR TITLE
This adds a clang format file to QUDA

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,14 +1,17 @@
 ﻿---
 BasedOnStyle: Webkit
+IndentWidth: 2
 AllowShortBlocksOnASingleLine: true
 AllowShortCaseLabelsOnASingleLine : true
 AllowShortIfStatementsOnASingleLine: true
 AllowShortLoopsOnASingleLine: true
-BreakBeforeBraces: Attach
+BreakBeforeBraces: Linux
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 Cpp11BracedListStyle: true
 FixNamespaceComments: true
 NamespaceIndentation: All
 SortIncludes: false
 SpaceBeforeAssignmentOperators: true
+CommentPragmas:  '^\\.+'
+UseTab: Never
 ...

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,14 @@
+﻿---
+BasedOnStyle: Webkit
+AllowShortBlocksOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine : true
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+BreakBeforeBraces: Attach
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+Cpp11BracedListStyle: true
+FixNamespaceComments: true
+NamespaceIndentation: All
+SortIncludes: false
+SpaceBeforeAssignmentOperators: true
+...

--- a/.clang-format
+++ b/.clang-format
@@ -1,15 +1,19 @@
-﻿---
+---
 BasedOnStyle: Webkit
 IndentWidth: 2
+AlignTrailingComments: true
 AllowShortBlocksOnASingleLine: true
 AllowShortCaseLabelsOnASingleLine : true
 AllowShortIfStatementsOnASingleLine: true
 AllowShortLoopsOnASingleLine: true
 BreakBeforeBraces: Linux
+BreakConstructorInitializers: AfterColon
+ColumnLimit: 160
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 Cpp11BracedListStyle: true
 FixNamespaceComments: true
 NamespaceIndentation: All
+PointerAlignment: Right
 SortIncludes: false
 SpaceBeforeAssignmentOperators: true
 CommentPragmas:  '^\\.+'


### PR DESCRIPTION
Style is based on webkit

Should result in minimal changes to files, but some points need discussion.

C.f.
https://clang.llvm.org/docs/ClangFormatStyleOptions.html

Open points:
- [ ] ColumnLimit _ Currently not set to avoid a lot of rewrapping of code_
- [ ] Spacing around operators _I guess it is fine the way it is but still ..._
- [ ] BreakBeforeBraces  (Attach or Linux)  _We seem to be a bit inconsistent here_
- [ ] ConstructorInitializerAllOnOneLineOrOnePerLine  _WIthout ColumLimit the OneLine version puts everything on a single line_
- [ ] Reflow Comments _This leads to a lot of changes, but if we enforce a column limit_

There are a couple of other options not currently other than in the webkit default.
The webkit default settings (i.e. the values used for those properties not specified in the file) can be obtained using `clang-format -style=llvm -dump-config` and the full version proposed here with
`clang-format -dump-config` somewhere in the quad directory.

I suggest just reformatting a few files and run a diff to see what has changed.

Later on we can probably use the __Script for patch reformatting__ suggested here: https://clang.llvm.org/docs/ClangFormat.html.



