### PR TITLE
Hotfix/milc plegma

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,7 @@
 ---
 BasedOnStyle: Webkit
 IndentWidth: 2
+AlignAfterOpenBracket: Align
 AlignTrailingComments: true
 AllowShortBlocksOnASingleLine: true
 AllowShortCaseLabelsOnASingleLine : true
@@ -11,6 +12,8 @@ BreakBeforeTernaryOperators: false
 BreakConstructorInitializers: AfterColon
 ColumnLimit: 120
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 2
 Cpp11BracedListStyle: true
 FixNamespaceComments: true
 NamespaceIndentation: All

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ CMakeCache.txt
 CMakeFiles
 externals
 !include/externals
+include/quda_define.h
+include/jitify_options.hpp
 .tags*
 autom4te.cache/*
 .vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -442,6 +442,7 @@ if(QUDA_JITIFY)
   LIST(APPEND QUDA_LIBS ${CUDA_nvrtc_LIBRARY})
   LIST(APPEND QUDA_LIBS ${LIBDL_LIBRARIES})
   configure_file(include/jitify_options.hpp.in include/jitify_options.hpp)
+  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/include/jitify_options.hpp" DESTINATION include/)
 endif()
 
 if(QUDA_USE_EIGEN)
@@ -668,6 +669,7 @@ mark_as_advanced(CMAKE_C_FLAGS_DEVICEDEBUG)
 mark_as_advanced(CMAKE_F_FLAGS)
 
 configure_file(include/quda_define.h.in include/quda_define.h @ONLY)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/include/quda_define.h" DESTINATION include/)
 
 set(BUILDNAME ${HASH})
 include( CTest )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -415,9 +415,6 @@ if(QUDA_ARPACK)
 endif(QUDA_ARPACK)
 
 
-# MAX_MULTI_BLAS_N
-add_definitions(-DMAX_MULTI_BLAS_N=${QUDA_MAX_MULTI_BLAS_N})
-
 # set which precisions to enable
 add_definitions(-DQUDA_PRECISION=${QUDA_PRECISION})
 
@@ -506,10 +503,6 @@ if(QUDA_GAUGE_ALG)
   LIST(APPEND QUDA_LIBS ${CUDA_cufft_LIBRARY} ${CUDA_curand_LIBRARY})
 endif(QUDA_GAUGE_ALG)
 
-if(QUDA_DYNAMIC_CLOVER)
-  add_definitions(-DDYNAMIC_CLOVER)
-endif(QUDA_DYNAMIC_CLOVER)
-
 if(QUDA_MPI_NVTX)
   LIST(APPEND COMM_OBJS nvtx_pmpi.c)
   set(QUDA_NVTX ON)
@@ -527,10 +520,6 @@ endif(QUDA_NVTX)
 if(QUDA_LEGACY_DSLASH)
   add_definitions(-DUSE_LEGACY_DSLASH)
 endif(QUDA_LEGACY_DSLASH)
-
-if(QUDA_TEX)
-  add_definitions(-DUSE_TEXTURE_OBJECTS)
-endif(QUDA_TEX)
 
 if(QUDA_INTERFACE_QDP)
   add_definitions(-DBUILD_QDP_INTERFACE)
@@ -620,9 +609,9 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(SYSTEM ${CUDA_INCLUDE_DIRS})
 include_directories(include)
 include_directories(lib)
-if(QUDA_JITIFY)
+#if(QUDA_JITIFY)
   include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
-endif()
+#endif()
 
 # QUDA_HASH for tunecache
 if(NOT GITVERSION)
@@ -653,7 +642,6 @@ endif()
 set(GITVERSION ${GITVERSION}-${QUDA_GPU_ARCH})
 STRING(REGEX REPLACE sm_ "" COMP_CAP ${QUDA_GPU_ARCH})
 SET(COMP_CAP "${COMP_CAP}0")
-add_definitions(-D__COMPUTE_CAPABILITY__=${COMP_CAP})
 
 # make the compiler flags an advanced option for all user defined build types (cmake defined build types are advanced by default )
 mark_as_advanced(CMAKE_CUDA_FLAGS_DEVEL)
@@ -678,6 +666,8 @@ mark_as_advanced(CMAKE_C_FLAGS_HOSTDEBUG)
 mark_as_advanced(CMAKE_C_FLAGS_DEVICEDEBUG)
 
 mark_as_advanced(CMAKE_F_FLAGS)
+
+configure_file(include/quda_define.h.in include/quda_define.h @ONLY)
 
 set(BUILDNAME ${HASH})
 include( CTest )

--- a/include/gauge_field_order.h
+++ b/include/gauge_field_order.h
@@ -2386,17 +2386,26 @@ namespace quda {
     const int geometry;
     const size_t offset;
     const size_t size;
-  MILCSiteOrder(const GaugeField &u, Float *gauge_=0, Float **ghost_=0) :
-    LegacyOrder<Float,length>(u, ghost_), gauge(gauge_ ? gauge_ : (Float*)u.Gauge_p()),
-      volumeCB(u.VolumeCB()), geometry(u.Geometry()),
-      offset(u.SiteOffset()), size(u.SiteSize())
-      {
-        if ( (uintptr_t)((char*)gauge + offset) % 16 != 0 ) { errorQuda("MILC structure has misaligned offset"); }
-      }
+    MILCSiteOrder(const GaugeField &u, Float *gauge_ = 0, Float **ghost_ = 0) :
+      LegacyOrder<Float, length>(u, ghost_),
+      gauge(gauge_ ? gauge_ : (Float *)u.Gauge_p()),
+      volumeCB(u.VolumeCB()),
+      geometry(u.Geometry()),
+      offset(u.SiteOffset()),
+      size(u.SiteSize())
+    {
+      if ((uintptr_t)((char *)gauge + offset) % 16 != 0) { errorQuda("MILC structure has misaligned offset"); }
+    }
 
-  MILCSiteOrder(const MILCSiteOrder &order) : LegacyOrder<Float,length>(order),
-      gauge(order.gauge), volumeCB(order.volumeCB), geometry(order.geometry),
-      offset(order.offset), size(order.size) { }
+    MILCSiteOrder(const MILCSiteOrder &order) :
+      LegacyOrder<Float, length>(order),
+      gauge(order.gauge),
+      volumeCB(order.volumeCB),
+      geometry(order.geometry),
+      offset(order.offset),
+      size(order.size)
+    {
+    }
 
     virtual ~MILCSiteOrder() { ; }
 

--- a/include/gauge_field_order.h
+++ b/include/gauge_field_order.h
@@ -2389,11 +2389,15 @@ namespace quda {
   MILCSiteOrder(const GaugeField &u, Float *gauge_=0, Float **ghost_=0) :
     LegacyOrder<Float,length>(u, ghost_), gauge(gauge_ ? gauge_ : (Float*)u.Gauge_p()),
       volumeCB(u.VolumeCB()), geometry(u.Geometry()),
-      offset(u.SiteOffset()), size(u.SiteSize()) { ; }
+      offset(u.SiteOffset()), size(u.SiteSize())
+      {
+        if ( (uintptr_t)((char*)gauge + offset) % 16 != 0 ) { errorQuda("MILC structure has misaligned offset"); }
+      }
+
   MILCSiteOrder(const MILCSiteOrder &order) : LegacyOrder<Float,length>(order),
       gauge(order.gauge), volumeCB(order.volumeCB), geometry(order.geometry),
-      offset(order.offset), size(order.size)
-      { ; }
+      offset(order.offset), size(order.size) { }
+
     virtual ~MILCSiteOrder() { ; }
 
     __device__ __host__ inline void load(RegType v[length], int x, int dir, int parity, Float inphase = 1.0) const

--- a/include/jitify_helper.cuh
+++ b/include/jitify_helper.cuh
@@ -49,15 +49,6 @@ namespace quda {
       kernel_cache = new jitify::JitCache;
 
       std::vector<std::string> options = {"-std=c++11", "-ftz=true", "-prec-div=false", "-prec-sqrt=false"};
-      options.push_back( std::string("-D__COMPUTE_CAPABILITY__=") + std::to_string(__COMPUTE_CAPABILITY__) );
-      options.push_back(std::string("-DMAX_MULTI_BLAS_N=") + std::to_string(MAX_MULTI_BLAS_N));
-
-#ifdef USE_TEXTURE_OBJECTS
-      options.push_back(std::string("-DUSE_TEXTURE_OBJECTS"));
-#endif
-#ifdef DYNAMIC_CLOVER
-      options.push_back(std::string("-DDYNAMIC_CLOVER"));
-#endif
 
 #ifdef DEVICE_DEBUG
       options.push_back(std::string("-G"));

--- a/include/kernels/block_orthogonalize.cuh
+++ b/include/kernels/block_orthogonalize.cuh
@@ -45,7 +45,7 @@ namespace quda {
     {
       const Vector Btmp[nVec]{*B...};
       if (sizeof(Btmp) > MAX_MATRIX_SIZE) errorQuda("B array size (%lu) is larger than maximum allowed (%d)\n", sizeof(Btmp), MAX_MATRIX_SIZE);
-      memcpy(B_array_h, (void*)Btmp, sizeof(Btmp));
+      memcpy(B_array_h, (void *)Btmp, sizeof(Btmp));
       int geoBlockSize = 1;
       for (int d = 0; d < V.Ndim(); d++) geoBlockSize *= geo_bs[d];
       geoBlockSizeCB = geoBlockSize/2;

--- a/include/kernels/block_orthogonalize.cuh
+++ b/include/kernels/block_orthogonalize.cuh
@@ -45,7 +45,7 @@ namespace quda {
     {
       const Vector Btmp[nVec]{*B...};
       if (sizeof(Btmp) > MAX_MATRIX_SIZE) errorQuda("B array size (%lu) is larger than maximum allowed (%d)\n", sizeof(Btmp), MAX_MATRIX_SIZE);
-      memcpy(B_array_h, Btmp, sizeof(Btmp));
+      memcpy(B_array_h, (void*)Btmp, sizeof(Btmp));
       int geoBlockSize = 1;
       for (int d = 0; d < V.Ndim(); d++) geoBlockSize *= geo_bs[d];
       geoBlockSizeCB = geoBlockSize/2;

--- a/include/mpi_comm_handle.h
+++ b/include/mpi_comm_handle.h
@@ -7,8 +7,8 @@ extern MPI_Comm MPI_COMM_HANDLE;
 #endif
 
 #ifdef QMP_COMMS
-extern "C"{
-QMP_status_t QMP_get_mpi_comm(QMP_comm_t comm, void** mpicomm);
+extern "C" {
+QMP_status_t QMP_get_mpi_comm(QMP_comm_t comm, void **mpicomm);
 }
 #endif
 

--- a/include/quda.h
+++ b/include/quda.h
@@ -12,6 +12,7 @@
 
 #include <enum_quda.h>
 #include <stdio.h> /* for FILE */
+#include <quda_define.h>
 #include <quda_constants.h>
 
 #ifndef __CUDACC_RTC__

--- a/include/quda_define.h.in
+++ b/include/quda_define.h.in
@@ -1,0 +1,41 @@
+/**
+   @file quda_define.h
+   @brief Macros defined set by the cmake build system.  This file
+   should not be edited manually.
+ */
+
+/**
+ * @def   __COMPUTE_CAPABILITY__
+ * @brief This macro sets the target GPU architecture.  Unlike
+ * __CUDA_ARCH__, this is defined on host and device.
+ */
+#define __COMPUTE_CAPABILITY__ @COMP_CAP@
+
+/**
+ * @def   MAX_MULTI_BLAS_N
+ * @brief This macro sets the limit of blas fusion in the multi-blas
+ * and multi-reduce kernels
+ */
+#define MAX_MULTI_BLAS_N @QUDA_MAX_MULTI_BLAS_N@
+
+#cmakedefine QUDA_TEX
+#ifdef QUDA_TEX
+/**
+ * @def   USE_TEXTURE_OBJECTS
+ * @brief This macro sets whether we are compiling QUDA with texture
+ * support enabled or not
+ */
+#define USE_TEXTURE_OBJECTS
+#undef QUDA_TEX
+#endif
+
+#cmakedefine QUDA_DYNAMIC_CLOVER
+#ifdef QUDA_DYNAMIC_CLOVER
+/**
+ * @def   DYNAMIC_CLOVER
+ * @brief This macro sets whether we are compiling QUDA with dynamic
+ * clover inversion support enabled or not
+ */
+#define DYNAMIC_CLOVER
+#undef QUDA_DYNAMIC_CLOVER
+#endif

--- a/lib/block_orthogonalize.cu
+++ b/lib/block_orthogonalize.cu
@@ -302,9 +302,17 @@ namespace quda {
     } else if (V.Precision() == QUDA_SINGLE_PRECISION && B[0]->Precision() == QUDA_SINGLE_PRECISION) {
       BlockOrthogonalize<float,float>(V, B, fine_to_coarse, coarse_to_fine, geo_bs, spin_bs);
     } else if (V.Precision() == QUDA_HALF_PRECISION && B[0]->Precision() == QUDA_SINGLE_PRECISION) {
+#if QUDA_PRECISION & 2
       BlockOrthogonalize<short,float>(V, B, fine_to_coarse, coarse_to_fine, geo_bs, spin_bs);
+#else
+      errorQuda("QUDA_PRECISION=%d does not enable half precision", QUDA_PRECISION);
+#endif
     } else if (V.Precision() == QUDA_HALF_PRECISION && B[0]->Precision() == QUDA_HALF_PRECISION) {
+#if QUDA_PRECISION & 2
       BlockOrthogonalize<short,short>(V, B, fine_to_coarse, coarse_to_fine, geo_bs, spin_bs);
+#else
+      errorQuda("QUDA_PRECISION=%d does not enable half precision", QUDA_PRECISION);
+#endif
     } else {
       errorQuda("Unsupported precision combination V=%d B=%d\n", V.Precision(), B[0]->Precision());
     }

--- a/lib/coarse_op.cuh
+++ b/lib/coarse_op.cuh
@@ -624,7 +624,10 @@ namespace quda {
         break;
       case COMPUTE_UV:
       case COMPUTE_TMAV:
-      case COMPUTE_AV: resizeVector(2, coarseColor); break;
+        resizeVector(2, coarseColor); break;
+      case COMPUTE_AV:
+      case COMPUTE_TMCAV:
+        resizeVector(4, coarseColor); break; // y dimension is chirality and parity
       default:
 	resizeVector(2,1);
 	break;
@@ -748,7 +751,7 @@ namespace quda {
 #ifdef DYNAMIC_CLOVER
       if (type == COMPUTE_AV || type == COMPUTE_CLOVER_INV_MAX || // ensure separate tuning for dynamic
           type == COMPUTE_TMCAV || type == COMPUTE_TWISTED_CLOVER_INV_MAX)
-        strcat(Aux, "Dynamic");
+        strcat(Aux, ",Dynamic");
 #endif
 
       if (type == COMPUTE_UV || type == COMPUTE_VUV) {

--- a/lib/coarse_op.cuh
+++ b/lib/coarse_op.cuh
@@ -623,14 +623,10 @@ namespace quda {
 	resizeVector(2*coarseColor,coarseColor);
         break;
       case COMPUTE_UV:
-      case COMPUTE_TMAV:
-        resizeVector(2, coarseColor); break;
+      case COMPUTE_TMAV: resizeVector(2, coarseColor); break;
       case COMPUTE_AV:
-      case COMPUTE_TMCAV:
-        resizeVector(4, coarseColor); break; // y dimension is chirality and parity
-      default:
-	resizeVector(2,1);
-	break;
+      case COMPUTE_TMCAV: resizeVector(4, coarseColor); break; // y dimension is chirality and parity
+      default: resizeVector(2, 1); break;
       }
 
       resizeStep(1,1);
@@ -755,10 +751,10 @@ namespace quda {
 #endif
 
       if (type == COMPUTE_UV || type == COMPUTE_VUV) {
-	if      (dim == 0) strcat(Aux,",dim=0");
-	else if (dim == 1) strcat(Aux,",dim=1");
-	else if (dim == 2) strcat(Aux,",dim=2");
-	else if (dim == 3) strcat(Aux,",dim=3");
+        if      (dim == 0) strcat(Aux, ",dim=0");
+        else if (dim == 1) strcat(Aux, ",dim=1");
+        else if (dim == 2) strcat(Aux, ",dim=2");
+        else if (dim == 3) strcat(Aux, ",dim=3");
 
 	if (dir == QUDA_BACKWARDS) strcat(Aux,",dir=back");
 	else if (dir == QUDA_FORWARDS) strcat(Aux,",dir=fwd");

--- a/lib/coarse_op.cuh
+++ b/lib/coarse_op.cuh
@@ -96,13 +96,17 @@ namespace quda {
 	bytes_ = arg.UV.Bytes() + arg.V.Bytes() + 2*arg.U.Bytes()*coarseColor;
 	break;
       case COMPUTE_AV:
-	bytes_ = arg.AV.Bytes() + arg.V.Bytes() + 2*arg.C.Bytes();
+	bytes_ = arg.AV.Bytes() + arg.V.Bytes() + 2*arg.C.Bytes()*coarseColor;
 	break;
       case COMPUTE_TMAV:
 	bytes_ = arg.AV.Bytes() + arg.V.Bytes();
 	break;
       case COMPUTE_TMCAV:
-	bytes_ = arg.AV.Bytes() + arg.V.Bytes() + arg.UV.Bytes() + 4*arg.C.Bytes(); // Two clover terms and more temporary storage
+#ifdef DYNAMIC_CLOVER
+	bytes_ = arg.AV.Bytes() + arg.V.Bytes() + 2*arg.C.Bytes()*coarseColor; // A single clover field
+#else
+	bytes_ = arg.AV.Bytes() + arg.V.Bytes() + 4*arg.C.Bytes()*coarseColor; // Both clover and its inverse
+#endif
 	break;
       case COMPUTE_CLOVER_INV_MAX:
       case COMPUTE_TWISTED_CLOVER_INV_MAX:

--- a/lib/color_spinor_pack.cu
+++ b/lib/color_spinor_pack.cu
@@ -386,15 +386,27 @@ namespace quda {
       if (a.GhostPrecision() == QUDA_SINGLE_PRECISION) {
         genericPackGhost<float,float>(ghost, a, parity, nFace, dagger, destination);
       } else if (a.GhostPrecision() == QUDA_HALF_PRECISION) {
+#if QUDA_PRECISION & 2
         genericPackGhost<float,short>(ghost, a, parity, nFace, dagger, destination);
+#else
+        errorQuda("QUDA_PRECISION=%d does not enable half precision", QUDA_PRECISION);
+#endif
       } else if (a.GhostPrecision() == QUDA_QUARTER_PRECISION) {
+#if QUDA_PRECISION & 1
         genericPackGhost<float,char>(ghost, a, parity, nFace, dagger, destination);
+#else
+        errorQuda("QUDA_PRECISION=%d does not enable quarter precision", QUDA_PRECISION);
+#endif
       } else {
         errorQuda("precision = %d and ghost precision = %d not supported", a.Precision(), a.GhostPrecision());
       }
     } else if (a.Precision() == QUDA_HALF_PRECISION) {
       if (a.GhostPrecision() == QUDA_HALF_PRECISION) {
+#if QUDA_PRECISION & 2
         genericPackGhost<short,short>(ghost, a, parity, nFace, dagger, destination);
+#else
+        errorQuda("QUDA_PRECISION=%d does not enable half precision", QUDA_PRECISION);
+#endif
       } else {
         errorQuda("precision = %d and ghost precision = %d not supported", a.Precision(), a.GhostPrecision());
       }

--- a/lib/comm_mpi.cpp
+++ b/lib/comm_mpi.cpp
@@ -50,7 +50,7 @@ static char topology_string[128];
 void comm_gather_hostname(char *hostname_recv_buf) {
   // determine which GPU this rank will use
   char *hostname = comm_hostname();
-  MPI_CHECK( MPI_Allgather(hostname, 128, MPI_CHAR, hostname_recv_buf, 128, MPI_CHAR, MPI_COMM_HANDLE) );
+  MPI_CHECK(MPI_Allgather(hostname, 128, MPI_CHAR, hostname_recv_buf, 128, MPI_CHAR, MPI_COMM_HANDLE));
 }
 
 void comm_gather_gpuid(int *gpuid_recv_buf) {
@@ -65,9 +65,9 @@ void comm_init(int ndim, const int *dims, QudaCommsMap rank_from_coords, void *m
   if (!initialized) {
     errorQuda("MPI has not been initialized");
   }
-  
-  MPI_CHECK( MPI_Comm_rank(MPI_COMM_HANDLE, &rank) );
-  MPI_CHECK( MPI_Comm_size(MPI_COMM_HANDLE, &size) );
+
+  MPI_CHECK(MPI_Comm_rank(MPI_COMM_HANDLE, &rank));
+  MPI_CHECK(MPI_Comm_size(MPI_COMM_HANDLE, &size));
 
   int grid_size = 1;
   for (int i = 0; i < ndim; i++) {
@@ -190,7 +190,7 @@ MsgHandle *comm_declare_send_displaced(void *buffer, const int displacement[], s
   tag = tag >= 0 ? tag : 2*pow(4*max_displacement,ndim) + tag;
 
   MsgHandle *mh = (MsgHandle *)safe_malloc(sizeof(MsgHandle));
-  MPI_CHECK( MPI_Send_init(buffer, nbytes, MPI_BYTE, rank, tag, MPI_COMM_HANDLE, &(mh->request)) );
+  MPI_CHECK(MPI_Send_init(buffer, nbytes, MPI_BYTE, rank, tag, MPI_COMM_HANDLE, &(mh->request)));
   mh->custom = false;
 
   return mh;
@@ -213,7 +213,7 @@ MsgHandle *comm_declare_receive_displaced(void *buffer, const int displacement[]
   tag = tag >= 0 ? tag : 2*pow(4*max_displacement,ndim) + tag;
 
   MsgHandle *mh = (MsgHandle *)safe_malloc(sizeof(MsgHandle));
-  MPI_CHECK( MPI_Recv_init(buffer, nbytes, MPI_BYTE, rank, tag, MPI_COMM_HANDLE, &(mh->request)) );
+  MPI_CHECK(MPI_Recv_init(buffer, nbytes, MPI_BYTE, rank, tag, MPI_COMM_HANDLE, &(mh->request)));
   mh->custom = false;
 
   return mh;
@@ -243,7 +243,7 @@ MsgHandle *comm_declare_strided_send_displaced(void *buffer, const int displacem
   MPI_CHECK( MPI_Type_commit(&(mh->datatype)) );
   mh->custom = true;
 
-  MPI_CHECK( MPI_Send_init(buffer, 1, mh->datatype, rank, tag, MPI_COMM_HANDLE, &(mh->request)) );
+  MPI_CHECK(MPI_Send_init(buffer, 1, mh->datatype, rank, tag, MPI_COMM_HANDLE, &(mh->request)));
 
   return mh;
 }
@@ -272,7 +272,7 @@ MsgHandle *comm_declare_strided_receive_displaced(void *buffer, const int displa
   MPI_CHECK( MPI_Type_commit(&(mh->datatype)) );
   mh->custom = true;
 
-  MPI_CHECK( MPI_Recv_init(buffer, 1, mh->datatype, rank, tag, MPI_COMM_HANDLE, &(mh->request)) );
+  MPI_CHECK(MPI_Recv_init(buffer, 1, mh->datatype, rank, tag, MPI_COMM_HANDLE, &(mh->request)));
 
   return mh;
 }
@@ -310,7 +310,7 @@ int comm_query(MsgHandle *mh)
 void comm_allreduce(double* data)
 {
   double recvbuf;
-  MPI_CHECK( MPI_Allreduce(data, &recvbuf, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_HANDLE) );
+  MPI_CHECK(MPI_Allreduce(data, &recvbuf, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_HANDLE));
   *data = recvbuf;
 }
 
@@ -318,21 +318,21 @@ void comm_allreduce(double* data)
 void comm_allreduce_max(double* data)
 {
   double recvbuf;
-  MPI_CHECK( MPI_Allreduce(data, &recvbuf, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_HANDLE) );
+  MPI_CHECK(MPI_Allreduce(data, &recvbuf, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_HANDLE));
   *data = recvbuf;
 }
 
 void comm_allreduce_min(double* data)
 {
   double recvbuf;
-  MPI_CHECK( MPI_Allreduce(data, &recvbuf, 1, MPI_DOUBLE, MPI_MIN, MPI_COMM_HANDLE) );
+  MPI_CHECK(MPI_Allreduce(data, &recvbuf, 1, MPI_DOUBLE, MPI_MIN, MPI_COMM_HANDLE));
   *data = recvbuf;
 }
 
 void comm_allreduce_array(double* data, size_t size)
 {
   double *recvbuf = new double[size];
-  MPI_CHECK( MPI_Allreduce(data, recvbuf, size, MPI_DOUBLE, MPI_SUM, MPI_COMM_HANDLE) );
+  MPI_CHECK(MPI_Allreduce(data, recvbuf, size, MPI_DOUBLE, MPI_SUM, MPI_COMM_HANDLE));
   memcpy(data, recvbuf, size*sizeof(double));
   delete []recvbuf;
 }
@@ -340,7 +340,7 @@ void comm_allreduce_array(double* data, size_t size)
 void comm_allreduce_max_array(double* data, size_t size)
 {
   double *recvbuf = new double[size];
-  MPI_CHECK( MPI_Allreduce(data, recvbuf, size, MPI_DOUBLE, MPI_MAX, MPI_COMM_HANDLE) );
+  MPI_CHECK(MPI_Allreduce(data, recvbuf, size, MPI_DOUBLE, MPI_MAX, MPI_COMM_HANDLE));
   memcpy(data, recvbuf, size*sizeof(double));
   delete []recvbuf;
 }
@@ -348,7 +348,7 @@ void comm_allreduce_max_array(double* data, size_t size)
 void comm_allreduce_int(int* data)
 {
   int recvbuf;
-  MPI_CHECK( MPI_Allreduce(data, &recvbuf, 1, MPI_INT, MPI_SUM, MPI_COMM_HANDLE) );
+  MPI_CHECK(MPI_Allreduce(data, &recvbuf, 1, MPI_INT, MPI_SUM, MPI_COMM_HANDLE));
   *data = recvbuf;
 }
 
@@ -356,7 +356,7 @@ void comm_allreduce_xor(uint64_t *data)
 {
   if (sizeof(uint64_t) != sizeof(unsigned long)) errorQuda("unsigned long is not 64-bit");
   uint64_t recvbuf;
-  MPI_CHECK( MPI_Allreduce(data, &recvbuf, 1, MPI_UNSIGNED_LONG, MPI_BXOR, MPI_COMM_HANDLE) );
+  MPI_CHECK(MPI_Allreduce(data, &recvbuf, 1, MPI_UNSIGNED_LONG, MPI_BXOR, MPI_COMM_HANDLE));
   *data = recvbuf;
 }
 
@@ -364,28 +364,19 @@ void comm_allreduce_xor(uint64_t *data)
 /**  broadcast from rank 0 */
 void comm_broadcast(void *data, size_t nbytes)
 {
-  MPI_CHECK( MPI_Bcast(data, (int)nbytes, MPI_BYTE, 0, MPI_COMM_HANDLE) );
+  MPI_CHECK(MPI_Bcast(data, (int)nbytes, MPI_BYTE, 0, MPI_COMM_HANDLE));
 }
 
-
-void comm_barrier(void)
-{
-  MPI_CHECK( MPI_Barrier(MPI_COMM_HANDLE) );
-}
-
+void comm_barrier(void) { MPI_CHECK(MPI_Barrier(MPI_COMM_HANDLE)); }
 
 void comm_abort(int status)
 {
 #ifdef HOST_DEBUG
   raise(SIGINT);
 #endif
-  MPI_Abort(MPI_COMM_HANDLE, status) ;
+  MPI_Abort(MPI_COMM_HANDLE, status);
 }
 
-const char* comm_dim_partitioned_string() {
-  return partition_string;
-}
+const char *comm_dim_partitioned_string() { return partition_string; }
 
-const char* comm_dim_topology_string() {
-  return topology_string;
-}
+const char *comm_dim_topology_string() { return topology_string; }

--- a/lib/comm_qmp.cpp
+++ b/lib/comm_qmp.cpp
@@ -306,7 +306,7 @@ void comm_allreduce_array(double* data, size_t size)
 
 void comm_allreduce_max_array(double* data, size_t size)
 {
-  for (int i=0; i<size; i++) {
+  for (size_t i=0; i<size; i++) {
     QMP_CHECK( QMP_max_double(data+i) );
   }
 }

--- a/lib/comm_qmp.cpp
+++ b/lib/comm_qmp.cpp
@@ -306,9 +306,7 @@ void comm_allreduce_array(double* data, size_t size)
 
 void comm_allreduce_max_array(double* data, size_t size)
 {
-  for (size_t i=0; i<size; i++) {
-    QMP_CHECK( QMP_max_double(data+i) );
-  }
+  for (size_t i = 0; i < size; i++) { QMP_CHECK(QMP_max_double(data + i)); }
 }
 
 void comm_allreduce_int(int* data)

--- a/lib/dirac_twisted_clover.cpp
+++ b/lib/dirac_twisted_clover.cpp
@@ -7,10 +7,10 @@
 
 namespace quda {
 
-  DiracTwistedClover::DiracTwistedClover(const DiracParam &param, const int nDim) 
+  DiracTwistedClover::DiracTwistedClover(const DiracParam &param, const int nDim)
     : DiracWilson(param, nDim), mu(param.mu), epsilon(param.epsilon), clover(*(param.clover)) { }
 
-  DiracTwistedClover::DiracTwistedClover(const DiracTwistedClover &dirac) 
+  DiracTwistedClover::DiracTwistedClover(const DiracTwistedClover &dirac)
     : DiracWilson(dirac), mu(dirac.mu), epsilon(dirac.epsilon), clover(dirac.clover) { }
 
   DiracTwistedClover::~DiracTwistedClover() { }
@@ -86,7 +86,7 @@ namespace quda {
   void DiracTwistedClover::M(ColorSpinorField &out, const ColorSpinorField &in) const
   {
     checkFullSpinor(out, in);
-    if (in.TwistFlavor() != out.TwistFlavor()) 
+    if (in.TwistFlavor() != out.TwistFlavor())
       errorQuda("Twist flavors %d %d don't match", in.TwistFlavor(), out.TwistFlavor());
 
     if (in.TwistFlavor() == QUDA_TWIST_NO || in.TwistFlavor() == QUDA_TWIST_INVALID) {
@@ -101,7 +101,7 @@ namespace quda {
     FullClover *cI = new FullClover(clover, true);
 
     if(in.TwistFlavor() == QUDA_TWIST_SINGLET){
-      double a = 2.0 * kappa * mu;//for direct twist (must be daggered separately)  
+      double a = 2.0 * kappa * mu;//for direct twist (must be daggered separately)
       twistedCloverDslashCuda(&static_cast<cudaColorSpinorField&>(out.Odd()),
 			      *gauge, cs, cI, &static_cast<const cudaColorSpinorField&>(in.Even()),
 			      QUDA_ODD_PARITY, dagger, &static_cast<const cudaColorSpinorField&>(in.Odd()),
@@ -131,7 +131,7 @@ namespace quda {
   }
 
   void DiracTwistedClover::prepare(ColorSpinorField* &src, ColorSpinorField* &sol,
-				   ColorSpinorField &x, ColorSpinorField &b, 
+				   ColorSpinorField &x, ColorSpinorField &b,
 				   const QudaSolutionType solType) const
   {
     if (solType == QUDA_MATPC_SOLUTION || solType == QUDA_MATPCDAG_MATPC_SOLUTION) {
@@ -192,7 +192,7 @@ namespace quda {
     checkParitySpinor(in, out);
     checkSpinorAlias(in, out);
 
-    if (in.TwistFlavor() != out.TwistFlavor()) 
+    if (in.TwistFlavor() != out.TwistFlavor())
       errorQuda("Twist flavors %d %d don't match", in.TwistFlavor(), out.TwistFlavor());
     if (in.TwistFlavor() == QUDA_TWIST_NO || in.TwistFlavor() == QUDA_TWIST_INVALID)
       errorQuda("Twist flavor not set %d", in.TwistFlavor());
@@ -215,7 +215,7 @@ namespace quda {
 
     if (in.TwistFlavor() == QUDA_TWIST_SINGLET) {
       double a = -2.0 * kappa * mu;  //for invert twist (not daggered)
-      double b = 1.;// / (1.0 + a*a);                     //for invert twist 
+      double b = 1.;// / (1.0 + a*a);                     //for invert twist
       if (!dagger || matpcType == QUDA_MATPC_EVEN_EVEN_ASYMMETRIC || matpcType == QUDA_MATPC_ODD_ODD_ASYMMETRIC) {
 	twistedCloverDslashCuda(&static_cast<cudaColorSpinorField&>(out), *gauge, cs, cI,
 				&static_cast<const cudaColorSpinorField&>(in), parity, dagger, 0,
@@ -245,7 +245,7 @@ namespace quda {
   {
     checkParitySpinor(in, out);
     checkSpinorAlias(in, out);
-    if (in.TwistFlavor() != out.TwistFlavor()) 
+    if (in.TwistFlavor() != out.TwistFlavor())
       errorQuda("Twist flavors %d %d don't match", in.TwistFlavor(), out.TwistFlavor());
     if (in.TwistFlavor() == QUDA_TWIST_NO || in.TwistFlavor() == QUDA_TWIST_INVALID)
       errorQuda("Twist flavor not set %d", in.TwistFlavor());
@@ -338,7 +338,7 @@ namespace quda {
   }
 
   void DiracTwistedCloverPC::prepare(ColorSpinorField* &src, ColorSpinorField* &sol,
-				     ColorSpinorField &x, ColorSpinorField &b, 
+				     ColorSpinorField &x, ColorSpinorField &b,
 				     const QudaSolutionType solType) const
   {
     // we desire solution to preconditioned system
@@ -359,28 +359,20 @@ namespace quda {
     TwistCloverInv(symmetric ? *src : *tmp1, odd_bit ? b.Even() : b.Odd(), odd_bit ? QUDA_EVEN_PARITY : QUDA_ODD_PARITY);
 
     // we desire solution to full system
-    if(b.TwistFlavor() == QUDA_TWIST_SINGLET) {
+    if (b.TwistFlavor() == QUDA_TWIST_SINGLET) {
 
       if (matpcType == QUDA_MATPC_EVEN_EVEN) {
         // src = A_ee^-1 (b_e + k D_eo A_oo^-1 b_o)
-        src = &(x.Odd());
         DiracWilson::DslashXpay(*tmp1, *src, QUDA_EVEN_PARITY, b.Even(), kappa);
-        sol = &(x.Even());
       } else if (matpcType == QUDA_MATPC_ODD_ODD) {
         // src = A_oo^-1 (b_o + k D_oe A_ee^-1 b_e)
-        src = &(x.Even());
         DiracWilson::DslashXpay(*tmp1, *src, QUDA_ODD_PARITY, b.Odd(), kappa);
-        sol = &(x.Odd());
       } else if (matpcType == QUDA_MATPC_EVEN_EVEN_ASYMMETRIC) {
         // src = b_e + k D_eo A_oo^-1 b_o
-        src = &(x.Odd());
         DiracWilson::DslashXpay(*src, *tmp1, QUDA_EVEN_PARITY, b.Even(), kappa);
-        sol = &(x.Even());
       } else if (matpcType == QUDA_MATPC_ODD_ODD_ASYMMETRIC) {
         // src = b_o + k D_oe A_ee^-1 b_e
-        src = &(x.Even());
         DiracWilson::DslashXpay(*src, *tmp1, QUDA_ODD_PARITY, b.Odd(), kappa);
-        sol = &(x.Odd());
       } else {
         errorQuda("MatPCType %d not valid for DiracTwistedCloverPC", matpcType);
       }
@@ -396,33 +388,32 @@ namespace quda {
 
     deleteTmp(&tmp1, reset);
   }
-  
+
   void DiracTwistedCloverPC::reconstruct(ColorSpinorField &x, const ColorSpinorField &b,
 					 const QudaSolutionType solType) const
   {
-    if (solType == QUDA_MATPC_SOLUTION || solType == QUDA_MATPCDAG_MATPC_SOLUTION) {
-      return;
-    }				
+    if (solType == QUDA_MATPC_SOLUTION || solType == QUDA_MATPCDAG_MATPC_SOLUTION) { return; }
 
     checkFullSpinor(x, b);
     bool reset = newTmp(&tmp1, b.Even());
+    int odd_bit = (matpcType == QUDA_MATPC_ODD_ODD || matpcType == QUDA_MATPC_ODD_ODD_ASYMMETRIC) ? 1 : 0;
 
     // create full solution
-    if(b.TwistFlavor() == QUDA_TWIST_SINGLET) {    
+    if (b.TwistFlavor() == QUDA_TWIST_SINGLET) {
       if (matpcType == QUDA_MATPC_EVEN_EVEN || matpcType == QUDA_MATPC_EVEN_EVEN_ASYMMETRIC) {
         // x_o = A_oo^-1 (b_o + k D_oe x_e)
         DiracWilson::DslashXpay(*tmp1, x.Even(), QUDA_ODD_PARITY, b.Odd(), kappa);
-        TwistCloverInv(x.Odd(), *tmp1, QUDA_ODD_PARITY);
       } else if (matpcType == QUDA_MATPC_ODD_ODD ||   matpcType == QUDA_MATPC_ODD_ODD_ASYMMETRIC) {
         // x_e = A_ee^-1 (b_e + k D_eo x_o)
         DiracWilson::DslashXpay(*tmp1, x.Odd(), QUDA_EVEN_PARITY, b.Even(), kappa);
-        TwistCloverInv(x.Even(), *tmp1, QUDA_EVEN_PARITY);
       } else {
         errorQuda("MatPCType %d not valid for DiracTwistedCloverPC", matpcType);
       }
     } else { //twist doublet:
       errorQuda("Non-degenerate operator is not implemented");
     }//end of twist doublet...
+
+    TwistCloverInv(odd_bit ? x.Even() : x.Odd(), *tmp1, odd_bit ? QUDA_EVEN_PARITY : QUDA_ODD_PARITY);
     deleteTmp(&tmp1, reset);
   }
 

--- a/lib/dirac_twisted_clover.cpp
+++ b/lib/dirac_twisted_clover.cpp
@@ -7,11 +7,21 @@
 
 namespace quda {
 
-  DiracTwistedClover::DiracTwistedClover(const DiracParam &param, const int nDim)
-    : DiracWilson(param, nDim), mu(param.mu), epsilon(param.epsilon), clover(*(param.clover)) { }
+  DiracTwistedClover::DiracTwistedClover(const DiracParam &param, const int nDim) :
+    DiracWilson(param, nDim),
+    mu(param.mu),
+    epsilon(param.epsilon),
+    clover(*(param.clover))
+  {
+  }
 
-  DiracTwistedClover::DiracTwistedClover(const DiracTwistedClover &dirac)
-    : DiracWilson(dirac), mu(dirac.mu), epsilon(dirac.epsilon), clover(dirac.clover) { }
+  DiracTwistedClover::DiracTwistedClover(const DiracTwistedClover &dirac) :
+    DiracWilson(dirac),
+    mu(dirac.mu),
+    epsilon(dirac.epsilon),
+    clover(dirac.clover)
+  {
+  }
 
   DiracTwistedClover::~DiracTwistedClover() { }
 
@@ -101,7 +111,7 @@ namespace quda {
     FullClover *cI = new FullClover(clover, true);
 
     if(in.TwistFlavor() == QUDA_TWIST_SINGLET){
-      double a = 2.0 * kappa * mu;//for direct twist (must be daggered separately)
+      double a = 2.0 * kappa * mu; // for direct twist (must be daggered separately)
       twistedCloverDslashCuda(&static_cast<cudaColorSpinorField&>(out.Odd()),
 			      *gauge, cs, cI, &static_cast<const cudaColorSpinorField&>(in.Even()),
 			      QUDA_ODD_PARITY, dagger, &static_cast<const cudaColorSpinorField&>(in.Odd()),
@@ -130,9 +140,8 @@ namespace quda {
     deleteTmp(&tmp1, reset);
   }
 
-  void DiracTwistedClover::prepare(ColorSpinorField* &src, ColorSpinorField* &sol,
-				   ColorSpinorField &x, ColorSpinorField &b,
-				   const QudaSolutionType solType) const
+  void DiracTwistedClover::prepare(ColorSpinorField *&src, ColorSpinorField *&sol, ColorSpinorField &x,
+                                   ColorSpinorField &b, const QudaSolutionType solType) const
   {
     if (solType == QUDA_MATPC_SOLUTION || solType == QUDA_MATPCDAG_MATPC_SOLUTION) {
       errorQuda("Preconditioned solution requires a preconditioned solve_type");
@@ -205,8 +214,8 @@ namespace quda {
       DiracWilson::Dslash(out, *tmp2, parity);
       deleteTmp(&tmp2, reset);
     } else {
-      ApplyTwistedCloverPreconditioned(
-          out, in, *gauge, clover, 1.0, -2.0 * kappa * mu, false, in, parity, dagger, commDim, profile);
+      ApplyTwistedCloverPreconditioned(out, in, *gauge, clover, 1.0, -2.0 * kappa * mu, false, in, parity, dagger,
+                                       commDim, profile);
       flops += (1320ll + 552ll) * in.Volume();
     }
 #else
@@ -215,7 +224,7 @@ namespace quda {
 
     if (in.TwistFlavor() == QUDA_TWIST_SINGLET) {
       double a = -2.0 * kappa * mu;  //for invert twist (not daggered)
-      double b = 1.;// / (1.0 + a*a);                     //for invert twist
+      double b = 1.;                 // / (1.0 + a*a);                     //for invert twist
       if (!dagger || matpcType == QUDA_MATPC_EVEN_EVEN_ASYMMETRIC || matpcType == QUDA_MATPC_ODD_ODD_ASYMMETRIC) {
 	twistedCloverDslashCuda(&static_cast<cudaColorSpinorField&>(out), *gauge, cs, cI,
 				&static_cast<const cudaColorSpinorField&>(in), parity, dagger, 0,
@@ -337,9 +346,8 @@ namespace quda {
     deleteTmp(&tmp2, reset);
   }
 
-  void DiracTwistedCloverPC::prepare(ColorSpinorField* &src, ColorSpinorField* &sol,
-				     ColorSpinorField &x, ColorSpinorField &b,
-				     const QudaSolutionType solType) const
+  void DiracTwistedCloverPC::prepare(ColorSpinorField *&src, ColorSpinorField *&sol, ColorSpinorField &x,
+                                     ColorSpinorField &b, const QudaSolutionType solType) const
   {
     // we desire solution to preconditioned system
     if (solType == QUDA_MATPC_SOLUTION || solType == QUDA_MATPCDAG_MATPC_SOLUTION) {
@@ -377,9 +385,9 @@ namespace quda {
         errorQuda("MatPCType %d not valid for DiracTwistedCloverPC", matpcType);
       }
 
-    } else {//doublet:
+    } else { // doublet:
       errorQuda("Non-degenerate operator is not implemented");
-    }//end of doublet
+    } // end of doublet
 
     if (symmetric) TwistCloverInv(*src, *tmp1, odd_bit ? QUDA_ODD_PARITY : QUDA_EVEN_PARITY);
 
@@ -409,9 +417,9 @@ namespace quda {
       } else {
         errorQuda("MatPCType %d not valid for DiracTwistedCloverPC", matpcType);
       }
-    } else { //twist doublet:
+    } else { // twist doublet:
       errorQuda("Non-degenerate operator is not implemented");
-    }//end of twist doublet...
+    } // end of twist doublet...
 
     TwistCloverInv(odd_bit ? x.Even() : x.Odd(), *tmp1, odd_bit ? QUDA_EVEN_PARITY : QUDA_ODD_PARITY);
     deleteTmp(&tmp1, reset);

--- a/lib/dirac_twisted_mass.cpp
+++ b/lib/dirac_twisted_mass.cpp
@@ -337,7 +337,7 @@ namespace quda {
   }
 
   void DiracTwistedMassPC::prepare(ColorSpinorField *&src, ColorSpinorField *&sol, ColorSpinorField &x,
-      ColorSpinorField &b, const QudaSolutionType solType) const
+                                   ColorSpinorField &b, const QudaSolutionType solType) const
   {
     // we desire solution to preconditioned system
     if (solType == QUDA_MATPC_SOLUTION || solType == QUDA_MATPCDAG_MATPC_SOLUTION) {

--- a/lib/dslash_coarse.cu
+++ b/lib/dslash_coarse.cu
@@ -7,10 +7,6 @@
 #include <jitify_helper.cuh>
 #include <kernels/dslash_coarse.cuh>
 
-// ESW HACK
-//#define ESW_HACK_HALF_EXCHANGE
-//#define ESW_HACK_QUARTER_EXCHANGE
-
 namespace quda {
 
 #ifdef GPU_MULTIGRID
@@ -561,15 +557,23 @@ namespace quda {
             errorQuda("Halo precision %d not supported with field precision %d and link precision %d", halo_precision, precision, Y.Precision());
           }
         } else if (Y.Precision() == QUDA_HALF_PRECISION) {
+#if QUDA_PRECISION & 2
           if (halo_precision == QUDA_HALF_PRECISION) {
             ApplyCoarse<float,short,short>(out, inA, inB, Y, X, kappa, parity, dslash, clover,
                                            dagger, comms ? DSLASH_FULL : DSLASH_INTERIOR, halo_location);
           } else if (halo_precision == QUDA_QUARTER_PRECISION) {
+#if QUDA_PRECISION & 1
             ApplyCoarse<float,short,char>(out, inA, inB, Y, X, kappa, parity, dslash, clover,
                                           dagger, comms ? DSLASH_FULL : DSLASH_INTERIOR, halo_location);
+#else
+            errorQuda("QUDA_PRECISION=%d does not enable quarter precision", QUDA_PRECISION);
+#endif
           } else {
             errorQuda("Halo precision %d not supported with field precision %d and link precision %d", halo_precision, precision, Y.Precision());
           }
+#else
+          errorQuda("QUDA_PRECISION=%d does not enable half precision", QUDA_PRECISION);
+#endif
         } else {
           errorQuda("Unsupported precision %d\n", Y.Precision());
         }

--- a/lib/dslash_quda.cu
+++ b/lib/dslash_quda.cu
@@ -200,7 +200,7 @@ namespace quda {
           a = 1.0;
         } else if (twist == QUDA_TWIST_GAMMA5_INVERSE) {
           b = -2.0 * kappa * mu;
-          a = 1.0 / (1.0 + a * a);
+          a = 1.0 / (1.0 + b * b);
         }
 	c = 0.0;
         if (dagger) b *= -1.0;

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -359,7 +359,6 @@ static int qmp_rank_from_coords(const int *coords, void *fdata)
 }
 #endif
 
-
 // Provision for user control over MPI comm handle
 // Assumes an MPI implementation of QMP
 
@@ -367,26 +366,29 @@ static int qmp_rank_from_coords(const int *coords, void *fdata)
 MPI_Comm MPI_COMM_HANDLE;
 static int user_set_comm_handle = 0;
 
-void setMPICommHandleQuda(void *mycomm){
+void setMPICommHandleQuda(void *mycomm)
+{
   MPI_COMM_HANDLE = *((MPI_Comm *)mycomm);
   user_set_comm_handle = 1;
 }
 #endif
 
 #ifdef QMP_COMMS
-static void initQMPComms(void){
+static void initQMPComms(void)
+{
   // Default comm handle is taken from QMP
   // WARNING: Assumes an MPI implementation of QMP
-  if(!user_set_comm_handle){
+  if (!user_set_comm_handle) {
     void *mycomm;
     QMP_get_mpi_comm(QMP_comm_get_default(), &mycomm);
     setMPICommHandleQuda(mycomm);
   }
 }
 #elif defined(MPI_COMMS)
-static void initMPIComms(void){
+static void initMPIComms(void)
+{
   // Default comm handle is MPI_COMM_WORLD
-  if(!user_set_comm_handle){
+  if (!user_set_comm_handle) {
     static MPI_Comm mycomm;
     MPI_Comm_dup(MPI_COMM_WORLD, &mycomm);
     setMPICommHandleQuda((void *)&mycomm);
@@ -394,13 +396,11 @@ static void initMPIComms(void){
 }
 #endif
 
-
 static bool comms_initialized = false;
 
 void initCommsGridQuda(int nDim, const int *dims, QudaCommsMap func, void *fdata)
 {
   if (comms_initialized) return;
-
 
 #if QMP_COMMS
   initQMPComms();
@@ -868,8 +868,8 @@ void loadGaugeQuda(void *h_gauge, QudaGaugeParam *param)
   gauge_param.reconstruct = param->reconstruct_refinement_sloppy;
   gauge_param.setPrecision(param->cuda_prec_refinement_sloppy, true);
   cudaGaugeField *refinement = nullptr;
-  if (param->cuda_prec_sloppy != param->cuda_prec_refinement_sloppy ||
-      param->reconstruct_sloppy != param->reconstruct_refinement_sloppy) {
+  if (param->cuda_prec_sloppy != param->cuda_prec_refinement_sloppy
+      || param->reconstruct_sloppy != param->reconstruct_refinement_sloppy) {
     refinement = new cudaGaugeField(gauge_param);
     refinement->copy(*sloppy);
   } else {
@@ -979,13 +979,10 @@ void saveGaugeQuda(void *h_gauge, QudaGaugeParam *param)
   cudaGauge->saveCPUField(cpuGauge);
   profileGauge.TPSTOP(QUDA_PROFILE_D2H);
 
-  if(param->type == QUDA_SMEARED_LINKS) {
-    delete cudaGauge;
-  }
+  if (param->type == QUDA_SMEARED_LINKS) { delete cudaGauge; }
 
   profileGauge.TPSTOP(QUDA_PROFILE_TOTAL);
 }
-
 
 void loadSloppyCloverQuda(const QudaPrecision prec[]);
 void freeSloppyCloverQuda();
@@ -1124,12 +1121,12 @@ void loadCloverQuda(void *h_clover, void *h_clovinv, QudaInvertParam *inv_param)
 
   cloverPrecise->setRho(inv_param->clover_rho);
 
-  QudaPrecision prec[] =
-    {inv_param->clover_cuda_prec_sloppy, inv_param->clover_cuda_prec_precondition, inv_param->clover_cuda_prec_refinement_sloppy};
+  QudaPrecision prec[] = {inv_param->clover_cuda_prec_sloppy, inv_param->clover_cuda_prec_precondition,
+                          inv_param->clover_cuda_prec_refinement_sloppy};
   loadSloppyCloverQuda(prec);
 
   // if requested, copy back the clover / inverse field
-  if ( inv_param->return_clover || inv_param->return_clover_inverse ) {
+  if (inv_param->return_clover || inv_param->return_clover_inverse) {
     if (!h_clover && !h_clovinv) errorQuda("Requested clover field return but no clover host pointers set");
 
     // copy the inverted clover term into host application order on the device
@@ -1297,7 +1294,6 @@ void freeGaugeQuda(void)
   }
 }
 
-
 void loadSloppyGaugeQuda(const QudaPrecision *prec, const QudaReconstructType *recon)
 {
   // first do SU3 links (if they exist)
@@ -1310,8 +1306,7 @@ void loadSloppyGaugeQuda(const QudaPrecision *prec, const QudaReconstructType *r
 
     if (gaugeSloppy) errorQuda("gaugeSloppy already exists");
 
-    if (gauge_param.Precision() != gaugePrecise->Precision() ||
-	gauge_param.reconstruct != gaugePrecise->Reconstruct()) {
+    if (gauge_param.Precision() != gaugePrecise->Precision() || gauge_param.reconstruct != gaugePrecise->Reconstruct()) {
       gaugeSloppy = new cudaGaugeField(gauge_param);
       gaugeSloppy->copy(*gaugePrecise);
     } else {
@@ -1324,8 +1319,7 @@ void loadSloppyGaugeQuda(const QudaPrecision *prec, const QudaReconstructType *r
 
     if (gaugePrecondition) errorQuda("gaugePrecondition already exists");
 
-    if (gauge_param.Precision() != gaugeSloppy->Precision() ||
-	gauge_param.reconstruct != gaugeSloppy->Reconstruct()) {
+    if (gauge_param.Precision() != gaugeSloppy->Precision() || gauge_param.reconstruct != gaugeSloppy->Reconstruct()) {
       gaugePrecondition = new cudaGaugeField(gauge_param);
       gaugePrecondition->copy(*gaugeSloppy);
     } else {
@@ -1338,8 +1332,7 @@ void loadSloppyGaugeQuda(const QudaPrecision *prec, const QudaReconstructType *r
 
     if (gaugeRefinement) errorQuda("gaugeRefinement already exists");
 
-    if (gauge_param.Precision() != gaugeSloppy->Precision() ||
-	gauge_param.reconstruct != gaugeSloppy->Reconstruct()) {
+    if (gauge_param.Precision() != gaugeSloppy->Precision() || gauge_param.reconstruct != gaugeSloppy->Reconstruct()) {
       gaugeRefinement = new cudaGaugeField(gauge_param);
       gaugeRefinement->copy(*gaugeSloppy);
     } else {
@@ -1358,12 +1351,12 @@ void loadSloppyGaugeQuda(const QudaPrecision *prec, const QudaReconstructType *r
       if (gaugeFatSloppy) errorQuda("gaugeFatSloppy already exists");
       if (gaugeFatSloppy != gaugeFatPrecise) delete gaugeFatSloppy;
 
-      if (gauge_param.Precision() != gaugeFatPrecise->Precision() ||
-	  gauge_param.reconstruct != gaugeFatPrecise->Reconstruct()) {
-	gaugeFatSloppy = new cudaGaugeField(gauge_param);
-	gaugeFatSloppy->copy(*gaugeFatPrecise);
+      if (gauge_param.Precision() != gaugeFatPrecise->Precision()
+          || gauge_param.reconstruct != gaugeFatPrecise->Reconstruct()) {
+        gaugeFatSloppy = new cudaGaugeField(gauge_param);
+        gaugeFatSloppy->copy(*gaugeFatPrecise);
       } else {
-	gaugeFatSloppy = gaugeFatPrecise;
+        gaugeFatSloppy = gaugeFatPrecise;
       }
     }
 
@@ -1373,12 +1366,12 @@ void loadSloppyGaugeQuda(const QudaPrecision *prec, const QudaReconstructType *r
 
       if (gaugeFatPrecondition) errorQuda("gaugeFatPrecondition already exists\n");
 
-      if (gauge_param.Precision() != gaugeFatSloppy->Precision() ||
-	  gauge_param.reconstruct != gaugeFatSloppy->Reconstruct()) {
-	gaugeFatPrecondition = new cudaGaugeField(gauge_param);
-	gaugeFatPrecondition->copy(*gaugeFatSloppy);
+      if (gauge_param.Precision() != gaugeFatSloppy->Precision()
+          || gauge_param.reconstruct != gaugeFatSloppy->Reconstruct()) {
+        gaugeFatPrecondition = new cudaGaugeField(gauge_param);
+        gaugeFatPrecondition->copy(*gaugeFatSloppy);
       } else {
-	gaugeFatPrecondition = gaugeFatSloppy;
+        gaugeFatPrecondition = gaugeFatSloppy;
       }
     }
 
@@ -1388,12 +1381,12 @@ void loadSloppyGaugeQuda(const QudaPrecision *prec, const QudaReconstructType *r
 
       if (gaugeFatRefinement) errorQuda("gaugeFatRefinement already exists\n");
 
-      if (gauge_param.Precision() != gaugeFatSloppy->Precision() ||
-	  gauge_param.reconstruct != gaugeFatSloppy->Reconstruct()) {
-	gaugeFatRefinement = new cudaGaugeField(gauge_param);
-	gaugeFatRefinement->copy(*gaugeFatSloppy);
+      if (gauge_param.Precision() != gaugeFatSloppy->Precision()
+          || gauge_param.reconstruct != gaugeFatSloppy->Reconstruct()) {
+        gaugeFatRefinement = new cudaGaugeField(gauge_param);
+        gaugeFatRefinement->copy(*gaugeFatSloppy);
       } else {
-	gaugeFatRefinement = gaugeFatSloppy;
+        gaugeFatRefinement = gaugeFatSloppy;
       }
     }
   }
@@ -1407,8 +1400,8 @@ void loadSloppyGaugeQuda(const QudaPrecision *prec, const QudaReconstructType *r
 
     if (gaugeLongSloppy) errorQuda("gaugeLongSloppy already exists");
 
-    if (gauge_param.Precision() != gaugeLongPrecise->Precision() ||
-	gauge_param.reconstruct != gaugeLongPrecise->Reconstruct()) {
+    if (gauge_param.Precision() != gaugeLongPrecise->Precision()
+        || gauge_param.reconstruct != gaugeLongPrecise->Reconstruct()) {
       gaugeLongSloppy = new cudaGaugeField(gauge_param);
       gaugeLongSloppy->copy(*gaugeLongPrecise);
     } else {
@@ -1421,8 +1414,8 @@ void loadSloppyGaugeQuda(const QudaPrecision *prec, const QudaReconstructType *r
 
     if (gaugeLongPrecondition) errorQuda("gaugeLongPrecondition already exists\n");
 
-    if (gauge_param.Precision() != gaugeLongSloppy->Precision() ||
-	gauge_param.reconstruct != gaugeLongSloppy->Reconstruct()) {
+    if (gauge_param.Precision() != gaugeLongSloppy->Precision()
+        || gauge_param.reconstruct != gaugeLongSloppy->Reconstruct()) {
       gaugeLongPrecondition = new cudaGaugeField(gauge_param);
       gaugeLongPrecondition->copy(*gaugeLongSloppy);
     } else {
@@ -1435,8 +1428,8 @@ void loadSloppyGaugeQuda(const QudaPrecision *prec, const QudaReconstructType *r
 
     if (gaugeLongRefinement) errorQuda("gaugeLongRefinement already exists\n");
 
-    if (gauge_param.Precision() != gaugeLongSloppy->Precision() ||
-        gauge_param.reconstruct != gaugeLongSloppy->Reconstruct()) {
+    if (gauge_param.Precision() != gaugeLongSloppy->Precision()
+        || gauge_param.reconstruct != gaugeLongSloppy->Reconstruct()) {
       gaugeLongRefinement = new cudaGaugeField(gauge_param);
       gaugeLongRefinement->copy(*gaugeLongSloppy);
     } else {
@@ -2255,7 +2248,7 @@ void checkClover(QudaInvertParam *param) {
   if (cloverRefinement == nullptr) errorQuda("Refinement clover field doesn't exist");
 }
 
-quda::cudaGaugeField* checkGauge(QudaInvertParam *param)
+quda::cudaGaugeField *checkGauge(QudaInvertParam *param)
 {
   if (param->cuda_prec != gaugePrecise->Precision()) {
     errorQuda("Solve precision %d doesn't match gauge precision %d", param->cuda_prec, gaugePrecise->Precision());
@@ -2263,11 +2256,13 @@ quda::cudaGaugeField* checkGauge(QudaInvertParam *param)
 
   quda::cudaGaugeField *cudaGauge = nullptr;
   if (param->dslash_type != QUDA_ASQTAD_DSLASH) {
-    if (param->cuda_prec_sloppy != gaugeSloppy->Precision() ||
-	param->cuda_prec_precondition != gaugePrecondition->Precision() ||
-        param->cuda_prec_refinement_sloppy != gaugeRefinement->Precision()) {
-      QudaPrecision precision[3] = {param->cuda_prec_sloppy, param->cuda_prec_precondition, param->cuda_prec_refinement_sloppy};
-      QudaReconstructType recon[3] = {gaugeSloppy->Reconstruct(), gaugePrecondition->Reconstruct(), gaugeRefinement->Reconstruct()};
+    if (param->cuda_prec_sloppy != gaugeSloppy->Precision()
+        || param->cuda_prec_precondition != gaugePrecondition->Precision()
+        || param->cuda_prec_refinement_sloppy != gaugeRefinement->Precision()) {
+      QudaPrecision precision[3]
+          = {param->cuda_prec_sloppy, param->cuda_prec_precondition, param->cuda_prec_refinement_sloppy};
+      QudaReconstructType recon[3]
+          = {gaugeSloppy->Reconstruct(), gaugePrecondition->Reconstruct(), gaugeRefinement->Reconstruct()};
       freeSloppyGaugeQuda();
       loadSloppyGaugeQuda(precision, recon);
     }
@@ -2281,16 +2276,18 @@ quda::cudaGaugeField* checkGauge(QudaInvertParam *param)
     }
     cudaGauge = gaugePrecise;
   } else {
-    if (param->cuda_prec_sloppy != gaugeFatSloppy->Precision() ||
-	param->cuda_prec_precondition != gaugeFatPrecondition->Precision() ||
-        param->cuda_prec_refinement_sloppy != gaugeFatRefinement->Precision() ||
-	param->cuda_prec_sloppy != gaugeLongSloppy->Precision() ||
-	param->cuda_prec_precondition != gaugeLongPrecondition->Precision() ||
-	param->cuda_prec_refinement_sloppy != gaugeLongRefinement->Precision()) {
+    if (param->cuda_prec_sloppy != gaugeFatSloppy->Precision()
+        || param->cuda_prec_precondition != gaugeFatPrecondition->Precision()
+        || param->cuda_prec_refinement_sloppy != gaugeFatRefinement->Precision()
+        || param->cuda_prec_sloppy != gaugeLongSloppy->Precision()
+        || param->cuda_prec_precondition != gaugeLongPrecondition->Precision()
+        || param->cuda_prec_refinement_sloppy != gaugeLongRefinement->Precision()) {
 
-      QudaPrecision precision[3] = {param->cuda_prec_sloppy, param->cuda_prec_precondition, param->cuda_prec_refinement_sloppy};
+      QudaPrecision precision[3]
+        = {param->cuda_prec_sloppy, param->cuda_prec_precondition, param->cuda_prec_refinement_sloppy};
       // recon is always no for fat links, so just use long reconstructs here
-      QudaReconstructType recon[3] = {gaugeLongSloppy->Reconstruct(), gaugeLongPrecondition->Reconstruct(), gaugeLongRefinement->Reconstruct()};
+      QudaReconstructType recon[3]
+        = {gaugeLongSloppy->Reconstruct(), gaugeLongPrecondition->Reconstruct(), gaugeLongRefinement->Reconstruct()};
       freeSloppyGaugeQuda();
       loadSloppyGaugeQuda(precision, recon);
     }
@@ -2739,7 +2736,7 @@ deflated_solver::deflated_solver(QudaEigParam &eig_param, TimeProfile &profile)
 
   QudaInvertParam *param = eig_param.invert_param;
 
-  if(param->inv_type != QUDA_EIGCG_INVERTER && param->inv_type != QUDA_INC_EIGCG_INVERTER)  return;
+  if (param->inv_type != QUDA_EIGCG_INVERTER && param->inv_type != QUDA_INC_EIGCG_INVERTER) return;
 
   profile.TPSTART(QUDA_PROFILE_INIT);
 
@@ -2782,12 +2779,13 @@ deflated_solver::deflated_solver(QudaEigParam &eig_param, TimeProfile &profile)
   int ritzVolume = 1;
   for(int d = 0; d < ritzParam.nDim; d++) ritzVolume *= ritzParam.x[d];
 
-  if( getVerbosity() == QUDA_DEBUG_VERBOSE ) {
+  if (getVerbosity() == QUDA_DEBUG_VERBOSE) {
 
     size_t byte_estimate = (size_t)ritzParam.composite_dim*(size_t)ritzVolume*(ritzParam.nColor*ritzParam.nSpin*ritzParam.Precision());
-    printfQuda("allocating bytes: %lu (lattice volume %d, prec %d)" , byte_estimate, ritzVolume, ritzParam.Precision());
+    printfQuda("allocating bytes: %lu (lattice volume %d, prec %d)", byte_estimate, ritzVolume, ritzParam.Precision());
     if(ritzParam.mem_type == QUDA_MEMORY_DEVICE) printfQuda("Using device memory type.\n");
-    else if (ritzParam.mem_type == QUDA_MEMORY_MAPPED) printfQuda("Using mapped memory type.\n");
+    else if (ritzParam.mem_type == QUDA_MEMORY_MAPPED)
+      printfQuda("Using mapped memory type.\n");
   }
 
   RV = ColorSpinorField::Create(ritzParam);
@@ -3048,7 +3046,7 @@ void invertQuda(void *hp_x, void *hp_b, QudaInvertParam *param)
       mre(*out, *tmp, basis, Ap);
 
       for (auto ap: Ap) {
-        if (ap) delete(ap);
+        if (ap) delete (ap);
       }
       delete tmp;
       if (tmp2 != out) delete tmp2;
@@ -3554,8 +3552,6 @@ for(int i=0; i < param->num_src; i++) {
 
   profileInvert.TPSTOP(QUDA_PROFILE_TOTAL);
 }
-
-
 
 /*!
  * Generic version of the multi-shift solver. Should work for
@@ -5468,8 +5464,7 @@ void copyExtendedResidentGaugeQuda(void* resident_gauge, QudaFieldLocation loc)
   return;
 }
 
-void performWuppertalnStep(void *h_out, void *h_in, QudaInvertParam *inv_param,
-                           unsigned int nSteps, double alpha)
+void performWuppertalnStep(void *h_out, void *h_in, QudaInvertParam *inv_param, unsigned int nSteps, double alpha)
 {
   profileWuppertal.TPSTART(QUDA_PROFILE_TOTAL);
 
@@ -5481,8 +5476,7 @@ void performWuppertalnStep(void *h_out, void *h_in, QudaInvertParam *inv_param,
   cudaGaugeField *precise = nullptr;
 
   if (gaugeSmeared != nullptr) {
-    if (getVerbosity() >= QUDA_VERBOSE)
-      printfQuda("Wuppertal smearing done with gaugeSmeared\n");
+    if (getVerbosity() >= QUDA_VERBOSE) printfQuda("Wuppertal smearing done with gaugeSmeared\n");
     GaugeFieldParam gParam(*gaugePrecise);
     gParam.create = QUDA_NULL_FIELD_CREATE;
     precise = new cudaGaugeField(gParam);

--- a/lib/milc_interface.cpp
+++ b/lib/milc_interface.cpp
@@ -880,9 +880,11 @@ void qudaMultishiftInvert(int external_precision,
         inv_args.max_iter, reliable_delta, local_parity, verbosity, QUDA_CG_INVERTER, &invertParam);
   }
 
-  gaugeParam.cuda_prec_refinement_sloppy = QUDA_HALF_PRECISION;
-  invertParam.cuda_prec_refinement_sloppy = QUDA_HALF_PRECISION;
-  invertParam.reliable_delta_refinement = 0.1;
+  if (inv_args.mixed_precision == 1) {
+    gaugeParam.cuda_prec_refinement_sloppy = QUDA_HALF_PRECISION;
+    invertParam.cuda_prec_refinement_sloppy = QUDA_HALF_PRECISION;
+    invertParam.reliable_delta_refinement = 0.1;
+  }
 
   ColorSpinorParam csParam;
   setColorSpinorParams(localDim, host_precision, &csParam);

--- a/lib/milc_interface.cpp
+++ b/lib/milc_interface.cpp
@@ -83,9 +83,7 @@ void inline qudamilc_called(const char * func){
   qudamilc_called<start>(func, getVerbosity());
 }
 
-void qudaSetMPICommHandle(void *mycomm){
-  setMPICommHandleQuda(mycomm);
-}
+void qudaSetMPICommHandle(void *mycomm) { setMPICommHandleQuda(mycomm); }
 
 void qudaInit(QudaInitArgs_t input)
 {
@@ -1547,18 +1545,10 @@ void qudaFreeGaugeField() {
     qudamilc_called<false>(__func__);
 } // qudaFreeGaugeField
 
-
-void qudaLoadCloverField(int external_precision,
-    int quda_precision,
-    QudaInvertArgs_t inv_args,
-    void* milc_clover,
-    void* milc_clover_inv,
-    QudaSolutionType solution_type,
-    QudaSolveType solve_type,
-    QudaInverterType inverter,
-    double clover_coeff,
-    int compute_trlog,
-    double *trlog) {
+void qudaLoadCloverField(int external_precision, int quda_precision, QudaInvertArgs_t inv_args, void *milc_clover,
+                         void *milc_clover_inv, QudaSolutionType solution_type, QudaSolveType solve_type, QudaInverterType inverter,
+                         double clover_coeff, int compute_trlog, double *trlog)
+{
   qudamilc_called<true>(__func__);
   QudaInvertParam invertParam = newQudaInvertParam();
   setInvertParam(invertParam, inv_args, external_precision, quda_precision, 0.0, 0.0);
@@ -1593,8 +1583,6 @@ void qudaLoadCloverField(int external_precision,
   }
   qudamilc_called<false>(__func__);
 } // qudaLoadCoverField
-
-
 
 void qudaFreeCloverField() {
   qudamilc_called<true>(__func__);
@@ -1633,8 +1621,8 @@ void qudaCloverInvert(int external_precision,
   if (link) qudaLoadGaugeField(external_precision, quda_precision, inv_args, link);
 
   if (clover || cloverInverse) {
-    qudaLoadCloverField(external_precision, quda_precision, inv_args, clover, cloverInverse,
-			QUDA_MAT_SOLUTION, QUDA_DIRECT_PC_SOLVE, QUDA_BICGSTAB_INVERTER, clover_coeff, 0, 0);
+    qudaLoadCloverField(external_precision, quda_precision, inv_args, clover, cloverInverse, QUDA_MAT_SOLUTION,
+                        QUDA_DIRECT_PC_SOLVE, QUDA_BICGSTAB_INVERTER, clover_coeff, 0, 0);
   }
 
   double reliable_delta = 1e-1;
@@ -1697,8 +1685,8 @@ void qudaEigCGCloverInvert(int external_precision,
   if (link && (rhs_idx == 0)) qudaLoadGaugeField(external_precision, quda_precision, inv_args, link);
 
   if ( (clover || cloverInverse) && (rhs_idx == 0)) {
-    qudaLoadCloverField(external_precision, quda_precision, inv_args, clover, cloverInverse,
-			QUDA_MAT_SOLUTION, QUDA_DIRECT_PC_SOLVE, QUDA_INC_EIGCG_INVERTER, clover_coeff, 0, 0);
+    qudaLoadCloverField(external_precision, quda_precision, inv_args, clover, cloverInverse, QUDA_MAT_SOLUTION,
+                        QUDA_DIRECT_PC_SOLVE, QUDA_INC_EIGCG_INVERTER, clover_coeff, 0, 0);
   }
 
   double reliable_delta = 1e-1;

--- a/lib/prolongator.cu
+++ b/lib/prolongator.cu
@@ -199,9 +199,13 @@ namespace quda {
     constexpr int fine_colors_per_thread = 1;
 
     if (v.Precision() == QUDA_HALF_PRECISION) {
+#if QUDA_PRECISION & 2
       ProlongateLaunch<Float, short, fineSpin, fineColor, coarseSpin, coarseColor, fine_colors_per_thread>
 	prolongator(out, in, v, fine_to_coarse, parity);
       prolongator.apply(0);
+#else
+      errorQuda("QUDA_PRECISION=%d does not enable half precision", QUDA_PRECISION);
+#endif
     } else if (v.Precision() == in.Precision()) {
       ProlongateLaunch<Float, Float, fineSpin, fineColor, coarseSpin, coarseColor, fine_colors_per_thread>
 	prolongator(out, in, v, fine_to_coarse, parity);

--- a/lib/restrictor.cu
+++ b/lib/restrictor.cu
@@ -165,9 +165,13 @@ namespace quda {
     //coarseColor >= 8 && coarseColor % 8 == 0 ? 8 : coarseColor >= 4 && coarseColor % 4 == 0 ? 4 : 2;
 
     if (v.Precision() == QUDA_HALF_PRECISION) {
+#if QUDA_PRECISION & 2
       RestrictLaunch<Float, short, fineSpin, fineColor, coarseSpin, coarseColor, coarse_colors_per_thread>
 	restrictor(out, in, v, fine_to_coarse, coarse_to_fine, parity);
       restrictor.apply(0);
+#else
+      errorQuda("QUDA_PRECISION=%d does not enable half precision", QUDA_PRECISION);
+#endif
     } else if (v.Precision() == in.Precision()) {
       RestrictLaunch<Float, Float, fineSpin, fineColor, coarseSpin, coarseColor, coarse_colors_per_thread>
 	restrictor(out, in, v, fine_to_coarse, coarse_to_fine, parity);


### PR DESCRIPTION
Fixes for a variety of issues in MILC, PLEGMA and twisted-clover multigrid
* Fix twisted-clover multigrid coarsening with dynamic clover enabled (as well as cleanup and optimization) (closes #793)
* Catch bad pointer alignment with `MILCSiteOrder` gauge accessor 
* Only set refinement precision to half precision in MILC interface if using mixed precision
* Fix bugs with gauge refinement not being set in `loadSloppyGaugeQuda`
* Fix bug in inverse twisted-mass operator where scale factor was set incorrectly (closes #792)
* Reduce compile time in some multigrid components through respecting `QUDA_PRECISION` macro
* Set compilation macros in a configured include file `quda_define.h` to ensure consistent behaviour for C++ application plugging directly into QUDA (e.g., PLEGMA) and simplify the Jitify helper