### PR TITLE
Pre-compute Yhat max for fixed-precision coarse preconditioned operator

### DIFF
--- a/include/atomic.cuh
+++ b/include/atomic.cuh
@@ -147,7 +147,7 @@ static inline __device__ double atomicMax(float *addr, float val){
   float old = *addr, assumed;
   do {
     assumed = old;
-    old = __int_as_float( atomicCAS((unsigned int*)addr,
+    old = __int_as_float( atomicCAS((unsigned long long int*)addr,
             __float_as_int(assumed),
             __float_as_int(val > assumed ? val : assumed)));
   } while ( __float_as_int(assumed) != __float_as_int(old) );

--- a/include/atomic.cuh
+++ b/include/atomic.cuh
@@ -117,4 +117,42 @@ static inline __device__ char2 atomicAdd(char2 *addr, char2 val){
   return old.s;
 }
 
+/**
+   @brief Implementation of double-precision atomic max using compare
+   and swap.
+
+   @param addr Address that stores the atomic variable to be updated
+   @param val Value to be added to the atomic
+*/
+static inline __device__ double atomicMax(double *addr, double val){
+  double old = *addr, assumed;
+  do {
+    assumed = old;
+    old = __longlong_as_double( atomicCAS((unsigned long long int*)addr,
+            __double_as_longlong(assumed),
+            __double_as_longlong(val > assumed ? val : assumed)));
+  } while ( __double_as_longlong(assumed) != __double_as_longlong(old) );
+  
+  return old;
+}
+
+/**
+   @brief Implementation of single-precision atomic max using compare
+   and swap.
+
+   @param addr Address that stores the atomic variable to be updated
+   @param val Value to be added to the atomic
+*/
+static inline __device__ double atomicMax(float *addr, float val){
+  float old = *addr, assumed;
+  do {
+    assumed = old;
+    old = __int_as_float( atomicCAS((unsigned int*)addr,
+            __float_as_int(assumed),
+            __float_as_int(val > assumed ? val : assumed)));
+  } while ( __float_as_int(assumed) != __float_as_int(old) );
+  
+  return old;
+}
+
 #endif

--- a/include/kernels/coarse_op_preconditioned.cuh
+++ b/include/kernels/coarse_op_preconditioned.cuh
@@ -3,7 +3,7 @@
 
 namespace quda {
 
-  template <typename PreconditionedGauge, typename Gauge, int n>
+  template <typename Float, typename PreconditionedGauge, typename Gauge, int n>
   struct CalculateYhatArg {
     PreconditionedGauge Yhat;
     const Gauge Y;
@@ -13,11 +13,14 @@ namespace quda {
     int nFace;
     const int coarseVolumeCB;   /** Coarse grid volume */
 
+    Float max_h; // host scalar that stores the maximum element of Yhat
+    Float *max_d; // device scalar that stores the maximum element of Yhat
+
     CalculateYhatArg(const PreconditionedGauge &Yhat, const Gauge Y, const Gauge Xinv, const int *dim, const int *comm_dim, int nFace)
-      : Yhat(Yhat), Y(Y), Xinv(Xinv), nFace(nFace), coarseVolumeCB(Y.VolumeCB()) {
+      : Yhat(Yhat), Y(Y), Xinv(Xinv), nFace(nFace), coarseVolumeCB(Y.VolumeCB()), max_h(0), max_d(nullptr) {
       for (int i=0; i<4; i++) {
-	this->comm_dim[i] = comm_dim[i];
-	this->dim[i] = dim[i];
+        this->comm_dim[i] = comm_dim[i];
+        this->dim[i] = dim[i];
       }
     }
   };
@@ -31,14 +34,16 @@ namespace quda {
     y.y += a.x*x.y;
   }
 
-  template<typename Float, int n, typename Arg>
-  inline __device__ __host__ void computeYhat(Arg &arg, int d, int x_cb, int parity, int i, int j) {
+  template<typename Float, int n, bool compute_max_only, typename Arg>
+  inline __device__ __host__ Float computeYhat(Arg &arg, int d, int x_cb, int parity, int i, int j) {
 
     constexpr int nDim = 4;
     int coord[nDim];
     getCoords(coord, x_cb, arg.dim, parity);
 
     const int ghost_idx = ghostFaceIndex<0, nDim>(coord, arg.dim, d, arg.nFace);
+
+    Float yHatMax = 0.0;
 
     // first do the backwards links Y^{+\mu} * X^{-\dagger}
     if ( arg.comm_dim[d] && (coord[d] - arg.nFace < 0) ) {
@@ -48,7 +53,11 @@ namespace quda {
       for(int k = 0; k<n; k++) {
         caxpy(arg.Y.Ghost(d,1-parity,ghost_idx,i,k), conj(arg.Xinv(0,parity,x_cb,j,k)), yHat);
       }
-      arg.Yhat.Ghost(d,1-parity,ghost_idx,i,j) = yHat;
+      if (compute_max_only) {
+        yHatMax = fmax(fabs(yHat.x),fabs(yHat.y));
+      } else {
+        arg.Yhat.Ghost(d,1-parity,ghost_idx,i,j) = yHat;
+      }
 
     } else {
       const int back_idx = linkIndexM1(coord, arg.dim, d);
@@ -58,7 +67,11 @@ namespace quda {
       for (int k = 0; k<n; k++) {
         caxpy(arg.Y(d,1-parity,back_idx,i,k), conj(arg.Xinv(0,parity,x_cb,j,k)), yHat);
       }
-      arg.Yhat(d,1-parity,back_idx,i,j) = yHat;
+      if (compute_max_only) {
+        yHatMax = fmax(fabs(yHat.x),fabs(yHat.y));
+      } else {
+        arg.Yhat(d,1-parity,back_idx,i,j) = yHat;
+      }
 
     }
 
@@ -68,26 +81,35 @@ namespace quda {
     for (int k = 0; k<n; k++) {
       caxpy(arg.Xinv(0,parity,x_cb,i,k), arg.Y(d+4,parity,x_cb,k,j), yHat);
     }
-    arg.Yhat(d+4,parity,x_cb,i,j) = yHat;
+    if (compute_max_only) {
+      yHatMax = fmax(yHatMax,fmax(fabs(yHat.x),fabs(yHat.y)));
+    } else {
+      arg.Yhat(d+4,parity,x_cb,i,j) = yHat;
+    }
+
+    return yHatMax;
 
   }
 
-  template<typename Float, int n, typename Arg>
+  template<typename Float, int n, bool compute_max_only, typename Arg>
   void CalculateYhatCPU(Arg &arg) {
-
+    Float max = 0.0;
     for (int d=0; d<4; d++) {
       for (int parity=0; parity<2; parity++) {
 #pragma omp parallel for
-	for (int x_cb=0; x_cb<arg.Y.VolumeCB(); x_cb++) {
-	  for (int i=0; i<n; i++)
-            for (int j=0; j<n; j++)
-              computeYhat<Float,n>(arg, d, x_cb, parity, i, j);
-	} // x_cb
+        for (int x_cb=0; x_cb<arg.Y.VolumeCB(); x_cb++) {
+          for (int i=0; i<n; i++)
+            for (int j=0; j<n; j++) {
+              Float max_x = computeYhat<Float,n,compute_max_only>(arg, d, x_cb, parity, i, j);
+              if (compute_max_only) max = max > max_x ? max : max_x;
+            }
+        }
       } //parity
     } // dimension
+    if (compute_max_only) arg.max_h = max;
   }
 
-  template<typename Float, int n, typename Arg>
+  template<typename Float, int n, bool compute_max_only, typename Arg>
   __global__ void CalculateYhatGPU(Arg arg) {
     int x_cb = blockDim.x*blockIdx.x + threadIdx.x;
     if (x_cb >= arg.coarseVolumeCB) return;
@@ -101,7 +123,8 @@ namespace quda {
     int j = j_d % n;
     int d = j_d / n;
     
-    computeYhat<Float,n>(arg, d, x_cb, parity, i, j);
+    Float max = computeYhat<Float,n,compute_max_only>(arg, d, x_cb, parity, i, j);
+    if (compute_max_only) atomicMax(arg.max_d, max);
   }
 
 } // namespace quda

--- a/lib/coarse_op.cuh
+++ b/lib/coarse_op.cuh
@@ -600,7 +600,7 @@ namespace quda {
     void setDimension(int dim_) { dim = dim_; }
 
     /**
-       Set which dimension we are working on (where applicable)
+       Set which direction we are working on (where applicable)
     */
     void setDirection(QudaDirection dir_) { dir = dir_; }
 
@@ -1003,7 +1003,7 @@ namespace quda {
 
     // work out what to set the scales to
     if (coarseGaugeAtomic::fixedPoint()) {
-      double max = 100.0; // FIXME - more accurate computation needed?
+      double max = 500.0; // Should be more than sufficient
       arg.Y_atomic.resetScale(max);
       arg.X_atomic.resetScale(max);
     }

--- a/lib/coarse_op_preconditioned.cu
+++ b/lib/coarse_op_preconditioned.cu
@@ -17,6 +17,8 @@ namespace quda {
     Arg &arg;
     const LatticeField &meta;
 
+    bool compute_max_only;
+
     long long flops() const { return 2l * arg.coarseVolumeCB * 8 * n * n * (8*n-2); } // 8 from dir, 8 from complexity,
     long long bytes() const { return 2l * (arg.Xinv.Bytes() + 8*arg.Y.Bytes() + 8*arg.Yhat.Bytes()) * n; }
 
@@ -25,7 +27,7 @@ namespace quda {
     bool tuneGridDim() const { return false; } // don't tune the grid dimension
 
   public:
-    CalculateYhat(Arg &arg, const LatticeField &meta) : TunableVectorYZ(2*n,4*n), arg(arg), meta(meta)
+    CalculateYhat(Arg &arg, const LatticeField &meta) : TunableVectorYZ(2*n,4*n), arg(arg), meta(meta), compute_max_only(false)
     {
       if (meta.Location() == QUDA_CUDA_FIELD_LOCATION) {
 #ifdef JITIFY
@@ -40,18 +42,32 @@ namespace quda {
     void apply(const cudaStream_t &stream) {
       TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
       if (meta.Location() == QUDA_CPU_FIELD_LOCATION) {
-	CalculateYhatCPU<Float,n,Arg>(arg);
+
+        if (compute_max_only) CalculateYhatCPU<Float,n,true,Arg>(arg);
+        else CalculateYhatCPU<Float,n,false,Arg>(arg);
+
       } else {
+        if (compute_max_only) arg.max_d = static_cast<Float*>(pool_device_malloc(sizeof(Float)));
 #ifdef JITIFY
         using namespace jitify::reflection;
         jitify_error = program->kernel("quda::CalculateYhatGPU")
-          .instantiate(Type<Float>(),n,Type<Arg>())
+          .instantiate(Type<Float>(),n,compute_max_only,Type<Arg>())
           .configure(tp.grid,tp.block,tp.shared_bytes,stream).launch(arg);
 #else
-	CalculateYhatGPU<Float,n,Arg> <<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+        if (compute_max_only) CalculateYhatGPU<Float,n,true,Arg> <<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+        else CalculateYhatGPU<Float,n,false,Arg> <<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
 #endif
+        if (compute_max_only) {
+          qudaMemcpy(&arg.max_h, arg.max_d, sizeof(Float), cudaMemcpyDeviceToHost);
+          pool_device_free(arg.max_d);
+        }
       }
     }
+
+    /**
+       Set if we're doing a max-only compute (fixed point only)
+    */
+    void setComputeMaxOnly(bool compute_max_only_) { compute_max_only = compute_max_only_; }
 
     // no locality in this kernel so no point in shared-memory tuning
     bool advanceSharedBytes(TuneParam &param) const { return false; }
@@ -64,6 +80,7 @@ namespace quda {
     TuneKey tuneKey() const {
       char Aux[TuneKey::aux_n];
       strcpy(Aux,aux);
+      if (compute_max_only) strcat(Aux,",compute_max_only");
       if (meta.Location() == QUDA_CUDA_FIELD_LOCATION) {
         strcat(Aux, meta.MemType() == QUDA_MEMORY_MAPPED ? ",GPU-mapped" : ",GPU-device");
       } else if (meta.Location() == QUDA_CPU_FIELD_LOCATION) {
@@ -130,16 +147,20 @@ namespace quda {
 
       int comm_dim[4];
       for (int i=0; i<4; i++) comm_dim[i] = comm_dim_partitioned(i);
-      typedef CalculateYhatArg<gPreconditionedCoarse,gCoarse,N> yHatArg;
+      typedef CalculateYhatArg<Float,gPreconditionedCoarse,gCoarse,N> yHatArg;
       yHatArg arg(yHatAccessor, yAccessor, xInvAccessor, xc_size, comm_dim, 1);
 
-      if (Yhat.Precision() == QUDA_HALF_PRECISION) {
-	double max = 3.0 * Y.abs_max() * Xinv.abs_max();
-	Yhat.Scale(max);
-	arg.Yhat.resetScale(max);
-      }
-
       CalculateYhat<Float, N, yHatArg> yHat(arg, Y);
+      if (Yhat.Precision() == QUDA_HALF_PRECISION || Yhat.Precision() == QUDA_QUARTER_PRECISION) {
+        yHat.setComputeMaxOnly(true);
+        yHat.apply(0);
+
+        if (getVerbosity() >= QUDA_VERBOSE) printfQuda("Yhat Max = %f\n", arg.max_h);
+
+        Yhat.Scale(arg.max_h);
+        arg.Yhat.resetScale(arg.max_h);
+      }
+      yHat.setComputeMaxOnly(false);
       yHat.apply(0);
 
       if (getVerbosity() >= QUDA_VERBOSE)
@@ -210,15 +231,15 @@ namespace quda {
 #endif
     } else if (precision == QUDA_SINGLE_PRECISION) {
       if (Yhat.Precision() == QUDA_SINGLE_PRECISION) {
-	calculateYhat<float,float>(Yhat, Xinv, Y, X);
+        calculateYhat<float,float>(Yhat, Xinv, Y, X);
       } else {
-	errorQuda("Unsupported precision %d\n", precision);
+        errorQuda("Unsupported precision %d\n", precision);
       }
     } else if (precision == QUDA_HALF_PRECISION) {
       if (Yhat.Precision() == QUDA_HALF_PRECISION) {
-	calculateYhat<short,float>(Yhat, Xinv, Y, X);
+        calculateYhat<short,float>(Yhat, Xinv, Y, X);
       } else {
-	errorQuda("Unsupported precision %d\n", precision);
+        errorQuda("Unsupported precision %d\n", precision);
       }
     } else {
       errorQuda("Unsupported precision %d\n", precision);


### PR DESCRIPTION
This PR makes building the coarse preconditioned operator (namely `Yhat = Xinv * Y`) a two-pass algorithm for fixed-precision fields, where the first pass properly computes the max over all 8 (directions * dimensions) and the second pass formally computes and saves the links. This replaces the previous heuristic in place (abuse of notation, `Yhat.scale < 3 * Xinv.abs_max * Y.abs_max`) which was breaking down in some cases for staggered MG (and mayhaps was more silently breaking down to a smaller degree elsewhere).

The algorithm is still single-pass for single precision links.

There's room for optimization in the future because the global max is currently done by each thread thrashing on an `atomicMax` into global memory as opposed to something (anything) smarter, but for now this "just works", and the overhead of this routine as a whole is low.