### PR TITLE
Hotfix/milc hq

### DIFF
--- a/include/color_spinor_field_order.h
+++ b/include/color_spinor_field_order.h
@@ -866,9 +866,9 @@ namespace quda {
   {
     for (int dim = 0; dim < 4; dim++) {
       for (int dir = 0; dir < 2; dir++) {
-        ghost[2 * dim + dir] = static_cast<Float *>(ghost_[2 * dim + dir]);
-        ghost_norm[2 * dim + dir] = reinterpret_cast<norm_type *>(
-            static_cast<char *>(ghost_[2 * dim + dir]) + nParity * length_ghost * faceVolumeCB[dim] * sizeof(Float));
+        ghost[2 * dim + dir] = comm_dim_partitioned(dim) ? static_cast<Float *>(ghost_[2 * dim + dir]) : nullptr;
+        ghost_norm[2 * dim + dir] = !comm_dim_partitioned(dim) ? nullptr :
+          reinterpret_cast<norm_type *>(static_cast<char *>(ghost_[2 * dim + dir]) + nParity * length_ghost * faceVolumeCB[dim] * sizeof(Float));
       }
     }
   }

--- a/include/invert_quda.h
+++ b/include/invert_quda.h
@@ -72,7 +72,7 @@ namespace quda {
        requires more low-precision memory allocation. */
     int solution_accumulator_pipeline;
 
-    /**< This parameter determines how many consective reliable update
+    /**< This parameter determines how many consecutive reliable update
     residual increases we tolerate before terminating the solver,
     i.e., how long do we want to keep trying to converge */
     int max_res_increase;
@@ -81,6 +81,16 @@ namespace quda {
     residual increases we tolerate before terminating the solver,
     i.e., how long do we want to keep trying to converge */
     int max_res_increase_total;
+
+    /**< This parameter determines how many consecutive heavy-quark
+    residual increases we tolerate before terminating the solver,
+    i.e., how long do we want to keep trying to converge */
+    int max_hq_res_increase;
+
+    /**< This parameter determines how many total heavy-quark residual
+    restarts we tolerate before terminating the solver, i.e., how long
+    do we want to keep trying to converge */
+    int max_hq_res_restart_total;
 
     /**< After how many iterations shall the heavy quark residual be updated */
     int heavy_quark_check;
@@ -246,6 +256,7 @@ namespace quda {
       use_sloppy_partial_accumulator(param.use_sloppy_partial_accumulator),
       solution_accumulator_pipeline(param.solution_accumulator_pipeline),
       max_res_increase(param.max_res_increase), max_res_increase_total(param.max_res_increase_total),
+      max_hq_res_increase(param.max_hq_res_increase), max_hq_res_restart_total(param.max_hq_res_restart_total),
       heavy_quark_check(param.heavy_quark_check), pipeline(param.pipeline),
       tol(param.tol), tol_restart(param.tol_restart), tol_hq(param.tol_hq),
       compute_true_res(param.compute_true_res), sloppy_converge(false), true_res(param.true_res),
@@ -285,6 +296,7 @@ namespace quda {
       use_sloppy_partial_accumulator(param.use_sloppy_partial_accumulator),
       solution_accumulator_pipeline(param.solution_accumulator_pipeline),
       max_res_increase(param.max_res_increase), max_res_increase_total(param.max_res_increase_total),
+      max_hq_res_increase(param.max_hq_res_increase), max_hq_res_restart_total(param.max_hq_res_restart_total),
       heavy_quark_check(param.heavy_quark_check), pipeline(param.pipeline),
       tol(param.tol), tol_restart(param.tol_restart), tol_hq(param.tol_hq),
       compute_true_res(param.compute_true_res), sloppy_converge(param.sloppy_converge), true_res(param.true_res),

--- a/include/quda.h
+++ b/include/quda.h
@@ -141,7 +141,7 @@ extern "C" {
        requires more low-precision memory allocation. */
     int solution_accumulator_pipeline;
 
-    /**< This parameter determines how many consective reliable update
+    /**< This parameter determines how many consecutive reliable update
     residual increases we tolerate before terminating the solver,
     i.e., how long do we want to keep trying to converge */
     int max_res_increase;
@@ -150,6 +150,16 @@ extern "C" {
     residual increases we tolerate before terminating the solver,
     i.e., how long do we want to keep trying to converge */
     int max_res_increase_total;
+
+    /**< This parameter determines how many consecutive heavy-quark
+    residual increases we tolerate before terminating the solver,
+    i.e., how long do we want to keep trying to converge */
+    int max_hq_res_increase;
+
+    /**< This parameter determines how many total heavy-quark residual
+    restarts we tolerate before terminating the solver, i.e., how long
+    do we want to keep trying to converge */
+    int max_hq_res_restart_total;
 
     /**< After how many iterations shall the heavy quark residual be updated */
     int heavy_quark_check;

--- a/lib/check_params.h
+++ b/lib/check_params.h
@@ -311,6 +311,8 @@ void printQudaInvertParam(QudaInvertParam *param) {
   P(solution_accumulator_pipeline, 1); /**< Default is solution accumulator depth of 1 */
   P(max_res_increase, 1); /**< Default is to allow one consecutive residual increase */
   P(max_res_increase_total, 10); /**< Default is to allow ten residual increase */
+  P(max_hq_res_increase, 1); /**< Default is to allow one consecutive heavy-quark residual increase */
+  P(max_hq_res_restart_total, 10); /**< Default is to allow ten heavy-quark restarts */
   P(heavy_quark_check, 10); /**< Default is to update heavy quark residual after 10 iterations */
  #else
   P(use_alternative_reliable, INVALID_INT);
@@ -318,6 +320,8 @@ void printQudaInvertParam(QudaInvertParam *param) {
   P(solution_accumulator_pipeline, INVALID_INT);
   P(max_res_increase, INVALID_INT);
   P(max_res_increase_total, INVALID_INT);
+  P(max_hq_res_increase, INVALID_INT);
+  P(max_hq_res_restart_total, INVALID_INT);
   P(heavy_quark_check, INVALID_INT);
 #endif
 

--- a/lib/inv_cg_quda.cpp
+++ b/lib/inv_cg_quda.cpp
@@ -596,12 +596,15 @@ namespace quda {
 
           if (heavy_quark_res > heavy_quark_res_old) { // check if new hq residual is greater than previous
             hqresIncrease++; // count the number of consecutive increases
-            warningQuda("CG: new reliable HQ residual norm %e is greater than previous reliable residual norm %e", heavy_quark_res, heavy_quark_res_old);
+            warningQuda("CG: new reliable HQ residual norm %e is greater than previous reliable residual norm %e",
+                        heavy_quark_res, heavy_quark_res_old);
             // break out if we do not improve here anymore
             if (hqresIncrease > hqmaxresIncrease) {
               warningQuda("CG: solver exiting due to too many heavy quark residual norm increases");
               break;
             }
+          } else {
+            hqresIncrease = 0;
           }
 
           if (hqresRestartTotal > hqmaxresRestartTotal) {
@@ -639,7 +642,7 @@ namespace quda {
 
       // check for recent enough reliable updates of the HQ residual if we use it
       if (use_heavy_quark_res) {
-        // L2 is concverged or precision maxed out for L2
+        // L2 is converged or precision maxed out for L2
         bool L2done = L2breakdown or convergenceL2(r2, heavy_quark_res, stop, param.tol_hq);
         // HQ is converged and if we do reliable update the HQ residual has been calculated using a reliable update
         bool HQdone = (steps_since_reliable == 0 and param.delta > 0) and convergenceHQ(r2, heavy_quark_res, stop, param.tol_hq);

--- a/lib/inv_cg_quda.cpp
+++ b/lib/inv_cg_quda.cpp
@@ -370,7 +370,6 @@ namespace quda {
     double maxrr = rNorm;
     double delta = param.delta;
 
-
     // this parameter determines how many consective reliable update
     // residual increases we tolerate before terminating the solver,
     // i.e., how long do we want to keep trying to converge
@@ -556,7 +555,7 @@ namespace quda {
         blas::zero(xSloppy);
 
         // alternative reliable updates
-        if(alternative_reliable){
+        if (alternative_reliable) {
           dinit = uhigh*(sqrt(r2) + Anorm * sqrt(blas::norm2(y)));
           d = d_new;
           xnorm = 0;//sqrt(norm2(x));
@@ -570,17 +569,16 @@ namespace quda {
           maxrx = rNorm;
         }
 
-
         // calculate new reliable HQ resididual
         if (use_heavy_quark_res) heavy_quark_res = sqrt(blas::HeavyQuarkResidualNorm(y, r).z);
 
         // break-out check if we have reached the limit of the precision
-        if (sqrt(r2) > r0Norm && updateX) { // reuse r0Norm for this
+        if (sqrt(r2) > r0Norm && updateX and not L2breakdown) { // reuse r0Norm for this
           resIncrease++;
           resIncreaseTotal++;
           warningQuda("CG: new reliable residual norm %e is greater than previous reliable residual norm %e (total #inc %i)",
-          sqrt(r2), r0Norm, resIncreaseTotal);
-          if ( resIncrease > maxResIncrease or resIncreaseTotal > maxResIncreaseTotal) {
+                      sqrt(r2), r0Norm, resIncreaseTotal);
+          if (resIncrease > maxResIncrease or resIncreaseTotal > maxResIncreaseTotal) {
             if (use_heavy_quark_res) {
               L2breakdown = true;
             } else {
@@ -591,6 +589,7 @@ namespace quda {
         } else {
           resIncrease = 0;
         }
+
         // if L2 broke down already we turn off reliable updates and restart the CG
         if (use_heavy_quark_res and L2breakdown) {
           delta = 0;

--- a/lib/inv_cg_quda.cpp
+++ b/lib/inv_cg_quda.cpp
@@ -373,12 +373,12 @@ namespace quda {
     // this parameter determines how many consective reliable update
     // residual increases we tolerate before terminating the solver,
     // i.e., how long do we want to keep trying to converge
-    const int maxResIncrease = (use_heavy_quark_res ? 0 : param.max_res_increase); //  check if we reached the limit of our tolerance
+    const int maxResIncrease = param.max_res_increase; //  check if we reached the limit of our tolerance
     const int maxResIncreaseTotal = param.max_res_increase_total;
 
     // this means when using heavy quarks we will switch to simple hq restarts as soon as the reliable strategy fails
-    const int hqmaxresIncrease = param.max_res_increase;
-    const int hqmaxresRestartTotal = maxResIncreaseTotal; // this limits the number of heavy quark restarts we can do
+    const int hqmaxresIncrease = param.max_hq_res_increase;
+    const int hqmaxresRestartTotal = param.max_hq_res_restart_total; // this limits the number of heavy quark restarts we can do
 
     int resIncrease = 0;
     int resIncreaseTotal = 0;
@@ -575,7 +575,7 @@ namespace quda {
           resIncreaseTotal++;
           warningQuda("CG: new reliable residual norm %e is greater than previous reliable residual norm %e (total #inc %i)",
                       sqrt(r2), r0Norm, resIncreaseTotal);
-          if (resIncrease > maxResIncrease or resIncreaseTotal > maxResIncreaseTotal) {
+          if (resIncrease > maxResIncrease or resIncreaseTotal > maxResIncreaseTotal or r2 < stop) {
             if (use_heavy_quark_res) {
               L2breakdown = true;
             } else {

--- a/lib/milc_interface.cpp
+++ b/lib/milc_interface.cpp
@@ -585,6 +585,10 @@ static void setInvertParams(const int dim[4], QudaPrecision cpu_prec, QudaPrecis
     invertParam->residual_type;
 
   invertParam->heavy_quark_check = (invertParam->residual_type & QUDA_HEAVY_QUARK_RESIDUAL ? 1 : 0);
+  if (invertParam->heavy_quark_check) {
+    invertParam->max_res_increase = 5;        // this caps the number of consecutive hq residual increases
+    invertParam->max_res_increase_total = 10; // this caps the number of hq restarts in case of solver stalling
+  }
 
   invertParam->use_sloppy_partial_accumulator = 0;
   invertParam->num_offset = 0;

--- a/lib/milc_interface.cpp
+++ b/lib/milc_interface.cpp
@@ -586,8 +586,8 @@ static void setInvertParams(const int dim[4], QudaPrecision cpu_prec, QudaPrecis
 
   invertParam->heavy_quark_check = (invertParam->residual_type & QUDA_HEAVY_QUARK_RESIDUAL ? 1 : 0);
   if (invertParam->heavy_quark_check) {
-    invertParam->max_res_increase = 5;        // this caps the number of consecutive hq residual increases
-    invertParam->max_res_increase_total = 10; // this caps the number of hq restarts in case of solver stalling
+    invertParam->max_hq_res_increase = 5;       // this caps the number of consecutive hq residual increases
+    invertParam->max_hq_res_restart_total = 10; // this caps the number of hq restarts in case of solver stalling
   }
 
   invertParam->use_sloppy_partial_accumulator = 0;

--- a/lib/milc_interface.cpp
+++ b/lib/milc_interface.cpp
@@ -584,7 +584,7 @@ static void setInvertParams(const int dim[4], QudaPrecision cpu_prec, QudaPrecis
     static_cast<QudaResidualType_s>(invertParam->residual_type | QUDA_HEAVY_QUARK_RESIDUAL) :
     invertParam->residual_type;
 
-  if (invertParam->residual_type == QUDA_HEAVY_QUARK_RESIDUAL) invertParam->heavy_quark_check = 1;
+  invertParam->heavy_quark_check = (invertParam->residual_type & QUDA_HEAVY_QUARK_RESIDUAL ? 1 : 0);
 
   invertParam->use_sloppy_partial_accumulator = 0;
   invertParam->num_offset = 0;
@@ -1400,7 +1400,7 @@ void qudaCloverInvert(int external_precision,
 
   invertParam.tol =  target_residual;
   invertParam.tol_hq = target_fermilab_residual;
-  if (invertParam.residual_type == QUDA_HEAVY_QUARK_RESIDUAL) invertParam.heavy_quark_check = 1;
+  invertParam.heavy_quark_check = (invertParam.residual_type & QUDA_HEAVY_QUARK_RESIDUAL ? 1 : 0);
   invertParam.clover_coeff = clover_coeff;
 
   // solution types
@@ -1452,7 +1452,7 @@ void qudaEigCGCloverInvert(int external_precision, int quda_precision, double ka
 
   invertParam.tol =  target_residual;
   invertParam.tol_hq = target_fermilab_residual;
-  if (invertParam.residual_type == QUDA_HEAVY_QUARK_RESIDUAL) invertParam.heavy_quark_check = 1;
+  invertParam.heavy_quark_check = (invertParam.residual_type & QUDA_HEAVY_QUARK_RESIDUAL ? 1 : 0);
   invertParam.clover_coeff = clover_coeff;
 
   // solution types

--- a/lib/quda_fortran.F90
+++ b/lib/quda_fortran.F90
@@ -116,6 +116,8 @@ module quda_fortran
      integer(4) :: solution_accumulator_pipeline ! How many direction vectors we accumulate into the solution vector at once
      integer(4) :: max_res_increase ! How many residual increases we tolerate when doing reliable updates
      integer(4) :: max_res_increase_total ! Total number of residual increases we tolerate
+     integer(4) :: max_hq_res_increase ! How many heavy-quark residual increases we tolerate when doing heavy-quark restarts
+     integer(4) :: max_hq_res_increase_total ! Total number of heavy-quark residual restarts we tolerate
      integer(4) :: heavy_quark_check ! After how many iterations shall the heavy quark residual be updated
      integer(4) :: pipeline ! Whether to enable pipeline solver option
      integer(4) :: num_offset ! Number of offsets in the multi-shift solver


### PR DESCRIPTION
This pull improves the robustness of the heavy quark solver:
* limit the number of heavy quark restarts (set by `QudaInvertParam::max_res_increase_total` parameter) to prevent non termination in case the heavy quark residual stalls
* set sensible defaults in MILC interface