### PR TITLE
Hotfix/milc naive

### DIFF
--- a/include/kernels/gauge_qcharge.cuh
+++ b/include/kernels/gauge_qcharge.cuh
@@ -24,7 +24,6 @@ namespace quda
   // Core routine for computing the topological charge from the field strength
   template <int blockSize, typename Float, typename Arg> __global__ void qChargeComputeKernel(Arg arg)
   {
-
     int idx = threadIdx.x + blockIdx.x * blockDim.x;
     int parity = threadIdx.y;
 
@@ -32,8 +31,8 @@ namespace quda
 
     while (idx < arg.threads) {
       // Load the field-strength tensor from global memory
-      Matrix<complex<Float>, 3> F[6];
-      for (int i = 0; i < 6; ++i) F[i] = arg.data(i, idx, parity);
+      Matrix<complex<Float>, 3> F[] = { arg.data(0, idx, parity), arg.data(1, idx, parity), arg.data(2, idx, parity),
+                                        arg.data(3, idx, parity), arg.data(4, idx, parity), arg.data(2, idx, parity) };
 
       double Q1 = getTrace(F[0] * F[5]).real();
       double Q2 = getTrace(F[1] * F[4]).real();

--- a/include/kernels/gauge_qcharge.cuh
+++ b/include/kernels/gauge_qcharge.cuh
@@ -31,8 +31,8 @@ namespace quda
 
     while (idx < arg.threads) {
       // Load the field-strength tensor from global memory
-      Matrix<complex<Float>, 3> F[] = { arg.data(0, idx, parity), arg.data(1, idx, parity), arg.data(2, idx, parity),
-                                        arg.data(3, idx, parity), arg.data(4, idx, parity), arg.data(2, idx, parity) };
+      Matrix<complex<Float>, 3> F[] = {arg.data(0, idx, parity), arg.data(1, idx, parity), arg.data(2, idx, parity),
+                                       arg.data(3, idx, parity), arg.data(4, idx, parity), arg.data(2, idx, parity)};
 
       double Q1 = getTrace(F[0] * F[5]).real();
       double Q2 = getTrace(F[1] * F[4]).real();

--- a/include/kernels/gauge_qcharge.cuh
+++ b/include/kernels/gauge_qcharge.cuh
@@ -32,7 +32,7 @@ namespace quda
     while (idx < arg.threads) {
       // Load the field-strength tensor from global memory
       Matrix<complex<Float>, 3> F[] = {arg.data(0, idx, parity), arg.data(1, idx, parity), arg.data(2, idx, parity),
-                                       arg.data(3, idx, parity), arg.data(4, idx, parity), arg.data(6, idx, parity)};
+                                       arg.data(3, idx, parity), arg.data(4, idx, parity), arg.data(5, idx, parity)};
 
       double Q1 = getTrace(F[0] * F[5]).real();
       double Q2 = getTrace(F[1] * F[4]).real();

--- a/include/kernels/gauge_qcharge.cuh
+++ b/include/kernels/gauge_qcharge.cuh
@@ -32,7 +32,7 @@ namespace quda
     while (idx < arg.threads) {
       // Load the field-strength tensor from global memory
       Matrix<complex<Float>, 3> F[] = {arg.data(0, idx, parity), arg.data(1, idx, parity), arg.data(2, idx, parity),
-                                       arg.data(3, idx, parity), arg.data(4, idx, parity), arg.data(2, idx, parity)};
+                                       arg.data(3, idx, parity), arg.data(4, idx, parity), arg.data(6, idx, parity)};
 
       double Q1 = getTrace(F[0] * F[5]).real();
       double Q2 = getTrace(F[1] * F[4]).real();

--- a/lib/check_params.h
+++ b/lib/check_params.h
@@ -56,8 +56,7 @@ void printQudaGaugeParam(QudaGaugeParam *param) {
 #else
   if (param->type == QUDA_WILSON_LINKS) {
     P(anisotropy, INVALID_DOUBLE);
-  } else if (param->type == QUDA_ASQTAD_FAT_LINKS ||
-	     param->type == QUDA_ASQTAD_LONG_LINKS) {
+  } else if (param->type == QUDA_ASQTAD_LONG_LINKS) {
     P(tadpole_coeff, INVALID_DOUBLE);
     P(scale, INVALID_DOUBLE);
   }

--- a/lib/gauge_qcharge.cu
+++ b/lib/gauge_qcharge.cu
@@ -6,7 +6,6 @@
 #include <jitify_helper.cuh>
 #include <kernels/gauge_qcharge.cuh>
 
-
 namespace quda
 {
 
@@ -14,7 +13,6 @@ namespace quda
 
   template <typename Float, typename Arg> class QChargeCompute : TunableLocalParity
   {
-
     Arg &arg;
     const GaugeField &meta;
 

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -2225,7 +2225,8 @@ void MatDagMatQuda(void *h_out, void *h_in, QudaInvertParam *inv_param)
   popVerbosity();
 }
 
-namespace quda {
+namespace quda
+{
   bool canReuseResidentGauge(QudaInvertParam *param)
   {
     if (param->dslash_type != QUDA_ASQTAD_DSLASH) {
@@ -2234,7 +2235,7 @@ namespace quda {
       return (gaugeFatPrecise != nullptr) and param->cuda_prec == gaugeFatPrecise->Precision();
     }
   }
-}
+} // namespace quda
 
 void checkClover(QudaInvertParam *param) {
 

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -2265,6 +2265,8 @@ quda::cudaGaugeField *checkGauge(QudaInvertParam *param)
 {
   quda::cudaGaugeField *cudaGauge = nullptr;
   if (param->dslash_type != QUDA_ASQTAD_DSLASH) {
+    if (gaugePrecise == nullptr) errorQuda("Precise gauge field doesn't exist");
+
     if (param->cuda_prec != gaugePrecise->Precision()) {
       errorQuda("Solve precision %d doesn't match gauge precision %d", param->cuda_prec, gaugePrecise->Precision());
     }
@@ -2280,7 +2282,6 @@ quda::cudaGaugeField *checkGauge(QudaInvertParam *param)
       loadSloppyGaugeQuda(precision, recon);
     }
 
-    if (gaugePrecise == nullptr) errorQuda("Precise gauge field doesn't exist");
     if (gaugeSloppy == nullptr) errorQuda("Sloppy gauge field doesn't exist");
     if (gaugePrecondition == nullptr) errorQuda("Precondition gauge field doesn't exist");
     if (gaugeRefinement == nullptr) errorQuda("Refinement gauge field doesn't exist");
@@ -2289,6 +2290,9 @@ quda::cudaGaugeField *checkGauge(QudaInvertParam *param)
     }
     cudaGauge = gaugePrecise;
   } else {
+    if (gaugeFatPrecise == nullptr) errorQuda("Precise gauge fat field doesn't exist");
+    if (gaugeLongPrecise == nullptr) errorQuda("Precise gauge long field doesn't exist");
+
     if (param->cuda_prec != gaugeFatPrecise->Precision()) {
       errorQuda("Solve precision %d doesn't match gauge precision %d", param->cuda_prec, gaugeFatPrecise->Precision());
     }
@@ -2309,7 +2313,6 @@ quda::cudaGaugeField *checkGauge(QudaInvertParam *param)
       loadSloppyGaugeQuda(precision, recon);
     }
 
-    if (gaugeFatPrecise == nullptr) errorQuda("Precise gauge fat field doesn't exist");
     if (gaugeFatSloppy == nullptr) errorQuda("Sloppy gauge fat field doesn't exist");
     if (gaugeFatPrecondition == nullptr) errorQuda("Precondition gauge fat field doesn't exist");
     if (gaugeFatRefinement == nullptr) errorQuda("Refinement gauge fat field doesn't exist");
@@ -2317,7 +2320,6 @@ quda::cudaGaugeField *checkGauge(QudaInvertParam *param)
       if (gaugeFatExtended == nullptr) errorQuda("Extended gauge fat field doesn't exist");
     }
 
-    if (gaugeLongPrecise == nullptr) errorQuda("Precise gauge long field doesn't exist");
     if (gaugeLongSloppy == nullptr) errorQuda("Sloppy gauge long field doesn't exist");
     if (gaugeLongPrecondition == nullptr) errorQuda("Precondition gauge long field doesn't exist");
     if (gaugeLongRefinement == nullptr) errorQuda("Refinement gauge long field doesn't exist");

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -2225,10 +2225,15 @@ void MatDagMatQuda(void *h_out, void *h_in, QudaInvertParam *inv_param)
   popVerbosity();
 }
 
-namespace quda{
-bool canReuseResidentGauge(QudaInvertParam *param){
-  return (gaugePrecise != nullptr) and param->cuda_prec == gaugePrecise->Precision();
-}
+namespace quda {
+  bool canReuseResidentGauge(QudaInvertParam *param)
+  {
+    if (param->dslash_type != QUDA_ASQTAD_DSLASH) {
+      return (gaugePrecise != nullptr) and param->cuda_prec == gaugePrecise->Precision();
+    } else {
+      return (gaugeFatPrecise != nullptr) and param->cuda_prec == gaugeFatPrecise->Precision();
+    }
+  }
 }
 
 void checkClover(QudaInvertParam *param) {

--- a/lib/milc_interface.cpp
+++ b/lib/milc_interface.cpp
@@ -61,27 +61,22 @@ using namespace quda::fermion_force;
 
 
 #define QUDAMILC_VERBOSE 1
-template <bool start>
-void inline qudamilc_called(const char* func, QudaVerbosity verb)
+template <bool start> void inline qudamilc_called(const char *func, QudaVerbosity verb)
 {
 #ifdef QUDAMILC_VERBOSE
 if (verb >= QUDA_VERBOSE) {
   if (start) {
-    printfQuda("QUDA_MILC_INTERFACE: %s (called) \n",func);
-    PUSH_RANGE(func,1);
+    printfQuda("QUDA_MILC_INTERFACE: %s (called) \n", func);
+    PUSH_RANGE(func, 1);
   } else {
-    printfQuda("QUDA_MILC_INTERFACE: %s (return) \n",func);
+    printfQuda("QUDA_MILC_INTERFACE: %s (return) \n", func);
     POP_RANGE;
   }
- }
+}
 #endif
 }
 
-template <bool start>
-void inline qudamilc_called(const char * func)
-{
-  qudamilc_called<start>(func, getVerbosity());
-}
+template <bool start> void inline qudamilc_called(const char *func) { qudamilc_called<start>(func, getVerbosity()); }
 
 void qudaSetMPICommHandle(void *mycomm) { setMPICommHandleQuda(mycomm); }
 
@@ -571,19 +566,10 @@ static int getFatLinkPadding(const int dim[4])
 }
 
 // set the params for the single mass solver
-static void setInvertParams(const int dim[4],
-                            QudaPrecision cpu_prec,
-                            QudaPrecision cuda_prec,
-                            QudaPrecision cuda_prec_sloppy,
-                            double mass,
-                            double target_residual,
-                            double target_residual_hq,
-                            int maxiter,
-                            double reliable_delta,
-                            QudaParity parity,
-                            QudaVerbosity verbosity,
-                            QudaInverterType inverter,
-                            QudaInvertParam *invertParam)
+static void setInvertParams(const int dim[4], QudaPrecision cpu_prec, QudaPrecision cuda_prec,
+                            QudaPrecision cuda_prec_sloppy, double mass, double target_residual,
+                            double target_residual_hq, int maxiter, double reliable_delta, QudaParity parity,
+                            QudaVerbosity verbosity, QudaInverterType inverter, QudaInvertParam *invertParam)
 {
   invertParam->verbosity = verbosity;
   invertParam->mass = mass;
@@ -592,9 +578,11 @@ static void setInvertParams(const int dim[4],
 
   invertParam->residual_type = static_cast<QudaResidualType_s>(0);
   invertParam->residual_type = (target_residual != 0) ?
-    static_cast<QudaResidualType_s> ( invertParam->residual_type | QUDA_L2_RELATIVE_RESIDUAL) : invertParam->residual_type;
+    static_cast<QudaResidualType_s>(invertParam->residual_type | QUDA_L2_RELATIVE_RESIDUAL) :
+    invertParam->residual_type;
   invertParam->residual_type = (target_residual_hq != 0) ?
-    static_cast<QudaResidualType_s> (invertParam->residual_type | QUDA_HEAVY_QUARK_RESIDUAL) : invertParam->residual_type;
+    static_cast<QudaResidualType_s>(invertParam->residual_type | QUDA_HEAVY_QUARK_RESIDUAL) :
+    invertParam->residual_type;
 
   if (invertParam->residual_type == QUDA_HEAVY_QUARK_RESIDUAL) invertParam->heavy_quark_check = 1;
 
@@ -626,7 +614,7 @@ static void setInvertParams(const int dim[4],
 
   if (parity == QUDA_EVEN_PARITY) { // even parity
     invertParam->matpc_type = QUDA_MATPC_EVEN_EVEN;
-  } else if(parity == QUDA_ODD_PARITY) {
+  } else if (parity == QUDA_ODD_PARITY) {
     invertParam->matpc_type = QUDA_MATPC_ODD_ODD;
   } else {
     errorQuda("Invalid parity\n");
@@ -647,28 +635,19 @@ static void setInvertParams(const int dim[4],
 
 
 // Set params for the multi-mass solver.
-static void setInvertParams(const int dim[4],
-                            QudaPrecision cpu_prec,
-                            QudaPrecision cuda_prec,
-                            QudaPrecision cuda_prec_sloppy,
-                            int num_offset,
-                            const double offset[],
-                            const double target_residual_offset[],
-                            const double target_residual_hq_offset[],
-                            int maxiter,
-                            double reliable_delta,
-                            QudaParity parity,
-                            QudaVerbosity verbosity,
-                            QudaInverterType inverter,
-                            QudaInvertParam *invertParam)
+static void setInvertParams(const int dim[4], QudaPrecision cpu_prec, QudaPrecision cuda_prec,
+                            QudaPrecision cuda_prec_sloppy, int num_offset, const double offset[],
+                            const double target_residual_offset[], const double target_residual_hq_offset[],
+                            int maxiter, double reliable_delta, QudaParity parity, QudaVerbosity verbosity,
+                            QudaInverterType inverter, QudaInvertParam *invertParam)
 {
   const double null_mass = -1;
 
-  setInvertParams(dim, cpu_prec, cuda_prec, cuda_prec_sloppy, null_mass, target_residual_offset[0], target_residual_hq_offset[0],
-                  maxiter, reliable_delta, parity, verbosity, inverter, invertParam);
+  setInvertParams(dim, cpu_prec, cuda_prec, cuda_prec_sloppy, null_mass, target_residual_offset[0],
+                  target_residual_hq_offset[0], maxiter, reliable_delta, parity, verbosity, inverter, invertParam);
 
   invertParam->num_offset = num_offset;
-  for (int i=0; i<num_offset; ++i) {
+  for (int i = 0; i < num_offset; ++i) {
     invertParam->offset[i] = offset[i];
     invertParam->tol_offset[i] = target_residual_offset[i];
     invertParam->tol_hq_offset[i] = target_residual_hq_offset[i];
@@ -679,11 +658,11 @@ static void getReconstruct(QudaReconstructType &reconstruct, QudaReconstructType
 {
   {
     char *reconstruct_env = getenv("QUDA_MILC_HISQ_RECONSTRUCT");
-    if (!reconstruct_env || strcmp(reconstruct_env,"18")==0) {
+    if (!reconstruct_env || strcmp(reconstruct_env, "18") == 0) {
       reconstruct = QUDA_RECONSTRUCT_NO;
-    } else if (strcmp(reconstruct_env,"13")==0) {
+    } else if (strcmp(reconstruct_env, "13") == 0) {
       reconstruct = QUDA_RECONSTRUCT_13;
-    } else if (strcmp(reconstruct_env,"9")==0) {
+    } else if (strcmp(reconstruct_env, "9") == 0) {
       reconstruct = QUDA_RECONSTRUCT_9;
     } else {
       errorQuda("QUDA_MILC_HISQ_RECONSTRUCT=%s not supported", reconstruct_env);
@@ -694,11 +673,11 @@ static void getReconstruct(QudaReconstructType &reconstruct, QudaReconstructType
     char *reconstruct_sloppy_env = getenv("QUDA_MILC_HISQ_RECONSTRUCT_SLOPPY");
     if (!reconstruct_sloppy_env) { // if env is not set, default to using outer reconstruct type
       reconstruct_sloppy = reconstruct;
-    } else if (strcmp(reconstruct_sloppy_env,"18")==0) {
+    } else if (strcmp(reconstruct_sloppy_env, "18") == 0) {
       reconstruct_sloppy = QUDA_RECONSTRUCT_NO;
-    } else if (strcmp(reconstruct_sloppy_env,"13")==0) {
+    } else if (strcmp(reconstruct_sloppy_env, "13") == 0) {
       reconstruct_sloppy = QUDA_RECONSTRUCT_13;
-    } else if (strcmp(reconstruct_sloppy_env,"9")==0) {
+    } else if (strcmp(reconstruct_sloppy_env, "9") == 0) {
       reconstruct_sloppy = QUDA_RECONSTRUCT_9;
     } else {
       errorQuda("QUDA_MILC_HISQ_RECONSTRUCT_SLOPPY=%s not supported", reconstruct_sloppy_env);
@@ -706,16 +685,11 @@ static void getReconstruct(QudaReconstructType &reconstruct, QudaReconstructType
   }
 }
 
-static void setGaugeParams(QudaGaugeParam &fat_param, QudaGaugeParam &long_param,
-                           const void * const fatlink, const void * const longlink,
-                           const int dim[4],
-                           QudaPrecision cpu_prec,
-                           QudaPrecision cuda_prec,
-                           QudaPrecision cuda_prec_sloppy,
-                           double tadpole,
-                           double naik_epsilon)
+static void setGaugeParams(QudaGaugeParam &fat_param, QudaGaugeParam &long_param, const void *const fatlink,
+                           const void *const longlink, const int dim[4], QudaPrecision cpu_prec,
+                           QudaPrecision cuda_prec, QudaPrecision cuda_prec_sloppy, double tadpole, double naik_epsilon)
 {
-  for (int dir=0; dir<4; ++dir) fat_param.X[dir] = dim[dir];
+  for (int dir = 0; dir < 4; ++dir) fat_param.X[dir] = dim[dir];
 
   fat_param.cpu_prec = cpu_prec;
   fat_param.cuda_prec = cuda_prec;
@@ -730,7 +704,7 @@ static void setGaugeParams(QudaGaugeParam &fat_param, QudaGaugeParam &long_param
   fat_param.gauge_order = QUDA_MILC_GAUGE_ORDER;
   fat_param.ga_pad = getFatLinkPadding(dim);
 
-  const int fat_pad  = getFatLinkPadding(dim);
+  const int fat_pad = getFatLinkPadding(dim);
   fat_param.type = QUDA_GENERAL_LINKS;
   fat_param.ga_pad = fat_pad;
 
@@ -740,22 +714,21 @@ static void setGaugeParams(QudaGaugeParam &fat_param, QudaGaugeParam &long_param
   // now set the long link parameters needed
   long_param = fat_param;
   long_param.tadpole_coeff = tadpole;
-  long_param.scale = -(1.0+naik_epsilon)/(24.0*long_param.tadpole_coeff*long_param.tadpole_coeff);
-  const int long_pad = 3*fat_pad;
+  long_param.scale = -(1.0 + naik_epsilon) / (24.0 * long_param.tadpole_coeff * long_param.tadpole_coeff);
+  const int long_pad = 3 * fat_pad;
   long_param.type = QUDA_THREE_LINKS;
   long_param.ga_pad = long_pad;
   getReconstruct(long_param.reconstruct, long_param.reconstruct_sloppy);
   long_param.reconstruct_precondition = long_param.reconstruct_sloppy;
 }
 
-
-static void setColorSpinorParams(const int dim[4], QudaPrecision precision, ColorSpinorParam* param)
+static void setColorSpinorParams(const int dim[4], QudaPrecision precision, ColorSpinorParam *param)
 {
   param->nColor = 3;
   param->nSpin = 1;
   param->nDim = 4;
 
-  for (int dir=0; dir<4; ++dir) param->x[dir] = dim[dir];
+  for (int dir = 0; dir < 4; ++dir) param->x[dir] = dim[dir];
   param->x[0] /= 2;
 
   param->setPrecision(precision);
@@ -767,13 +740,8 @@ static void setColorSpinorParams(const int dim[4], QudaPrecision precision, Colo
   param->create = QUDA_ZERO_FIELD_CREATE;
 }
 
-void setDeflationParam(QudaPrecision ritz_prec,
-                       QudaFieldLocation location_ritz,
-                       QudaMemoryType mem_type_ritz,
-                       QudaExtLibType deflation_ext_lib,
-                       char vec_infile[],
-                       char vec_outfile[],
-                       QudaEigParam *df_param)
+void setDeflationParam(QudaPrecision ritz_prec, QudaFieldLocation location_ritz, QudaMemoryType mem_type_ritz,
+                       QudaExtLibType deflation_ext_lib, char vec_infile[], char vec_outfile[], QudaEigParam *df_param)
 {
 
   df_param->import_vectors = strcmp(vec_infile,"") ? QUDA_BOOLEAN_YES : QUDA_BOOLEAN_NO;
@@ -806,20 +774,11 @@ static size_t getColorVectorOffset(QudaParity local_parity, bool even_odd_exchan
   return offset;
 }
 
-void qudaMultishiftInvert(int external_precision,
-                          int quda_precision,
-                          int num_offsets,
-                          double* const offset,
-                          QudaInvertArgs_t inv_args,
-                          const double target_residual[],
-                          const double target_fermilab_residual[],
-                          const void* const fatlink,
-                          const void* const longlink,
-                          void* source,
-                          void** solutionArray,
-                          double* const final_residual,
-                          double* const final_fermilab_residual,
-                          int *num_iters)
+void qudaMultishiftInvert(int external_precision, int quda_precision, int num_offsets, double *const offset,
+                          QudaInvertArgs_t inv_args, const double target_residual[],
+                          const double target_fermilab_residual[], const void *const fatlink,
+                          const void *const longlink, void *source, void **solutionArray, double *const final_residual,
+                          double *const final_fermilab_residual, int *num_iters)
 {
   static const QudaVerbosity verbosity = getVerbosity();
   qudamilc_called<true>(__func__, verbosity);
@@ -839,15 +798,16 @@ void qudaMultishiftInvert(int external_precision,
 
   QudaGaugeParam fat_param = newQudaGaugeParam();
   QudaGaugeParam long_param = newQudaGaugeParam();
-  setGaugeParams(fat_param, long_param, fatlink, longlink, localDim, host_precision, device_precision, device_precision_sloppy,
-                 inv_args.tadpole, inv_args.naik_epsilon);
+  setGaugeParams(fat_param, long_param, fatlink, longlink, localDim, host_precision, device_precision,
+                 device_precision_sloppy, inv_args.tadpole, inv_args.naik_epsilon);
 
   QudaInvertParam invertParam = newQudaInvertParam();
 
   QudaParity local_parity = inv_args.evenodd;
   const double reliable_delta = (use_mixed_precision ? 1e-1 : 0.0);
-  setInvertParams(localDim, host_precision, device_precision, device_precision_sloppy, num_offsets, offset, target_residual,
-                  target_fermilab_residual, inv_args.max_iter, reliable_delta, local_parity, verbosity, QUDA_CG_INVERTER, &invertParam);
+  setInvertParams(localDim, host_precision, device_precision, device_precision_sloppy, num_offsets, offset,
+                  target_residual, target_fermilab_residual, inv_args.max_iter, reliable_delta, local_parity, verbosity,
+                  QUDA_CG_INVERTER, &invertParam);
 
   if (inv_args.mixed_precision == 1) {
     fat_param.cuda_prec_refinement_sloppy = QUDA_HALF_PRECISION;
@@ -865,25 +825,25 @@ void qudaMultishiftInvert(int external_precision,
 
   // set the solver
   if (invalidate_quda_gauge || !create_quda_gauge) {
-    loadGaugeQuda(const_cast<void*>(fatlink), &fat_param);
-    if (longlink != nullptr) loadGaugeQuda(const_cast<void*>(longlink), &long_param);
+    loadGaugeQuda(const_cast<void *>(fatlink), &fat_param);
+    if (longlink != nullptr) loadGaugeQuda(const_cast<void *>(longlink), &long_param);
     invalidate_quda_gauge = false;
   }
 
   if (longlink == nullptr) invertParam.dslash_type = QUDA_STAGGERED_DSLASH;
 
   void** sln_pointer = (void**)malloc(num_offsets*sizeof(void*));
-  int quark_offset = getColorVectorOffset(local_parity, false, localDim)*host_precision;
+  int quark_offset = getColorVectorOffset(local_parity, false, localDim) * host_precision;
   void* src_pointer = static_cast<char*>(source) + quark_offset;
 
-  for (int i=0; i<num_offsets; ++i) sln_pointer[i] = static_cast<char*>(solutionArray[i]) + quark_offset;
+  for (int i = 0; i < num_offsets; ++i) sln_pointer[i] = static_cast<char *>(solutionArray[i]) + quark_offset;
 
   invertMultiShiftQuda(sln_pointer, src_pointer, &invertParam);
   free(sln_pointer);
 
   // return the number of iterations taken by the inverter
   *num_iters = invertParam.iter;
-  for (int i=0; i<num_offsets; ++i) {
+  for (int i = 0; i < num_offsets; ++i) {
     final_residual[i] = invertParam.true_res_offset[i];
     final_fermilab_residual[i] = invertParam.true_res_hq_offset[i];
   } // end loop over number of offsets
@@ -893,19 +853,10 @@ void qudaMultishiftInvert(int external_precision,
   qudamilc_called<false>(__func__, verbosity);
 } // qudaMultiShiftInvert
 
-void qudaInvert(int external_precision,
-                int quda_precision,
-                double mass,
-                QudaInvertArgs_t inv_args,
-                double target_residual,
-                double target_fermilab_residual,
-                const void* const fatlink,
-                const void* const longlink,
-                void *source,
-                void *solution,
-                double* const final_residual,
-                double* const final_fermilab_residual,
-                int *num_iters)
+void qudaInvert(int external_precision, int quda_precision, double mass, QudaInvertArgs_t inv_args,
+                double target_residual, double target_fermilab_residual, const void *const fatlink,
+                const void *const longlink, void *source, void *solution, double *const final_residual,
+                double *const final_fermilab_residual, int *num_iters)
 {
   static const QudaVerbosity verbosity = getVerbosity();
   qudamilc_called<true>(__func__, verbosity);
@@ -925,35 +876,35 @@ void qudaInvert(int external_precision,
 
   QudaGaugeParam fat_param = newQudaGaugeParam();
   QudaGaugeParam long_param = newQudaGaugeParam();
-  setGaugeParams(fat_param, long_param, fatlink, longlink, localDim, host_precision, device_precision, device_precision_sloppy,
-                 inv_args.tadpole, inv_args.naik_epsilon);
+  setGaugeParams(fat_param, long_param, fatlink, longlink, localDim, host_precision, device_precision,
+                 device_precision_sloppy, inv_args.tadpole, inv_args.naik_epsilon);
 
   QudaInvertParam invertParam = newQudaInvertParam();
 
   QudaParity local_parity = inv_args.evenodd;
   const double reliable_delta = 1e-1;
 
-  setInvertParams(localDim, host_precision, device_precision, device_precision_sloppy,
-                  mass, target_residual, target_fermilab_residual, inv_args.max_iter, reliable_delta,
-                  local_parity, verbosity, QUDA_CG_INVERTER, &invertParam);
+  setInvertParams(localDim, host_precision, device_precision, device_precision_sloppy, mass, target_residual,
+                  target_fermilab_residual, inv_args.max_iter, reliable_delta, local_parity, verbosity,
+                  QUDA_CG_INVERTER, &invertParam);
 
   ColorSpinorParam csParam;
   setColorSpinorParams(localDim, host_precision, &csParam);
 
   // dirty hack to invalidate the cached gauge field without breaking interface compatability
-  if (*num_iters == -1  || !canReuseResidentGauge(&invertParam) ) invalidateGaugeQuda();
+  if (*num_iters == -1 || !canReuseResidentGauge(&invertParam)) invalidateGaugeQuda();
 
   if (invalidate_quda_gauge || !create_quda_gauge) {
-    loadGaugeQuda(const_cast<void*>(fatlink), &fat_param);
-    if (longlink != nullptr) loadGaugeQuda(const_cast<void*>(longlink), &long_param);
+    loadGaugeQuda(const_cast<void *>(fatlink), &fat_param);
+    if (longlink != nullptr) loadGaugeQuda(const_cast<void *>(longlink), &long_param);
     invalidate_quda_gauge = false;
   }
 
   if (longlink == nullptr) invertParam.dslash_type = QUDA_STAGGERED_DSLASH;
 
-  int quark_offset = getColorVectorOffset(local_parity, false, localDim)*host_precision;
+  int quark_offset = getColorVectorOffset(local_parity, false, localDim) * host_precision;
 
-  invertQuda(static_cast<char*>(solution) + quark_offset, static_cast<char*>(source) + quark_offset, &invertParam);
+  invertQuda(static_cast<char *>(solution) + quark_offset, static_cast<char *>(source) + quark_offset, &invertParam);
 
   // return the number of iterations taken by the inverter
   *num_iters = invertParam.iter;
@@ -985,26 +936,26 @@ void qudaDslash(int external_precision,
 
   QudaGaugeParam fat_param = newQudaGaugeParam();
   QudaGaugeParam long_param = newQudaGaugeParam();
-  setGaugeParams(fat_param, long_param, fatlink, longlink, localDim, host_precision, device_precision, device_precision_sloppy,
-                 inv_args.tadpole, inv_args.naik_epsilon);
+  setGaugeParams(fat_param, long_param, fatlink, longlink, localDim, host_precision, device_precision,
+                 device_precision_sloppy, inv_args.tadpole, inv_args.naik_epsilon);
 
   QudaInvertParam invertParam = newQudaInvertParam();
 
   QudaParity local_parity = inv_args.evenodd;
   QudaParity other_parity = local_parity == QUDA_EVEN_PARITY ? QUDA_ODD_PARITY : QUDA_EVEN_PARITY;
 
-  setInvertParams(localDim, host_precision, device_precision, device_precision_sloppy,
-		  0.0, 0, 0, 0, 0.0, local_parity, verbosity, QUDA_CG_INVERTER, &invertParam);
+  setInvertParams(localDim, host_precision, device_precision, device_precision_sloppy, 0.0, 0, 0, 0, 0.0, local_parity,
+                  verbosity, QUDA_CG_INVERTER, &invertParam);
 
   ColorSpinorParam csParam;
   setColorSpinorParams(localDim, host_precision, &csParam);
 
   // dirty hack to invalidate the cached gauge field without breaking interface compatability
-  if (*num_iters == -1  || !canReuseResidentGauge(&invertParam) ) invalidateGaugeQuda();
+  if (*num_iters == -1 || !canReuseResidentGauge(&invertParam)) invalidateGaugeQuda();
 
   if (invalidate_quda_gauge || !create_quda_gauge) {
-    loadGaugeQuda(const_cast<void*>(fatlink), &fat_param);
-    if (longlink != nullptr) loadGaugeQuda(const_cast<void*>(longlink), &long_param);
+    loadGaugeQuda(const_cast<void *>(fatlink), &fat_param);
+    if (longlink != nullptr) loadGaugeQuda(const_cast<void *>(longlink), &long_param);
     invalidate_quda_gauge = false;
   }
 
@@ -1022,21 +973,10 @@ void qudaDslash(int external_precision,
   qudamilc_called<false>(__func__, verbosity);
 } // qudaDslash
 
-
-void qudaInvertMsrc(int external_precision,
-                    int quda_precision,
-                    double mass,
-                    QudaInvertArgs_t inv_args,
-                    double target_residual,
-                    double target_fermilab_residual,
-                    const void* const fatlink,
-                    const void* const longlink,
-                    void** sourceArray,
-                    void** solutionArray,
-                    double* const final_residual,
-                    double* const final_fermilab_residual,
-                    int* num_iters,
-                    int num_src)
+void qudaInvertMsrc(int external_precision, int quda_precision, double mass, QudaInvertArgs_t inv_args,
+                    double target_residual, double target_fermilab_residual, const void *const fatlink,
+                    const void *const longlink, void **sourceArray, void **solutionArray, double *const final_residual,
+                    double *const final_fermilab_residual, int *num_iters, int num_src)
 {
   static const QudaVerbosity verbosity = getVerbosity();
   qudamilc_called<true>(__func__, verbosity);
@@ -1056,39 +996,39 @@ void qudaInvertMsrc(int external_precision,
 
   QudaGaugeParam fat_param = newQudaGaugeParam();
   QudaGaugeParam long_param = newQudaGaugeParam();
-  setGaugeParams(fat_param, long_param, fatlink, longlink, localDim, host_precision, device_precision, device_precision_sloppy,
-                 inv_args.tadpole, inv_args.naik_epsilon);
+  setGaugeParams(fat_param, long_param, fatlink, longlink, localDim, host_precision, device_precision,
+                 device_precision_sloppy, inv_args.tadpole, inv_args.naik_epsilon);
 
   QudaInvertParam invertParam = newQudaInvertParam();
 
   QudaParity local_parity = inv_args.evenodd;
   const double reliable_delta = 1e-1;
 
-  setInvertParams(localDim, host_precision, device_precision, device_precision_sloppy,
-                  mass, target_residual, target_fermilab_residual, inv_args.max_iter, reliable_delta,
-                  local_parity, verbosity, QUDA_CG_INVERTER, &invertParam);
+  setInvertParams(localDim, host_precision, device_precision, device_precision_sloppy, mass, target_residual,
+                  target_fermilab_residual, inv_args.max_iter, reliable_delta, local_parity, verbosity,
+                  QUDA_CG_INVERTER, &invertParam);
   invertParam.num_src = num_src;
 
   ColorSpinorParam csParam;
   setColorSpinorParams(localDim, host_precision, &csParam);
 
   // dirty hack to invalidate the cached gauge field without breaking interface compatability
-  if (*num_iters == -1  || !canReuseResidentGauge(&invertParam) ) invalidateGaugeQuda();
+  if (*num_iters == -1 || !canReuseResidentGauge(&invertParam)) invalidateGaugeQuda();
 
   if (invalidate_quda_gauge || !create_quda_gauge) {
-    loadGaugeQuda(const_cast<void*>(fatlink), &fat_param);
-    if (longlink != nullptr) loadGaugeQuda(const_cast<void*>(longlink), &long_param);
+    loadGaugeQuda(const_cast<void *>(fatlink), &fat_param);
+    if (longlink != nullptr) loadGaugeQuda(const_cast<void *>(longlink), &long_param);
     invalidate_quda_gauge = false;
   }
 
   if (longlink == nullptr) invertParam.dslash_type = QUDA_STAGGERED_DSLASH;
 
-  int quark_offset = getColorVectorOffset(local_parity, false, localDim)*host_precision;
+  int quark_offset = getColorVectorOffset(local_parity, false, localDim) * host_precision;
   void** sln_pointer = (void**)malloc(num_src*sizeof(void*));
   void** src_pointer = (void**)malloc(num_src*sizeof(void*));
 
-  for (int i=0; i<num_src; ++i) sln_pointer[i] = static_cast<char*>(solutionArray[i]) + quark_offset;
-  for (int i=0; i<num_src; ++i) src_pointer[i] = static_cast<char*>(sourceArray[i]) + quark_offset;
+  for (int i = 0; i < num_src; ++i) sln_pointer[i] = static_cast<char *>(solutionArray[i]) + quark_offset;
+  for (int i = 0; i < num_src; ++i) src_pointer[i] = static_cast<char *>(sourceArray[i]) + quark_offset;
 
   invertMultiSrcQuda(sln_pointer, src_pointer, &invertParam);
 
@@ -1105,23 +1045,15 @@ void qudaInvertMsrc(int external_precision,
   qudamilc_called<false>(__func__, verbosity);
 } // qudaInvert
 
-
-void qudaEigCGInvert(int external_precision,
-                     int quda_precision,
-                     double mass,
-                     QudaInvertArgs_t inv_args,
-                     double target_residual,
-                     double target_fermilab_residual,
-                     const void* const fatlink,
-                     const void* const longlink,
-                     void* source,//array of source vectors -> overwritten on exit
-                     void* solution,//temporary
+void qudaEigCGInvert(int external_precision, int quda_precision, double mass, QudaInvertArgs_t inv_args,
+                     double target_residual, double target_fermilab_residual, const void *const fatlink,
+                     const void *const longlink,
+                     void *source,   // array of source vectors -> overwritten on exit
+                     void *solution, // temporary
                      QudaEigArgs_t eig_args,
-                     const int rhs_idx,//current rhs
-                     const int last_rhs_flag,//is this the last rhs to solve
-                     double* const final_residual,
-                     double* const final_fermilab_residual,
-                     int *num_iters)
+                     const int rhs_idx,       // current rhs
+                     const int last_rhs_flag, // is this the last rhs to solve
+                     double *const final_residual, double *const final_fermilab_residual, int *num_iters)
 {
   static const QudaVerbosity verbosity = getVerbosity();
   qudamilc_called<true>(__func__, verbosity);
@@ -1140,8 +1072,8 @@ void qudaEigCGInvert(int external_precision,
 
   QudaGaugeParam fat_param = newQudaGaugeParam();
   QudaGaugeParam long_param = newQudaGaugeParam();
-  setGaugeParams(fat_param, long_param, fatlink, longlink, localDim, host_precision, device_precision, device_precision_sloppy,
-                 inv_args.tadpole, inv_args.naik_epsilon);
+  setGaugeParams(fat_param, long_param, fatlink, longlink, localDim, host_precision, device_precision,
+                 device_precision_sloppy, inv_args.tadpole, inv_args.naik_epsilon);
 
   QudaInvertParam invertParam = newQudaInvertParam();
 
@@ -1167,7 +1099,8 @@ void qudaEigCGInvert(int external_precision,
   invertParam.eigenval_tol       = eig_args.eigenval_tol;
   invertParam.rhs_idx            = rhs_idx;
 
-  if ((inv_args.solver_type != QUDA_INC_EIGCG_INVERTER) && (inv_args.solver_type != QUDA_EIGCG_INVERTER)) errorQuda("Incorrect inverter type.\n");
+  if ((inv_args.solver_type != QUDA_INC_EIGCG_INVERTER) && (inv_args.solver_type != QUDA_EIGCG_INVERTER))
+    errorQuda("Incorrect inverter type.\n");
   invertParam.inv_type = inv_args.solver_type;
 
   if (inv_args.solver_type == QUDA_INC_EIGCG_INVERTER) invertParam.inv_type_precondition = QUDA_INVALID_INVERTER;
@@ -1178,25 +1111,25 @@ void qudaEigCGInvert(int external_precision,
   setColorSpinorParams(localDim, host_precision, &csParam);
 
   // dirty hack to invalidate the cached gauge field without breaking interface compatability
-  if (*num_iters == -1  || !canReuseResidentGauge(&invertParam) ) invalidateGaugeQuda();
+  if (*num_iters == -1 || !canReuseResidentGauge(&invertParam)) invalidateGaugeQuda();
 
-  if ((invalidate_quda_gauge || !create_quda_gauge) && (rhs_idx == 0)) { //do this for the first RHS
-    loadGaugeQuda(const_cast<void*>(fatlink), &fat_param);
-    if (longlink != nullptr) loadGaugeQuda(const_cast<void*>(longlink), &long_param);
+  if ((invalidate_quda_gauge || !create_quda_gauge) && (rhs_idx == 0)) { // do this for the first RHS
+    loadGaugeQuda(const_cast<void *>(fatlink), &fat_param);
+    if (longlink != nullptr) loadGaugeQuda(const_cast<void *>(longlink), &long_param);
     invalidate_quda_gauge = false;
   }
 
   if (longlink == nullptr) invertParam.dslash_type = QUDA_STAGGERED_DSLASH;
 
-  int quark_offset = getColorVectorOffset(local_parity, false, localDim)*host_precision;
+  int quark_offset = getColorVectorOffset(local_parity, false, localDim) * host_precision;
 
   if(rhs_idx == 0) df_preconditioner = newDeflationQuda(&df_param);
 
   invertParam.deflation_op = df_preconditioner;
 
-  invertQuda(static_cast<char*>(solution) + quark_offset, static_cast<char*>(source) + quark_offset, &invertParam);
+  invertQuda(static_cast<char *>(solution) + quark_offset, static_cast<char *>(source) + quark_offset, &invertParam);
 
-  if(last_rhs_flag) destroyDeflationQuda(df_preconditioner);
+  if (last_rhs_flag) destroyDeflationQuda(df_preconditioner);
 
   // return the number of iterations taken by the inverter
   *num_iters = invertParam.iter;
@@ -1491,25 +1424,17 @@ void qudaCloverInvert(int external_precision,
   qudamilc_called<false>(__func__);
 } // qudaCloverInvert
 
-
-void qudaEigCGCloverInvert(int external_precision,
-    int quda_precision,
-    double kappa,
-    double clover_coeff,
-    QudaInvertArgs_t inv_args,
-    double target_residual,
-    double target_fermilab_residual,
-    const void* link,
-    void* clover, // could be stored in Milc format
-    void* cloverInverse,
-    void* source,//array of source vectors -> overwritten on exit!
-    void* solution,//temporary
-    QudaEigArgs_t eig_args,
-    const int rhs_idx,//current rhs
-    const int last_rhs_flag,//is this the last rhs to solve?
-    double* const final_residual,
-    double* const final_fermilab_residual,
-    int *num_iters)
+void qudaEigCGCloverInvert(int external_precision, int quda_precision, double kappa, double clover_coeff,
+                           QudaInvertArgs_t inv_args, double target_residual, double target_fermilab_residual,
+                           const void *link,
+                           void *clover, // could be stored in Milc format
+                           void *cloverInverse,
+                           void *source,   // array of source vectors -> overwritten on exit!
+                           void *solution, // temporary
+                           QudaEigArgs_t eig_args,
+                           const int rhs_idx,       // current rhs
+                           const int last_rhs_flag, // is this the last rhs to solve?
+                           double *const final_residual, double *const final_fermilab_residual, int *num_iters)
 {
   qudamilc_called<true>(__func__);
   if (target_fermilab_residual == 0 && target_residual == 0) errorQuda("qudaCloverInvert: requesting zero residual\n");
@@ -1567,7 +1492,7 @@ void qudaEigCGCloverInvert(int external_precision,
 
   invertQuda(solution, source, &invertParam);
 
-  if(last_rhs_flag) destroyDeflationQuda(df_preconditioner);
+  if (last_rhs_flag) destroyDeflationQuda(df_preconditioner);
 
   *num_iters = invertParam.iter;
   *final_residual = invertParam.true_res;
@@ -1598,7 +1523,7 @@ void qudaCloverMultishiftInvert(int external_precision,
   static const QudaVerbosity verbosity = getVerbosity();
   qudamilc_called<true>(__func__, verbosity);
 
-  for (int i=0; i<num_offsets; ++i) {
+  for (int i = 0; i < num_offsets; ++i) {
     if (target_residual_offset[i] == 0) errorQuda("qudaCloverMultishiftInvert: target residual cannot be zero\n");
   }
 
@@ -1662,16 +1587,8 @@ void qudaCloverMultishiftInvert(int external_precision,
   qudamilc_called<false>(__func__, verbosity);
 } // qudaCloverMultishiftInvert
 
-
-void qudaGaugeFixingOVR( int precision,
-                         unsigned int gauge_dir,
-                         int Nsteps,
-                         int verbose_interval,
-                         double relax_boost,
-                         double tolerance,
-                         unsigned int reunit_interval,
-                         unsigned int stopWtheta,
-                         void* milc_sitelink)
+void qudaGaugeFixingOVR(int precision, unsigned int gauge_dir, int Nsteps, int verbose_interval, double relax_boost,
+                        double tolerance, unsigned int reunit_interval, unsigned int stopWtheta, void *milc_sitelink)
 {
   QudaGaugeParam qudaGaugeParam = newMILCGaugeParam(localDim,
       (precision==1) ? QUDA_SINGLE_PRECISION : QUDA_DOUBLE_PRECISION,


### PR DESCRIPTION
This is a bug fix and clean up pull
* Set `QudaGaugeParam::staggered_phase_type = QUDA_STAGGERED_PHASE_MILC` when using naive fermions (bug introduced in pull #776 owing to increased parameter checking)
* Clean up of milc_interface.cpp to reduce repeated parameter setting boilerplate
* Fix bug introduced in pull #799 which lead to `canReuseResidentGauge` interface function returning false erroneously
* Fix compilation warning for gauge_qcharge.cu when compiling with `-G`

I have checked this pull is correct running against the MILC APEX benchmarks.

@jxy this pull request should fix the issue you were seeing.  Can you verify please?