### PR TITLE
Hotfix/blas svd deflate

### DIFF
--- a/include/color_spinor_field.h
+++ b/include/color_spinor_field.h
@@ -156,7 +156,6 @@ namespace quda {
 
       if (!pc_solution) {
         siteSubset = QUDA_FULL_SITE_SUBSET;
-        ;
       } else {
         x[0] /= 2; // X defined the full lattice dimensions
         siteSubset = QUDA_PARITY_SITE_SUBSET;
@@ -219,8 +218,8 @@ namespace quda {
         component_id(0)
     {
       siteSubset = cpuParam.siteSubset;
-      fieldOrder = (precision == QUDA_DOUBLE_PRECISION || nSpin == 1) ? QUDA_FLOAT2_FIELD_ORDER : QUDA_FLOAT4_FIELD_ORDER;
-      }
+      fieldOrder = (precision == QUDA_DOUBLE_PRECISION || nSpin == 1 || nSpin == 2) ? QUDA_FLOAT2_FIELD_ORDER : QUDA_FLOAT4_FIELD_ORDER;
+    }
 
     /**
        If using CUDA native fields, this function will ensure that the

--- a/include/color_spinor_field.h
+++ b/include/color_spinor_field.h
@@ -175,8 +175,8 @@ namespace quda {
       }
 
       if (inv_param.dirac_order == QUDA_INTERNAL_DIRAC_ORDER) {
-        fieldOrder
-          = (precision == QUDA_DOUBLE_PRECISION || nSpin == 1 || nSpin == 2) ? QUDA_FLOAT2_FIELD_ORDER : QUDA_FLOAT4_FIELD_ORDER;
+        fieldOrder = (precision == QUDA_DOUBLE_PRECISION || nSpin == 1 || nSpin == 2) ? QUDA_FLOAT2_FIELD_ORDER :
+                                                                                        QUDA_FLOAT4_FIELD_ORDER;
         siteOrder = QUDA_EVEN_ODD_SITE_ORDER;
       } else if (inv_param.dirac_order == QUDA_CPS_WILSON_DIRAC_ORDER) {
         fieldOrder = QUDA_SPACE_SPIN_COLOR_FIELD_ORDER;

--- a/include/color_spinor_field.h
+++ b/include/color_spinor_field.h
@@ -176,7 +176,7 @@ namespace quda {
 
       if (inv_param.dirac_order == QUDA_INTERNAL_DIRAC_ORDER) {
         fieldOrder
-            = (precision == QUDA_DOUBLE_PRECISION || nSpin == 1) ? QUDA_FLOAT2_FIELD_ORDER : QUDA_FLOAT4_FIELD_ORDER;
+          = (precision == QUDA_DOUBLE_PRECISION || nSpin == 1 || nSpin == 2) ? QUDA_FLOAT2_FIELD_ORDER : QUDA_FLOAT4_FIELD_ORDER;
         siteOrder = QUDA_EVEN_ODD_SITE_ORDER;
       } else if (inv_param.dirac_order == QUDA_CPS_WILSON_DIRAC_ORDER) {
         fieldOrder = QUDA_SPACE_SPIN_COLOR_FIELD_ORDER;

--- a/include/eigensolve_quda.h
+++ b/include/eigensolve_quda.h
@@ -147,14 +147,14 @@ public:
        @param[in] eig_vecs The eigenvectors to load
        @param[in] file The filename to load
     */
-    void loadVectors(std::vector<ColorSpinorField *> &eig_vecs, std::string file);
+    static void loadVectors(std::vector<ColorSpinorField *> &eig_vecs, std::string file);
 
     /**
        @brief Save vectors to file
        @param[in] eig_vecs The eigenvectors to save
        @param[in] file The filename to save
     */
-    void saveVectors(const std::vector<ColorSpinorField *> &eig_vecs, std::string file);
+    static void saveVectors(const std::vector<ColorSpinorField *> &eig_vecs, std::string file);
 
     /**
        @brief Load and check eigenpairs from file

--- a/include/kernels/multi_blas_core.cuh
+++ b/include/kernels/multi_blas_core.cuh
@@ -28,11 +28,11 @@ namespace quda
        @tparam Functor Functor used to operate on data
     */
     template <int NXZ, typename SpinorX, typename SpinorY, typename SpinorZ, typename SpinorW, typename Functor>
-    struct MultiBlasArg : SpinorXZ<NXZ, SpinorX, SpinorZ, Functor::use_z>,
-                          SpinorYW<max_YW_size<NXZ, typename SpinorX::StoreType, typename SpinorY::StoreType, Functor>(),
-                                   SpinorY, SpinorW, Functor::use_w> {
-      static constexpr int NYW_max
-        = max_YW_size<NXZ, typename SpinorX::StoreType, typename SpinorY::StoreType, Functor>();
+    struct MultiBlasArg :
+      SpinorXZ<NXZ, SpinorX, SpinorZ, Functor::use_z>,
+      SpinorYW<max_YW_size<NXZ, SpinorX, SpinorY, SpinorZ, SpinorW, Functor>(), SpinorY, SpinorW, Functor::use_w>
+    {
+      static constexpr int NYW_max = max_YW_size<NXZ, SpinorX, SpinorY, SpinorZ, SpinorW, Functor>();
       const int NYW;
       Functor f;
       const int length;

--- a/include/kernels/multi_blas_core.cuh
+++ b/include/kernels/multi_blas_core.cuh
@@ -28,10 +28,9 @@ namespace quda
        @tparam Functor Functor used to operate on data
     */
     template <int NXZ, typename SpinorX, typename SpinorY, typename SpinorZ, typename SpinorW, typename Functor>
-    struct MultiBlasArg :
-      SpinorXZ<NXZ, SpinorX, SpinorZ, Functor::use_z>,
-      SpinorYW<max_YW_size<NXZ, SpinorX, SpinorY, SpinorZ, SpinorW, Functor>(), SpinorY, SpinorW, Functor::use_w>
-    {
+    struct MultiBlasArg
+      : SpinorXZ<NXZ, SpinorX, SpinorZ, Functor::use_z>,
+        SpinorYW<max_YW_size<NXZ, SpinorX, SpinorY, SpinorZ, SpinorW, Functor>(), SpinorY, SpinorW, Functor::use_w> {
       static constexpr int NYW_max = max_YW_size<NXZ, SpinorX, SpinorY, SpinorZ, SpinorW, Functor>();
       const int NYW;
       Functor f;

--- a/include/kernels/multi_reduce_core.cuh
+++ b/include/kernels/multi_reduce_core.cuh
@@ -26,11 +26,10 @@ namespace quda
     */
     template <int NXZ, typename ReduceType, typename SpinorX, typename SpinorY, typename SpinorZ, typename SpinorW,
               typename Reducer>
-    struct MultiReduceArg :
-      public ReduceArg<vector_type<ReduceType, NXZ>>,
-      SpinorXZ<NXZ, SpinorX, SpinorZ, Reducer::use_z>,
-      SpinorYW<max_YW_size<NXZ, SpinorX, SpinorY, SpinorZ, SpinorW, Reducer>(), SpinorY, SpinorW, Reducer::use_w>
-    {
+    struct MultiReduceArg
+      : public ReduceArg<vector_type<ReduceType, NXZ>>,
+        SpinorXZ<NXZ, SpinorX, SpinorZ, Reducer::use_z>,
+        SpinorYW<max_YW_size<NXZ, SpinorX, SpinorY, SpinorZ, SpinorW, Reducer>(), SpinorY, SpinorW, Reducer::use_w> {
       static constexpr int NYW_max = max_YW_size<NXZ, SpinorX, SpinorY, SpinorZ, SpinorW, Reducer>();
       const int NYW;
       Reducer r;

--- a/include/kernels/multi_reduce_core.cuh
+++ b/include/kernels/multi_reduce_core.cuh
@@ -26,13 +26,12 @@ namespace quda
     */
     template <int NXZ, typename ReduceType, typename SpinorX, typename SpinorY, typename SpinorZ, typename SpinorW,
               typename Reducer>
-    struct MultiReduceArg
-      : public ReduceArg<vector_type<ReduceType, NXZ>>,
-        SpinorXZ<NXZ, SpinorX, SpinorZ, Reducer::use_z>,
-        SpinorYW<max_YW_size<NXZ, typename SpinorX::StoreType, typename SpinorY::StoreType, Reducer>(), SpinorY,
-                 SpinorW, Reducer::use_w> {
-      static constexpr int NYW_max
-        = max_YW_size<NXZ, typename SpinorX::StoreType, typename SpinorY::StoreType, Reducer>();
+    struct MultiReduceArg :
+      public ReduceArg<vector_type<ReduceType, NXZ>>,
+      SpinorXZ<NXZ, SpinorX, SpinorZ, Reducer::use_z>,
+      SpinorYW<max_YW_size<NXZ, SpinorX, SpinorY, SpinorZ, SpinorW, Reducer>(), SpinorY, SpinorW, Reducer::use_w>
+    {
+      static constexpr int NYW_max = max_YW_size<NXZ, SpinorX, SpinorY, SpinorZ, SpinorW, Reducer>();
       const int NYW;
       Reducer r;
       const int length;

--- a/include/malloc_quda.h
+++ b/include/malloc_quda.h
@@ -2,6 +2,7 @@
 #define _MALLOC_QUDA_H
 
 #include <cstdlib>
+#include <cstdint>
 #include <enum_quda.h>
 
 namespace quda {

--- a/include/multi_blas_helper.cuh
+++ b/include/multi_blas_helper.cuh
@@ -56,6 +56,14 @@ namespace quda
       }
     }
 
+    template <int writeX, int writeY, int writeZ, int writeW>
+    struct write {
+      static constexpr int X = writeX;
+      static constexpr int Y = writeY;
+      static constexpr int Z = writeZ;
+      static constexpr int W = writeW;
+    };
+
     /**
        @brief Helper function to compute the maximum YW size for the
        multi-blas runctions.  Since the SpinorX and SpinorZ arrays are
@@ -63,13 +71,8 @@ namespace quda
        the maximum size of YW is and allocate this amount of space.  This
        allows for a much larger NXZ (NYW) when NYW (NXZ) is small.
     */
-    template <int NXZ, typename xType, typename yType, typename Functor> inline constexpr int max_YW_size()
+    template <int NXZ, typename SpinorX, typename SpinorY, typename SpinorZ, typename SpinorW, typename Functor> inline constexpr int max_YW_size()
     {
-      using SpinorX = SpinorTexture<typename mapper<xType>::type, xType, 6>;
-      using SpinorY = Spinor<typename mapper<yType>::type, yType, 6, 1>;
-      using SpinorZ = SpinorX;
-      using SpinorW = Spinor<typename mapper<xType>::type, xType, 6, 1>;
-
       // compute the size remaining for the Y and W accessors
       constexpr int arg_size = (MAX_ARG_SIZE - sizeof(int)                                    // NYW parameter
                                 - sizeof(SpinorX[NXZ])                                        // SpinorX array
@@ -94,6 +97,23 @@ namespace quda
        the maximum size of YW is and allocate this amount of space.  This
        allows for a much larger NXZ (NYW) when NYW (NXZ) is small.
     */
+    template <int NXZ, typename xType, typename yType, typename write, typename Functor> inline constexpr int max_YW_size()
+    {
+      using SpinorX = SpinorTexture<typename mapper<xType>::type, xType, 6>;
+      using SpinorY = Spinor<typename mapper<yType>::type, yType, 6, write::Y>;
+      using SpinorZ = SpinorX;
+      using SpinorW = Spinor<typename mapper<xType>::type, xType, 6, write::W>;
+      return max_YW_size<NXZ,SpinorX, SpinorY, SpinorZ, SpinorW, Functor>();
+    }
+
+    /**
+       @brief Helper function to compute the maximum YW size for the
+       multi-blas runctions.  Since the SpinorX and SpinorZ arrays are
+       statically allocated with length NXZ, we can statically compute how
+       the maximum size of YW is and allocate this amount of space.  This
+       allows for a much larger NXZ (NYW) when NYW (NXZ) is small.
+    */
+    template <typename write>
     inline int max_YW_size(int NXZ, QudaPrecision x_prec, QudaPrecision y_prec, bool use_z, bool use_w, bool reduce)
     {
       bool x_fixed = x_prec < QUDA_SINGLE_PRECISION;
@@ -102,9 +122,10 @@ namespace quda
       NXZ = is_valid_NXZ(NXZ, reduce, x_fixed) ? NXZ : MAX_MULTI_BLAS_N; // ensure NXZ is a valid size
       size_t spinor_x_size
         = x_fixed ? sizeof(SpinorTexture<float4, short4, 6>) : sizeof(SpinorTexture<float4, float4, 6>);
-      size_t spinor_y_size = y_fixed ? sizeof(Spinor<float4, short4, 6, 1>) : sizeof(Spinor<float4, float4, 6, 1>);
+      size_t spinor_y_size = y_fixed ? sizeof(Spinor<float4, short4, 6, write::Y>) : sizeof(Spinor<float4, float4, 6, write::Y>);
+
       size_t spinor_z_size = spinor_x_size;
-      size_t spinor_w_size = x_fixed ? sizeof(Spinor<float4, short4, 6, 1>) : sizeof(Spinor<float4, float4, 6, 1>);
+      size_t spinor_w_size = x_fixed ? sizeof(Spinor<float4, short4, 6, write::W>) : sizeof(Spinor<float4, float4, 6, write::W>);
 
       // compute the size remaining for the Y and W accessors
       int arg_size = (MAX_ARG_SIZE - sizeof(int)                       // NYW parameter

--- a/include/multi_blas_helper.cuh
+++ b/include/multi_blas_helper.cuh
@@ -56,8 +56,7 @@ namespace quda
       }
     }
 
-    template <int writeX, int writeY, int writeZ, int writeW>
-    struct write {
+    template <int writeX, int writeY, int writeZ, int writeW> struct write {
       static constexpr int X = writeX;
       static constexpr int Y = writeY;
       static constexpr int Z = writeZ;
@@ -71,7 +70,8 @@ namespace quda
        the maximum size of YW is and allocate this amount of space.  This
        allows for a much larger NXZ (NYW) when NYW (NXZ) is small.
     */
-    template <int NXZ, typename SpinorX, typename SpinorY, typename SpinorZ, typename SpinorW, typename Functor> inline constexpr int max_YW_size()
+    template <int NXZ, typename SpinorX, typename SpinorY, typename SpinorZ, typename SpinorW, typename Functor>
+    inline constexpr int max_YW_size()
     {
       // compute the size remaining for the Y and W accessors
       constexpr int arg_size = (MAX_ARG_SIZE - sizeof(int)                                    // NYW parameter
@@ -97,13 +97,14 @@ namespace quda
        the maximum size of YW is and allocate this amount of space.  This
        allows for a much larger NXZ (NYW) when NYW (NXZ) is small.
     */
-    template <int NXZ, typename xType, typename yType, typename write, typename Functor> inline constexpr int max_YW_size()
+    template <int NXZ, typename xType, typename yType, typename write, typename Functor>
+    inline constexpr int max_YW_size()
     {
       using SpinorX = SpinorTexture<typename mapper<xType>::type, xType, 6>;
       using SpinorY = Spinor<typename mapper<yType>::type, yType, 6, write::Y>;
       using SpinorZ = SpinorX;
       using SpinorW = Spinor<typename mapper<xType>::type, xType, 6, write::W>;
-      return max_YW_size<NXZ,SpinorX, SpinorY, SpinorZ, SpinorW, Functor>();
+      return max_YW_size<NXZ, SpinorX, SpinorY, SpinorZ, SpinorW, Functor>();
     }
 
     /**
@@ -122,10 +123,12 @@ namespace quda
       NXZ = is_valid_NXZ(NXZ, reduce, x_fixed) ? NXZ : MAX_MULTI_BLAS_N; // ensure NXZ is a valid size
       size_t spinor_x_size
         = x_fixed ? sizeof(SpinorTexture<float4, short4, 6>) : sizeof(SpinorTexture<float4, float4, 6>);
-      size_t spinor_y_size = y_fixed ? sizeof(Spinor<float4, short4, 6, write::Y>) : sizeof(Spinor<float4, float4, 6, write::Y>);
+      size_t spinor_y_size
+        = y_fixed ? sizeof(Spinor<float4, short4, 6, write::Y>) : sizeof(Spinor<float4, float4, 6, write::Y>);
 
       size_t spinor_z_size = spinor_x_size;
-      size_t spinor_w_size = x_fixed ? sizeof(Spinor<float4, short4, 6, write::W>) : sizeof(Spinor<float4, float4, 6, write::W>);
+      size_t spinor_w_size
+        = x_fixed ? sizeof(Spinor<float4, short4, 6, write::W>) : sizeof(Spinor<float4, float4, 6, write::W>);
 
       // compute the size remaining for the Y and W accessors
       int arg_size = (MAX_ARG_SIZE - sizeof(int)                       // NYW parameter

--- a/include/texture.h
+++ b/include/texture.h
@@ -196,8 +196,9 @@ template <typename RegType, typename StoreType> struct SpinorNorm<RegType, Store
    @param StoreType Type used to store field in memory
    @param N Length of vector of RegType elements that this Spinor represents
 */
-template <typename RegType, typename StoreType_, int N>
-struct SpinorTexture : SpinorNorm<RegType, StoreType_, isFixed<StoreType_>::value> {
+template <typename RegType_, typename StoreType_, int N>
+struct SpinorTexture : SpinorNorm<RegType_, StoreType_, isFixed<StoreType_>::value> {
+  typedef RegType_ RegType;
   typedef StoreType_ StoreType;
   typedef typename bridge_mapper<RegType,StoreType>::type InterType;
   typedef SpinorNorm<RegType, StoreType_, isFixed<StoreType>::value> SN;
@@ -362,9 +363,10 @@ public:
    @param StoreType Type used to store field in memory
    @param N Length of vector of RegType elements that this Spinor represents
 */
-template <typename RegType, typename StoreType_, int N, int write_>
-struct Spinor : public SpinorTexture<RegType, StoreType_, N> {
+template <typename RegType_, typename StoreType_, int N, int write_>
+struct Spinor : public SpinorTexture<RegType_, StoreType_, N> {
   static constexpr bool write = write_;
+  typedef RegType_ RegType;
   typedef StoreType_ StoreType;
   typedef typename bridge_mapper<RegType,StoreType>::type InterType;
   typedef SpinorTexture<RegType, StoreType, N> ST;
@@ -483,4 +485,5 @@ public:
 #endif
     return (void *)spinor;
   }
+
 };

--- a/include/texture.h
+++ b/include/texture.h
@@ -485,5 +485,4 @@ public:
 #endif
     return (void *)spinor;
   }
-
 };

--- a/lib/blas_cublas.cu
+++ b/lib/blas_cublas.cu
@@ -1,5 +1,7 @@
+#ifdef CUBLAS_LIB
 #include <blas_cublas.h>
 #include <cublas_v2.h>
+#endif
 #include <malloc_quda.h>
 
 #define FMULS_GETRF(m_, n_) ( ((m_) < (n_)) \

--- a/lib/blas_quda.cu
+++ b/lib/blas_quda.cu
@@ -184,9 +184,7 @@ namespace quda {
 
       if (checkLocation(x, y, z, w, v) == QUDA_CUDA_FIELD_LOCATION) {
 
-        if (!x.isNative()
-            && !(x.Nspin() == 4 && x.FieldOrder() == QUDA_FLOAT2_FIELD_ORDER && x.Precision() == QUDA_SINGLE_PRECISION
-                || x.Nspin() == 4 && x.FieldOrder() == QUDA_FLOAT2_FIELD_ORDER && x.Precision() == QUDA_HALF_PRECISION)) {
+        if (!x.isNative() && x.FieldOrder() != QUDA_FLOAT2_FIELD_ORDER) {
           warningQuda("Device blas on non-native fields is not supported\n");
           return;
         }
@@ -216,8 +214,8 @@ namespace quda {
 #else
             errorQuda("blas has not been built for Nspin=%d fields", x.Nspin());
 #endif
-          } else if (x.Nspin() == 2 || x.Nspin() == 1 || (x.Nspin() == 4 && x.FieldOrder() == QUDA_FLOAT2_FIELD_ORDER)) {
-#if defined(GPU_WILSON_DIRAC) || defined(GPU_DOMAIN_WALL_DIRAC) || defined(GPU_STAGGERED_DIRAC)
+          } else if (x.Nspin() == 1 || x.Nspin() == 2 || (x.Nspin() == 4 && x.FieldOrder() == QUDA_FLOAT2_FIELD_ORDER)) {
+#if defined(GPU_STAGGERED_DIRAC) || defined(GPU_MULTIGRID)
             const int M = 1;
             nativeBlas<float2, float2, float2, M, Functor, writeX, writeY, writeZ, writeW, writeV>(
                 a, b, c, x, y, z, w, v, x.Length() / (2 * M));
@@ -244,7 +242,7 @@ namespace quda {
             errorQuda("blas has not been built for Nspin=%d fields", x.Nspin());
 #endif
           } else if (x.Nspin() == 4 && x.FieldOrder() == QUDA_FLOAT2_FIELD_ORDER) { // wilson
-#if defined(GPU_WILSON_DIRAC) || defined(GPU_DOMAIN_WALL_DIRAC)
+#if defined(GPU_MULTIGRID)
             const int M = 12;
             nativeBlas<float2, short2, short2, M, Functor, writeX, writeY, writeZ, writeW, writeV>(
                 a, b, c, x, y, z, w, v, x.Volume());
@@ -270,10 +268,18 @@ namespace quda {
 
 #if QUDA_PRECISION & 1
           if (x.Ncolor() != 3) { errorQuda("nColor = %d is not supported", x.Ncolor()); }
-          if (x.Nspin() == 4) { // wilson
+          if (x.Nspin() == 4 && x.FieldOrder() == QUDA_FLOAT4_FIELD_ORDER) { // wilson
 #if defined(GPU_WILSON_DIRAC) || defined(GPU_DOMAIN_WALL_DIRAC)
             const int M = 6;
             nativeBlas<float4, char4, char4, M, Functor, writeX, writeY, writeZ, writeW, writeV>(
+                a, b, c, x, y, z, w, v, x.Volume());
+#else
+            errorQuda("blas has not been built for Nspin=%d fields", x.Nspin());
+#endif
+          } else if (x.Nspin() == 4 && x.FieldOrder() == QUDA_FLOAT2_FIELD_ORDER) { // wilson
+#if defined(GPU_MULTIGRID)
+            const int M = 12;
+            nativeBlas<float2, char2, char2, M, Functor, writeX, writeY, writeZ, writeW, writeV>(
                 a, b, c, x, y, z, w, v, x.Volume());
 #else
             errorQuda("blas has not been built for Nspin=%d fields", x.Nspin());

--- a/lib/blas_quda.cu
+++ b/lib/blas_quda.cu
@@ -279,8 +279,8 @@ namespace quda {
           } else if (x.Nspin() == 4 && x.FieldOrder() == QUDA_FLOAT2_FIELD_ORDER) { // wilson
 #if defined(GPU_MULTIGRID)
             const int M = 12;
-            nativeBlas<float2, char2, char2, M, Functor, writeX, writeY, writeZ, writeW, writeV>(
-                a, b, c, x, y, z, w, v, x.Volume());
+            nativeBlas<float2, char2, char2, M, Functor, writeX, writeY, writeZ, writeW, writeV>(a, b, c, x, y, z, w, v,
+                                                                                                 x.Volume());
 #else
             errorQuda("blas has not been built for Nspin=%d fields", x.Nspin());
 #endif

--- a/lib/eigensolve_quda.cpp
+++ b/lib/eigensolve_quda.cpp
@@ -320,8 +320,8 @@ namespace quda
     // 1. Take block inner product: L_i^dag * vec = A_i
     std::vector<ColorSpinorField *> left_vecs_ptr;
     for (int i = n_defl; i < 2 * n_defl; i++) left_vecs_ptr.push_back(eig_vecs[i]);
-    double *s = (double *)safe_malloc(n_defl * sizeof(double));
-    blas::reDotProduct(s, left_vecs_ptr, vec);
+    Complex *s = (Complex *)safe_malloc(n_defl * sizeof(Complex));
+    blas::cDotProduct(s, left_vecs_ptr, vec);
 
     // 2. Perform block caxpy
     //    A_i -> (\sigma_i)^{-1} * A_i
@@ -332,7 +332,7 @@ namespace quda
       right_vecs_ptr.push_back(eig_vecs[i]);
       s[i] /= evals[i].real();
     }
-    blas::axpy(s, right_vecs_ptr, vec_defl);
+    blas::caxpy(s, right_vecs_ptr, vec_defl);
 
     // FIXME - we can optimize the zeroing out with a "multi-caxy"
     // function that just writes over vec_defl and doesn't sum.  When

--- a/lib/inv_cg_quda.cpp
+++ b/lib/inv_cg_quda.cpp
@@ -297,8 +297,12 @@ namespace quda {
     // alternative reliable updates
     // alternative reliable updates - set precision - does not hurt performance here
 
-    const double u = param.precision_sloppy == 8 ? std::numeric_limits<double>::epsilon()/2. : ((param.precision_sloppy == 4) ? std::numeric_limits<float>::epsilon()/2. : pow(2.,-13));
-    const double uhigh= param.precision == 8 ? std::numeric_limits<double>::epsilon()/2. : ((param.precision == 4) ? std::numeric_limits<float>::epsilon()/2. : pow(2.,-13));
+    const double u = param.precision_sloppy == 8 ? std::numeric_limits<double>::epsilon()/2. :
+      param.precision_sloppy == 4 ? std::numeric_limits<float>::epsilon()/2. :
+      param.precision == 2 ? pow(2.,-13) : pow(2.,-6);
+    const double uhigh = param.precision == 8 ? std::numeric_limits<double>::epsilon()/2. :
+      param.precision == 4 ? std::numeric_limits<float>::epsilon()/2. :
+      param.precision == 2 ? pow(2.,-13) : pow(2.,-6);
     const double deps=sqrt(u);
     constexpr double dfac = 1.1;
     double d_new = 0;

--- a/lib/inv_cg_quda.cpp
+++ b/lib/inv_cg_quda.cpp
@@ -297,12 +297,13 @@ namespace quda {
     // alternative reliable updates
     // alternative reliable updates - set precision - does not hurt performance here
 
-    const double u = param.precision_sloppy == 8 ? std::numeric_limits<double>::epsilon()/2. :
-      param.precision_sloppy == 4 ? std::numeric_limits<float>::epsilon()/2. :
-      param.precision == 2 ? pow(2.,-13) : pow(2.,-6);
-    const double uhigh = param.precision == 8 ? std::numeric_limits<double>::epsilon()/2. :
-      param.precision == 4 ? std::numeric_limits<float>::epsilon()/2. :
-      param.precision == 2 ? pow(2.,-13) : pow(2.,-6);
+    const double u = param.precision_sloppy == 8 ?
+      std::numeric_limits<double>::epsilon() / 2. :
+      param.precision_sloppy == 4 ? std::numeric_limits<float>::epsilon() / 2. :
+                                    param.precision == 2 ? pow(2., -13) : pow(2., -6);
+    const double uhigh = param.precision == 8 ? std::numeric_limits<double>::epsilon() / 2. :
+                                                param.precision == 4 ? std::numeric_limits<float>::epsilon() / 2. :
+                                                                       param.precision == 2 ? pow(2., -13) : pow(2., -6);
     const double deps=sqrt(u);
     constexpr double dfac = 1.1;
     double d_new = 0;

--- a/lib/multi_blas_quda.cu
+++ b/lib/multi_blas_quda.cu
@@ -255,7 +255,8 @@ namespace quda {
       constexpr int NXZ = isFixed<StoreType>::value && NXZ_ == 128 ? 64 : NXZ_;
       Functor<NXZ, Float2, RegType> f(NYW);
       constexpr int NYW_max = max_YW_size<NXZ, StoreType, yType, write, decltype(f)>();
-      const int NYW_max_check = max_YW_size<write>(x.size(), x[0]->Precision(), y[0]->Precision(), f.use_z, f.use_w, false);
+      const int NYW_max_check
+        = max_YW_size<write>(x.size(), x[0]->Precision(), y[0]->Precision(), f.use_z, f.use_w, false);
 
       if (!is_valid_NXZ(NXZ, false, x[0]->Precision() < QUDA_SINGLE_PRECISION))
         errorQuda("NXZ=%d is not a valid size ( MAX_MULTI_BLAS_N %d)", NXZ, MAX_MULTI_BLAS_N);
@@ -278,10 +279,8 @@ namespace quda {
         W[i].set(*dynamic_cast<cudaColorSpinorField *>(w[i]));
       }
 
-      MultiBlas<NXZ, RegType, M,
-                typename std::remove_reference<decltype(X[0])>::type,
-                typename std::remove_reference<decltype(Y[0])>::type,
-                typename std::remove_reference<decltype(Z[0])>::type,
+      MultiBlas<NXZ, RegType, M, typename std::remove_reference<decltype(X[0])>::type,
+                typename std::remove_reference<decltype(Y[0])>::type, typename std::remove_reference<decltype(Z[0])>::type,
                 typename std::remove_reference<decltype(W[0])>::type, decltype(f), T>
         blas(X, Y, Z, W, f, a, b, c, x, y, z, w, NYW, length);
       blas.apply(*getStream());

--- a/lib/multi_blas_quda.cu
+++ b/lib/multi_blas_quda.cu
@@ -16,14 +16,6 @@ namespace quda {
 
     cudaStream_t* getStream();
 
-    template <int writeX, int writeY, int writeZ, int writeW>
-    struct write {
-      static constexpr int X = writeX;
-      static constexpr int Y = writeY;
-      static constexpr int Z = writeZ;
-      static constexpr int W = writeW;
-    };
-
     template <int NXZ, typename FloatN, int M, typename SpinorX, typename SpinorY, typename SpinorZ, typename SpinorW,
         typename Functor, typename T>
     class MultiBlas : public TunableVectorY
@@ -32,7 +24,7 @@ namespace quda {
   private:
     typedef typename scalar<FloatN>::type Float;
     typedef typename vector<Float, 2>::type Float2;
-    static constexpr int NYW_max = max_YW_size<NXZ, typename SpinorX::StoreType, typename SpinorY::StoreType, Functor>();
+    static constexpr int NYW_max = max_YW_size<NXZ, SpinorX, SpinorY, SpinorZ, SpinorW, Functor>();
     const int NYW;
     int max_warp_split;
     mutable int warp_split; // helper used to keep track of current warp splitting
@@ -187,16 +179,16 @@ namespace quda {
       void preTune()
       {
         for (int i = 0; i < NYW; ++i) {
-          arg.Y[i].backup(&Y_h[i], &Ynorm_h[i], y[i]->Bytes(), y[i]->NormBytes());
-          arg.W[i].backup(&W_h[i], &Wnorm_h[i], w[i]->Bytes(), w[i]->NormBytes());
+          if (SpinorY::write) arg.Y[i].backup(&Y_h[i], &Ynorm_h[i], y[i]->Bytes(), y[i]->NormBytes());
+          if (SpinorW::write) arg.W[i].backup(&W_h[i], &Wnorm_h[i], w[i]->Bytes(), w[i]->NormBytes());
         }
       }
 
       void postTune()
       {
         for (int i = 0; i < NYW; ++i) {
-          arg.Y[i].restore(&Y_h[i], &Ynorm_h[i], y[i]->Bytes(), y[i]->NormBytes());
-          arg.W[i].restore(&W_h[i], &Wnorm_h[i], w[i]->Bytes(), w[i]->NormBytes());
+          if (SpinorY::write) arg.Y[i].restore(&Y_h[i], &Ynorm_h[i], y[i]->Bytes(), y[i]->NormBytes());
+          if (SpinorW::write) arg.W[i].restore(&W_h[i], &Wnorm_h[i], w[i]->Bytes(), w[i]->NormBytes());
         }
       }
 
@@ -262,8 +254,8 @@ namespace quda {
       // the below line enable NXZ = 128 for floating point types, which is invalid for fixed-point types
       constexpr int NXZ = isFixed<StoreType>::value && NXZ_ == 128 ? 64 : NXZ_;
       Functor<NXZ, Float2, RegType> f(NYW);
-      constexpr int NYW_max = max_YW_size<NXZ, StoreType, yType, decltype(f)>();
-      const int NYW_max_check = max_YW_size(x.size(), x[0]->Precision(), y[0]->Precision(), f.use_z, f.use_w, false);
+      constexpr int NYW_max = max_YW_size<NXZ, StoreType, yType, write, decltype(f)>();
+      const int NYW_max_check = max_YW_size<write>(x.size(), x[0]->Precision(), y[0]->Precision(), f.use_z, f.use_w, false);
 
       if (!is_valid_NXZ(NXZ, false, x[0]->Precision() < QUDA_SINGLE_PRECISION))
         errorQuda("NXZ=%d is not a valid size ( MAX_MULTI_BLAS_N %d)", NXZ, MAX_MULTI_BLAS_N);
@@ -286,8 +278,11 @@ namespace quda {
         W[i].set(*dynamic_cast<cudaColorSpinorField *>(w[i]));
       }
 
-      MultiBlas<NXZ, RegType, M, SpinorTexture<RegType, StoreType, M>, Spinor<RegType, yType, M, write::Y>,
-                SpinorTexture<RegType, StoreType, M>, Spinor<RegType, StoreType, M, write::W>, decltype(f), T>
+      MultiBlas<NXZ, RegType, M,
+                typename std::remove_reference<decltype(X[0])>::type,
+                typename std::remove_reference<decltype(Y[0])>::type,
+                typename std::remove_reference<decltype(Z[0])>::type,
+                typename std::remove_reference<decltype(W[0])>::type, decltype(f), T>
         blas(X, Y, Z, W, f, a, b, c, x, y, z, w, NYW, length);
       blas.apply(*getStream());
 
@@ -683,9 +678,10 @@ namespace quda {
     void axpy_recurse(const T *a_, std::vector<ColorSpinorField *> &x, std::vector<ColorSpinorField *> &y, int i_idx,
                       int j_idx, int upper)
     {
+      using write_ = write<0, 1, 0, 0>;
 
       // if greater than max single-kernel size, recurse
-      if (y.size() > (size_t)max_YW_size(x.size(), x[0]->Precision(), y[0]->Precision(), false, false, false)) {
+      if (y.size() > (size_t)max_YW_size<write_>(x.size(), x[0]->Precision(), y[0]->Precision(), false, false, false)) {
         // We need to split up 'a' carefully since it's row-major.
         T *tmpmajor = new T[x.size() * y.size()];
         T *tmpmajor0 = &tmpmajor[0];
@@ -720,7 +716,7 @@ namespace quda {
 
           // mark true since we will copy the "a" matrix into constant memory
           coeff_array<T> a(a_), b, c;
-          multiBlas<Functor, write<0, 1, 0, 0>>(a, b, c, x, y, x, y);
+          multiBlas<Functor, write_>(a, b, c, x, y, x, y);
         } else {
           // split the problem in half and recurse
           const T *a0 = &a_[0];
@@ -776,7 +772,9 @@ namespace quda {
     void caxpyz_recurse(const Complex *a_, std::vector<ColorSpinorField*> &x, std::vector<ColorSpinorField*> &y, std::vector<ColorSpinorField*> &z, int i, int j, int pass, int upper) {
 
       // if greater than max single-kernel size, recurse
-      if (y.size() > (size_t)max_YW_size(x.size(), x[0]->Precision(), y[0]->Precision(), false, true, false)) {
+      using write_ = write<0, 0, 0, 1>;
+
+      if (y.size() > (size_t)max_YW_size<write_>(x.size(), x[0]->Precision(), y[0]->Precision(), false, true, false)) {
         // We need to split up 'a' carefully since it's row-major.
         Complex* tmpmajor = new Complex[x.size()*y.size()];
         Complex* tmpmajor0 = &tmpmajor[0];
@@ -819,7 +817,7 @@ namespace quda {
           }
 
           coeff_array<Complex> a(a_), b, c;
-          multiBlas<multicaxpyz_, write<0, 0, 0, 1>>(a, b, c, x, y, x, z);
+          multiBlas<multicaxpyz_, write_>(a, b, c, x, y, x, z);
         } else {
           // split the problem in half and recurse
           const Complex *a0 = &a_[0];
@@ -873,7 +871,9 @@ namespace quda {
     void axpyBzpcx(const double *a_, std::vector<ColorSpinorField *> &x_, std::vector<ColorSpinorField *> &y_,
                    const double *b_, ColorSpinorField &z_, const double *c_)
     {
-      if (y_.size() <= (size_t)max_YW_size(1, z_.Precision(), y_[0]->Precision(), false, true, false)) {
+      using write_ = write<0, 1, 0, 1>;
+
+      if (y_.size() <= (size_t)max_YW_size<write_>(1, z_.Precision(), y_[0]->Precision(), false, true, false)) {
         // swizzle order since we are writing to x_ and y_, but the
 	// multi-blas only allow writing to y and w, and moreover the
 	// block width of y and w must match, and x and z must match.
@@ -885,7 +885,7 @@ namespace quda {
 	x.push_back(&z_);
 
         coeff_array<double> a(a_), b(b_), c(c_);
-        multiBlas<1, multi_axpyBzpcx_, write<0, 1, 0, 1>>(a, b, c, x, y, x, w);
+        multiBlas<1, multi_axpyBzpcx_, write_>(a, b, c, x, y, x, w);
       } else {
         // split the problem in half and recurse
 	const double *a0 = &a_[0];
@@ -911,6 +911,8 @@ namespace quda {
     void caxpyBxpz(const Complex *a_, std::vector<ColorSpinorField*> &x_, ColorSpinorField &y_,
 		   const Complex *b_, ColorSpinorField &z_)
     {
+      using write_ = write<0, 1, 0, 1>;
+
       if (is_valid_NXZ(x_.size(), false, x_[0]->Precision() < QUDA_SINGLE_PRECISION)) // only swizzle if we have to.
       {
         // swizzle order since we are writing to y_ and z_, but the
@@ -926,7 +928,7 @@ namespace quda {
         std::vector<ColorSpinorField*> &x = x_;
 
         coeff_array<Complex> a(a_), b(b_), c;
-        multiBlas<multi_caxpyBxpz_, write<0, 1, 0, 1>>(a, b, c, x, y, x, w);
+        multiBlas<multi_caxpyBxpz_, write_>(a, b, c, x, y, x, w);
       } else {
         // split the problem in half and recurse
         const Complex *a0 = &a_[0];

--- a/lib/multi_reduce_quda.cu
+++ b/lib/multi_reduce_quda.cu
@@ -16,14 +16,6 @@ namespace quda {
     cudaEvent_t* getReduceEvent();
     bool getFastReduce();
 
-    template <int writeX, int writeY, int writeZ, int writeW>
-    struct write {
-      static constexpr int X = writeX;
-      static constexpr int Y = writeY;
-      static constexpr int Z = writeZ;
-      static constexpr int W = writeW;
-    };
-
     template <typename doubleN, typename ReduceType, typename FloatN, int M, int NXZ, typename Arg>
     void multiReduceLaunch(doubleN result[], Arg &arg, const TuneParam &tp, const cudaStream_t &stream, Tunable &tunable)
     {
@@ -101,7 +93,7 @@ namespace quda {
   private:
     typedef typename scalar<FloatN>::type Float;
     typedef typename vector<Float, 2>::type Float2;
-    static constexpr int NYW_max = max_YW_size<NXZ, typename SpinorX::StoreType, typename SpinorY::StoreType, Reducer>();
+      static constexpr int NYW_max = max_YW_size<NXZ, SpinorX, SpinorY, SpinorZ, SpinorW, Reducer>();
     const int NYW;
     int nParity;
     MultiReduceArg<NXZ, ReduceType, SpinorX, SpinorY, SpinorZ, SpinorW, Reducer> arg;
@@ -235,16 +227,16 @@ namespace quda {
       void preTune()
       {
         for (int i = 0; i < NYW; ++i) {
-          arg.Y[i].backup(&Y_h[i], &Ynorm_h[i], y[i]->Bytes(), y[i]->NormBytes());
-          arg.W[i].backup(&W_h[i], &Wnorm_h[i], w[i]->Bytes(), w[i]->NormBytes());
+          if (SpinorY::write) arg.Y[i].backup(&Y_h[i], &Ynorm_h[i], y[i]->Bytes(), y[i]->NormBytes());
+          if (SpinorW::write) arg.W[i].backup(&W_h[i], &Wnorm_h[i], w[i]->Bytes(), w[i]->NormBytes());
         }
       }
 
       void postTune()
       {
         for (int i = 0; i < NYW; ++i) {
-          arg.Y[i].restore(&Y_h[i], &Ynorm_h[i], y[i]->Bytes(), y[i]->NormBytes());
-          arg.W[i].restore(&W_h[i], &Wnorm_h[i], w[i]->Bytes(), w[i]->NormBytes());
+          if (SpinorY::write) arg.Y[i].restore(&Y_h[i], &Ynorm_h[i], y[i]->Bytes(), y[i]->NormBytes());
+          if (SpinorW::write) arg.W[i].restore(&W_h[i], &Wnorm_h[i], w[i]->Bytes(), w[i]->NormBytes());
         }
       }
 
@@ -274,11 +266,11 @@ namespace quda {
 
       const int NYW = y.size();
       Reducer<NXZ, ReduceType, Float2, RegType> r(a, b, c, NYW);
-      constexpr int NYW_max = max_YW_size<NXZ, StoreType, yType, decltype(r)>();
+      constexpr int NYW_max = max_YW_size<NXZ, StoreType, yType, write, decltype(r)>();
 
       memset(result, 0, NXZ * NYW * sizeof(doubleN));
 
-      const int NYW_max_check = max_YW_size(x.size(), x[0]->Precision(), y[0]->Precision(), r.use_z, r.use_w, true);
+      const int NYW_max_check = max_YW_size<write>(x.size(), x[0]->Precision(), y[0]->Precision(), r.use_z, r.use_w, true);
 
       if (!is_valid_NXZ(NXZ, true))
         errorQuda("NXZ=%d is not a valid size ( MAX_MULTI_BLAS_N %d)", NXZ, MAX_MULTI_BLAS_N);
@@ -355,9 +347,11 @@ namespace quda {
         W[i].set(*dynamic_cast<cudaColorSpinorField *>(w[i]));
       }
 
-      MultiReduce<NXZ, doubleN, ReduceType, RegType, M, SpinorTexture<RegType, StoreType, M>,
-                  Spinor<RegType, yType, M, write::Y>, SpinorTexture<RegType, StoreType, M>,
-                  Spinor<RegType, StoreType, M, write::W>, decltype(r)>
+      MultiReduce<NXZ, doubleN, ReduceType, RegType, M,
+                  typename std::remove_reference<decltype(X[0])>::type,
+                  typename std::remove_reference<decltype(Y[0])>::type,
+                  typename std::remove_reference<decltype(Z[0])>::type,
+                  typename std::remove_reference<decltype(W[0])>::type, decltype(r)>
         reduce(result, X, Y, Z, W, r, x, y, z, w, NYW, length);
       reduce.apply(*blas::getStream());
 
@@ -902,7 +896,7 @@ namespace quda {
         hermitian(hermitian),
         Anorm(Anorm)
       {
-        NYW_max = max_YW_size(x.size(), x[0]->Precision(), y[0]->Precision(), false, false, true);
+        NYW_max = max_YW_size<writeDiagonal>(x.size(), x[0]->Precision(), y[0]->Precision(), false, false, true);
         max_tile_size = make_uint2(1, 1);
 
         strcpy(aux, nested_policy ? "nested_policy," : "policy,");
@@ -1194,25 +1188,26 @@ namespace quda {
 
     void reDotProduct(double *result, std::vector<ColorSpinorField *> &x, std::vector<ColorSpinorField *> &y)
     {
+      using write_ = write<0, 0, 0, 0>;
       if (x.size() == 0 || y.size() == 0) errorQuda("vector.size() == 0");
       double *result_tmp = new double[x.size() * y.size()];
       for (unsigned int i = 0; i < x.size()*y.size(); i++) result_tmp[i] = 0.0;
 
       if (x.size() == 1) {
-        int NYW_max = max_YW_size(x.size(), x[0]->Precision(), y[0]->Precision(), false, false, true);
+        int NYW_max = max_YW_size<write_>(x.size(), x[0]->Precision(), y[0]->Precision(), false, false, true);
         // if fine-grid then we set max tile size to 32 to avoid unnecessary tuning
         uint2 max_tile_size = make_uint2(1, std::min( {NYW_max, (int)y.size(), x[0]->Ncolor() == 3 ? 32 : NYW_max} ));
-        multiReduce_recurse<double, QudaSumFloat, Dot, write<0, 0, 0, 0>, Dot, write<0, 0, 0, 0>>(
+        multiReduce_recurse<double, QudaSumFloat, Dot, write_, Dot, write_>(
           result_tmp, x, y, x, y, 0, 0, false, max_tile_size);
       } else if (y.size() == 1) {
 
         double *result_trans = new double[x.size() * y.size()];
 
         // swap (x<->y and w<-z> when doing transpose calculation)
-        int NXZ_max = max_YW_size(y.size(), y[0]->Precision(), x[0]->Precision(), false, false, true);
+        int NXZ_max = max_YW_size<write_>(y.size(), y[0]->Precision(), x[0]->Precision(), false, false, true);
         // if fine-grid then we set max tile size to 32 to avoid unnecessary tuning
         uint2 max_tile_size = make_uint2(1, std::min( {NXZ_max, (int)x.size(), x[0]->Ncolor() == 3 ? 32 : NXZ_max} ));
-        multiReduce_recurse<double, QudaSumFloat, Dot, write<0, 0, 0, 0>, Dot, write<0, 0, 0, 0>>(
+        multiReduce_recurse<double, QudaSumFloat, Dot, write_, Dot, write_>(
           result_trans, y, x, y, x, 0, 0, false, max_tile_size);
 
         // tranpose the result if we are doing the transpose calculation
@@ -1224,8 +1219,7 @@ namespace quda {
         delete[] result_trans;
 
       } else {
-        TileSizeTune<double, QudaSumFloat, Dot, write<0, 0, 0, 0>, Dot, write<0, 0, 0, 0>, double> tile(result_tmp, x,
-                                                                                                        y, x, y, false);
+        TileSizeTune<double, QudaSumFloat, Dot, write_, Dot, write_, double> tile(result_tmp, x, y, x, y, false);
         // tile.apply(0);//
         tile.apply(*(blas::getStream()));
       }
@@ -1247,25 +1241,26 @@ namespace quda {
 
     void cDotProduct(Complex *result, std::vector<ColorSpinorField *> &x, std::vector<ColorSpinorField *> &y)
     {
+      using write_ = write<0, 0, 0, 0>;
       if (x.size() == 0 || y.size() == 0) errorQuda("vector.size() == 0");
       Complex *result_tmp = new Complex[x.size() * y.size()];
       for (unsigned int i = 0; i < x.size() * y.size(); i++) result_tmp[i] = 0.0;
 
       if (x.size() == 1) {
-        int NYW_max = max_YW_size(x.size(), x[0]->Precision(), y[0]->Precision(), false, false, true);
+        int NYW_max = max_YW_size<write_>(x.size(), x[0]->Precision(), y[0]->Precision(), false, false, true);
         // if fine-grid then we set max tile size to 32 to avoid unnecessary tuning
         uint2 max_tile_size = make_uint2(1, std::min( {NYW_max, (int)y.size(), x[0]->Ncolor() == 3 ? 32 : NYW_max} ));
-        multiReduce_recurse<double2, QudaSumFloat2, Cdot, write<0, 0, 0, 0>, Cdot, write<0, 0, 0, 0>>(
+        multiReduce_recurse<double2, QudaSumFloat2, Cdot, write_, Cdot, write_>(
           result_tmp, x, y, x, y, 0, 0, false, max_tile_size);
       } else if (y.size() == 1) {
 
         Complex *result_trans = new Complex[x.size() * y.size()];
 
         // swap (x<->y and w<-z> when doing transpose calculation)
-        int NXZ_max = max_YW_size(y.size(), y[0]->Precision(), x[0]->Precision(), false, false, true);
+        int NXZ_max = max_YW_size<write_>(y.size(), y[0]->Precision(), x[0]->Precision(), false, false, true);
         // if fine-grid then we set max tile size to 32 to avoid unnecessary tuning
         uint2 max_tile_size = make_uint2(1, std::min( {NXZ_max, (int)x.size(), x[0]->Ncolor() == 3 ? 32 : NXZ_max} ));
-        multiReduce_recurse<double2, QudaSumFloat2, Cdot, write<0, 0, 0, 0>, Cdot, write<0, 0, 0, 0>>(
+        multiReduce_recurse<double2, QudaSumFloat2, Cdot, write_, Cdot, write_>(
           result_trans, y, x, y, x, 0, 0, false, max_tile_size);
 
         // tranpose the result if we are doing the transpose calculation
@@ -1277,7 +1272,7 @@ namespace quda {
         delete[] result_trans;
 
       } else {
-        TransposeTune<double2, QudaSumFloat2, Cdot, write<0, 0, 0, 0>, Cdot, write<0, 0, 0, 0>, Complex> trans(
+        TransposeTune<double2, QudaSumFloat2, Cdot, write_, Cdot, write_, Complex> trans(
           result_tmp, x, y, x, y, false);
         trans.apply(0);
       }
@@ -1298,14 +1293,16 @@ namespace quda {
       delete[] result_tmp;
     }
 
-    void hDotProduct(Complex* result, std::vector<ColorSpinorField*>& x, std::vector<ColorSpinorField*>& y){
+    void hDotProduct(Complex* result, std::vector<ColorSpinorField*>& x, std::vector<ColorSpinorField*>& y)
+    {
+      using write_ = write<0, 0, 0, 0>;
       if (x.size() == 0 || y.size() == 0) errorQuda("vector.size() == 0");
       if (x.size() != y.size()) errorQuda("Cannot call Hermitian block dot product on non-square inputs");
 
       Complex* result_tmp = new Complex[x.size()*y.size()];
       for (unsigned int i = 0; i < x.size()*y.size(); i++) result_tmp[i] = 0.0;
 
-      TileSizeTune<double2,QudaSumFloat2, Cdot,write<0,0,0,0>,Cdot,write<0,0,0,0>, Complex> tile(result_tmp, x, y, x, y, true, false); // last false is b/c L2 norm
+      TileSizeTune<double2,QudaSumFloat2, Cdot,write_,Cdot,write_,Complex> tile(result_tmp, x, y, x, y, true, false); // last false is b/c L2 norm
       tile.apply(0);
 
       // do a single multi-node reduction only once we have computed all local dot products
@@ -1325,14 +1322,16 @@ namespace quda {
     }
 
     // for (p, Ap) norms in CG which are Hermitian.
-    void hDotProduct_Anorm(Complex* result, std::vector<ColorSpinorField*>& x, std::vector<ColorSpinorField*>& y){
+    void hDotProduct_Anorm(Complex* result, std::vector<ColorSpinorField*>& x, std::vector<ColorSpinorField*>& y)
+    {
+      using write_ = write<0, 0, 0, 0>;
       if (x.size() == 0 || y.size() == 0) errorQuda("vector.size() == 0");
       if (x.size() != y.size()) errorQuda("Cannot call Hermitian block A-norm dot product on non-square inputs");
 
       Complex* result_tmp = new Complex[x.size()*y.size()];
       for (unsigned int i = 0; i < x.size()*y.size(); i++) result_tmp[i] = 0.0;
 
-      TileSizeTune<double2,QudaSumFloat2, Cdot,write<0,0,0,0>,Cdot,write<0,0,0,0>, Complex > tile(result_tmp, x, y, x, y, true, true); // last true is b/c A norm
+      TileSizeTune<double2,QudaSumFloat2, Cdot,write_,Cdot,write_,Complex> tile(result_tmp, x, y, x, y, true, true); // last true is b/c A norm
       tile.apply(0);
 
       // do a single multi-node reduction only once we have computed all local dot products
@@ -1356,7 +1355,10 @@ namespace quda {
 			 std::vector<ColorSpinorField*>&z){
 
 #if 0
-      // FIXME - if this is enabled we need to ensure that use_w is enabled above
+      // FIXME - if this is enabled we need to ensure that use_w is
+      // enabled above.  Also, I think this might break if the diagonal
+      // write is different from the off-diagonal write
+      using write_ = write<0, 0, 0, 1>;
       if (x.size() == 0 || y.size() == 0) errorQuda("vector.size() == 0");
       if (y.size() != z.size()) errorQuda("Cannot copy input y of size %lu into z of size %lu\n", y.size(), z.size());
 
@@ -1364,7 +1366,7 @@ namespace quda {
       for (unsigned int i = 0; i < x.size()*y.size(); i++) result_tmp[i] = 0.0;
 
       // When recursing, only the diagonal tiles will do the copy, the rest just do the outer product
-      TileSizeTune<double2,QudaSumFloat2, CdotCopy,write<0,0,0,1>,Cdot,write<0,0,0,0>, Complex > tile(result_tmp, x, y, x, y, true);
+      TileSizeTune<double2,QudaSumFloat2,CdotCopy,write_,Cdot,write_,Complex > tile(result_tmp, x, y, x, y, true);
       tile.apply(0);
 
       // do a single multi-node reduction only once we have computed all local dot products

--- a/lib/multi_reduce_quda.cu
+++ b/lib/multi_reduce_quda.cu
@@ -93,7 +93,7 @@ namespace quda {
   private:
     typedef typename scalar<FloatN>::type Float;
     typedef typename vector<Float, 2>::type Float2;
-      static constexpr int NYW_max = max_YW_size<NXZ, SpinorX, SpinorY, SpinorZ, SpinorW, Reducer>();
+    static constexpr int NYW_max = max_YW_size<NXZ, SpinorX, SpinorY, SpinorZ, SpinorW, Reducer>();
     const int NYW;
     int nParity;
     MultiReduceArg<NXZ, ReduceType, SpinorX, SpinorY, SpinorZ, SpinorW, Reducer> arg;
@@ -270,7 +270,8 @@ namespace quda {
 
       memset(result, 0, NXZ * NYW * sizeof(doubleN));
 
-      const int NYW_max_check = max_YW_size<write>(x.size(), x[0]->Precision(), y[0]->Precision(), r.use_z, r.use_w, true);
+      const int NYW_max_check
+        = max_YW_size<write>(x.size(), x[0]->Precision(), y[0]->Precision(), r.use_z, r.use_w, true);
 
       if (!is_valid_NXZ(NXZ, true))
         errorQuda("NXZ=%d is not a valid size ( MAX_MULTI_BLAS_N %d)", NXZ, MAX_MULTI_BLAS_N);
@@ -347,10 +348,8 @@ namespace quda {
         W[i].set(*dynamic_cast<cudaColorSpinorField *>(w[i]));
       }
 
-      MultiReduce<NXZ, doubleN, ReduceType, RegType, M,
-                  typename std::remove_reference<decltype(X[0])>::type,
-                  typename std::remove_reference<decltype(Y[0])>::type,
-                  typename std::remove_reference<decltype(Z[0])>::type,
+      MultiReduce<NXZ, doubleN, ReduceType, RegType, M, typename std::remove_reference<decltype(X[0])>::type,
+                  typename std::remove_reference<decltype(Y[0])>::type, typename std::remove_reference<decltype(Z[0])>::type,
                   typename std::remove_reference<decltype(W[0])>::type, decltype(r)>
         reduce(result, X, Y, Z, W, r, x, y, z, w, NYW, length);
       reduce.apply(*blas::getStream());
@@ -1197,8 +1196,8 @@ namespace quda {
         int NYW_max = max_YW_size<write_>(x.size(), x[0]->Precision(), y[0]->Precision(), false, false, true);
         // if fine-grid then we set max tile size to 32 to avoid unnecessary tuning
         uint2 max_tile_size = make_uint2(1, std::min( {NYW_max, (int)y.size(), x[0]->Ncolor() == 3 ? 32 : NYW_max} ));
-        multiReduce_recurse<double, QudaSumFloat, Dot, write_, Dot, write_>(
-          result_tmp, x, y, x, y, 0, 0, false, max_tile_size);
+        multiReduce_recurse<double, QudaSumFloat, Dot, write_, Dot, write_>(result_tmp, x, y, x, y, 0, 0, false,
+                                                                            max_tile_size);
       } else if (y.size() == 1) {
 
         double *result_trans = new double[x.size() * y.size()];
@@ -1207,8 +1206,8 @@ namespace quda {
         int NXZ_max = max_YW_size<write_>(y.size(), y[0]->Precision(), x[0]->Precision(), false, false, true);
         // if fine-grid then we set max tile size to 32 to avoid unnecessary tuning
         uint2 max_tile_size = make_uint2(1, std::min( {NXZ_max, (int)x.size(), x[0]->Ncolor() == 3 ? 32 : NXZ_max} ));
-        multiReduce_recurse<double, QudaSumFloat, Dot, write_, Dot, write_>(
-          result_trans, y, x, y, x, 0, 0, false, max_tile_size);
+        multiReduce_recurse<double, QudaSumFloat, Dot, write_, Dot, write_>(result_trans, y, x, y, x, 0, 0, false,
+                                                                            max_tile_size);
 
         // tranpose the result if we are doing the transpose calculation
         const auto xlen = x.size();
@@ -1250,8 +1249,8 @@ namespace quda {
         int NYW_max = max_YW_size<write_>(x.size(), x[0]->Precision(), y[0]->Precision(), false, false, true);
         // if fine-grid then we set max tile size to 32 to avoid unnecessary tuning
         uint2 max_tile_size = make_uint2(1, std::min( {NYW_max, (int)y.size(), x[0]->Ncolor() == 3 ? 32 : NYW_max} ));
-        multiReduce_recurse<double2, QudaSumFloat2, Cdot, write_, Cdot, write_>(
-          result_tmp, x, y, x, y, 0, 0, false, max_tile_size);
+        multiReduce_recurse<double2, QudaSumFloat2, Cdot, write_, Cdot, write_>(result_tmp, x, y, x, y, 0, 0, false,
+                                                                                max_tile_size);
       } else if (y.size() == 1) {
 
         Complex *result_trans = new Complex[x.size() * y.size()];
@@ -1260,8 +1259,8 @@ namespace quda {
         int NXZ_max = max_YW_size<write_>(y.size(), y[0]->Precision(), x[0]->Precision(), false, false, true);
         // if fine-grid then we set max tile size to 32 to avoid unnecessary tuning
         uint2 max_tile_size = make_uint2(1, std::min( {NXZ_max, (int)x.size(), x[0]->Ncolor() == 3 ? 32 : NXZ_max} ));
-        multiReduce_recurse<double2, QudaSumFloat2, Cdot, write_, Cdot, write_>(
-          result_trans, y, x, y, x, 0, 0, false, max_tile_size);
+        multiReduce_recurse<double2, QudaSumFloat2, Cdot, write_, Cdot, write_>(result_trans, y, x, y, x, 0, 0, false,
+                                                                                max_tile_size);
 
         // tranpose the result if we are doing the transpose calculation
         const auto xlen = x.size();
@@ -1272,8 +1271,7 @@ namespace quda {
         delete[] result_trans;
 
       } else {
-        TransposeTune<double2, QudaSumFloat2, Cdot, write_, Cdot, write_, Complex> trans(
-          result_tmp, x, y, x, y, false);
+        TransposeTune<double2, QudaSumFloat2, Cdot, write_, Cdot, write_, Complex> trans(result_tmp, x, y, x, y, false);
         trans.apply(0);
       }
 
@@ -1293,7 +1291,7 @@ namespace quda {
       delete[] result_tmp;
     }
 
-    void hDotProduct(Complex* result, std::vector<ColorSpinorField*>& x, std::vector<ColorSpinorField*>& y)
+    void hDotProduct(Complex *result, std::vector<ColorSpinorField *> &x, std::vector<ColorSpinorField *> &y)
     {
       using write_ = write<0, 0, 0, 0>;
       if (x.size() == 0 || y.size() == 0) errorQuda("vector.size() == 0");
@@ -1302,7 +1300,8 @@ namespace quda {
       Complex* result_tmp = new Complex[x.size()*y.size()];
       for (unsigned int i = 0; i < x.size()*y.size(); i++) result_tmp[i] = 0.0;
 
-      TileSizeTune<double2,QudaSumFloat2, Cdot,write_,Cdot,write_,Complex> tile(result_tmp, x, y, x, y, true, false); // last false is b/c L2 norm
+      TileSizeTune<double2, QudaSumFloat2, Cdot, write_, Cdot, write_, Complex> tile(
+        result_tmp, x, y, x, y, true, false); // last false is b/c L2 norm
       tile.apply(0);
 
       // do a single multi-node reduction only once we have computed all local dot products
@@ -1322,7 +1321,7 @@ namespace quda {
     }
 
     // for (p, Ap) norms in CG which are Hermitian.
-    void hDotProduct_Anorm(Complex* result, std::vector<ColorSpinorField*>& x, std::vector<ColorSpinorField*>& y)
+    void hDotProduct_Anorm(Complex *result, std::vector<ColorSpinorField *> &x, std::vector<ColorSpinorField *> &y)
     {
       using write_ = write<0, 0, 0, 0>;
       if (x.size() == 0 || y.size() == 0) errorQuda("vector.size() == 0");
@@ -1331,7 +1330,8 @@ namespace quda {
       Complex* result_tmp = new Complex[x.size()*y.size()];
       for (unsigned int i = 0; i < x.size()*y.size(); i++) result_tmp[i] = 0.0;
 
-      TileSizeTune<double2,QudaSumFloat2, Cdot,write_,Cdot,write_,Complex> tile(result_tmp, x, y, x, y, true, true); // last true is b/c A norm
+      TileSizeTune<double2, QudaSumFloat2, Cdot, write_, Cdot, write_, Complex> tile(result_tmp, x, y, x, y, true,
+                                                                                     true); // last true is b/c A norm
       tile.apply(0);
 
       // do a single multi-node reduction only once we have computed all local dot products

--- a/lib/multigrid.cpp
+++ b/lib/multigrid.cpp
@@ -1011,7 +1011,7 @@ namespace quda
     vec_infile += std::to_string(param.level);
     vec_infile += "_nvec_";
     vec_infile += std::to_string(param.mg_global.n_vec[param.level]);
-    eig_solve->loadVectors(B, vec_infile);
+    EigenSolver::loadVectors(B, vec_infile);
     popLevel(param.level);
     profile_global.TPSTOP(QUDA_PROFILE_IO);
     profile_global.TPSTART(QUDA_PROFILE_INIT);
@@ -1027,7 +1027,7 @@ namespace quda
     vec_outfile += std::to_string(param.level);
     vec_outfile += "_nvec_";
     vec_outfile += std::to_string(param.mg_global.n_vec[param.level]);
-    eig_solve->saveVectors(B, vec_outfile);
+    EigenSolver::saveVectors(B, vec_outfile);
     popLevel(param.level);
     profile_global.TPSTOP(QUDA_PROFILE_IO);
     profile_global.TPSTART(QUDA_PROFILE_INIT);

--- a/lib/reduce_quda.cu
+++ b/lib/reduce_quda.cu
@@ -337,9 +337,7 @@ namespace quda {
       doubleN value;
       if (checkLocation(x, y, z, w, v) == QUDA_CUDA_FIELD_LOCATION) {
 
-        if (!x.isNative()
-            && !(x.Nspin() == 4 && x.FieldOrder() == QUDA_FLOAT2_FIELD_ORDER && x.Precision() == QUDA_SINGLE_PRECISION
-                || x.Nspin() == 4 && x.FieldOrder() == QUDA_FLOAT2_FIELD_ORDER && x.Precision() == QUDA_HALF_PRECISION)) {
+        if (!x.isNative() && x.FieldOrder() != QUDA_FLOAT2_FIELD_ORDER) {
           warningQuda("Device reductions on non-native fields is not supported\n");
           doubleN value;
           ::quda::zero(value);
@@ -391,7 +389,7 @@ namespace quda {
 #endif
           } else if (x.Nspin() == 1 || x.Nspin() == 2 || (x.Nspin() == 4 && x.FieldOrder() == QUDA_FLOAT2_FIELD_ORDER)) {
 #if defined(GPU_STAGGERED_DIRAC) || defined(GPU_MULTIGRID)
-            const int M = siteUnroll ? 3 : 1; // determines how much work per thread to do
+            const int M = siteUnroll ? 12 : 1; // determines how much work per thread to do
             if (x.Nspin() == 2 && siteUnroll) errorQuda("siteUnroll not supported for nSpin==2");
             value = nativeReduce<doubleN, ReduceType, float2, float2, float2, M, Reducer, writeX, writeY, writeZ,
                 writeW, writeV>(a, b, x, y, z, w, v, reduce_length / (2 * M));

--- a/lib/reduce_quda.cu
+++ b/lib/reduce_quda.cu
@@ -389,8 +389,8 @@ namespace quda {
 #endif
           } else if (x.Nspin() == 1 || x.Nspin() == 2 || (x.Nspin() == 4 && x.FieldOrder() == QUDA_FLOAT2_FIELD_ORDER)) {
 #if defined(GPU_STAGGERED_DIRAC) || defined(GPU_MULTIGRID)
-            const int M = siteUnroll ? 12 : 1; // determines how much work per thread to do
-            if (x.Nspin() == 2 && siteUnroll) errorQuda("siteUnroll not supported for nSpin==2");
+            const int M = siteUnroll ? 3 : 1; // determines how much work per thread to do
+            if ((x.Nspin() == 2 || x.Nspin() == 4) && siteUnroll) errorQuda("siteUnroll not supported here for nSpin=%d", x.Nspin());
             value = nativeReduce<doubleN, ReduceType, float2, float2, float2, M, Reducer, writeX, writeY, writeZ,
                 writeW, writeV>(a, b, x, y, z, w, v, reduce_length / (2 * M));
 #else

--- a/lib/reduce_quda.cu
+++ b/lib/reduce_quda.cu
@@ -457,7 +457,7 @@ namespace quda {
             const int M = 12; // determines how much work per thread to do
             value
               = nativeReduce<doubleN, ReduceType, float2, char2, char2, M, Reducer, writeX, writeY, writeZ, writeW, writeV>(
-                    a, b, x, y, z, w, v, y.Volume());
+                a, b, x, y, z, w, v, y.Volume());
 #else
             errorQuda("blas has not been built for Nspin=%d fields", x.Nspin());
 #endif

--- a/lib/reduce_quda.cu
+++ b/lib/reduce_quda.cu
@@ -443,7 +443,7 @@ namespace quda {
         } else if (x.Precision() == QUDA_QUARTER_PRECISION) { // quarter precision
 
 #if QUDA_PRECISION & 1
-          if (x.Nspin() == 4 && x.FieldOrder() == QUDA_FLOAT2_FIELD_ORDER) { // wilson
+          if (x.Nspin() == 4 && x.FieldOrder() == QUDA_FLOAT4_FIELD_ORDER) { // wilson
 #if defined(GPU_WILSON_DIRAC) || defined(GPU_DOMAIN_WALL_DIRAC) || defined(GPU_COVDEV)
             const int M = 6; // determines how much work per thread to do
             value

--- a/lib/reduce_quda.cu
+++ b/lib/reduce_quda.cu
@@ -443,11 +443,20 @@ namespace quda {
         } else if (x.Precision() == QUDA_QUARTER_PRECISION) { // quarter precision
 
 #if QUDA_PRECISION & 1
-          if (x.Nspin() == 4) { // wilson
+          if (x.Nspin() == 4 && x.FieldOrder() == QUDA_FLOAT2_FIELD_ORDER) { // wilson
 #if defined(GPU_WILSON_DIRAC) || defined(GPU_DOMAIN_WALL_DIRAC) || defined(GPU_COVDEV)
             const int M = 6; // determines how much work per thread to do
             value
                 = nativeReduce<doubleN, ReduceType, float4, char4, char4, M, Reducer, writeX, writeY, writeZ, writeW, writeV>(
+                    a, b, x, y, z, w, v, y.Volume());
+#else
+            errorQuda("blas has not been built for Nspin=%d fields", x.Nspin());
+#endif
+          } else if (x.Nspin() == 4 && x.FieldOrder() == QUDA_FLOAT2_FIELD_ORDER) { // wilson
+#if defined(GPU_MULTIGRID)
+            const int M = 12; // determines how much work per thread to do
+            value
+              = nativeReduce<doubleN, ReduceType, float2, char2, char2, M, Reducer, writeX, writeY, writeZ, writeW, writeV>(
                     a, b, x, y, z, w, v, y.Volume());
 #else
             errorQuda("blas has not been built for Nspin=%d fields", x.Nspin());

--- a/tests/blas_test.cu
+++ b/tests/blas_test.cu
@@ -122,11 +122,10 @@ const char *names[] = {"copyHS",
                        "reDotProduct_block",
                        "axpy_block"};
 
-bool is_multi(int kernel) {
-  return std::string(names[kernel]).find("_block") != std::string::npos ? true : false;
-}
+bool is_multi(int kernel) { return std::string(names[kernel]).find("_block") != std::string::npos ? true : false; }
 
-bool skip_kernel(int precision, int kernel, int order) {
+bool skip_kernel(int precision, int kernel, int order)
+{
   if ((QUDA_PRECISION & getPrecision(precision)) == 0) return true;
 
   // if we've selected a given kernel then make sure we only run that
@@ -156,7 +155,7 @@ bool skip_kernel(int precision, int kernel, int order) {
     // ordered nspin-4 fields in single precision and less, skip all other cases
     if (Nspin == 1 || Nspin == 2 || this_prec == QUDA_DOUBLE_PRECISION) {
       return true;
-    } else if (Nspin == 4 && prec < Nprec-1 && is_multi(kernel)) {
+    } else if (Nspin == 4 && prec < Nprec - 1 && is_multi(kernel)) {
       // we don't instantiate multi-blas kernels for float-2 nspin-4
       // fields, so skip these
       return true;
@@ -1096,20 +1095,22 @@ using ::testing::Values;
 using ::testing::Range;
 using ::testing::Combine;
 
-class BlasTest : public ::testing::TestWithParam<::testing::tuple<int, int, int>> {
+class BlasTest : public ::testing::TestWithParam<::testing::tuple<int, int, int>>
+{
 protected:
   ::testing::tuple<int, int, int> param;
   const int &prec;
   const int &kernel;
   const int &order;
 
- public:
+public:
   BlasTest() :
     param(GetParam()),
     prec(::testing::get<0>(param)),
     kernel(::testing::get<1>(param)),
     order(::testing::get<2>(param))
-      { }
+  {
+  }
   virtual ~BlasTest() { }
   virtual void SetUp() {
     if (!skip_kernel(prec, kernel, order)) initFields(prec, order);
@@ -1119,7 +1120,6 @@ protected:
     if (!skip_kernel(prec, kernel, order)) freeFields();
   }
 };
-
 
 TEST_P(BlasTest, verify) {
   int prec = ::testing::get<0>(GetParam());
@@ -1158,7 +1158,8 @@ TEST_P(BlasTest, benchmark) {
   printfQuda("%-31s: Gflop/s = %6.1f, GB/s = %6.1f\n", names[kernel], gflops, gbytes);
 }
 
-std::string getblasname(testing::TestParamInfo<::testing::tuple<int, int, int>> param){
+std::string getblasname(testing::TestParamInfo<::testing::tuple<int, int, int>> param)
+{
   int prec = ::testing::get<0>(param.param);
   int kernel = ::testing::get<1>(param.param);
   int order = ::testing::get<2>(param.param);


### PR DESCRIPTION
This is primarily a bugfix pull
* Fix SVD deflation what was broken by #855 
* Fix silent blas failure when using quarter-precision fields with float-2 ordering
* Add support for quarter precision to alternative reliable updates
* `EigenSolver` methods `loadVector` and `saveVector` should be static - fixes undefined behaviour from calling a method on a `nullptr`
* Robustness and cleanup of multi-blas framework.  Fixes an ASAN warning.