### PR TITLE
Topological charge density function

### DIFF
--- a/include/gauge_tools.h
+++ b/include/gauge_tools.h
@@ -108,4 +108,12 @@ namespace quda {
      @return double The total topological charge
    */
   double computeQCharge(const GaugeField &Fmunu);
+
+    /**
+     Compute the topological charge density per lattice site
+     @param[in] Fmunu The Fmunu tensor, usually calculated from a smeared configuration
+     @param[out] qDensity The topological charge at each lattice site
+     @return double The total topological charge
+    */
+  double computeQChargeDensity(const GaugeField &Fmunu, void *result);
 }

--- a/include/gauge_tools.h
+++ b/include/gauge_tools.h
@@ -109,11 +109,11 @@ namespace quda {
    */
   double computeQCharge(const GaugeField &Fmunu);
 
-    /**
-     Compute the topological charge density per lattice site
-     @param[in] Fmunu The Fmunu tensor, usually calculated from a smeared configuration
-     @param[out] qDensity The topological charge at each lattice site
-     @return double The total topological charge
-    */
+  /**
+   Compute the topological charge density per lattice site
+   @param[in] Fmunu The Fmunu tensor, usually calculated from a smeared configuration
+   @param[out] qDensity The topological charge at each lattice site
+   @return double The total topological charge
+  */
   double computeQChargeDensity(const GaugeField &Fmunu, void *result);
 }

--- a/include/kernels/gauge_qcharge.cuh
+++ b/include/kernels/gauge_qcharge.cuh
@@ -12,7 +12,7 @@ namespace quda
   template <typename Float, typename Gauge> struct QChargeArg : public ReduceArg<double> {
     int threads; // number of active threads required
     Gauge data;
-
+    
     QChargeArg(const Gauge &data, const GaugeField &Fmunu) :
       ReduceArg<double>(),
       data(data),
@@ -20,7 +20,7 @@ namespace quda
     {
     }
   };
-
+  
   // Core routine for computing the topological charge from the field strength
   template <int blockSize, typename Float, typename Arg> __global__ void qChargeComputeKernel(Arg arg)
   {
@@ -28,7 +28,7 @@ namespace quda
     int parity = threadIdx.y;
 
     double Q = 0.0;
-
+    
     while (idx < arg.threads) {
       // Load the field-strength tensor from global memory
       Matrix<complex<Float>, 3> F[] = {arg.data(0, idx, parity), arg.data(1, idx, parity), arg.data(2, idx, parity),
@@ -42,7 +42,52 @@ namespace quda
       idx += blockDim.x * gridDim.x;
     }
     Q /= (Pi2 * Pi2);
-
+    
     reduce2d<blockSize, 2>(arg, Q);
   }
+
+
+  template <typename Float, typename Gauge> struct QChargeDensityArg : public ReduceArg<double> {
+    int threads; // number of active threads required
+    Gauge data;
+    Float *qDensity;
+    
+    QChargeDensityArg(const Gauge &data, const GaugeField &Fmunu, Float *qDensity) :
+      ReduceArg<double>(),
+      data(data),
+      threads(Fmunu.VolumeCB()),
+      qDensity(qDensity)
+    {
+    }
+  };
+  
+  // Core routine for computing the topological charge from the field strength
+  template <int blockSize, typename Float, typename Arg> __global__ void qChargeDensityComputeKernel(Arg arg)
+  {
+    int x_cb = threadIdx.x + blockIdx.x * blockDim.x;
+    int parity = threadIdx.y;
+
+    double Q = 0.0;
+    double Q_idx = 0.0;
+    int idx;
+    
+    while (x_cb < arg.threads) {
+      // Load the field-strength tensor from global memory
+      Matrix<complex<Float>, 3> F[] = {arg.data(0, x_cb, parity), arg.data(1, x_cb, parity), arg.data(2, x_cb, parity),
+                                       arg.data(3, x_cb, parity), arg.data(4, x_cb, parity), arg.data(5, x_cb, parity)};
+      
+      double Q1 = getTrace(F[0] * F[5]).real();
+      double Q2 = getTrace(F[1] * F[4]).real();
+      double Q3 = getTrace(F[3] * F[2]).real();
+      Q_idx = (Q1 + Q3 - Q2);
+      Q += Q_idx;
+      
+      idx = x_cb + parity*arg.threads;
+      reinterpret_cast<Float*>(arg.qDensity)[idx] = Q_idx/(Pi2 * Pi2);
+      x_cb += blockDim.x * gridDim.x;
+    }
+    Q /= (Pi2 * Pi2);
+    
+    reduce2d<blockSize, 2>(arg, Q);
+  }  
 } // namespace quda

--- a/include/kernels/gauge_qcharge.cuh
+++ b/include/kernels/gauge_qcharge.cuh
@@ -9,50 +9,13 @@
 namespace quda
 {
   
-  template <typename Float, typename Gauge> struct QChargeArg : public ReduceArg<double> {
-    int threads; // number of active threads required
-    Gauge data;
-    
-    QChargeArg(const Gauge &data, const GaugeField &Fmunu) :
-      ReduceArg<double>(),
-      data(data),
-      threads(Fmunu.VolumeCB())
-    {
-    }
-  };
-  
-  // Core routine for computing the topological charge from the field strength
-  template <int blockSize, typename Float, typename Arg> __global__ void qChargeComputeKernel(Arg arg)
-  {
-    int idx = threadIdx.x + blockIdx.x * blockDim.x;
-    int parity = threadIdx.y;
-
-    double Q = 0.0;
-    
-    while (idx < arg.threads) {
-      // Load the field-strength tensor from global memory
-      Matrix<complex<Float>, 3> F[] = {arg.data(0, idx, parity), arg.data(1, idx, parity), arg.data(2, idx, parity),
-                                       arg.data(3, idx, parity), arg.data(4, idx, parity), arg.data(5, idx, parity)};
-
-      double Q1 = getTrace(F[0] * F[5]).real();
-      double Q2 = getTrace(F[1] * F[4]).real();
-      double Q3 = getTrace(F[3] * F[2]).real();
-      Q += (Q1 + Q3 - Q2);
-
-      idx += blockDim.x * gridDim.x;
-    }
-    Q /= (Pi2 * Pi2);
-    
-    reduce2d<blockSize, 2>(arg, Q);
-  }
-
-
-  template <typename Float, typename Gauge> struct QChargeDensityArg : public ReduceArg<double> {
+  template <typename Float, typename Gauge, bool density_=false> struct QChargeArg : public ReduceArg<double> {
+    static constexpr bool density = density_;
     int threads; // number of active threads required
     Gauge data;
     Float *qDensity;
     
-    QChargeDensityArg(const Gauge &data, const GaugeField &Fmunu, Float *qDensity) :
+    QChargeArg(const Gauge &data, const GaugeField &Fmunu, Float *qDensity=nullptr) :
       ReduceArg<double>(),
       data(data),
       threads(Fmunu.VolumeCB()),
@@ -62,32 +25,33 @@ namespace quda
   };
   
   // Core routine for computing the topological charge from the field strength
-  template <int blockSize, typename Float, typename Arg> __global__ void qChargeDensityComputeKernel(Arg arg)
+  template <int blockSize, typename Float, typename Arg> __global__ void qChargeComputeKernel(Arg arg)
   {
     int x_cb = threadIdx.x + blockIdx.x * blockDim.x;
     int parity = threadIdx.y;
 
     double Q = 0.0;
-    double Q_idx = 0.0;
-    int idx;
     
     while (x_cb < arg.threads) {
       // Load the field-strength tensor from global memory
       Matrix<complex<Float>, 3> F[] = {arg.data(0, x_cb, parity), arg.data(1, x_cb, parity), arg.data(2, x_cb, parity),
                                        arg.data(3, x_cb, parity), arg.data(4, x_cb, parity), arg.data(5, x_cb, parity)};
-      
+
       double Q1 = getTrace(F[0] * F[5]).real();
       double Q2 = getTrace(F[1] * F[4]).real();
       double Q3 = getTrace(F[3] * F[2]).real();
-      Q_idx = (Q1 + Q3 - Q2);
+      double Q_idx = (Q1 + Q3 - Q2);
       Q += Q_idx;
       
-      idx = x_cb + parity*arg.threads;
-      reinterpret_cast<Float*>(arg.qDensity)[idx] = Q_idx/(Pi2 * Pi2);
+      if (Arg::density) {
+        int idx = x_cb + parity*arg.threads;
+        arg.qDensity[idx] = Q_idx/(Pi2 * Pi2);
+      }
       x_cb += blockDim.x * gridDim.x;
     }
     Q /= (Pi2 * Pi2);
     
     reduce2d<blockSize, 2>(arg, Q);
-  }  
+  }
+
 } // namespace quda

--- a/include/quda.h
+++ b/include/quda.h
@@ -1172,6 +1172,14 @@ extern "C" {
   double qChargeQuda();
 
   /**
+     @brief Calculates the topological charge from gaugeSmeared, if it exist, 
+     or from gaugePrecise if no smeared fields are present.
+     @param[in] arr_length Size in bytes of complex host array
+     @param[out] qDensity array holding Q charge density
+  */
+  double qChargeDensityQuda(const int arr_length, void *qDensity);
+  
+  /**
    * @brief Gauge fixing with overrelaxation with support for single and multi GPU.
    * @param[in,out] gauge, gauge field to be fixed
    * @param[in] gauge_dir, 3 for Coulomb gauge fixing, other for Landau gauge fixing

--- a/include/quda.h
+++ b/include/quda.h
@@ -1174,10 +1174,9 @@ extern "C" {
   /**
      @brief Calculates the topological charge from gaugeSmeared, if it exist,
      or from gaugePrecise if no smeared fields are present.
-     @param[in] arr_length Size in bytes of complex host array
      @param[out] qDensity array holding Q charge density
   */
-  double qChargeDensityQuda(const int arr_length, void *qDensity);
+  double qChargeDensityQuda(void *qDensity);
 
   /**
    * @brief Gauge fixing with overrelaxation with support for single and multi GPU.

--- a/include/quda.h
+++ b/include/quda.h
@@ -1172,13 +1172,13 @@ extern "C" {
   double qChargeQuda();
 
   /**
-     @brief Calculates the topological charge from gaugeSmeared, if it exist, 
+     @brief Calculates the topological charge from gaugeSmeared, if it exist,
      or from gaugePrecise if no smeared fields are present.
      @param[in] arr_length Size in bytes of complex host array
      @param[out] qDensity array holding Q charge density
   */
   double qChargeDensityQuda(const int arr_length, void *qDensity);
-  
+
   /**
    * @brief Gauge fixing with overrelaxation with support for single and multi GPU.
    * @param[in,out] gauge, gauge field to be fixed

--- a/lib/gauge_qcharge.cu
+++ b/lib/gauge_qcharge.cu
@@ -19,7 +19,7 @@ namespace quda
   private:
     bool tuneGridDim() const { return true; }
     unsigned int minThreads() const { return arg.threads; }
-    
+
   public:
     QChargeCompute(Arg &arg, const GaugeField &meta) : arg(arg), meta(meta)
     {
@@ -28,7 +28,7 @@ namespace quda
 #endif
     }
     virtual ~QChargeCompute() {}
-    
+
     void apply(const cudaStream_t &stream)
     {
       if (meta.Location() == QUDA_CUDA_FIELD_LOCATION) {
@@ -48,7 +48,7 @@ namespace quda
         errorQuda("qChargeComputeKernel not supported on CPU");
       }
     }
-    
+
     TuneKey tuneKey() const
     {
       std::stringstream aux;
@@ -57,53 +57,52 @@ namespace quda
     }
 
     long long flops() const { return 2 * arg.threads * (3 * 198 + 9); }
-    long long bytes() const { return 2 * arg.threads * (6 * 18) * sizeof(Float); }
+    long long bytes() const { return 2 * arg.threads * ((6 * 18) + Arg::density) * sizeof(Float); }
   }; // QChargeCompute
 
-  template <typename Float, typename Gauge> void computeQCharge(const Gauge data, const GaugeField &Fmunu, Float &qChg)
+  template <typename Float, typename Gauge, bool density> void computeQCharge(const Gauge data, const GaugeField &Fmunu, Float *qDensity, Float &qChg)
   {
-    QChargeArg<Float, Gauge> arg(data, Fmunu);
-    QChargeCompute<Float, QChargeArg<Float, Gauge>> qChargeCompute(arg, Fmunu);
+    QChargeArg<Float, Gauge, density> arg(data, Fmunu, qDensity);
+    QChargeCompute<Float, decltype(arg)> qChargeCompute(arg, Fmunu);
     qChargeCompute.apply(0);
     checkCudaError();
     comm_allreduce((double *)arg.result_h);
     qChg = arg.result_h[0];
   }
 
-  template <typename Float> Float computeQCharge(const GaugeField &Fmunu)
+  template <typename Float, bool density> Float computeQCharge(const GaugeField &Fmunu, Float *qDensity=nullptr)
   {
-
     Float qChg = 0.0;
 
     if (!Fmunu.isNative()) errorQuda("Topological charge computation only supported on native ordered fields");
 
     if (Fmunu.Reconstruct() == QUDA_RECONSTRUCT_NO) {
       typedef typename gauge_mapper<Float, QUDA_RECONSTRUCT_NO>::type Gauge;
-      computeQCharge<Float>(Gauge(Fmunu), Fmunu, qChg);
+      computeQCharge<Float,Gauge,density>(Gauge(Fmunu), Fmunu, qDensity, qChg);
     } else if (Fmunu.Reconstruct() == QUDA_RECONSTRUCT_12) {
       typedef typename gauge_mapper<Float, QUDA_RECONSTRUCT_12>::type Gauge;
-      computeQCharge<Float>(Gauge(Fmunu), Fmunu, qChg);
+      computeQCharge<Float,Gauge,density>(Gauge(Fmunu), Fmunu, qDensity, qChg);
     } else if (Fmunu.Reconstruct() == QUDA_RECONSTRUCT_8) {
       typedef typename gauge_mapper<Float, QUDA_RECONSTRUCT_8>::type Gauge;
-      computeQCharge<Float>(Gauge(Fmunu), Fmunu, qChg);
+      computeQCharge<Float,Gauge,density>(Gauge(Fmunu), Fmunu, qDensity, qChg);
     } else {
       errorQuda("Reconstruction type %d of gauge field not supported", Fmunu.Reconstruct());
-    }    
+    }
+
     return qChg;
   }
-#endif
+#endif // GPU_GAUGE_TOOLS
 
   double computeQCharge(const GaugeField &Fmunu)
-  {    
+  {
     double qChg = 0.0;
 #ifdef GPU_GAUGE_TOOLS
-    
     if (!Fmunu.isNative()) errorQuda("Order %d with %d reconstruct not supported", Fmunu.Order(), Fmunu.Reconstruct());
-    
+
     if (Fmunu.Precision() == QUDA_SINGLE_PRECISION) {
-      qChg = computeQCharge<float>(Fmunu);
+      qChg = computeQCharge<float,false>(Fmunu);
     } else if (Fmunu.Precision() == QUDA_DOUBLE_PRECISION) {
-      qChg = computeQCharge<double>(Fmunu);
+      qChg = computeQCharge<double,false>(Fmunu);
     } else {
       errorQuda("Precision %d not supported", Fmunu.Precision());
     }
@@ -111,106 +110,18 @@ namespace quda
     errorQuda("Gauge tools are not built");
 #endif // GPU_GAUGE_TOOLS
     return qChg;
-  }    
-  
-#ifdef GPU_GAUGE_TOOLS
-  
-  template <typename Float, typename Arg> class QChargeDensityCompute : TunableLocalParity
-  {
-    Arg &arg;
-    const GaugeField &meta;
-    Float *qDensity;
-    
-  private:
-    bool tuneGridDim() const { return true; }
-    unsigned int minThreads() const { return arg.threads; }
-    
-  public:
-    QChargeDensityCompute(Arg &arg, const GaugeField &meta, Float *qDensity) : arg(arg), meta(meta), qDensity(qDensity)
-    {
-#ifdef JITIFY
-      create_jitify_program("kernels/gauge_qcharge.cuh");
-#endif
-    }
-    virtual ~QChargeDensityCompute() {}
-    
-    void apply(const cudaStream_t &stream)
-    {
-      if (meta.Location() == QUDA_CUDA_FIELD_LOCATION) {
-        arg.result_h[0] = 0.;
-        TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
-#ifdef JITIFY
-        using namespace jitify::reflection;
-        jitify_error = program->kernel("quda::qChargeDensityComputeKernel")
-	  .instantiate((int)tp.block.x, Type<Float>(), Type<Arg>())
-	  .configure(tp.grid, tp.block, tp.shared_bytes, stream)
-	  .launch(arg);
-#else
-	LAUNCH_KERNEL(qChargeDensityComputeKernel, tp, stream, arg, Float);
-#endif
-        qudaDeviceSynchronize();
-      } else { // run the CPU code
-        errorQuda("qChargeDensityComputeKernel not supported on CPU");
-      }
-    }
-    
-    TuneKey tuneKey() const
-    {
-      std::stringstream aux;
-      aux << "threads=" << arg.threads << ",prec=" << sizeof(Float);
-      return TuneKey(meta.VolString(), typeid(*this).name(), aux.str().c_str());
-    }
-
-    long long flops() const { return 2 * arg.threads * (3 * 198 + 9); }
-    long long bytes() const { return 2 * arg.threads * (6 * 18) * sizeof(Float); }
-  }; // QChargeDensityCompute
-  
-  template <typename Float, typename Gauge> void computeQChargeDensity(const Gauge data, const GaugeField &Fmunu, Float *qDensity, Float &qChg)
-  {
-    QChargeDensityArg<Float, Gauge> arg(data, Fmunu, qDensity);
-    QChargeDensityCompute<Float, QChargeDensityArg<Float, Gauge>> qChargeDensityCompute(arg, Fmunu, qDensity);
-    qChargeDensityCompute.apply(0);
-    checkCudaError();
-    comm_allreduce((double *)arg.result_h);
-    qChg = arg.result_h[0];
   }
 
-  template <typename Float> Float computeQChargeDensity(const GaugeField &Fmunu, Float *qDensity)
-  {    
-    Float qChg = 0.0;
-
-    if (!Fmunu.isNative()) errorQuda("Topological charge computation only supported on native ordered fields");
-
-    if (Fmunu.Reconstruct() == QUDA_RECONSTRUCT_NO) {
-      typedef typename gauge_mapper<Float, QUDA_RECONSTRUCT_NO>::type Gauge;
-      computeQChargeDensity<Float>(Gauge(Fmunu), Fmunu, qDensity, qChg);
-    } else if (Fmunu.Reconstruct() == QUDA_RECONSTRUCT_12) {
-      typedef typename gauge_mapper<Float, QUDA_RECONSTRUCT_12>::type Gauge;
-      computeQChargeDensity<Float>(Gauge(Fmunu), Fmunu, qDensity, qChg);
-    } else if (Fmunu.Reconstruct() == QUDA_RECONSTRUCT_8) {
-      typedef typename gauge_mapper<Float, QUDA_RECONSTRUCT_8>::type Gauge;
-      computeQChargeDensity<Float>(Gauge(Fmunu), Fmunu, qDensity, qChg);
-    } else {
-      errorQuda("Reconstruction type %d of gauge field not supported", Fmunu.Reconstruct());
-    }
-
-    return qChg;
-  }
-#endif // GPU_GAUGE_TOOLS
-
-  
   double computeQChargeDensity(const GaugeField &Fmunu, void *qDensity)
   {
-    
     double qChg = 0.0;
 #ifdef GPU_GAUGE_TOOLS
-    
     if (!Fmunu.isNative()) errorQuda("Order %d with %d reconstruct not supported", Fmunu.Order(), Fmunu.Reconstruct());
-    
+
     if (Fmunu.Precision() == QUDA_SINGLE_PRECISION) {
-      qChg = computeQChargeDensity<float>(Fmunu, (float*)qDensity);
+      qChg = computeQCharge<float,true>(Fmunu, (float*)qDensity);
     } else if (Fmunu.Precision() == QUDA_DOUBLE_PRECISION) {
-      qChg = computeQChargeDensity<double>(Fmunu, (double*)qDensity);
+      qChg = computeQCharge<double,true>(Fmunu, (double*)qDensity);
     } else {
       errorQuda("Precision %d not supported", Fmunu.Precision());
     }

--- a/lib/gauge_qcharge.cu
+++ b/lib/gauge_qcharge.cu
@@ -16,17 +16,19 @@ namespace quda
     Arg &arg;
     const GaugeField &meta;
 
-private:
+  private:
     bool tuneGridDim() const { return true; }
     unsigned int minThreads() const { return arg.threads; }
-
-public:
-    QChargeCompute(Arg &arg, const GaugeField &meta) : arg(arg), meta(meta) {}
+    
+  public:
+    QChargeCompute(Arg &arg, const GaugeField &meta) : arg(arg), meta(meta)
+    {
 #ifdef JITIFY
-    create_jitify_program("kernels/gauge_qcharge.cuh");
+      create_jitify_program("kernels/gauge_qcharge.cuh");
 #endif
+    }
     virtual ~QChargeCompute() {}
-
+    
     void apply(const cudaStream_t &stream)
     {
       if (meta.Location() == QUDA_CUDA_FIELD_LOCATION) {
@@ -35,9 +37,9 @@ public:
 #ifdef JITIFY
         using namespace jitify::reflection;
         jitify_error = program->kernel("quda::qChargeComputeKernel")
-                         .instantiate(Type<Float>(), Type<Arg>())
-                         .configure(tp.grid, tp.block, tp.shared_bytes, stream)
-                         .launch(arg);
+	  .instantiate((int)tp.block.x, Type<Float>(), Type<Arg>())
+	  .configure(tp.grid, tp.block, tp.shared_bytes, stream)
+	  .launch(arg);
 #else
 	LAUNCH_KERNEL(qChargeComputeKernel, tp, stream, arg, Float);
 #endif
@@ -46,7 +48,7 @@ public:
         errorQuda("qChargeComputeKernel not supported on CPU");
       }
     }
-
+    
     TuneKey tuneKey() const
     {
       std::stringstream aux;
@@ -86,25 +88,129 @@ public:
       computeQCharge<Float>(Gauge(Fmunu), Fmunu, qChg);
     } else {
       errorQuda("Reconstruction type %d of gauge field not supported", Fmunu.Reconstruct());
-    }
-
+    }    
     return qChg;
   }
-
-#endif // GPU_GAUGE_TOOLS
+#endif
 
   double computeQCharge(const GaugeField &Fmunu)
-  {
-
+  {    
     double qChg = 0.0;
 #ifdef GPU_GAUGE_TOOLS
-
+    
     if (!Fmunu.isNative()) errorQuda("Order %d with %d reconstruct not supported", Fmunu.Order(), Fmunu.Reconstruct());
-
+    
     if (Fmunu.Precision() == QUDA_SINGLE_PRECISION) {
       qChg = computeQCharge<float>(Fmunu);
     } else if (Fmunu.Precision() == QUDA_DOUBLE_PRECISION) {
       qChg = computeQCharge<double>(Fmunu);
+    } else {
+      errorQuda("Precision %d not supported", Fmunu.Precision());
+    }
+#else
+    errorQuda("Gauge tools are not built");
+#endif // GPU_GAUGE_TOOLS
+    return qChg;
+  }    
+  
+#ifdef GPU_GAUGE_TOOLS
+  
+  template <typename Float, typename Arg> class QChargeDensityCompute : TunableLocalParity
+  {
+    Arg &arg;
+    const GaugeField &meta;
+    Float *qDensity;
+    
+  private:
+    bool tuneGridDim() const { return true; }
+    unsigned int minThreads() const { return arg.threads; }
+    
+  public:
+    QChargeDensityCompute(Arg &arg, const GaugeField &meta, Float *qDensity) : arg(arg), meta(meta), qDensity(qDensity)
+    {
+#ifdef JITIFY
+      create_jitify_program("kernels/gauge_qcharge.cuh");
+#endif
+    }
+    virtual ~QChargeDensityCompute() {}
+    
+    void apply(const cudaStream_t &stream)
+    {
+      if (meta.Location() == QUDA_CUDA_FIELD_LOCATION) {
+        arg.result_h[0] = 0.;
+        TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
+#ifdef JITIFY
+        using namespace jitify::reflection;
+        jitify_error = program->kernel("quda::qChargeDensityComputeKernel")
+	  .instantiate((int)tp.block.x, Type<Float>(), Type<Arg>())
+	  .configure(tp.grid, tp.block, tp.shared_bytes, stream)
+	  .launch(arg);
+#else
+	LAUNCH_KERNEL(qChargeDensityComputeKernel, tp, stream, arg, Float);
+#endif
+        qudaDeviceSynchronize();
+      } else { // run the CPU code
+        errorQuda("qChargeDensityComputeKernel not supported on CPU");
+      }
+    }
+    
+    TuneKey tuneKey() const
+    {
+      std::stringstream aux;
+      aux << "threads=" << arg.threads << ",prec=" << sizeof(Float);
+      return TuneKey(meta.VolString(), typeid(*this).name(), aux.str().c_str());
+    }
+
+    long long flops() const { return 2 * arg.threads * (3 * 198 + 9); }
+    long long bytes() const { return 2 * arg.threads * (6 * 18) * sizeof(Float); }
+  }; // QChargeDensityCompute
+  
+  template <typename Float, typename Gauge> void computeQChargeDensity(const Gauge data, const GaugeField &Fmunu, Float *qDensity, Float &qChg)
+  {
+    QChargeDensityArg<Float, Gauge> arg(data, Fmunu, qDensity);
+    QChargeDensityCompute<Float, QChargeDensityArg<Float, Gauge>> qChargeDensityCompute(arg, Fmunu, qDensity);
+    qChargeDensityCompute.apply(0);
+    checkCudaError();
+    comm_allreduce((double *)arg.result_h);
+    qChg = arg.result_h[0];
+  }
+
+  template <typename Float> Float computeQChargeDensity(const GaugeField &Fmunu, Float *qDensity)
+  {    
+    Float qChg = 0.0;
+
+    if (!Fmunu.isNative()) errorQuda("Topological charge computation only supported on native ordered fields");
+
+    if (Fmunu.Reconstruct() == QUDA_RECONSTRUCT_NO) {
+      typedef typename gauge_mapper<Float, QUDA_RECONSTRUCT_NO>::type Gauge;
+      computeQChargeDensity<Float>(Gauge(Fmunu), Fmunu, qDensity, qChg);
+    } else if (Fmunu.Reconstruct() == QUDA_RECONSTRUCT_12) {
+      typedef typename gauge_mapper<Float, QUDA_RECONSTRUCT_12>::type Gauge;
+      computeQChargeDensity<Float>(Gauge(Fmunu), Fmunu, qDensity, qChg);
+    } else if (Fmunu.Reconstruct() == QUDA_RECONSTRUCT_8) {
+      typedef typename gauge_mapper<Float, QUDA_RECONSTRUCT_8>::type Gauge;
+      computeQChargeDensity<Float>(Gauge(Fmunu), Fmunu, qDensity, qChg);
+    } else {
+      errorQuda("Reconstruction type %d of gauge field not supported", Fmunu.Reconstruct());
+    }
+
+    return qChg;
+  }
+#endif // GPU_GAUGE_TOOLS
+
+  
+  double computeQChargeDensity(const GaugeField &Fmunu, void *qDensity)
+  {
+    
+    double qChg = 0.0;
+#ifdef GPU_GAUGE_TOOLS
+    
+    if (!Fmunu.isNative()) errorQuda("Order %d with %d reconstruct not supported", Fmunu.Order(), Fmunu.Reconstruct());
+    
+    if (Fmunu.Precision() == QUDA_SINGLE_PRECISION) {
+      qChg = computeQChargeDensity<float>(Fmunu, (float*)qDensity);
+    } else if (Fmunu.Precision() == QUDA_DOUBLE_PRECISION) {
+      qChg = computeQChargeDensity<double>(Fmunu, (double*)qDensity);
     } else {
       errorQuda("Precision %d not supported", Fmunu.Precision());
     }

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -5881,7 +5881,7 @@ double qChargeQuda()
 
   computeFmunu(Fmunu, *gauge);
   double charge = quda::computeQCharge(Fmunu);
-  
+
   profileQCharge.TPSTOP(QUDA_PROFILE_COMPUTE);
   profileQCharge.TPSTOP(QUDA_PROFILE_TOTAL);
 
@@ -5901,7 +5901,7 @@ double qChargeDensityQuda(const int array_size, void *h_qDensity)
   }
   // Do we keep the smeared extended field on memory, or the unsmeared one?
   profileQCharge.TPSTART(QUDA_PROFILE_INIT);
-  // create the Fmunu field  
+  // create the Fmunu field
   GaugeFieldParam tensorParam(gaugePrecise->X(), gauge->Precision(), QUDA_RECONSTRUCT_NO, 0, QUDA_TENSOR_GEOMETRY);
   tensorParam.siteSubset = QUDA_FULL_SITE_SUBSET;
   tensorParam.order = QUDA_FLOAT2_GAUGE_ORDER;
@@ -5910,20 +5910,20 @@ double qChargeDensityQuda(const int array_size, void *h_qDensity)
 
   void *d_qDensity = device_malloc(array_size);
   profileQCharge.TPSTOP(QUDA_PROFILE_INIT);
-  
+
   profileQCharge.TPSTART(QUDA_PROFILE_COMPUTE);
-  computeFmunu(Fmunu, *gauge);  
+  computeFmunu(Fmunu, *gauge);
   double charge = quda::computeQChargeDensity(Fmunu, d_qDensity);
   profileQCharge.TPSTOP(QUDA_PROFILE_COMPUTE);
-  
+
   profileQCharge.TPSTART(QUDA_PROFILE_D2H);
   qudaMemcpy(h_qDensity, d_qDensity, array_size, cudaMemcpyDeviceToHost);
   profileQCharge.TPSTOP(QUDA_PROFILE_D2H);
 
   profileQCharge.TPSTART(QUDA_PROFILE_FREE);
-  device_free(d_qDensity);  
+  device_free(d_qDensity);
   profileQCharge.TPSTOP(QUDA_PROFILE_FREE);
-  
+
   profileQCharge.TPSTOP(QUDA_PROFILE_TOTAL);
 
   return charge;

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -5881,8 +5881,49 @@ double qChargeQuda()
 
   computeFmunu(Fmunu, *gauge);
   double charge = quda::computeQCharge(Fmunu);
-
+  
   profileQCharge.TPSTOP(QUDA_PROFILE_COMPUTE);
+  profileQCharge.TPSTOP(QUDA_PROFILE_TOTAL);
+
+  return charge;
+}
+
+double qChargeDensityQuda(const int array_size, void *h_qDensity)
+{
+  profileQCharge.TPSTART(QUDA_PROFILE_TOTAL);
+
+  cudaGaugeField *gauge = nullptr;
+  if (!gaugeSmeared) {
+    if (!extendedGaugeResident) extendedGaugeResident = createExtendedGauge(*gaugePrecise, R, profileQCharge);
+    gauge = extendedGaugeResident;
+  } else {
+    gauge = gaugeSmeared;
+  }
+  // Do we keep the smeared extended field on memory, or the unsmeared one?
+  profileQCharge.TPSTART(QUDA_PROFILE_INIT);
+  // create the Fmunu field  
+  GaugeFieldParam tensorParam(gaugePrecise->X(), gauge->Precision(), QUDA_RECONSTRUCT_NO, 0, QUDA_TENSOR_GEOMETRY);
+  tensorParam.siteSubset = QUDA_FULL_SITE_SUBSET;
+  tensorParam.order = QUDA_FLOAT2_GAUGE_ORDER;
+  tensorParam.ghostExchange = QUDA_GHOST_EXCHANGE_NO;
+  cudaGaugeField Fmunu(tensorParam);
+
+  void *d_qDensity = device_malloc(array_size);
+  profileQCharge.TPSTOP(QUDA_PROFILE_INIT);
+  
+  profileQCharge.TPSTART(QUDA_PROFILE_COMPUTE);
+  computeFmunu(Fmunu, *gauge);  
+  double charge = quda::computeQChargeDensity(Fmunu, d_qDensity);
+  profileQCharge.TPSTOP(QUDA_PROFILE_COMPUTE);
+  
+  profileQCharge.TPSTART(QUDA_PROFILE_D2H);
+  qudaMemcpy(h_qDensity, d_qDensity, array_size, cudaMemcpyDeviceToHost);
+  profileQCharge.TPSTOP(QUDA_PROFILE_D2H);
+
+  profileQCharge.TPSTART(QUDA_PROFILE_FREE);
+  device_free(d_qDensity);  
+  profileQCharge.TPSTOP(QUDA_PROFILE_FREE);
+  
   profileQCharge.TPSTOP(QUDA_PROFILE_TOTAL);
 
   return charge;

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -5888,7 +5888,7 @@ double qChargeQuda()
   return charge;
 }
 
-double qChargeDensityQuda(const int array_size, void *h_qDensity)
+double qChargeDensityQuda(void *h_qDensity)
 {
   profileQCharge.TPSTART(QUDA_PROFILE_TOTAL);
 
@@ -5908,7 +5908,8 @@ double qChargeDensityQuda(const int array_size, void *h_qDensity)
   tensorParam.ghostExchange = QUDA_GHOST_EXCHANGE_NO;
   cudaGaugeField Fmunu(tensorParam);
 
-  void *d_qDensity = device_malloc(array_size);
+  size_t size = Fmunu.Volume() * Fmunu.Precision();
+  void *d_qDensity = device_malloc(size);
   profileQCharge.TPSTOP(QUDA_PROFILE_INIT);
 
   profileQCharge.TPSTART(QUDA_PROFILE_COMPUTE);
@@ -5917,7 +5918,7 @@ double qChargeDensityQuda(const int array_size, void *h_qDensity)
   profileQCharge.TPSTOP(QUDA_PROFILE_COMPUTE);
 
   profileQCharge.TPSTART(QUDA_PROFILE_D2H);
-  qudaMemcpy(h_qDensity, d_qDensity, array_size, cudaMemcpyDeviceToHost);
+  qudaMemcpy(h_qDensity, d_qDensity, size, cudaMemcpyDeviceToHost);
   profileQCharge.TPSTOP(QUDA_PROFILE_D2H);
 
   profileQCharge.TPSTART(QUDA_PROFILE_FREE);

--- a/tests/su3_test.cpp
+++ b/tests/su3_test.cpp
@@ -140,7 +140,7 @@ void SU3test(int argc, char **argv) {
   printfQuda("Computed plaquette gauge precise is %e (spatial = %e, temporal = %e)\n", plaq[0], plaq[1], plaq[2]);
 
 #ifdef GPU_GAUGE_TOOLS
-  
+
   // Topological charge
   double qCharge = 0.0, qChargeCheck = 0.0;
   // start the timer
@@ -150,23 +150,24 @@ void SU3test(int argc, char **argv) {
   time0 += clock();
   time0 /= CLOCKS_PER_SEC;
   printfQuda("Computed topological charge gauge precise is %.16e Done in %g secs\n", qCharge, time0);
-  
-  //Size of floating point data
+
+  // Size of floating point data
   size_t sSize = prec == QUDA_DOUBLE_PRECISION ? sizeof(double) : sizeof(float);
-  int array_size = V*sSize;  
-  //Void array passed to the GPU. QUDA will allocate GPU memory and pass back a populated host array.
+  int array_size = V * sSize;
+  // Void array passed to the GPU. QUDA will allocate GPU memory and pass back a populated host array.
   void *qDensity = malloc(array_size);
   qCharge = qChargeDensityQuda(array_size, qDensity);
-  
+
   // Ensure host array sums to return value
   if (prec == QUDA_DOUBLE_PRECISION) {
-    for (int i=0; i<V; i++) qChargeCheck += ((double*)qDensity)[i];
+    for (int i = 0; i < V; i++) qChargeCheck += ((double *)qDensity)[i];
   } else {
-    for (int i=0; i<V; i++) qChargeCheck += ((float*)qDensity)[i];
+    for (int i = 0; i < V; i++) qChargeCheck += ((float *)qDensity)[i];
   }
   printfQuda("Computed topological charge gauge precise from density function is %.16e\n", qCharge);
-  printfQuda("GPU value %e and host density sum %e. Q charge deviation: %e\n", qCharge, qChargeCheck, qCharge - qChargeCheck); 
-  
+  printfQuda("GPU value %e and host density sum %e. Q charge deviation: %e\n", qCharge, qChargeCheck,
+             qCharge - qChargeCheck);
+
   // Stout smearing should be equivalent to APE smearing
   // on D dimensional lattices for rho = alpha/2*(D-1). 
   // Typical APE values are aplha=0.6, rho=0.1 for Stout.

--- a/tests/su3_test.cpp
+++ b/tests/su3_test.cpp
@@ -140,8 +140,9 @@ void SU3test(int argc, char **argv) {
   printfQuda("Computed plaquette gauge precise is %e (spatial = %e, temporal = %e)\n", plaq[0], plaq[1], plaq[2]);
 
 #ifdef GPU_GAUGE_TOOLS
+  
   // Topological charge
-  double qCharge;
+  double qCharge = 0.0, qChargeCheck = 0.0;
   // start the timer
   double time0 = -((double)clock());
   qCharge = qChargeQuda();
@@ -149,7 +150,23 @@ void SU3test(int argc, char **argv) {
   time0 += clock();
   time0 /= CLOCKS_PER_SEC;
   printfQuda("Computed topological charge gauge precise is %.16e Done in %g secs\n", qCharge, time0);
-
+  
+  //Size of floating point data
+  size_t sSize = prec == QUDA_DOUBLE_PRECISION ? sizeof(double) : sizeof(float);
+  int array_size = V*sSize;  
+  //Void array passed to the GPU. QUDA will allocate GPU memory and pass back a populated host array.
+  void *qDensity = malloc(array_size);
+  qCharge = qChargeDensityQuda(array_size, qDensity);
+  
+  // Ensure host array sums to return value
+  if (prec == QUDA_DOUBLE_PRECISION) {
+    for (int i=0; i<V; i++) qChargeCheck += ((double*)qDensity)[i];
+  } else {
+    for (int i=0; i<V; i++) qChargeCheck += ((float*)qDensity)[i];
+  }
+  printfQuda("Computed topological charge gauge precise from density function is %.16e\n", qCharge);
+  printfQuda("GPU value %e and host density sum %e. Q charge deviation: %e\n", qCharge, qChargeCheck, qCharge - qChargeCheck); 
+  
   // Stout smearing should be equivalent to APE smearing
   // on D dimensional lattices for rho = alpha/2*(D-1). 
   // Typical APE values are aplha=0.6, rho=0.1 for Stout.

--- a/tests/su3_test.cpp
+++ b/tests/su3_test.cpp
@@ -153,10 +153,10 @@ void SU3test(int argc, char **argv) {
 
   // Size of floating point data
   size_t sSize = prec == QUDA_DOUBLE_PRECISION ? sizeof(double) : sizeof(float);
-  int array_size = V * sSize;
+  size_t array_size = V * sSize;
   // Void array passed to the GPU. QUDA will allocate GPU memory and pass back a populated host array.
   void *qDensity = malloc(array_size);
-  qCharge = qChargeDensityQuda(array_size, qDensity);
+  qCharge = qChargeDensityQuda(qDensity);
 
   // Ensure host array sums to return value
   if (prec == QUDA_DOUBLE_PRECISION) {


### PR DESCRIPTION
This PR adds some functionality to the topological charge routines. One can now pass an array to the function, and QUDA passes back the individual q(x)/(4xPixPi) values in Even/Odd order. Useful for \eta prime calculations.