### PR TITLE
Feature/alias sloppy

### DIFF
--- a/include/color_spinor_field.h
+++ b/include/color_spinor_field.h
@@ -540,6 +540,16 @@ namespace quda {
     static ColorSpinorField* Create(const ColorSpinorField &src, const ColorSpinorParam &param);
 
     /**
+       @brief Create a field that aliases this field's storage.  The
+       alias field can use a different precision than this field,
+       though it cannot be greater.  This functionality is useful for
+       the case where we have multiple temporaries in different
+       precisions, but do not need them simultaneously.  Use this functionality with caution.
+       @param[in] param Parameters for the alias field
+    */
+    ColorSpinorField* CreateAlias(const ColorSpinorParam &param);
+
+    /**
        @brief Create a coarse color-spinor field, using this field to set the meta data
        @param[in] geoBlockSize Geometric block size that defines the coarse grid dimensions
        @param[in] spinlockSize Geometric block size that defines the coarse spin dimension

--- a/include/invert_quda.h
+++ b/include/invert_quda.h
@@ -838,9 +838,8 @@ namespace quda {
     bool init;
 
     ColorSpinorField *rp;       //! residual vector
-    ColorSpinorField *yp;       //! high precision accumulator
     ColorSpinorField *tmpp;     //! temporary for mat-vec
-    ColorSpinorField *y_sloppy; //! sloppy solution vector
+    ColorSpinorField *tmp_sloppy; //! temporary for sloppy mat-vec
     ColorSpinorField *r_sloppy; //! sloppy residual vector
 
     std::vector<ColorSpinorField*> p;  // GCR direction vectors

--- a/lib/color_spinor_field.cpp
+++ b/lib/color_spinor_field.cpp
@@ -777,6 +777,38 @@ namespace quda {
     return field;
   }
 
+  ColorSpinorField* ColorSpinorField::CreateAlias(const ColorSpinorParam &param_)
+  {
+    if (param_.Precision() > precision) errorQuda("Cannot create an alias to source with lower precision than the alias");
+    ColorSpinorParam param(param_);
+    param.create = QUDA_REFERENCE_FIELD_CREATE;
+    param.v = V();
+
+    // if norm field in the source exists, use it, else use the second
+    // half of main field for norm storage, ensuring that the start of
+    // the norm field is on an alignment boundary if we're using an
+    // internal field
+    if (param.Precision() < QUDA_SINGLE_PRECISION) {
+      auto norm_offset = (isNative() || fieldOrder == QUDA_FLOAT2_FIELD_ORDER) ?
+        (siteSubset == QUDA_FULL_SITE_SUBSET) ? 2*ALIGNMENT_ADJUST(Bytes()/4) : ALIGNMENT_ADJUST(Bytes()/2) : 0;
+      param.norm = Norm() ? Norm() : static_cast<char*>(V()) + norm_offset;
+    }
+
+    auto alias = ColorSpinorField::Create(param);
+
+    if (alias->Bytes() > Bytes()) errorQuda("Alias footprint %lu greater than source %lu", alias->Bytes(), Bytes());
+    if (alias->Precision() < QUDA_SINGLE_PRECISION) {
+      // check that norm does not overlap with body
+      if (static_cast<char*>(alias->V()) + alias->Bytes() > alias->Norm())
+        errorQuda("Overlap between alias body and norm");
+      // check that norm does fall off the end
+      if (static_cast<char*>(alias->Norm()) + alias->NormBytes() > static_cast<char*>(V()) + Bytes())
+        errorQuda("Norm is not contained in the srouce field");
+    }
+
+    return alias;
+  }
+
   ColorSpinorField* ColorSpinorField::CreateCoarse(const int *geoBlockSize, int spinBlockSize, int Nvec,
                                                    QudaPrecision new_precision, QudaFieldLocation new_location,
                                                    QudaMemoryType new_mem_type) {

--- a/lib/inv_ca_gcr.cpp
+++ b/lib/inv_ca_gcr.cpp
@@ -88,7 +88,7 @@ namespace quda {
       if (param.deflate && !deflate_init) { constructDeflationSpace(b, DiracMdagM(mat.Expose()), true); }
 
       //sloppy temporary for mat-vec
-      tmp_sloppy = mixed ? ColorSpinorField::Create(csParam) : nullptr;
+      tmp_sloppy = mixed ? tmpp->CreateAlias(csParam) : nullptr;
 
       if (!param.is_preconditioner) profile.TPSTOP(QUDA_PROFILE_INIT);
 

--- a/lib/inv_gcr_quda.cpp
+++ b/lib/inv_gcr_quda.cpp
@@ -143,8 +143,8 @@ namespace quda {
   }
 
   void updateSolution(ColorSpinorField &x, const Complex *alpha, Complex** const beta, 
-		      double *gamma, int k, std::vector<ColorSpinorField*> p) {
-
+		      double *gamma, int k, std::vector<ColorSpinorField*> p)
+  {
     Complex *delta = new Complex[k];
 
     // Update the solution vector
@@ -163,10 +163,8 @@ namespace quda {
   GCR::GCR(DiracMatrix &mat, DiracMatrix &matSloppy, DiracMatrix &matPrecon, SolverParam &param,
 	   TimeProfile &profile) :
     Solver(param, profile), mat(mat), matSloppy(matSloppy), matPrecon(matPrecon), K(0), Kparam(param),
-    nKrylov(param.Nkrylov), init(false),  rp(nullptr), yp(nullptr), tmpp(nullptr), y_sloppy(nullptr),
-    r_sloppy(nullptr)
+    nKrylov(param.Nkrylov), init(false),  rp(nullptr), tmpp(nullptr), tmp_sloppy(nullptr), r_sloppy(nullptr)
   {
-
     fillInnerSolveParam(Kparam, param);
 
     if (param.inv_type_precondition == QUDA_CG_INVERTER) // inner CG solver
@@ -196,8 +194,7 @@ namespace quda {
   GCR::GCR(DiracMatrix &mat, Solver &K, DiracMatrix &matSloppy, DiracMatrix &matPrecon, 
 	   SolverParam &param, TimeProfile &profile) :
     Solver(param, profile), mat(mat), matSloppy(matSloppy), matPrecon(matPrecon), K(&K), Kparam(param),
-    nKrylov(param.Nkrylov), init(false), rp(nullptr), yp(nullptr), tmpp(nullptr), y_sloppy(nullptr),
-    r_sloppy(nullptr)
+    nKrylov(param.Nkrylov), init(false),  rp(nullptr), tmpp(nullptr), tmp_sloppy(nullptr), r_sloppy(nullptr)
   {
     p.resize(nKrylov+1);
     Ap.resize(nKrylov);
@@ -217,17 +214,16 @@ namespace quda {
 
     if (K && param.inv_type_precondition != QUDA_MG_INVERTER) delete K;
 
-    if (init && param.precision_sloppy != yp->Precision()) {
-      if (y_sloppy && param.use_sloppy_partial_accumulator) delete y_sloppy;
+    if (init && param.precision_sloppy != tmpp->Precision()) {
       if (r_sloppy && r_sloppy != rp) delete r_sloppy;
     }
 
     for (int i=0; i<nKrylov+1; i++) if (p[i]) delete p[i];
     for (int i=0; i<nKrylov; i++) if (Ap[i]) delete Ap[i];
 
+    if (tmp_sloppy != tmpp) delete tmp_sloppy;
     if (tmpp) delete tmpp;
     if (rp) delete rp;
-    if (yp) delete yp;
 
     if (deflate_init) {
       for (auto veci : param.evecs)
@@ -254,8 +250,8 @@ namespace quda {
 
       rp = (K || x.Precision() != param.precision_sloppy) ? ColorSpinorField::Create(csParam) : nullptr;
 
-      // high precision accumulator
-      yp = ColorSpinorField::Create(csParam);
+      // high precision temporary
+      tmpp = ColorSpinorField::Create(csParam);
 
       // create sloppy fields used for orthogonalization
       csParam.setPrecision(param.precision_sloppy);
@@ -263,12 +259,10 @@ namespace quda {
       for (int i=0; i<nKrylov; i++) Ap[i] = ColorSpinorField::Create(csParam);
 
       csParam.setPrecision(param.precision_sloppy);
-      tmpp = ColorSpinorField::Create(csParam); //temporary for sloppy mat-vec
-
-      if (param.precision_sloppy != x.Precision() && param.use_sloppy_partial_accumulator) {
-        y_sloppy = ColorSpinorField::Create(csParam);
+      if (param.precision_sloppy != x.Precision()) {
+        tmp_sloppy = tmpp->CreateAlias(csParam);
       } else {
-        y_sloppy = yp;
+        tmp_sloppy = tmpp;
       }
 
       if (param.precision_sloppy != x.Precision()) {
@@ -286,9 +280,8 @@ namespace quda {
 
     ColorSpinorField &r = rp ? *rp : *p[0];
     ColorSpinorField &rSloppy = r_sloppy ? *r_sloppy : *p[0];
-    ColorSpinorField &y = *yp;
-    ColorSpinorField &ySloppy = *y_sloppy;
     ColorSpinorField &tmp = *tmpp;
+    ColorSpinorField &tmpSloppy = *tmp_sloppy;
 
     double b2 = blas::norm2(b);  // norm sq of source
     double r2;                // norm sq of residual
@@ -296,7 +289,7 @@ namespace quda {
     // compute initial residual depending on whether we have an initial guess or not
     if (param.use_init_guess == QUDA_USE_INIT_GUESS_YES) {
       // Compute r = b - A * x
-      mat(r, x, y);
+      mat(r, x, tmp);
       r2 = blas::xmyNorm(b, r);
       // x contains the original guess.
     } else {
@@ -322,9 +315,6 @@ namespace quda {
       // defl_tmp must be added to the solution at the end
       blas::axpy(1.0, *defl_tmp1[0], x);
     }
-
-    blas::zero(y); // FIXME optimize first updates of y and ySloppy
-    if (&y != &ySloppy) blas::zero(ySloppy);
 
     // Check to see that we're not trying to invert on a zero-field source
     if (b2 == 0) {
@@ -387,14 +377,11 @@ namespace quda {
 	pushVerbosity(param.verbosity_precondition);
 	(*K)(*p[k], rSloppy);
 	popVerbosity();
-
 	// relaxation p = omega*p + (1-omega)*r
 	//if (param.omega!=1.0) blas::axpby((1.0-param.omega), rPre, param.omega, pPre);
-      } else {
-        // no preconditioner
       }
 
-      matSloppy(*Ap[k], *p[k], tmp);
+      matSloppy(*Ap[k], *p[k], tmpSloppy);
 
       if (getVerbosity()>= QUDA_DEBUG_VERBOSE)
 	printfQuda("GCR debug iter=%d: Ap2=%e, p2=%e, r2=%e\n",
@@ -429,13 +416,10 @@ namespace quda {
       if (k==nKrylov || total_iter==param.maxiter || (r2 < stop && !l2_converge) || sqrt(r2/r2_old) < param.delta) {
 
         // update the solution vector
-        updateSolution(ySloppy, alpha, beta, gamma, k, p);
-
-        // recalculate residual in high precision
-        blas::xpy(ySloppy, x);
+        updateSolution(x, alpha, beta, gamma, k, p);
 
         if ( (r2 < stop || total_iter==param.maxiter) && param.sloppy_converge) break;
-        mat(r, x, y);
+        mat(r, x, tmp);
         r2 = blas::xmyNorm(b, r);  
 
         if (use_heavy_quark_res) heavy_quark_res = sqrt(blas::HeavyQuarkResidualNorm(x, r).z);
@@ -462,7 +446,6 @@ namespace quda {
 
           PrintStats("GCR (restart)", restart, r2, b2, heavy_quark_res);
           blas::copy(rSloppy, r);
-          blas::zero(ySloppy);
 
           r2_old = r2;
 
@@ -491,7 +474,7 @@ namespace quda {
 
     if (param.compute_true_res) {
       // Calculate the true residual
-      mat(r, x, y);
+      mat(r, x, tmp);
       double true_res = blas::xmyNorm(b, r);
       param.true_res = sqrt(true_res / b2);
       if (param.residual_type & QUDA_HEAVY_QUARK_RESIDUAL)


### PR DESCRIPTION
* Adds new method for allocating `ColorSpinorField` objects that alias to another's memory allocation, including in different precisions.  This allows us to reduce memory overhead when we require multiple concurrent temporaries in different precisions.
* Applied this optimization to GCR and CA-GCR.
* Some further cleanup and optimization of GCR to remove unneeded copy and zero calls