### PR TITLE
Added a routine to compute plaquette of staggered fields

### DIFF
--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -2470,7 +2470,10 @@ void eigensolveQuda(void **host_evecs, double _Complex *host_evals, QudaEigParam
   // If you use polynomial acceleration on a non-symmetric matrix,
   // the solver will fail.
   if (eig_param->use_poly_acc && !eig_param->use_norm_op && !(inv_param->dslash_type == QUDA_LAPLACE_DSLASH)) {
-    errorQuda("Polynomial acceleration with non-symmetric matrices not supported");
+    // Breaking up the boolean check a little bit. If it's a staggered dslash type and a PC type, we can use poly accel.
+    if (!((inv_param->dslash_type == QUDA_STAGGERED_DSLASH || inv_param->dslash_type == QUDA_ASQTAD_DSLASH) && inv_param->solve_type == QUDA_DIRECT_PC_SOLVE)) {
+      errorQuda("Polynomial acceleration with non-symmetric matrices not supported");
+    }
   }
 
   profileEigensolve.TPSTOP(QUDA_PROFILE_INIT);

--- a/tests/staggered_eigensolve_test.cpp
+++ b/tests/staggered_eigensolve_test.cpp
@@ -135,12 +135,10 @@ void display_test_info()
 void usage_extra(char **argv)
 {
   printfQuda("Extra options:\n");
-  printfQuda("    --test <0/1/2/3/4/5/6>    # Test method\n");
-  printfQuda("                                0: Full parity inverter\n");
-  printfQuda("                                1: Even even spinor CG inverter, reconstruct to full parity\n");
-  printfQuda("                                2: Odd odd spinor CG inverter, reconstruct to full parity\n");
-  printfQuda("                                3: Even even spinor CG inverter\n");
-  printfQuda("                                4: Odd odd spinor CG inverter\n");
+  printfQuda("    --test <0/3/4>    # Test method\n");
+  printfQuda("                      0: Full parity inverter\n");
+  printfQuda("                      3: Even even spinor CG inverter\n");
+  printfQuda("                      4: Odd odd spinor CG inverter\n");
   return;
 }
 
@@ -467,8 +465,6 @@ void eigensolve_test()
 
   switch (test_type) {
   case 0: // full parity solution
-  case 1: // solving prec system, reconstructing
-  case 2:
   case 3: // even
   case 4: {
     // QUDA eigensolver test
@@ -557,7 +553,7 @@ int main(int argc, char **argv)
   // initialize QMP/MPI, QUDA comms grid and RNG (test_util.cpp)
   initComms(argc, argv, gridsize_from_cmdline);
 
-  if (test_type < 0 || test_type > 4) { errorQuda("Test type %d is outside the valid range.\n", test_type); }
+  if (test_type != 0 && test_type != 3 && test_type != 4) { errorQuda("Test type %d is outside the valid range.\n", test_type); }
 
   // Ensure a reasonable default
   // ensure that the default is improved staggered
@@ -582,15 +578,15 @@ int main(int argc, char **argv)
       }
     }
 
-    if (test_type == 1 || test_type == 3) {
+    if (test_type == 3) {
       matpc_type = QUDA_MATPC_EVEN_EVEN;
-    } else if (test_type == 2 || test_type == 4) {
+    } else if (test_type == 4) {
       matpc_type = QUDA_MATPC_ODD_ODD;
     } else if (test_type == 0) {
       matpc_type = QUDA_MATPC_EVEN_EVEN; // it doesn't matter
     }
 
-    if (test_type == 0 || test_type == 1 || test_type == 2) {
+    if (test_type == 0) {
       solution_type = QUDA_MAT_SOLUTION;
     } else {
       solution_type = QUDA_MATPC_SOLUTION;

--- a/tests/staggered_eigensolve_test.cpp
+++ b/tests/staggered_eigensolve_test.cpp
@@ -144,21 +144,6 @@ void usage_extra(char **argv)
   return;
 }
 
-template <typename Float> void constructSpinorField(Float *res)
-{
-  const int vol = (solution_type == QUDA_MAT_SOLUTION) ? V : Vh;
-  for (int src = 0; src < Nsrc; src++) {
-    for (int i = 0; i < vol; i++) {
-      for (int s = 0; s < 1; s++) {
-        for (int m = 0; m < 3; m++) {
-          res[(src * Vh + i) * (1 * 3 * 2) + s * (3 * 2) + m * (2) + 0] = rand() / (Float)RAND_MAX;
-          res[(src * Vh + i) * (1 * 3 * 2) + s * (3 * 2) + m * (2) + 1] = rand() / (Float)RAND_MAX;
-        }
-      }
-    }
-  }
-}
-
 void setGaugeParam(QudaGaugeParam &gauge_param)
 {
   gauge_param.X[0] = xdim;
@@ -393,6 +378,12 @@ void eigensolve_test()
     }
   }
 
+  // Compute plaquette. Routine is aware that the gauge fields already have the phases on them.
+  double plaq[3];
+  computeStaggeredPlaquetteQDPOrder(qdp_inlink, plaq, gauge_param, dslash_type);
+
+  printfQuda("Computed plaquette is %e (spatial = %e, temporal = %e)\n", plaq[0], plaq[1], plaq[2]);
+
   // QUDA_STAGGERED_DSLASH follows the same codepath whether or not you
   // "compute" the fat/long links or not.
   if (dslash_type == QUDA_STAGGERED_DSLASH || dslash_type == QUDA_LAPLACE_DSLASH) {
@@ -407,6 +398,11 @@ void eigensolve_test()
     } else {
       for (int dir = 0; dir < 4; dir++) { memcpy(qdp_fatlink[dir], qdp_inlink[dir], V * gaugeSiteSize * gSize); }
     }
+
+    // Compute fat link plaquette.
+    computeStaggeredPlaquetteQDPOrder(qdp_fatlink, plaq, gauge_param, dslash_type);
+
+    printfQuda("Computed fat link plaquette is %e (spatial = %e, temporal = %e)\n", plaq[0], plaq[1], plaq[2]);
   }
 
   reorderQDPtoMILC(milc_fatlink, qdp_fatlink, V, gaugeSiteSize, gauge_param.cpu_prec, gauge_param.cpu_prec);

--- a/tests/staggered_gauge_utils.h
+++ b/tests/staggered_gauge_utils.h
@@ -22,3 +22,10 @@ void computeFatLongGPU(void **qdp_fatlink, void **qdp_longlink, void **qdp_inlin
 void computeFatLongGPUandCPU(void **qdp_fatlink_gpu, void **qdp_longlink_gpu, void **qdp_fatlink_cpu,
                              void **qdp_longlink_cpu, void **qdp_inlink, QudaGaugeParam &gauge_param, size_t gSize,
                              int n_naiks, double eps_naik);
+
+// Routine that takes in a QDP-ordered field and outputs the plaquette.
+// Assumes the gauge fields already have phases on them (unless it's the Laplace op),
+// so it corrects the sign as appropriate.
+void computeStaggeredPlaquetteQDPOrder(void** qdp_link, double plaq[3], const QudaGaugeParam &gauge_param_in,
+                                       const QudaDslashType dslash_type);
+


### PR DESCRIPTION
Contains some wrapper code to properly manage reconstruct settings, dealing with staggered phases, etc. This is only called in `staggered_invert_test`. When using HISQ links, it also computes the fat link plaquette.

This pull also adds proper random spinor field creation to `staggered_invert_test`. 

There's nothing particularly controversial keeping it from being merged into `release/1.0.x` instead, but I don't see a pressing need, either. It's easy enough to change that, though.

I verified that the test works correctly for staggered, hisq, and the Laplace operator, including multishift.