### PR TITLE
Cherry-picked staggered plaquette, deflation modifications

### DIFF
--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -2470,7 +2470,10 @@ void eigensolveQuda(void **host_evecs, double _Complex *host_evals, QudaEigParam
   // If you use polynomial acceleration on a non-symmetric matrix,
   // the solver will fail.
   if (eig_param->use_poly_acc && !eig_param->use_norm_op && !(inv_param->dslash_type == QUDA_LAPLACE_DSLASH)) {
-    errorQuda("Polynomial acceleration with non-symmetric matrices not supported");
+    // Breaking up the boolean check a little bit. If it's a staggered dslash type and a PC type, we can use poly accel.
+    if (!((inv_param->dslash_type == QUDA_STAGGERED_DSLASH || inv_param->dslash_type == QUDA_ASQTAD_DSLASH) && inv_param->solve_type == QUDA_DIRECT_PC_SOLVE)) {
+      errorQuda("Polynomial acceleration with non-symmetric matrices not supported");
+    }
   }
 
   profileEigensolve.TPSTOP(QUDA_PROFILE_INIT);

--- a/tests/staggered_eigensolve_test.cpp
+++ b/tests/staggered_eigensolve_test.cpp
@@ -135,12 +135,10 @@ void display_test_info()
 void usage_extra(char **argv)
 {
   printfQuda("Extra options:\n");
-  printfQuda("    --test <0/1/2/3/4/5/6>    # Test method\n");
-  printfQuda("                                0: Full parity inverter\n");
-  printfQuda("                                1: Even even spinor CG inverter, reconstruct to full parity\n");
-  printfQuda("                                2: Odd odd spinor CG inverter, reconstruct to full parity\n");
-  printfQuda("                                3: Even even spinor CG inverter\n");
-  printfQuda("                                4: Odd odd spinor CG inverter\n");
+  printfQuda("    --test <0/3/4>    # Test method\n");
+  printfQuda("                      0: Full parity inverter\n");
+  printfQuda("                      3: Even even spinor CG inverter\n");
+  printfQuda("                      4: Odd odd spinor CG inverter\n");
   return;
 }
 
@@ -467,8 +465,6 @@ void eigensolve_test()
 
   switch (test_type) {
   case 0: // full parity solution
-  case 1: // solving prec system, reconstructing
-  case 2:
   case 3: // even
   case 4: {
     // QUDA eigensolver test
@@ -557,7 +553,7 @@ int main(int argc, char **argv)
   // initialize QMP/MPI, QUDA comms grid and RNG (test_util.cpp)
   initComms(argc, argv, gridsize_from_cmdline);
 
-  if (test_type < 0 || test_type > 4) { errorQuda("Test type %d is outside the valid range.\n", test_type); }
+  if (test_type != 0 && test_type != 3 && test_type != 4) { errorQuda("Test type %d is outside the valid range.\n", test_type); }
 
   // Ensure a reasonable default
   // ensure that the default is improved staggered
@@ -582,15 +578,15 @@ int main(int argc, char **argv)
       }
     }
 
-    if (test_type == 1 || test_type == 3) {
+    if (test_type == 3) {
       matpc_type = QUDA_MATPC_EVEN_EVEN;
-    } else if (test_type == 2 || test_type == 4) {
+    } else if (test_type == 4) {
       matpc_type = QUDA_MATPC_ODD_ODD;
     } else if (test_type == 0) {
       matpc_type = QUDA_MATPC_EVEN_EVEN; // it doesn't matter
     }
 
-    if (test_type == 0 || test_type == 1 || test_type == 2) {
+    if (test_type == 0) {
       solution_type = QUDA_MAT_SOLUTION;
     } else {
       solution_type = QUDA_MATPC_SOLUTION;

--- a/tests/staggered_eigensolve_test.cpp
+++ b/tests/staggered_eigensolve_test.cpp
@@ -144,21 +144,6 @@ void usage_extra(char **argv)
   return;
 }
 
-template <typename Float> void constructSpinorField(Float *res)
-{
-  const int vol = (solution_type == QUDA_MAT_SOLUTION) ? V : Vh;
-  for (int src = 0; src < Nsrc; src++) {
-    for (int i = 0; i < vol; i++) {
-      for (int s = 0; s < 1; s++) {
-        for (int m = 0; m < 3; m++) {
-          res[(src * Vh + i) * (1 * 3 * 2) + s * (3 * 2) + m * (2) + 0] = rand() / (Float)RAND_MAX;
-          res[(src * Vh + i) * (1 * 3 * 2) + s * (3 * 2) + m * (2) + 1] = rand() / (Float)RAND_MAX;
-        }
-      }
-    }
-  }
-}
-
 void setGaugeParam(QudaGaugeParam &gauge_param)
 {
   gauge_param.X[0] = xdim;
@@ -393,6 +378,12 @@ void eigensolve_test()
     }
   }
 
+  // Compute plaquette. Routine is aware that the gauge fields already have the phases on them.
+  double plaq[3];
+  computeStaggeredPlaquetteQDPOrder(qdp_inlink, plaq, gauge_param, dslash_type);
+
+  printfQuda("Computed plaquette is %e (spatial = %e, temporal = %e)\n", plaq[0], plaq[1], plaq[2]);
+
   // QUDA_STAGGERED_DSLASH follows the same codepath whether or not you
   // "compute" the fat/long links or not.
   if (dslash_type == QUDA_STAGGERED_DSLASH || dslash_type == QUDA_LAPLACE_DSLASH) {
@@ -407,6 +398,11 @@ void eigensolve_test()
     } else {
       for (int dir = 0; dir < 4; dir++) { memcpy(qdp_fatlink[dir], qdp_inlink[dir], V * gaugeSiteSize * gSize); }
     }
+
+    // Compute fat link plaquette.
+    computeStaggeredPlaquetteQDPOrder(qdp_fatlink, plaq, gauge_param, dslash_type);
+
+    printfQuda("Computed fat link plaquette is %e (spatial = %e, temporal = %e)\n", plaq[0], plaq[1], plaq[2]);
   }
 
   reorderQDPtoMILC(milc_fatlink, qdp_fatlink, V, gaugeSiteSize, gauge_param.cpu_prec, gauge_param.cpu_prec);

--- a/tests/staggered_gauge_utils.cpp
+++ b/tests/staggered_gauge_utils.cpp
@@ -275,3 +275,60 @@ void computeFatLongGPUandCPU(void **qdp_fatlink_gpu, void **qdp_longlink_gpu, vo
   for (int i = 0; i < 3; i++) delete act_paths[i];
   delete act_paths;
 }
+
+
+// Routine that takes in a QDP-ordered field and outputs the plaquette.
+// Assumes the gauge fields already have phases on them (unless it's the Laplace op),
+// so it corrects the sign as appropriate.
+void computeStaggeredPlaquetteQDPOrder(void** qdp_link, double plaq[3], const QudaGaugeParam& gauge_param_in,
+                                       const QudaDslashType dslash_type)
+{
+  if (dslash_type != QUDA_STAGGERED_DSLASH && dslash_type != QUDA_ASQTAD_DSLASH && dslash_type != QUDA_LAPLACE_DSLASH) {
+    errorQuda("computeStaggeredPlaquetteQDPOrder does not support dslash type %d\n", dslash_type);
+  }
+
+  // Make no assumptions about any part of gauge_param_in beyond what we need to grab.
+  QudaGaugeParam gauge_param = newQudaGaugeParam();
+  for (int d = 0; d < 4; d++) {
+    gauge_param.X[d] = gauge_param_in.X[d];
+  }
+
+  gauge_param.type = QUDA_WILSON_LINKS;
+  gauge_param.gauge_order = QUDA_QDP_GAUGE_ORDER;
+  gauge_param.t_boundary = QUDA_ANTI_PERIODIC_T;
+
+  gauge_param.cpu_prec = gauge_param_in.cpu_prec;
+
+  gauge_param.cuda_prec = gauge_param_in.cuda_prec;
+  gauge_param.reconstruct = QUDA_RECONSTRUCT_NO;
+
+  gauge_param.cuda_prec_sloppy = gauge_param_in.cuda_prec; // for ease of use
+  gauge_param.reconstruct_sloppy = QUDA_RECONSTRUCT_NO;
+
+  gauge_param.anisotropy = 1;
+  gauge_param.gauge_fix = QUDA_GAUGE_FIXED_NO;
+
+  gauge_param.ga_pad = 0;
+  // For multi-GPU, ga_pad must be large enough to store a time-slice
+#ifdef MULTI_GPU
+  int x_face_size = gauge_param.X[1]*gauge_param.X[2]*gauge_param.X[3]/2;
+  int y_face_size = gauge_param.X[0]*gauge_param.X[2]*gauge_param.X[3]/2;
+  int z_face_size = gauge_param.X[0]*gauge_param.X[1]*gauge_param.X[3]/2;
+  int t_face_size = gauge_param.X[0]*gauge_param.X[1]*gauge_param.X[2]/2;
+  int pad_size = x_face_size > y_face_size ? x_face_size : y_face_size;
+  pad_size = pad_size > z_face_size ? pad_size : z_face_size; 
+  pad_size = pad_size > t_face_size ? pad_size : t_face_size;
+  gauge_param.ga_pad = pad_size;
+#endif
+
+  loadGaugeQuda(qdp_link, &gauge_param);
+  plaqQuda(plaq);
+
+  if (dslash_type == QUDA_STAGGERED_DSLASH || dslash_type == QUDA_ASQTAD_DSLASH) {
+    plaq[0] = -plaq[0];
+    plaq[1] = -plaq[1];
+    plaq[2] = -plaq[2];
+  }
+
+}
+

--- a/tests/staggered_gauge_utils.h
+++ b/tests/staggered_gauge_utils.h
@@ -22,3 +22,10 @@ void computeFatLongGPU(void **qdp_fatlink, void **qdp_longlink, void **qdp_inlin
 void computeFatLongGPUandCPU(void **qdp_fatlink_gpu, void **qdp_longlink_gpu, void **qdp_fatlink_cpu,
                              void **qdp_longlink_cpu, void **qdp_inlink, QudaGaugeParam &gauge_param, size_t gSize,
                              int n_naiks, double eps_naik);
+
+// Routine that takes in a QDP-ordered field and outputs the plaquette.
+// Assumes the gauge fields already have phases on them (unless it's the Laplace op),
+// so it corrects the sign as appropriate.
+void computeStaggeredPlaquetteQDPOrder(void** qdp_link, double plaq[3], const QudaGaugeParam &gauge_param_in,
+                                       const QudaDslashType dslash_type);
+


### PR DESCRIPTION
Cherry-picked a few commits from my PR into the `develop` branch. Adds support for computing the plaquette and (as appropriate) fat-link plaquette into `staggered_invert_test` and `staggered_eigensolve_test`. Adds a few boolean checks to enable polynomial acceleration of the staggered and HISQ preconditioned op, which are unique relative to other operators in that they are Hermitian. 

Removed `--test 1` and `--test 2` from the staggered eigensolve as they don't do anything extra and lead to errors. For `staggered_invert_test`, those tests do a solve using the Schur operator then reconstruct to the full operator. Since the eigensolve doesn't do any inversions, that combination isn't necessary. Further, if you use it, you get some errors w/regards to some fields being full parity vs single parity. That may be something worth addressing in the future, but isn't relevant now.

Reference-esque command for computing the 16 smallest eigenvalues of a HISQ Schur operator using polynomial acceleration:

`./staggered_eigensolve_test --dim [whatever] --gridsize [whatever] --prec double --recon 18 --test 3 --dslash-type asqtad --compute-fat-long true --eig-nConv 16 --eig-nEv 18 --eig-nKr 32 --eig-tol 1e-4 --eig-use-normop false --eig-use-poly-acc true --eig-poly-deg 100 --eig-amin 1e-2 --eig-amax 24 --load-gauge [field] --mass [mass] --tadpole-coeff [tadpole]`
