### PR TITLE
Fixed bug: initialized max in yhat calculation to zero.

### DIFF
--- a/lib/coarse_op_preconditioned.cu
+++ b/lib/coarse_op_preconditioned.cu
@@ -47,7 +47,13 @@ namespace quda {
         else CalculateYhatCPU<Float,n,false,Arg>(arg);
 
       } else {
-        if (compute_max_only) arg.max_d = static_cast<Float*>(pool_device_malloc(sizeof(Float)));
+        if (compute_max_only) {
+          arg.max_d = static_cast<Float*>(pool_device_malloc(sizeof(Float)));
+          if (!activeTuning())
+          {
+            cudaMemset(arg.max_d, 0, sizeof(Float));
+          }
+        }
 #ifdef JITIFY
         using namespace jitify::reflection;
         jitify_error = program->kernel("quda::CalculateYhatGPU")


### PR DESCRIPTION
This PR fixes a bug I introduced in pre-calculating the max of the `Yhat` fields for fixed precision MG preconditioners---I never initialized the GPU-side accumulator to zero!