### PR TITLE
Add missing support for running on Xavier - sm_72

### DIFF
--- a/include/tune_quda.h
+++ b/include/tune_quda.h
@@ -162,6 +162,7 @@ namespace quda {
       case 7:
         switch (deviceProp.minor) {
         case 0: return 32;
+        case 2: return 32;
         case 5: return 16;
         }
       default: errorQuda("Unknown SM architecture %d.%d\n", deviceProp.major, deviceProp.minor); return 0;
@@ -201,6 +202,7 @@ namespace quda {
       case 7:
         switch (deviceProp.minor) {
         case 0: return 96 * 1024;
+        case 2: return 96 * 1024;
         case 5: return 64 * 1024;
         }
       default:


### PR DESCRIPTION
This hotfix adds support for running on Xavier's iGPU (sm_72), which would otherwise fail at runtime (`switch-case` statement didn't support Xavier). 