### PR TITLE
Feature/deflate svd

### DIFF
--- a/include/eigensolve_quda.h
+++ b/include/eigensolve_quda.h
@@ -116,6 +116,16 @@ public:
                  std::vector<ColorSpinorField *> evecs, std::vector<Complex> evals);
 
     /**
+       @brief Deflate vector with both left and Right singular vectors
+       @param[in] vec_defl The deflated vector
+       @param[in] vec The input vector
+       @param[in] evecs The singular vectors to use in deflation
+       @param[in] evals The singular values to use in deflation
+    */
+    void deflateSVD(std::vector<ColorSpinorField *> vec_defl, std::vector<ColorSpinorField *> vec,
+		    std::vector<ColorSpinorField *> evecs, std::vector<Complex> evals);
+
+    /**
        @brief Compute eigenvalues and their residiua
        @param[in] mat Matrix operator
        @param[in] evecs The eigenvectors

--- a/include/eigensolve_quda.h
+++ b/include/eigensolve_quda.h
@@ -123,7 +123,7 @@ public:
        @param[in] evals The singular values to use in deflation
     */
     void deflateSVD(std::vector<ColorSpinorField *> vec_defl, std::vector<ColorSpinorField *> vec,
-		    std::vector<ColorSpinorField *> evecs, std::vector<Complex> evals);
+                    std::vector<ColorSpinorField *> evecs, std::vector<Complex> evals);
 
     /**
        @brief Compute eigenvalues and their residiua

--- a/include/invert_quda.h
+++ b/include/invert_quda.h
@@ -600,7 +600,7 @@ namespace quda {
        @brief Constructs the deflation space for CG
     */
     void constructDeflationSpace();
-    
+
     void blocksolve(ColorSpinorField& out, ColorSpinorField& in);
   };
 
@@ -863,11 +863,10 @@ namespace quda {
        @brief Constructs the deflation space
     */
     void constructDeflationSpace();
-    
+
     void operator()(ColorSpinorField &out, ColorSpinorField &in);
-    
   };
-  
+
   class MR : public Solver {
 
   private:
@@ -954,6 +953,11 @@ namespace quda {
     CACG(DiracMatrix &mat, DiracMatrix &matSloppy, SolverParam &param, TimeProfile &profile);
     virtual ~CACG();
 
+    /**
+       @brief Constructs the deflation space for CG
+    */
+    void constructDeflationSpace();
+    
     void operator()(ColorSpinorField &out, ColorSpinorField &in);
   };
 
@@ -984,7 +988,7 @@ namespace quda {
   public:
     CACGNR(DiracMatrix &mat, DiracMatrix &matSloppy, SolverParam &param, TimeProfile &profile);
     virtual ~CACGNR();
-
+    
     void operator()(ColorSpinorField &out, ColorSpinorField &in);
   };
 
@@ -1032,7 +1036,7 @@ namespace quda {
     */
     void solve(Complex *psi_, std::vector<ColorSpinorField*> &q, ColorSpinorField &b);
 
-  public:
+public:
     CAGCR(DiracMatrix &mat, DiracMatrix &matSloppy, SolverParam &param, TimeProfile &profile);
     virtual ~CAGCR();
 

--- a/include/invert_quda.h
+++ b/include/invert_quda.h
@@ -542,8 +542,17 @@ namespace quda {
     */
     EigenSolver *eig_solve;
     bool deflate_init = false;
-    std::vector<ColorSpinorField *> defl_tmp;
+    std::vector<ColorSpinorField *> defl_tmp1;
+    std::vector<ColorSpinorField *> defl_tmp2;
 
+    /**
+       @brief Constructs the deflation space
+       @param[in] vec A sample ColorSpinorField with which to instantiate 
+       the eigensolver
+       @pram[in] mat The operator to eigensolve
+    */
+    void constructDeflationSpace(ColorSpinorField *vec, const DiracMatrix &mat);
+    
     /**
      * Return flops
      * @return flops expended by this operator
@@ -586,9 +595,7 @@ namespace quda {
      * @param r2_old_init [description]
      */
     void operator()(ColorSpinorField &out, ColorSpinorField &in, ColorSpinorField *p_init, double r2_old_init);
-
-    void constructDeflationSpace();
-
+    
     void blocksolve(ColorSpinorField& out, ColorSpinorField& in);
   };
 
@@ -848,8 +855,9 @@ namespace quda {
     virtual ~GCR();
 
     void operator()(ColorSpinorField &out, ColorSpinorField &in);
+    
   };
-
+  
   class MR : public Solver {
 
   private:

--- a/include/invert_quda.h
+++ b/include/invert_quda.h
@@ -860,7 +860,7 @@ namespace quda {
     virtual ~GCR();
 
     /**
-       @brief Constructs the deflation space
+       @brief Constructs the deflation space for GCR
     */
     void constructDeflationSpace();
 
@@ -954,7 +954,7 @@ namespace quda {
     virtual ~CACG();
 
     /**
-       @brief Constructs the deflation space for CG
+       @brief Constructs the deflation space for CACG
     */
     void constructDeflationSpace();
     
@@ -1041,7 +1041,7 @@ public:
     virtual ~CAGCR();
 
     /**
-       @brief Constructs the deflation space for CG
+       @brief Constructs the deflation space for CAGCR
     */
     void constructDeflationSpace();
     

--- a/include/invert_quda.h
+++ b/include/invert_quda.h
@@ -547,12 +547,12 @@ namespace quda {
 
     /**
        @brief Constructs the deflation space
-       @param[in] vec A sample ColorSpinorField with which to instantiate 
+       @param[in] vec A sample ColorSpinorField with which to instantiate
        the eigensolver
        @pram[in] mat The operator to eigensolve
     */
     void constructDeflationSpace(ColorSpinorField *vec, const DiracMatrix &mat);
-    
+
     /**
      * Return flops
      * @return flops expended by this operator
@@ -595,6 +595,11 @@ namespace quda {
      * @param r2_old_init [description]
      */
     void operator()(ColorSpinorField &out, ColorSpinorField &in, ColorSpinorField *p_init, double r2_old_init);
+
+    /**
+       @brief Constructs the deflation space for CG
+    */
+    void constructDeflationSpace();
     
     void blocksolve(ColorSpinorField& out, ColorSpinorField& in);
   };
@@ -849,11 +854,16 @@ namespace quda {
 
     /**
        @param K Preconditioner
-     */
-    GCR(DiracMatrix &mat, Solver &K, DiracMatrix &matSloppy, DiracMatrix &matPrecon,
-	SolverParam &param, TimeProfile &profile);
+    */
+    GCR(DiracMatrix &mat, Solver &K, DiracMatrix &matSloppy, DiracMatrix &matPrecon, SolverParam &param,
+        TimeProfile &profile);
     virtual ~GCR();
 
+    /**
+       @brief Constructs the deflation space
+    */
+    void constructDeflationSpace();
+    
     void operator()(ColorSpinorField &out, ColorSpinorField &in);
     
   };
@@ -1026,6 +1036,11 @@ namespace quda {
     CAGCR(DiracMatrix &mat, DiracMatrix &matSloppy, SolverParam &param, TimeProfile &profile);
     virtual ~CAGCR();
 
+    /**
+       @brief Constructs the deflation space for CG
+    */
+    void constructDeflationSpace();
+    
     void operator()(ColorSpinorField &out, ColorSpinorField &in);
   };
 

--- a/lib/eigensolve_quda.cpp
+++ b/lib/eigensolve_quda.cpp
@@ -260,22 +260,23 @@ namespace quda
     host_free(s);
   }
 
-    // Deflate vec, place result in vec_defl
+  // Deflate vec, place result in vec_defl
   void EigenSolver::deflateSVD(std::vector<ColorSpinorField *> vec_defl, std::vector<ColorSpinorField *> vec,
-			       std::vector<ColorSpinorField *> eig_vecs, std::vector<Complex> evals)
+                               std::vector<ColorSpinorField *> eig_vecs, std::vector<Complex> evals)
   {
     // number of evecs
-    if ((eig_param->nConv)%2 != 0) errorQuda("Must pass equal number of left and right singular vectors");
-    int n_defl = eig_param->nConv/2;
-    
+    if ((eig_param->nConv) % 2 != 0)
+      errorQuda("Must pass equal number of left and right singular vectors: %d given", eig_param->nConv);
+    int n_defl = eig_param->nConv / 2;
+
     if (getVerbosity() >= QUDA_VERBOSE) printfQuda("Deflating %d left and %d right singular vectors\n", n_defl, n_defl);
-    
+
     // Perform Sum_i (L_i * (\sigma_i)^{-1} * (L_i)^dag) + (R_i * (\sigma_i)^{-1} * R_i)^dag) * vec = vec_defl
     // for all i computed eigenvectors and values.
-    
+
     // 1. Take block inner product: (R_i)^dag * vec = A_i
     std::vector<ColorSpinorField *> left_vecs_ptr;
-    for (int i = n_defl; i < 2*n_defl; i++) left_vecs_ptr.push_back(eig_vecs[i]);
+    for (int i = n_defl; i < 2 * n_defl; i++) left_vecs_ptr.push_back(eig_vecs[i]);
     Complex *s = (Complex *)safe_malloc(n_defl * sizeof(Complex));
     blas::cDotProduct(s, left_vecs_ptr, vec);
 
@@ -285,7 +286,7 @@ namespace quda
     // 3. Accumulate sum vec_defl = Sum_i V_i * (L_i)^{-1} * A_i
     blas::zero(*vec_defl[0]);
     std::vector<ColorSpinorField *> right_vecs_ptr;
-    for (int i = 0; i < n_defl; i++) right_vecs_ptr.push_back(eig_vecs[i]);    
+    for (int i = 0; i < n_defl; i++) right_vecs_ptr.push_back(eig_vecs[i]);
     blas::caxpy(s, right_vecs_ptr, vec_defl);
 
     // FIXME - we can optimize the zeroing out with a "multi-caxy"

--- a/lib/inv_ca_cg.cpp
+++ b/lib/inv_ca_cg.cpp
@@ -48,6 +48,13 @@ namespace quda {
       if (rp) delete rp;
     }
 
+    if (deflate_init) {
+      for (auto veci : param.evecs)
+	if (veci) delete veci;
+      delete defl_tmp1[0];
+      delete defl_tmp2[0];            
+    }      
+    
     if (!param.is_preconditioner) profile.TPSTOP(QUDA_PROFILE_FREE);
   }
 
@@ -254,6 +261,10 @@ namespace quda {
       for (int i=0; i<param.Nkrylov; i++) Qtmp[i] = ColorSpinorField::Create(csParam);
       for (int i=0; i<param.Nkrylov; i++) AQ[i] = ColorSpinorField::Create(csParam);
 
+      // Once the CACG operator is called, we are able to construct an appropriate
+      // Krylov space for deflation
+      if (param.deflate && !deflate_init) { constructDeflationSpace(); }
+      
       //sloppy temporary for mat-vec
       tmp_sloppy = mixed ? ColorSpinorField::Create(csParam) : nullptr;
       tmp_sloppy2 = mixed ? ColorSpinorField::Create(csParam) : nullptr;
@@ -430,6 +441,34 @@ namespace quda {
     return updateR;
   }
 
+  void CACG::constructDeflationSpace()
+  {
+    // Deflation requested + first instance of solver    
+    profile.TPSTOP(QUDA_PROFILE_INIT);
+    eig_solve = EigenSolver::create(&param.eig_param, mat, profile);
+    profile.TPSTART(QUDA_PROFILE_INIT);
+    
+    // Clone from an existing vector
+    ColorSpinorParam csParam(*tmpp);
+    csParam.create = QUDA_ZERO_FIELD_CREATE;
+    // This is the vector precision used by matResidual
+    csParam.setPrecision(param.precision_sloppy, QUDA_INVALID_PRECISION, true);
+    param.evecs.resize(param.eig_param.nKr);
+    for (int i = 0; i < param.eig_param.nKr; i++) param.evecs[i] = ColorSpinorField::Create(csParam);
+    
+    // Construct vectors to hold deflated RHS
+    defl_tmp1.push_back(ColorSpinorField::Create(csParam));
+    defl_tmp2.push_back(ColorSpinorField::Create(csParam));
+    
+    param.evals.resize(param.eig_param.nEv);
+    for (int i = 0; i < param.eig_param.nEv; i++) param.evals[i] = 0.0;
+    profile.TPSTOP(QUDA_PROFILE_INIT);
+    (*eig_solve)(param.evecs, param.evals);
+    profile.TPSTART(QUDA_PROFILE_INIT);
+
+    deflate_init = true;
+  }
+  
   /*
     The main CA-CG algorithm, which consists of three main steps:
     1. Build basis vectors q_k = A p_k for k = 1..Nkrlylov
@@ -479,6 +518,24 @@ namespace quda {
       blas::zero(x);
     }
 
+    if (param.deflate == true) {
+      std::vector<ColorSpinorField *> rhs;
+      // Use residual from supplied guess r, or original
+      // rhs b. use `x` as a temp.
+      blas::copy(*defl_tmp2[0], r_);
+      rhs.push_back(defl_tmp2[0]);
+
+      // Deflate
+      eig_solve->deflate(defl_tmp1, rhs, param.evecs, param.evals);
+      
+      // Compute r_defl = RHS - A * LHS
+      mat(r_, *defl_tmp1[0], tmp, tmp2);
+      r2 = blas::xmyNorm(*rhs[0], r_);
+      
+      // defl_tmp1 must be added to the solution at the end
+      blas::axpy(1.0, *defl_tmp1[0], x);      
+    }
+    
     // Use power iterations to approx lambda_max
     auto &lambda_min = param.ca_lambda_min;
     auto &lambda_max = param.ca_lambda_max;

--- a/lib/inv_ca_gcr.cpp
+++ b/lib/inv_ca_gcr.cpp
@@ -29,11 +29,11 @@ namespace quda {
 
     if (deflate_init) {
       for (auto veci : param.evecs)
-	if (veci) delete veci;
+        if (veci) delete veci;
       delete defl_tmp1[0];
-      delete defl_tmp2[0];            
+      delete defl_tmp2[0];
     }
-    
+
     if (!param.is_preconditioner) profile.TPSTOP(QUDA_PROFILE_FREE);
   }
 
@@ -86,7 +86,7 @@ namespace quda {
       // Once the GCR operator is called, we are able to construct an appropriate
       // Krylov space for deflation
       if (param.deflate && !deflate_init) { constructDeflationSpace(); }
-      
+
       //sloppy temporary for mat-vec
       tmp_sloppy = mixed ? ColorSpinorField::Create(csParam) : nullptr;
 
@@ -164,13 +164,13 @@ namespace quda {
 
   void CAGCR::constructDeflationSpace()
   {
-    // Deflation requested + first instance of solver    
+    // Deflation requested + first instance of solver
     profile.TPSTOP(QUDA_PROFILE_INIT);
     param.eig_param.compute_svd = QUDA_BOOLEAN_YES;
-    DiracMdagM mdagm(mat.Expose());	
+    DiracMdagM mdagm(mat.Expose());
     eig_solve = EigenSolver::create(&param.eig_param, mdagm, profile);
     profile.TPSTART(QUDA_PROFILE_INIT);
-    
+
     // Clone from an existing vector
     ColorSpinorParam csParam(*p[0]);
     csParam.create = QUDA_ZERO_FIELD_CREATE;
@@ -178,11 +178,11 @@ namespace quda {
     csParam.setPrecision(param.precision_sloppy, QUDA_INVALID_PRECISION, true);
     param.evecs.resize(param.eig_param.nKr);
     for (int i = 0; i < param.eig_param.nKr; i++) param.evecs[i] = ColorSpinorField::Create(csParam);
-    
+
     // Construct vectors to hold deflated RHS
     defl_tmp1.push_back(ColorSpinorField::Create(csParam));
     defl_tmp2.push_back(ColorSpinorField::Create(csParam));
-    
+
     param.evals.resize(param.eig_param.nEv);
     for (int i = 0; i < param.eig_param.nEv; i++) param.evals[i] = 0.0;
     profile.TPSTOP(QUDA_PROFILE_INIT);
@@ -191,7 +191,7 @@ namespace quda {
 
     deflate_init = true;
   }
-  
+
   /*
     The main CA-GCR algorithm, which consists of three main steps:
     1. Build basis vectors q_k = A p_k for k = 1..Nkrlylov
@@ -218,7 +218,7 @@ namespace quda {
     ColorSpinorField &tmpSloppy = tmp_sloppy ? *tmp_sloppy : tmp;
 
     if (!param.is_preconditioner) profile.TPSTART(QUDA_PROFILE_PREAMBLE);
-    
+
     // compute b2, but only if we need to
     bool fixed_iteration = param.sloppy_converge && nKrylov==param.maxiter && !param.compute_true_res;
     double b2 = !fixed_iteration ? blas::norm2(b) : 1.0;
@@ -239,25 +239,25 @@ namespace quda {
       blas::copy(r, b);
       blas::zero(x);
     }
-    
+
     if (param.deflate == true) {
       std::vector<ColorSpinorField *> rhs;
       // Use residual from supplied guess r, or original
       // rhs b. use `defl_tmp2` as a temp.
       blas::copy(*defl_tmp2[0], r);
       rhs.push_back(defl_tmp2[0]);
-      
+
       // Deflate: Hardcoded to SVD
       eig_solve->deflateSVD(defl_tmp1, rhs, param.evecs, param.evals);
-      
+
       // Compute r_defl = RHS - A * LHS
       mat(r, *defl_tmp1[0]);
       r2 = blas::xmyNorm(*rhs[0], r);
-      
+
       // defl_tmp must be added to the solution at the end
       blas::axpy(1.0, *defl_tmp1[0], x);
     }
-    
+
     // Check to see that we're not trying to invert on a zero-field source
     if (b2 == 0) {
       if (param.compute_null_vector == QUDA_COMPUTE_NULL_VECTOR_NO) {

--- a/lib/inv_cg_quda.cpp
+++ b/lib/inv_cg_quda.cpp
@@ -44,8 +44,15 @@ namespace quda {
         if (tmp2p && tmpp != tmp2p) delete tmp2p;
         if (tmp3p && tmpp != tmp3p && param.precision != param.precision_sloppy) delete tmp3p;
       }
-      if (rnewp) delete rnewp;      
+      if (rnewp) delete rnewp;
       init = false;
+
+      if (deflate_init) {
+	for (auto veci : param.evecs)
+	  if (veci) delete veci;
+	delete defl_tmp1[0];
+	delete defl_tmp2[0];            
+      }      
     }
     profile.TPSTOP(QUDA_PROFILE_FREE);
   }
@@ -62,7 +69,7 @@ namespace quda {
       init = false;
     }
   }
-
+  
   // CGNE: M Mdag y = b is solved; x = Mdag y is returned as solution.
   void CGNE::operator()(ColorSpinorField &x, ColorSpinorField &b) {
     if (param.maxiter == 0 || param.Nsteps == 0) {
@@ -195,6 +202,34 @@ namespace quda {
     }
 
   }
+
+  void CG::constructDeflationSpace()
+  {
+    // Deflation requested + first instance of solver    
+    profile.TPSTOP(QUDA_PROFILE_INIT);
+    eig_solve = EigenSolver::create(&param.eig_param, mat, profile);
+    profile.TPSTART(QUDA_PROFILE_INIT);
+    
+    // Clone from an existing vector
+    ColorSpinorParam csParam(*rp);
+    csParam.create = QUDA_ZERO_FIELD_CREATE;
+    // This is the vector precision used by matResidual
+    csParam.setPrecision(param.precision_sloppy, QUDA_INVALID_PRECISION, true);
+    param.evecs.resize(param.eig_param.nKr);
+    for (int i = 0; i < param.eig_param.nKr; i++) param.evecs[i] = ColorSpinorField::Create(csParam);
+    
+    // Construct vectors to hold deflated RHS
+    defl_tmp1.push_back(ColorSpinorField::Create(csParam));
+    defl_tmp2.push_back(ColorSpinorField::Create(csParam));
+    
+    param.evals.resize(param.eig_param.nEv);
+    for (int i = 0; i < param.eig_param.nEv; i++) param.evals[i] = 0.0;
+    profile.TPSTOP(QUDA_PROFILE_INIT);
+    (*eig_solve)(param.evecs, param.evals);
+    profile.TPSTART(QUDA_PROFILE_INIT);
+
+    deflate_init = true;
+  }
   
   void CG::operator()(ColorSpinorField &x, ColorSpinorField &b, ColorSpinorField *p_init, double r2_old_init)
   {
@@ -264,7 +299,7 @@ namespace quda {
 
     // Once the CG operator is called, we are able to construct an appropriate
     // Krylov space for deflation
-    if (param.deflate && !deflate_init) { constructDeflationSpace(rp, mat); }
+    if (param.deflate && !deflate_init) { constructDeflationSpace(); }
     
     ColorSpinorField &r = *rp;
     ColorSpinorField &y = *yp;

--- a/lib/inv_cg_quda.cpp
+++ b/lib/inv_cg_quda.cpp
@@ -48,11 +48,11 @@ namespace quda {
       init = false;
 
       if (deflate_init) {
-	for (auto veci : param.evecs)
-	  if (veci) delete veci;
-	delete defl_tmp1[0];
-	delete defl_tmp2[0];            
-      }      
+        for (auto veci : param.evecs)
+          if (veci) delete veci;
+        delete defl_tmp1[0];
+        delete defl_tmp2[0];
+      }
     }
     profile.TPSTOP(QUDA_PROFILE_FREE);
   }
@@ -69,7 +69,7 @@ namespace quda {
       init = false;
     }
   }
-  
+
   // CGNE: M Mdag y = b is solved; x = Mdag y is returned as solution.
   void CGNE::operator()(ColorSpinorField &x, ColorSpinorField &b) {
     if (param.maxiter == 0 || param.Nsteps == 0) {
@@ -205,11 +205,11 @@ namespace quda {
 
   void CG::constructDeflationSpace()
   {
-    // Deflation requested + first instance of solver    
+    // Deflation requested + first instance of solver
     profile.TPSTOP(QUDA_PROFILE_INIT);
     eig_solve = EigenSolver::create(&param.eig_param, mat, profile);
     profile.TPSTART(QUDA_PROFILE_INIT);
-    
+
     // Clone from an existing vector
     ColorSpinorParam csParam(*rp);
     csParam.create = QUDA_ZERO_FIELD_CREATE;
@@ -217,11 +217,11 @@ namespace quda {
     csParam.setPrecision(param.precision_sloppy, QUDA_INVALID_PRECISION, true);
     param.evecs.resize(param.eig_param.nKr);
     for (int i = 0; i < param.eig_param.nKr; i++) param.evecs[i] = ColorSpinorField::Create(csParam);
-    
+
     // Construct vectors to hold deflated RHS
     defl_tmp1.push_back(ColorSpinorField::Create(csParam));
     defl_tmp2.push_back(ColorSpinorField::Create(csParam));
-    
+
     param.evals.resize(param.eig_param.nEv);
     for (int i = 0; i < param.eig_param.nEv; i++) param.evals[i] = 0.0;
     profile.TPSTOP(QUDA_PROFILE_INIT);
@@ -230,7 +230,7 @@ namespace quda {
 
     deflate_init = true;
   }
-  
+
   void CG::operator()(ColorSpinorField &x, ColorSpinorField &b, ColorSpinorField *p_init, double r2_old_init)
   {
     if (checkLocation(x, b) != QUDA_CUDA_FIELD_LOCATION)
@@ -300,7 +300,7 @@ namespace quda {
     // Once the CG operator is called, we are able to construct an appropriate
     // Krylov space for deflation
     if (param.deflate && !deflate_init) { constructDeflationSpace(); }
-    
+
     ColorSpinorField &r = *rp;
     ColorSpinorField &y = *yp;
     ColorSpinorField &Ap = *App;

--- a/lib/inv_gcr_quda.cpp
+++ b/lib/inv_gcr_quda.cpp
@@ -233,20 +233,20 @@ namespace quda {
       for (auto veci : param.evecs)
         if (veci) delete veci;
       delete defl_tmp1[0];
-      delete defl_tmp2[0];            
+      delete defl_tmp2[0];
     }
     profile.TPSTOP(QUDA_PROFILE_FREE);
   }
 
   void GCR::constructDeflationSpace()
   {
-    // Deflation requested + first instance of solver    
+    // Deflation requested + first instance of solver
     profile.TPSTOP(QUDA_PROFILE_INIT);
     param.eig_param.compute_svd = QUDA_BOOLEAN_YES;
-    DiracMdagM mdagm(mat.Expose());	
+    DiracMdagM mdagm(mat.Expose());
     eig_solve = EigenSolver::create(&param.eig_param, mdagm, profile);
     profile.TPSTART(QUDA_PROFILE_INIT);
-    
+
     // Clone from an existing vector
     ColorSpinorParam csParam(*p[0]);
     csParam.create = QUDA_ZERO_FIELD_CREATE;
@@ -254,11 +254,11 @@ namespace quda {
     csParam.setPrecision(param.precision_sloppy, QUDA_INVALID_PRECISION, true);
     param.evecs.resize(param.eig_param.nKr);
     for (int i = 0; i < param.eig_param.nKr; i++) param.evecs[i] = ColorSpinorField::Create(csParam);
-    
+
     // Construct vectors to hold deflated RHS
     defl_tmp1.push_back(ColorSpinorField::Create(csParam));
     defl_tmp2.push_back(ColorSpinorField::Create(csParam));
-    
+
     param.evals.resize(param.eig_param.nEv);
     for (int i = 0; i < param.eig_param.nEv; i++) param.evals[i] = 0.0;
     profile.TPSTOP(QUDA_PROFILE_INIT);
@@ -267,7 +267,7 @@ namespace quda {
 
     deflate_init = true;
   }
-  
+
   void GCR::operator()(ColorSpinorField &x, ColorSpinorField &b)
   {
     if (nKrylov == 0) {
@@ -341,7 +341,7 @@ namespace quda {
       // rhs b. use `defl_tmp2` as a temp.
       blas::copy(*defl_tmp2[0], r);
       rhs.push_back(defl_tmp2[0]);
-      
+
       // Deflate: Hardcoded to SVD
       eig_solve->deflateSVD(defl_tmp1, rhs, param.evecs, param.evals);
 
@@ -483,7 +483,7 @@ namespace quda {
         } else {
           resIncrease = 0;
         }
-	
+
         k_break = k;
         k = 0;
 

--- a/lib/inv_gcr_quda.cpp
+++ b/lib/inv_gcr_quda.cpp
@@ -228,9 +228,10 @@ namespace quda {
     if (tmpp) delete tmpp;
     if (rp) delete rp;
     if (yp) delete yp;
+
     profile.TPSTOP(QUDA_PROFILE_FREE);
   }
-
+  
   void GCR::operator()(ColorSpinorField &x, ColorSpinorField &b)
   {
     if (nKrylov == 0) {
@@ -273,6 +274,10 @@ namespace quda {
       init = true;
     }
 
+    // Once the GCR operator is called, we are able to construct an appropriate
+    // Krylov space for deflation
+    if (param.deflate && !deflate_init) { constructDeflationSpace(p[0], mat); }
+    
     ColorSpinorField &r = rp ? *rp : *p[0];
     ColorSpinorField &rSloppy = r_sloppy ? *r_sloppy : *p[0];
     ColorSpinorField &y = *yp;
@@ -284,13 +289,34 @@ namespace quda {
 
     // compute initial residual depending on whether we have an initial guess or not
     if (param.use_init_guess == QUDA_USE_INIT_GUESS_YES) {
+      // Compute r = b - A * x
       mat(r, x, y);
       r2 = blas::xmyNorm(b, r);
+      // x contains the original guess.
     } else {
       blas::copy(r, b);
       r2 = b2;
       blas::zero(x);
     }
+
+    if (param.deflate == true) {
+      std::vector<ColorSpinorField *> rhs;
+      // Use residual from supplied guess r, or original
+      // rhs b. use `defl_tmp2` as a temp.
+      blas::copy(*defl_tmp2[0], r);
+      rhs.push_back(defl_tmp2[0]);
+      
+      // Deflate: Hardcoded to SVD
+      eig_solve->deflateSVD(defl_tmp1, rhs, param.evecs, param.evals);
+
+      // Compute r_defl = RHS - A * LHS
+      mat(r, *defl_tmp1[0]);
+      r2 = blas::xmyNorm(*rhs[0], r);
+
+      // defl_tmp must be added to the solution at the end
+      blas::axpy(1.0, *defl_tmp1[0], x);
+    }
+
     blas::zero(y); // FIXME optimize first updates of y and ySloppy
     if (&y != &ySloppy) blas::zero(ySloppy);
 
@@ -421,7 +447,7 @@ namespace quda {
         } else {
           resIncrease = 0;
         }
-
+	
         k_break = k;
         k = 0;
 

--- a/lib/multigrid.cpp
+++ b/lib/multigrid.cpp
@@ -473,7 +473,7 @@ namespace quda
 
         if (strcmp(param_coarse_solver->eig_param.vec_outfile, "") == 0 && // check that output file not already set
             param.mg_global.vec_store == QUDA_BOOLEAN_YES && (strcmp(param.mg_global.vec_outfile, "") != 0)) {
-          std::string vec_outfile(param.mg_global.vec_infile);
+          std::string vec_outfile(param.mg_global.vec_outfile);
           vec_outfile += "_level_";
           vec_outfile += std::to_string(param.level + 1);
           vec_outfile += "_defl_";

--- a/lib/multigrid.cpp
+++ b/lib/multigrid.cpp
@@ -285,7 +285,7 @@ namespace quda
     param_presmooth->preserve_source = QUDA_PRESERVE_SOURCE_NO;
     param_presmooth->return_residual = true; // pre-smoother returns the residual vector for subsequent coarsening
     param_presmooth->use_init_guess = QUDA_USE_INIT_GUESS_NO;
-
+    
     param_presmooth->precision = param.mg_global.invert_param->cuda_prec_sloppy;
     param_presmooth->precision_sloppy = (param.level == 0) ? param.mg_global.invert_param->cuda_prec_precondition : param.mg_global.invert_param->cuda_prec_sloppy;
     param_presmooth->precision_precondition = (param.level == 0) ? param.mg_global.invert_param->cuda_prec_precondition : param.mg_global.invert_param->cuda_prec_sloppy;
@@ -443,7 +443,9 @@ namespace quda
       param_coarse_solver->return_residual = false; // coarse solver does need to return residual vector
 
       param_coarse_solver->use_init_guess = QUDA_USE_INIT_GUESS_NO;
-      if (param.mg_global.use_eig_solver[param.Nlevel - 1]) {
+      // Coarse level deflation id triggered if the eig param structure exists
+      // on the coarsest level, and we are on the next to coarsest level.
+      if (param.mg_global.use_eig_solver[param.Nlevel - 1] && (param.level == param.Nlevel - 2)) {
         param_coarse_solver->eig_param = *param.mg_global.eig_param[param.Nlevel - 1];
         param_coarse_solver->deflate = QUDA_BOOLEAN_YES;
         // Due to coherence between these levels, an initial guess
@@ -472,6 +474,7 @@ namespace quda
           strcpy(param_coarse_solver->eig_param.vec_outfile, vec_outfile.c_str());
         }
       }
+      
       param_coarse_solver->tol = param.mg_global.coarse_solver_tol[param.level+1];
       param_coarse_solver->global_reduction = true;
       param_coarse_solver->compute_true_res = false;

--- a/lib/multigrid.cpp
+++ b/lib/multigrid.cpp
@@ -285,7 +285,7 @@ namespace quda
     param_presmooth->preserve_source = QUDA_PRESERVE_SOURCE_NO;
     param_presmooth->return_residual = true; // pre-smoother returns the residual vector for subsequent coarsening
     param_presmooth->use_init_guess = QUDA_USE_INIT_GUESS_NO;
-    
+
     param_presmooth->precision = param.mg_global.invert_param->cuda_prec_sloppy;
     param_presmooth->precision_sloppy = (param.level == 0) ? param.mg_global.invert_param->cuda_prec_precondition : param.mg_global.invert_param->cuda_prec_sloppy;
     param_presmooth->precision_precondition = (param.level == 0) ? param.mg_global.invert_param->cuda_prec_precondition : param.mg_global.invert_param->cuda_prec_sloppy;
@@ -474,7 +474,7 @@ namespace quda
           strcpy(param_coarse_solver->eig_param.vec_outfile, vec_outfile.c_str());
         }
       }
-      
+
       param_coarse_solver->tol = param.mg_global.coarse_solver_tol[param.level+1];
       param_coarse_solver->global_reduction = true;
       param_coarse_solver->compute_true_res = false;

--- a/lib/multigrid.cpp
+++ b/lib/multigrid.cpp
@@ -443,7 +443,7 @@ namespace quda
       param_coarse_solver->return_residual = false; // coarse solver does need to return residual vector
 
       param_coarse_solver->use_init_guess = QUDA_USE_INIT_GUESS_NO;
-      // Coarse level deflation id triggered if the eig param structure exists
+      // Coarse level deflation is triggered if the eig param structure exists
       // on the coarsest level, and we are on the next to coarsest level.
       if (param.mg_global.use_eig_solver[param.Nlevel - 1] && (param.level == param.Nlevel - 2)) {
         param_coarse_solver->eig_param = *param.mg_global.eig_param[param.Nlevel - 1];
@@ -454,6 +454,13 @@ namespace quda
           param_coarse_solver->use_init_guess = QUDA_USE_INIT_GUESS_YES;
         }
 
+	// Deflation on the coarse is supported for 6 solvers only
+	if (param_coarse_solver->inv_type != QUDA_CA_CGNR_INVERTER && param_coarse_solver->inv_type != QUDA_CGNR_INVERTER &&
+	    param_coarse_solver->inv_type != QUDA_CA_CGNE_INVERTER && param_coarse_solver->inv_type != QUDA_CGNE_INVERTER &&
+	    param_coarse_solver->inv_type != QUDA_CA_GCR_INVERTER && param_coarse_solver->inv_type != QUDA_GCR_INVERTER) {
+	  errorQuda("Coarse grid deflation not supported with coarse solver %d", param_coarse_solver->inv_type);
+	}
+	  
         if (strcmp(param_coarse_solver->eig_param.vec_infile, "") == 0 && // check that input file not already set
             param.mg_global.vec_load == QUDA_BOOLEAN_YES && (strcmp(param.mg_global.vec_infile, "") != 0)) {
           std::string vec_infile(param.mg_global.vec_infile);

--- a/lib/solver.cpp
+++ b/lib/solver.cpp
@@ -26,10 +26,6 @@ namespace quda {
     if (eig_solve) {
       delete eig_solve;
       eig_solve = nullptr;
-      for (auto veci : param.evecs)
-	if (veci) delete veci;
-      delete defl_tmp1[0];
-      delete defl_tmp2[0];      
     }
   }
 
@@ -268,40 +264,5 @@ namespace quda {
 
     return true;
   }
-  
-  void Solver::constructDeflationSpace(ColorSpinorField *vec, const DiracMatrix &mat)
-  {
-    // Deflation requested + first instance of solver    
-    profile.TPSTOP(QUDA_PROFILE_INIT);
-    // Discern if performing and normop solve
-    if (param.inv_type == QUDA_GCR_INVERTER || param.inv_type == QUDA_CA_GCR_INVERTER) {
-      param.eig_param.compute_svd = QUDA_BOOLEAN_YES;
-      DiracMdagM mdagm(mat.Expose());	
-      eig_solve = EigenSolver::create(&param.eig_param, mdagm, profile);
-    } else {
-      eig_solve = EigenSolver::create(&param.eig_param, mat, profile);
-    }
-    profile.TPSTART(QUDA_PROFILE_INIT);
-    
-    // Clone from an existing vector
-    ColorSpinorParam csParam(*vec);
-    csParam.create = QUDA_ZERO_FIELD_CREATE;
-    // This is the vector precision used by matResidual
-    csParam.setPrecision(param.precision_sloppy, QUDA_INVALID_PRECISION, true);
-    param.evecs.resize(param.eig_param.nKr);
-    for (int i = 0; i < param.eig_param.nKr; i++) param.evecs[i] = ColorSpinorField::Create(csParam);
-    
-    // Construct vectors to hold deflated RHS
-    defl_tmp1.push_back(ColorSpinorField::Create(csParam));
-    defl_tmp2.push_back(ColorSpinorField::Create(csParam));
-    
-    param.evals.resize(param.eig_param.nEv);
-    for (int i = 0; i < param.eig_param.nEv; i++) param.evals[i] = 0.0;
-    profile.TPSTOP(QUDA_PROFILE_INIT);
-    (*eig_solve)(param.evecs, param.evals);
-    profile.TPSTART(QUDA_PROFILE_INIT);
-    
-    deflate_init = true;
-  }
-  
+
 } // namespace quda


### PR DESCRIPTION
Uses the Lanczos solver on the coarse grid to compute the SVD of the low modes. This can then be used to deflate `M` and `Mdag` type operators.