### PR TITLE
Feature/large multi blas

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,8 +176,8 @@ set(QUDA_CTEST_SEP_DSLASH_POLICIES
     CACHE BOOL "Test Dslash policies separately in ctest instead of only autotuning them.")
 
 set(QUDA_OPENMP OFF CACHE BOOL "enable OpenMP")
-set(QUDA_CXX_STANDARD 11 CACHE STRING "set the CXX Standard (11 or 14)")
-set_property(CACHE QUDA_CXX_STANDARD PROPERTY STRINGS 11 14)
+set(QUDA_CXX_STANDARD 14 CACHE STRING "set the CXX Standard (14 or 17)")
+set_property(CACHE QUDA_CXX_STANDARD PROPERTY STRINGS 14 17)
 
 # NVTX options
 set(QUDA_MPI_NVTX OFF CACHE BOOL "add nvtx markup to MPI API calls for the visual profiler")

--- a/include/externals/jitify.hpp
+++ b/include/externals/jitify.hpp
@@ -1231,7 +1231,7 @@ static const char* jitsafe_header_type_traits = R"(
     template<bool B, class T = void> struct enable_if {};
     template<class T>                struct enable_if<true, T> { typedef T type; };
     #if __cplusplus >= 201402L
-    template< bool B, class T = void > using enable_if_t = typename enable_if<B,T>::type
+    template< bool B, class T = void > using enable_if_t = typename enable_if<B,T>::type;
     #endif
 
     struct true_type  {
@@ -1340,7 +1340,7 @@ static const char* jitsafe_header_type_traits = R"(
     }
     template< class T > struct add_pointer : __jitify_detail::add_pointer<T, is_function<T>::value> {};
     #if __cplusplus >= 201402L
-    template< class T > using add_pointer_t = typename add_pointer<T>::type
+    template< class T > using add_pointer_t = typename add_pointer<T>::type;
     #endif
 
     template< class T > struct decay {
@@ -1699,9 +1699,38 @@ static const char* jitsafe_header_mutex = R"(
     bool try_lock();
     void unlock();
     };
-    // namespace __jitify_mutex_ns
+    } // namespace __jitify_mutex_ns
     namespace std { using namespace __jitify_mutex_ns; }
     using namespace __jitify_mutex_ns;
+    #endif
+ )";
+
+static const char* jitsafe_header_algorithm = R"(
+    #pragma once
+    #if __cplusplus >= 201103L
+    namespace __jitify_algorithm_ns {
+    #if __cplusplus == 201103L
+    template<class T> const T& max(const T& a, const T& b)
+    {
+      return (b > a) ? b : a;
+    }
+    template<class T> const T& min(const T& a, const T& b)
+    {
+      return (b < a) ? b : a;
+    }
+    #else
+    template<class T> constexpr const T& max(const T& a, const T& b)
+    {
+      return (b > a) ? b : a;
+    }
+    template<class T> constexpr const T& min(const T& a, const T& b)
+    {
+      return (b < a) ? b : a;
+    }
+    #endif
+    } // namespace __jitify_algorithm_ns
+    namespace std { using namespace __jitify_algorithm_ns; }
+    using namespace __jitify_algorithm_ns;
     #endif
  )";
 
@@ -1720,7 +1749,8 @@ static const char* jitsafe_headers[] = {
     jitsafe_header_iostream,     jitsafe_header_ostream,
     jitsafe_header_istream,      jitsafe_header_sstream,
     jitsafe_header_vector,       jitsafe_header_string,
-    jitsafe_header_stdexcept,    jitsafe_header_mutex};
+    jitsafe_header_stdexcept,    jitsafe_header_mutex,
+    jitsafe_header_algorithm};
 static const char* jitsafe_header_names[] = {"jitify_preinclude.h",
                                              "float.h",
                                              "cfloat",
@@ -1750,7 +1780,8 @@ static const char* jitsafe_header_names[] = {"jitify_preinclude.h",
                                              "vector",
                                              "string",
                                              "stdexcept",
-                                             "mutex"};
+                                             "mutex",
+                                             "algorithm"};
 
 template <class T, size_t N>
 size_t array_size(T (&)[N]) {

--- a/include/jitify_helper.cuh
+++ b/include/jitify_helper.cuh
@@ -48,7 +48,7 @@ namespace quda {
     if (!jitify_init) {
       kernel_cache = new jitify::JitCache;
 
-      std::vector<std::string> options = {"-std=c++11", "-ftz=true", "-prec-div=false", "-prec-sqrt=false"};
+      std::vector<std::string> options = {"-std=c++14", "-ftz=true", "-prec-div=false", "-prec-sqrt=false"};
 
 #ifdef DEVICE_DEBUG
       options.push_back(std::string("-G"));

--- a/include/kernels/dslash_coarse.cuh
+++ b/include/kernels/dslash_coarse.cuh
@@ -328,12 +328,8 @@ namespace quda {
 	constexpr int warp_size = 32; // FIXME - this is buggy when x-dim * color_stride < 32
 #pragma unroll
 	for (int offset = warp_size/2; offset >= warp_size/color_stride; offset /= 2)
-#if (__CUDACC_VER_MAJOR__ >= 9)
 #define WARP_CONVERGED 0xffffffff // we know warp should be converged here
 	  out[color_local] += __shfl_down_sync(WARP_CONVERGED, out[color_local], offset);
-#else
-	  out[color_local] += __shfl_down(out[color_local], offset);
-#endif
       }
 
 #endif // __CUDA_ARCH__ >= 300

--- a/include/kernels/multi_blas_core.cuh
+++ b/include/kernels/multi_blas_core.cuh
@@ -83,15 +83,8 @@ namespace quda
        @param[in,out] arg Argument struct with required meta data
        (input/output fields, functor, etc.)
     */
-#ifndef CONSTANT_ARG
     template <typename FloatN, int M, int NXZ, int warp_split, typename Arg> __global__ void multiBlasKernel(Arg arg)
     {
-#else
-    template <typename FloatN, int M, int NXZ, int warp_split, typename Arg> __global__ void multiBlasKernel()
-    {
-      Arg &arg = *((Arg *)arg_buffer);
-#endif
-
       // use i to loop over elements in kernel
       const int k = blockIdx.y * blockDim.y + threadIdx.y;
       const int parity = blockIdx.z;

--- a/include/kernels/multi_blas_core.cuh
+++ b/include/kernels/multi_blas_core.cuh
@@ -27,9 +27,9 @@ namespace quda
     template <int NXZ, typename SpinorX, typename SpinorY, typename SpinorZ, typename SpinorW, typename Functor>
     struct MultiBlasArg :
       SpinorXZ<NXZ,SpinorX,SpinorZ,Functor::use_z>,
-      SpinorYW<max_YW_size<NXZ, Functor>(), SpinorY, SpinorW, Functor::use_w>
+      SpinorYW<max_YW_size<NXZ, typename SpinorX::StoreType, typename SpinorY::StoreType, Functor>(), SpinorY, SpinorW, Functor::use_w>
     {
-      static constexpr int NYW_max = max_YW_size<NXZ, Functor>();
+      static constexpr int NYW_max = max_YW_size<NXZ, typename SpinorX::StoreType, typename SpinorY::StoreType, Functor>();
       const int NYW;
       Functor f;
       const int length;
@@ -117,17 +117,17 @@ namespace quda
 
       __device__ __host__ inline Float2 b(int i, int j) const {
 #ifdef __CUDA_ARCH__
-        return reinterpret_cast<Float2 *>(Amatrix_d)[i*NYW + j];
+        return reinterpret_cast<Float2 *>(Bmatrix_d)[i*NYW + j];
 #else
-        return reinterpret_cast<Float2 *>(Amatrix_h)[i*NYW + j];
+        return reinterpret_cast<Float2 *>(Bmatrix_h)[i*NYW + j];
 #endif
       }
 
       __device__ __host__ inline Float2 c(int i, int j) const {
 #ifdef __CUDA_ARCH__
-        return reinterpret_cast<Float2 *>(Amatrix_d)[i*NYW + j];
+        return reinterpret_cast<Float2 *>(Cmatrix_d)[i*NYW + j];
 #else
-        return reinterpret_cast<Float2 *>(Amatrix_h)[i*NYW + j];
+        return reinterpret_cast<Float2 *>(Cmatrix_h)[i*NYW + j];
 #endif
       }
 

--- a/include/kernels/multi_blas_core.cuh
+++ b/include/kernels/multi_blas_core.cuh
@@ -11,10 +11,6 @@
 #include <generics/shfl.h>
 #endif
 
-#if CUDA_VERSION < 9000
-#define CONSTANT_ARG
-#endif
-
 namespace quda
 {
 

--- a/include/kernels/multi_blas_core.cuh
+++ b/include/kernels/multi_blas_core.cuh
@@ -138,8 +138,8 @@ namespace quda
         }
 
         // now combine the results across the warp if needed
-        warp_combine<M,warp_split>(y);
-        warp_combine<M,warp_split>(w);
+        if (arg.Y[k].write) warp_combine<M,warp_split>(y);
+        if (arg.W[k].write) warp_combine<M,warp_split>(w);
 
         if (l_idx == 0 || warp_split == 1) {
           arg.Y[k].save(y, idx, parity);

--- a/include/kernels/multi_blas_core.cuh
+++ b/include/kernels/multi_blas_core.cuh
@@ -65,12 +65,8 @@ namespace quda
           // reduce down to the first group of column-split threads
 #pragma unroll
           for (int offset = warp_size / 2; offset >= warp_size / warp_split; offset /= 2) {
-#if (__CUDACC_VER_MAJOR__ >= 9)
 #define WARP_CONVERGED 0xffffffff // we know warp should be converged here
             x[j] += __shfl_down_sync(WARP_CONVERGED, x[j], offset);
-#else
-            x[j] += __shfl_down(x[j], offset);
-#endif
           }
         }
       }

--- a/include/kernels/multi_blas_core.cuh
+++ b/include/kernels/multi_blas_core.cuh
@@ -2,6 +2,7 @@
 
 #include <color_spinor_field_order.h>
 #include <blas_helper.cuh>
+#include <multi_blas_helper.cuh>
 
 #if CUDA_VERSION < 9000
 #define CONSTANT_ARG
@@ -12,119 +13,6 @@ namespace quda
 
   namespace blas
   {
-
-#define BLAS_SPINOR // do not include ghost functions in Spinor class to reduce parameter space overhead
-#include <texture.h>
-
-    // storage for matrix coefficients
-#define MAX_MATRIX_SIZE 8192
-#define MAX_ARG_SIZE 4096
-    static __constant__ signed char Amatrix_d[MAX_MATRIX_SIZE];
-    static __constant__ signed char Bmatrix_d[MAX_MATRIX_SIZE];
-    static __constant__ signed char Cmatrix_d[MAX_MATRIX_SIZE];
-
-    static signed char *Amatrix_h;
-    static signed char *Bmatrix_h;
-    static signed char *Cmatrix_h;
-
-#ifdef CONSTANT_ARG
-    // as a performance work around we put the argument struct into
-    // __constant__ memory to prevent the compiler from spilling
-    // registers on older CUDA
-    static __constant__ signed char arg_buffer[MAX_ARG_SIZE];
-#endif
-
-    /**
-       @brief Helper function to compute the maximum YW size for the
-       multi-blas runctions.  Since the SpinorX and SpinorZ arrays are
-       statically allocated with length NXZ, we can statically compute how
-       the maximum size of YW is and allocate this amount of space.  This
-       allows for a much larger NXZ (NYW) when NYW (NXZ) is small.
-    */
-    template <int NXZ, typename RegType, bool use_z, bool use_w> inline constexpr int max_YW_size()
-    {
-      // the size of the accessor doesn't change with precision just instantiate some precision
-      using SpinorX = SpinorTexture<float4,short4,6>;
-      using SpinorY = Spinor<float4,short4,6,1>;
-      using SpinorZ = SpinorTexture<float4,short4,6>;
-      using SpinorW = Spinor<float4,short4,6,1>;
-
-      // compute the size remaining for the Y and W accessors
-      constexpr int arg_size = (MAX_ARG_SIZE
-                                - sizeof(int)          // NYW parameter
-                                - sizeof(SpinorX[NXZ]) // SpinorX array
-                                - (use_z ? sizeof(SpinorZ[NXZ]) : sizeof(SpinorZ*)) // SpinorZ array
-                                - sizeof(int)          // functor NYW member
-                                - sizeof(int) - 16     // length parameter
-                                - (!use_w ? sizeof(SpinorW*) : 0) // subtract pointer if not using W
-                                - 16)                  // there seems to be 16 bytes other argument space we need
-        / (sizeof(SpinorY) + (use_w ? sizeof(SpinorW) : 0) );
-
-      // this is the maximum size limit imposed by the coefficient arrays
-      constexpr int coeff_size = MAX_MATRIX_SIZE / (NXZ * sizeof(RegType));
-
-      return std::min(arg_size, coeff_size);
-    }
-
-    /**
-       @brief Helper function to compute the maximum YW size for the
-       multi-blas runctions.  Since the SpinorX and SpinorZ arrays are
-       statically allocated with length NXZ, we can statically compute how
-       the maximum size of YW is and allocate this amount of space.  This
-       allows for a much larger NXZ (NYW) when NYW (NXZ) is small.
-    */
-    inline int max_YW_size(int NXZ, int precision, bool use_z, bool use_w)
-    {
-      // ensure NXZ is a valid size
-      NXZ = std::min(NXZ, MAX_MULTI_BLAS_N);
-
-      // the size of the accessor doesn't change with precision just instantiate some precision
-      using SpinorX = SpinorTexture<float4,short4,6>;
-      using SpinorY = Spinor<float4,short4,6,1>;
-      using SpinorZ = SpinorTexture<float4,short4,6>;
-      using SpinorW = Spinor<float4,short4,6,1>;
-
-      // compute the size remaining for the Y and W accessors
-      int arg_size = (MAX_ARG_SIZE
-                      - sizeof(int)         // NYW parameter
-                      - NXZ*sizeof(SpinorX) // SpinorX array
-                      - (use_z ? NXZ*sizeof(SpinorZ) : sizeof(SpinorZ*)) // SpinorZ array
-                      - sizeof(int)         // functor NYW member
-                      - sizeof(int)         // length parameter
-                      - (!use_w ? sizeof(SpinorW*) : 0) // subtract pointer if not using W
-                      - 16)                  // there seems to be 16 bytes other argument space we need
-        / (sizeof(SpinorY) + (use_w ? sizeof(SpinorW) : 0) );
-
-      int coeff_size = MAX_MATRIX_SIZE / (NXZ * precision);
-
-      return std::min(arg_size, coeff_size);
-    }
-
-    template <int NXZ, typename SpinorX, typename SpinorZ, bool> struct SpinorXZ
-    {
-      SpinorX X[NXZ];
-      SpinorZ *Z;
-      SpinorXZ() : Z(reinterpret_cast<SpinorZ*>(X)) { }
-    };
-
-    template <int NXZ, typename SpinorX, typename SpinorZ> struct SpinorXZ<NXZ,SpinorX,SpinorZ,true>
-    {
-      SpinorX X[NXZ];
-      SpinorZ Z[NXZ];
-    };
-
-    template <int NYW, typename SpinorY, typename SpinorW, bool> struct SpinorYW
-    {
-      SpinorY Y[NYW];
-      SpinorW *W;
-      SpinorYW() : W(reinterpret_cast<SpinorW*>(Y)) { }
-    };
-
-    template <int NYW, typename SpinorY, typename SpinorW> struct SpinorYW<NYW,SpinorY,SpinorW,true>
-    {
-      SpinorY Y[NYW];
-      SpinorW W[NYW];
-    };
 
     /**
        @brief Parameter struct for generic multi-blas kernel.
@@ -139,9 +27,9 @@ namespace quda
     template <int NXZ, typename SpinorX, typename SpinorY, typename SpinorZ, typename SpinorW, typename Functor>
     struct MultiBlasArg :
       SpinorXZ<NXZ,SpinorX,SpinorZ,Functor::use_z>,
-      SpinorYW<max_YW_size<NXZ, typename Functor::type, Functor::use_z, Functor::use_w>(), SpinorY, SpinorW, Functor::use_w>
+      SpinorYW<max_YW_size<NXZ, Functor>(), SpinorY, SpinorW, Functor::use_w>
     {
-      static constexpr int NYW_max = max_YW_size<NXZ, typename Functor::type, Functor::use_z, Functor::use_w>();
+      static constexpr int NYW_max = max_YW_size<NXZ, Functor>();
       const int NYW;
       Functor f;
       const int length;
@@ -215,6 +103,7 @@ namespace quda
     template <int NXZ, typename Float2, typename FloatN> struct MultiBlasFunctor
     {
       typedef Float2 type;
+      static constexpr bool reducer = false;
       int NYW;
       MultiBlasFunctor(int NYW) : NYW(NYW) { }
 

--- a/include/kernels/multi_reduce_core.cuh
+++ b/include/kernels/multi_reduce_core.cuh
@@ -33,9 +33,9 @@ namespace quda
     struct MultiReduceArg :
       public ReduceArg<vector_type<ReduceType, NXZ>>,
       SpinorXZ<NXZ,SpinorX,SpinorZ,Reducer::use_z>,
-      SpinorYW<max_YW_size<NXZ, Reducer>(), SpinorY, SpinorW, Reducer::use_w>
+      SpinorYW<max_YW_size<NXZ, typename SpinorX::StoreType, typename SpinorY::StoreType, Reducer>(), SpinorY, SpinorW, Reducer::use_w>
     {
-      static constexpr int NYW_max = max_YW_size<NXZ, Reducer>();
+      static constexpr int NYW_max = max_YW_size<NXZ, typename SpinorX::StoreType, typename SpinorY::StoreType, Reducer>();
       const int NYW;
       Reducer r;
       const int length;
@@ -143,17 +143,17 @@ namespace quda
 
       __device__ __host__ inline Float2 b(int i, int j) const {
 #ifdef __CUDA_ARCH__
-        return reinterpret_cast<Float2 *>(Amatrix_d)[i*NYW + j];
+        return reinterpret_cast<Float2 *>(Bmatrix_d)[i*NYW + j];
 #else
-        return reinterpret_cast<Float2 *>(Amatrix_h)[i*NYW + j];
+        return reinterpret_cast<Float2 *>(Bmatrix_h)[i*NYW + j];
 #endif
       }
 
       __device__ __host__ inline Float2 c(int i, int j) const {
 #ifdef __CUDA_ARCH__
-        return reinterpret_cast<Float2 *>(Amatrix_d)[i*NYW + j];
+        return reinterpret_cast<Float2 *>(Cmatrix_d)[i*NYW + j];
 #else
-        return reinterpret_cast<Float2 *>(Amatrix_h)[i*NYW + j];
+        return reinterpret_cast<Float2 *>(Cmatrix_h)[i*NYW + j];
 #endif
       }
 

--- a/include/kernels/multi_reduce_core.cuh
+++ b/include/kernels/multi_reduce_core.cuh
@@ -7,10 +7,6 @@
 
 //#define WARP_MULTI_REDUCE
 
-#if CUDA_VERSION < 9000
-#define CONSTANT_ARG
-#endif
-
 namespace quda
 {
 
@@ -91,19 +87,18 @@ namespace quda
         // Each NYW owns its own thread.
         // The NXZ's are all in the same thread block,
         // so they can share the same memory.
-#pragma unroll NXZ
+#pragma unroll
         for (int l = 0; l < NXZ; l++) {
           arg.X[l].load(x, idx, parity);
           arg.Z[l].load(z, idx, parity);
 
           arg.r.pre();
 
-#pragma unroll M
+#pragma unroll
           for (int j = 0; j < M; j++) arg.r(sum[l], x[j], y[j], z[j], w[j], k, l);
 
           arg.r.post(sum[l]);
         }
-
         arg.Y[k].save(y, idx, parity);
         arg.W[k].save(w, idx, parity);
 

--- a/include/kernels/multi_reduce_core.cuh
+++ b/include/kernels/multi_reduce_core.cuh
@@ -25,13 +25,14 @@ namespace quda
        @tparam Reducer Functor used to operate on data
     */
     template <int NXZ, typename ReduceType, typename SpinorX, typename SpinorY, typename SpinorZ, typename SpinorW,
-        typename Reducer>
-    struct MultiReduceArg :
-      public ReduceArg<vector_type<ReduceType, NXZ>>,
-      SpinorXZ<NXZ,SpinorX,SpinorZ,Reducer::use_z>,
-      SpinorYW<max_YW_size<NXZ, typename SpinorX::StoreType, typename SpinorY::StoreType, Reducer>(), SpinorY, SpinorW, Reducer::use_w>
-    {
-      static constexpr int NYW_max = max_YW_size<NXZ, typename SpinorX::StoreType, typename SpinorY::StoreType, Reducer>();
+              typename Reducer>
+    struct MultiReduceArg
+      : public ReduceArg<vector_type<ReduceType, NXZ>>,
+        SpinorXZ<NXZ, SpinorX, SpinorZ, Reducer::use_z>,
+        SpinorYW<max_YW_size<NXZ, typename SpinorX::StoreType, typename SpinorY::StoreType, Reducer>(), SpinorY,
+                 SpinorW, Reducer::use_w> {
+      static constexpr int NYW_max
+        = max_YW_size<NXZ, typename SpinorX::StoreType, typename SpinorY::StoreType, Reducer>();
       const int NYW;
       Reducer r;
       const int length;
@@ -41,7 +42,7 @@ namespace quda
           r(r),
           length(length)
       {
-	if (NYW > NYW_max) errorQuda("NYW = %d greater than maximum size of %d", NYW, NYW_max);
+        if (NYW > NYW_max) errorQuda("NYW = %d greater than maximum size of %d", NYW, NYW_max);
 
         for (int i = 0; i < NXZ; ++i) {
           this->X[i] = X[i];
@@ -121,34 +122,36 @@ namespace quda
     /**
        Base class from which all reduction functors should derive.
     */
-    template <int NXZ, typename ReduceType, typename Float2, typename FloatN> struct MultiReduceFunctor
-    {
+    template <int NXZ, typename ReduceType, typename Float2, typename FloatN> struct MultiReduceFunctor {
       typedef Float2 type;
       static constexpr bool reducer = true;
       int NYW;
-      MultiReduceFunctor(int NYW) : NYW(NYW) { }
+      MultiReduceFunctor(int NYW) : NYW(NYW) {}
 
-      __device__ __host__ inline Float2 a(int i, int j) const {
+      __device__ __host__ inline Float2 a(int i, int j) const
+      {
 #ifdef __CUDA_ARCH__
-        return reinterpret_cast<Float2 *>(Amatrix_d)[i*NYW + j];
+        return reinterpret_cast<Float2 *>(Amatrix_d)[i * NYW + j];
 #else
-        return reinterpret_cast<Float2 *>(Amatrix_h)[i*NYW + j];
+        return reinterpret_cast<Float2 *>(Amatrix_h)[i * NYW + j];
 #endif
       }
 
-      __device__ __host__ inline Float2 b(int i, int j) const {
+      __device__ __host__ inline Float2 b(int i, int j) const
+      {
 #ifdef __CUDA_ARCH__
-        return reinterpret_cast<Float2 *>(Bmatrix_d)[i*NYW + j];
+        return reinterpret_cast<Float2 *>(Bmatrix_d)[i * NYW + j];
 #else
-        return reinterpret_cast<Float2 *>(Bmatrix_h)[i*NYW + j];
+        return reinterpret_cast<Float2 *>(Bmatrix_h)[i * NYW + j];
 #endif
       }
 
-      __device__ __host__ inline Float2 c(int i, int j) const {
+      __device__ __host__ inline Float2 c(int i, int j) const
+      {
 #ifdef __CUDA_ARCH__
-        return reinterpret_cast<Float2 *>(Cmatrix_d)[i*NYW + j];
+        return reinterpret_cast<Float2 *>(Cmatrix_d)[i * NYW + j];
 #else
-        return reinterpret_cast<Float2 *>(Cmatrix_h)[i*NYW + j];
+        return reinterpret_cast<Float2 *>(Cmatrix_h)[i * NYW + j];
 #endif
       }
 

--- a/include/kernels/multi_reduce_core.cuh
+++ b/include/kernels/multi_reduce_core.cuh
@@ -2,6 +2,7 @@
 
 #include <color_spinor_field_order.h>
 #include <blas_helper.cuh>
+#include <multi_blas_helper.cuh>
 #include <cub_helper.cuh>
 
 //#define WARP_MULTI_REDUCE
@@ -10,127 +11,11 @@
 #define CONSTANT_ARG
 #endif
 
-
 namespace quda
 {
 
   namespace blas
   {
-
-#define BLAS_SPINOR // do not include ghost functions in Spinor class to reduce parameter space overhead
-#include <texture.h>
-
-    // storage for matrix coefficients
-#define MAX_MATRIX_SIZE 8192
-#define MAX_ARG_SIZE 4096
-    static __constant__ signed char Amatrix_d[MAX_MATRIX_SIZE];
-    static __constant__ signed char Bmatrix_d[MAX_MATRIX_SIZE];
-    static __constant__ signed char Cmatrix_d[MAX_MATRIX_SIZE];
-
-    static signed char *Amatrix_h;
-    static signed char *Bmatrix_h;
-    static signed char *Cmatrix_h;
-
-#ifdef CONSTANT_ARG
-    // as a performance work around we put the argument struct into
-    // __constant__ memory to prevent the compiler from spilling
-    // registers on older CUDA
-    static __constant__ signed char arg_buffer[MAX_ARG_SIZE];
-#endif
-
-    /**
-       @brief Helper function to compute the maximum YW size for the
-       multi-blas runctions.  Since the SpinorX and SpinorZ arrays are
-       statically allocated with length NXZ, we can statically compute how
-       the maximum size of YW is and allocate this amount of space.  This
-       allows for a much larger NXZ (NYW) when NYW (NXZ) is small.
-    */
-    template <int NXZ, typename RegType, bool use_z, bool use_w> inline constexpr int max_YW_size()
-    {
-      // the size of the accessor doesn't change with precision just instantiate some precision
-      using SpinorX = SpinorTexture<float4,short4,6>;
-      using SpinorY = Spinor<float4,short4,6,1>;
-      using SpinorZ = SpinorTexture<float4,short4,6>;
-      using SpinorW = Spinor<float4,short4,6,1>;
-
-      // compute the size remaining for the Y and W accessors
-      constexpr int arg_size = (MAX_ARG_SIZE
-                                - sizeof(int)           // NYW parameter
-                                - sizeof(SpinorX[NXZ])  // SpinorX array
-                                - (use_z ? sizeof(SpinorZ[NXZ]) : sizeof(SpinorZ*)) // SpinorZ array
-                                - sizeof(int)           // functor NYW member
-                                - sizeof(int)           // length parameter
-                                - (!use_w ? sizeof(SpinorW*) : 0) // subtract pointer if not using W
-                                - 3*sizeof(void*)      // pointers for reduction buffers
-                                - 16)                  // there seems to be 16 bytes other argument space we need
-        / (sizeof(SpinorY) + (use_w ? sizeof(SpinorW) : 0) );
-
-      // this is the maximum size limit imposed by the coefficient arrays
-      constexpr int coeff_size = MAX_MATRIX_SIZE / (NXZ * sizeof(RegType));
-
-      return std::min(arg_size, coeff_size);
-    }
-
-    /**
-       @brief Helper function to compute the maximum YW size for the
-       multi-blas runctions.  Since the SpinorX and SpinorZ arrays are
-       statically allocated with length NXZ, we can statically compute how
-       the maximum size of YW is and allocate this amount of space.  This
-       allows for a much larger NXZ (NYW) when NYW (NXZ) is small.
-    */
-    inline int max_YW_size(int NXZ, int precision, bool use_z, bool use_w)
-    {
-      // ensure NXZ is a valid size
-      NXZ = std::min(NXZ, MAX_MULTI_BLAS_N);
-
-      // the size of the accessor doesn't change with precision just instantiate some precision
-      using SpinorX = SpinorTexture<float4,short4,6>;
-      using SpinorY = Spinor<float4,short4,6,1>;
-      using SpinorZ = SpinorTexture<float4,short4,6>;
-      using SpinorW = Spinor<float4,short4,6,1>;
-
-      // compute the size remaining for the Y and W accessors
-      int arg_size = (MAX_ARG_SIZE
-                      - sizeof(int)         // NYW parameter
-                      - NXZ*sizeof(SpinorX) // SpinorX array
-                      - (use_z ? NXZ*sizeof(SpinorZ) : sizeof(SpinorZ*)) // SpinorZ array
-                      - sizeof(int)         // functor NYW member
-                      - sizeof(int)         // length parameter
-                      - (!use_w ? sizeof(SpinorW*) : 0) // subtract pointer if not using W
-                      - 3*sizeof(void*)     // pointers for reduction buffers
-                      - 16)                 // there seems to be 16 bytes other argument space we need
-        / (sizeof(SpinorY) + (use_w ? sizeof(SpinorW) : 0) );
-
-      int coeff_size = MAX_MATRIX_SIZE / (NXZ * precision);
-
-      return std::min(arg_size, coeff_size);
-    }
-
-    template <int NXZ, typename SpinorX, typename SpinorZ, bool> struct SpinorXZ
-    {
-      SpinorX X[NXZ];
-      SpinorZ *Z;
-      SpinorXZ() : Z(reinterpret_cast<SpinorZ*>(X)) { }
-    };
-
-    template <int NXZ, typename SpinorX, typename SpinorZ> struct SpinorXZ<NXZ,SpinorX,SpinorZ,true>
-    {
-      SpinorX X[NXZ];
-      SpinorZ Z[NXZ];
-    };
-
-    template <int NYW, typename SpinorY, typename SpinorW, bool> struct SpinorYW
-    {
-      SpinorY Y[NYW];
-      SpinorW *W;
-      SpinorYW() : W(reinterpret_cast<SpinorW*>(Y)) { }
-    };
-
-    template <int NYW, typename SpinorY, typename SpinorW> struct SpinorYW<NYW,SpinorY,SpinorW,true>
-    {
-      SpinorY Y[NYW];
-      SpinorW W[NYW];
-    };
 
     /**
        @brief Parameter struct for generic multi-blas kernel.
@@ -148,9 +33,9 @@ namespace quda
     struct MultiReduceArg :
       public ReduceArg<vector_type<ReduceType, NXZ>>,
       SpinorXZ<NXZ,SpinorX,SpinorZ,Reducer::use_z>,
-      SpinorYW<max_YW_size<NXZ, typename Reducer::type, Reducer::use_z, Reducer::use_w>(), SpinorY, SpinorW, Reducer::use_w>
+      SpinorYW<max_YW_size<NXZ, Reducer>(), SpinorY, SpinorW, Reducer::use_w>
     {
-      static constexpr int NYW_max = max_YW_size<NXZ, typename Reducer::type, Reducer::use_z, Reducer::use_w>();
+      static constexpr int NYW_max = max_YW_size<NXZ, Reducer>();
       const int NYW;
       Reducer r;
       const int length;
@@ -244,6 +129,7 @@ namespace quda
     template <int NXZ, typename ReduceType, typename Float2, typename FloatN> struct MultiReduceFunctor
     {
       typedef Float2 type;
+      static constexpr bool reducer = true;
       int NYW;
       MultiReduceFunctor(int NYW) : NYW(NYW) { }
 

--- a/include/kernels/multi_reduce_core.cuh
+++ b/include/kernels/multi_reduce_core.cuh
@@ -62,14 +62,8 @@ namespace quda
     template <int block_size, typename ReduceType, typename FloatN, int M, int NXZ, typename Arg>
 #endif
 
-#ifndef CONSTANT_ARG
     __global__ void multiReduceKernel(Arg arg)
     {
-#else
-    __global__ void multiReduceKernel()
-    {
-      Arg &arg = *((Arg *)arg_buffer);
-#endif
       unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
       unsigned int k = blockIdx.y * blockDim.y + threadIdx.y;
       unsigned int parity = blockIdx.z;

--- a/include/launch_kernel.cuh
+++ b/include/launch_kernel.cuh
@@ -230,11 +230,11 @@
   default: errorQuda("%s block size %d not instantiated", #kernel, tp.block.x);                                        \
   }
 
-#define LAUNCH_KERNEL_REDUCE(kernel, tp, stream, arg, ...)              \
-  switch (tp.block.x) {                                                 \
-  case 32: kernel<32,__VA_ARGS__> <<< tp.grid, tp.block, tp.shared_bytes, stream >>>(arg); break; \
-  case 64: kernel<64,__VA_ARGS__> <<< tp.grid, tp.block, tp.shared_bytes, stream >>>(arg); break; \
-  case 96: kernel<96,__VA_ARGS__> <<< tp.grid, tp.block, tp.shared_bytes, stream >>>(arg); break; \
-  case 128: kernel<128,__VA_ARGS__> <<< tp.grid, tp.block, tp.shared_bytes, stream >>>(arg); break; \
-  default: errorQuda("%s block size %d not instantiated", #kernel, tp.block.x); \
+#define LAUNCH_KERNEL_REDUCE(kernel, tp, stream, arg, ...)                                                             \
+  switch (tp.block.x) {                                                                                                \
+  case 32: kernel<32, __VA_ARGS__><<<tp.grid, tp.block, tp.shared_bytes, stream>>>(arg); break;                        \
+  case 64: kernel<64, __VA_ARGS__><<<tp.grid, tp.block, tp.shared_bytes, stream>>>(arg); break;                        \
+  case 96: kernel<96, __VA_ARGS__><<<tp.grid, tp.block, tp.shared_bytes, stream>>>(arg); break;                        \
+  case 128: kernel<128, __VA_ARGS__><<<tp.grid, tp.block, tp.shared_bytes, stream>>>(arg); break;                      \
+  default: errorQuda("%s block size %d not instantiated", #kernel, tp.block.x);                                        \
   }

--- a/include/launch_kernel.cuh
+++ b/include/launch_kernel.cuh
@@ -229,3 +229,12 @@
   case 512: kernel<512, __VA_ARGS__><<<tp.grid, tp.block, tp.shared_bytes, stream>>>(arg); break;                      \
   default: errorQuda("%s block size %d not instantiated", #kernel, tp.block.x);                                        \
   }
+
+#define LAUNCH_KERNEL_REDUCE(kernel, tp, stream, arg, ...)              \
+  switch (tp.block.x) {                                                 \
+  case 32: kernel<32,__VA_ARGS__> <<< tp.grid, tp.block, tp.shared_bytes, stream >>>(arg); break; \
+  case 64: kernel<64,__VA_ARGS__> <<< tp.grid, tp.block, tp.shared_bytes, stream >>>(arg); break; \
+  case 96: kernel<96,__VA_ARGS__> <<< tp.grid, tp.block, tp.shared_bytes, stream >>>(arg); break; \
+  case 128: kernel<128,__VA_ARGS__> <<< tp.grid, tp.block, tp.shared_bytes, stream >>>(arg); break; \
+  default: errorQuda("%s block size %d not instantiated", #kernel, tp.block.x); \
+  }

--- a/include/multi_blas_helper.cuh
+++ b/include/multi_blas_helper.cuh
@@ -1,0 +1,124 @@
+namespace quda
+{
+
+  namespace blas
+  {
+
+#define BLAS_SPINOR // do not include ghost functions in Spinor class to reduce parameter space overhead
+#include <texture.h>
+
+    // storage for matrix coefficients
+#define MAX_MATRIX_SIZE 8192
+#define MAX_ARG_SIZE 4096
+    static __constant__ signed char Amatrix_d[MAX_MATRIX_SIZE];
+    static __constant__ signed char Bmatrix_d[MAX_MATRIX_SIZE];
+    static __constant__ signed char Cmatrix_d[MAX_MATRIX_SIZE];
+
+    static signed char *Amatrix_h;
+    static signed char *Bmatrix_h;
+    static signed char *Cmatrix_h;
+
+#ifdef CONSTANT_ARG
+    // as a performance work around we put the argument struct into
+    // __constant__ memory to prevent the compiler from spilling
+    // registers on older CUDA
+    static __constant__ signed char arg_buffer[MAX_ARG_SIZE];
+#endif
+
+    /**
+       @brief Helper function to compute the maximum YW size for the
+       multi-blas runctions.  Since the SpinorX and SpinorZ arrays are
+       statically allocated with length NXZ, we can statically compute how
+       the maximum size of YW is and allocate this amount of space.  This
+       allows for a much larger NXZ (NYW) when NYW (NXZ) is small.
+    */
+    template <int NXZ, typename Functor> inline constexpr int max_YW_size()
+    {
+      // the size of the accessor doesn't change with precision just instantiate some precision
+      using SpinorX = SpinorTexture<float4,short4,6>;
+      using SpinorY = Spinor<float4,short4,6,1>;
+      using SpinorZ = SpinorX;
+      using SpinorW = SpinorY;
+
+      // compute the size remaining for the Y and W accessors
+      constexpr int arg_size = (MAX_ARG_SIZE
+                                - sizeof(int)          // NYW parameter
+                                - sizeof(SpinorX[NXZ]) // SpinorX array
+                                - (Functor::use_z ? sizeof(SpinorZ[NXZ]) : sizeof(SpinorZ*)) // SpinorZ array
+                                - sizeof(int)          // functor NYW member
+                                - sizeof(int) - 16     // length parameter
+                                - (!Functor::use_w ? sizeof(SpinorW*) : 0) // subtract pointer if not using W
+                                - (Functor::reducer ? 3 * sizeof(void*) : 0) // reduction buffers
+                                - 16)                  // there seems to be 16 bytes other argument space we need
+        / (sizeof(SpinorY) + (Functor::use_w ? sizeof(SpinorW) : 0) );
+
+      // this is the maximum size limit imposed by the coefficient arrays
+      constexpr int coeff_size = MAX_MATRIX_SIZE / (NXZ * sizeof(typename Functor::type));
+
+      return std::min(arg_size, coeff_size);
+    }
+
+    /**
+       @brief Helper function to compute the maximum YW size for the
+       multi-blas runctions.  Since the SpinorX and SpinorZ arrays are
+       statically allocated with length NXZ, we can statically compute how
+       the maximum size of YW is and allocate this amount of space.  This
+       allows for a much larger NXZ (NYW) when NYW (NXZ) is small.
+    */
+    inline int max_YW_size(int NXZ, int precision, bool use_z, bool use_w, bool reduce)
+    {
+      // ensure NXZ is a valid size
+      NXZ = std::min(NXZ, MAX_MULTI_BLAS_N);
+
+      // the size of the accessor doesn't change with precision just instantiate some precision
+      using SpinorX = SpinorTexture<float4,short4,6>;
+      using SpinorY = Spinor<float4,short4,6,1>;
+      using SpinorZ = SpinorX;
+      using SpinorW = SpinorY;
+
+      // compute the size remaining for the Y and W accessors
+      int arg_size = (MAX_ARG_SIZE
+                      - sizeof(int)         // NYW parameter
+                      - NXZ*sizeof(SpinorX) // SpinorX array
+                      - (use_z ? NXZ*sizeof(SpinorZ) : sizeof(SpinorZ*)) // SpinorZ array
+                      - sizeof(int)         // functor NYW member
+                      - sizeof(int)         // length parameter
+                      - (!use_w ? sizeof(SpinorW*) : 0) // subtract pointer if not using W
+                      - (reduce ? 3 * sizeof(void*) : 0) // reduction buffers
+                      - 16)                  // there seems to be 16 bytes other argument space we need
+        / (sizeof(SpinorY) + (use_w ? sizeof(SpinorW) : 0) );
+
+      int coeff_size = MAX_MATRIX_SIZE / (NXZ * precision);
+
+      return std::min(arg_size, coeff_size);
+    }
+
+    template <int NXZ, typename SpinorX, typename SpinorZ, bool> struct SpinorXZ
+    {
+      SpinorX X[NXZ];
+      SpinorZ *Z;
+      SpinorXZ() : Z(reinterpret_cast<SpinorZ*>(X)) { }
+    };
+
+    template <int NXZ, typename SpinorX, typename SpinorZ> struct SpinorXZ<NXZ,SpinorX,SpinorZ,true>
+    {
+      SpinorX X[NXZ];
+      SpinorZ Z[NXZ];
+    };
+
+    template <int NYW, typename SpinorY, typename SpinorW, bool> struct SpinorYW
+    {
+      SpinorY Y[NYW];
+      SpinorW *W;
+      SpinorYW() : W(reinterpret_cast<SpinorW*>(Y)) { }
+    };
+
+    template <int NYW, typename SpinorY, typename SpinorW> struct SpinorYW<NYW,SpinorY,SpinorW,true>
+    {
+      SpinorY Y[NYW];
+      SpinorW W[NYW];
+    };
+
+  } // namespace blas
+
+} // namespace quda

--- a/include/multi_blas_helper.cuh
+++ b/include/multi_blas_helper.cuh
@@ -10,10 +10,6 @@ namespace quda
 #define BLAS_SPINOR // do not include ghost functions in Spinor class to reduce parameter space overhead
 #include <texture.h>
 
-#if __CUDACC_VER_MAJOR__ < 9
-#define CONSTANT_ARG
-#endif
-
     // storage for matrix coefficients
 #define MAX_MATRIX_SIZE 8192
 #define MAX_ARG_SIZE 4096
@@ -24,13 +20,6 @@ namespace quda
     static signed char *Amatrix_h;
     static signed char *Bmatrix_h;
     static signed char *Cmatrix_h;
-
-#ifdef CONSTANT_ARG
-    // as a performance work around we put the argument struct into
-    // __constant__ memory to prevent the compiler from spilling
-    // registers on older CUDA
-    static __constant__ signed char arg_buffer[MAX_ARG_SIZE];
-#endif
 
     /**
        @param[in] x Value we are testing

--- a/include/multi_blas_helper.cuh
+++ b/include/multi_blas_helper.cuh
@@ -112,13 +112,12 @@ namespace quda
        the maximum size of YW is and allocate this amount of space.  This
        allows for a much larger NXZ (NYW) when NYW (NXZ) is small.
     */
-    inline int max_YW_size(int NXZ, QudaPrecision x_prec, QudaPrecision y_prec, size_t scalar_size,
-                           bool use_z, bool use_w, bool reduce)
+    inline int max_YW_size(int NXZ, QudaPrecision x_prec, QudaPrecision y_prec, bool use_z, bool use_w, bool reduce)
     {
       bool x_fixed = x_prec < QUDA_SINGLE_PRECISION;
       bool y_fixed = y_prec < QUDA_SINGLE_PRECISION;
-      // ensure NXZ is a valid size
-      NXZ = is_valid_NXZ(NXZ, reduce, x_fixed) ?  NXZ : MAX_MULTI_BLAS_N;
+      size_t scalar_size = 2 * std::max( {x_prec, y_prec, QUDA_SINGLE_PRECISION} );
+      NXZ = is_valid_NXZ(NXZ, reduce, x_fixed) ?  NXZ : MAX_MULTI_BLAS_N; // ensure NXZ is a valid size
       size_t spinor_x_size = x_fixed ? sizeof(SpinorTexture<float4,short4,6>) :
         sizeof(SpinorTexture<float4,float4,6>);
       size_t spinor_y_size = y_fixed ? sizeof(Spinor<float4,short4,6,1>) : sizeof(Spinor<float4,float4,6,1>);

--- a/include/multi_blas_helper.cuh
+++ b/include/multi_blas_helper.cuh
@@ -61,7 +61,7 @@ namespace quda
     inline bool is_valid_NXZ(int nxz, bool reducer, bool fixed = false)
     {
       if (nxz <= MAX_MULTI_BLAS_N || // all values below MAX_MULTI_BLAS_N are valid
-          ( is_power2(nxz) && nxz <= max_NXZ_power2(reducer, fixed)) ) {
+          (is_power2(nxz) && nxz <= max_NXZ_power2(reducer, fixed)) ) {
         return true;
       } else {
         return false;
@@ -162,6 +162,24 @@ namespace quda
     {
       SpinorY Y[NYW];
       SpinorW W[NYW];
+    };
+
+    namespace detail
+    {
+      template <unsigned... digits> struct to_chars {
+        static const char value[];
+      };
+
+      template <unsigned... digits> const char to_chars<digits...>::value[] = {('0' + digits)..., 0};
+
+      template <unsigned rem, unsigned... digits> struct explode : explode<rem / 10, rem % 10, digits...> {
+      };
+
+      template <unsigned... digits> struct explode<0, digits...> : to_chars<digits...> {
+      };
+    } // namespace detail
+
+    template <unsigned num> struct num_to_string : detail::explode<num / 10, num % 10> {
     };
 
   } // namespace blas

--- a/include/multi_blas_helper.cuh
+++ b/include/multi_blas_helper.cuh
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <register_traits.h>
 
 namespace quda
@@ -8,6 +9,10 @@ namespace quda
 
 #define BLAS_SPINOR // do not include ghost functions in Spinor class to reduce parameter space overhead
 #include <texture.h>
+
+#if __CUDACC_VER_MAJOR__ < 9
+#define CONSTANT_ARG
+#endif
 
     // storage for matrix coefficients
 #define MAX_MATRIX_SIZE 8192

--- a/include/quda_constants.h
+++ b/include/quda_constants.h
@@ -60,4 +60,4 @@
  * @brief Maximum number of simultaneous reductions that can take
  * place.  This number may be increased if needed.
  */
-#define QUDA_MAX_MULTI_REDUCE 256
+#define QUDA_MAX_MULTI_REDUCE 1024

--- a/include/texture.h
+++ b/include/texture.h
@@ -376,9 +376,10 @@ template <typename RegType, typename StoreType_, int N> struct SpinorTexture :
    @param StoreType Type used to store field in memory
    @param N Length of vector of RegType elements that this Spinor represents
 */
-template <typename RegType, typename StoreType_, int N, int write>
+template <typename RegType, typename StoreType_, int N, int write_>
 struct Spinor : public SpinorTexture<RegType, StoreType_, N>
 {
+  static constexpr bool write = write_;
   typedef StoreType_ StoreType;
   typedef typename bridge_mapper<RegType,StoreType>::type InterType;
   typedef SpinorTexture<RegType, StoreType, N> ST;

--- a/include/tune_quda.h
+++ b/include/tune_quda.h
@@ -82,10 +82,9 @@ namespace quda {
     virtual bool advanceGridDim(TuneParam &param) const
     {
       if (tuneGridDim()) {
-	const unsigned int max_blocks = maxGridSize();
         const int step = gridStep();
         param.grid.x += step;
-	if (param.grid.x > max_blocks) {
+	if (param.grid.x > maxGridSize()) {
 	  param.grid.x = minGridSize();
 	  return false;
 	} else {
@@ -111,14 +110,14 @@ namespace quda {
     virtual int blockMin() const { return deviceProp.warpSize; }
 
     virtual void resetBlockDim(TuneParam &param) const {
-      const unsigned int max_threads = maxBlockSize(param);
-      const unsigned int max_blocks = deviceProp.maxGridSize[0];
-      const int step = blockStep();
-
       if (tuneGridDim()) {
-	param.block.x = step;
+	param.block.x = blockMin();
       } else { // not tuning the grid dimension so have to set a valid grid size
-	// ensure the blockDim is large enough given the limit on gridDim
+        const auto step = blockStep();
+        const auto max_threads = maxBlockSize(param);
+        const auto max_blocks = deviceProp.maxGridSize[0];
+
+        // ensure the blockDim is large enough given the limit on gridDim
 	param.block.x = (minThreads()+max_blocks-1)/max_blocks;
 	param.block.x = ((param.block.x+step-1)/step)*step; // round up to nearest step size
 	if (param.block.x > max_threads && param.block.y == 1 && param.block.z == 1)
@@ -344,7 +343,7 @@ namespace quda {
     virtual void defaultTuneParam(TuneParam &param) const
     {
       initTuneParam(param);
-      if (tuneGridDim()) param.grid = dim3(128,1,1);
+      if (tuneGridDim()) param.grid = dim3(maxGridSize(),1,1);
     }
 
     virtual bool advanceTuneParam(TuneParam &param) const

--- a/include/tune_quda.h
+++ b/include/tune_quda.h
@@ -338,7 +338,6 @@ namespace quda {
       param.shared_bytes = sharedBytesPerThread()*nthreads > sharedBytesPerBlock(param) ?
 	sharedBytesPerThread()*nthreads : sharedBytesPerBlock(param);
 
-      param.aux = make_int4(0, 0, 0, 0);
     }
 
     /** sets default values for when tuning is disabled */
@@ -346,7 +345,6 @@ namespace quda {
     {
       initTuneParam(param);
       if (tuneGridDim()) param.grid = dim3(128,1,1);
-      param.aux = make_int4(0, 0, 0, 0);
     }
 
     virtual bool advanceTuneParam(TuneParam &param) const

--- a/include/tune_quda.h
+++ b/include/tune_quda.h
@@ -337,6 +337,8 @@ namespace quda {
       int nthreads = param.block.x*param.block.y*param.block.z;
       param.shared_bytes = sharedBytesPerThread()*nthreads > sharedBytesPerBlock(param) ?
 	sharedBytesPerThread()*nthreads : sharedBytesPerBlock(param);
+
+      param.aux = make_int4(0, 0, 0, 0);
     }
 
     /** sets default values for when tuning is disabled */
@@ -344,6 +346,7 @@ namespace quda {
     {
       initTuneParam(param);
       if (tuneGridDim()) param.grid = dim3(128,1,1);
+      param.aux = make_int4(0, 0, 0, 0);
     }
 
     virtual bool advanceTuneParam(TuneParam &param) const

--- a/include/tune_quda.h
+++ b/include/tune_quda.h
@@ -84,12 +84,12 @@ namespace quda {
       if (tuneGridDim()) {
         const int step = gridStep();
         param.grid.x += step;
-	if (param.grid.x > maxGridSize()) {
-	  param.grid.x = minGridSize();
+        if (param.grid.x > maxGridSize()) {
+          param.grid.x = minGridSize();
 	  return false;
-	} else {
-	  return true;
-	}
+        } else {
+          return true;
+        }
       } else {
 	return false;
       }
@@ -111,14 +111,14 @@ namespace quda {
 
     virtual void resetBlockDim(TuneParam &param) const {
       if (tuneGridDim()) {
-	param.block.x = blockMin();
+        param.block.x = blockMin();
       } else { // not tuning the grid dimension so have to set a valid grid size
         const auto step = blockStep();
         const auto max_threads = maxBlockSize(param);
         const auto max_blocks = deviceProp.maxGridSize[0];
 
         // ensure the blockDim is large enough given the limit on gridDim
-	param.block.x = (minThreads()+max_blocks-1)/max_blocks;
+        param.block.x = (minThreads()+max_blocks-1)/max_blocks;
 	param.block.x = ((param.block.x+step-1)/step)*step; // round up to nearest step size
 	if (param.block.x > max_threads && param.block.y == 1 && param.block.z == 1)
 	  errorQuda("Local lattice volume is too large for device");
@@ -336,14 +336,13 @@ namespace quda {
       int nthreads = param.block.x*param.block.y*param.block.z;
       param.shared_bytes = sharedBytesPerThread()*nthreads > sharedBytesPerBlock(param) ?
 	sharedBytesPerThread()*nthreads : sharedBytesPerBlock(param);
-
     }
 
     /** sets default values for when tuning is disabled */
     virtual void defaultTuneParam(TuneParam &param) const
     {
       initTuneParam(param);
-      if (tuneGridDim()) param.grid = dim3(maxGridSize(),1,1);
+      if (tuneGridDim()) param.grid = dim3(maxGridSize(), 1, 1);
     }
 
     virtual bool advanceTuneParam(TuneParam &param) const

--- a/lib/blas_quda.cu
+++ b/lib/blas_quda.cu
@@ -43,18 +43,12 @@ namespace quda {
       unsigned int sharedBytesPerThread() const { return 0; }
       unsigned int sharedBytesPerBlock(const TuneParam &param) const { return 0; }
 
-      virtual bool advanceSharedBytes(TuneParam &param) const
-      {
-        TuneParam next(param);
-        advanceBlockDim(next); // to get next blockDim
-        int nthreads = next.block.x * next.block.y * next.block.z;
-        param.shared_bytes = sharedBytesPerThread() * nthreads > sharedBytesPerBlock(param) ?
-            sharedBytesPerThread() * nthreads :
-            sharedBytesPerBlock(param);
-        return false;
-      }
+      bool tuneSharedBytes() const { return false; }
 
-  public:
+      // for these streaming kernels, there is no need to tune the grid size, just use max
+      unsigned int minGridSize() const { return maxGridSize(); }
+
+    public:
       BlasCuda(SpinorX &X, SpinorY &Y, SpinorZ &Z, SpinorW &W, SpinorV &V, Functor &f, ColorSpinorField &x,
           ColorSpinorField &y, ColorSpinorField &z, ColorSpinorField &w, ColorSpinorField &v, int length) :
           nParity((x.IsComposite() ? x.CompositeDim() : 1) * x.SiteSubset()), // must be first

--- a/lib/cuda_color_spinor_field.cpp
+++ b/lib/cuda_color_spinor_field.cpp
@@ -246,7 +246,6 @@ namespace quda {
       {
          if(composite_descr.dim <= 0) errorQuda("\nComposite size is not defined\n");
          //if(bytes > 1811939328) warningQuda("\nCUDA API probably won't be able to create texture object for the eigenvector set... Object size is : %u bytes\n", bytes);
-         if (getVerbosity() == QUDA_DEBUG_VERBOSE) printfQuda("\nEigenvector set constructor...\n");
          // create the associated even and odd subsets
          ColorSpinorParam param;
          param.siteSubset = QUDA_PARITY_SITE_SUBSET;

--- a/lib/multi_blas_quda.cu
+++ b/lib/multi_blas_quda.cu
@@ -173,29 +173,13 @@ namespace quda {
 
         tp.block.x *= tp.aux.x; // include warp-split factor
 
-#ifdef CONSTANT_ARG
-        cudaMemcpyToSymbolAsync(arg_buffer, reinterpret_cast<char *>(&arg), sizeof(arg), 0, cudaMemcpyHostToDevice,
-                                stream);
-        switch (tp.aux.x) {
-        case 1:
-          multiBlasKernel<FloatN, M, NXZ, 1, decltype(arg)><<<tp.grid, tp.block, tp.shared_bytes, stream>>>(arg);
-          break;
-        case 2:
-          multiBlasKernel<FloatN, M, NXZ, 2, decltype(arg)><<<tp.grid, tp.block, tp.shared_bytes, stream>>>(arg);
-          break;
-        case 4:
-          multiBlasKernel<FloatN, M, NXZ, 4, decltype(arg)><<<tp.grid, tp.block, tp.shared_bytes, stream>>>(arg);
-          break;
-        default: errorQuda("warp-split factor %d not instantiated", tp.aux.x);
-        }
-#else
         switch (tp.aux.x) {
         case 1: multiBlasKernel<FloatN, M, NXZ, 1><<<tp.grid, tp.block, tp.shared_bytes, stream>>>(arg); break;
         case 2: multiBlasKernel<FloatN, M, NXZ, 2><<<tp.grid, tp.block, tp.shared_bytes, stream>>>(arg); break;
         case 4: multiBlasKernel<FloatN, M, NXZ, 4><<<tp.grid, tp.block, tp.shared_bytes, stream>>>(arg); break;
         default: errorQuda("warp-split factor %d not instantiated", tp.aux.x);
         }
-#endif
+
         tp.block.x /= tp.aux.x; // restore block size
 #endif
       }

--- a/lib/multi_blas_quda.cu
+++ b/lib/multi_blas_quda.cu
@@ -24,24 +24,6 @@ namespace quda {
       static constexpr int W = writeW;
     };
 
-    namespace detail
-    {
-      template <unsigned... digits> struct to_chars {
-        static const char value[];
-      };
-
-      template <unsigned... digits> const char to_chars<digits...>::value[] = {('0' + digits)..., 0};
-
-      template <unsigned rem, unsigned... digits> struct explode : explode<rem / 10, rem % 10, digits...> {
-      };
-
-      template <unsigned... digits> struct explode<0, digits...> : to_chars<digits...> {
-      };
-    } // namespace detail
-
-    template <unsigned num> struct num_to_string : detail::explode<num / 10, num % 10> {
-    };
-
     template <int NXZ, typename FloatN, int M, typename SpinorX, typename SpinorY, typename SpinorZ, typename SpinorW,
         typename Functor, typename T>
     class MultiBlas : public TunableVectorY
@@ -681,7 +663,8 @@ namespace quda {
     void caxpy_recurse(const Complex *a_, std::vector<ColorSpinorField*> &x, std::vector<ColorSpinorField*> &y,
           int i_idx ,int j_idx, int upper) {
 
-      if (y.size() > max_YW_size(x.size(), x[0]->Precision(), y[0]->Precision(), 2*y[0]->Precision(), false, false, false)) { // if greater than max single-kernel size, recurse.
+      if (y.size() > (size_t)max_YW_size(x.size(), x[0]->Precision(), y[0]->Precision(), 2*y[0]->Precision(),
+                                         false, false, false)) { // if greater than max single-kernel size, recurse.
         // We need to split up 'a' carefully since it's row-major.
         Complex* tmpmajor = new Complex[x.size()*y.size()];
         Complex* tmpmajor0 = &tmpmajor[0];
@@ -771,7 +754,8 @@ namespace quda {
 
     void caxpyz_recurse(const Complex *a_, std::vector<ColorSpinorField*> &x, std::vector<ColorSpinorField*> &y, std::vector<ColorSpinorField*> &z, int i, int j, int pass, int upper) {
 
-      if (y.size() > max_YW_size(x.size(), x[0]->Precision(), y[0]->Precision(), 2*y[0]->Precision(), false, true, false)) { // if greater than max single-kernel size, recurse.
+      if (y.size() > (size_t)max_YW_size(x.size(), x[0]->Precision(), y[0]->Precision(), 2*y[0]->Precision(),
+                                         false, true, false)) { // if greater than max single-kernel size, recurse.
         // We need to split up 'a' carefully since it's row-major.
         Complex* tmpmajor = new Complex[x.size()*y.size()];
         Complex* tmpmajor0 = &tmpmajor[0];
@@ -868,7 +852,8 @@ namespace quda {
     void axpyBzpcx(const double *a_, std::vector<ColorSpinorField*> &x_, std::vector<ColorSpinorField*> &y_,
 		   const double *b_, ColorSpinorField &z_, const double *c_)
     {
-      if (y_.size() <= max_YW_size(1, z_.Precision(), y_[0]->Precision(), 2*y_[0]->Precision(), false, true, false)) {
+      if (y_.size() <= (size_t)max_YW_size(1, z_.Precision(), y_[0]->Precision(), 2*y_[0]->Precision(),
+                                           false, true, false)) {
 	// swizzle order since we are writing to x_ and y_, but the
 	// multi-blas only allow writing to y and w, and moreover the
 	// block width of y and w must match, and x and z must match.

--- a/lib/multi_blas_quda.cu
+++ b/lib/multi_blas_quda.cu
@@ -47,7 +47,10 @@ namespace quda {
 
       bool tuneSharedBytes() const { return false; }
 
-  public:
+      // for these streaming kernels, there is no need to tune the grid size, just use max
+      unsigned int minGridSize() const { return maxGridSize(); }
+
+    public:
       MultiBlas(SpinorX X[], SpinorY Y[], SpinorZ Z[], SpinorW W[], Functor &f, const coeff_array<T> &a,
           const coeff_array<T> &b, const coeff_array<T> &c, std::vector<ColorSpinorField *> &x,
           std::vector<ColorSpinorField *> &y, std::vector<ColorSpinorField *> &z, std::vector<ColorSpinorField *> &w,
@@ -71,7 +74,7 @@ namespace quda {
       {
         // heuristic for enabling if we need the warp-splitting optimization
         const int gpu_size = 2 * deviceProp.maxThreadsPerBlock * deviceProp.multiProcessorCount;
-        switch (gpu_size/x[0]->Length()) {
+        switch (gpu_size/(x[0]->Length() * NYW)) {
         case 0: max_warp_split = 1; break; // we have plenty of work, no need to split
         case 1: max_warp_split = 2; break; // double the thread count
         case 2:                            // quadruple the thread count

--- a/lib/multi_blas_quda.cu
+++ b/lib/multi_blas_quda.cu
@@ -50,7 +50,7 @@ namespace quda {
   private:
       typedef typename scalar<FloatN>::type Float;
       typedef typename vector<Float, 2>::type Float2;
-      static constexpr int NYW_max = max_YW_size<NXZ, Float2>();
+      static constexpr int NYW_max = max_YW_size<NXZ, Functor>();
       const int NYW;
       const int nParity;
       mutable MultiBlasArg<NXZ, SpinorX, SpinorY, SpinorZ, SpinorW, Functor> arg;
@@ -235,7 +235,7 @@ namespace quda {
       typedef typename vector<Float, 2>::type Float2;
       typedef vector<Float, 2> vec2;
 
-      constexpr int NYW_max = max_YW_size<NXZ, Float2>();
+      constexpr int NYW_max = max_YW_size<NXZ, Functor<NXZ, Float2, RegType>>();
       printfQuda("NXZ = %d max NYW = %d\n", NXZ, NYW_max);
       const int NYW = y.size();
 
@@ -644,7 +644,7 @@ namespace quda {
     void caxpy_recurse(const Complex *a_, std::vector<ColorSpinorField*> &x, std::vector<ColorSpinorField*> &y,
           int i_idx ,int j_idx, int upper) {
 
-      if (y.size() > max_YW_size(x.size(), 2*y[0]->Precision())) { // if greater than max single-kernel size, recurse.
+      if (y.size() > max_YW_size(x.size(), 2*y[0]->Precision(), false, false, false)) { // if greater than max single-kernel size, recurse.
         // We need to split up 'a' carefully since it's row-major.
         Complex* tmpmajor = new Complex[x.size()*y.size()];
         Complex* tmpmajor0 = &tmpmajor[0];
@@ -734,7 +734,7 @@ namespace quda {
 
     void caxpyz_recurse(const Complex *a_, std::vector<ColorSpinorField*> &x, std::vector<ColorSpinorField*> &y, std::vector<ColorSpinorField*> &z, int i, int j, int pass, int upper) {
 
-      if (y.size() > max_YW_size(x.size(), 2*y[0]->Precision())) { // if greater than max single-kernel size, recurse.
+      if (y.size() > max_YW_size(x.size(), 2*y[0]->Precision(), false, true, false)) { // if greater than max single-kernel size, recurse.
         // We need to split up 'a' carefully since it's row-major.
         Complex* tmpmajor = new Complex[x.size()*y.size()];
         Complex* tmpmajor0 = &tmpmajor[0];
@@ -831,7 +831,7 @@ namespace quda {
     void axpyBzpcx(const double *a_, std::vector<ColorSpinorField*> &x_, std::vector<ColorSpinorField*> &y_,
 		   const double *b_, ColorSpinorField &z_, const double *c_)
     {
-      if (y_.size() <= max_YW_size(1, 2*y_[0]->Precision())) {
+      if (y_.size() <= max_YW_size(1, 2*y_[0]->Precision(), false, true, false)) {
 	// swizzle order since we are writing to x_ and y_, but the
 	// multi-blas only allow writing to y and w, and moreover the
 	// block width of y and w must match, and x and z must match.

--- a/lib/multi_blas_quda.cu
+++ b/lib/multi_blas_quda.cu
@@ -286,7 +286,7 @@ namespace quda {
                                             f.use_z, f.use_w, false);
 
       if (NYW_max != NYW_max_check) errorQuda("Runtime %d and compile time %d limits disagree", NYW_max, NYW_max_check);
-      if (!is_valid_NXZ(NXZ)) errorQuda("NXZ=%d is not a valid size ( MAX_MULTI_BLAS_N %d)", NXZ, MAX_MULTI_BLAS_N);
+      if (!is_valid_NXZ<false>(NXZ)) errorQuda("NXZ=%d is not a valid size ( MAX_MULTI_BLAS_N %d)", NXZ, MAX_MULTI_BLAS_N);
       if (NYW > NYW_max) errorQuda("NYW exceeds max size (%d > %d)", NYW, NYW_max);
       if (NXZ * NYW * sizeof(Float2) > MAX_MATRIX_SIZE)
         errorQuda("Coefficient  matrix exceeds max size (%lu > %d)", NXZ * NYW * sizeof(Float2), MAX_MATRIX_SIZE);
@@ -706,7 +706,7 @@ namespace quda {
         // if at the bottom of recursion,
         // return if on lower left for upper triangular,
         // return if on upper right for lower triangular.
-        if ( is_valid_NXZ(x.size()) ) {
+        if ( is_valid_NXZ<false>(x.size()) ) {
           if (upper == 1 && j_idx < i_idx) { return; }
           if (upper == -1 && j_idx > i_idx) { return; }
 
@@ -797,7 +797,7 @@ namespace quda {
         delete[] tmpmajor;
       } else {
       	// if at bottom of recursion check where we are
-        if ( is_valid_NXZ(x.size()) ) {
+        if ( is_valid_NXZ<false>(x.size()) ) {
       	  if (pass==1) {
 	    if (i!=j) {
               if (upper == 1 && j < i) { return; } // upper right, don't need to update lower left.
@@ -902,7 +902,7 @@ namespace quda {
     void caxpyBxpz(const Complex *a_, std::vector<ColorSpinorField*> &x_, ColorSpinorField &y_,
 		   const Complex *b_, ColorSpinorField &z_)
     {
-      if ( is_valid_NXZ(x_.size()) ) // only swizzle if we have to.
+      if ( is_valid_NXZ<false>(x_.size()) ) // only swizzle if we have to.
       {
         // swizzle order since we are writing to y_ and z_, but the
         // multi-blas only allow writing to y and w, and moreover the

--- a/lib/multi_blas_quda.cu
+++ b/lib/multi_blas_quda.cu
@@ -282,10 +282,12 @@ namespace quda {
       Functor<NXZ, Float2, RegType> f(NYW);
       constexpr int NYW_max = max_YW_size<NXZ, StoreType, yType, decltype(f)>();
 
+      const int NYW_max_check = max_YW_size(x.size(), x[0]->Precision(), y[0]->Precision(), 2*y[0]->Precision(),
+                                            f.use_z, f.use_w, false);
+
+      if (NYW_max != NYW_max_check) errorQuda("Runtime %d and compile time %d limits disagree", NYW_max, NYW_max_check);
       if (!is_valid_NXZ(NXZ)) errorQuda("NXZ=%d is not a valid size ( MAX_MULTI_BLAS_N %d)", NXZ, MAX_MULTI_BLAS_N);
-
       if (NYW > NYW_max) errorQuda("NYW exceeds max size (%d > %d)", NYW, NYW_max);
-
       if (NXZ * NYW * sizeof(Float2) > MAX_MATRIX_SIZE)
         errorQuda("Coefficient  matrix exceeds max size (%lu > %d)", NXZ * NYW * sizeof(Float2), MAX_MATRIX_SIZE);
 

--- a/lib/multi_reduce_quda.cu
+++ b/lib/multi_reduce_quda.cu
@@ -51,12 +51,7 @@ namespace quda {
                                   .configure(tp.grid, tp.block, tp.shared_bytes, stream)
                                   .launch(arg);
 #else
-#ifdef CONSTANT_ARG
-      cudaMemcpyToSymbolAsync(arg_buffer, reinterpret_cast<char *>(&arg), sizeof(arg), 0, cudaMemcpyHostToDevice, stream);
-      LAUNCH_KERNEL_REDUCE(multiReduceKernel, tp, stream, , ReduceType, FloatN, M, NXZ, Arg);
-#else
       LAUNCH_KERNEL_REDUCE(multiReduceKernel, tp, stream, arg, ReduceType, FloatN, M, NXZ, Arg);
-#endif
 #endif
 #endif
 

--- a/lib/multi_reduce_quda.cu
+++ b/lib/multi_reduce_quda.cu
@@ -282,8 +282,7 @@ namespace quda {
 
       memset(result, 0, NXZ * NYW * sizeof(doubleN));
 
-      const int NYW_max_check = max_YW_size(x.size(), x[0]->Precision(), y[0]->Precision(), sizeof(Float2),
-                                            r.use_z, r.use_w, true);
+      const int NYW_max_check = max_YW_size(x.size(), x[0]->Precision(), y[0]->Precision(), r.use_z, r.use_w, true);
 
       if (!is_valid_NXZ(NXZ, true)) errorQuda("NXZ=%d is not a valid size ( MAX_MULTI_BLAS_N %d)", NXZ, MAX_MULTI_BLAS_N);
       if (NYW_max != NYW_max_check) errorQuda("Runtime %d and compile time %d limits disagree", NYW_max_check, NYW_max);
@@ -895,7 +894,7 @@ template <typename doubleN, typename ReduceType, template <int MXZ, typename Red
                    bool nested_policy = false)
 	: result(result), x(x), y(y), z(z), w(w), hermitian(hermitian), Anorm(Anorm)
       {
-        NYW_max = max_YW_size(x.size(), x[0]->Precision(), y[0]->Precision(), 2*y[0]->Precision(), false, false, true);
+        NYW_max = max_YW_size(x.size(), x[0]->Precision(), y[0]->Precision(), false, false, true);
         max_tile_size = make_uint2(1,1);
 
         strcpy(aux, nested_policy ? "nested_policy," : "policy,");

--- a/lib/multi_reduce_quda.cu
+++ b/lib/multi_reduce_quda.cu
@@ -290,7 +290,7 @@ namespace quda {
       if (NXZ * NYW > QUDA_MAX_MULTI_REDUCE) errorQuda("NXZ * NYW = %d exceeds maximum number of reductions %d", NXZ * NYW, QUDA_MAX_MULTI_REDUCE);
       if (NYW > NYW_max) errorQuda("NYW exceeds max size (%d > %d)", NYW, NYW_max);
       if (NXZ * NYW * sizeof(Float2) > MAX_MATRIX_SIZE)
-        errorQuda("Coefficient  matrix exceeds max size (%lu > %d)", NXZ * NYW * sizeof(Float2), MAX_MATRIX_SIZE);
+        errorQuda("Coefficient matrix exceeds max size (%lu > %d)", NXZ * NYW * sizeof(Float2), MAX_MATRIX_SIZE);
 
       const int N_MIN = NXZ < NYW ? NXZ : NYW;
       for (int i = 0; i < N_MIN; i++) {
@@ -308,8 +308,6 @@ namespace quda {
       if (a.data || b.data || c.data) errorQuda("Constant memory buffer support not enabled with jitify yet");
 #endif
 
-      // FIXME - if NXZ=1 no need to copy entire array
-      // FIXME - do we really need strided access here?
       if (a.data) {
         Float2 A[MAX_MATRIX_SIZE / sizeof(Float2)];
         // since the kernel doesn't know the width of them matrix at compile
@@ -318,7 +316,7 @@ namespace quda {
           for (int j = 0; j < NYW; j++)
             A[NYW * i + j] = make_Float2<Float2>(Complex(a.data[NYW * i + j]));
 
-        cudaMemcpyToSymbolAsync(Amatrix_d, A, MAX_MATRIX_SIZE, 0, cudaMemcpyHostToDevice, *getStream());
+        cudaMemcpyToSymbolAsync(Amatrix_d, A, NXZ*NYW*sizeof(decltype(A[0])), 0, cudaMemcpyHostToDevice, *getStream());
         Amatrix_h = reinterpret_cast<signed char *>(const_cast<T *>(a.data));
       }
 
@@ -330,7 +328,7 @@ namespace quda {
           for (int j = 0; j < NYW; j++)
             B[NYW * i + j] = make_Float2<Float2>(Complex(b.data[NYW * i + j]));
 
-        cudaMemcpyToSymbolAsync(Bmatrix_d, B, MAX_MATRIX_SIZE, 0, cudaMemcpyHostToDevice, *getStream());
+        cudaMemcpyToSymbolAsync(Bmatrix_d, B, NXZ*NYW*sizeof(decltype(B[0])), 0, cudaMemcpyHostToDevice, *getStream());
         Bmatrix_h = reinterpret_cast<signed char *>(const_cast<T *>(b.data));
       }
 
@@ -342,7 +340,7 @@ namespace quda {
           for (int j = 0; j < NYW; j++)
             C[NYW * i + j] = make_Float2<Float2>(Complex(c.data[NYW * i + j]));
 
-        cudaMemcpyToSymbolAsync(Cmatrix_d, C, MAX_MATRIX_SIZE, 0, cudaMemcpyHostToDevice, *getStream());
+        cudaMemcpyToSymbolAsync(Cmatrix_d, C, NXZ*NYW*sizeof(decltype(C[0])), 0, cudaMemcpyHostToDevice, *getStream());
         Cmatrix_h = reinterpret_cast<signed char *>(const_cast<T *>(c.data));
       }
 

--- a/lib/multi_reduce_quda.cu
+++ b/lib/multi_reduce_quda.cu
@@ -1205,7 +1205,8 @@ namespace quda {
 
       if (x.size() == 1) {
         int NYW_max = max_YW_size(x.size(), x[0]->Precision(), y[0]->Precision(), false, false, true);
-        uint2 max_tile_size = make_uint2(1, std::min(NYW_max, (int)y.size()));
+        // if fine-grid then we set max tile size to 32 to avoid unnecessary tuning
+        uint2 max_tile_size = make_uint2(1, std::min( {NYW_max, (int)y.size(), x[0]->Ncolor() == 3 ? 32 : NYW_max} ));
         multiReduce_recurse<double, QudaSumFloat, Dot, write<0, 0, 0, 0>, Dot, write<0, 0, 0, 0>>(
           result_tmp, x, y, x, y, 0, 0, false, max_tile_size);
       } else if (y.size() == 1) {
@@ -1214,7 +1215,8 @@ namespace quda {
 
         // swap (x<->y and w<-z> when doing transpose calculation)
         int NXZ_max = max_YW_size(y.size(), y[0]->Precision(), x[0]->Precision(), false, false, true);
-        uint2 max_tile_size = make_uint2(1, std::min(NXZ_max, (int)x.size()));
+        // if fine-grid then we set max tile size to 32 to avoid unnecessary tuning
+        uint2 max_tile_size = make_uint2(1, std::min( {NXZ_max, (int)x.size(), x[0]->Ncolor() == 3 ? 32 : NXZ_max} ));
         multiReduce_recurse<double, QudaSumFloat, Dot, write<0, 0, 0, 0>, Dot, write<0, 0, 0, 0>>(
           result_trans, y, x, y, x, 0, 0, false, max_tile_size);
 
@@ -1256,7 +1258,8 @@ namespace quda {
 
       if (x.size() == 1) {
         int NYW_max = max_YW_size(x.size(), x[0]->Precision(), y[0]->Precision(), false, false, true);
-        uint2 max_tile_size = make_uint2(1, std::min(NYW_max, (int)y.size()));
+        // if fine-grid then we set max tile size to 32 to avoid unnecessary tuning
+        uint2 max_tile_size = make_uint2(1, std::min( {NYW_max, (int)y.size(), x[0]->Ncolor() == 3 ? 32 : NYW_max} ));
         multiReduce_recurse<double2, QudaSumFloat2, Cdot, write<0, 0, 0, 0>, Cdot, write<0, 0, 0, 0>>(
           result_tmp, x, y, x, y, 0, 0, false, max_tile_size);
       } else if (y.size() == 1) {
@@ -1265,7 +1268,8 @@ namespace quda {
 
         // swap (x<->y and w<-z> when doing transpose calculation)
         int NXZ_max = max_YW_size(y.size(), y[0]->Precision(), x[0]->Precision(), false, false, true);
-        uint2 max_tile_size = make_uint2(1, std::min(NXZ_max, (int)x.size()));
+        // if fine-grid then we set max tile size to 32 to avoid unnecessary tuning
+        uint2 max_tile_size = make_uint2(1, std::min( {NXZ_max, (int)x.size(), x[0]->Ncolor() == 3 ? 32 : NXZ_max} ));
         multiReduce_recurse<double2, QudaSumFloat2, Cdot, write<0, 0, 0, 0>, Cdot, write<0, 0, 0, 0>>(
           result_trans, y, x, y, x, 0, 0, false, max_tile_size);
 

--- a/lib/reduce_quda.cu
+++ b/lib/reduce_quda.cu
@@ -38,7 +38,7 @@ namespace quda {
            blocks = 2 x SM count
 
 	 - multi-reductions where we are reducing to a matrix of size
-	   of size MAX_MULTI_BLAS_N^2 of vectors (max length 4), with
+	   of size QUDA_MAX_MULTI_REDUCE of vectors (max length 4), with
 	   possible parity dimension, and a grid-stride loop with
 	   maximum number of blocks = 2 x SM count
       */
@@ -47,7 +47,7 @@ namespace quda {
       const int max_reduce_blocks = 2*deviceProp.multiProcessorCount;
 
       const int max_reduce = 2 * max_reduce_blocks * reduce_size;
-      const int max_multi_reduce = 2 * MAX_MULTI_BLAS_N * MAX_MULTI_BLAS_N * max_reduce_blocks * reduce_size;
+      const int max_multi_reduce = 2 * QUDA_MAX_MULTI_REDUCE * max_reduce_blocks * reduce_size;
 
       // reduction buffer size
       size_t bytes = max_reduce > max_multi_reduce ? max_reduce : max_multi_reduce;

--- a/lib/reduce_quda.cu
+++ b/lib/reduce_quda.cu
@@ -32,15 +32,15 @@ namespace quda {
     {
       /* we have these different reductions to cater for:
 
-	 - regular reductions (reduce_quda.cu) where are reducing to a
+         - regular reductions (reduce_quda.cu) where are reducing to a
            single vector type (max length 4 presently), with possibly
            parity dimension, and a grid-stride loop with max number of
            blocks = 2 x SM count
 
-	 - multi-reductions where we are reducing to a matrix of size
-	   of size QUDA_MAX_MULTI_REDUCE of vectors (max length 4), with
-	   possible parity dimension, and a grid-stride loop with
-	   maximum number of blocks = 2 x SM count
+         - multi-reductions where we are reducing to a matrix of size
+           of size QUDA_MAX_MULTI_REDUCE of vectors (max length 4), with
+           possible parity dimension, and a grid-stride loop with
+           maximum number of blocks = 2 x SM count
       */
 
       const int reduce_size = 4 * sizeof(QudaSumFloat);

--- a/lib/tune.cpp
+++ b/lib/tune.cpp
@@ -229,9 +229,10 @@ namespace quda {
       strncpy(tmp, key.aux, 13);
       bool is_policy_kernel = strncmp(tmp, "policy_kernel", 13) == 0 ? true : false;
       bool is_policy = (strncmp(tmp, "policy", 6) == 0 && !is_policy_kernel) ? true : false;
+      bool is_nested_policy = (strncmp(tmp, "nested_policy", 6) == 0) ? true : false; // nested policies not included
 
       // synchronous profile
-      if (param.n_calls > 0 && !is_policy) {
+      if (param.n_calls > 0 && !is_policy && !is_nested_policy) {
 	double time = param.n_calls * param.time;
 
 	out << std::setw(12) << param.n_calls * param.time << "\t" << std::setw(12) << (time / total_time) * 100 << "\t";

--- a/lib/tune.cpp
+++ b/lib/tune.cpp
@@ -233,7 +233,7 @@ namespace quda {
 
       // synchronous profile
       if (param.n_calls > 0 && !is_policy && !is_nested_policy) {
-	double time = param.n_calls * param.time;
+        double time = param.n_calls * param.time;
 
 	out << std::setw(12) << param.n_calls * param.time << "\t" << std::setw(12) << (time / total_time) * 100 << "\t";
 	out << std::setw(12) << param.n_calls << "\t" << std::setw(12) << param.time << "\t" << std::setw(16) << key.volume << "\t";

--- a/tests/blas_test.cu
+++ b/tests/blas_test.cu
@@ -944,17 +944,17 @@ double test(int kernel) {
     for (int i=0; i < Msrc; i++) ymD->Component(i) = *(ymH[i]);
 
     blas::axpy(Ar, *xmD, *ymD);
-    for (int i=0; i < Nsrc; i++){
-      for(int j=0; j < Msrc; j++){
+    for (int i=0; i < Nsrc; i++) {
+      for(int j=0; j < Msrc; j++) {
 	blas::axpy(Ar[Msrc*i+j], *(xmH[i]), *(ymH[j]));
       }
     }
 
     error = 0;
-    for (int i=0; i < Nsrc; i++){
+    for (int i=0; i < Msrc; i++) {
       error+= fabs(blas::norm2((ymD->Component(i))) - blas::norm2(*(ymH[i]))) / blas::norm2(*(ymH[i]));
     }
-    error/= Nsrc;
+    error/= Msrc;
     break;
 
   default:

--- a/tests/blas_test.cu
+++ b/tests/blas_test.cu
@@ -308,7 +308,7 @@ double benchmark(int kernel, const int niter) {
   quda::Complex * B = new quda::Complex[Nsrc*Msrc];
   quda::Complex * C = new quda::Complex[Nsrc*Msrc];
   quda::Complex * A2 = new quda::Complex[Nsrc*Nsrc]; // for the block cDotProductNorm test
-  double * Ar = new double[Nsrc*Msrc];
+  double *Ar = new double[Nsrc * Msrc];
 
   cudaEvent_t start, end;
   cudaEventCreate(&start);
@@ -490,7 +490,7 @@ double benchmark(int kernel, const int niter) {
       break;
 
     case 42:
-      for (int i=0; i < niter; ++i) blas::axpy(Ar, xmD->Components(), ymD->Components());
+      for (int i = 0; i < niter; ++i) blas::axpy(Ar, xmD->Components(), ymD->Components());
       break;
 
     default:
@@ -525,17 +525,17 @@ double test(int kernel) {
   quda::Complex * C = new quda::Complex[Nsrc*Msrc];
   quda::Complex * A2 = new quda::Complex[Nsrc*Nsrc]; // for the block cDotProductNorm test
   quda::Complex * B2 = new quda::Complex[Nsrc*Nsrc]; // for the block cDotProductNorm test
-  double *Ar = new double[Nsrc*Msrc];
+  double *Ar = new double[Nsrc * Msrc];
 
-  for (int i=0; i < Nsrc*Msrc; i++) {
-    A[i] = a2 * (1.0*((i/(double)Nsrc) + i)) + b2 * (1.0*i) + c2 *(1.0*(0.5*Nsrc*Msrc-i));
-    B[i] = a2 * (1.0*((i/(double)Nsrc) + i)) - b2 * (M_PI*i) + c2 *(1.0*(0.5*Nsrc*Msrc-i));
-    C[i] = a2 * (1.0*((M_PI/(double)Nsrc) + i)) + b2 * (1.0*i) + c2 *(1.0*(0.5*Nsrc*Msrc-i));
+  for (int i = 0; i < Nsrc * Msrc; i++) {
+    A[i] = a2 * (1.0 * ((i / (double)Nsrc) + i)) + b2 * (1.0 * i) + c2 * (1.0 * (0.5 * Nsrc * Msrc - i));
+    B[i] = a2 * (1.0 * ((i / (double)Nsrc) + i)) - b2 * (M_PI * i) + c2 * (1.0 * (0.5 * Nsrc * Msrc - i));
+    C[i] = a2 * (1.0 * ((M_PI / (double)Nsrc) + i)) + b2 * (1.0 * i) + c2 * (1.0 * (0.5 * Nsrc * Msrc - i));
     Ar[i] = A[i].real();
   }
-  for (int i=0; i < Nsrc*Nsrc; i++) {
-    A2[i] = a2 * (1.0*((i/(double)Nsrc) + i)) + b2 * (1.0*i) + c2 *(1.0*(0.5*Nsrc*Nsrc-i));
-    B2[i] = a2 * (1.0*((i/(double)Nsrc) + i)) - b2 * (M_PI*i) + c2 *(1.0*(0.5*Nsrc*Nsrc-i));
+  for (int i = 0; i < Nsrc * Nsrc; i++) {
+    A2[i] = a2 * (1.0 * ((i / (double)Nsrc) + i)) + b2 * (1.0 * i) + c2 * (1.0 * (0.5 * Nsrc * Nsrc - i));
+    B2[i] = a2 * (1.0 * ((i / (double)Nsrc) + i)) - b2 * (M_PI * i) + c2 * (1.0 * (0.5 * Nsrc * Nsrc - i));
   }
   // A[0] = a2;
   // A[1] = 0.;
@@ -940,21 +940,19 @@ double test(int kernel) {
     break;
 
   case 42:
-    for (int i=0; i < Nsrc; i++) xmD->Component(i) = *(xmH[i]);
-    for (int i=0; i < Msrc; i++) ymD->Component(i) = *(ymH[i]);
+    for (int i = 0; i < Nsrc; i++) xmD->Component(i) = *(xmH[i]);
+    for (int i = 0; i < Msrc; i++) ymD->Component(i) = *(ymH[i]);
 
     blas::axpy(Ar, *xmD, *ymD);
-    for (int i=0; i < Nsrc; i++) {
-      for(int j=0; j < Msrc; j++) {
-	blas::axpy(Ar[Msrc*i+j], *(xmH[i]), *(ymH[j]));
-      }
+    for (int i = 0; i < Nsrc; i++) {
+      for (int j = 0; j < Msrc; j++) { blas::axpy(Ar[Msrc * i + j], *(xmH[i]), *(ymH[j])); }
     }
 
     error = 0;
-    for (int i=0; i < Msrc; i++) {
-      error+= fabs(blas::norm2((ymD->Component(i))) - blas::norm2(*(ymH[i]))) / blas::norm2(*(ymH[i]));
+    for (int i = 0; i < Msrc; i++) {
+      error += fabs(blas::norm2((ymD->Component(i))) - blas::norm2(*(ymH[i]))) / blas::norm2(*(ymH[i]));
     }
-    error/= Msrc;
+    error /= Msrc;
     break;
 
   default:
@@ -974,51 +972,49 @@ const char *prec_str[] = {"quarter", "half", "single", "double"};
 
 // For googletest names must be non-empty, unique, and may only contain ASCII
 // alphanumeric characters or underscore
-const char *names[] = {
-  "copyHS",
-  "copyMS",
-  "copyLS",
-  "axpby",
-  "xpy",
-  "axpy",
-  "xpay",
-  "mxpy",
-  "ax",
-  "caxpy",
-  "caxpby",
-  "cxpaypbz",
-  "axpyBzpcx",
-  "axpyZpbx",
-  "caxpbypzYmbw",
-  "cabxpyAx",
-  "caxpyXmaz",
-  "norm",
-  "reDotProduct",
-  "axpyNorm",
-  "xmyNorm",
-  "caxpyNorm",
-  "caxpyXmazNormX",
-  "cabxpyzAxNorm",
-  "cDotProduct",
-  "caxpyDotzy",
-  "cDotProductNormA",
-  "cDotProductNormB",
-  "caxpbypzYmbwcDotProductUYNormY",
-  "HeavyQuarkResidualNorm",
-  "xpyHeavyQuarkResidualNorm",
-  "tripleCGReduction",
-  "tripleCGUpdate",
-  "axpyReDot",
-  "caxpy_block",
-  "axpyBzpcx_block",
-  "caxpyBxpz",
-  "caxpyBzpx",
-  "cDotProductNorm_block",
-  "cDotProduct_block",
-  "reDotProductNorm_block",
-  "reDotProduct_block",
-  "axpy_block"
-};
+const char *names[] = {"copyHS",
+                       "copyMS",
+                       "copyLS",
+                       "axpby",
+                       "xpy",
+                       "axpy",
+                       "xpay",
+                       "mxpy",
+                       "ax",
+                       "caxpy",
+                       "caxpby",
+                       "cxpaypbz",
+                       "axpyBzpcx",
+                       "axpyZpbx",
+                       "caxpbypzYmbw",
+                       "cabxpyAx",
+                       "caxpyXmaz",
+                       "norm",
+                       "reDotProduct",
+                       "axpyNorm",
+                       "xmyNorm",
+                       "caxpyNorm",
+                       "caxpyXmazNormX",
+                       "cabxpyzAxNorm",
+                       "cDotProduct",
+                       "caxpyDotzy",
+                       "cDotProductNormA",
+                       "cDotProductNormB",
+                       "caxpbypzYmbwcDotProductUYNormY",
+                       "HeavyQuarkResidualNorm",
+                       "xpyHeavyQuarkResidualNorm",
+                       "tripleCGReduction",
+                       "tripleCGUpdate",
+                       "axpyReDot",
+                       "caxpy_block",
+                       "axpyBzpcx_block",
+                       "caxpyBxpz",
+                       "caxpyBzpx",
+                       "cDotProductNorm_block",
+                       "cDotProduct_block",
+                       "reDotProductNorm_block",
+                       "reDotProduct_block",
+                       "axpy_block"};
 
 int main(int argc, char** argv)
 {
@@ -1084,16 +1080,16 @@ protected:
   const int &prec;
   const int &kernel;
 
- public:
-  BlasTest() :
-    param(GetParam()),
-    prec(::testing::get<0>(param)),
-    kernel(::testing::get<1>(param)) { }
+public:
+  BlasTest() : param(GetParam()), prec(::testing::get<0>(param)), kernel(::testing::get<1>(param)) {}
   virtual ~BlasTest() { }
   virtual void SetUp() {
     if (!skip_kernel(prec, kernel)) initFields(prec);
   }
-  virtual void TearDown() { if (!skip_kernel(prec, kernel)) freeFields();}
+  virtual void TearDown()
+  {
+    if (!skip_kernel(prec, kernel)) freeFields();
+  }
 };
 
 

--- a/tests/blas_test.cu
+++ b/tests/blas_test.cu
@@ -147,8 +147,6 @@ void initFields(int prec)
   // xmH = new cpuColorSpinorField(param);
   // ymH = new cpuColorSpinorField(param);
 
-
-
   xmH.reserve(Nsrc);
   for (int cid = 0; cid < Nsrc; cid++) xmH.push_back(new cpuColorSpinorField(param));
   ymH.reserve(Msrc);
@@ -217,7 +215,7 @@ void initFields(int prec)
   param.is_composite = true;
   param.is_component = false;
 
-// create composite fields
+  // create composite fields
   param.composite_dim = Nsrc;
   xmD = new cudaColorSpinorField(param);
 
@@ -249,6 +247,7 @@ void initFields(int prec)
                                 low_aux_prec == QUDA_QUARTER_PRECISION || mid_aux_prec == QUDA_QUARTER_PRECISION) );
 
   if ( flag ) {
+
     *vD = *vH;
     *wD = *wH;
     *xD = *xH;
@@ -257,6 +256,7 @@ void initFields(int prec)
     *hD = *hH;
     *mD = *mH;
     *lD = *lH;
+
     // for (int i=0; i < Nsrc; i++){
     //   xmD->Component(i) = *(xmH[i]);
     //   ymD->Component(i) = *(ymH[i]);
@@ -1015,15 +1015,19 @@ using ::testing::Combine;
 class BlasTest : public ::testing::TestWithParam<::testing::tuple<int, int>> {
 protected:
   ::testing::tuple<int, int> param;
+  const int &prec;
+  const int &kernel;
 
-public:
+ public:
+  BlasTest() :
+    param(GetParam()),
+    prec(::testing::get<0>(param)),
+    kernel(::testing::get<1>(param)) { }
   virtual ~BlasTest() { }
   virtual void SetUp() {
-    param = GetParam();
-    initFields(::testing::get<0>(GetParam()));
+    if (!skip_kernel(prec, kernel)) initFields(prec);
   }
-  virtual void TearDown() { freeFields(); }
-
+  virtual void TearDown() { if (!skip_kernel(prec, kernel)) freeFields();}
 };
 
 

--- a/tests/test_util.cpp
+++ b/tests/test_util.cpp
@@ -2746,7 +2746,7 @@ int process_command_line_option(int argc, char** argv, int* idx)
       usage(argv);
     }
     Nsrc = atoi(argv[i+1]);
-    if (Nsrc < 0 || Nsrc > 256){ // allow 0 for testing setup in isolation
+    if (Nsrc < 0 || Nsrc > 2048){ // allow 0 for testing setup in isolation
       printf("ERROR: invalid number of sources (Nsrc=%d)\n", Nsrc);
       usage(argv);
     }
@@ -2760,7 +2760,7 @@ int process_command_line_option(int argc, char** argv, int* idx)
       usage(argv);
     }
     Msrc = atoi(argv[i+1]);
-    if (Msrc < 1 || Msrc > 256){
+    if (Msrc < 1 || Msrc > 2048){
       printf("ERROR: invalid number of sources (Msrc=%d)\n", Msrc);
       usage(argv);
     }

--- a/tests/test_util.cpp
+++ b/tests/test_util.cpp
@@ -2746,7 +2746,7 @@ int process_command_line_option(int argc, char** argv, int* idx)
       usage(argv);
     }
     Nsrc = atoi(argv[i+1]);
-    if (Nsrc < 0 || Nsrc > 2048){ // allow 0 for testing setup in isolation
+    if (Nsrc < 0 || Nsrc > 2048) { // allow 0 for testing setup in isolation
       printf("ERROR: invalid number of sources (Nsrc=%d)\n", Nsrc);
       usage(argv);
     }
@@ -2760,7 +2760,7 @@ int process_command_line_option(int argc, char** argv, int* idx)
       usage(argv);
     }
     Msrc = atoi(argv[i+1]);
-    if (Msrc < 1 || Msrc > 2048){
+    if (Msrc < 1 || Msrc > 2048) {
       printf("ERROR: invalid number of sources (Msrc=%d)\n", Msrc);
       usage(argv);
     }

--- a/tests/test_util.cpp
+++ b/tests/test_util.cpp
@@ -2746,7 +2746,7 @@ int process_command_line_option(int argc, char** argv, int* idx)
       usage(argv);
     }
     Nsrc = atoi(argv[i+1]);
-    if (Nsrc < 0 || Nsrc > 128){ // allow 0 for testing setup in isolation
+    if (Nsrc < 0 || Nsrc > 256){ // allow 0 for testing setup in isolation
       printf("ERROR: invalid number of sources (Nsrc=%d)\n", Nsrc);
       usage(argv);
     }
@@ -2760,7 +2760,7 @@ int process_command_line_option(int argc, char** argv, int* idx)
       usage(argv);
     }
     Msrc = atoi(argv[i+1]);
-    if (Msrc < 1 || Msrc > 128){
+    if (Msrc < 1 || Msrc > 256){
       printf("ERROR: invalid number of sources (Msrc=%d)\n", Msrc);
       usage(argv);
     }


### PR DESCRIPTION
This pull request is a significant improvement to the multi-blas and multi-reduction framework
* Increase the supported size of `MAX_MULTI_BLAS_N` to 32
* Optimization of the multi-blas routines to parallelize the `NXZ` dimension (the accumulation dimension) through warp splitting (degree of splitting picked by the autotuner).  This optimization is only applied for small problem sizes that are parallelism limited.
* One side effect of this dynamic calculation is that in order to keep relatively sane code I've bumped QUDA up to required C++14.  While not yet supported by the CUDA toolkit, I've also added C++17 as an option to cmake for future development.
* Limit of multi-blas problem size is no longer simply given by `MAX_MULTI_BLAS_N`, rather the limit is computed dynamically to allow for larger tall and skinny or short and fat fused kernels.  E.g., while the 2-d square kernel limit is given by `MAX_MULTI_BLAS_N * MAX_MULTI_BLAS_N`, a 1-d multi-blas function can be up to `1x166`
* Regardless of what `MAX_MULTI_BLAS_N` is set to, we always compile all powers of two for the `NXZ` dimension (up to 128 for multi-blas and 16 for multi-reductions) .  Thus for most cases, there is no need to set a large `MAX_MULTI_BLAS_N` value
* Added a `TransposeTune` class that picks the optimum layout for doing 2-d multi-reductions, e.g., is it better to pose the problem as a `n x m` or `m x n` problem?
* When doing 1-d multi reductions, we always pose the problem as a `1 x n` problem, and do not apply any tile-size tuning - simply use the largest tile size possible.  This means that any 1-d multi-reduction can be done using the run-time `NYW` parameter, and not the compile-time `NXZ` parameter.
* Reduced compilation overhead of multi-reductions by not instantiating unnecessary large block sizes that are never picked by the autotuner
* Dramatic reduction in autotuning overheads for streaming blas kernels - these have no dependence on the grid size, so simply set the grid size to be 2x SM count.
* Fix bugs from #855 

The result of this rework is that:
* Coarse-grid deflation is now up to 8x faster.  E.g., when deflating 1024 vectors we would previously have needed to use 64 `multi-axpy` and `multi-dot` with kernels which were massively latency bound on small grids.  However, now these can now be done as 8 kernels instead, e.g., as 128-way fused multi-blas and multi-reductions, coming closer to saturating memory bandwidth and amortizing the launch latency.
* Eigensolvers now run much faster in the tuning phase, with up to a 10x reduction in end-to-end autotuning overhead observed