### PR TITLE
Feature/multi blas fast compile

### DIFF
--- a/include/kernels/multi_blas_core.cuh
+++ b/include/kernels/multi_blas_core.cuh
@@ -22,7 +22,12 @@ namespace quda
     static signed char *Bmatrix_h;
     static signed char *Cmatrix_h;
 
+#if CUDA_VERSION < 9000
+    // as a performance work around we put the argument struct into
+    // __constant__ memory to prevent the compiler from spilling
+    // registers on older CUDA
     static __constant__ signed char arg_buffer[MAX_MATRIX_SIZE];
+#endif
 
     /**
        @brief Parameter struct for generic multi-blas kernel.

--- a/include/kernels/multi_blas_core.cuh
+++ b/include/kernels/multi_blas_core.cuh
@@ -22,6 +22,8 @@ namespace quda
     static signed char *Bmatrix_h;
     static signed char *Cmatrix_h;
 
+    static __constant__ signed char arg_buffer[MAX_MATRIX_SIZE];
+
     /**
        @brief Parameter struct for generic multi-blas kernel.
        @tparam NXZ is dimension of input vectors: X,Z
@@ -58,9 +60,26 @@ namespace quda
       }
     };
 
-    template <int k, int NXZ, typename FloatN, int M, typename Arg>
-    __device__ inline void compute(Arg &arg, int idx, int parity)
+    /**
+       @brief Generic multi-blas kernel with four loads and up to four stores.
+       @param[in,out] arg Argument struct with required meta data
+       (input/output fields, functor, etc.)
+    */
+    template <typename FloatN, int M, int NXZ, typename Arg> __global__ void multiBlasKernel(Arg arg_)
     {
+#if CUDA_VERSION >= 9000
+      Arg &arg = arg_;
+#else
+      Arg &arg = *((Arg*)arg_buffer);
+#endif
+
+      // use i to loop over elements in kernel
+      unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
+      unsigned int k = blockIdx.y * blockDim.y + threadIdx.y;
+      unsigned int parity = blockIdx.z;
+
+      arg.f.init();
+      if (k >= arg.NYW) return;
 
       while (idx < arg.length) {
 
@@ -80,72 +99,6 @@ namespace quda
         arg.W[k].save(w, idx, parity);
 
         idx += gridDim.x * blockDim.x;
-      }
-    }
-
-    /**
-       @brief Generic multi-blas kernel with four loads and up to four stores.
-       @param[in,out] arg Argument struct with required meta data
-       (input/output fields, functor, etc.)
-    */
-    template <typename FloatN, int M, int NXZ, typename Arg> __global__ void multiBlasKernel(Arg arg)
-    {
-
-      // use i to loop over elements in kernel
-      unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
-      unsigned int k = blockIdx.y * blockDim.y + threadIdx.y;
-      unsigned int parity = blockIdx.z;
-
-      arg.f.init();
-      if (k >= arg.NYW) return;
-
-      switch (k) {
-      case 0: compute<0, NXZ, FloatN, M>(arg, i, parity); break;
-#if MAX_MULTI_BLAS_N >= 2
-      case 1: compute<1, NXZ, FloatN, M>(arg, i, parity); break;
-#if MAX_MULTI_BLAS_N >= 3
-      case 2: compute<2, NXZ, FloatN, M>(arg, i, parity); break;
-#if MAX_MULTI_BLAS_N >= 4
-      case 3: compute<3, NXZ, FloatN, M>(arg, i, parity); break;
-#if MAX_MULTI_BLAS_N >= 5
-      case 4: compute<4, NXZ, FloatN, M>(arg, i, parity); break;
-#if MAX_MULTI_BLAS_N >= 6
-      case 5: compute<5, NXZ, FloatN, M>(arg, i, parity); break;
-#if MAX_MULTI_BLAS_N >= 7
-      case 6: compute<6, NXZ, FloatN, M>(arg, i, parity); break;
-#if MAX_MULTI_BLAS_N >= 8
-      case 7: compute<7, NXZ, FloatN, M>(arg, i, parity); break;
-#if MAX_MULTI_BLAS_N >= 9
-      case 8: compute<8, NXZ, FloatN, M>(arg, i, parity); break;
-#if MAX_MULTI_BLAS_N >= 10
-      case 9: compute<9, NXZ, FloatN, M>(arg, i, parity); break;
-#if MAX_MULTI_BLAS_N >= 11
-      case 10: compute<10, NXZ, FloatN, M>(arg, i, parity); break;
-#if MAX_MULTI_BLAS_N >= 12
-      case 11: compute<11, NXZ, FloatN, M>(arg, i, parity); break;
-#if MAX_MULTI_BLAS_N >= 13
-      case 12: compute<12, NXZ, FloatN, M>(arg, i, parity); break;
-#if MAX_MULTI_BLAS_N >= 14
-      case 13: compute<13, NXZ, FloatN, M>(arg, i, parity); break;
-#if MAX_MULTI_BLAS_N >= 15
-      case 14: compute<14, NXZ, FloatN, M>(arg, i, parity); break;
-#if MAX_MULTI_BLAS_N >= 16
-      case 15: compute<15, NXZ, FloatN, M>(arg, i, parity); break;
-#endif // 16
-#endif // 15
-#endif // 14
-#endif // 13
-#endif // 12
-#endif // 11
-#endif // 10
-#endif // 9
-#endif // 8
-#endif // 7
-#endif // 6
-#endif // 5
-#endif // 4
-#endif // 3
-#endif // 2
       }
     }
 

--- a/include/kernels/multi_reduce_core.cuh
+++ b/include/kernels/multi_reduce_core.cuh
@@ -25,7 +25,12 @@ namespace quda
     static signed char *Bmatrix_h;
     static signed char *Cmatrix_h;
 
+#if CUDA_VERSION < 9000
+    // as a performance work around we put the argument struct into
+    // __constant__ memory to prevent the compiler from spilling
+    // registers on older CUDA
     static __constant__ signed char arg_buffer[MAX_MATRIX_SIZE];
+#endif
 
     /**
        @brief Parameter struct for generic multi-blas kernel.

--- a/include/kernels/multi_reduce_core.cuh
+++ b/include/kernels/multi_reduce_core.cuh
@@ -25,6 +25,8 @@ namespace quda
     static signed char *Bmatrix_h;
     static signed char *Cmatrix_h;
 
+    static __constant__ signed char arg_buffer[MAX_MATRIX_SIZE];
+
     /**
        @brief Parameter struct for generic multi-blas kernel.
        @tparam NXZ is dimension of input vectors: X,Z,V
@@ -64,23 +66,32 @@ namespace quda
       }
     };
 
-    // 'sum' should be an array of length NXZ...?
-    template <int k, int NXZ, typename FloatN, int M, typename ReduceType, typename Arg>
-    __device__ inline void compute(vector_type<ReduceType, NXZ> &sum, Arg &arg, int idx, int parity)
+#ifdef WARP_MULTI_REDUCE
+    template <typename ReduceType, typename FloatN, int M, int NXZ, typename Arg>
+#else
+    template <int block_size, typename ReduceType, typename FloatN, int M, int NXZ, typename Arg>
+#endif
+    __global__ void multiReduceKernel(Arg arg_)
     {
+#if CUDA_VERSION >= 9000
+      Arg &arg = arg_;
+#else
+      Arg &arg = *((Arg*)arg_buffer);
+#endif
+      unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
+      unsigned int k = blockIdx.y * blockDim.y + threadIdx.y;
+      unsigned int parity = blockIdx.z;
 
-      constexpr int kmod = k;
-      // there's an old warning about silencing an out-of-bounds compiler warning,
-      // but I never seem to get it, and I'd need to compare against NYW anyway,
-      // which we can't really get at here b/c it's not a const, and I don't want
-      // to fix that. It works fine based on the switch in the function below.
+      if (k >= arg.NYW) return; // safe since k are different thread blocks
+
+      vector_type<ReduceType, NXZ> sum;
 
       while (idx < arg.length) {
 
         FloatN x[M], y[M], z[M], w[M];
 
-        arg.Y[kmod].load(y, idx, parity);
-        arg.W[kmod].load(w, idx, parity);
+        arg.Y[k].load(y, idx, parity);
+        arg.W[k].load(w, idx, parity);
 
         // Each NYW owns its own thread.
         // The NXZ's are all in the same thread block,
@@ -98,75 +109,10 @@ namespace quda
           arg.r.post(sum[l]);
         }
 
-        arg.Y[kmod].save(y, idx, parity);
-        arg.W[kmod].save(w, idx, parity);
+        arg.Y[k].save(y, idx, parity);
+        arg.W[k].save(w, idx, parity);
 
         idx += gridDim.x * blockDim.x;
-      }
-    }
-
-#ifdef WARP_MULTI_REDUCE
-    template <typename ReduceType, typename FloatN, int M, int NXZ, typename Arg>
-#else
-    template <int block_size, typename ReduceType, typename FloatN, int M, int NXZ, typename Arg>
-#endif
-    __global__ void multiReduceKernel(Arg arg)
-    {
-      unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
-      unsigned int k = blockIdx.y * blockDim.y + threadIdx.y;
-      unsigned int parity = blockIdx.z;
-
-      if (k >= arg.NYW) return; // safe since k are different thread blocks
-
-      vector_type<ReduceType, NXZ> sum;
-
-      switch (k) {
-      case 0: compute<0, NXZ, FloatN, M, ReduceType>(sum, arg, i, parity); break;
-#if MAX_MULTI_BLAS_N >= 2
-      case 1: compute<1, NXZ, FloatN, M, ReduceType>(sum, arg, i, parity); break;
-#if MAX_MULTI_BLAS_N >= 3
-      case 2: compute<2, NXZ, FloatN, M, ReduceType>(sum, arg, i, parity); break;
-#if MAX_MULTI_BLAS_N >= 4
-      case 3: compute<3, NXZ, FloatN, M, ReduceType>(sum, arg, i, parity); break;
-#if MAX_MULTI_BLAS_N >= 5
-      case 4: compute<4, NXZ, FloatN, M, ReduceType>(sum, arg, i, parity); break;
-#if MAX_MULTI_BLAS_N >= 6
-      case 5: compute<5, NXZ, FloatN, M, ReduceType>(sum, arg, i, parity); break;
-#if MAX_MULTI_BLAS_N >= 7
-      case 6: compute<6, NXZ, FloatN, M, ReduceType>(sum, arg, i, parity); break;
-#if MAX_MULTI_BLAS_N >= 8
-      case 7: compute<7, NXZ, FloatN, M, ReduceType>(sum, arg, i, parity); break;
-#if MAX_MULTI_BLAS_N >= 9
-      case 8: compute<8, NXZ, FloatN, M, ReduceType>(sum, arg, i, parity); break;
-#if MAX_MULTI_BLAS_N >= 10
-      case 9: compute<9, NXZ, FloatN, M, ReduceType>(sum, arg, i, parity); break;
-#if MAX_MULTI_BLAS_N >= 11
-      case 10: compute<10, NXZ, FloatN, M, ReduceType>(sum, arg, i, parity); break;
-#if MAX_MULTI_BLAS_N >= 12
-      case 11: compute<11, NXZ, FloatN, M, ReduceType>(sum, arg, i, parity); break;
-#if MAX_MULTI_BLAS_N >= 13
-      case 12: compute<12, NXZ, FloatN, M, ReduceType>(sum, arg, i, parity); break;
-#if MAX_MULTI_BLAS_N >= 14
-      case 13: compute<13, NXZ, FloatN, M, ReduceType>(sum, arg, i, parity); break;
-#if MAX_MULTI_BLAS_N >= 15
-      case 14: compute<14, NXZ, FloatN, M, ReduceType>(sum, arg, i, parity); break;
-#if MAX_MULTI_BLAS_N >= 16
-      case 15: compute<15, NXZ, FloatN, M, ReduceType>(sum, arg, i, parity); break;
-#endif // 16
-#endif // 15
-#endif // 14
-#endif // 13
-#endif // 12
-#endif // 11
-#endif // 10
-#endif // 9
-#endif // 8
-#endif // 7
-#endif // 6
-#endif // 5
-#endif // 4
-#endif // 3
-#endif // 2
       }
 
 #ifdef WARP_MULTI_REDUCE
@@ -174,7 +120,6 @@ namespace quda
 #else
       ::quda::reduce<block_size, vector_type<ReduceType, NXZ>>(arg, sum, arg.NYW * parity + k);
 #endif
-
     } // multiReduceKernel
 
     template <typename T> struct coeff_array {

--- a/lib/multi_blas_quda.cu
+++ b/lib/multi_blas_quda.cu
@@ -193,7 +193,9 @@ namespace quda {
 
           cudaMemcpyToSymbolAsync(Cmatrix_d, C, MAX_MATRIX_SIZE, 0, cudaMemcpyHostToDevice, *getStream());
         }
-
+#if CUDA_VERSION < 9000
+        cudaMemcpyToSymbolAsync(arg_buffer, reinterpret_cast<char*>(&arg), sizeof(arg), 0, cudaMemcpyHostToDevice, *getStream());
+#endif
         multiBlasKernel<FloatN, M, NXZ><<<tp.grid, tp.block, tp.shared_bytes, stream>>>(arg);
 #endif
       }

--- a/lib/multi_reduce_quda.cu
+++ b/lib/multi_reduce_quda.cu
@@ -57,6 +57,9 @@ namespace quda {
                                   .configure(tp.grid, tp.block, tp.shared_bytes, stream)
                                   .launch(arg);
 #else
+#if CUDA_VERSION < 9000
+      cudaMemcpyToSymbolAsync(arg_buffer, reinterpret_cast<char*>(&arg), sizeof(arg), 0, cudaMemcpyHostToDevice, *getStream());
+#endif
       LAUNCH_KERNEL_LOCAL_PARITY(multiReduceKernel, tp, stream, arg, ReduceType, FloatN, M, NXZ);
 #endif
 #endif

--- a/tests/blas_test.cu
+++ b/tests/blas_test.cu
@@ -26,7 +26,6 @@ extern int tdim;
 extern int gridsize_from_cmdline[];
 extern int niter;
 
-extern bool verify_results;
 extern int Nsrc;
 extern int Msrc;
 extern QudaSolveType solve_type;
@@ -112,11 +111,16 @@ void initFields(int prec)
 
   param.pad = 0; // padding must be zero for cpu fields
 
-  if (solve_type == QUDA_DIRECT_PC_SOLVE) {
+  switch (solve_type) {
+  case QUDA_DIRECT_PC_SOLVE:
+  case QUDA_NORMOP_PC_SOLVE:
     param.siteSubset = QUDA_PARITY_SITE_SUBSET;
-  } else if (solve_type == QUDA_DIRECT_SOLVE) {
+    break;
+  case QUDA_DIRECT_SOLVE:
+  case QUDA_NORMOP_SOLVE:
     param.siteSubset = QUDA_FULL_SITE_SUBSET;
-  } else {
+    break;
+  default:
     errorQuda("Unexpected solve_type=%d\n", solve_type);
   }
 
@@ -994,11 +998,9 @@ int main(int argc, char** argv)
   cudaGetLastError();
 
   // lastly check for correctness
-  if (verify_results) {
-    ::testing::TestEventListeners &listeners = ::testing::UnitTest::GetInstance()->listeners();
-    if (comm_rank() != 0) { delete listeners.Release(listeners.default_result_printer()); }
-    result = RUN_ALL_TESTS();
-  }
+  ::testing::TestEventListeners &listeners = ::testing::UnitTest::GetInstance()->listeners();
+  if (comm_rank() != 0) { delete listeners.Release(listeners.default_result_printer()); }
+  result = RUN_ALL_TESTS();
 
   endQuda();
 


### PR DESCRIPTION
This pull request removes the template specialization from the multi-blas and multi-reduce kernels.  This was required with older CUDA compilers for performance, but results in quadratic compile time.  With modern CUDA (9.0 and up) this is no longer needed.  A work around is in place to avoid the performance cliff with older CUDA.

End result is less code, and much faster compilation for multi-blas and multi-reduce.