### PR TITLE
Check pointer alignment before creating textures.

### DIFF
--- a/include/malloc_quda.h
+++ b/include/malloc_quda.h
@@ -50,6 +50,14 @@ namespace quda {
 
   QudaFieldLocation get_pointer_location(const void *ptr);
 
+  /**
+   * @return whether the pointer is aligned
+   */
+  static inline bool is_aligned(const void *ptr, size_t alignment)
+  {
+    return (reinterpret_cast<std::uintptr_t>(ptr) & (alignment - 1)) == 0;
+  }
+
 } // namespace quda
 
 #define device_malloc(size) quda::device_malloc_(__func__, quda::file_name(__FILE__), __LINE__, size)

--- a/lib/clover_field.cpp
+++ b/lib/clover_field.cpp
@@ -187,10 +187,11 @@ namespace quda {
       resDesc.res.linear.devPtr = field;
       resDesc.res.linear.desc = desc;
       resDesc.res.linear.sizeInBytes = bytes/(!full ? 2 : 1);
-      
-      if (resDesc.res.linear.sizeInBytes % deviceProp.textureAlignment != 0) {
-	errorQuda("Allocation size %lu does not have correct alignment for textures (%lu)",
-		  resDesc.res.linear.sizeInBytes, deviceProp.textureAlignment);
+
+      if (resDesc.res.linear.sizeInBytes % deviceProp.textureAlignment != 0
+          || !is_aligned(resDesc.res.linear.devPtr, deviceProp.textureAlignment)) {
+        errorQuda("Allocation size %lu does not have correct alignment for textures (%lu)",
+                  resDesc.res.linear.sizeInBytes, deviceProp.textureAlignment);
       }
 
       unsigned long texels = resDesc.res.linear.sizeInBytes / texel_size;

--- a/lib/clover_field.cpp
+++ b/lib/clover_field.cpp
@@ -222,8 +222,13 @@ namespace quda {
 	resDesc.res.linear.devPtr = norm;
 	resDesc.res.linear.desc = desc;
 	resDesc.res.linear.sizeInBytes = norm_bytes/(!full ? 2 : 1);
-	
-	cudaTextureDesc texDesc;
+
+        if (!is_aligned(resDesc.res.linear.devPtr, deviceProp.textureAlignment)) {
+          errorQuda("Allocation size %lu does not have correct alignment for textures (%lu)",
+                    resDesc.res.linear.sizeInBytes, deviceProp.textureAlignment);
+        }
+
+        cudaTextureDesc texDesc;
 	memset(&texDesc, 0, sizeof(texDesc));
 	texDesc.readMode = cudaReadModeElementType;
 	

--- a/lib/cuda_color_spinor_field.cpp
+++ b/lib/cuda_color_spinor_field.cpp
@@ -335,7 +335,8 @@ namespace quda {
       if (precision == QUDA_HALF_PRECISION || precision == QUDA_QUARTER_PRECISION) texDesc.readMode = cudaReadModeNormalizedFloat;
       else texDesc.readMode = cudaReadModeElementType;
 
-      if (resDesc.res.linear.sizeInBytes % deviceProp.textureAlignment != 0) {
+      if (resDesc.res.linear.sizeInBytes % deviceProp.textureAlignment != 0
+          || !is_aligned(resDesc.res.linear.devPtr, deviceProp.textureAlignment)) {
         errorQuda("Allocation size %lu does not have correct alignment for textures (%lu)",
           resDesc.res.linear.sizeInBytes, deviceProp.textureAlignment);
       }
@@ -363,7 +364,8 @@ namespace quda {
         resDesc.res.linear.desc = desc;
         resDesc.res.linear.sizeInBytes = norm_bytes;
 
-        if (resDesc.res.linear.sizeInBytes % deviceProp.textureAlignment != 0) {
+        if (resDesc.res.linear.sizeInBytes % deviceProp.textureAlignment != 0
+            || !is_aligned(resDesc.res.linear.devPtr, deviceProp.textureAlignment)) {
           errorQuda("Allocation size %lu does not have correct alignment for textures (%lu)",
         	    resDesc.res.linear.sizeInBytes, deviceProp.textureAlignment);
         }

--- a/lib/cuda_color_spinor_field.cpp
+++ b/lib/cuda_color_spinor_field.cpp
@@ -416,6 +416,11 @@ namespace quda {
 	resDesc.res.linear.desc = desc;
 	resDesc.res.linear.sizeInBytes = ghost_bytes;
 
+        if (!is_aligned(resDesc.res.linear.devPtr, deviceProp.textureAlignment)) {
+          errorQuda("Allocation size %lu does not have correct alignment for textures (%lu)",
+        	    resDesc.res.linear.sizeInBytes, deviceProp.textureAlignment);
+        }
+
 	cudaTextureDesc texDesc;
 	memset(&texDesc, 0, sizeof(texDesc));
 	if (ghost_precision == QUDA_HALF_PRECISION || ghost_precision == QUDA_QUARTER_PRECISION) texDesc.readMode = cudaReadModeNormalizedFloat;
@@ -425,6 +430,10 @@ namespace quda {
 
 	// second set of ghost texture map to the host-mapped pinned receive buffers
 	resDesc.res.linear.devPtr = ghost_pinned_recv_buffer_hd[b];
+        if (!is_aligned(resDesc.res.linear.devPtr, deviceProp.textureAlignment)) {
+          errorQuda("Allocation size %lu does not have correct alignment for textures (%lu)",
+        	    resDesc.res.linear.sizeInBytes, deviceProp.textureAlignment);
+        }
 	cudaCreateTextureObject(&ghostTex[2+b], &resDesc, &texDesc, NULL);
 
 	if (ghost_precision == QUDA_HALF_PRECISION || ghost_precision == QUDA_QUARTER_PRECISION) {
@@ -440,17 +449,26 @@ namespace quda {
 	  resDesc.res.linear.desc = desc;
 	  resDesc.res.linear.sizeInBytes = ghost_bytes;
 
-	  cudaTextureDesc texDesc;
+          if (!is_aligned(resDesc.res.linear.devPtr, deviceProp.textureAlignment)) {
+            errorQuda("Allocation size %lu does not have correct alignment for textures (%lu)",
+                      resDesc.res.linear.sizeInBytes, deviceProp.textureAlignment);
+          }
+
+          cudaTextureDesc texDesc;
 	  memset(&texDesc, 0, sizeof(texDesc));
 	  texDesc.readMode = cudaReadModeElementType;
 
 	  cudaCreateTextureObject(&ghostTexNorm[b], &resDesc, &texDesc, NULL);
 
 	  resDesc.res.linear.devPtr = ghost_pinned_recv_buffer_hd[b];
-	  cudaCreateTextureObject(&ghostTexNorm[2+b], &resDesc, &texDesc, NULL);
-	}
+          if (!is_aligned(resDesc.res.linear.devPtr, deviceProp.textureAlignment)) {
+            errorQuda("Allocation size %lu does not have correct alignment for textures (%lu)",
+                      resDesc.res.linear.sizeInBytes, deviceProp.textureAlignment);
+          }
+          cudaCreateTextureObject(&ghostTexNorm[2+b], &resDesc, &texDesc, NULL);
+        }
 
-	ghost_field_tex[b] = ghost_recv_buffer_d[b];
+        ghost_field_tex[b] = ghost_recv_buffer_d[b];
 	ghost_field_tex[2+b] = ghost_pinned_recv_buffer_hd[b];
       } // buffer index
 

--- a/lib/cuda_gauge_field.cpp
+++ b/lib/cuda_gauge_field.cpp
@@ -145,8 +145,9 @@ namespace quda {
       resDesc.res.linear.desc = desc;
       resDesc.res.linear.sizeInBytes = (isPhase ? phase_bytes : bytes) / (!full ? 2 : 1);
 
-      if (resDesc.res.linear.sizeInBytes % deviceProp.textureAlignment != 0) {
-	errorQuda("Allocation size %lu does not have correct alignment for textures (%lu)",
+      if (resDesc.res.linear.sizeInBytes % deviceProp.textureAlignment != 0
+          || !is_aligned(resDesc.res.linear.devPtr, deviceProp.textureAlignment)) {
+        errorQuda("Allocation size %lu does not have correct alignment for textures (%lu)",
 		  resDesc.res.linear.sizeInBytes, deviceProp.textureAlignment);
       }
 


### PR DESCRIPTION
cudaCreateTextureObject requires the pointer to be align to textureAlignment, but only the size of the allocation being multiple of the textureAlignment was checked.