### PR TITLE
Feature/mg per level io

### DIFF
--- a/include/quda.h
+++ b/include/quda.h
@@ -624,19 +624,19 @@ extern "C" {
     QudaBoolean run_oblique_proj_check;
 
     /** Whether to load the null-space vectors to disk (requires QIO) */
-    QudaBoolean vec_load;
+    QudaBoolean vec_load[QUDA_MAX_MG_LEVEL];
 
     /** Filename prefix where to load the null-space vectors */
-    char vec_infile[256];
+    char vec_infile[QUDA_MAX_MG_LEVEL][256];
 
     /** Whether to store the null-space vectors to disk (requires QIO) */
-    QudaBoolean vec_store;
+    QudaBoolean vec_store[QUDA_MAX_MG_LEVEL];
+
+    /** Filename prefix for where to save the null-space vectors */
+    char vec_outfile[QUDA_MAX_MG_LEVEL][256];
 
     /** Whether to use and initial guess during coarse grid deflation */
     QudaBoolean coarse_guess;
-
-    /** Filename prefix for where to save the null-space vectors */
-    char vec_outfile[256];
 
     /** The Gflops rate of the multigrid solver setup */
     double gflops;

--- a/lib/check_params.h
+++ b/lib/check_params.h
@@ -776,7 +776,7 @@ void printQudaMultigridParam(QudaMultigridParam *param) {
   P(coarse_guess, QUDA_BOOLEAN_INVALID);
 #endif
 
-  for (int i=0; i<n_level-1; i++) {
+  for (int i = 0; i < n_level - 1; i++) {
 #ifdef INIT_PARAM
     P(vec_load[i], QUDA_BOOLEAN_INVALID);
     P(vec_store[i], QUDA_BOOLEAN_INVALID);

--- a/lib/check_params.h
+++ b/lib/check_params.h
@@ -776,13 +776,15 @@ void printQudaMultigridParam(QudaMultigridParam *param) {
   P(coarse_guess, QUDA_BOOLEAN_INVALID);
 #endif
 
+  for (int i=0; i<n_level-1; i++) {
 #ifdef INIT_PARAM
-  P(vec_load, QUDA_BOOLEAN_INVALID);
-  P(vec_store, QUDA_BOOLEAN_INVALID);
+    P(vec_load[i], QUDA_BOOLEAN_INVALID);
+    P(vec_store[i], QUDA_BOOLEAN_INVALID);
 #else
-  P(vec_load, QUDA_BOOLEAN_NO);
-  P(vec_store, QUDA_BOOLEAN_NO);
+    P(vec_load[i], QUDA_BOOLEAN_NO);
+    P(vec_store[i], QUDA_BOOLEAN_NO);
 #endif
+  }
 
 #ifdef INIT_PARAM
   P(gflops, 0.0);

--- a/lib/multigrid.cpp
+++ b/lib/multigrid.cpp
@@ -88,7 +88,7 @@ namespace quda
           }
         }
         if (param.mg_global.num_setup_iter[param.level] > 0) {
-          if (strcmp(param.mg_global.vec_infile, "") != 0) { // only load if infile is defined and not computing
+          if (strcmp(param.mg_global.vec_infile[param.level], "") != 0) { // only load if infile is defined and not computing
             loadVectors(param.B);
           } else if (param.mg_global.use_eig_solver[param.level]) {
             generateEigenVectors(); // Run the eigensolver
@@ -96,9 +96,9 @@ namespace quda
             generateNullVectors(param.B);
           }
         }
-      } else if (strcmp(param.mg_global.vec_infile, "") != 0) { // only load if infile is defined and not computing
+      } else if (strcmp(param.mg_global.vec_infile[param.level], "") != 0) { // only load if infile is defined and not computing
         if ( param.mg_global.num_setup_iter[param.level] > 0 ) generateNullVectors(param.B);
-      } else if (param.mg_global.vec_load == QUDA_BOOLEAN_YES) { // only conditional load of null vectors
+      } else if (param.mg_global.vec_load[param.level] == QUDA_BOOLEAN_YES) { // only conditional load of null vectors
 
         loadVectors(param.B);
       } else { // generate free field vectors
@@ -463,8 +463,8 @@ namespace quda
         }
 
         if (strcmp(param_coarse_solver->eig_param.vec_infile, "") == 0 && // check that input file not already set
-            param.mg_global.vec_load == QUDA_BOOLEAN_YES && (strcmp(param.mg_global.vec_infile, "") != 0)) {
-          std::string vec_infile(param.mg_global.vec_infile);
+            param.mg_global.vec_load[param.level + 1] == QUDA_BOOLEAN_YES && (strcmp(param.mg_global.vec_infile[param.level + 1], "") != 0)) {
+          std::string vec_infile(param.mg_global.vec_infile[param.level + 1]);
           vec_infile += "_level_";
           vec_infile += std::to_string(param.level + 1);
           vec_infile += "_defl_";
@@ -473,8 +473,8 @@ namespace quda
         }
 
         if (strcmp(param_coarse_solver->eig_param.vec_outfile, "") == 0 && // check that output file not already set
-            param.mg_global.vec_store == QUDA_BOOLEAN_YES && (strcmp(param.mg_global.vec_outfile, "") != 0)) {
-          std::string vec_outfile(param.mg_global.vec_outfile);
+            param.mg_global.vec_store[param.level + 1] == QUDA_BOOLEAN_YES && (strcmp(param.mg_global.vec_outfile[param.level + 1], "") != 0)) {
+          std::string vec_outfile(param.mg_global.vec_outfile[param.level + 1]);
           vec_outfile += "_level_";
           vec_outfile += std::to_string(param.level + 1);
           vec_outfile += "_defl_";
@@ -1006,7 +1006,7 @@ namespace quda
     profile_global.TPSTOP(QUDA_PROFILE_INIT);
     profile_global.TPSTART(QUDA_PROFILE_IO);
     pushLevel(param.level);
-    std::string vec_infile(param.mg_global.vec_infile);
+    std::string vec_infile(param.mg_global.vec_infile[param.level]);
     vec_infile += "_level_";
     vec_infile += std::to_string(param.level);
     vec_infile += "_nvec_";
@@ -1022,7 +1022,7 @@ namespace quda
     profile_global.TPSTOP(QUDA_PROFILE_INIT);
     profile_global.TPSTART(QUDA_PROFILE_IO);
     pushLevel(param.level);
-    std::string vec_outfile(param.mg_global.vec_outfile);
+    std::string vec_outfile(param.mg_global.vec_outfile[param.level]);
     vec_outfile += "_level_";
     vec_outfile += std::to_string(param.level);
     vec_outfile += "_nvec_";
@@ -1220,7 +1220,7 @@ namespace quda
       diracSmootherSloppy->setCommDim(commDim);
     }
 
-    if (param.mg_global.vec_store == QUDA_BOOLEAN_YES) { // conditional store of null vectors
+    if (param.mg_global.vec_store[param.level] == QUDA_BOOLEAN_YES) { // conditional store of null vectors
       saveVectors(B);
     }
 
@@ -1468,7 +1468,7 @@ namespace quda
     for (auto b : B_evecs) { delete b; }
 
     // only save if outfile is defined
-    if (strcmp(param.mg_global.vec_outfile, "") != 0) { saveVectors(param.B); }
+    if (strcmp(param.mg_global.vec_outfile[param.level], "") != 0) { saveVectors(param.B); }
 
     popLevel(param.level);
   }

--- a/lib/multigrid.cpp
+++ b/lib/multigrid.cpp
@@ -88,7 +88,8 @@ namespace quda
           }
         }
         if (param.mg_global.num_setup_iter[param.level] > 0) {
-          if (strcmp(param.mg_global.vec_infile[param.level], "") != 0) { // only load if infile is defined and not computing
+          if (strcmp(param.mg_global.vec_infile[param.level], "")
+              != 0) { // only load if infile is defined and not computing
             loadVectors(param.B);
           } else if (param.mg_global.use_eig_solver[param.level]) {
             generateEigenVectors(); // Run the eigensolver
@@ -96,7 +97,8 @@ namespace quda
             generateNullVectors(param.B);
           }
         }
-      } else if (strcmp(param.mg_global.vec_infile[param.level], "") != 0) { // only load if infile is defined and not computing
+      } else if (strcmp(param.mg_global.vec_infile[param.level], "")
+                 != 0) { // only load if infile is defined and not computing
         if ( param.mg_global.num_setup_iter[param.level] > 0 ) generateNullVectors(param.B);
       } else if (param.mg_global.vec_load[param.level] == QUDA_BOOLEAN_YES) { // only conditional load of null vectors
 
@@ -463,7 +465,8 @@ namespace quda
         }
 
         if (strcmp(param_coarse_solver->eig_param.vec_infile, "") == 0 && // check that input file not already set
-            param.mg_global.vec_load[param.level + 1] == QUDA_BOOLEAN_YES && (strcmp(param.mg_global.vec_infile[param.level + 1], "") != 0)) {
+            param.mg_global.vec_load[param.level + 1] == QUDA_BOOLEAN_YES
+            && (strcmp(param.mg_global.vec_infile[param.level + 1], "") != 0)) {
           std::string vec_infile(param.mg_global.vec_infile[param.level + 1]);
           vec_infile += "_level_";
           vec_infile += std::to_string(param.level + 1);
@@ -473,7 +476,8 @@ namespace quda
         }
 
         if (strcmp(param_coarse_solver->eig_param.vec_outfile, "") == 0 && // check that output file not already set
-            param.mg_global.vec_store[param.level + 1] == QUDA_BOOLEAN_YES && (strcmp(param.mg_global.vec_outfile[param.level + 1], "") != 0)) {
+            param.mg_global.vec_store[param.level + 1] == QUDA_BOOLEAN_YES
+            && (strcmp(param.mg_global.vec_outfile[param.level + 1], "") != 0)) {
           std::string vec_outfile(param.mg_global.vec_outfile[param.level + 1]);
           vec_outfile += "_level_";
           vec_outfile += std::to_string(param.level + 1);

--- a/tests/deflated_invert_test.cpp
+++ b/tests/deflated_invert_test.cpp
@@ -61,8 +61,8 @@ extern QudaInverterType precon_type;
 extern QudaMatPCType matpc_type;
 extern QudaSolveType solve_type;
 
-extern char vec_infile[];
-extern char vec_outfile[];
+extern char eig_vec_infile[];
+extern char eig_vec_outfile[];
 
 //Twisted mass flavor type
 extern QudaTwistFlavorType twist_flavor;
@@ -298,8 +298,8 @@ void setDeflationParam(QudaEigParam &df_param) {
   df_param.mem_type_ritz  = mem_type_ritz;
 
   // set file i/o parameters
-  strcpy(df_param.vec_infile, vec_infile);
-  strcpy(df_param.vec_outfile, vec_outfile);
+  strcpy(df_param.vec_infile, eig_vec_infile);
+  strcpy(df_param.vec_outfile, eig_vec_outfile);
 }
 
 int main(int argc, char **argv)

--- a/tests/multigrid_evolve_test.cpp
+++ b/tests/multigrid_evolve_test.cpp
@@ -116,8 +116,8 @@ extern int schwarz_cycle[QUDA_MAX_MG_LEVEL];
 extern QudaMatPCType matpc_type;
 extern QudaSolveType solve_type;
 
-extern char vec_infile[];
-extern char vec_outfile[];
+extern char mg_vec_infile[QUDA_MAX_MG_LEVEL][256];
+extern char mg_vec_outfile[QUDA_MAX_MG_LEVEL][256];
 
 //Twisted mass flavor type
 extern QudaTwistFlavorType twist_flavor;
@@ -424,10 +424,12 @@ void setMultigridParam(QudaMultigridParam &mg_param) {
   mg_param.run_verify = verify_results ? QUDA_BOOLEAN_YES : QUDA_BOOLEAN_NO;
 
   // set file i/o parameters
-  strcpy(mg_param.vec_infile, vec_infile);
-  strcpy(mg_param.vec_outfile, vec_outfile);
-  if (strcmp(mg_param.vec_infile,"")!=0) mg_param.vec_load = QUDA_BOOLEAN_YES;
-  if (strcmp(mg_param.vec_outfile,"")!=0) mg_param.vec_store = QUDA_BOOLEAN_YES;
+  for (int i=0; i<mg_param.n_level; i++) {
+    strcpy(mg_param.vec_infile[i], mg_vec_infile[i]);
+    strcpy(mg_param.vec_outfile[i], mg_vec_outfile[i]);
+    if (strcmp(mg_param.vec_infile[i],"")!=0) mg_param.vec_load[i] = QUDA_BOOLEAN_YES;
+    if (strcmp(mg_param.vec_outfile[i],"")!=0) mg_param.vec_store[i] = QUDA_BOOLEAN_YES;
+  }
 
   // these need to tbe set for now but are actually ignored by the MG setup
   // needed to make it pass the initialization test
@@ -593,6 +595,9 @@ int main(int argc, char **argv)
     coarse_solver_ca_basis_size[i] = 4;
     coarse_solver_ca_lambda_min[i] = 0.0;
     coarse_solver_ca_lambda_max[i] = -1.0;
+
+    strcpy(mg_vec_infile[i], "");
+    strcpy(mg_vec_outfile[i], "");
   }
   reliable_delta = 1e-4;
 

--- a/tests/multigrid_evolve_test.cpp
+++ b/tests/multigrid_evolve_test.cpp
@@ -424,11 +424,11 @@ void setMultigridParam(QudaMultigridParam &mg_param) {
   mg_param.run_verify = verify_results ? QUDA_BOOLEAN_YES : QUDA_BOOLEAN_NO;
 
   // set file i/o parameters
-  for (int i=0; i<mg_param.n_level; i++) {
+  for (int i = 0; i < mg_param.n_level; i++) {
     strcpy(mg_param.vec_infile[i], mg_vec_infile[i]);
     strcpy(mg_param.vec_outfile[i], mg_vec_outfile[i]);
-    if (strcmp(mg_param.vec_infile[i],"")!=0) mg_param.vec_load[i] = QUDA_BOOLEAN_YES;
-    if (strcmp(mg_param.vec_outfile[i],"")!=0) mg_param.vec_store[i] = QUDA_BOOLEAN_YES;
+    if (strcmp(mg_param.vec_infile[i], "") != 0) mg_param.vec_load[i] = QUDA_BOOLEAN_YES;
+    if (strcmp(mg_param.vec_outfile[i], "") != 0) mg_param.vec_store[i] = QUDA_BOOLEAN_YES;
   }
 
   // these need to tbe set for now but are actually ignored by the MG setup

--- a/tests/multigrid_invert_test.cpp
+++ b/tests/multigrid_invert_test.cpp
@@ -99,8 +99,8 @@ extern int schwarz_cycle[QUDA_MAX_MG_LEVEL];
 extern QudaMatPCType matpc_type;
 extern QudaSolveType solve_type;
 
-extern char vec_infile[];
-extern char vec_outfile[];
+extern char mg_vec_infile[QUDA_MAX_MG_LEVEL][256];
+extern char mg_vec_outfile[QUDA_MAX_MG_LEVEL][256];
 
 //Twisted mass flavor type
 extern QudaTwistFlavorType twist_flavor;
@@ -491,10 +491,12 @@ void setMultigridParam(QudaMultigridParam &mg_param)
   mg_param.run_oblique_proj_check = oblique_proj_check ? QUDA_BOOLEAN_YES : QUDA_BOOLEAN_NO;
 
   // set file i/o parameters
-  strcpy(mg_param.vec_infile, vec_infile);
-  strcpy(mg_param.vec_outfile, vec_outfile);
-  if (strcmp(mg_param.vec_infile,"")!=0) mg_param.vec_load = QUDA_BOOLEAN_YES;
-  if (strcmp(mg_param.vec_outfile,"")!=0) mg_param.vec_store = QUDA_BOOLEAN_YES;
+  for (int i=0; i<mg_param.n_level; i++) {
+    strcpy(mg_param.vec_infile[i], mg_vec_infile[i]);
+    strcpy(mg_param.vec_outfile[i], mg_vec_outfile[i]);
+    if (strcmp(mg_param.vec_infile[i],"")!=0) mg_param.vec_load[i] = QUDA_BOOLEAN_YES;
+    if (strcmp(mg_param.vec_outfile[i],"")!=0) mg_param.vec_store[i] = QUDA_BOOLEAN_YES;
+  }
 
   mg_param.coarse_guess = mg_eig_coarse_guess ? QUDA_BOOLEAN_YES : QUDA_BOOLEAN_NO;
 
@@ -652,6 +654,9 @@ int main(int argc, char **argv)
     coarse_solver_ca_basis_size[i] = 4;
     coarse_solver_ca_lambda_min[i] = 0.0;
     coarse_solver_ca_lambda_max[i] = -1.0;
+
+    strcpy(mg_vec_infile[i], "");
+    strcpy(mg_vec_outfile[i], "");
   }
   reliable_delta = 1e-4;
 

--- a/tests/multigrid_invert_test.cpp
+++ b/tests/multigrid_invert_test.cpp
@@ -491,11 +491,11 @@ void setMultigridParam(QudaMultigridParam &mg_param)
   mg_param.run_oblique_proj_check = oblique_proj_check ? QUDA_BOOLEAN_YES : QUDA_BOOLEAN_NO;
 
   // set file i/o parameters
-  for (int i=0; i<mg_param.n_level; i++) {
+  for (int i = 0; i < mg_param.n_level; i++) {
     strcpy(mg_param.vec_infile[i], mg_vec_infile[i]);
     strcpy(mg_param.vec_outfile[i], mg_vec_outfile[i]);
-    if (strcmp(mg_param.vec_infile[i],"")!=0) mg_param.vec_load[i] = QUDA_BOOLEAN_YES;
-    if (strcmp(mg_param.vec_outfile[i],"")!=0) mg_param.vec_store[i] = QUDA_BOOLEAN_YES;
+    if (strcmp(mg_param.vec_infile[i], "") != 0) mg_param.vec_load[i] = QUDA_BOOLEAN_YES;
+    if (strcmp(mg_param.vec_outfile[i], "") != 0) mg_param.vec_store[i] = QUDA_BOOLEAN_YES;
   }
 
   mg_param.coarse_guess = mg_eig_coarse_guess ? QUDA_BOOLEAN_YES : QUDA_BOOLEAN_NO;

--- a/tests/test_util.cpp
+++ b/tests/test_util.cpp
@@ -1912,7 +1912,8 @@ void usage(char** argv )
   printf("    --mg-mu-factor <level factor>             # Set the multiplicative factor for the twisted mass mu parameter on each level (default 1)\n");
   printf("    --mg-generate-nullspace <true/false>      # Generate the null-space vector dynamically (default true, if set false and mg-load-vec isn't set, creates free-field null vectors)\n");
   printf("    --mg-generate-all-levels <true/talse>     # true=generate null-space on all levels, false=generate on level 0 and create other levels from that (default true)\n");
-  printf("    --mg-load-vec <level file>                # Load the vectors \"file\" for the multigrid_test (requires QIO)\n");
+  printf("    --mg-load-vec <level file>                # Load the vectors \"file\" for the multigrid_test (requires "
+         "QIO)\n");
   printf("    --mg-save-vec <level file>                # Save the generated null-space vectors \"file\" from the "
          "multigrid_test (requires QIO)\n");
   printf("    --mg-verbosity <level verb>               # The verbosity to use on each level of the multigrid (default "
@@ -3524,17 +3525,15 @@ int process_command_line_option(int argc, char** argv, int* idx)
   }
 
   if( strcmp(argv[i], "--mg-load-vec") == 0){
-    if (i+2 >= argc){
-      usage(argv);
-    }
-    int level = atoi(argv[i+1]);
+    if (i + 2 >= argc) { usage(argv); }
+    int level = atoi(argv[i + 1]);
     if (level < 0 || level >= QUDA_MAX_MG_LEVEL) {
       printf("ERROR: invalid multigrid level %d", level);
       usage(argv);
     }
     i++;
 
-    strcpy(mg_vec_infile[level], argv[i+1]);
+    strcpy(mg_vec_infile[level], argv[i + 1]);
     i++;
     ret = 0;
     goto out;
@@ -3544,13 +3543,13 @@ int process_command_line_option(int argc, char** argv, int* idx)
     if (i+1 >= argc){
       usage(argv);
     }
-    int level = atoi(argv[i+1]);
+    int level = atoi(argv[i + 1]);
     if (level < 0 || level >= QUDA_MAX_MG_LEVEL) {
       printf("ERROR: invalid multigrid level %d", level);
       usage(argv);
     }
     i++;
-    strcpy(mg_vec_outfile[level], argv[i+1]);
+    strcpy(mg_vec_outfile[level], argv[i + 1]);
     i++;
     ret = 0;
     goto out;

--- a/tests/test_util.cpp
+++ b/tests/test_util.cpp
@@ -1641,8 +1641,8 @@ int pipeline = 0;
 int solution_accumulator_pipeline = 0;
 int test_type = 0;
 int nvec[QUDA_MAX_MG_LEVEL] = { };
-char vec_infile[256] = "";
-char vec_outfile[256] = "";
+char mg_vec_infile[QUDA_MAX_MG_LEVEL][256];
+char mg_vec_outfile[QUDA_MAX_MG_LEVEL][256];
 QudaInverterType inv_type;
 QudaInverterType precon_type = QUDA_INVALID_INVERTER;
 int multishift = 0;
@@ -1912,8 +1912,8 @@ void usage(char** argv )
   printf("    --mg-mu-factor <level factor>             # Set the multiplicative factor for the twisted mass mu parameter on each level (default 1)\n");
   printf("    --mg-generate-nullspace <true/false>      # Generate the null-space vector dynamically (default true, if set false and mg-load-vec isn't set, creates free-field null vectors)\n");
   printf("    --mg-generate-all-levels <true/talse>     # true=generate null-space on all levels, false=generate on level 0 and create other levels from that (default true)\n");
-  printf("    --mg-load-vec file                        # Load the vectors \"file\" for the multigrid_test (requires QIO)\n");
-  printf("    --mg-save-vec file                        # Save the generated null-space vectors \"file\" from the "
+  printf("    --mg-load-vec <level file>                # Load the vectors \"file\" for the multigrid_test (requires QIO)\n");
+  printf("    --mg-save-vec <level file>                # Save the generated null-space vectors \"file\" from the "
          "multigrid_test (requires QIO)\n");
   printf("    --mg-verbosity <level verb>               # The verbosity to use on each level of the multigrid (default "
          "summarize)\n");
@@ -3524,10 +3524,17 @@ int process_command_line_option(int argc, char** argv, int* idx)
   }
 
   if( strcmp(argv[i], "--mg-load-vec") == 0){
-    if (i+1 >= argc){
+    if (i+2 >= argc){
       usage(argv);
     }
-    strcpy(vec_infile, argv[i+1]);
+    int level = atoi(argv[i+1]);
+    if (level < 0 || level >= QUDA_MAX_MG_LEVEL) {
+      printf("ERROR: invalid multigrid level %d", level);
+      usage(argv);
+    }
+    i++;
+
+    strcpy(mg_vec_infile[level], argv[i+1]);
     i++;
     ret = 0;
     goto out;
@@ -3537,7 +3544,13 @@ int process_command_line_option(int argc, char** argv, int* idx)
     if (i+1 >= argc){
       usage(argv);
     }
-    strcpy(vec_outfile, argv[i+1]);
+    int level = atoi(argv[i+1]);
+    if (level < 0 || level >= QUDA_MAX_MG_LEVEL) {
+      printf("ERROR: invalid multigrid level %d", level);
+      usage(argv);
+    }
+    i++;
+    strcpy(mg_vec_outfile[level], argv[i+1]);
     i++;
     ret = 0;
     goto out;


### PR DESCRIPTION
Trivial change to the multigrid interface to allow per-level setting of the null-space and eigenvector filenames.  E.g., previously we set `--mg-save-vec null` and this filename would be used for all levels.  Now we can set `--mg-load-vec 0 null --mg-load-vec 1 null --mg-save-vec 2 evector` for example, which would load null-space vectors for levels 0 and 1, but generate new vectors on level 2 and dump them to disk.  The previous behaviour of appending the level number and number of vectors into the filename is preserved.

This pull also fixes the `deflation_test` to use `--eig-vec-infile` and `--eig-vec-outfile` to set the i/o parmeters as opposed to the incorrectly using multigrid i/o parameters.

This pull request depends on #848, so should not be merged until after that has been merged.