### PR TITLE
Feature/low prec lanczos

### DIFF
--- a/include/eigensolve_quda.h
+++ b/include/eigensolve_quda.h
@@ -17,12 +17,12 @@ protected:
 
     // Problem parameters
     //------------------
-    int nEv;        // Size of initial factorisation
-    int nKr;        // Size of Krylov space after extension
-    int nConv;      // Number of converged eigenvalues requested
-    double tol;     // Tolerance on eigenvalues
-    bool reverse;   // True if using polynomial acceleration
-    char *spectrum; // Part of the spectrum to be computed.
+    int nEv;          /** Size of initial factorisation */
+    int nKr;          /** Size of Krylov space after extension */
+    int nConv;        /** Number of converged eigenvalues requested */
+    double tol;       /** Tolerance on eigenvalues */
+    bool reverse;     /** True if using polynomial acceleration */
+    char spectrum[3]; /** Part of the spectrum to be computed */
 
     // Algorithm variables
     //--------------------

--- a/lib/eigensolve_quda.cpp
+++ b/lib/eigensolve_quda.cpp
@@ -67,26 +67,13 @@ namespace quda
 
     // Part of the spectrum to be computed.
     switch (eig_param->spectrum) {
-    case QUDA_SPECTRUM_SR_EIG:
-      strcpy(spectrum,"SR");
-      break;
-    case QUDA_SPECTRUM_LR_EIG:
-      strcpy(spectrum,"LR");
-      break;
-    case QUDA_SPECTRUM_SM_EIG:
-      strcpy(spectrum,"SM");
-      break;
-    case QUDA_SPECTRUM_LM_EIG:
-      strcpy(spectrum,"LM");
-      break;
-    case QUDA_SPECTRUM_SI_EIG:
-      strcpy(spectrum,"SI");
-      break;
-    case QUDA_SPECTRUM_LI_EIG:
-      strcpy(spectrum,"LI");
-      break;
-    default:
-      errorQuda("Unexpected spectrum type %d", eig_param->spectrum);
+    case QUDA_SPECTRUM_SR_EIG: strcpy(spectrum, "SR"); break;
+    case QUDA_SPECTRUM_LR_EIG: strcpy(spectrum, "LR"); break;
+    case QUDA_SPECTRUM_SM_EIG: strcpy(spectrum, "SM"); break;
+    case QUDA_SPECTRUM_LM_EIG: strcpy(spectrum, "LM"); break;
+    case QUDA_SPECTRUM_SI_EIG: strcpy(spectrum, "SI"); break;
+    case QUDA_SPECTRUM_LI_EIG: strcpy(spectrum, "LI"); break;
+    default: errorQuda("Unexpected spectrum type %d", eig_param->spectrum);
     }
 
     // Deduce whether to reverse the sorting

--- a/lib/eigensolve_quda.cpp
+++ b/lib/eigensolve_quda.cpp
@@ -159,20 +159,15 @@ namespace quda
     if (eig_param->poly_deg == 0) { errorQuda("Polynomial acceleration requested with zero polynomial degree"); }
 
     // Compute the polynomial accelerated operator.
-    double delta, theta;
-    double sigma, sigma1, sigma_old;
-    double d1, d2, d3;
-
     double a = eig_param->a_min;
     double b = eig_param->a_max;
-
-    delta = (b - a) / 2.0;
-    theta = (b + a) / 2.0;
-
-    sigma1 = -delta / theta;
-
-    d1 = sigma1 / delta;
-    d2 = 1.0;
+    double delta = (b - a) / 2.0;
+    double theta = (b + a) / 2.0;
+    double sigma1 = -delta / theta;
+    double sigma;
+    double d1 = sigma1 / delta;
+    double d2 = 1.0;
+    double d3;
 
     // out = d2 * in + d1 * out
     // C_1(x) = x
@@ -193,17 +188,17 @@ namespace quda
     // Using Chebyshev polynomial recursion relation,
     // C_{m+1}(x) = 2*x*C_{m} - C_{m-1}
 
-    sigma_old = sigma1;
+    double sigma_old = sigma1;
 
     // construct C_{m+1}(x)
     for (int i = 2; i < eig_param->poly_deg; i++) {
-
       sigma = 1.0 / (2.0 / sigma1 - sigma_old);
 
       d1 = 2.0 * sigma / delta;
       d2 = -d1 * theta;
       d3 = -sigma * sigma_old;
 
+      // FIXME - we could introduce a fused matVec + blas kernel here, eliminating one temporary
       // mat*C_{m}(x)
       matVec(mat, out, *tmp2);
 

--- a/lib/eigensolve_quda.cpp
+++ b/lib/eigensolve_quda.cpp
@@ -66,49 +66,43 @@ namespace quda
     Qmat = (Complex *)safe_malloc(nEv * nKr * sizeof(Complex));
 
     // Part of the spectrum to be computed.
-    spectrum = strdup("SR"); // Initialised to stop the compiler warning.
-
-    if (eig_param->use_poly_acc) {
-      if (eig_param->spectrum == QUDA_SPECTRUM_SR_EIG)
-        spectrum = strdup("LR");
-      else if (eig_param->spectrum == QUDA_SPECTRUM_LR_EIG)
-        spectrum = strdup("SR");
-      else if (eig_param->spectrum == QUDA_SPECTRUM_SM_EIG)
-        spectrum = strdup("LM");
-      else if (eig_param->spectrum == QUDA_SPECTRUM_LM_EIG)
-        spectrum = strdup("SM");
-      else if (eig_param->spectrum == QUDA_SPECTRUM_SI_EIG)
-        spectrum = strdup("LI");
-      else if (eig_param->spectrum == QUDA_SPECTRUM_LI_EIG)
-        spectrum = strdup("SI");
-    } else {
-      if (eig_param->spectrum == QUDA_SPECTRUM_SR_EIG)
-        spectrum = strdup("SR");
-      else if (eig_param->spectrum == QUDA_SPECTRUM_LR_EIG)
-        spectrum = strdup("LR");
-      else if (eig_param->spectrum == QUDA_SPECTRUM_SM_EIG)
-        spectrum = strdup("SM");
-      else if (eig_param->spectrum == QUDA_SPECTRUM_LM_EIG)
-        spectrum = strdup("LM");
-      else if (eig_param->spectrum == QUDA_SPECTRUM_SI_EIG)
-        spectrum = strdup("SI");
-      else if (eig_param->spectrum == QUDA_SPECTRUM_LI_EIG)
-        spectrum = strdup("LI");
+    switch (eig_param->spectrum) {
+    case QUDA_SPECTRUM_SR_EIG:
+      strcpy(spectrum,"SR");
+      break;
+    case QUDA_SPECTRUM_LR_EIG:
+      strcpy(spectrum,"LR");
+      break;
+    case QUDA_SPECTRUM_SM_EIG:
+      strcpy(spectrum,"SM");
+      break;
+    case QUDA_SPECTRUM_LM_EIG:
+      strcpy(spectrum,"LM");
+      break;
+    case QUDA_SPECTRUM_SI_EIG:
+      strcpy(spectrum,"SI");
+      break;
+    case QUDA_SPECTRUM_LI_EIG:
+      strcpy(spectrum,"LI");
+      break;
+    default:
+      errorQuda("Unexpected spectrum type %d", eig_param->spectrum);
     }
 
     // Deduce whether to reverse the sorting
-    const char *L = "L";
-    const char *S = "S";
-    if (strncmp(L, spectrum, 1) == 0 && !eig_param->use_poly_acc) {
+    if (strncmp("L", spectrum, 1) == 0 && !eig_param->use_poly_acc) {
       reverse = true;
-    } else if (strncmp(S, spectrum, 1) == 0 && eig_param->use_poly_acc) {
+    } else if (strncmp("S", spectrum, 1) == 0 && eig_param->use_poly_acc) {
       reverse = true;
-    } else if (strncmp(L, spectrum, 1) == 0 && eig_param->use_poly_acc) {
+      spectrum[0] = 'L';
+    } else if (strncmp("L", spectrum, 1) == 0 && eig_param->use_poly_acc) {
       reverse = true;
+      spectrum[0] = 'S';
     }
 
     // Print Eigensolver params
     if (getVerbosity() >= QUDA_VERBOSE) {
+      printfQuda("spectrum %s\n", spectrum);
       printfQuda("tol %.4e\n", tol);
       printfQuda("nConv %d\n", nConv);
       printfQuda("nEv %d\n", nEv);

--- a/lib/multi_reduce_quda.cu
+++ b/lib/multi_reduce_quda.cu
@@ -920,6 +920,9 @@ namespace quda {
 	strcat(aux,",m=");
 	u64toa(size, y.size());
 	strcat(aux,size);
+        u64toa(size, MAX_MULTI_BLAS_N);
+        strcat(aux,",multi-blas-n=");
+        strcat(aux, size);
 
       	// before we do policy tuning we must ensure the kernel
       	// constituents have been tuned since we can't do nested tuning
@@ -986,7 +989,6 @@ namespace quda {
       // aux.x is the tile size
       bool advanceAux(TuneParam &param) const
       {
-
 	if ( x.size()==1 || y.size()==1 ) { // 1-d reduction
 
 	  param.aux.x++;

--- a/lib/multi_reduce_quda.cu
+++ b/lib/multi_reduce_quda.cu
@@ -921,10 +921,10 @@ namespace quda {
 	u64toa(size, y.size());
 	strcat(aux,size);
         u64toa(size, MAX_MULTI_BLAS_N);
-        strcat(aux,",multi-blas-n=");
+        strcat(aux, ",multi-blas-n=");
         strcat(aux, size);
 
-      	// before we do policy tuning we must ensure the kernel
+        // before we do policy tuning we must ensure the kernel
       	// constituents have been tuned since we can't do nested tuning
       	// FIXME this will break if the kernels are destructive - which they aren't here
 	if (getTuning() && getTuneCache().find(tuneKey()) == getTuneCache().end()) {

--- a/lib/quda_arpack_interface.cpp
+++ b/lib/quda_arpack_interface.cpp
@@ -76,45 +76,41 @@ namespace quda
     // ARPACK problem type to be solved
     char howmny = 'P';
     char bmat = 'I';
-    char *spectrum = nullptr;
+    char spectrum[3];
 
-    if (eig_param->use_poly_acc) {
-      if (eig_param->spectrum == QUDA_SPECTRUM_SR_EIG)
-        spectrum = strdup("LR");
-      else if (eig_param->spectrum == QUDA_SPECTRUM_LR_EIG)
-        spectrum = strdup("SR");
-      else if (eig_param->spectrum == QUDA_SPECTRUM_SM_EIG)
-        spectrum = strdup("LM");
-      else if (eig_param->spectrum == QUDA_SPECTRUM_LM_EIG)
-        spectrum = strdup("SM");
-      else if (eig_param->spectrum == QUDA_SPECTRUM_SI_EIG)
-        spectrum = strdup("LI");
-      else if (eig_param->spectrum == QUDA_SPECTRUM_LI_EIG)
-        spectrum = strdup("SI");
-    } else {
-      if (eig_param->spectrum == QUDA_SPECTRUM_SR_EIG)
-        spectrum = strdup("SR");
-      else if (eig_param->spectrum == QUDA_SPECTRUM_LR_EIG)
-        spectrum = strdup("LR");
-      else if (eig_param->spectrum == QUDA_SPECTRUM_SM_EIG)
-        spectrum = strdup("SM");
-      else if (eig_param->spectrum == QUDA_SPECTRUM_LM_EIG)
-        spectrum = strdup("LM");
-      else if (eig_param->spectrum == QUDA_SPECTRUM_SI_EIG)
-        spectrum = strdup("SI");
-      else if (eig_param->spectrum == QUDA_SPECTRUM_LI_EIG)
-        spectrum = strdup("LI");
+    // Part of the spectrum to be computed.
+    switch (eig_param->spectrum) {
+    case QUDA_SPECTRUM_SR_EIG:
+      strcpy(spectrum,"SR");
+      break;
+    case QUDA_SPECTRUM_LR_EIG:
+      strcpy(spectrum,"LR");
+      break;
+    case QUDA_SPECTRUM_SM_EIG:
+      strcpy(spectrum,"SM");
+      break;
+    case QUDA_SPECTRUM_LM_EIG:
+      strcpy(spectrum,"LM");
+      break;
+    case QUDA_SPECTRUM_SI_EIG:
+      strcpy(spectrum,"SI");
+      break;
+    case QUDA_SPECTRUM_LI_EIG:
+      strcpy(spectrum,"LI");
+      break;
+    default:
+      errorQuda("Unexpected spectrum type %d", eig_param->spectrum);
     }
 
     bool reverse = true;
-    const char *L = "L";
-    const char *S = "S";
-    if (strncmp(L, spectrum, 1) == 0 && !eig_param->use_poly_acc) {
+    if (strncmp("L", spectrum, 1) == 0 && !eig_param->use_poly_acc) {
       reverse = false;
-    } else if (strncmp(S, spectrum, 1) == 0 && eig_param->use_poly_acc) {
+    } else if (strncmp("S", spectrum, 1) == 0 && eig_param->use_poly_acc) {
       reverse = false;
-    } else if (strncmp(L, spectrum, 1) == 0 && eig_param->use_poly_acc) {
+      spectrum[0] = 'L';
+    } else if (strncmp("L", spectrum, 1) == 0 && eig_param->use_poly_acc) {
       reverse = false;
+      spectrum[0] = 'S';
     }
 
     double tol_ = eig_param->tol;
@@ -430,7 +426,6 @@ namespace quda
     host_free(w_workev_);
     host_free(w_rwork_);
     host_free(select_);
-    free(spectrum);
 
     delete h_v;
     delete h_v2;

--- a/lib/quda_arpack_interface.cpp
+++ b/lib/quda_arpack_interface.cpp
@@ -80,26 +80,13 @@ namespace quda
 
     // Part of the spectrum to be computed.
     switch (eig_param->spectrum) {
-    case QUDA_SPECTRUM_SR_EIG:
-      strcpy(spectrum,"SR");
-      break;
-    case QUDA_SPECTRUM_LR_EIG:
-      strcpy(spectrum,"LR");
-      break;
-    case QUDA_SPECTRUM_SM_EIG:
-      strcpy(spectrum,"SM");
-      break;
-    case QUDA_SPECTRUM_LM_EIG:
-      strcpy(spectrum,"LM");
-      break;
-    case QUDA_SPECTRUM_SI_EIG:
-      strcpy(spectrum,"SI");
-      break;
-    case QUDA_SPECTRUM_LI_EIG:
-      strcpy(spectrum,"LI");
-      break;
-    default:
-      errorQuda("Unexpected spectrum type %d", eig_param->spectrum);
+    case QUDA_SPECTRUM_SR_EIG: strcpy(spectrum, "SR"); break;
+    case QUDA_SPECTRUM_LR_EIG: strcpy(spectrum, "LR"); break;
+    case QUDA_SPECTRUM_SM_EIG: strcpy(spectrum, "SM"); break;
+    case QUDA_SPECTRUM_LM_EIG: strcpy(spectrum, "LM"); break;
+    case QUDA_SPECTRUM_SI_EIG: strcpy(spectrum, "SI"); break;
+    case QUDA_SPECTRUM_LI_EIG: strcpy(spectrum, "LI"); break;
+    default: errorQuda("Unexpected spectrum type %d", eig_param->spectrum);
     }
 
     bool reverse = true;

--- a/lib/spinor_noise.cu
+++ b/lib/spinor_noise.cu
@@ -186,9 +186,10 @@ namespace quda {
   {
     // if src is a CPU field then create GPU field
     ColorSpinorField *src = &src_;
-    if (src_.Location() == QUDA_CPU_FIELD_LOCATION) {
+    if (src_.Location() == QUDA_CPU_FIELD_LOCATION || src_.Precision() < QUDA_SINGLE_PRECISION) {
       ColorSpinorParam param(src_);
-      param.setPrecision(param.Precision(), param.Precision(), true); // change to native field order
+      QudaPrecision prec = std::max(src_.Precision(), QUDA_SINGLE_PRECISION);
+      param.setPrecision(prec, prec, true); // change to native field order
       param.create = QUDA_NULL_FIELD_CREATE;
       param.location = QUDA_CUDA_FIELD_LOCATION;
       src = ColorSpinorField::Create(param);

--- a/tests/eigensolve_test.cpp
+++ b/tests/eigensolve_test.cpp
@@ -59,6 +59,7 @@ extern int pipeline;   // length of pipeline for fused operations in GCR or BiCG
 extern QudaVerbosity verbosity;
 
 extern QudaMatPCType matpc_type;
+extern QudaSolutionType solution_type;
 extern QudaSolveType solve_type;
 
 // Twisted mass flavor type
@@ -135,7 +136,7 @@ void display_test_info()
   return;
 }
 
-QudaPrecision &cpu_prec = prec;
+QudaPrecision cpu_prec = QUDA_DOUBLE_PRECISION;
 QudaPrecision &cuda_prec = prec;
 QudaPrecision &cuda_prec_sloppy = prec_sloppy;
 QudaPrecision &cuda_prec_precondition = prec_precondition;
@@ -247,8 +248,7 @@ void setInvertParam(QudaInvertParam &inv_param)
   inv_param.dagger = QUDA_DAG_NO;
   inv_param.mass_normalization = QUDA_MASS_NORMALIZATION;
 
-  // No Even-Odd PC for the moment...
-  inv_param.solution_type = QUDA_MAT_SOLUTION;
+  inv_param.solution_type = solution_type;
   inv_param.solve_type = (inv_param.solution_type == QUDA_MAT_SOLUTION ? QUDA_DIRECT_SOLVE : QUDA_DIRECT_PC_SOLVE);
 
   inv_param.matpc_type = matpc_type;


### PR DESCRIPTION
Low-hanging fruit improvements for Lanczos solver
* Add half and quarter precision support
* In doing so this adds low-precision support to the `spinorNoise` routine (using a single-precision temporary)
* eigensolve_test now respects the `--solution` flag, which is used to switch between full or pc matrices
* Cleanup of handling of `spectrum` in eigensolver and ARPACK interface
* Add `MAX_MULTI_BLAS_N` macro value to multi-reduce tile-size tuner `tuneKey` to prevent incorrect policies being used when this macro changes value
* Fix minor memory leak in eigensolver class (`spectrum` pointer not being freed)