### PR TITLE
Feature/managed memory

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,7 @@
 ---
 BasedOnStyle: Webkit
 IndentWidth: 2
+AccessModifierOffset: -2
 AlignAfterOpenBracket: Align
 AlignTrailingComments: true
 AllowShortBlocksOnASingleLine: true

--- a/include/blas_helper.cuh
+++ b/include/blas_helper.cuh
@@ -20,13 +20,13 @@ namespace quda
   inline void checkSpinor(const ColorSpinorField &a, const ColorSpinorField &b)
   {
     if (a.Length() != b.Length()) errorQuda("lengths do not match: %lu %lu", a.Length(), b.Length());
-    if (a.Stride() != b.Stride()) errorQuda("strides do not match: %d %d", a.Stride(), b.Stride());
+    if (a.Stride() != b.Stride()) errorQuda("strides do not match: %lu %lu", a.Stride(), b.Stride());
   }
 
   inline void checkLength(const ColorSpinorField &a, const ColorSpinorField &b)
   {
     if (a.Length() != b.Length()) errorQuda("lengths do not match: %lu %lu", a.Length(), b.Length());
-    if (a.Stride() != b.Stride()) errorQuda("strides do not match: %d %d", a.Stride(), b.Stride());
+    if (a.Stride() != b.Stride()) errorQuda("strides do not match: %lu %lu", a.Stride(), b.Stride());
   }
 
 #ifdef QUAD_SUM

--- a/include/color_spinor_field.h
+++ b/include/color_spinor_field.h
@@ -34,9 +34,9 @@ namespace quda {
      int  dim;//individual component has dim = 0
      int  id;
 
-     int volume;       // volume of a single eigenvector
-     int volumeCB;     // CB volume of a single eigenvector
-     int stride;       // stride of a single eigenvector
+     size_t volume;       // volume of a single eigenvector
+     size_t volumeCB;     // CB volume of a single eigenvector
+     size_t stride;       // stride of a single eigenvector
      size_t real_length;  // physical length of a single eigenvector
      size_t length;       // length including pads (but not ghost zones)
 
@@ -330,10 +330,10 @@ namespace quda {
     int nDim;
     int x[QUDA_MAX_DIM];
 
-    int volume;
-    int volumeCB;
-    int pad;
-    int stride;
+    size_t volume;
+    size_t volumeCB;
+    size_t pad;
+    size_t stride;
 
     QudaTwistFlavorType twistFlavor;
 
@@ -412,9 +412,9 @@ namespace quda {
     int X(int d) const { return x[d]; }
     size_t RealLength() const { return real_length; }
     size_t Length() const { return length; }
-    int Stride() const { return stride; }
-    int Volume() const { return volume; }
-    int VolumeCB() const { return siteSubset == QUDA_PARITY_SITE_SUBSET ? volume : volume / 2; }
+    size_t Stride() const { return stride; }
+    size_t Volume() const { return volume; }
+    size_t VolumeCB() const { return siteSubset == QUDA_PARITY_SITE_SUBSET ? volume : volume / 2; }
     int Pad() const { return pad; }
     size_t Bytes() const { return bytes; }
     size_t NormBytes() const { return norm_bytes; }

--- a/include/kernels/dslash_coarse.cuh
+++ b/include/kernels/dslash_coarse.cuh
@@ -40,14 +40,20 @@ namespace quda {
     const int volumeCB;
 
     inline DslashCoarseArg(ColorSpinorField &out, const ColorSpinorField &inA, const ColorSpinorField &inB,
-			   const GaugeField &Y, const GaugeField &X, Float kappa, int parity)
-      : out(const_cast<ColorSpinorField&>(out)), inA(const_cast<ColorSpinorField&>(inA)),
-	inB(const_cast<ColorSpinorField&>(inB)), Y(const_cast<GaugeField&>(Y)),
-	X(const_cast<GaugeField&>(X)), kappa(kappa), parity(parity),
-	nParity(out.SiteSubset()), nFace(1), X0h( ((3-nParity) * out.X(0)) /2),
-	dim{ (3-nParity) * out.X(0), out.X(1), out.X(2), out.X(3), out.Ndim() == 5 ? out.X(4) : 1 },
-      commDim{comm_dim_partitioned(0), comm_dim_partitioned(1), comm_dim_partitioned(2), comm_dim_partitioned(3)},
-      volumeCB(out.VolumeCB()/dim[4])
+                           const GaugeField &Y, const GaugeField &X, Float kappa, int parity) :
+      out(const_cast<ColorSpinorField &>(out)),
+      inA(const_cast<ColorSpinorField &>(inA)),
+      inB(const_cast<ColorSpinorField &>(inB)),
+      Y(const_cast<GaugeField &>(Y)),
+      X(const_cast<GaugeField &>(X)),
+      kappa(kappa),
+      parity(parity),
+      nParity(out.SiteSubset()),
+      nFace(1),
+      X0h(((3 - nParity) * out.X(0)) / 2),
+      dim {(3 - nParity) * out.X(0), out.X(1), out.X(2), out.X(3), out.Ndim() == 5 ? out.X(4) : 1},
+      commDim {comm_dim_partitioned(0), comm_dim_partitioned(1), comm_dim_partitioned(2), comm_dim_partitioned(3)},
+      volumeCB((unsigned int)out.VolumeCB() / dim[4])
     {  }
   };
 

--- a/include/lattice_field.h
+++ b/include/lattice_field.h
@@ -145,258 +145,257 @@ namespace quda {
 
   protected:
     /** Lattice volume */
-    size_t volume;
+      size_t volume;
 
-    /** Checkerboarded volume */
-    size_t volumeCB;
+      /** Checkerboarded volume */
+      size_t volumeCB;
 
-    size_t stride;
-    int pad;
+      size_t stride;
+      int pad;
 
-    size_t total_bytes;
+      size_t total_bytes;
 
-    /** Number of field dimensions */
-    int nDim;
-    
-    /** Array storing the length of dimension */
-    int x[QUDA_MAX_DIM];
+      /** Number of field dimensions */
+      int nDim;
 
-    int surface[QUDA_MAX_DIM];
-    int surfaceCB[QUDA_MAX_DIM];
+      /** Array storing the length of dimension */
+      int x[QUDA_MAX_DIM];
 
-    /** The extended lattice radius (if applicable) */
-    int r[QUDA_MAX_DIM];
+      int surface[QUDA_MAX_DIM];
+      int surfaceCB[QUDA_MAX_DIM];
 
-    /** Precision of the field */
-    QudaPrecision precision;
-    
-    /** Precision of the ghost */
-    mutable QudaPrecision ghost_precision;
+      /** The extended lattice radius (if applicable) */
+      int r[QUDA_MAX_DIM];
 
-    /** Bool which is triggered if the ghost precision is reset */
-    mutable bool ghost_precision_reset;
+      /** Precision of the field */
+      QudaPrecision precision;
 
-    /** For fixed-point fields that need a global scaling factor */
-    double scale;
+      /** Precision of the ghost */
+      mutable QudaPrecision ghost_precision;
 
-    /** Whether the field is full or single parity */
-    QudaSiteSubset siteSubset;
+      /** Bool which is triggered if the ghost precision is reset */
+      mutable bool ghost_precision_reset;
 
-    /** Type of ghost exchange to perform */
-    QudaGhostExchange ghostExchange;
+      /** For fixed-point fields that need a global scaling factor */
+      double scale;
 
-    // The below are additions for inter-GPU communication (merging FaceBuffer functionality)
+      /** Whether the field is full or single parity */
+      QudaSiteSubset siteSubset;
 
-    /** The number of dimensions we partition for communication */
-    int nDimComms;
+      /** Type of ghost exchange to perform */
+      QudaGhostExchange ghostExchange;
 
-    /* 
-       The need for persistent message handlers (for GPUDirect support)
-       means that we allocate different message handlers for each number of
-       faces we can send.
-    */
+      // The below are additions for inter-GPU communication (merging FaceBuffer functionality)
 
-    /**
-       Double buffered static GPU halo send buffer
-    */
-    static void *ghost_send_buffer_d[2];
+      /** The number of dimensions we partition for communication */
+      int nDimComms;
 
-    /**
-       Double buffered static GPU halo receive buffer
-     */
-    static void *ghost_recv_buffer_d[2];
+      /*
+         The need for persistent message handlers (for GPUDirect support)
+         means that we allocate different message handlers for each number of
+         faces we can send.
+      */
 
-    /**
-       Double buffered static pinned send buffers
-    */
-    static void *ghost_pinned_send_buffer_h[2];
+      /**
+         Double buffered static GPU halo send buffer
+      */
+      static void *ghost_send_buffer_d[2];
 
-    /**
-       Double buffered static pinned recv buffers
-    */
-    static void *ghost_pinned_recv_buffer_h[2];
+      /**
+         Double buffered static GPU halo receive buffer
+       */
+      static void *ghost_recv_buffer_d[2];
 
-    /**
-       Mapped version of pinned send buffers
-    */
-    static void *ghost_pinned_send_buffer_hd[2];
+      /**
+         Double buffered static pinned send buffers
+      */
+      static void *ghost_pinned_send_buffer_h[2];
 
-    /**
-       Mapped version of pinned recv buffers
-    */
-    static void *ghost_pinned_recv_buffer_hd[2];
+      /**
+         Double buffered static pinned recv buffers
+      */
+      static void *ghost_pinned_recv_buffer_h[2];
 
-    /**
-       Remove ghost pointer for sending to
-    */
-    static void *ghost_remote_send_buffer_d[2][QUDA_MAX_DIM][2];
+      /**
+         Mapped version of pinned send buffers
+      */
+      static void *ghost_pinned_send_buffer_hd[2];
 
-    /**
-       The current size of the static ghost allocation
-    */
-    static size_t ghostFaceBytes;
+      /**
+         Mapped version of pinned recv buffers
+      */
+      static void *ghost_pinned_recv_buffer_hd[2];
 
-    /**
-       Whether the ghost buffers have been initialized
-    */
-    static bool initGhostFaceBuffer;
+      /**
+         Remove ghost pointer for sending to
+      */
+      static void *ghost_remote_send_buffer_d[2][QUDA_MAX_DIM][2];
 
-    /**
-       Size in bytes of this ghost field
-    */
-    mutable size_t ghost_bytes;
+      /**
+         The current size of the static ghost allocation
+      */
+      static size_t ghostFaceBytes;
 
-    /**
-       Size in bytes of prior ghost allocation
-    */
-    mutable size_t ghost_bytes_old;
+      /**
+         Whether the ghost buffers have been initialized
+      */
+      static bool initGhostFaceBuffer;
 
-    /**
-       Size in bytes of the ghost in each dimension
-    */
-    mutable size_t ghost_face_bytes[QUDA_MAX_DIM];
+      /**
+         Size in bytes of this ghost field
+      */
+      mutable size_t ghost_bytes;
 
-    /**
-       Real-number offsets to each ghost zone
-    */
-    mutable int ghostOffset[QUDA_MAX_DIM][2];
+      /**
+         Size in bytes of prior ghost allocation
+      */
+      mutable size_t ghost_bytes_old;
 
-    /**
-       Real-number (in floats) offsets to each ghost zone for norm field
-    */
-    mutable int ghostNormOffset[QUDA_MAX_DIM][2];
+      /**
+         Size in bytes of the ghost in each dimension
+      */
+      mutable size_t ghost_face_bytes[QUDA_MAX_DIM];
 
-    /**
-       Pinned memory buffer used for sending messages
-    */
-    void *my_face_h[2];
+      /**
+         Real-number offsets to each ghost zone
+      */
+      mutable int ghostOffset[QUDA_MAX_DIM][2];
 
-    /**
-       Mapped version of my_face_h
-    */
-    void *my_face_hd[2];
+      /**
+         Real-number (in floats) offsets to each ghost zone for norm field
+      */
+      mutable int ghostNormOffset[QUDA_MAX_DIM][2];
 
-    /**
-       Device memory buffer for sending messages
-     */
-    void *my_face_d[2];
+      /**
+         Pinned memory buffer used for sending messages
+      */
+      void *my_face_h[2];
 
-    /** Local pointers to the pinned my_face buffer */
-    void *my_face_dim_dir_h[2][QUDA_MAX_DIM][2];
+      /**
+         Mapped version of my_face_h
+      */
+      void *my_face_hd[2];
 
-    /** Local pointers to the mapped my_face buffer */
-    void *my_face_dim_dir_hd[2][QUDA_MAX_DIM][2];
+      /**
+         Device memory buffer for sending messages
+       */
+      void *my_face_d[2];
 
-    /** Local pointers to the device ghost_send buffer */
-    void *my_face_dim_dir_d[2][QUDA_MAX_DIM][2];
+      /** Local pointers to the pinned my_face buffer */
+      void *my_face_dim_dir_h[2][QUDA_MAX_DIM][2];
 
-    /**
-       Memory buffer used for receiving all messages
-    */
-    void *from_face_h[2];
+      /** Local pointers to the mapped my_face buffer */
+      void *my_face_dim_dir_hd[2][QUDA_MAX_DIM][2];
 
-    /**
-       Mapped version of from_face_h
-    */
-    void *from_face_hd[2];
+      /** Local pointers to the device ghost_send buffer */
+      void *my_face_dim_dir_d[2][QUDA_MAX_DIM][2];
 
-    /**
-       Device memory buffer for receiving messages
-     */
-    void *from_face_d[2];
+      /**
+         Memory buffer used for receiving all messages
+      */
+      void *from_face_h[2];
 
-    /** Local pointers to the pinned from_face buffer */
-    void *from_face_dim_dir_h[2][QUDA_MAX_DIM][2];
+      /**
+         Mapped version of from_face_h
+      */
+      void *from_face_hd[2];
 
-    /** Local pointers to the mapped from_face buffer */
-    void *from_face_dim_dir_hd[2][QUDA_MAX_DIM][2];
+      /**
+         Device memory buffer for receiving messages
+       */
+      void *from_face_d[2];
 
-    /** Local pointers to the device ghost_recv buffer */
-    void *from_face_dim_dir_d[2][QUDA_MAX_DIM][2];
-    
-    /** Message handles for receiving from forwards */
-    MsgHandle *mh_recv_fwd[2][QUDA_MAX_DIM];
+      /** Local pointers to the pinned from_face buffer */
+      void *from_face_dim_dir_h[2][QUDA_MAX_DIM][2];
 
-    /** Message handles for receiving from backwards */
-    MsgHandle *mh_recv_back[2][QUDA_MAX_DIM];
+      /** Local pointers to the mapped from_face buffer */
+      void *from_face_dim_dir_hd[2][QUDA_MAX_DIM][2];
 
-    /** Message handles for sending forwards */
-    MsgHandle *mh_send_fwd[2][QUDA_MAX_DIM];
+      /** Local pointers to the device ghost_recv buffer */
+      void *from_face_dim_dir_d[2][QUDA_MAX_DIM][2];
 
-    /** Message handles for sending backwards */
-    MsgHandle *mh_send_back[2][QUDA_MAX_DIM];
+      /** Message handles for receiving from forwards */
+      MsgHandle *mh_recv_fwd[2][QUDA_MAX_DIM];
 
-    /** Message handles for rdma receiving from forwards */
-    MsgHandle *mh_recv_rdma_fwd[2][QUDA_MAX_DIM];
+      /** Message handles for receiving from backwards */
+      MsgHandle *mh_recv_back[2][QUDA_MAX_DIM];
 
-    /** Message handles for rdma receiving from backwards */
-    MsgHandle *mh_recv_rdma_back[2][QUDA_MAX_DIM];
+      /** Message handles for sending forwards */
+      MsgHandle *mh_send_fwd[2][QUDA_MAX_DIM];
 
-    /** Message handles for rdma sending to forwards */
-    MsgHandle *mh_send_rdma_fwd[2][QUDA_MAX_DIM];
+      /** Message handles for sending backwards */
+      MsgHandle *mh_send_back[2][QUDA_MAX_DIM];
 
-    /** Message handles for rdma sending to backwards */
-    MsgHandle *mh_send_rdma_back[2][QUDA_MAX_DIM];
+      /** Message handles for rdma receiving from forwards */
+      MsgHandle *mh_recv_rdma_fwd[2][QUDA_MAX_DIM];
 
-    /** Peer-to-peer message handler for signaling event posting */
-    static MsgHandle* mh_send_p2p_fwd[2][QUDA_MAX_DIM];
+      /** Message handles for rdma receiving from backwards */
+      MsgHandle *mh_recv_rdma_back[2][QUDA_MAX_DIM];
 
-    /** Peer-to-peer message handler for signaling event posting */
-    static MsgHandle* mh_send_p2p_back[2][QUDA_MAX_DIM];
+      /** Message handles for rdma sending to forwards */
+      MsgHandle *mh_send_rdma_fwd[2][QUDA_MAX_DIM];
 
-    /** Peer-to-peer message handler for signaling event posting */
-    static MsgHandle* mh_recv_p2p_fwd[2][QUDA_MAX_DIM];
+      /** Message handles for rdma sending to backwards */
+      MsgHandle *mh_send_rdma_back[2][QUDA_MAX_DIM];
 
-    /** Peer-to-peer message handler for signaling event posting */
-    static MsgHandle* mh_recv_p2p_back[2][QUDA_MAX_DIM];
+      /** Peer-to-peer message handler for signaling event posting */
+      static MsgHandle *mh_send_p2p_fwd[2][QUDA_MAX_DIM];
 
-    /** Buffer used by peer-to-peer message handler */
-    static int buffer_send_p2p_fwd[2][QUDA_MAX_DIM];
+      /** Peer-to-peer message handler for signaling event posting */
+      static MsgHandle *mh_send_p2p_back[2][QUDA_MAX_DIM];
 
-    /** Buffer used by peer-to-peer message handler */
-    static int buffer_recv_p2p_fwd[2][QUDA_MAX_DIM];
+      /** Peer-to-peer message handler for signaling event posting */
+      static MsgHandle *mh_recv_p2p_fwd[2][QUDA_MAX_DIM];
 
-    /** Buffer used by peer-to-peer message handler */
-    static int buffer_send_p2p_back[2][QUDA_MAX_DIM];
+      /** Peer-to-peer message handler for signaling event posting */
+      static MsgHandle *mh_recv_p2p_back[2][QUDA_MAX_DIM];
 
-    /** Buffer used by peer-to-peer message handler */
-    static int buffer_recv_p2p_back[2][QUDA_MAX_DIM];
+      /** Buffer used by peer-to-peer message handler */
+      static int buffer_send_p2p_fwd[2][QUDA_MAX_DIM];
 
-    /** Local copy of event used for peer-to-peer synchronization */
-    static cudaEvent_t ipcCopyEvent[2][2][QUDA_MAX_DIM];
+      /** Buffer used by peer-to-peer message handler */
+      static int buffer_recv_p2p_fwd[2][QUDA_MAX_DIM];
 
-    /** Remote copy of event used for peer-to-peer synchronization */
-    static cudaEvent_t ipcRemoteCopyEvent[2][2][QUDA_MAX_DIM];
+      /** Buffer used by peer-to-peer message handler */
+      static int buffer_send_p2p_back[2][QUDA_MAX_DIM];
 
-    /** Whether we have initialized communication for this field */
-    bool initComms;
+      /** Buffer used by peer-to-peer message handler */
+      static int buffer_recv_p2p_back[2][QUDA_MAX_DIM];
 
-    /** Whether we have initialized peer-to-peer communication */
-    static bool initIPCComms;
+      /** Local copy of event used for peer-to-peer synchronization */
+      static cudaEvent_t ipcCopyEvent[2][2][QUDA_MAX_DIM];
 
-    /** Used as a label in the autotuner */
-    char vol_string[TuneKey::volume_n];
-    
-    /** used as a label in the autotuner */
-    char aux_string[TuneKey::aux_n];
+      /** Remote copy of event used for peer-to-peer synchronization */
+      static cudaEvent_t ipcRemoteCopyEvent[2][2][QUDA_MAX_DIM];
 
-    /** Sets the vol_string for use in tuning */
-    virtual void setTuningString();
+      /** Whether we have initialized communication for this field */
+      bool initComms;
 
-    /** The type of allocation we are going to do for this field */
-    QudaMemoryType mem_type;
+      /** Whether we have initialized peer-to-peer communication */
+      static bool initIPCComms;
 
-    void precisionCheck() {
-      switch(precision) {
-      case QUDA_QUARTER_PRECISION:
-      case QUDA_HALF_PRECISION:
-      case QUDA_SINGLE_PRECISION:
-      case QUDA_DOUBLE_PRECISION:
-	break;
-      default:
-	errorQuda("Unknown precision %d\n", precision);
+      /** Used as a label in the autotuner */
+      char vol_string[TuneKey::volume_n];
+
+      /** used as a label in the autotuner */
+      char aux_string[TuneKey::aux_n];
+
+      /** Sets the vol_string for use in tuning */
+      virtual void setTuningString();
+
+      /** The type of allocation we are going to do for this field */
+      QudaMemoryType mem_type;
+
+      void precisionCheck()
+      {
+        switch (precision) {
+        case QUDA_QUARTER_PRECISION:
+        case QUDA_HALF_PRECISION:
+        case QUDA_SINGLE_PRECISION:
+        case QUDA_DOUBLE_PRECISION: break;
+        default: errorQuda("Unknown precision %d\n", precision);
+        }
       }
-    }
 
     mutable char *backup_h;
     mutable char *backup_norm_h;
@@ -502,12 +501,12 @@ namespace quda {
        @return The full-field volume
     */
     size_t Volume() const { return volume; }
-    
+
     /**
        @return The single-parity volume
     */
     size_t VolumeCB() const { return volumeCB; }
-    
+
     /**
        @param i The dimension of the requested surface 
        @return The single-parity surface of dimension i
@@ -524,7 +523,7 @@ namespace quda {
        @return The single-parity stride of the field     
     */
     size_t Stride() const { return stride; }
-    
+
     /**
        @return The field padding
     */

--- a/include/lattice_field.h
+++ b/include/lattice_field.h
@@ -145,257 +145,257 @@ namespace quda {
 
   protected:
     /** Lattice volume */
-      size_t volume;
+    size_t volume;
 
-      /** Checkerboarded volume */
-      size_t volumeCB;
+    /** Checkerboarded volume */
+    size_t volumeCB;
 
-      size_t stride;
-      int pad;
+    size_t stride;
+    int pad;
 
-      size_t total_bytes;
+    size_t total_bytes;
 
-      /** Number of field dimensions */
-      int nDim;
+    /** Number of field dimensions */
+    int nDim;
 
-      /** Array storing the length of dimension */
-      int x[QUDA_MAX_DIM];
+    /** Array storing the length of dimension */
+    int x[QUDA_MAX_DIM];
 
-      int surface[QUDA_MAX_DIM];
-      int surfaceCB[QUDA_MAX_DIM];
+    int surface[QUDA_MAX_DIM];
+    int surfaceCB[QUDA_MAX_DIM];
 
-      /** The extended lattice radius (if applicable) */
-      int r[QUDA_MAX_DIM];
+    /** The extended lattice radius (if applicable) */
+    int r[QUDA_MAX_DIM];
 
-      /** Precision of the field */
-      QudaPrecision precision;
+    /** Precision of the field */
+    QudaPrecision precision;
 
-      /** Precision of the ghost */
-      mutable QudaPrecision ghost_precision;
+    /** Precision of the ghost */
+    mutable QudaPrecision ghost_precision;
 
-      /** Bool which is triggered if the ghost precision is reset */
-      mutable bool ghost_precision_reset;
-
-      /** For fixed-point fields that need a global scaling factor */
-      double scale;
-
-      /** Whether the field is full or single parity */
-      QudaSiteSubset siteSubset;
+    /** Bool which is triggered if the ghost precision is reset */
+    mutable bool ghost_precision_reset;
+
+    /** For fixed-point fields that need a global scaling factor */
+    double scale;
+
+    /** Whether the field is full or single parity */
+    QudaSiteSubset siteSubset;
 
-      /** Type of ghost exchange to perform */
-      QudaGhostExchange ghostExchange;
+    /** Type of ghost exchange to perform */
+    QudaGhostExchange ghostExchange;
 
-      // The below are additions for inter-GPU communication (merging FaceBuffer functionality)
-
-      /** The number of dimensions we partition for communication */
-      int nDimComms;
+    // The below are additions for inter-GPU communication (merging FaceBuffer functionality)
+
+    /** The number of dimensions we partition for communication */
+    int nDimComms;
 
-      /*
-         The need for persistent message handlers (for GPUDirect support)
-         means that we allocate different message handlers for each number of
-         faces we can send.
-      */
+    /*
+       The need for persistent message handlers (for GPUDirect support)
+       means that we allocate different message handlers for each number of
+       faces we can send.
+    */
 
-      /**
-         Double buffered static GPU halo send buffer
-      */
-      static void *ghost_send_buffer_d[2];
+    /**
+       Double buffered static GPU halo send buffer
+    */
+    static void *ghost_send_buffer_d[2];
 
-      /**
-         Double buffered static GPU halo receive buffer
-       */
-      static void *ghost_recv_buffer_d[2];
+    /**
+       Double buffered static GPU halo receive buffer
+     */
+    static void *ghost_recv_buffer_d[2];
 
-      /**
-         Double buffered static pinned send buffers
-      */
-      static void *ghost_pinned_send_buffer_h[2];
-
-      /**
-         Double buffered static pinned recv buffers
-      */
-      static void *ghost_pinned_recv_buffer_h[2];
+    /**
+       Double buffered static pinned send buffers
+    */
+    static void *ghost_pinned_send_buffer_h[2];
+
+    /**
+       Double buffered static pinned recv buffers
+    */
+    static void *ghost_pinned_recv_buffer_h[2];
 
-      /**
-         Mapped version of pinned send buffers
-      */
-      static void *ghost_pinned_send_buffer_hd[2];
+    /**
+       Mapped version of pinned send buffers
+    */
+    static void *ghost_pinned_send_buffer_hd[2];
 
-      /**
-         Mapped version of pinned recv buffers
-      */
-      static void *ghost_pinned_recv_buffer_hd[2];
+    /**
+       Mapped version of pinned recv buffers
+    */
+    static void *ghost_pinned_recv_buffer_hd[2];
 
-      /**
-         Remove ghost pointer for sending to
-      */
-      static void *ghost_remote_send_buffer_d[2][QUDA_MAX_DIM][2];
+    /**
+       Remove ghost pointer for sending to
+    */
+    static void *ghost_remote_send_buffer_d[2][QUDA_MAX_DIM][2];
 
-      /**
-         The current size of the static ghost allocation
-      */
-      static size_t ghostFaceBytes;
+    /**
+       The current size of the static ghost allocation
+    */
+    static size_t ghostFaceBytes;
 
-      /**
-         Whether the ghost buffers have been initialized
-      */
-      static bool initGhostFaceBuffer;
+    /**
+       Whether the ghost buffers have been initialized
+    */
+    static bool initGhostFaceBuffer;
 
-      /**
-         Size in bytes of this ghost field
-      */
-      mutable size_t ghost_bytes;
+    /**
+       Size in bytes of this ghost field
+    */
+    mutable size_t ghost_bytes;
 
-      /**
-         Size in bytes of prior ghost allocation
-      */
-      mutable size_t ghost_bytes_old;
+    /**
+       Size in bytes of prior ghost allocation
+    */
+    mutable size_t ghost_bytes_old;
 
-      /**
-         Size in bytes of the ghost in each dimension
-      */
-      mutable size_t ghost_face_bytes[QUDA_MAX_DIM];
+    /**
+       Size in bytes of the ghost in each dimension
+    */
+    mutable size_t ghost_face_bytes[QUDA_MAX_DIM];
 
-      /**
-         Real-number offsets to each ghost zone
-      */
-      mutable int ghostOffset[QUDA_MAX_DIM][2];
+    /**
+       Real-number offsets to each ghost zone
+    */
+    mutable int ghostOffset[QUDA_MAX_DIM][2];
 
-      /**
-         Real-number (in floats) offsets to each ghost zone for norm field
-      */
-      mutable int ghostNormOffset[QUDA_MAX_DIM][2];
+    /**
+       Real-number (in floats) offsets to each ghost zone for norm field
+    */
+    mutable int ghostNormOffset[QUDA_MAX_DIM][2];
 
-      /**
-         Pinned memory buffer used for sending messages
-      */
-      void *my_face_h[2];
+    /**
+       Pinned memory buffer used for sending messages
+    */
+    void *my_face_h[2];
 
-      /**
-         Mapped version of my_face_h
-      */
-      void *my_face_hd[2];
+    /**
+       Mapped version of my_face_h
+    */
+    void *my_face_hd[2];
 
-      /**
-         Device memory buffer for sending messages
-       */
-      void *my_face_d[2];
+    /**
+       Device memory buffer for sending messages
+     */
+    void *my_face_d[2];
 
-      /** Local pointers to the pinned my_face buffer */
-      void *my_face_dim_dir_h[2][QUDA_MAX_DIM][2];
+    /** Local pointers to the pinned my_face buffer */
+    void *my_face_dim_dir_h[2][QUDA_MAX_DIM][2];
 
-      /** Local pointers to the mapped my_face buffer */
-      void *my_face_dim_dir_hd[2][QUDA_MAX_DIM][2];
+    /** Local pointers to the mapped my_face buffer */
+    void *my_face_dim_dir_hd[2][QUDA_MAX_DIM][2];
 
-      /** Local pointers to the device ghost_send buffer */
-      void *my_face_dim_dir_d[2][QUDA_MAX_DIM][2];
+    /** Local pointers to the device ghost_send buffer */
+    void *my_face_dim_dir_d[2][QUDA_MAX_DIM][2];
 
-      /**
-         Memory buffer used for receiving all messages
-      */
-      void *from_face_h[2];
+    /**
+       Memory buffer used for receiving all messages
+    */
+    void *from_face_h[2];
 
-      /**
-         Mapped version of from_face_h
-      */
-      void *from_face_hd[2];
+    /**
+       Mapped version of from_face_h
+    */
+    void *from_face_hd[2];
 
-      /**
-         Device memory buffer for receiving messages
-       */
-      void *from_face_d[2];
+    /**
+       Device memory buffer for receiving messages
+     */
+    void *from_face_d[2];
 
-      /** Local pointers to the pinned from_face buffer */
-      void *from_face_dim_dir_h[2][QUDA_MAX_DIM][2];
+    /** Local pointers to the pinned from_face buffer */
+    void *from_face_dim_dir_h[2][QUDA_MAX_DIM][2];
 
-      /** Local pointers to the mapped from_face buffer */
-      void *from_face_dim_dir_hd[2][QUDA_MAX_DIM][2];
+    /** Local pointers to the mapped from_face buffer */
+    void *from_face_dim_dir_hd[2][QUDA_MAX_DIM][2];
 
-      /** Local pointers to the device ghost_recv buffer */
-      void *from_face_dim_dir_d[2][QUDA_MAX_DIM][2];
+    /** Local pointers to the device ghost_recv buffer */
+    void *from_face_dim_dir_d[2][QUDA_MAX_DIM][2];
 
-      /** Message handles for receiving from forwards */
-      MsgHandle *mh_recv_fwd[2][QUDA_MAX_DIM];
+    /** Message handles for receiving from forwards */
+    MsgHandle *mh_recv_fwd[2][QUDA_MAX_DIM];
 
-      /** Message handles for receiving from backwards */
-      MsgHandle *mh_recv_back[2][QUDA_MAX_DIM];
+    /** Message handles for receiving from backwards */
+    MsgHandle *mh_recv_back[2][QUDA_MAX_DIM];
 
-      /** Message handles for sending forwards */
-      MsgHandle *mh_send_fwd[2][QUDA_MAX_DIM];
+    /** Message handles for sending forwards */
+    MsgHandle *mh_send_fwd[2][QUDA_MAX_DIM];
 
-      /** Message handles for sending backwards */
-      MsgHandle *mh_send_back[2][QUDA_MAX_DIM];
+    /** Message handles for sending backwards */
+    MsgHandle *mh_send_back[2][QUDA_MAX_DIM];
 
-      /** Message handles for rdma receiving from forwards */
-      MsgHandle *mh_recv_rdma_fwd[2][QUDA_MAX_DIM];
+    /** Message handles for rdma receiving from forwards */
+    MsgHandle *mh_recv_rdma_fwd[2][QUDA_MAX_DIM];
 
-      /** Message handles for rdma receiving from backwards */
-      MsgHandle *mh_recv_rdma_back[2][QUDA_MAX_DIM];
+    /** Message handles for rdma receiving from backwards */
+    MsgHandle *mh_recv_rdma_back[2][QUDA_MAX_DIM];
 
-      /** Message handles for rdma sending to forwards */
-      MsgHandle *mh_send_rdma_fwd[2][QUDA_MAX_DIM];
+    /** Message handles for rdma sending to forwards */
+    MsgHandle *mh_send_rdma_fwd[2][QUDA_MAX_DIM];
 
-      /** Message handles for rdma sending to backwards */
-      MsgHandle *mh_send_rdma_back[2][QUDA_MAX_DIM];
+    /** Message handles for rdma sending to backwards */
+    MsgHandle *mh_send_rdma_back[2][QUDA_MAX_DIM];
 
-      /** Peer-to-peer message handler for signaling event posting */
-      static MsgHandle *mh_send_p2p_fwd[2][QUDA_MAX_DIM];
+    /** Peer-to-peer message handler for signaling event posting */
+    static MsgHandle *mh_send_p2p_fwd[2][QUDA_MAX_DIM];
 
-      /** Peer-to-peer message handler for signaling event posting */
-      static MsgHandle *mh_send_p2p_back[2][QUDA_MAX_DIM];
+    /** Peer-to-peer message handler for signaling event posting */
+    static MsgHandle *mh_send_p2p_back[2][QUDA_MAX_DIM];
 
-      /** Peer-to-peer message handler for signaling event posting */
-      static MsgHandle *mh_recv_p2p_fwd[2][QUDA_MAX_DIM];
+    /** Peer-to-peer message handler for signaling event posting */
+    static MsgHandle *mh_recv_p2p_fwd[2][QUDA_MAX_DIM];
 
-      /** Peer-to-peer message handler for signaling event posting */
-      static MsgHandle *mh_recv_p2p_back[2][QUDA_MAX_DIM];
+    /** Peer-to-peer message handler for signaling event posting */
+    static MsgHandle *mh_recv_p2p_back[2][QUDA_MAX_DIM];
 
-      /** Buffer used by peer-to-peer message handler */
-      static int buffer_send_p2p_fwd[2][QUDA_MAX_DIM];
+    /** Buffer used by peer-to-peer message handler */
+    static int buffer_send_p2p_fwd[2][QUDA_MAX_DIM];
 
-      /** Buffer used by peer-to-peer message handler */
-      static int buffer_recv_p2p_fwd[2][QUDA_MAX_DIM];
+    /** Buffer used by peer-to-peer message handler */
+    static int buffer_recv_p2p_fwd[2][QUDA_MAX_DIM];
 
-      /** Buffer used by peer-to-peer message handler */
-      static int buffer_send_p2p_back[2][QUDA_MAX_DIM];
+    /** Buffer used by peer-to-peer message handler */
+    static int buffer_send_p2p_back[2][QUDA_MAX_DIM];
 
-      /** Buffer used by peer-to-peer message handler */
-      static int buffer_recv_p2p_back[2][QUDA_MAX_DIM];
+    /** Buffer used by peer-to-peer message handler */
+    static int buffer_recv_p2p_back[2][QUDA_MAX_DIM];
 
-      /** Local copy of event used for peer-to-peer synchronization */
-      static cudaEvent_t ipcCopyEvent[2][2][QUDA_MAX_DIM];
+    /** Local copy of event used for peer-to-peer synchronization */
+    static cudaEvent_t ipcCopyEvent[2][2][QUDA_MAX_DIM];
 
-      /** Remote copy of event used for peer-to-peer synchronization */
-      static cudaEvent_t ipcRemoteCopyEvent[2][2][QUDA_MAX_DIM];
+    /** Remote copy of event used for peer-to-peer synchronization */
+    static cudaEvent_t ipcRemoteCopyEvent[2][2][QUDA_MAX_DIM];
 
-      /** Whether we have initialized communication for this field */
-      bool initComms;
+    /** Whether we have initialized communication for this field */
+    bool initComms;
 
-      /** Whether we have initialized peer-to-peer communication */
-      static bool initIPCComms;
+    /** Whether we have initialized peer-to-peer communication */
+    static bool initIPCComms;
 
-      /** Used as a label in the autotuner */
-      char vol_string[TuneKey::volume_n];
+    /** Used as a label in the autotuner */
+    char vol_string[TuneKey::volume_n];
 
-      /** used as a label in the autotuner */
-      char aux_string[TuneKey::aux_n];
+    /** used as a label in the autotuner */
+    char aux_string[TuneKey::aux_n];
 
-      /** Sets the vol_string for use in tuning */
-      virtual void setTuningString();
+    /** Sets the vol_string for use in tuning */
+    virtual void setTuningString();
 
-      /** The type of allocation we are going to do for this field */
-      QudaMemoryType mem_type;
+    /** The type of allocation we are going to do for this field */
+    QudaMemoryType mem_type;
 
-      void precisionCheck()
-      {
-        switch (precision) {
-        case QUDA_QUARTER_PRECISION:
-        case QUDA_HALF_PRECISION:
-        case QUDA_SINGLE_PRECISION:
-        case QUDA_DOUBLE_PRECISION: break;
-        default: errorQuda("Unknown precision %d\n", precision);
-        }
+    void precisionCheck()
+    {
+      switch (precision) {
+      case QUDA_QUARTER_PRECISION:
+      case QUDA_HALF_PRECISION:
+      case QUDA_SINGLE_PRECISION:
+      case QUDA_DOUBLE_PRECISION: break;
+      default: errorQuda("Unknown precision %d\n", precision);
       }
+    }
 
     mutable char *backup_h;
     mutable char *backup_norm_h;
@@ -496,7 +496,7 @@ namespace quda {
        @return The pointer to the lattice-dimension array
     */
     const int* X() const { return x; }
-    
+
     /**
        @return The full-field volume
     */
@@ -518,9 +518,9 @@ namespace quda {
        @return The single-parity surface of dimension i
     */
     int SurfaceCB(const int i) const { return surfaceCB[i]; }
-    
+
     /**
-       @return The single-parity stride of the field     
+       @return The single-parity stride of the field
     */
     size_t Stride() const { return stride; }
 

--- a/include/lattice_field.h
+++ b/include/lattice_field.h
@@ -145,12 +145,12 @@ namespace quda {
 
   protected:
     /** Lattice volume */
-    int volume;
+    size_t volume;
 
     /** Checkerboarded volume */
-    int volumeCB;
+    size_t volumeCB;
 
-    int stride;
+    size_t stride;
     int pad;
 
     size_t total_bytes;
@@ -501,12 +501,12 @@ namespace quda {
     /**
        @return The full-field volume
     */
-    int Volume() const { return volume; }
+    size_t Volume() const { return volume; }
     
     /**
        @return The single-parity volume
     */
-    int VolumeCB() const { return volumeCB; }
+    size_t VolumeCB() const { return volumeCB; }
     
     /**
        @param i The dimension of the requested surface 
@@ -523,7 +523,7 @@ namespace quda {
     /**
        @return The single-parity stride of the field     
     */
-    int Stride() const { return stride; }
+    size_t Stride() const { return stride; }
     
     /**
        @return The field padding

--- a/include/malloc_quda.h
+++ b/include/malloc_quda.h
@@ -38,8 +38,10 @@ namespace quda {
   void *safe_malloc_(const char *func, const char *file, int line, size_t size);
   void *pinned_malloc_(const char *func, const char *file, int line, size_t size);
   void *mapped_malloc_(const char *func, const char *file, int line, size_t size);
+  void *managed_malloc_(const char *func, const char *file, int line, size_t size);
   void device_free_(const char *func, const char *file, int line, void *ptr);
   void device_pinned_free_(const char *func, const char *file, int line, void *ptr);
+  void managed_free_(const char *func, const char *file, int line, void *ptr);
   void host_free_(const char *func, const char *file, int line, void *ptr);
 
   // strip path from __FILE__
@@ -65,8 +67,10 @@ namespace quda {
 #define safe_malloc(size) quda::safe_malloc_(__func__, quda::file_name(__FILE__), __LINE__, size)
 #define pinned_malloc(size) quda::pinned_malloc_(__func__, quda::file_name(__FILE__), __LINE__, size)
 #define mapped_malloc(size) quda::mapped_malloc_(__func__, quda::file_name(__FILE__), __LINE__, size)
+#define managed_malloc(size) quda::managed_malloc_(__func__, quda::file_name(__FILE__), __LINE__, size)
 #define device_free(ptr) quda::device_free_(__func__, quda::file_name(__FILE__), __LINE__, ptr)
 #define device_pinned_free(ptr) quda::device_pinned_free_(__func__, quda::file_name(__FILE__), __LINE__, ptr)
+#define managed_free(ptr) quda::managed_free_(__func__, quda::file_name(__FILE__), __LINE__, ptr)
 #define host_free(ptr) quda::host_free_(__func__, quda::file_name(__FILE__), __LINE__, ptr)
 
 

--- a/include/malloc_quda.h
+++ b/include/malloc_quda.h
@@ -29,6 +29,11 @@ namespace quda {
    */
   long host_allocated_peak();
 
+  /**
+     @return are we using managed memory for device allocations
+  */
+  bool use_managed_memory();
+
   /*
    * The following functions should not be called directly.  Use the
    * macros below instead.

--- a/include/tune_quda.h
+++ b/include/tune_quda.h
@@ -55,6 +55,11 @@ namespace quda {
     }
   };
 
+  /**
+   * @brief Returns a reference to the tunecache map
+   * @return tunecache reference
+   */
+  const std::map<TuneKey, TuneParam> &getTuneCache();
 
   class Tunable {
 
@@ -268,6 +273,21 @@ namespace quda {
 
     /** This is the return result from kernels launched using jitify */
     CUresult jitify_error;
+
+    /**
+       @brief Whether the present instance has already been tuned or not
+       @return True if tuned, false if not
+    */
+    bool tuned()
+    {
+      // not tuning is equivalent to already tuned
+      if (!getTuning()) return true;
+
+      TuneKey key = tuneKey();
+      if (use_managed_memory()) strcat(key.aux, ",managed");
+      // if key is present in cache then already tuned
+      return getTuneCache().find(key) != getTuneCache().end();
+    }
 
   public:
     Tunable() : jitify_error(CUDA_SUCCESS) { aux[0] = '\0'; }
@@ -558,12 +578,6 @@ namespace quda {
    * @brief Post an event in the trace, recording where it was posted
    */
   void postTrace_(const char *func, const char *file, int line);
-
-  /**
-   * @brief Returns a reference to the tunecache map
-   * @return tunecache reference
-   */
-  const std::map<TuneKey, TuneParam> &getTuneCache();
 
   /**
    * @brief Enable the profile kernel counting

--- a/lib/color_spinor_field.cpp
+++ b/lib/color_spinor_field.cpp
@@ -274,8 +274,8 @@ namespace quda {
     {
       int aux_string_n = TuneKey::aux_n / 2;
       char aux_tmp[aux_string_n];
-      int check = snprintf(aux_string, aux_string_n, "vol=%lu,stride=%lu,precision=%d,Ns=%d,Nc=%d",
-                           volume, stride, precision, nSpin, nColor);
+      int check = snprintf(aux_string, aux_string_n, "vol=%lu,stride=%lu,precision=%d,Ns=%d,Nc=%d", volume, stride,
+                           precision, nSpin, nColor);
       if (check < 0 || check >= aux_string_n) errorQuda("Error writing aux string");
       if (twistFlavor != QUDA_TWIST_NO && twistFlavor != QUDA_TWIST_INVALID) {
         strcpy(aux_tmp, aux_string);

--- a/lib/color_spinor_field.cpp
+++ b/lib/color_spinor_field.cpp
@@ -274,7 +274,7 @@ namespace quda {
     {
       int aux_string_n = TuneKey::aux_n / 2;
       char aux_tmp[aux_string_n];
-      int check = snprintf(aux_string, aux_string_n, "vol=%d,stride=%d,precision=%d,Ns=%d,Nc=%d",
+      int check = snprintf(aux_string, aux_string_n, "vol=%lu,stride=%lu,precision=%d,Ns=%d,Nc=%d",
                            volume, stride, precision, nSpin, nColor);
       if (check < 0 || check >= aux_string_n) errorQuda("Error writing aux string");
       if (twistFlavor != QUDA_TWIST_NO && twistFlavor != QUDA_TWIST_INVALID) {

--- a/lib/copy_color_spinor.cuh
+++ b/lib/copy_color_spinor.cuh
@@ -378,8 +378,7 @@ namespace quda {
     if (dst.Ndim() != src.Ndim())
       errorQuda("Number of dimensions %d %d don't match", dst.Ndim(), src.Ndim());
 
-    if (dst.Volume() != src.Volume())
-      errorQuda("Volumes %lu %lu don't match", dst.Volume(), src.Volume());
+    if (dst.Volume() != src.Volume()) errorQuda("Volumes %lu %lu don't match", dst.Volume(), src.Volume());
 
     if (!( dst.SiteOrder() == src.SiteOrder() ||
 	   (dst.SiteOrder() == QUDA_EVEN_ODD_SITE_ORDER && 

--- a/lib/copy_color_spinor.cuh
+++ b/lib/copy_color_spinor.cuh
@@ -379,7 +379,7 @@ namespace quda {
       errorQuda("Number of dimensions %d %d don't match", dst.Ndim(), src.Ndim());
 
     if (dst.Volume() != src.Volume())
-      errorQuda("Volumes %d %d don't match", dst.Volume(), src.Volume());
+      errorQuda("Volumes %lu %lu don't match", dst.Volume(), src.Volume());
 
     if (!( dst.SiteOrder() == src.SiteOrder() ||
 	   (dst.SiteOrder() == QUDA_EVEN_ODD_SITE_ORDER && 

--- a/lib/copy_color_spinor_mg.cuh
+++ b/lib/copy_color_spinor_mg.cuh
@@ -133,8 +133,7 @@ namespace quda {
     if (dst.Ndim() != src.Ndim())
       errorQuda("Number of dimensions %d %d don't match", dst.Ndim(), src.Ndim());
 
-    if (dst.Volume() != src.Volume())
-      errorQuda("Volumes %d %d don't match", dst.Volume(), src.Volume());
+    if (dst.Volume() != src.Volume()) errorQuda("Volumes %lu %lu don't match", dst.Volume(), src.Volume());
 
     if (!( dst.SiteOrder() == src.SiteOrder() ||
 	   (dst.SiteOrder() == QUDA_EVEN_ODD_SITE_ORDER &&

--- a/lib/copy_quda.cu
+++ b/lib/copy_quda.cu
@@ -9,7 +9,7 @@
     if (a.Length() != b.Length())					\
       errorQuda("lengths do not match: %lu %lu", a.Length(), b.Length()); \
     if (a.Stride() != b.Stride())					\
-      errorQuda("strides do not match: %d %d", a.Stride(), b.Stride());	\
+      errorQuda("strides do not match: %lu %lu", a.Stride(), b.Stride());	\
     if (a.GammaBasis() != b.GammaBasis())				\
       errorQuda("gamma basis does not match: %d %d", a.GammaBasis(), b.GammaBasis());	\
   }

--- a/lib/copy_quda.cu
+++ b/lib/copy_quda.cu
@@ -4,14 +4,12 @@
 #include <register_traits.h>
 
 // For kernels with precision conversion built in
-#define checkSpinorLength(a, b)						\
-  {									\
-    if (a.Length() != b.Length())					\
-      errorQuda("lengths do not match: %lu %lu", a.Length(), b.Length()); \
-    if (a.Stride() != b.Stride())					\
-      errorQuda("strides do not match: %lu %lu", a.Stride(), b.Stride());	\
-    if (a.GammaBasis() != b.GammaBasis())				\
-      errorQuda("gamma basis does not match: %d %d", a.GammaBasis(), b.GammaBasis());	\
+#define checkSpinorLength(a, b)                                                                                        \
+  {                                                                                                                    \
+    if (a.Length() != b.Length()) errorQuda("lengths do not match: %lu %lu", a.Length(), b.Length());                  \
+    if (a.Stride() != b.Stride()) errorQuda("strides do not match: %lu %lu", a.Stride(), b.Stride());                  \
+    if (a.GammaBasis() != b.GammaBasis())                                                                              \
+      errorQuda("gamma basis does not match: %d %d", a.GammaBasis(), b.GammaBasis());                                  \
   }
 
 namespace quda {

--- a/lib/dirac.cpp
+++ b/lib/dirac.cpp
@@ -116,11 +116,6 @@ namespace quda {
 		in.Precision(), out.Precision());
     }
 
-    if (in.Stride() != out.Stride()) {
-      errorQuda("Input %d and output %d spinor strides don't match in dslash_quda", 
-		in.Stride(), out.Stride());
-    }
-
     if (in.SiteSubset() != QUDA_PARITY_SITE_SUBSET || out.SiteSubset() != QUDA_PARITY_SITE_SUBSET) {
       errorQuda("ColorSpinorFields are not single parity: in = %d, out = %d", 
 		in.SiteSubset(), out.SiteSubset());
@@ -132,13 +127,13 @@ namespace quda {
     if (out.Ndim() != 5) {
       if ((out.Volume() != gauge->Volume() && out.SiteSubset() == QUDA_FULL_SITE_SUBSET) ||
 	  (out.Volume() != gauge->VolumeCB() && out.SiteSubset() == QUDA_PARITY_SITE_SUBSET) ) {
-	errorQuda("Spinor volume %d doesn't match gauge volume %d", out.Volume(), gauge->VolumeCB());
+	errorQuda("Spinor volume %lu doesn't match gauge volume %lu", out.Volume(), gauge->VolumeCB());
       }
     } else {
       // Domain wall fermions, compare 4d volumes not 5d
       if ((out.Volume()/out.X(4) != gauge->Volume() && out.SiteSubset() == QUDA_FULL_SITE_SUBSET) ||
 	  (out.Volume()/out.X(4) != gauge->VolumeCB() && out.SiteSubset() == QUDA_PARITY_SITE_SUBSET) ) {
-	errorQuda("Spinor volume %d doesn't match gauge volume %d", out.Volume(), gauge->VolumeCB());
+	errorQuda("Spinor volume %lu doesn't match gauge volume %lu", out.Volume(), gauge->VolumeCB());
       }
     }
   }

--- a/lib/dirac.cpp
+++ b/lib/dirac.cpp
@@ -127,13 +127,13 @@ namespace quda {
     if (out.Ndim() != 5) {
       if ((out.Volume() != gauge->Volume() && out.SiteSubset() == QUDA_FULL_SITE_SUBSET) ||
 	  (out.Volume() != gauge->VolumeCB() && out.SiteSubset() == QUDA_PARITY_SITE_SUBSET) ) {
-	errorQuda("Spinor volume %lu doesn't match gauge volume %lu", out.Volume(), gauge->VolumeCB());
+        errorQuda("Spinor volume %lu doesn't match gauge volume %lu", out.Volume(), gauge->VolumeCB());
       }
     } else {
       // Domain wall fermions, compare 4d volumes not 5d
       if ((out.Volume()/out.X(4) != gauge->Volume() && out.SiteSubset() == QUDA_FULL_SITE_SUBSET) ||
 	  (out.Volume()/out.X(4) != gauge->VolumeCB() && out.SiteSubset() == QUDA_PARITY_SITE_SUBSET) ) {
-	errorQuda("Spinor volume %lu doesn't match gauge volume %lu", out.Volume(), gauge->VolumeCB());
+        errorQuda("Spinor volume %lu doesn't match gauge volume %lu", out.Volume(), gauge->VolumeCB());
       }
     }
   }

--- a/lib/dirac_clover.cpp
+++ b/lib/dirac_clover.cpp
@@ -27,7 +27,7 @@ namespace quda {
     Dirac::checkParitySpinor(out, in);
 
     if (out.Volume() != clover.VolumeCB()) {
-      errorQuda("Parity spinor volume %d doesn't match clover checkboard volume %d",
+      errorQuda("Parity spinor volume %lu doesn't match clover checkboard volume %lu",
 		out.Volume(), clover.VolumeCB());
     }
   }

--- a/lib/dirac_clover.cpp
+++ b/lib/dirac_clover.cpp
@@ -27,8 +27,7 @@ namespace quda {
     Dirac::checkParitySpinor(out, in);
 
     if (out.Volume() != clover.VolumeCB()) {
-      errorQuda("Parity spinor volume %lu doesn't match clover checkboard volume %lu",
-		out.Volume(), clover.VolumeCB());
+      errorQuda("Parity spinor volume %lu doesn't match clover checkboard volume %lu", out.Volume(), clover.VolumeCB());
     }
   }
 

--- a/lib/dirac_improved_staggered.cpp
+++ b/lib/dirac_improved_staggered.cpp
@@ -31,10 +31,6 @@ namespace quda {
       errorQuda("Input and output spinor precisions don't match in dslash_quda");
     }
 
-    if (in.Stride() != out.Stride()) {
-      errorQuda("Input %d and output %d spinor strides don't match in dslash_quda", in.Stride(), out.Stride());
-    }
-
     if (in.SiteSubset() != QUDA_PARITY_SITE_SUBSET || out.SiteSubset() != QUDA_PARITY_SITE_SUBSET) {
       errorQuda("ColorSpinorFields are not single parity, in = %d, out = %d", 
 		in.SiteSubset(), out.SiteSubset());
@@ -42,7 +38,7 @@ namespace quda {
 
     if ((out.Volume()/out.X(4) != 2*fatGauge.VolumeCB() && out.SiteSubset() == QUDA_FULL_SITE_SUBSET) ||
 	(out.Volume()/out.X(4) != fatGauge.VolumeCB() && out.SiteSubset() == QUDA_PARITY_SITE_SUBSET) ) {
-      errorQuda("Spinor volume %d doesn't match gauge volume %d", out.Volume(), fatGauge.VolumeCB());
+      errorQuda("Spinor volume %lu doesn't match gauge volume %lu", out.Volume(), fatGauge.VolumeCB());
     }
   }
 

--- a/lib/dirac_staggered.cpp
+++ b/lib/dirac_staggered.cpp
@@ -27,10 +27,6 @@ namespace quda {
       errorQuda("Input and output spinor precisions don't match in dslash_quda");
     }
 
-    if (in.Stride() != out.Stride()) {
-      errorQuda("Input %d and output %d spinor strides don't match in dslash_quda", in.Stride(), out.Stride());
-    }
-
     if (in.SiteSubset() != QUDA_PARITY_SITE_SUBSET || out.SiteSubset() != QUDA_PARITY_SITE_SUBSET) {
       errorQuda("ColorSpinorFields are not single parity, in = %d, out = %d", 
 		in.SiteSubset(), out.SiteSubset());
@@ -38,7 +34,7 @@ namespace quda {
 
     if ((out.Volume()/out.X(4) != 2*gauge->VolumeCB() && out.SiteSubset() == QUDA_FULL_SITE_SUBSET) ||
 	(out.Volume()/out.X(4) != gauge->VolumeCB() && out.SiteSubset() == QUDA_PARITY_SITE_SUBSET) ) {
-      errorQuda("Spinor volume %d doesn't match gauge volume %d", out.Volume(), gauge->VolumeCB());
+      errorQuda("Spinor volume %lu doesn't match gauge volume %lu", out.Volume(), gauge->VolumeCB());
     }
   }
 

--- a/lib/dirac_twisted_clover.cpp
+++ b/lib/dirac_twisted_clover.cpp
@@ -41,7 +41,7 @@ namespace quda {
     Dirac::checkParitySpinor(out, in);
 
     if (out.Volume() != clover.VolumeCB())
-      errorQuda("Parity spinor volume %d doesn't match clover checkboard volume %d", out.Volume(), clover.VolumeCB());
+      errorQuda("Parity spinor volume %lu doesn't match clover checkboard volume %lu", out.Volume(), clover.VolumeCB());
   }
 
   // Protected method for applying twist

--- a/lib/dslash_coarse.cu
+++ b/lib/dslash_coarse.cu
@@ -693,7 +693,7 @@ namespace quda {
       // before we do policy tuning we must ensure the kernel
       // constituents have been tuned since we can't do nested tuning
       if (!tuned()) {
-	disableProfileCount();
+        disableProfileCount();
 	for (auto &i : policies) if(i!= DslashCoarsePolicy::DSLASH_COARSE_POLICY_DISABLED) dslash(i);
 	enableProfileCount();
 	setPolicyTuning(true);

--- a/lib/dslash_coarse.cu
+++ b/lib/dslash_coarse.cu
@@ -692,7 +692,7 @@ namespace quda {
 
       // before we do policy tuning we must ensure the kernel
       // constituents have been tuned since we can't do nested tuning
-      if (getTuning() && getTuneCache().find(tuneKey()) == getTuneCache().end()) {
+      if (!tuned()) {
 	disableProfileCount();
 	for (auto &i : policies) if(i!= DslashCoarsePolicy::DSLASH_COARSE_POLICY_DISABLED) dslash(i);
 	enableProfileCount();

--- a/lib/dslash_policy.cuh
+++ b/lib/dslash_policy.cuh
@@ -1919,7 +1919,7 @@ public:
 
      // before we do policy tuning we must ensure the kernel
      // constituents have been tuned since we can't do nested tuning
-     if (getTuning() && getTuneCache().find(tuneKey()) == getTuneCache().end()) {
+      if (!tuned()) {
        disableProfileCount();
 
        for (auto &p2p : p2p_policies) {

--- a/lib/dslash_policy.cuh
+++ b/lib/dslash_policy.cuh
@@ -1917,93 +1917,90 @@ public:
        }
       }
 
-     // before we do policy tuning we must ensure the kernel
-     // constituents have been tuned since we can't do nested tuning
+      // before we do policy tuning we must ensure the kernel
+      // constituents have been tuned since we can't do nested tuning
       if (!tuned()) {
-       disableProfileCount();
+        disableProfileCount();
 
-       for (auto &p2p : p2p_policies) {
+        for (auto &p2p : p2p_policies) {
 
-         if (p2p == QudaP2PPolicy::QUDA_P2P_POLICY_DISABLED) continue;
+          if (p2p == QudaP2PPolicy::QUDA_P2P_POLICY_DISABLED) continue;
 
-         bool p2p_enabled = comm_peer2peer_enabled_global();
-         if (p2p == QudaP2PPolicy::QUDA_P2P_DEFAULT) comm_enable_peer2peer(false);  // disable p2p if using default policy
-         dslashParam.remote_write = (p2p == QudaP2PPolicy::QUDA_P2P_REMOTE_WRITE ? 1 : 0);
+          bool p2p_enabled = comm_peer2peer_enabled_global();
+          if (p2p == QudaP2PPolicy::QUDA_P2P_DEFAULT)
+            comm_enable_peer2peer(false); // disable p2p if using default policy
+          dslashParam.remote_write = (p2p == QudaP2PPolicy::QUDA_P2P_REMOTE_WRITE ? 1 : 0);
 
-         for (auto &i : policies) {
+          for (auto &i : policies) {
 
-           if ( (i == QudaDslashPolicy::QUDA_DSLASH ||
-                 i == QudaDslashPolicy::QUDA_FUSED_DSLASH ||
-                 i == QudaDslashPolicy::QUDA_DSLASH_ASYNC ||
-                 i == QudaDslashPolicy::QUDA_FUSED_DSLASH_ASYNC) &&
-                !dslashParam.remote_write) {
+            if ((i == QudaDslashPolicy::QUDA_DSLASH || i == QudaDslashPolicy::QUDA_FUSED_DSLASH
+                 || i == QudaDslashPolicy::QUDA_DSLASH_ASYNC || i == QudaDslashPolicy::QUDA_FUSED_DSLASH_ASYNC)
+                && !dslashParam.remote_write) {
 
-             DslashPolicyImp<Dslash> *dslashImp = DslashFactory<Dslash>::create(i);
-             (*dslashImp)(dslash, in, volume, ghostFace, profile);
-             delete dslashImp;
+              DslashPolicyImp<Dslash> *dslashImp = DslashFactory<Dslash>::create(i);
+              (*dslashImp)(dslash, in, volume, ghostFace, profile);
+              delete dslashImp;
 
-           } else if ( (i == QudaDslashPolicy::QUDA_GDR_DSLASH ||
-                        i == QudaDslashPolicy::QUDA_FUSED_GDR_DSLASH ||
-                        i == QudaDslashPolicy::QUDA_GDR_RECV_DSLASH ||
-                        i == QudaDslashPolicy::QUDA_FUSED_GDR_RECV_DSLASH ||
-                        i == QudaDslashPolicy::QUDA_ZERO_COPY_PACK_DSLASH ||
-                        i == QudaDslashPolicy::QUDA_FUSED_ZERO_COPY_PACK_DSLASH ||
-                        i == QudaDslashPolicy::QUDA_ZERO_COPY_PACK_GDR_RECV_DSLASH ||
-                        i == QudaDslashPolicy::QUDA_FUSED_ZERO_COPY_PACK_GDR_RECV_DSLASH ||
-                        i == QudaDslashPolicy::QUDA_ZERO_COPY_DSLASH ||
-                        i == QudaDslashPolicy::QUDA_FUSED_ZERO_COPY_DSLASH) ||
-                       ((i == QudaDslashPolicy::QUDA_DSLASH ||
-                         i == QudaDslashPolicy::QUDA_FUSED_DSLASH ||
-                         i == QudaDslashPolicy::QUDA_DSLASH_ASYNC ||
-                         i == QudaDslashPolicy::QUDA_FUSED_DSLASH_ASYNC) && dslashParam.remote_write) ) {
-             // these dslash policies all must have kernel packing enabled
+            } else if ((i == QudaDslashPolicy::QUDA_GDR_DSLASH || i == QudaDslashPolicy::QUDA_FUSED_GDR_DSLASH
+                        || i == QudaDslashPolicy::QUDA_GDR_RECV_DSLASH || i == QudaDslashPolicy::QUDA_FUSED_GDR_RECV_DSLASH
+                        || i == QudaDslashPolicy::QUDA_ZERO_COPY_PACK_DSLASH
+                        || i == QudaDslashPolicy::QUDA_FUSED_ZERO_COPY_PACK_DSLASH
+                        || i == QudaDslashPolicy::QUDA_ZERO_COPY_PACK_GDR_RECV_DSLASH
+                        || i == QudaDslashPolicy::QUDA_FUSED_ZERO_COPY_PACK_GDR_RECV_DSLASH
+                        || i == QudaDslashPolicy::QUDA_ZERO_COPY_DSLASH
+                        || i == QudaDslashPolicy::QUDA_FUSED_ZERO_COPY_DSLASH)
+                       || ((i == QudaDslashPolicy::QUDA_DSLASH || i == QudaDslashPolicy::QUDA_FUSED_DSLASH
+                            || i == QudaDslashPolicy::QUDA_DSLASH_ASYNC || i == QudaDslashPolicy::QUDA_FUSED_DSLASH_ASYNC)
+                           && dslashParam.remote_write)) {
+              // these dslash policies all must have kernel packing enabled
 
-             // clumsy, but we call setKernelPackT a handful of times before
-             // we restore the the current state, so this will "just work"
-             pushKernelPackT(getKernelPackT());
+              // clumsy, but we call setKernelPackT a handful of times before
+              // we restore the the current state, so this will "just work"
+              pushKernelPackT(getKernelPackT());
 
-             // if we are using GDR policies then we must tune the
-             // non-GDR variants as well with and without kernel
-             // packing enabled - this ensures that all GPUs will have
-             // the required tune cache entries prior to potential
-             // process divergence regardless of which GPUs are
-             // blacklisted.  don't enter if remote writing since
-             // there we always use kernel packing
-             if ( (i == QudaDslashPolicy::QUDA_GDR_DSLASH ||
-                   i == QudaDslashPolicy::QUDA_FUSED_GDR_DSLASH ||
-                   i == QudaDslashPolicy::QUDA_GDR_RECV_DSLASH ||
-                   i == QudaDslashPolicy::QUDA_FUSED_GDR_RECV_DSLASH) && !dslashParam.remote_write ) {
-               QudaDslashPolicy policy = (i==QudaDslashPolicy::QUDA_GDR_DSLASH || i==QudaDslashPolicy::QUDA_GDR_RECV_DSLASH) ?
-                 QudaDslashPolicy::QUDA_DSLASH : QudaDslashPolicy::QUDA_FUSED_DSLASH;
-               DslashPolicyImp<Dslash> *dslashImp = DslashFactory<Dslash>::create(policy);
-               setKernelPackT(false);
-               (*dslashImp)(dslash, in, volume, ghostFace, profile);
-               setKernelPackT(true);
-               (*dslashImp)(dslash, in, volume, ghostFace, profile);
-               delete dslashImp;
-             }
+              // if we are using GDR policies then we must tune the
+              // non-GDR variants as well with and without kernel
+              // packing enabled - this ensures that all GPUs will have
+              // the required tune cache entries prior to potential
+              // process divergence regardless of which GPUs are
+              // blacklisted.  don't enter if remote writing since
+              // there we always use kernel packing
+              if ((i == QudaDslashPolicy::QUDA_GDR_DSLASH || i == QudaDslashPolicy::QUDA_FUSED_GDR_DSLASH
+                   || i == QudaDslashPolicy::QUDA_GDR_RECV_DSLASH || i == QudaDslashPolicy::QUDA_FUSED_GDR_RECV_DSLASH)
+                  && !dslashParam.remote_write) {
+                QudaDslashPolicy policy
+                  = (i == QudaDslashPolicy::QUDA_GDR_DSLASH || i == QudaDslashPolicy::QUDA_GDR_RECV_DSLASH) ?
+                  QudaDslashPolicy::QUDA_DSLASH :
+                  QudaDslashPolicy::QUDA_FUSED_DSLASH;
+                DslashPolicyImp<Dslash> *dslashImp = DslashFactory<Dslash>::create(policy);
+                setKernelPackT(false);
+                (*dslashImp)(dslash, in, volume, ghostFace, profile);
+                setKernelPackT(true);
+                (*dslashImp)(dslash, in, volume, ghostFace, profile);
+                delete dslashImp;
+              }
 
-             setKernelPackT(true);
+              setKernelPackT(true);
 
-             DslashPolicyImp<Dslash> *dslashImp = DslashFactory<Dslash>::create(i);
-             (*dslashImp)(dslash, in, volume, ghostFace, profile);
-             delete dslashImp;
+              DslashPolicyImp<Dslash> *dslashImp = DslashFactory<Dslash>::create(i);
+              (*dslashImp)(dslash, in, volume, ghostFace, profile);
+              delete dslashImp;
 
-             // restore default kernel packing
-             popKernelPackT();
+              // restore default kernel packing
+              popKernelPackT();
 
-           } else if (i != QudaDslashPolicy::QUDA_DSLASH_POLICY_DISABLED){
-             errorQuda("Unsupported dslash policy %d\n", static_cast<int>(i));
-           }
-         }
+            } else if (i != QudaDslashPolicy::QUDA_DSLASH_POLICY_DISABLED) {
+              errorQuda("Unsupported dslash policy %d\n", static_cast<int>(i));
+            }
+          }
 
-         comm_enable_peer2peer(p2p_enabled); // restore p2p state
-       } // p2p policies
+          comm_enable_peer2peer(p2p_enabled); // restore p2p state
+        }                                     // p2p policies
 
-       enableProfileCount();
-       setPolicyTuning(true);
-     }
-     dslash_policy_init = true;
+        enableProfileCount();
+        setPolicyTuning(true);
+      }
+      dslash_policy_init = true;
    }
 
    virtual ~DslashPolicyTune() { setPolicyTuning(false); }

--- a/lib/gauge_field.cpp
+++ b/lib/gauge_field.cpp
@@ -104,8 +104,8 @@ namespace quda {
   void GaugeField::setTuningString() {
     LatticeField::setTuningString();
     int aux_string_n = TuneKey::aux_n / 2;
-    int check = snprintf(aux_string, aux_string_n, "vol=%lu,stride=%lu,precision=%d,geometry=%d,Nc=%d",
-                         volume, stride, precision, geometry, nColor);
+    int check = snprintf(aux_string, aux_string_n, "vol=%lu,stride=%lu,precision=%d,geometry=%d,Nc=%d", volume, stride,
+                         precision, geometry, nColor);
     if (check < 0 || check >= aux_string_n) errorQuda("Error writing aux string");
   }
 

--- a/lib/gauge_field.cpp
+++ b/lib/gauge_field.cpp
@@ -104,7 +104,7 @@ namespace quda {
   void GaugeField::setTuningString() {
     LatticeField::setTuningString();
     int aux_string_n = TuneKey::aux_n / 2;
-    int check = snprintf(aux_string, aux_string_n, "vol=%d,stride=%d,precision=%d,geometry=%d,Nc=%d",
+    int check = snprintf(aux_string, aux_string_n, "vol=%lu,stride=%lu,precision=%d,geometry=%d,Nc=%d",
                          volume, stride, precision, geometry, nColor);
     if (check < 0 || check >= aux_string_n) errorQuda("Error writing aux string");
   }

--- a/lib/lattice_field.cpp
+++ b/lib/lattice_field.cpp
@@ -645,7 +645,8 @@ namespace quda {
 	if (x[i]-2*r[i] != a.x[i]) errorQuda("x[%d] does not match %d %d", i, x[i]-2*r[i], a.x[i]);
 	this_volume_interior *= x[i] - 2*r[i];
       }
-      if (this_volume_interior != a.volume) errorQuda("Interior volume does not match %lu %lu", this_volume_interior, a.volume);
+      if (this_volume_interior != a.volume)
+        errorQuda("Interior volume does not match %lu %lu", this_volume_interior, a.volume);
     } else {
       if (a.volume != volume) errorQuda("Volume does not match %lu %lu", volume, a.volume);
       if (a.volumeCB != volumeCB) errorQuda("VolumeCB does not match %lu %lu", volumeCB, a.volumeCB);

--- a/lib/lattice_field.cpp
+++ b/lib/lattice_field.cpp
@@ -632,23 +632,23 @@ namespace quda {
     if (a.nDim != nDim) errorQuda("nDim does not match %d %d", nDim, a.nDim);
     if (ghostExchange != QUDA_GHOST_EXCHANGE_EXTENDED && a.ghostExchange == QUDA_GHOST_EXCHANGE_EXTENDED) {
       // if source is extended by I am not then we need to compare their interior volume to my volume
-      int a_volume_interior = 1;
+      size_t a_volume_interior = 1;
       for (int i=0; i<nDim; i++) {
 	if (a.x[i]-2*a.r[i] != x[i]) errorQuda("x[%d] does not match %d %d", i, x[i], a.x[i]-2*a.r[i]);
 	a_volume_interior *= a.x[i] - 2*a.r[i];
       }
-      if (a_volume_interior != volume) errorQuda("Interior volume does not match %d %d", volume, a_volume_interior);
+      if (a_volume_interior != volume) errorQuda("Interior volume does not match %lu %lu", volume, a_volume_interior);
     } else if (a.ghostExchange != QUDA_GHOST_EXCHANGE_EXTENDED && ghostExchange == QUDA_GHOST_EXCHANGE_EXTENDED) {
       // if source is extended by I am not then we need to compare their interior volume to my volume
-      int this_volume_interior = 1;
+      size_t this_volume_interior = 1;
       for (int i=0; i<nDim; i++) {
 	if (x[i]-2*r[i] != a.x[i]) errorQuda("x[%d] does not match %d %d", i, x[i]-2*r[i], a.x[i]);
 	this_volume_interior *= x[i] - 2*r[i];
       }
-      if (this_volume_interior != a.volume) errorQuda("Interior volume does not match %d %d", this_volume_interior, a.volume);
+      if (this_volume_interior != a.volume) errorQuda("Interior volume does not match %lu %lu", this_volume_interior, a.volume);
     } else {
-      if (a.volume != volume) errorQuda("Volume does not match %d %d", volume, a.volume);
-      if (a.volumeCB != volumeCB) errorQuda("VolumeCB does not match %d %d", volumeCB, a.volumeCB);
+      if (a.volume != volume) errorQuda("Volume does not match %lu %lu", volume, a.volume);
+      if (a.volumeCB != volumeCB) errorQuda("VolumeCB does not match %lu %lu", volumeCB, a.volumeCB);
       for (int i=0; i<nDim; i++) {
 	if (a.x[i] != x[i]) errorQuda("x[%d] does not match %d %d", i, x[i], a.x[i]);
 	if (a.surface[i] != surface[i]) errorQuda("surface[%d] does not match %d %d", i, surface[i], a.surface[i]);

--- a/lib/malloc.cpp
+++ b/lib/malloc.cpp
@@ -155,7 +155,7 @@ namespace quda {
     return ptr;
   }
 
-  static bool use_managed_memory()
+  bool use_managed_memory()
   {
     static bool managed = false;
     static bool init = false;

--- a/lib/malloc.cpp
+++ b/lib/malloc.cpp
@@ -13,15 +13,7 @@
 
 namespace quda {
 
-  enum AllocType {
-    DEVICE,
-    DEVICE_PINNED,
-    HOST,
-    PINNED,
-    MAPPED,
-    MANAGED,
-    N_ALLOC_TYPE
-  };
+  enum AllocType { DEVICE, DEVICE_PINNED, HOST, PINNED, MAPPED, MANAGED, N_ALLOC_TYPE };
 
   class MemAlloc {
 
@@ -163,8 +155,8 @@ namespace quda {
     return ptr;
   }
 
-
-  static bool use_managed_memory() {
+  static bool use_managed_memory()
+  {
     static bool managed = false;
     static bool init = false;
 
@@ -312,8 +304,7 @@ namespace quda {
     memset(ptr, 0xff, a.base_size);
 #endif
     return ptr;
-  }  
-
+  }
 
   /**
    * Perform a standard cudaMallocManaged() with error-checking.  This
@@ -337,7 +328,6 @@ namespace quda {
 #endif
     return ptr;
   }
-
 
   /**
    * Free device memory allocated with device_malloc().  This function
@@ -386,7 +376,6 @@ namespace quda {
     track_free(DEVICE_PINNED, ptr);
   }
 
-
   /**
    * Free device memory allocated with device_malloc().  This function
    * should only be called via the device_free() macro, defined in
@@ -402,7 +391,6 @@ namespace quda {
     if (err != cudaSuccess) { errorQuda("Failed to free device memory (%s:%d in %s())\n", file, line, func); }
     track_free(MANAGED, ptr);
   }
-
 
   /**
    * Free host memory allocated with safe_malloc(), pinned_malloc(),
@@ -444,7 +432,7 @@ namespace quda {
   {
     printfQuda("Device memory used = %.1f MB\n", max_total_bytes[DEVICE] / (double)(1<<20));
     printfQuda("Pinned device memory used = %.1f MB\n", max_total_bytes[DEVICE_PINNED] / (double)(1<<20));
-    printfQuda("Managed memory used = %.1f MB\n", max_total_bytes[MANAGED] / (double)(1<<20));
+    printfQuda("Managed memory used = %.1f MB\n", max_total_bytes[MANAGED] / (double)(1 << 20));
     printfQuda("Page-locked host memory used = %.1f MB\n", max_total_pinned_bytes / (double)(1<<20));
     printfQuda("Total host memory used >= %.1f MB\n", max_total_host_bytes / (double)(1<<20));
   }

--- a/lib/malloc.cpp
+++ b/lib/malloc.cpp
@@ -165,6 +165,8 @@ namespace quda {
       if (enable_managed_memory && strcmp(enable_managed_memory, "1") == 0) {
         warningQuda("Using managed memory for CUDA allocations");
         managed = true;
+
+        if (deviceProp.major < 6) warningQuda("Using managed memory on pre-Pascal architecture is limited");
       }
 
       init = true;

--- a/lib/multi_reduce_quda.cu
+++ b/lib/multi_reduce_quda.cu
@@ -927,7 +927,7 @@ namespace quda {
         // before we do policy tuning we must ensure the kernel
         // constituents have been tuned since we can't do nested tuning
         // FIXME this will break if the kernels are destructive - which they aren't here
-        if (getTuning() && getTuneCache().find(tuneKey()) == getTuneCache().end()) {
+        if (!tuned()) {
           disableProfileCount(); // purely for profiling reasons, don't want to profile tunings.
 
           if (x.size() == 1 || y.size() == 1) { // 1-d reduction

--- a/lib/transfer.cpp
+++ b/lib/transfer.cpp
@@ -1,4 +1,6 @@
+
 #include <transfer.h>
+
 #include <blas_quda.h>
 
 #include <transfer.h>
@@ -254,7 +256,7 @@ namespace quda {
     ColorSpinorField &coarse(*coarse_tmp_h);
 
     // compute the coarse grid point for every site (assuming parity ordering currently)
-    for (int i=0; i<fine.Volume(); i++) {
+    for (auto i=0; i<fine.Volume(); i++) {
       // compute the lattice-site index for this offset index
       fine.LatticeIndex(x, i);
       

--- a/lib/transfer.cpp
+++ b/lib/transfer.cpp
@@ -256,7 +256,7 @@ namespace quda {
     ColorSpinorField &coarse(*coarse_tmp_h);
 
     // compute the coarse grid point for every site (assuming parity ordering currently)
-    for (auto i = 0; i < fine.Volume(); i++) {
+    for (size_t i = 0; i < fine.Volume(); i++) {
       // compute the lattice-site index for this offset index
       fine.LatticeIndex(x, i);
       

--- a/lib/transfer.cpp
+++ b/lib/transfer.cpp
@@ -256,7 +256,7 @@ namespace quda {
     ColorSpinorField &coarse(*coarse_tmp_h);
 
     // compute the coarse grid point for every site (assuming parity ordering currently)
-    for (auto i=0; i<fine.Volume(); i++) {
+    for (auto i = 0; i < fine.Volume(); i++) {
       // compute the lattice-site index for this offset index
       fine.LatticeIndex(x, i);
       

--- a/lib/tune.cpp
+++ b/lib/tune.cpp
@@ -648,7 +648,8 @@ namespace quda {
     launchTimer.TPSTART(QUDA_PROFILE_INIT);
 #endif
 
-    const TuneKey key = tunable.tuneKey();
+    TuneKey key = tunable.tuneKey();
+    if (use_managed_memory()) strcat(key.aux, ",managed");
     last_key = key;
     static TuneParam param;
 


### PR DESCRIPTION
This pull request adds support for managed memory to QUDA, and is designed to quickly enable large problems or memory intensive algorithms to just work, e.g., eigenvector solvers
* managed_malloc / managed_free allocators that are tracked similar to other memory allocations
* if `QUDA_ENABLE_MANAGED_MEMORY=1`, all `device_malloc`/`device_free` requests are directed to to use managed memory

Initial testing shows the expected behaviour: when the memory allocations are smaller than available GPU memory, there is negligible performance impact after allocations have migrated to the GPU.  Performance drops off at large problem sizes, but it just works.

@weinbe2 It might be worth trying this with staggered multigrid, I imagine this will allow you to dramatically reduce the node count with minimal impact on the final solver.