### PR TITLE
Fix to zero mass Dirac(Improved)StaggeredPC sign quirk

### DIFF
--- a/lib/dirac_improved_staggered.cpp
+++ b/lib/dirac_improved_staggered.cpp
@@ -68,10 +68,10 @@ namespace quda {
       } else {
         ApplyImprovedStaggered(out, in, fatGauge, longGauge, 0., x, parity, QUDA_DAG_YES, commDim, profile);
       }
-      flops += 1146ll*in.Volume();
+      flops += 1146ll * in.Volume();
     } else {
       ApplyImprovedStaggered(out, in, fatGauge, longGauge, k, x, parity, dagger, commDim, profile);
-      flops += 1158ll*in.Volume();
+      flops += 1158ll * in.Volume();
     }
   }
 
@@ -81,8 +81,7 @@ namespace quda {
     checkFullSpinor(out, in);
     // Need to flip sign via dagger convention if mass == 0.
     if (mass == 0.0) {
-      if (dagger == QUDA_DAG_YES)
-      {
+      if (dagger == QUDA_DAG_YES) {
         ApplyImprovedStaggered(out, in, fatGauge, longGauge, 0., in, QUDA_INVALID_PARITY, QUDA_DAG_NO, commDim, profile);
       } else {
         ApplyImprovedStaggered(out, in, fatGauge, longGauge, 0., in, QUDA_INVALID_PARITY, QUDA_DAG_YES, commDim, profile);

--- a/lib/dirac_improved_staggered.cpp
+++ b/lib/dirac_improved_staggered.cpp
@@ -59,16 +59,39 @@ namespace quda {
   {    
     checkParitySpinor(in, out);
 
-    ApplyImprovedStaggered(out, in, fatGauge, longGauge, k, x, parity, dagger, commDim, profile);
-    flops += 1158ll*in.Volume();
+    // Need to catch the zero mass case.
+    if (k == 0.0) {
+      // There's a sign convention difference for Dslash vs DslashXpay, which is
+      // triggered by looking for k == 0. We need to hack around this.
+      if (dagger == QUDA_DAG_YES) {
+        ApplyImprovedStaggered(out, in, fatGauge, longGauge, 0., x, parity, QUDA_DAG_NO, commDim, profile);
+      } else {
+        ApplyImprovedStaggered(out, in, fatGauge, longGauge, 0., x, parity, QUDA_DAG_YES, commDim, profile);
+      }
+      flops += 1146ll*in.Volume();
+    } else {
+      ApplyImprovedStaggered(out, in, fatGauge, longGauge, k, x, parity, dagger, commDim, profile);
+      flops += 1158ll*in.Volume();
+    }
   }
 
   // Full staggered operator
   void DiracImprovedStaggered::M(ColorSpinorField &out, const ColorSpinorField &in) const
   {
     checkFullSpinor(out, in);
-    ApplyImprovedStaggered(out, in, fatGauge, longGauge, 2. * mass, in, QUDA_INVALID_PARITY, dagger, commDim, profile);
-    flops += 1158ll * in.Volume();
+    // Need to flip sign via dagger convention if mass == 0.
+    if (mass == 0.0) {
+      if (dagger == QUDA_DAG_YES)
+      {
+        ApplyImprovedStaggered(out, in, fatGauge, longGauge, 0., in, QUDA_INVALID_PARITY, QUDA_DAG_NO, commDim, profile);
+      } else {
+        ApplyImprovedStaggered(out, in, fatGauge, longGauge, 0., in, QUDA_INVALID_PARITY, QUDA_DAG_YES, commDim, profile);
+      }
+      flops += 1146ll * in.Volume();
+    } else {
+      ApplyImprovedStaggered(out, in, fatGauge, longGauge, 2. * mass, in, QUDA_INVALID_PARITY, dagger, commDim, profile);
+      flops += 1158ll * in.Volume();
+    }
   }
 
   void DiracImprovedStaggered::MdagM(ColorSpinorField &out, const ColorSpinorField &in) const

--- a/lib/dirac_staggered.cpp
+++ b/lib/dirac_staggered.cpp
@@ -60,17 +60,17 @@ namespace quda {
 
     // Need to catch the zero mass case.
     if (k == 0.0) {
-      // There's a sign convention difference for Dslash vs DslashXpay, which is 
+      // There's a sign convention difference for Dslash vs DslashXpay, which is
       // triggered by looking for k == 0. We need to hack around this.
       if (dagger == QUDA_DAG_YES) {
         ApplyStaggered(out, in, *gauge, 0., x, parity, QUDA_DAG_NO, commDim, profile);
       } else {
         ApplyStaggered(out, in, *gauge, 0., x, parity, QUDA_DAG_YES, commDim, profile);
       }
-      flops += 570ll*in.Volume();
+      flops += 570ll * in.Volume();
     } else {
       ApplyStaggered(out, in, *gauge, k, x, parity, dagger, commDim, profile);
-      flops += 582ll*in.Volume();
+      flops += 582ll * in.Volume();
     }
   }
 

--- a/lib/dirac_staggered.cpp
+++ b/lib/dirac_staggered.cpp
@@ -58,8 +58,20 @@ namespace quda {
   {    
     checkParitySpinor(in, out);
 
-    ApplyStaggered(out, in, *gauge, k, x, parity, dagger, commDim, profile);
-    flops += 582ll*in.Volume();
+    // Need to catch the zero mass case.
+    if (k == 0.0) {
+      // There's a sign convention difference for Dslash vs DslashXpay, which is 
+      // triggered by looking for k == 0. We need to hack around this.
+      if (dagger == QUDA_DAG_YES) {
+        ApplyStaggered(out, in, *gauge, 0., x, parity, QUDA_DAG_NO, commDim, profile);
+      } else {
+        ApplyStaggered(out, in, *gauge, 0., x, parity, QUDA_DAG_YES, commDim, profile);
+      }
+      flops += 570ll*in.Volume();
+    } else {
+      ApplyStaggered(out, in, *gauge, k, x, parity, dagger, commDim, profile);
+      flops += 582ll*in.Volume();
+    }
   }
 
   // Full staggered operator
@@ -68,10 +80,21 @@ namespace quda {
     // Due to the staggered convention, this is applying
     // (  2m     -D_eo ) (x_e) = (b_e)
     // ( -D_oe   2m    ) (x_o) = (b_o)
+    // ... but under the hood we need to catch the zero mass case.
 
     checkFullSpinor(out, in);
-    ApplyStaggered(out, in, *gauge, 2. * mass, in, QUDA_INVALID_PARITY, dagger, commDim, profile);
-    flops += 582ll * in.Volume();
+
+    if (mass == 0.) {
+      if (dagger == QUDA_DAG_YES) {
+        ApplyStaggered(out, in, *gauge, 0., in, QUDA_INVALID_PARITY, QUDA_DAG_NO, commDim, profile);
+      } else {
+        ApplyStaggered(out, in, *gauge, 0., in, QUDA_INVALID_PARITY, QUDA_DAG_YES, commDim, profile);
+      }
+      flops += 570ll * in.Volume();
+    } else {
+      ApplyStaggered(out, in, *gauge, 2. * mass, in, QUDA_INVALID_PARITY, dagger, commDim, profile);
+      flops += 582ll * in.Volume();
+    }
   }
 
   void DiracStaggered::MdagM(ColorSpinorField &out, const ColorSpinorField &in) const


### PR DESCRIPTION
This hotfix catches an issue where the preconditioned staggered operator comes out with the wrong sign if the mass is zero. The origin of the issue is the quirky sign convention between Dslash and DslashXpay. Technically there is still an issue if you prepare/reconstruct, but in the zero mass case that is ill defined anyway, so eh.

We may want to ultimately address this sign convention qurk as noted in #875, but I don't think this is the time or place for that change, since it requires upstream changes in MILC and elsewhere.

We can put this into `develop` later by merging `release/1.0.x` back in.