### PR TITLE
initCommsGridQuda: returns early if comms_initialized

### DIFF
--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -365,6 +365,8 @@ static bool comms_initialized = false;
 
 void initCommsGridQuda(int nDim, const int *dims, QudaCommsMap func, void *fdata)
 {
+  if (comms_initialized) return;
+
   if (nDim != 4) {
     errorQuda("Number of communication grid dimensions must be 4");
   }


### PR DESCRIPTION
Repeated calls of `initCommsGridQuda`, such as is done in
`milc_interface.cpp`, would overwrite the comms map that has been
setup from previous calls, leading to an unintended comms map.

This commit makes the exposed interface `initCommsGridQuda` return
early if `comms_initialized`.  As it sets `comms_initialized` upon
successful return, we create the restriction that only the first
call of `initCommsGridQuda` has an effect.