### PR TITLE
Block ortho optimization

### DIFF
--- a/include/kernels/block_orthogonalize.cuh
+++ b/include/kernels/block_orthogonalize.cuh
@@ -55,23 +55,20 @@ namespace quda {
     }
   };
 
-  template <int nColor, typename sumType, typename real, typename Arg>
-  inline __device__ __host__ void colorInnerProduct(
-      complex<sumType> &dot, int i, complex<real> v[nColor], int parity, int x_cb, int s, const Arg &arg)
+  template <int nColor, typename sumType, typename real>
+  inline __device__ __host__ void colorInnerProduct(complex<sumType> &dot, int i, complex<real> v[nColor], complex<real> w[nColor])
   {
 #pragma unroll
     for (int c = 0; c < nColor; c++) {
-      complex<real> a = arg.V(parity, x_cb, s, c, i);
-      dot.x += a.real() * v[c].real();
-      dot.x += a.imag() * v[c].imag();
-      dot.y += a.real() * v[c].imag();
-      dot.y -= a.imag() * v[c].real();
+      dot.x += w[c].real() * v[c].real();
+      dot.x += w[c].imag() * v[c].imag();
+      dot.y += w[c].real() * v[c].imag();
+      dot.y -= w[c].imag() * v[c].real();
     }
   }
 
-  template <int nColor, typename sumType, typename real, typename Arg>
-  inline __device__ __host__ void colorNorm(
-      sumType &nrm, complex<real> v[nColor], int parity, int x_cb, int s, const Arg &arg)
+  template <int nColor, typename sumType, typename real>
+  inline __device__ __host__ void colorNorm(sumType &nrm, complex<real> v[nColor])
   {
 #pragma unroll
     for (int c = 0; c < nColor; c++) {
@@ -80,20 +77,21 @@ namespace quda {
     }
   }
 
-  template<typename real, int nColor, typename Arg>
-  inline __device__ __host__ void colorScaleSubtract(complex<real> v[nColor], complex<real> a, int i, int parity, int x_cb, int s, const Arg &arg) {
+  template<typename real, int nColor>
+  inline __device__ __host__ void colorScaleSubtract(complex<real> v[nColor], complex<real> a, complex<real> w[nColor])
+  {
 #pragma unroll
     for (int c = 0; c < nColor; c++) {
-      complex<real> b = arg.V(parity, x_cb, s, c, i);
-      v[c].x -= a.real() * b.real();
-      v[c].x += a.imag() * b.imag();
-      v[c].y -= a.real() * b.imag();
-      v[c].y -= a.imag() * b.real();
+      v[c].x -= a.real() * w[c].real();
+      v[c].x += a.imag() * w[c].imag();
+      v[c].y -= a.real() * w[c].imag();
+      v[c].y -= a.imag() * w[c].real();
     }
   }
 
-  template<typename real, int nColor, typename Arg>
-  inline __device__ __host__ void colorScale(complex<real> v[nColor], real a, int parity, int x_cb, int s, const Arg &arg) {
+  template<typename real, int nColor>
+  inline __device__ __host__ void colorScale(complex<real> v[nColor], real a)
+  {
 #pragma unroll
     for (int c=0; c<nColor; c++) v[c] *= a;
   }
@@ -111,7 +109,8 @@ namespace quda {
 	for (int i=0; i<j; i++) {
 
 	  // compute (j,i) block inner products
-	  complex<sumFloat> dot[coarseSpin];
+
+        complex<sumFloat> dot[coarseSpin];
 	  for (int s=0; s<coarseSpin; s++) dot[s] = 0.0;
 	  for (int parity=0; parity<arg.nParity; parity++) {
 	    parity = (arg.nParity == 2) ? parity : arg.parity;
@@ -125,7 +124,9 @@ namespace quda {
 	      for (int s=0; s<nSpin; s++) for (int c=0; c<nColor; c++) v[s][c] = arg.B[j](parity, x_cb, s, c);
 
 	      for (int s=0; s<nSpin; s++) {
-                colorInnerProduct<nColor>(dot[arg.spin_map(s, parity)], i, v[s], parity, x_cb, s, arg);
+                complex<Float> vis[nColor];
+                for (int c=0; c<nColor; c++) vis[c] = arg.V(parity, x_cb, s, c, i);
+                colorInnerProduct<nColor>(dot[arg.spin_map(s, parity)], i, v[s], vis);
               }
 	    }
 	  }
@@ -144,7 +145,9 @@ namespace quda {
 	      else for (int s=0; s<nSpin; s++) for (int c=0; c<nColor; c++) v[s][c] = arg.V(parity, x_cb, s, c, j);
 
 	      for (int s=0; s<nSpin; s++) {
-		colorScaleSubtract<Float,nColor,Arg>(v[s], static_cast<complex<Float> >(dot[arg.spin_map(s,parity)]), i, parity, x_cb, s, arg);
+                complex<Float> vis[nColor];
+                for (int c=0; c<nColor; c++) vis[c] = arg.V(parity, x_cb, s, c, i);
+		colorScaleSubtract<Float,nColor>(v[s], static_cast<complex<Float> >(dot[arg.spin_map(s,parity)]), vis);
 	      }
 
 	      for (int s=0; s<nSpin; s++) for (int c=0; c<nColor; c++) arg.V(parity, x_cb, s, c, j) = v[s][c];
@@ -167,7 +170,7 @@ namespace quda {
 	    else for (int s=0; s<nSpin; s++) for (int c=0; c<nColor; c++) v[s][c] = arg.V(parity, x_cb, s, c, j);
 
 	    for (int s=0; s<nSpin; s++) {
-              colorNorm<nColor>(nrm[arg.spin_map(s, parity)], v[s], parity, x_cb, s, arg);
+              colorNorm<nColor>(nrm[arg.spin_map(s, parity)], v[s]);
             }
 	  }
 	}
@@ -187,7 +190,7 @@ namespace quda {
 	    else for (int s=0; s<nSpin; s++) for (int c=0; c<nColor; c++) v[s][c] = arg.V(parity, x_cb, s, c, j);
 
 	    for (int s=0; s<nSpin; s++) {
-	      colorScale<Float,nColor,Arg>(v[s], nrm[arg.spin_map(s,parity)], parity, x_cb, s, arg);
+	      colorScale<Float,nColor>(v[s], nrm[arg.spin_map(s,parity)]);
 	    }
 
 	    for (int s=0; s<nSpin; s++) for (int c=0; c<nColor; c++) arg.V(parity, x_cb, s, c, j) = v[s][c];
@@ -224,16 +227,16 @@ namespace quda {
     int x = arg.coarse_to_fine[ (x_coarse*2 + parity) * blockDim.x + threadIdx.x];
     int x_cb = x - parity*arg.fineVolumeCB;
     if (x_cb >= arg.fineVolumeCB) return;
+    int chirality = blockIdx.z; // which chiral block we're working on (if chirality is present)
 
-    typedef vector_type<complex<sumFloat>,coarseSpin> cvector;
-    typedef vector_type<sumFloat,coarseSpin> rvector;
-    typedef cub::BlockReduce<cvector, block_size, cub::BLOCK_REDUCE_WARP_REDUCTIONS, 2> dotReduce;
-    typedef cub::BlockReduce<rvector, block_size, cub::BLOCK_REDUCE_WARP_REDUCTIONS, 2> normReduce;
+    constexpr int spinBlock = nSpin / coarseSpin; // size of spin block
+    typedef cub::BlockReduce<complex<sumFloat>, block_size, cub::BLOCK_REDUCE_WARP_REDUCTIONS, 2> dotReduce;
+    typedef cub::BlockReduce<sumFloat, block_size, cub::BLOCK_REDUCE_WARP_REDUCTIONS, 2> normReduce;
 
     __shared__ typename dotReduce::TempStorage dot_storage;
     typename normReduce::TempStorage *norm_storage = (typename normReduce::TempStorage*)&dot_storage;
-    cvector *dot_ = (cvector*)&dot_storage;
-    rvector *nrm_ = (rvector*)&dot_storage;
+    complex<sumFloat> *dot_ = (complex<sumFloat>*)&dot_storage;
+    sumFloat *nrm_ = (sumFloat*)&dot_storage;
 
     // cast the constant memory buffer to a Vector array
     typedef typename std::remove_reference<decltype(*arg.B)>::type Vector;
@@ -241,22 +244,26 @@ namespace quda {
 
     for (int j=0; j<nVec; j++) {
 
-      complex<Float> v[nSpin][nColor];
+      complex<Float> v[spinBlock][nColor];
 #pragma unroll
-      for (int s=0; s<nSpin; s++)
+      for (int s=0; s<spinBlock; s++)
 #pragma unroll
-	for (int c=0; c<nColor; c++) v[s][c] = B[j](parity, x_cb, s, c);
+	for (int c=0; c<nColor; c++) v[s][c] = B[j](parity, x_cb, chirality * spinBlock + s, c);
 
       for (int i=0; i<j; i++) {
 
-	cvector dot;
-#pragma unroll
-	for (int s=0; s<coarseSpin; s++) dot[s] = 0.0;
+	complex<Float> dot = 0.0;
 
 	// compute (j,i) block inner products
+        complex<Float> vi[spinBlock][nColor];
 #pragma unroll
-	for (int s=0; s<nSpin; s++) {
-          colorInnerProduct<nColor>(dot[arg.spin_map(s, parity)], i, v[s], parity, x_cb, s, arg);
+        for (int s=0; s<spinBlock; s++)
+#pragma unroll
+          for (int c=0; c<nColor; c++) vi[s][c] = arg.V(parity, x_cb, chirality * spinBlock + s, c, i);
+
+#pragma unroll
+	for (int s=0; s<spinBlock; s++) {
+          colorInnerProduct<nColor>(dot, i, v[s], vi[s]);
         }
 
 	__syncthreads();
@@ -267,19 +274,17 @@ namespace quda {
 
 	// subtract the blocks to orthogonalise
 #pragma unroll
-	for (int s=0; s<nSpin; s++) {
-	  colorScaleSubtract<Float,nColor,Arg>(v[s], static_cast<complex<Float> >(dot[arg.spin_map(s,parity)]), i, parity, x_cb, s, arg);
+	for (int s=0; s<spinBlock; s++) {
+	  colorScaleSubtract<Float,nColor>(v[s], dot, vi[s]);
 	}
 
       } // i
 
       // normalize the block
-      rvector nrm;
-#pragma unroll
-      for (int s=0; s<coarseSpin; s++) nrm[s] = static_cast<sumFloat>(0.0);
+      sumFloat nrm = static_cast<sumFloat>(0.0);
 
 #pragma unroll
-      for (int s = 0; s < nSpin; s++) { colorNorm<nColor>(nrm[arg.spin_map(s, parity)], v[s], parity, x_cb, s, arg); }
+      for (int s = 0; s < spinBlock; s++) { colorNorm<nColor>(nrm, v[s]); }
 
       __syncthreads();
       nrm = normReduce(*norm_storage).Sum(nrm);
@@ -287,18 +292,17 @@ namespace quda {
       __syncthreads();
       nrm = *nrm_;
 
-#pragma unroll
-      for (int s=0; s<coarseSpin; s++) nrm[s] = nrm[s] > 0.0 ? rsqrt(nrm[s]) : 0.0;
+      nrm = nrm > 0.0 ? rsqrt(nrm) : 0.0;
 
 #pragma unroll
-      for (int s=0; s<nSpin; s++) {
-	colorScale<Float,nColor,Arg>(v[s], nrm[arg.spin_map(s,parity)], parity, x_cb, s, arg);
+      for (int s=0; s<spinBlock; s++) {
+	colorScale<Float,nColor>(v[s], nrm);
       }
 
 #pragma unroll
-      for (int s=0; s<nSpin; s++)
+      for (int s=0; s<spinBlock; s++)
 #pragma unroll
-	for (int c=0; c<nColor; c++) arg.V(parity, x_cb, s, c, j) = v[s][c];
+	for (int c=0; c<nColor; c++) arg.V(parity, x_cb, chirality * spinBlock + s, c, j) = v[s][c];
 
     } // j
 

--- a/lib/block_orthogonalize.cu
+++ b/lib/block_orthogonalize.cu
@@ -170,7 +170,7 @@ namespace quda {
     /** sets default values for when tuning is disabled */
     void defaultTuneParam(TuneParam &param) const {
       param.block = dim3(geoBlockSize/2, V.SiteSubset(), 1);
-      param.grid = dim3( (minThreads()+param.block.x-1) / param.block.x, 1, 1);
+      param.grid = dim3( (minThreads()+param.block.x-1) / param.block.x, 1, coarseSpin);
       param.shared_bytes = 0;
       param.aux.x = 1; // swizzle factor
     }


### PR DESCRIPTION
Split the chiral blocks onto different thread blocks to reduce register pressure, improve locality and parallelization of the block orthogonalization.

@weinbe2 This no longer uses the parity in determining the spin partitioning, but I don't think you use that any more in the staggered MG, is that correct?