### PR TITLE
Fixed old hard-coded reconstructs in staggered_invert_test.

### DIFF
--- a/tests/staggered_eigensolve_test.cpp
+++ b/tests/staggered_eigensolve_test.cpp
@@ -361,6 +361,9 @@ void eigensolve_test()
   milc_fatlink = malloc(4 * V * gaugeSiteSize * gSize);
   milc_longlink = malloc(4 * V * gaugeSiteSize * gSize);
 
+  // for load, etc
+  gauge_param.reconstruct = QUDA_RECONSTRUCT_NO;
+
   // load a field WITHOUT PHASES
   if (strcmp(latfile, "")) {
     read_gauge_field(latfile, qdp_inlink, gauge_param.cpu_prec, gauge_param.X, argc_copy, argv_copy);
@@ -398,9 +401,7 @@ void eigensolve_test()
     }
 
     // Compute fat link plaquette.
-    gauge_param.reconstruct = QUDA_RECONSTRUCT_NO;
     computeStaggeredPlaquetteQDPOrder(qdp_fatlink, plaq, gauge_param, dslash_type);
-    gauge_param.reconstruct = link_recon;
 
     printfQuda("Computed fat link plaquette is %e (spatial = %e, temporal = %e)\n", plaq[0], plaq[1], plaq[2]);
   }

--- a/tests/staggered_eigensolve_test.cpp
+++ b/tests/staggered_eigensolve_test.cpp
@@ -398,7 +398,9 @@ void eigensolve_test()
     }
 
     // Compute fat link plaquette.
+    gauge_param.reconstruct = QUDA_RECONSTRUCT_NO;
     computeStaggeredPlaquetteQDPOrder(qdp_fatlink, plaq, gauge_param, dslash_type);
+    gauge_param.reconstruct = link_recon;
 
     printfQuda("Computed fat link plaquette is %e (spatial = %e, temporal = %e)\n", plaq[0], plaq[1], plaq[2]);
   }
@@ -453,11 +455,8 @@ void eigensolve_test()
     gauge_param.type = QUDA_ASQTAD_LONG_LINKS;
     gauge_param.ga_pad = link_pad;
     gauge_param.staggered_phase_type = QUDA_STAGGERED_PHASE_NO;
-    gauge_param.reconstruct
-      = (link_recon == QUDA_RECONSTRUCT_12 || link_recon == QUDA_RECONSTRUCT_8) ? QUDA_RECONSTRUCT_13 : link_recon;
-    gauge_param.reconstruct_sloppy
-      = (link_recon_sloppy == QUDA_RECONSTRUCT_12 || link_recon_sloppy == QUDA_RECONSTRUCT_8) ? QUDA_RECONSTRUCT_13 :
-                                                                                                link_recon_sloppy;
+    gauge_param.reconstruct = link_recon;
+    gauge_param.reconstruct_sloppy = link_recon_sloppy;
     gauge_param.cuda_prec_precondition = gauge_param.cuda_prec_sloppy;
     gauge_param.reconstruct_precondition = gauge_param.reconstruct_sloppy;
     loadGaugeQuda(milc_longlink, &gauge_param);

--- a/tests/staggered_gauge_utils.cpp
+++ b/tests/staggered_gauge_utils.cpp
@@ -300,10 +300,10 @@ void computeStaggeredPlaquetteQDPOrder(void** qdp_link, double plaq[3], const Qu
   gauge_param.cpu_prec = gauge_param_in.cpu_prec;
 
   gauge_param.cuda_prec = gauge_param_in.cuda_prec;
-  gauge_param.reconstruct = gauge_param_in.reconstruct; //QUDA_RECONSTRUCT_NO;
+  gauge_param.reconstruct = gauge_param_in.reconstruct;
 
   gauge_param.cuda_prec_sloppy = gauge_param_in.cuda_prec; // for ease of use
-  gauge_param.reconstruct_sloppy = gauge_param_in.reconstruct_sloppy; //QUDA_RECONSTRUCT_NO;
+  gauge_param.reconstruct_sloppy = gauge_param_in.reconstruct_sloppy;
 
   gauge_param.anisotropy = 1;
   gauge_param.gauge_fix = QUDA_GAUGE_FIXED_NO;

--- a/tests/staggered_gauge_utils.cpp
+++ b/tests/staggered_gauge_utils.cpp
@@ -300,10 +300,10 @@ void computeStaggeredPlaquetteQDPOrder(void** qdp_link, double plaq[3], const Qu
   gauge_param.cpu_prec = gauge_param_in.cpu_prec;
 
   gauge_param.cuda_prec = gauge_param_in.cuda_prec;
-  gauge_param.reconstruct = QUDA_RECONSTRUCT_NO;
+  gauge_param.reconstruct = gauge_param_in.reconstruct; //QUDA_RECONSTRUCT_NO;
 
   gauge_param.cuda_prec_sloppy = gauge_param_in.cuda_prec; // for ease of use
-  gauge_param.reconstruct_sloppy = QUDA_RECONSTRUCT_NO;
+  gauge_param.reconstruct_sloppy = gauge_param_in.reconstruct_sloppy; //QUDA_RECONSTRUCT_NO;
 
   gauge_param.anisotropy = 1;
   gauge_param.gauge_fix = QUDA_GAUGE_FIXED_NO;

--- a/tests/staggered_invert_test.cpp
+++ b/tests/staggered_invert_test.cpp
@@ -392,11 +392,8 @@ int invert_test()
     gauge_param.type = QUDA_ASQTAD_LONG_LINKS;
     gauge_param.ga_pad = link_pad;
     gauge_param.staggered_phase_type = QUDA_STAGGERED_PHASE_NO;
-    gauge_param.reconstruct
-      = (link_recon == QUDA_RECONSTRUCT_12 || link_recon == QUDA_RECONSTRUCT_8) ? QUDA_RECONSTRUCT_13 : link_recon;
-    gauge_param.reconstruct_sloppy
-      = (link_recon_sloppy == QUDA_RECONSTRUCT_12 || link_recon_sloppy == QUDA_RECONSTRUCT_8) ? QUDA_RECONSTRUCT_13 :
-                                                                                                link_recon_sloppy;
+    gauge_param.reconstruct = link_recon; 
+    gauge_param.reconstruct_sloppy = link_recon_sloppy; 
     gauge_param.cuda_prec_precondition = gauge_param.cuda_prec_sloppy;
     gauge_param.reconstruct_precondition = gauge_param.reconstruct_sloppy;
     loadGaugeQuda(milc_longlink, &gauge_param);

--- a/tests/staggered_invert_test.cpp
+++ b/tests/staggered_invert_test.cpp
@@ -304,8 +304,10 @@ int invert_test()
       }
     }
 
-    // Compute fat link plaquette.
+    // Compute fat link plaquette
+    gauge_param.reconstruct = QUDA_RECONSTRUCT_NO;
     computeStaggeredPlaquetteQDPOrder(qdp_fatlink, plaq, gauge_param, dslash_type);
+    gauge_param.reconstruct = link_recon;
 
     printfQuda("Computed fat link plaquette is %e (spatial = %e, temporal = %e)\n", plaq[0], plaq[1], plaq[2]);
   }

--- a/tests/staggered_invert_test.cpp
+++ b/tests/staggered_invert_test.cpp
@@ -266,6 +266,9 @@ int invert_test()
   milc_fatlink = malloc(4*V*gaugeSiteSize*gSize);
   milc_longlink = malloc(4 * V * gaugeSiteSize * gSize);
 
+  // for load, etc
+  gauge_param.reconstruct = QUDA_RECONSTRUCT_NO;
+
   // load a field WITHOUT PHASES
   if (strcmp(latfile, "")) {
     read_gauge_field(latfile, qdp_inlink, gauge_param.cpu_prec, gauge_param.X, argc_copy, argv_copy);
@@ -305,9 +308,7 @@ int invert_test()
     }
 
     // Compute fat link plaquette
-    gauge_param.reconstruct = QUDA_RECONSTRUCT_NO;
     computeStaggeredPlaquetteQDPOrder(qdp_fatlink, plaq, gauge_param, dslash_type);
-    gauge_param.reconstruct = link_recon;
 
     printfQuda("Computed fat link plaquette is %e (spatial = %e, temporal = %e)\n", plaq[0], plaq[1], plaq[2]);
   }


### PR DESCRIPTION
Removed a few hard codings of reconstruct values. Should be generally non-controversial. 