### PR TITLE
Hotfix/cast fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,10 +303,10 @@ set(CMAKE_CXX_FLAGS_HOSTDEBUG
     "${OpenMP_CXX_FLAGS} -Wall -Wno-unknown-pragmas -g -fno-inline -DHOST_DEBUG ${CLANG_FORCE_COLOR}"
     CACHE STRING "Flags used by the C++ compiler during host-debug builds.")
 set(CMAKE_CXX_FLAGS_DEVICEDEBUG
-    "${OpenMP_CXX_FLAGS} -Wall -Wno-unknown-pragmas ${CLANG_FORCE_COLOR}"
+    "${OpenMP_CXX_FLAGS} -Wall -Wno-unknown-pragmas -DDEVICE_DEBUG ${CLANG_FORCE_COLOR}"
     CACHE STRING "Flags used by the C++ compiler during device-debug builds.")
 set(CMAKE_CXX_FLAGS_DEBUG
-    "${OpenMP_CXX_FLAGS} -Wall -Wno-unknown-pragmas -g -fno-inline -DHOST_DEBUG ${CLANG_FORCE_COLOR}"
+    "${OpenMP_CXX_FLAGS} -Wall -Wno-unknown-pragmas -g -fno-inline -DHOST_DEBUG -DDEVICE_DEBUG ${CLANG_FORCE_COLOR}"
     CACHE STRING "Flags used by the C++ compiler during full (host+device) debug builds.")
 set(
   CMAKE_CXX_FLAGS_SANITIZE
@@ -324,9 +324,9 @@ set(CMAKE_C_FLAGS_RELEASE "-Wall -O3 -w" CACHE STRING "Flags used by the C compi
 set(CMAKE_C_FLAGS_HOSTDEBUG
     "-Wall -Wno-unknown-pragmas -g -fno-inline -DHOST_DEBUG"
     CACHE STRING "Flags used by the C compiler during host-debug builds.")
-set(CMAKE_C_FLAGS_DEVICEDEBUG "-Wall" CACHE STRING "Flags used by the C compiler during device-debug builds.")
+set(CMAKE_C_FLAGS_DEVICEDEBUG "-Wall -DDEVICE_DEBUG" CACHE STRING "Flags used by the C compiler during device-debug builds.")
 set(CMAKE_C_FLAGS_DEBUG
-    "-Wall -g -fno-inline -DHOST_DEBUG"
+    "-Wall -g -fno-inline -DHOST_DEBUG -DDEVICE_DEBUG"
     CACHE STRING "Flags used by the C compiler during full (host+device) debug builds.")
 set(CMAKE_C_FLAGS_SANITIZE
     "-Wall -g -fno-inline -DHOST_DEBUG -fsanitize=address,undefined"
@@ -818,10 +818,10 @@ set(CMAKE_CUDA_FLAGS_HOSTDEBUG
     "${QUDA_NVCC_FLAGS} -g -lineinfo -DHOST_DEBUG"
     CACHE STRING "Flags used by the C++ compiler during host-debug builds.")
 set(CMAKE_CUDA_FLAGS_DEVICEDEBUG
-    "${QUDA_NVCC_FLAGS} -G"
+    "${QUDA_NVCC_FLAGS} -G -DDEVICE_DEBUG"
     CACHE STRING "Flags used by the C++ compiler during device-debug builds.")
 set(CMAKE_CUDA_FLAGS_DEBUG
-    "${QUDA_NVCC_FLAGS} -g -DHOST_DEBUG -G"
+    "${QUDA_NVCC_FLAGS} -g -DHOST_DEBUG -DDEVICE_DEBUG -G"
     CACHE STRING "Flags used by the C++ compiler during full (host+device) debug builds.")
 set(CMAKE_CUDA_FLAGS_SANITIZE
     "${QUDA_NVCC_FLAGS} -g -lineinfo -DHOST_DEBUG -Xcompiler -fsanitize=address,-fsanitize=undefined"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -871,6 +871,11 @@ set(GITVERSION ${GITVERSION}-${QUDA_GPU_ARCH})
 string(REGEX REPLACE sm_ "" COMP_CAP ${QUDA_GPU_ARCH})
 set(COMP_CAP "${COMP_CAP}0")
 
+if(${CUDA_VERSION} STREQUAL "10.2")
+  set(CMAKE_CUDA_FLAGS
+      "${CMAKE_CUDA_FLAGS} -Xcicc \"--Xllc -dag-vectorize-ops=1\"")
+endif()
+
 # make the compiler flags an advanced option for all user defined build types (cmake defined build types are advanced by
 # default )
 mark_as_advanced(CMAKE_CUDA_FLAGS_DEVEL)

--- a/include/clover_field.h
+++ b/include/clover_field.h
@@ -115,7 +115,7 @@ namespace quda {
     /**
        @return Clover coefficient (usually includes kappa)
     */
-    bool Csw() const { return csw; }
+    double Csw() const { return csw; }
 
     /**
        @return If the clover field is associated with twisted-clover fermions

--- a/include/clover_field_order.h
+++ b/include/clover_field_order.h
@@ -7,18 +7,13 @@
  *
  */
 
-// trove requires the warp shuffle instructions introduced with Kepler
-#if __COMPUTE_CAPABILITY__ >= 300
-#include <trove/ptr.h>
-#else
-#define DISABLE_TROVE
-#endif
 #include <register_traits.h>
 #include <clover_field.h>
 #include <complex_quda.h>
 #include <thrust_helper.cuh>
 #include <quda_matrix.h>
 #include <color_spinor.h>
+#include <trove_helper.cuh>
 
 namespace quda {
 

--- a/include/clover_field_order.h
+++ b/include/clover_field_order.h
@@ -57,7 +57,7 @@ namespace quda {
       */
       template<typename C>
       __device__ __host__ inline void operator=(const C &a) {
-	field.save(a.data, x_cb, parity, chirality);
+        field.save(a.data, x_cb, parity, chirality);
       }
     };
 

--- a/include/clover_field_order.h
+++ b/include/clover_field_order.h
@@ -57,20 +57,20 @@ namespace quda {
       */
       template<typename C>
       __device__ __host__ inline void operator=(const C &a) {
-	field.save((Float*)a.data, x_cb, parity, chirality);
+	field.save(a.data, x_cb, parity, chirality);
       }
     };
 
   template <typename T, int N>
     template <typename S>
     __device__ __host__ inline void HMatrix<T,N>::operator=(const clover_wrapper<T,S> &a) {
-    a.field.load((T*)data, a.x_cb, a.parity, a.chirality);
+    a.field.load(data, a.x_cb, a.parity, a.chirality);
   }
 
   template <typename T, int N>
     template <typename S>
     __device__ __host__ inline HMatrix<T,N>::HMatrix(const clover_wrapper<T,S> &a) {
-    a.field.load((T*)data, a.x_cb, a.parity, a.chirality);
+    a.field.load(data, a.x_cb, a.parity, a.chirality);
   }
 
   namespace clover {

--- a/include/clover_field_order.h
+++ b/include/clover_field_order.h
@@ -414,8 +414,6 @@ namespace quda {
 	
 	CloverField& Field() { return A; }
 	
-	virtual ~FieldOrder() { ; } 
-    
     	/**
 	 * @brief Read-only complex-member accessor function
 	 *

--- a/include/color_spinor_field_order.h
+++ b/include/color_spinor_field_order.h
@@ -249,7 +249,8 @@ namespace quda {
     AccessorCB() : offset_cb(0) { }
     __device__ __host__ inline int index(int parity, int x_cb, int s, int c, int v) const
     {
-      return parity * offset_cb + ((x_cb * nSpin + s) * nColor + c) * nVec + v; }
+      return parity * offset_cb + ((x_cb * nSpin + s) * nColor + c) * nVec + v;
+    }
     };
 
     template<typename Float, int nSpin, int nColor, int nVec>
@@ -287,7 +288,8 @@ namespace quda {
     AccessorCB(): stride(0), offset_cb(0) { }
     __device__ __host__ inline int index(int parity, int x_cb, int s, int c, int v) const
     {
-      return parity * offset_cb + ((s * nColor + c) * nVec + v) * stride + x_cb; }
+      return parity * offset_cb + ((s * nColor + c) * nVec + v) * stride + x_cb;
+    }
     };
 
     template<typename Float, int nSpin, int nColor, int nVec>
@@ -317,7 +319,8 @@ namespace quda {
     AccessorCB() : stride(0), offset_cb(0) { }
     __device__ __host__ inline int index(int parity, int x_cb, int s, int c, int v) const
     {
-      return parity * offset_cb + indexFloatN<nSpin, nColor, nVec, 4>(x_cb, s, c, v, stride); }
+      return parity * offset_cb + indexFloatN<nSpin, nColor, nVec, 4>(x_cb, s, c, v, stride);
+    }
     };
 
     template<typename Float, int nSpin, int nColor, int nVec>
@@ -1126,7 +1129,7 @@ namespace quda {
 
     template <typename Float, int Ns, int Nc>
       struct SpaceColorSpinorOrder {
-        using Accessor = SpaceColorSpinorOrder<Float, Ns, Nc>;
+      using Accessor = SpaceColorSpinorOrder<Float, Ns, Nc>;
       using real = typename mapper<Float>::type;
       using complex = complex<real>;
       static const int length = 2 * Ns * Nc;

--- a/include/color_spinor_field_order.h
+++ b/include/color_spinor_field_order.h
@@ -1171,7 +1171,7 @@ namespace quda {
 #endif
   }
 
-  __device__ __host__ inline void save(const complex in[length / 2], int x, int parity = 0)
+  __device__ __host__ inline void save(const complex v[length / 2], int x, int parity = 0)
   {
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
     typedef S<Float,length> structure;

--- a/include/color_spinor_field_order.h
+++ b/include/color_spinor_field_order.h
@@ -12,8 +12,8 @@
  *  also.
  */
 
-// trove requires the warp shuffle instructions introduced with Kepler
-#if __COMPUTE_CAPABILITY__ >= 300
+// trove requires the warp shuffle instructions introduced with Kepler and has issues with device debug
+#if __COMPUTE_CAPABILITY__ >= 300 && !defined(DEVICE_DEBUG)
 #include <trove/ptr.h>
 #else
 #define DISABLE_TROVE

--- a/include/color_spinor_field_order.h
+++ b/include/color_spinor_field_order.h
@@ -12,12 +12,6 @@
  *  also.
  */
 
-// trove requires the warp shuffle instructions introduced with Kepler and has issues with device debug
-#if __COMPUTE_CAPABILITY__ >= 300 && !defined(DEVICE_DEBUG)
-#include <trove/ptr.h>
-#else
-#define DISABLE_TROVE
-#endif
 #include <register_traits.h>
 #include <typeinfo>
 #include <complex_quda.h>
@@ -25,6 +19,7 @@
 #include <color_spinor.h>
 #include <thrust_helper.cuh>
 #include <color_spinor_field.h>
+#include <trove_helper.cuh>
 
 namespace quda {
 

--- a/include/color_spinor_field_order.h
+++ b/include/color_spinor_field_order.h
@@ -63,10 +63,7 @@ namespace quda {
          @brief Assignment operator with ColorSpinor instance as input
          @param[in] C ColorSpinor we want to store in this accessor
       */
-      template<typename C>
-      __device__ __host__ inline void operator=(const C &a) {
-        field.save(a.data, x_cb, parity);
-      }
+      template <typename C> __device__ __host__ inline void operator=(const C &a) { field.save(a.data, x_cb, parity); }
     };
 
   template <typename T, int Nc, int Ns>
@@ -232,7 +229,7 @@ namespace quda {
       { return abs(scale * complex<Float>(x.real(), x.imag())); }
     };
 
-    template<typename Float, int nSpin, int nColor, int nVec, QudaFieldOrder order> struct AccessorCB {
+    template <typename Float, int nSpin, int nColor, int nVec, QudaFieldOrder order> struct AccessorCB {
       AccessorCB(const ColorSpinorField &) { errorQuda("Not implemented"); }
       AccessorCB() { errorQuda("Not implemented"); }
       __device__ __host__ inline int index(int parity, int x_cb, int s, int c, int v) const { return 0; }
@@ -245,13 +242,14 @@ namespace quda {
       { return 0; }
     };
 
-    template<typename Float, int nSpin, int nColor, int nVec>
-      struct AccessorCB<Float,nSpin,nColor,nVec,QUDA_SPACE_SPIN_COLOR_FIELD_ORDER> {
+    template <typename Float, int nSpin, int nColor, int nVec>
+    struct AccessorCB<Float, nSpin, nColor, nVec, QUDA_SPACE_SPIN_COLOR_FIELD_ORDER> {
       const int offset_cb;
     AccessorCB(const ColorSpinorField &field) : offset_cb((field.Bytes()>>1) / sizeof(complex<Float>)) { }
     AccessorCB() : offset_cb(0) { }
-      __device__ __host__ inline int index(int parity, int x_cb, int s, int c, int v) const
-      { return parity*offset_cb + ((x_cb*nSpin+s)*nColor+c)*nVec+v; }
+    __device__ __host__ inline int index(int parity, int x_cb, int s, int c, int v) const
+    {
+      return parity * offset_cb + ((x_cb * nSpin + s) * nColor + c) * nVec + v; }
     };
 
     template<typename Float, int nSpin, int nColor, int nVec>
@@ -277,15 +275,19 @@ namespace quda {
       return ((j*stride+x_cb)*N+i) / 2; // back to a complex offset
     };
 
-    template<typename Float, int nSpin, int nColor, int nVec>
-      struct AccessorCB<Float,nSpin,nColor,nVec,QUDA_FLOAT2_FIELD_ORDER> {
+    template <typename Float, int nSpin, int nColor, int nVec>
+    struct AccessorCB<Float, nSpin, nColor, nVec, QUDA_FLOAT2_FIELD_ORDER> {
       const int stride;
       const int offset_cb;
-    AccessorCB(const ColorSpinorField &field): stride(field.Stride()),
-	offset_cb((field.Bytes()>>1) / sizeof(complex<Float>)) { }
+      AccessorCB(const ColorSpinorField &field) :
+        stride(field.Stride()),
+        offset_cb((field.Bytes() >> 1) / sizeof(complex<Float>))
+      {
+      }
     AccessorCB(): stride(0), offset_cb(0) { }
-      __device__ __host__ inline int index(int parity, int x_cb, int s, int c, int v) const
-      { return parity*offset_cb + ((s*nColor+c)*nVec+v)*stride+x_cb; }
+    __device__ __host__ inline int index(int parity, int x_cb, int s, int c, int v) const
+    {
+      return parity * offset_cb + ((s * nColor + c) * nVec + v) * stride + x_cb; }
     };
 
     template<typename Float, int nSpin, int nColor, int nVec>
@@ -303,15 +305,19 @@ namespace quda {
       { return parity*ghostOffset[dim] + ((s*nColor+c)*nVec+v)*faceVolumeCB[dim] + x_cb; }
     };
 
-    template<typename Float, int nSpin, int nColor, int nVec>
-      struct AccessorCB<Float,nSpin,nColor,nVec,QUDA_FLOAT4_FIELD_ORDER> {
+    template <typename Float, int nSpin, int nColor, int nVec>
+    struct AccessorCB<Float, nSpin, nColor, nVec, QUDA_FLOAT4_FIELD_ORDER> {
       const int stride;
       const int offset_cb;
-    AccessorCB(const ColorSpinorField &field): stride(field.Stride()),
-	offset_cb((field.Bytes()>>1) / sizeof(complex<Float>)) { }
+      AccessorCB(const ColorSpinorField &field) :
+        stride(field.Stride()),
+        offset_cb((field.Bytes() >> 1) / sizeof(complex<Float>))
+      {
+      }
     AccessorCB() : stride(0), offset_cb(0) { }
-      __device__ __host__ inline int index(int parity, int x_cb, int s, int c, int v) const
-      { return parity*offset_cb + indexFloatN<nSpin,nColor,nVec,4>(x_cb, s, c, v, stride); }
+    __device__ __host__ inline int index(int parity, int x_cb, int s, int c, int v) const
+    {
+      return parity * offset_cb + indexFloatN<nSpin, nColor, nVec, 4>(x_cb, s, c, v, stride); }
     };
 
     template<typename Float, int nSpin, int nColor, int nVec>
@@ -876,7 +882,7 @@ namespace quda {
     }
   }
 
-  __device__ __host__ inline void load(complex out[length/2], int x, int parity=0) const
+  __device__ __host__ inline void load(complex out[length / 2], int x, int parity = 0) const
   {
     real v[length];
     norm_type nrm;
@@ -897,7 +903,7 @@ namespace quda {
         TexVector vecTmp = tex1Dfetch<TexVector>(tex, parity*tex_offset + stride*i + x);
         // now insert into output array
 #pragma unroll
-        for (int j = 0; j < N; j++) copy(v[i * N + j], reinterpret_cast<real*>(&vecTmp)[j]);
+        for (int j = 0; j < N; j++) copy(v[i * N + j], reinterpret_cast<real *>(&vecTmp)[j]);
         if (isFixed<Float>::value) {
 #pragma unroll
           for (int j = 0; j < N; j++) v[i * N + j] *= nrm;
@@ -914,16 +920,17 @@ namespace quda {
     }
 
 #pragma unroll
-    for (int i=0; i<length/2; i++) out[i] = complex(v[2*i+0], v[2*i+1]);
+    for (int i = 0; i < length / 2; i++) out[i] = complex(v[2 * i + 0], v[2 * i + 1]);
   }
 
-  __device__ __host__ inline void save(const complex in[length/2], int x, int parity=0) {
+  __device__ __host__ inline void save(const complex in[length / 2], int x, int parity = 0)
+  {
     real v[length];
 
 #pragma unroll
-    for (int i=0; i<length/2; i++) {
-      v[2*i+0] = in[i].real();
-      v[2*i+1] = in[i].imag();
+    for (int i = 0; i < length / 2; i++) {
+      v[2 * i + 0] = in[i].real();
+      v[2 * i + 1] = in[i].imag();
     }
 
     if (isFixed<Float>::value) {
@@ -942,7 +949,7 @@ namespace quda {
       real scale_inv = fixedMaxValue<Float>::value / scale;
 #endif
 #pragma unroll
-      for (int i=0; i<length; i++) v[i] = v[i] * scale_inv;
+      for (int i = 0; i < length; i++) v[i] = v[i] * scale_inv;
     }
 
 #pragma unroll
@@ -984,7 +991,7 @@ namespace quda {
     return colorspinor_wrapper<real, Accessor>(const_cast<Accessor &>(*this), x_cb, parity);
   }
 
-  __device__ __host__ inline void loadGhost(complex out[length_ghost/2], int x, int dim, int dir, int parity = 0) const
+  __device__ __host__ inline void loadGhost(complex out[length_ghost / 2], int x, int dim, int dir, int parity = 0) const
   {
     real v[length_ghost];
     norm_type nrm;
@@ -997,7 +1004,7 @@ namespace quda {
       if (!huge_alloc) {                                        // use textures unless we have a huge alloc
         TexVector vecTmp = tex1Dfetch<TexVector>(ghostTex, parity * tex_offset + stride * i + x);
 #pragma unroll
-        for (int j = 0; j < N; j++) copy(v[i * N + j], reinterpret_cast<real*>(&vecTmp)[j]);
+        for (int j = 0; j < N; j++) copy(v[i * N + j], reinterpret_cast<real *>(&vecTmp)[j]);
         if (isFixed<Float>::value) {
 #pragma unroll
           for (int i = 0; i < N; i++) v[i * N + j] *= nrm;
@@ -1013,16 +1020,17 @@ namespace quda {
     }
 
 #pragma unroll
-    for (int i=0; i<length_ghost/2; i++) out[i] = complex(v[2*i+0], v[2*i+1]);
+    for (int i = 0; i < length_ghost / 2; i++) out[i] = complex(v[2 * i + 0], v[2 * i + 1]);
   }
 
-  __device__ __host__ inline void saveGhost(const complex in[length_ghost/2], int x, int dim, int dir, int parity = 0) const
+  __device__ __host__ inline void saveGhost(const complex in[length_ghost / 2], int x, int dim, int dir,
+                                            int parity = 0) const
   {
     real v[length_ghost];
 #pragma unroll
     for (int i = 0; i < length_ghost; i++) {
-      v[i] = in[2*i + 0].real();
-      v[i] = in[2*i + 1].imag();
+      v[i] = in[2 * i + 0].real();
+      v[i] = in[2 * i + 1].imag();
     }
 
     if (isFixed<Float>::value) {
@@ -1066,8 +1074,7 @@ namespace quda {
      @return Instance of a colorspinor_ghost_wrapper that curries in access to
      this field at the above coordinates.
   */
-  __device__ __host__ inline colorspinor_ghost_wrapper<real, Accessor> Ghost(
-      int dim, int dir, int ghost_idx, int parity)
+  __device__ __host__ inline colorspinor_ghost_wrapper<real, Accessor> Ghost(int dim, int dir, int ghost_idx, int parity)
   {
     return colorspinor_ghost_wrapper<real, Accessor>(*this, dim, dir, ghost_idx, parity);
   }
@@ -1083,8 +1090,8 @@ namespace quda {
      @return Instance of a colorspinor_ghost+wrapper that curries in access to
      this field at the above coordinates.
   */
-  __device__ __host__ inline const colorspinor_ghost_wrapper<real, Accessor> Ghost(
-      int dim, int dir, int ghost_idx, int parity) const
+  __device__ __host__ inline const colorspinor_ghost_wrapper<real, Accessor> Ghost(int dim, int dir, int ghost_idx,
+                                                                                   int parity) const
   {
     return colorspinor_ghost_wrapper<real, Accessor>(const_cast<Accessor &>(*this), dim, dir, ghost_idx, parity);
   }
@@ -1125,16 +1132,16 @@ namespace quda {
 
     template <typename Float, int Ns, int Nc>
       struct SpaceColorSpinorOrder {
-        using real = typename mapper<Float>::type;
-        using complex = complex<real>;
-        static const int length = 2 * Ns * Nc;
-  Float *field;
-  size_t offset;
-  Float *ghost[8];
-  int volumeCB;
-  int faceVolumeCB[4];
-  int stride;
-  int nParity;
+      using real = typename mapper<Float>::type;
+      using complex = complex<real>;
+      static const int length = 2 * Ns * Nc;
+      Float *field;
+      size_t offset;
+      Float *ghost[8];
+      int volumeCB;
+      int faceVolumeCB[4];
+      int stride;
+      int nParity;
       SpaceColorSpinorOrder(const ColorSpinorField &a, int nFace=1, Float *field_=0, float *dummy=0, Float **ghost_=0)
       : field(field_ ? field_ : (Float*)a.V()), offset(a.Bytes()/(2*sizeof(Float))),
     volumeCB(a.VolumeCB()), stride(a.Stride()), nParity(a.SiteSubset())
@@ -1148,32 +1155,32 @@ namespace quda {
   }
   virtual ~SpaceColorSpinorOrder() { ; }
 
-  __device__ __host__ inline void load(complex v[length/2], int x, int parity=0) const {
+  __device__ __host__ inline void load(complex v[length / 2], int x, int parity = 0) const
+  {
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
     typedef S<Float,length> structure;
     trove::coalesced_ptr<structure> field_((structure*)field);
     structure v_ = field_[parity*volumeCB + x];
     for (int s=0; s<Ns; s++) {
-      for (int c=0; c<Nc; c++) {
-        v[s*Nc+c] = complex(v_.v[(c*Ns + s)*2 + 0], v_.v[(c*Ns + s)*2 + 1]);
-      }
+      for (int c = 0; c < Nc; c++) { v[s * Nc + c] = complex(v_.v[(c * Ns + s) * 2 + 0], v_.v[(c * Ns + s) * 2 + 1]); }
     }
 #else
     for (int s=0; s<Ns; s++) {
       for (int c=0; c<Nc; c++) {
-        v[s*Nc+c] = complex(field[parity*offset + ((x*Nc + c)*Ns + s)*2 + 0],
-                            field[parity*offset + ((x*Nc + c)*Ns + s)*2 + 1]);
+        v[s * Nc + c] = complex(field[parity * offset + ((x * Nc + c) * Ns + s) * 2 + 0],
+                                field[parity * offset + ((x * Nc + c) * Ns + s) * 2 + 1]);
       }
     }
 #endif
   }
 
-  __device__ __host__ inline void save(const complex in[length/2], int x, int parity=0) {
+  __device__ __host__ inline void save(const complex in[length / 2], int x, int parity = 0)
+  {
     real v[length];
 #pragma unroll
-    for (int i = 0; i < length/2; i++) {
-      v[i] = in[2*i + 0].real();
-      v[i] = in[2*i + 1].imag();
+    for (int i = 0; i < length / 2; i++) {
+      v[i] = in[2 * i + 0].real();
+      v[i] = in[2 * i + 1].imag();
     }
 
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
@@ -1208,9 +1215,10 @@ namespace quda {
      @return Instance of a colorspinor_wrapper that curries in access to
      this field at the above coordinates.
   */
-  __device__ __host__ inline colorspinor_wrapper<real,SpaceColorSpinorOrder<Float,Ns,Nc> >
-    operator()(int x_cb, int parity) {
-    return colorspinor_wrapper<real,SpaceColorSpinorOrder<Float,Ns,Nc> >(*this, x_cb, parity);
+  __device__ __host__ inline colorspinor_wrapper<real, SpaceColorSpinorOrder<Float, Ns, Nc>> operator()(int x_cb,
+                                                                                                        int parity)
+  {
+    return colorspinor_wrapper<real, SpaceColorSpinorOrder<Float, Ns, Nc>>(*this, x_cb, parity);
   }
 
   /**
@@ -1222,26 +1230,29 @@ namespace quda {
      @return Instance of a colorspinor_wrapper that curries in access to
      this field at the above coordinates.
   */
-        __device__ __host__ inline const colorspinor_wrapper<real,SpaceColorSpinorOrder<Float,Ns,Nc> >
-    operator()(int x_cb, int parity) const {
-    return colorspinor_wrapper<real,SpaceColorSpinorOrder<Float,Ns,Nc> >
-      (const_cast<SpaceColorSpinorOrder<Float,Ns,Nc>&>(*this), x_cb, parity);
+  __device__ __host__ inline const colorspinor_wrapper<real, SpaceColorSpinorOrder<Float, Ns, Nc>>
+  operator()(int x_cb, int parity) const
+  {
+    return colorspinor_wrapper<real, SpaceColorSpinorOrder<Float, Ns, Nc>>(
+      const_cast<SpaceColorSpinorOrder<Float, Ns, Nc> &>(*this), x_cb, parity);
   }
 
-  __device__ __host__ inline void loadGhost(complex v[length/2], int x, int dim, int dir, int parity=0) const {
+  __device__ __host__ inline void loadGhost(complex v[length / 2], int x, int dim, int dir, int parity = 0) const
+  {
     for (int s=0; s<Ns; s++) {
       for (int c=0; c<Nc; c++) {
-        v[s*Nc+c] = complex(ghost[2*dim+dir][(((parity*faceVolumeCB[dim]+x)*Nc + c)*Ns + s)*2 + 0],
-                            ghost[2*dim+dir][(((parity*faceVolumeCB[dim]+x)*Nc + c)*Ns + s)*2 + 1]);
+        v[s * Nc + c] = complex(ghost[2 * dim + dir][(((parity * faceVolumeCB[dim] + x) * Nc + c) * Ns + s) * 2 + 0],
+                                ghost[2 * dim + dir][(((parity * faceVolumeCB[dim] + x) * Nc + c) * Ns + s) * 2 + 1]);
       }
     }
   }
 
-  __device__ __host__ inline void saveGhost(const complex v[length/2], int x, int dim, int dir, int parity=0) {
+  __device__ __host__ inline void saveGhost(const complex v[length / 2], int x, int dim, int dir, int parity = 0)
+  {
     for (int s=0; s<Ns; s++) {
       for (int c=0; c<Nc; c++) {
-        ghost[2*dim+dir][(((parity*faceVolumeCB[dim]+x)*Nc + c)*Ns + s)*2 + 0] = v[s*Nc+c].real();
-        ghost[2*dim+dir][(((parity*faceVolumeCB[dim]+x)*Nc + c)*Ns + s)*2 + 1] = v[s*Nc+c].imag();
+        ghost[2 * dim + dir][(((parity * faceVolumeCB[dim] + x) * Nc + c) * Ns + s) * 2 + 0] = v[s * Nc + c].real();
+        ghost[2 * dim + dir][(((parity * faceVolumeCB[dim] + x) * Nc + c) * Ns + s) * 2 + 1] = v[s * Nc + c].imag();
       }
     }
   }
@@ -1251,16 +1262,16 @@ namespace quda {
 
     template <typename Float, int Ns, int Nc>
       struct SpaceSpinorColorOrder {
-        using real = typename mapper<Float>::type;
-        using complex = complex<real>;
-  static const int length = 2 * Ns * Nc;
-  Float *field;
-  size_t offset;
-  Float *ghost[8];
-  int volumeCB;
-  int faceVolumeCB[4];
-  int stride;
-  int nParity;
+      using real = typename mapper<Float>::type;
+      using complex = complex<real>;
+      static const int length = 2 * Ns * Nc;
+      Float *field;
+      size_t offset;
+      Float *ghost[8];
+      int volumeCB;
+      int faceVolumeCB[4];
+      int stride;
+      int nParity;
       SpaceSpinorColorOrder(const ColorSpinorField &a, int nFace=1, Float *field_=0, float *dummy=0, Float **ghost_=0)
       : field(field_ ? field_ : (Float*)a.V()), offset(a.Bytes()/(2*sizeof(Float))),
     volumeCB(a.VolumeCB()), stride(a.Stride()), nParity(a.SiteSubset())
@@ -1274,42 +1285,43 @@ namespace quda {
   }
   virtual ~SpaceSpinorColorOrder() { ; }
 
-  __device__ __host__ inline void load(complex v[length/2], int x, int parity=0) const {
+  __device__ __host__ inline void load(complex v[length / 2], int x, int parity = 0) const
+  {
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
     typedef S<Float,length> structure;
     trove::coalesced_ptr<structure> field_((structure*)field);
     structure v_ = field_[parity*volumeCB + x];
     for (int s=0; s<Ns; s++) {
-      for (int c=0; c<Nc; c++) {
-        v[s*Nc+c] = complex(v_.v[(s*Nc + c)*2 + 0], v_.v[(s*Nc + c)*2 + 1]);
-      }
+      for (int c = 0; c < Nc; c++) { v[s * Nc + c] = complex(v_.v[(s * Nc + c) * 2 + 0], v_.v[(s * Nc + c) * 2 + 1]); }
     }
 #else
     for (int s=0; s<Ns; s++) {
       for (int c=0; c<Nc; c++) {
-        v[s*Nc+c] = complex(field[parity*offset + ((x*Ns + s)*Nc + c)*2 + 0], field[parity*offset + ((x*Ns + s)*Nc + c)*2 + 1]);
+        v[s * Nc + c] = complex(field[parity * offset + ((x * Ns + s) * Nc + c) * 2 + 0],
+                                field[parity * offset + ((x * Ns + s) * Nc + c) * 2 + 1]);
       }
     }
 #endif
   }
 
-  __device__ __host__ inline void save(const complex v[length/2], int x, int parity=0) {
+  __device__ __host__ inline void save(const complex v[length / 2], int x, int parity = 0)
+  {
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
     typedef S<Float,length> structure;
     trove::coalesced_ptr<structure> field_((structure*)field);
     structure v_;
     for (int s=0; s<Ns; s++) {
       for (int c=0; c<Nc; c++) {
-        v_.v[(s*Nc + c)*2 + 0] = v[s*Nc+c].real();
-        v_.v[(s*Nc + c)*2 + 1] = v[s*Nc+c].imag();
+        v_.v[(s * Nc + c) * 2 + 0] = v[s * Nc + c].real();
+        v_.v[(s * Nc + c) * 2 + 1] = v[s * Nc + c].imag();
       }
     }
     field_[parity*volumeCB + x] = v_;
 #else
     for (int s=0; s<Ns; s++) {
       for (int c=0; c<Nc; c++) {
-        field[parity*offset + ((x*Ns + s)*Nc + c)*2 + 0] = v[s*Nc+c].real();
-        field[parity*offset + ((x*Ns + s)*Nc + c)*2 + 1] = v[s*Nc+c].imag();
+        field[parity * offset + ((x * Ns + s) * Nc + c) * 2 + 0] = v[s * Nc + c].real();
+        field[parity * offset + ((x * Ns + s) * Nc + c) * 2 + 1] = v[s * Nc + c].imag();
       }
     }
 #endif
@@ -1324,9 +1336,10 @@ namespace quda {
      @return Instance of a colorspinor_wrapper that curries in access to
      this field at the above coordinates.
   */
-  __device__ __host__ inline colorspinor_wrapper<real,SpaceSpinorColorOrder<Float,Ns,Nc> >
-    operator()(int x_cb, int parity) {
-    return colorspinor_wrapper<real,SpaceSpinorColorOrder<Float,Ns,Nc> >(*this, x_cb, parity);
+  __device__ __host__ inline colorspinor_wrapper<real, SpaceSpinorColorOrder<Float, Ns, Nc>> operator()(int x_cb,
+                                                                                                        int parity)
+  {
+    return colorspinor_wrapper<real, SpaceSpinorColorOrder<Float, Ns, Nc>>(*this, x_cb, parity);
   }
 
   /**
@@ -1338,26 +1351,29 @@ namespace quda {
      @return Instance of a colorspinor_wrapper that curries in access to
      this field at the above coordinates.
   */
-  __device__ __host__ inline const colorspinor_wrapper<real,SpaceSpinorColorOrder<Float,Ns,Nc> >
-    operator()(int x_cb, int parity) const {
-    return colorspinor_wrapper<real,SpaceSpinorColorOrder<Float,Ns,Nc> >
-      (const_cast<SpaceSpinorColorOrder<Float,Ns,Nc>&>(*this), x_cb, parity);
+  __device__ __host__ inline const colorspinor_wrapper<real, SpaceSpinorColorOrder<Float, Ns, Nc>>
+  operator()(int x_cb, int parity) const
+  {
+    return colorspinor_wrapper<real, SpaceSpinorColorOrder<Float, Ns, Nc>>(
+      const_cast<SpaceSpinorColorOrder<Float, Ns, Nc> &>(*this), x_cb, parity);
   }
 
-  __device__ __host__ inline void loadGhost(complex v[length/2], int x, int dim, int dir, int parity=0) const {
+  __device__ __host__ inline void loadGhost(complex v[length / 2], int x, int dim, int dir, int parity = 0) const
+  {
     for (int s=0; s<Ns; s++) {
       for (int c=0; c<Nc; c++) {
-        v[s*Nc+c] = complex(ghost[2*dim+dir][(((parity*faceVolumeCB[dim]+x)*Ns + s)*Nc + c)*2 + 0],
-                            ghost[2*dim+dir][(((parity*faceVolumeCB[dim]+x)*Ns + s)*Nc + c)*2 + 1]);
+        v[s * Nc + c] = complex(ghost[2 * dim + dir][(((parity * faceVolumeCB[dim] + x) * Ns + s) * Nc + c) * 2 + 0],
+                                ghost[2 * dim + dir][(((parity * faceVolumeCB[dim] + x) * Ns + s) * Nc + c) * 2 + 1]);
       }
     }
   }
 
-  __device__ __host__ inline void saveGhost(const complex v[length/2], int x, int dim, int dir, int parity=0) {
+  __device__ __host__ inline void saveGhost(const complex v[length / 2], int x, int dim, int dir, int parity = 0)
+  {
     for (int s=0; s<Ns; s++) {
       for (int c=0; c<Nc; c++) {
-        ghost[2*dim+dir][(((parity*faceVolumeCB[dim]+x)*Ns + s)*Nc + c)*2 + 0] = v[s*Nc+c].real();
-        ghost[2*dim+dir][(((parity*faceVolumeCB[dim]+x)*Ns + s)*Nc + c)*2 + 1] = v[s*Nc+c].imag();
+        ghost[2 * dim + dir][(((parity * faceVolumeCB[dim] + x) * Ns + s) * Nc + c) * 2 + 0] = v[s * Nc + c].real();
+        ghost[2 * dim + dir][(((parity * faceVolumeCB[dim] + x) * Ns + s) * Nc + c) * 2 + 1] = v[s * Nc + c].imag();
       }
     }
   }
@@ -1368,19 +1384,19 @@ namespace quda {
     // custom accessor for TIFR z-halo padded arrays
     template <typename Float, int Ns, int Nc>
       struct PaddedSpaceSpinorColorOrder {
-        using real = typename mapper<Float>::type;
-        using complex = complex<real>;
-        static const int length = 2 * Ns * Nc;
-        Float *field;
-        size_t offset;
-        Float *ghost[8];
-        int volumeCB;
-        int exVolumeCB;
-        int faceVolumeCB[4];
-        int stride;
-        int nParity;
-        int dim[4]; // full field dimensions
-        int exDim[4]; // full field dimensions
+      using real = typename mapper<Float>::type;
+      using complex = complex<real>;
+      static const int length = 2 * Ns * Nc;
+      Float *field;
+      size_t offset;
+      Float *ghost[8];
+      int volumeCB;
+      int exVolumeCB;
+      int faceVolumeCB[4];
+      int stride;
+      int nParity;
+      int dim[4];   // full field dimensions
+      int exDim[4]; // full field dimensions
       PaddedSpaceSpinorColorOrder(const ColorSpinorField &a, int nFace=1, Float *field_=0, float *dummy=0, Float **ghost_=0)
       : field(field_ ? field_ : (Float*)a.V()),
     volumeCB(a.VolumeCB()), exVolumeCB(1), stride(a.Stride()), nParity(a.SiteSubset()),
@@ -1415,7 +1431,8 @@ namespace quda {
     return linkIndex(coord, exDim);
   }
 
-  __device__ __host__ inline void load(complex v[length/2], int x, int parity=0) const {
+  __device__ __host__ inline void load(complex v[length / 2], int x, int parity = 0) const
+  {
     int y = getPaddedIndex(x, parity);
 
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
@@ -1423,21 +1440,19 @@ namespace quda {
     trove::coalesced_ptr<structure> field_((structure*)field);
     structure v_ = field_[parity*exVolumeCB + y];
     for (int s=0; s<Ns; s++) {
-      for (int c=0; c<Nc; c++) {
-        v[s*Nc+c] = complex(v_.v[(s*Nc + c)*2 + 0], v_.v[(s*Nc + c)*2 + 1]);
-      }
+      for (int c = 0; c < Nc; c++) { v[s * Nc + c] = complex(v_.v[(s * Nc + c) * 2 + 0], v_.v[(s * Nc + c) * 2 + 1]); }
     }
 #else
     for (int s=0; s<Ns; s++) {
       for (int c=0; c<Nc; c++) {
-        v[s*Nc+c] = complex(field[parity*offset + ((y*Ns + s)*Nc + c)*2 + 0],
-                            field[parity*offset + ((y*Ns + s)*Nc + c)*2 + 1]);
+        v[s * Nc + c] = complex(field[parity * offset + ((y * Ns + s) * Nc + c) * 2 + 0],
+                                field[parity * offset + ((y * Ns + s) * Nc + c) * 2 + 1]);
       }
     }
 #endif
   }
 
-  __device__ __host__ inline void save(const complex v[length/2], int x, int parity=0)
+  __device__ __host__ inline void save(const complex v[length / 2], int x, int parity = 0)
   {
     int y = getPaddedIndex(x, parity);
 
@@ -1447,16 +1462,16 @@ namespace quda {
     structure v_;
     for (int s=0; s<Ns; s++) {
       for (int c=0; c<Nc; c++) {
-        v_.v[(s*Nc + c)*2 + 0] = v[s*Nc+c].real();
-        v_.v[(s*Nc + c)*2 + 1] = v[s*Nc+c].imag();
+        v_.v[(s * Nc + c) * 2 + 0] = v[s * Nc + c].real();
+        v_.v[(s * Nc + c) * 2 + 1] = v[s * Nc + c].imag();
       }
     }
     field_[parity*exVolumeCB + y] = v_;
 #else
     for (int s=0; s<Ns; s++) {
       for (int c=0; c<Nc; c++) {
-        field[parity*offset + ((y*Ns + s)*Nc + c)*2 + 0] = v[s*Nc+c].real();
-        field[parity*offset + ((y*Ns + s)*Nc + c)*2 + 1] = v[s*Nc+c].imag();
+        field[parity * offset + ((y * Ns + s) * Nc + c) * 2 + 0] = v[s * Nc + c].real();
+        field[parity * offset + ((y * Ns + s) * Nc + c) * 2 + 1] = v[s * Nc + c].imag();
       }
     }
 #endif
@@ -1471,9 +1486,10 @@ namespace quda {
      @return Instance of a colorspinor_wrapper that curries in access to
      this field at the above coordinates.
   */
-  __device__ __host__ inline colorspinor_wrapper<real,PaddedSpaceSpinorColorOrder<Float,Ns,Nc> >
-    operator()(int x_cb, int parity) {
-    return colorspinor_wrapper<real,PaddedSpaceSpinorColorOrder<Float,Ns,Nc> >(*this, x_cb, parity);
+  __device__ __host__ inline colorspinor_wrapper<real, PaddedSpaceSpinorColorOrder<Float, Ns, Nc>> operator()(int x_cb,
+                                                                                                              int parity)
+  {
+    return colorspinor_wrapper<real, PaddedSpaceSpinorColorOrder<Float, Ns, Nc>>(*this, x_cb, parity);
   }
 
   /**
@@ -1485,26 +1501,29 @@ namespace quda {
      @return Instance of a colorspinor_wrapper that curries in access to
      this field at the above coordinates.
   */
-  __device__ __host__ inline const colorspinor_wrapper<real,PaddedSpaceSpinorColorOrder<Float,Ns,Nc> >
-    operator()(int x_cb, int parity) const {
-    return colorspinor_wrapper<real,PaddedSpaceSpinorColorOrder<Float,Ns,Nc> >
-      (const_cast<PaddedSpaceSpinorColorOrder<Float,Ns,Nc>&>(*this), x_cb, parity);
+  __device__ __host__ inline const colorspinor_wrapper<real, PaddedSpaceSpinorColorOrder<Float, Ns, Nc>>
+  operator()(int x_cb, int parity) const
+  {
+    return colorspinor_wrapper<real, PaddedSpaceSpinorColorOrder<Float, Ns, Nc>>(
+      const_cast<PaddedSpaceSpinorColorOrder<Float, Ns, Nc> &>(*this), x_cb, parity);
   }
 
-  __device__ __host__ inline void loadGhost(complex v[length/2], int x, int dim, int dir, int parity=0) const {
+  __device__ __host__ inline void loadGhost(complex v[length / 2], int x, int dim, int dir, int parity = 0) const
+  {
     for (int s=0; s<Ns; s++) {
       for (int c=0; c<Nc; c++) {
-        v[s*Nc+c] = complex(ghost[2*dim+dir][(((parity*faceVolumeCB[dim]+x)*Ns + s)*Nc + c)*2 + 0],
-                            ghost[2*dim+dir][(((parity*faceVolumeCB[dim]+x)*Ns + s)*Nc + c)*2 + 1]);
+        v[s * Nc + c] = complex(ghost[2 * dim + dir][(((parity * faceVolumeCB[dim] + x) * Ns + s) * Nc + c) * 2 + 0],
+                                ghost[2 * dim + dir][(((parity * faceVolumeCB[dim] + x) * Ns + s) * Nc + c) * 2 + 1]);
       }
     }
   }
 
-  __device__ __host__ inline void saveGhost(const complex v[length/2], int x, int dim, int dir, int parity=0) {
+  __device__ __host__ inline void saveGhost(const complex v[length / 2], int x, int dim, int dir, int parity = 0)
+  {
     for (int s=0; s<Ns; s++) {
       for (int c=0; c<Nc; c++) {
-        ghost[2*dim+dir][(((parity*faceVolumeCB[dim]+x)*Ns + s)*Nc + c)*2 + 0] = v[s*Nc+c].real();
-        ghost[2*dim+dir][(((parity*faceVolumeCB[dim]+x)*Ns + s)*Nc + c)*2 + 1] = v[s*Nc+c].imag();
+        ghost[2 * dim + dir][(((parity * faceVolumeCB[dim] + x) * Ns + s) * Nc + c) * 2 + 0] = v[s * Nc + c].real();
+        ghost[2 * dim + dir][(((parity * faceVolumeCB[dim] + x) * Ns + s) * Nc + c) * 2 + 1] = v[s * Nc + c].imag();
       }
     }
   }
@@ -1515,31 +1534,33 @@ namespace quda {
 
     template <typename Float, int Ns, int Nc>
       struct QDPJITDiracOrder {
-        using real = typename mapper<Float>::type;
-        using complex = complex<real>;
-        Float *field;
-        int volumeCB;
-        int stride;
-        int nParity;
+      using real = typename mapper<Float>::type;
+      using complex = complex<real>;
+      Float *field;
+      int volumeCB;
+      int stride;
+      int nParity;
       QDPJITDiracOrder(const ColorSpinorField &a, int nFace=1, Float *field_=0)
       : field(field_ ? field_ : (Float*)a.V()), volumeCB(a.VolumeCB()), stride(a.Stride()), nParity(a.SiteSubset())
   { if (volumeCB != a.Stride()) errorQuda("Stride must equal volume for this field order"); }
   virtual ~QDPJITDiracOrder() { ; }
 
-  __device__ __host__ inline void load(complex v[Ns*Nc], int x, int parity=0) const {
+  __device__ __host__ inline void load(complex v[Ns * Nc], int x, int parity = 0) const
+  {
     for (int s=0; s<Ns; s++) {
       for (int c=0; c<Nc; c++) {
-        v[s*Nc+c] = complex(field[(((0*Nc + c)*Ns + s)*2 + (1-parity))*volumeCB + x],
-                            field[(((1*Nc + c)*Ns + s)*2 + (1-parity))*volumeCB + x]);
+        v[s * Nc + c] = complex(field[(((0 * Nc + c) * Ns + s) * 2 + (1 - parity)) * volumeCB + x],
+                                field[(((1 * Nc + c) * Ns + s) * 2 + (1 - parity)) * volumeCB + x]);
       }
     }
   }
 
-  __device__ __host__ inline void save(const complex v[Ns*Nc], int x, int parity=0) {
+  __device__ __host__ inline void save(const complex v[Ns * Nc], int x, int parity = 0)
+  {
     for (int s=0; s<Ns; s++) {
       for (int c=0; c<Nc; c++) {
-        field[(((0*Nc + c)*Ns + s)*2 + (1-parity))*volumeCB + x] = v[s*Nc+c].real();
-        field[(((1*Nc + c)*Ns + s)*2 + (1-parity))*volumeCB + x] = v[s*Nc+c].imag();
+        field[(((0 * Nc + c) * Ns + s) * 2 + (1 - parity)) * volumeCB + x] = v[s * Nc + c].real();
+        field[(((1 * Nc + c) * Ns + s) * 2 + (1 - parity)) * volumeCB + x] = v[s * Nc + c].imag();
       }
     }
   }
@@ -1553,9 +1574,9 @@ namespace quda {
      @return Instance of a colorspinor_wrapper that curries in access to
      this field at the above coordinates.
   */
-  __device__ __host__ inline colorspinor_wrapper<real,QDPJITDiracOrder<Float,Ns,Nc> >
-    operator()(int x_cb, int parity) {
-    return colorspinor_wrapper<real,QDPJITDiracOrder<Float,Ns,Nc> >(*this, x_cb, parity);
+  __device__ __host__ inline colorspinor_wrapper<real, QDPJITDiracOrder<Float, Ns, Nc>> operator()(int x_cb, int parity)
+  {
+    return colorspinor_wrapper<real, QDPJITDiracOrder<Float, Ns, Nc>>(*this, x_cb, parity);
   }
 
   /**
@@ -1567,10 +1588,11 @@ namespace quda {
      @return Instance of a colorspinor_wrapper that curries in access to
      this field at the above coordinates.
   */
-  __device__ __host__ inline const colorspinor_wrapper<real,QDPJITDiracOrder<Float,Ns,Nc> >
-    operator()(int x_cb, int parity) const {
-    return colorspinor_wrapper<real,QDPJITDiracOrder<Float,Ns,Nc> >
-      (const_cast<QDPJITDiracOrder<Float,Ns,Nc>&>(*this), x_cb, parity);
+  __device__ __host__ inline const colorspinor_wrapper<real, QDPJITDiracOrder<Float, Ns, Nc>> operator()(int x_cb,
+                                                                                                         int parity) const
+  {
+    return colorspinor_wrapper<real, QDPJITDiracOrder<Float, Ns, Nc>>(
+      const_cast<QDPJITDiracOrder<Float, Ns, Nc> &>(*this), x_cb, parity);
   }
 
   size_t Bytes() const { return nParity * volumeCB * Nc * Ns * 2 * sizeof(Float); }

--- a/include/color_spinor_field_order.h
+++ b/include/color_spinor_field_order.h
@@ -1173,31 +1173,22 @@ namespace quda {
 
   __device__ __host__ inline void save(const complex in[length / 2], int x, int parity = 0)
   {
-    real v[length];
-#pragma unroll
-    for (int i = 0; i < length / 2; i++) {
-      v[i] = in[2 * i + 0].real();
-      v[i] = in[2 * i + 1].imag();
-    }
-
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
     typedef S<Float,length> structure;
     trove::coalesced_ptr<structure> field_((structure*)field);
     structure v_;
     for (int s=0; s<Ns; s++) {
       for (int c=0; c<Nc; c++) {
-        for (int z=0; z<2; z++) {
-          v_.v[(c*Ns + s)*2 + z] = (Float)v[(s*Nc+c)*2+z];
-        }
+        v_.v[(c*Ns + s)*2 + 0] = (Float)v[s*Nc+c].real();
+        v_.v[(c*Ns + s)*2 + 1] = (Float)v[s*Nc+c].imag();
       }
     }
     field_[parity*volumeCB + x] = v_;
 #else
     for (int s=0; s<Ns; s++) {
       for (int c=0; c<Nc; c++) {
-        for (int z=0; z<2; z++) {
-          field[parity*offset + ((x*Nc + c)*Ns + s)*2 + z] = v[(s*Nc+c)*2+z];
-        }
+        field[parity*offset + ((x*Nc + c)*Ns + s)*2 + 0] = v[s*Nc+c].real();
+        field[parity*offset + ((x*Nc + c)*Ns + s)*2 + 1] = v[s*Nc+c].imag();
       }
     }
 #endif

--- a/include/color_spinor_field_order.h
+++ b/include/color_spinor_field_order.h
@@ -4,7 +4,7 @@
 /**
  * @file color_spinor_field_order.h
  *
- * @section DESCRIPTION 
+ * @section DESCRIPTION
  *
  * Define functors to allow for generic accessors regardless of field
  * ordering.  Currently this is used for cpu fields only with limited
@@ -65,44 +65,44 @@ namespace quda {
       */
       template<typename C>
       __device__ __host__ inline void operator=(const C &a) {
-        field.save((Float *)a.data, x_cb, parity);
+        field.save(a.data, x_cb, parity);
       }
     };
 
   template <typename T, int Nc, int Ns>
     template <typename S>
     __device__ __host__ inline void ColorSpinor<T,Nc,Ns>::operator=(const colorspinor_wrapper<T,S> &a) {
-    a.field.load((T*)data, a.x_cb, a.parity);
+    a.field.load(data, a.x_cb, a.parity);
   }
 
   template <typename T, int Nc, int Ns>
     template <typename S>
     __device__ __host__ inline ColorSpinor<T,Nc,Ns>::ColorSpinor(const colorspinor_wrapper<T,S> &a) {
-    a.field.load((T*)data, a.x_cb, a.parity);
+    a.field.load(data, a.x_cb, a.parity);
   }
 
   template <typename T, int Nc>
     template <typename S>
     __device__ __host__ inline void ColorSpinor<T,Nc,2>::operator=(const colorspinor_wrapper<T,S> &a) {
-    a.field.load((T*)data, a.x_cb, a.parity);
+    a.field.load(data, a.x_cb, a.parity);
   }
 
   template <typename T, int Nc>
     template <typename S>
     __device__ __host__ inline ColorSpinor<T,Nc,2>::ColorSpinor(const colorspinor_wrapper<T,S> &a) {
-    a.field.load((T*)data, a.x_cb, a.parity);
+    a.field.load(data, a.x_cb, a.parity);
   }
 
   template <typename T, int Nc>
     template <typename S>
     __device__ __host__ inline void ColorSpinor<T,Nc,4>::operator=(const colorspinor_wrapper<T,S> &a) {
-    a.field.load((T*)data, a.x_cb, a.parity);
+    a.field.load(data, a.x_cb, a.parity);
   }
 
   template <typename T, int Nc>
     template <typename S>
     __device__ __host__ inline ColorSpinor<T,Nc,4>::ColorSpinor(const colorspinor_wrapper<T,S> &a) {
-    a.field.load((T*)data, a.x_cb, a.parity);
+    a.field.load(data, a.x_cb, a.parity);
   }
 
   /**
@@ -149,46 +149,46 @@ namespace quda {
       */
       template<typename C>
       __device__ __host__ inline void operator=(const C &a) {
-        field.saveGhost((Float *)a.data, ghost_idx, dim, dir, parity);
+        field.saveGhost(a.data, ghost_idx, dim, dir, parity);
       }
     };
 
   template <typename T, int Nc, int Ns>
     template <typename S>
     __device__ __host__ inline void ColorSpinor<T,Nc,Ns>::operator=(const colorspinor_ghost_wrapper<T,S> &a) {
-    a.field.loadGhost((T*)data, a.ghost_idx, a.dim, a.dir, a.parity);
+    a.field.loadGhost(data, a.ghost_idx, a.dim, a.dir, a.parity);
   }
 
   template <typename T, int Nc, int Ns>
     template <typename S>
     __device__ __host__ inline ColorSpinor<T,Nc,Ns>::ColorSpinor(const colorspinor_ghost_wrapper<T,S> &a) {
-    a.field.loadGhost((T*)data, a.ghost_idx, a.dim, a.dir, a.parity);
+    a.field.loadGhost(data, a.ghost_idx, a.dim, a.dir, a.parity);
   }
 
   template <typename T, int Nc>
   template <typename S>
   __device__ __host__ inline void ColorSpinor<T, Nc, 2>::operator=(const colorspinor_ghost_wrapper<T, S> &a)
   {
-    a.field.loadGhost((T *)data, a.ghost_idx, a.dim, a.dir, a.parity);
+    a.field.loadGhost(data, a.ghost_idx, a.dim, a.dir, a.parity);
   }
 
   template <typename T, int Nc>
   template <typename S>
   __device__ __host__ inline ColorSpinor<T, Nc, 2>::ColorSpinor(const colorspinor_ghost_wrapper<T, S> &a)
   {
-    a.field.loadGhost((T *)data, a.ghost_idx, a.dim, a.dir, a.parity);
+    a.field.loadGhost(data, a.ghost_idx, a.dim, a.dir, a.parity);
   }
 
   template <typename T, int Nc>
     template <typename S>
     __device__ __host__ inline void ColorSpinor<T,Nc,4>::operator=(const colorspinor_ghost_wrapper<T,S> &a) {
-    a.field.loadGhost((T*)data, a.ghost_idx, a.dim, a.dir, a.parity);
+    a.field.loadGhost(data, a.ghost_idx, a.dim, a.dir, a.parity);
   }
 
   template <typename T, int Nc>
     template <typename S>
     __device__ __host__ inline ColorSpinor<T,Nc,4>::ColorSpinor(const colorspinor_ghost_wrapper<T,S> &a) {
-    a.field.loadGhost((T*)data, a.ghost_idx, a.dim, a.dir, a.parity);
+    a.field.loadGhost(data, a.ghost_idx, a.dim, a.dir, a.parity);
   }
 
   namespace colorspinor {
@@ -232,7 +232,7 @@ namespace quda {
       { return abs(scale * complex<Float>(x.real(), x.imag())); }
     };
 
-    template<typename Float, int nSpin, int nColor, int nVec, QudaFieldOrder order> struct AccessorCB { 
+    template<typename Float, int nSpin, int nColor, int nVec, QudaFieldOrder order> struct AccessorCB {
       AccessorCB(const ColorSpinorField &) { errorQuda("Not implemented"); }
       AccessorCB() { errorQuda("Not implemented"); }
       __device__ __host__ inline int index(int parity, int x_cb, int s, int c, int v) const { return 0; }
@@ -245,12 +245,12 @@ namespace quda {
       { return 0; }
     };
 
-    template<typename Float, int nSpin, int nColor, int nVec> 
-      struct AccessorCB<Float,nSpin,nColor,nVec,QUDA_SPACE_SPIN_COLOR_FIELD_ORDER> { 
+    template<typename Float, int nSpin, int nColor, int nVec>
+      struct AccessorCB<Float,nSpin,nColor,nVec,QUDA_SPACE_SPIN_COLOR_FIELD_ORDER> {
       const int offset_cb;
     AccessorCB(const ColorSpinorField &field) : offset_cb((field.Bytes()>>1) / sizeof(complex<Float>)) { }
     AccessorCB() : offset_cb(0) { }
-      __device__ __host__ inline int index(int parity, int x_cb, int s, int c, int v) const 
+      __device__ __host__ inline int index(int parity, int x_cb, int s, int c, int v) const
       { return parity*offset_cb + ((x_cb*nSpin+s)*nColor+c)*nVec+v; }
     };
 
@@ -273,18 +273,18 @@ namespace quda {
       __device__ __host__ inline int indexFloatN(int x_cb, int s, int c, int v, int stride) {
       int k = ((s*nColor+c)*nVec+v)*2; // factor of two for complexity
       int j = k / N; // factor of two for complexity
-      int i = k % N;      
+      int i = k % N;
       return ((j*stride+x_cb)*N+i) / 2; // back to a complex offset
     };
 
-    template<typename Float, int nSpin, int nColor, int nVec> 
-      struct AccessorCB<Float,nSpin,nColor,nVec,QUDA_FLOAT2_FIELD_ORDER> { 
+    template<typename Float, int nSpin, int nColor, int nVec>
+      struct AccessorCB<Float,nSpin,nColor,nVec,QUDA_FLOAT2_FIELD_ORDER> {
       const int stride;
       const int offset_cb;
-    AccessorCB(const ColorSpinorField &field): stride(field.Stride()), 
+    AccessorCB(const ColorSpinorField &field): stride(field.Stride()),
 	offset_cb((field.Bytes()>>1) / sizeof(complex<Float>)) { }
     AccessorCB(): stride(0), offset_cb(0) { }
-      __device__ __host__ inline int index(int parity, int x_cb, int s, int c, int v) const 
+      __device__ __host__ inline int index(int parity, int x_cb, int s, int c, int v) const
       { return parity*offset_cb + ((s*nColor+c)*nVec+v)*stride+x_cb; }
     };
 
@@ -303,14 +303,14 @@ namespace quda {
       { return parity*ghostOffset[dim] + ((s*nColor+c)*nVec+v)*faceVolumeCB[dim] + x_cb; }
     };
 
-    template<typename Float, int nSpin, int nColor, int nVec> 
-      struct AccessorCB<Float,nSpin,nColor,nVec,QUDA_FLOAT4_FIELD_ORDER> { 
+    template<typename Float, int nSpin, int nColor, int nVec>
+      struct AccessorCB<Float,nSpin,nColor,nVec,QUDA_FLOAT4_FIELD_ORDER> {
       const int stride;
       const int offset_cb;
-    AccessorCB(const ColorSpinorField &field): stride(field.Stride()), 
+    AccessorCB(const ColorSpinorField &field): stride(field.Stride()),
 	offset_cb((field.Bytes()>>1) / sizeof(complex<Float>)) { }
     AccessorCB() : stride(0), offset_cb(0) { }
-      __device__ __host__ inline int index(int parity, int x_cb, int s, int c, int v) const 
+      __device__ __host__ inline int index(int parity, int x_cb, int s, int c, int v) const
       { return parity*offset_cb + indexFloatN<nSpin,nColor,nVec,4>(x_cb, s, c, v, stride); }
     };
 
@@ -797,9 +797,10 @@ namespace quda {
     template <typename Float, int Ns, int Nc, int N, bool spin_project = false, bool huge_alloc = false>
     struct FloatNOrder {
       using Accessor = FloatNOrder<Float, Ns, Nc, N, spin_project, huge_alloc>;
-      typedef typename mapper<Float>::type RegType;
+      using real = typename mapper<Float>::type;
+      using complex = complex<real>;
       typedef typename VectorType<Float, N>::type Vector;
-      typedef typename VectorType<RegType, N>::type RegVector;
+      typedef typename VectorType<real, N>::type RegVector;
       typedef typename AllocType<huge_alloc>::type AllocInt;
       typedef float norm_type;
       static constexpr int length = 2 * Ns * Nc;
@@ -811,7 +812,7 @@ namespace quda {
       const AllocInt offset; // offset can be 32-bit or 64-bit
       const AllocInt norm_offset;
 #ifdef USE_TEXTURE_OBJECTS
-      typedef typename TexVectorType<RegType, N>::type TexVector;
+      typedef typename TexVectorType<real, N>::type TexVector;
       cudaTextureObject_t tex;
       cudaTextureObject_t texNorm;
       const int tex_offset;
@@ -875,8 +876,9 @@ namespace quda {
     }
   }
 
-  __device__ __host__ inline void load(RegType v[length], int x, int parity=0) const {
-
+  __device__ __host__ inline void load(complex out[length/2], int x, int parity=0) const
+  {
+    real v[length];
     norm_type nrm;
     if (isFixed<Float>::value) {
 #if defined(USE_TEXTURE_OBJECTS) && defined(__CUDA_ARCH__)
@@ -895,7 +897,7 @@ namespace quda {
         TexVector vecTmp = tex1Dfetch<TexVector>(tex, parity*tex_offset + stride*i + x);
         // now insert into output array
 #pragma unroll
-        for (int j = 0; j < N; j++) copy(v[i * N + j], reinterpret_cast<RegType *>(&vecTmp)[j]);
+        for (int j = 0; j < N; j++) copy(v[i * N + j], reinterpret_cast<real*>(&vecTmp)[j]);
         if (isFixed<Float>::value) {
 #pragma unroll
           for (int j = 0; j < N; j++) v[i * N + j] *= nrm;
@@ -911,10 +913,18 @@ namespace quda {
       }
     }
 
+#pragma unroll
+    for (int i=0; i<length/2; i++) out[i] = complex(v[2*i+0], v[2*i+1]);
   }
 
-  __device__ __host__ inline void save(const RegType v[length], int x, int parity=0) {
-    RegType tmp[length];
+  __device__ __host__ inline void save(const complex in[length/2], int x, int parity=0) {
+    real v[length];
+
+#pragma unroll
+    for (int i=0; i<length/2; i++) {
+      v[2*i+0] = in[i].real();
+      v[2*i+1] = in[i].imag();
+    }
 
     if (isFixed<Float>::value) {
       norm_type max_[length / 2];
@@ -927,15 +937,12 @@ namespace quda {
       norm[x+parity*norm_offset] = scale;
 
 #ifdef __CUDA_ARCH__
-      RegType scale_inv = __fdividef(fixedMaxValue<Float>::value, scale);
+      real scale_inv = __fdividef(fixedMaxValue<Float>::value, scale);
 #else
-      RegType scale_inv = fixedMaxValue<Float>::value / scale;
+      real scale_inv = fixedMaxValue<Float>::value / scale;
 #endif
 #pragma unroll
-      for (int i=0; i<length; i++) tmp[i] = v[i] * scale_inv;
-    } else {
-#pragma unroll
-      for (int i=0; i<length; i++) tmp[i] = v[i];
+      for (int i=0; i<length; i++) v[i] = v[i] * scale_inv;
     }
 
 #pragma unroll
@@ -943,7 +950,7 @@ namespace quda {
       Vector vecTmp;
       // first do scalar copy converting into storage type
 #pragma unroll
-      for (int j = 0; j < N; j++) copy_scaled(reinterpret_cast<Float *>(&vecTmp)[j], tmp[i * N + j]);
+      for (int j = 0; j < N; j++) copy_scaled(reinterpret_cast<Float *>(&vecTmp)[j], v[i * N + j]);
       // second do vectorized copy into memory
       vector_store(field + parity*offset, x + stride*i, vecTmp);
     }
@@ -958,9 +965,9 @@ namespace quda {
      @return Instance of a colorspinor_wrapper that curries in access to
      this field at the above coordinates.
   */
-  __device__ __host__ inline colorspinor_wrapper<RegType, Accessor> operator()(int x_cb, int parity)
+  __device__ __host__ inline colorspinor_wrapper<real, Accessor> operator()(int x_cb, int parity)
   {
-    return colorspinor_wrapper<RegType, Accessor>(*this, x_cb, parity);
+    return colorspinor_wrapper<real, Accessor>(*this, x_cb, parity);
   }
 
   /**
@@ -972,14 +979,14 @@ namespace quda {
      @return Instance of a colorspinor_wrapper that curries in access to
      this field at the above coordinates.
   */
-  __device__ __host__ inline const colorspinor_wrapper<RegType, Accessor> operator()(int x_cb, int parity) const
+  __device__ __host__ inline const colorspinor_wrapper<real, Accessor> operator()(int x_cb, int parity) const
   {
-    return colorspinor_wrapper<RegType, Accessor>(const_cast<Accessor &>(*this), x_cb, parity);
+    return colorspinor_wrapper<real, Accessor>(const_cast<Accessor &>(*this), x_cb, parity);
   }
 
-  __device__ __host__ inline void loadGhost(RegType v[length_ghost], int x, int dim, int dir, int parity = 0) const
+  __device__ __host__ inline void loadGhost(complex out[length_ghost/2], int x, int dim, int dir, int parity = 0) const
   {
-
+    real v[length_ghost];
     norm_type nrm;
     if (isFixed<Float>::value) { nrm = ghost_norm[2 * dim + dir][parity * faceVolumeCB[dim] + x]; }
 
@@ -990,7 +997,7 @@ namespace quda {
       if (!huge_alloc) {                                        // use textures unless we have a huge alloc
         TexVector vecTmp = tex1Dfetch<TexVector>(ghostTex, parity * tex_offset + stride * i + x);
 #pragma unroll
-        for (int j = 0; j < N; j++) copy(v[i * N + j], reinterpret_cast<RegType *>(&vecTmp)[j]);
+        for (int j = 0; j < N; j++) copy(v[i * N + j], reinterpret_cast<real*>(&vecTmp)[j]);
         if (isFixed<Float>::value) {
 #pragma unroll
           for (int i = 0; i < N; i++) v[i * N + j] *= nrm;
@@ -1004,11 +1011,19 @@ namespace quda {
         for (int j = 0; j < N; j++) copy_and_scale(v[i * N + j], reinterpret_cast<Float *>(&vecTmp)[j], nrm);
       }
     }
+
+#pragma unroll
+    for (int i=0; i<length_ghost/2; i++) out[i] = complex(v[2*i+0], v[2*i+1]);
   }
 
-  __device__ __host__ inline void saveGhost(RegType v[length_ghost], int x, int dim, int dir, int parity = 0) const
+  __device__ __host__ inline void saveGhost(const complex in[length_ghost/2], int x, int dim, int dir, int parity = 0) const
   {
-    RegType tmp[length_ghost];
+    real v[length_ghost];
+#pragma unroll
+    for (int i = 0; i < length_ghost; i++) {
+      v[i] = in[2*i + 0].real();
+      v[i] = in[2*i + 1].imag();
+    }
 
     if (isFixed<Float>::value) {
       norm_type max_[length_ghost / 2];
@@ -1022,15 +1037,12 @@ namespace quda {
       ghost_norm[2 * dim + dir][parity * faceVolumeCB[dim] + x] = scale;
 
 #ifdef __CUDA_ARCH__
-      RegType scale_inv = __fdividef(fixedMaxValue<Float>::value, scale);
+      real scale_inv = __fdividef(fixedMaxValue<Float>::value, scale);
 #else
-      RegType scale_inv = fixedMaxValue<Float>::value / scale;
+      real scale_inv = fixedMaxValue<Float>::value / scale;
 #endif
 #pragma unroll
-      for (int i = 0; i < length_ghost; i++) tmp[i] = v[i] * scale_inv;
-    } else {
-#pragma unroll
-      for (int i = 0; i < length_ghost; i++) tmp[i] = v[i];
+      for (int i = 0; i < length_ghost; i++) v[i] = v[i] * scale_inv;
     }
 
 #pragma unroll
@@ -1038,7 +1050,7 @@ namespace quda {
       Vector vecTmp;
       // first do scalar copy converting into storage type
 #pragma unroll
-      for (int j = 0; j < N; j++) copy_scaled(reinterpret_cast<Float *>(&vecTmp)[j], tmp[i * N + j]);
+      for (int j = 0; j < N; j++) copy_scaled(reinterpret_cast<Float *>(&vecTmp)[j], v[i * N + j]);
       // second do vectorized copy into memory
       vector_store(ghost[2 * dim + dir] + parity * faceVolumeCB[dim] * M_ghost * N, i * faceVolumeCB[dim] + x, vecTmp);
     }
@@ -1054,10 +1066,10 @@ namespace quda {
      @return Instance of a colorspinor_ghost_wrapper that curries in access to
      this field at the above coordinates.
   */
-  __device__ __host__ inline colorspinor_ghost_wrapper<RegType, Accessor> Ghost(
+  __device__ __host__ inline colorspinor_ghost_wrapper<real, Accessor> Ghost(
       int dim, int dir, int ghost_idx, int parity)
   {
-    return colorspinor_ghost_wrapper<RegType, Accessor>(*this, dim, dir, ghost_idx, parity);
+    return colorspinor_ghost_wrapper<real, Accessor>(*this, dim, dir, ghost_idx, parity);
   }
 
   /**
@@ -1071,10 +1083,10 @@ namespace quda {
      @return Instance of a colorspinor_ghost+wrapper that curries in access to
      this field at the above coordinates.
   */
-  __device__ __host__ inline const colorspinor_ghost_wrapper<RegType, Accessor> Ghost(
+  __device__ __host__ inline const colorspinor_ghost_wrapper<real, Accessor> Ghost(
       int dim, int dir, int ghost_idx, int parity) const
   {
-    return colorspinor_ghost_wrapper<RegType, Accessor>(const_cast<Accessor &>(*this), dim, dir, ghost_idx, parity);
+    return colorspinor_ghost_wrapper<real, Accessor>(const_cast<Accessor &>(*this), dim, dir, ghost_idx, parity);
   }
 
   /**
@@ -1113,8 +1125,9 @@ namespace quda {
 
     template <typename Float, int Ns, int Nc>
       struct SpaceColorSpinorOrder {
-  typedef typename mapper<Float>::type RegType;
-  static const int length = 2 * Ns * Nc;
+        using real = typename mapper<Float>::type;
+        using complex = complex<real>;
+        static const int length = 2 * Ns * Nc;
   Float *field;
   size_t offset;
   Float *ghost[8];
@@ -1135,30 +1148,34 @@ namespace quda {
   }
   virtual ~SpaceColorSpinorOrder() { ; }
 
-  __device__ __host__ inline void load(RegType v[length], int x, int parity=0) const {
+  __device__ __host__ inline void load(complex v[length/2], int x, int parity=0) const {
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
     typedef S<Float,length> structure;
     trove::coalesced_ptr<structure> field_((structure*)field);
     structure v_ = field_[parity*volumeCB + x];
     for (int s=0; s<Ns; s++) {
       for (int c=0; c<Nc; c++) {
-        for (int z=0; z<2; z++) {
-    v[(s*Nc+c)*2+z] = (RegType)v_.v[(c*Ns + s)*2 + z];
-        }
+        v[s*Nc+c] = complex(v_.v[(c*Ns + s)*2 + 0], v_.v[(c*Ns + s)*2 + 1]);
       }
     }
 #else
     for (int s=0; s<Ns; s++) {
       for (int c=0; c<Nc; c++) {
-        for (int z=0; z<2; z++) {
-    v[(s*Nc+c)*2+z] = field[parity*offset + ((x*Nc + c)*Ns + s)*2 + z];
-        }
+        v[s*Nc+c] = complex(field[parity*offset + ((x*Nc + c)*Ns + s)*2 + 0],
+                            field[parity*offset + ((x*Nc + c)*Ns + s)*2 + 1]);
       }
     }
 #endif
   }
 
-  __device__ __host__ inline void save(const RegType v[length], int x, int parity=0) {
+  __device__ __host__ inline void save(const complex in[length/2], int x, int parity=0) {
+    real v[length];
+#pragma unroll
+    for (int i = 0; i < length/2; i++) {
+      v[i] = in[2*i + 0].real();
+      v[i] = in[2*i + 1].imag();
+    }
+
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
     typedef S<Float,length> structure;
     trove::coalesced_ptr<structure> field_((structure*)field);
@@ -1191,9 +1208,9 @@ namespace quda {
      @return Instance of a colorspinor_wrapper that curries in access to
      this field at the above coordinates.
   */
-  __device__ __host__ inline colorspinor_wrapper<RegType,SpaceColorSpinorOrder<Float,Ns,Nc> >
+  __device__ __host__ inline colorspinor_wrapper<real,SpaceColorSpinorOrder<Float,Ns,Nc> >
     operator()(int x_cb, int parity) {
-    return colorspinor_wrapper<RegType,SpaceColorSpinorOrder<Float,Ns,Nc> >(*this, x_cb, parity);
+    return colorspinor_wrapper<real,SpaceColorSpinorOrder<Float,Ns,Nc> >(*this, x_cb, parity);
   }
 
   /**
@@ -1205,28 +1222,26 @@ namespace quda {
      @return Instance of a colorspinor_wrapper that curries in access to
      this field at the above coordinates.
   */
-  __device__ __host__ inline const colorspinor_wrapper<RegType,SpaceColorSpinorOrder<Float,Ns,Nc> >
+        __device__ __host__ inline const colorspinor_wrapper<real,SpaceColorSpinorOrder<Float,Ns,Nc> >
     operator()(int x_cb, int parity) const {
-    return colorspinor_wrapper<RegType,SpaceColorSpinorOrder<Float,Ns,Nc> >
+    return colorspinor_wrapper<real,SpaceColorSpinorOrder<Float,Ns,Nc> >
       (const_cast<SpaceColorSpinorOrder<Float,Ns,Nc>&>(*this), x_cb, parity);
   }
 
-  __device__ __host__ inline void loadGhost(RegType v[length], int x, int dim, int dir, int parity=0) const {
+  __device__ __host__ inline void loadGhost(complex v[length/2], int x, int dim, int dir, int parity=0) const {
     for (int s=0; s<Ns; s++) {
       for (int c=0; c<Nc; c++) {
-        for (int z=0; z<2; z++) {
-          v[(s*Nc+c)*2+z] = ghost[2*dim+dir][(((parity*faceVolumeCB[dim]+x)*Nc + c)*Ns + s)*2 + z];
-        }
+        v[s*Nc+c] = complex(ghost[2*dim+dir][(((parity*faceVolumeCB[dim]+x)*Nc + c)*Ns + s)*2 + 0],
+                            ghost[2*dim+dir][(((parity*faceVolumeCB[dim]+x)*Nc + c)*Ns + s)*2 + 1]);
       }
     }
   }
 
-  __device__ __host__ inline void saveGhost(const RegType v[length], int x, int dim, int dir, int parity=0) {
+  __device__ __host__ inline void saveGhost(const complex v[length/2], int x, int dim, int dir, int parity=0) {
     for (int s=0; s<Ns; s++) {
       for (int c=0; c<Nc; c++) {
-        for (int z=0; z<2; z++) {
-          ghost[2*dim+dir][(((parity*faceVolumeCB[dim]+x)*Nc + c)*Ns + s)*2 + z] = v[(s*Nc+c)*2+z];
-        }
+        ghost[2*dim+dir][(((parity*faceVolumeCB[dim]+x)*Nc + c)*Ns + s)*2 + 0] = v[s*Nc+c].real();
+        ghost[2*dim+dir][(((parity*faceVolumeCB[dim]+x)*Nc + c)*Ns + s)*2 + 1] = v[s*Nc+c].imag();
       }
     }
   }
@@ -1236,7 +1251,8 @@ namespace quda {
 
     template <typename Float, int Ns, int Nc>
       struct SpaceSpinorColorOrder {
-  typedef typename mapper<Float>::type RegType;
+        using real = typename mapper<Float>::type;
+        using complex = complex<real>;
   static const int length = 2 * Ns * Nc;
   Float *field;
   size_t offset;
@@ -1258,48 +1274,42 @@ namespace quda {
   }
   virtual ~SpaceSpinorColorOrder() { ; }
 
-  __device__ __host__ inline void load(RegType v[length], int x, int parity=0) const {
+  __device__ __host__ inline void load(complex v[length/2], int x, int parity=0) const {
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
     typedef S<Float,length> structure;
     trove::coalesced_ptr<structure> field_((structure*)field);
     structure v_ = field_[parity*volumeCB + x];
     for (int s=0; s<Ns; s++) {
       for (int c=0; c<Nc; c++) {
-        for (int z=0; z<2; z++) {
-          v[(s*Nc+c)*2+z] = (RegType)v_.v[(s*Nc + c)*2 + z];
-        }
+        v[s*Nc+c] = complex(v_.v[(s*Nc + c)*2 + 0], v_.v[(s*Nc + c)*2 + 1]);
       }
     }
 #else
     for (int s=0; s<Ns; s++) {
       for (int c=0; c<Nc; c++) {
-        for (int z=0; z<2; z++) {
-          v[(s*Nc+c)*2+z] = field[parity*offset + ((x*Ns + s)*Nc + c)*2 + z];
-        }
+        v[s*Nc+c] = complex(field[parity*offset + ((x*Ns + s)*Nc + c)*2 + 0], field[parity*offset + ((x*Ns + s)*Nc + c)*2 + 1]);
       }
     }
 #endif
   }
 
-  __device__ __host__ inline void save(const RegType v[length], int x, int parity=0) {
+  __device__ __host__ inline void save(const complex v[length/2], int x, int parity=0) {
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
     typedef S<Float,length> structure;
     trove::coalesced_ptr<structure> field_((structure*)field);
     structure v_;
     for (int s=0; s<Ns; s++) {
       for (int c=0; c<Nc; c++) {
-        for (int z=0; z<2; z++) {
-          v_.v[(s*Nc + c)*2 + z] = (Float)v[(s*Nc+c)*2+z];
-        }
+        v_.v[(s*Nc + c)*2 + 0] = v[s*Nc+c].real();
+        v_.v[(s*Nc + c)*2 + 1] = v[s*Nc+c].imag();
       }
     }
     field_[parity*volumeCB + x] = v_;
 #else
     for (int s=0; s<Ns; s++) {
       for (int c=0; c<Nc; c++) {
-        for (int z=0; z<2; z++) {
-          field[parity*offset + ((x*Ns + s)*Nc + c)*2 + z] = v[(s*Nc+c)*2+z];
-        }
+        field[parity*offset + ((x*Ns + s)*Nc + c)*2 + 0] = v[s*Nc+c].real();
+        field[parity*offset + ((x*Ns + s)*Nc + c)*2 + 1] = v[s*Nc+c].imag();
       }
     }
 #endif
@@ -1314,9 +1324,9 @@ namespace quda {
      @return Instance of a colorspinor_wrapper that curries in access to
      this field at the above coordinates.
   */
-  __device__ __host__ inline colorspinor_wrapper<RegType,SpaceSpinorColorOrder<Float,Ns,Nc> >
+  __device__ __host__ inline colorspinor_wrapper<real,SpaceSpinorColorOrder<Float,Ns,Nc> >
     operator()(int x_cb, int parity) {
-    return colorspinor_wrapper<RegType,SpaceSpinorColorOrder<Float,Ns,Nc> >(*this, x_cb, parity);
+    return colorspinor_wrapper<real,SpaceSpinorColorOrder<Float,Ns,Nc> >(*this, x_cb, parity);
   }
 
   /**
@@ -1328,28 +1338,26 @@ namespace quda {
      @return Instance of a colorspinor_wrapper that curries in access to
      this field at the above coordinates.
   */
-  __device__ __host__ inline const colorspinor_wrapper<RegType,SpaceSpinorColorOrder<Float,Ns,Nc> >
+  __device__ __host__ inline const colorspinor_wrapper<real,SpaceSpinorColorOrder<Float,Ns,Nc> >
     operator()(int x_cb, int parity) const {
-    return colorspinor_wrapper<RegType,SpaceSpinorColorOrder<Float,Ns,Nc> >
+    return colorspinor_wrapper<real,SpaceSpinorColorOrder<Float,Ns,Nc> >
       (const_cast<SpaceSpinorColorOrder<Float,Ns,Nc>&>(*this), x_cb, parity);
   }
 
-  __device__ __host__ inline void loadGhost(RegType v[length], int x, int dim, int dir, int parity=0) const {
+  __device__ __host__ inline void loadGhost(complex v[length/2], int x, int dim, int dir, int parity=0) const {
     for (int s=0; s<Ns; s++) {
       for (int c=0; c<Nc; c++) {
-        for (int z=0; z<2; z++) {
-          v[(s*Nc+c)*2+z] = ghost[2*dim+dir][(((parity*faceVolumeCB[dim]+x)*Ns + s)*Nc + c)*2 + z];
-        }
+        v[s*Nc+c] = complex(ghost[2*dim+dir][(((parity*faceVolumeCB[dim]+x)*Ns + s)*Nc + c)*2 + 0],
+                            ghost[2*dim+dir][(((parity*faceVolumeCB[dim]+x)*Ns + s)*Nc + c)*2 + 1]);
       }
     }
   }
 
-  __device__ __host__ inline void saveGhost(const RegType v[length], int x, int dim, int dir, int parity=0) {
+  __device__ __host__ inline void saveGhost(const complex v[length/2], int x, int dim, int dir, int parity=0) {
     for (int s=0; s<Ns; s++) {
       for (int c=0; c<Nc; c++) {
-        for (int z=0; z<2; z++) {
-          ghost[2*dim+dir][(((parity*faceVolumeCB[dim]+x)*Ns + s)*Nc + c)*2 + z] = v[(s*Nc+c)*2+z];
-        }
+        ghost[2*dim+dir][(((parity*faceVolumeCB[dim]+x)*Ns + s)*Nc + c)*2 + 0] = v[s*Nc+c].real();
+        ghost[2*dim+dir][(((parity*faceVolumeCB[dim]+x)*Ns + s)*Nc + c)*2 + 1] = v[s*Nc+c].imag();
       }
     }
   }
@@ -1360,18 +1368,19 @@ namespace quda {
     // custom accessor for TIFR z-halo padded arrays
     template <typename Float, int Ns, int Nc>
       struct PaddedSpaceSpinorColorOrder {
-  typedef typename mapper<Float>::type RegType;
-  static const int length = 2 * Ns * Nc;
-  Float *field;
-  size_t offset;
-  Float *ghost[8];
-  int volumeCB;
-  int exVolumeCB;
-  int faceVolumeCB[4];
-  int stride;
-  int nParity;
-  int dim[4]; // full field dimensions
-  int exDim[4]; // full field dimensions
+        using real = typename mapper<Float>::type;
+        using complex = complex<real>;
+        static const int length = 2 * Ns * Nc;
+        Float *field;
+        size_t offset;
+        Float *ghost[8];
+        int volumeCB;
+        int exVolumeCB;
+        int faceVolumeCB[4];
+        int stride;
+        int nParity;
+        int dim[4]; // full field dimensions
+        int exDim[4]; // full field dimensions
       PaddedSpaceSpinorColorOrder(const ColorSpinorField &a, int nFace=1, Float *field_=0, float *dummy=0, Float **ghost_=0)
       : field(field_ ? field_ : (Float*)a.V()),
     volumeCB(a.VolumeCB()), exVolumeCB(1), stride(a.Stride()), nParity(a.SiteSubset()),
@@ -1406,7 +1415,7 @@ namespace quda {
     return linkIndex(coord, exDim);
   }
 
-  __device__ __host__ inline void load(RegType v[length], int x, int parity=0) const {
+  __device__ __host__ inline void load(complex v[length/2], int x, int parity=0) const {
     int y = getPaddedIndex(x, parity);
 
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
@@ -1415,23 +1424,21 @@ namespace quda {
     structure v_ = field_[parity*exVolumeCB + y];
     for (int s=0; s<Ns; s++) {
       for (int c=0; c<Nc; c++) {
-        for (int z=0; z<2; z++) {
-          v[(s*Nc+c)*2+z] = (RegType)v_.v[(s*Nc + c)*2 + z];
-        }
+        v[s*Nc+c] = complex(v_.v[(s*Nc + c)*2 + 0], v_.v[(s*Nc + c)*2 + 1]);
       }
     }
 #else
     for (int s=0; s<Ns; s++) {
       for (int c=0; c<Nc; c++) {
-        for (int z=0; z<2; z++) {
-          v[(s*Nc+c)*2+z] = field[parity*offset + ((y*Ns + s)*Nc + c)*2 + z];
-        }
+        v[s*Nc+c] = complex(field[parity*offset + ((y*Ns + s)*Nc + c)*2 + 0],
+                            field[parity*offset + ((y*Ns + s)*Nc + c)*2 + 1]);
       }
     }
 #endif
   }
 
-  __device__ __host__ inline void save(const RegType v[length], int x, int parity=0) {
+  __device__ __host__ inline void save(const complex v[length/2], int x, int parity=0)
+  {
     int y = getPaddedIndex(x, parity);
 
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
@@ -1440,18 +1447,16 @@ namespace quda {
     structure v_;
     for (int s=0; s<Ns; s++) {
       for (int c=0; c<Nc; c++) {
-        for (int z=0; z<2; z++) {
-          v_.v[(s*Nc + c)*2 + z] = (Float)v[(s*Nc+c)*2+z];
-        }
+        v_.v[(s*Nc + c)*2 + 0] = v[s*Nc+c].real();
+        v_.v[(s*Nc + c)*2 + 1] = v[s*Nc+c].imag();
       }
     }
     field_[parity*exVolumeCB + y] = v_;
 #else
     for (int s=0; s<Ns; s++) {
       for (int c=0; c<Nc; c++) {
-        for (int z=0; z<2; z++) {
-          field[parity*offset + ((y*Ns + s)*Nc + c)*2 + z] = v[(s*Nc+c)*2+z];
-        }
+        field[parity*offset + ((y*Ns + s)*Nc + c)*2 + 0] = v[s*Nc+c].real();
+        field[parity*offset + ((y*Ns + s)*Nc + c)*2 + 1] = v[s*Nc+c].imag();
       }
     }
 #endif
@@ -1466,9 +1471,9 @@ namespace quda {
      @return Instance of a colorspinor_wrapper that curries in access to
      this field at the above coordinates.
   */
-  __device__ __host__ inline colorspinor_wrapper<RegType,PaddedSpaceSpinorColorOrder<Float,Ns,Nc> >
+  __device__ __host__ inline colorspinor_wrapper<real,PaddedSpaceSpinorColorOrder<Float,Ns,Nc> >
     operator()(int x_cb, int parity) {
-    return colorspinor_wrapper<RegType,PaddedSpaceSpinorColorOrder<Float,Ns,Nc> >(*this, x_cb, parity);
+    return colorspinor_wrapper<real,PaddedSpaceSpinorColorOrder<Float,Ns,Nc> >(*this, x_cb, parity);
   }
 
   /**
@@ -1480,28 +1485,26 @@ namespace quda {
      @return Instance of a colorspinor_wrapper that curries in access to
      this field at the above coordinates.
   */
-  __device__ __host__ inline const colorspinor_wrapper<RegType,PaddedSpaceSpinorColorOrder<Float,Ns,Nc> >
+  __device__ __host__ inline const colorspinor_wrapper<real,PaddedSpaceSpinorColorOrder<Float,Ns,Nc> >
     operator()(int x_cb, int parity) const {
-    return colorspinor_wrapper<RegType,PaddedSpaceSpinorColorOrder<Float,Ns,Nc> >
+    return colorspinor_wrapper<real,PaddedSpaceSpinorColorOrder<Float,Ns,Nc> >
       (const_cast<PaddedSpaceSpinorColorOrder<Float,Ns,Nc>&>(*this), x_cb, parity);
   }
 
-  __device__ __host__ inline void loadGhost(RegType v[length], int x, int dim, int dir, int parity=0) const {
+  __device__ __host__ inline void loadGhost(complex v[length/2], int x, int dim, int dir, int parity=0) const {
     for (int s=0; s<Ns; s++) {
       for (int c=0; c<Nc; c++) {
-        for (int z=0; z<2; z++) {
-          v[(s*Nc+c)*2+z] = ghost[2*dim+dir][(((parity*faceVolumeCB[dim]+x)*Ns + s)*Nc + c)*2 + z];
-        }
+        v[s*Nc+c] = complex(ghost[2*dim+dir][(((parity*faceVolumeCB[dim]+x)*Ns + s)*Nc + c)*2 + 0],
+                            ghost[2*dim+dir][(((parity*faceVolumeCB[dim]+x)*Ns + s)*Nc + c)*2 + 1]);
       }
     }
   }
 
-  __device__ __host__ inline void saveGhost(const RegType v[length], int x, int dim, int dir, int parity=0) {
+  __device__ __host__ inline void saveGhost(const complex v[length/2], int x, int dim, int dir, int parity=0) {
     for (int s=0; s<Ns; s++) {
       for (int c=0; c<Nc; c++) {
-        for (int z=0; z<2; z++) {
-          ghost[2*dim+dir][(((parity*faceVolumeCB[dim]+x)*Ns + s)*Nc + c)*2 + z] = v[(s*Nc+c)*2+z];
-        }
+        ghost[2*dim+dir][(((parity*faceVolumeCB[dim]+x)*Ns + s)*Nc + c)*2 + 0] = v[s*Nc+c].real();
+        ghost[2*dim+dir][(((parity*faceVolumeCB[dim]+x)*Ns + s)*Nc + c)*2 + 1] = v[s*Nc+c].imag();
       }
     }
   }
@@ -1512,32 +1515,31 @@ namespace quda {
 
     template <typename Float, int Ns, int Nc>
       struct QDPJITDiracOrder {
-  typedef typename mapper<Float>::type RegType;
-  Float *field;
-  int volumeCB;
-  int stride;
-  int nParity;
+        using real = typename mapper<Float>::type;
+        using complex = complex<real>;
+        Float *field;
+        int volumeCB;
+        int stride;
+        int nParity;
       QDPJITDiracOrder(const ColorSpinorField &a, int nFace=1, Float *field_=0)
       : field(field_ ? field_ : (Float*)a.V()), volumeCB(a.VolumeCB()), stride(a.Stride()), nParity(a.SiteSubset())
   { if (volumeCB != a.Stride()) errorQuda("Stride must equal volume for this field order"); }
   virtual ~QDPJITDiracOrder() { ; }
 
-  __device__ __host__ inline void load(RegType v[Ns*Nc*2], int x, int parity=0) const {
+  __device__ __host__ inline void load(complex v[Ns*Nc], int x, int parity=0) const {
     for (int s=0; s<Ns; s++) {
       for (int c=0; c<Nc; c++) {
-        for (int z=0; z<2; z++) {
-          v[(s*Nc+c)*2+z] = field[(((z*Nc + c)*Ns + s)*2 + (1-parity))*volumeCB + x];
-        }
+        v[s*Nc+c] = complex(field[(((0*Nc + c)*Ns + s)*2 + (1-parity))*volumeCB + x],
+                            field[(((1*Nc + c)*Ns + s)*2 + (1-parity))*volumeCB + x]);
       }
     }
   }
 
-  __device__ __host__ inline void save(const RegType v[Ns*Nc*2], int x, int parity=0) {
+  __device__ __host__ inline void save(const complex v[Ns*Nc], int x, int parity=0) {
     for (int s=0; s<Ns; s++) {
       for (int c=0; c<Nc; c++) {
-        for (int z=0; z<2; z++) {
-          field[(((z*Nc + c)*Ns + s)*2 + (1-parity))*volumeCB + x] = v[(s*Nc+c)*2+z];
-        }
+        field[(((0*Nc + c)*Ns + s)*2 + (1-parity))*volumeCB + x] = v[s*Nc+c].real();
+        field[(((1*Nc + c)*Ns + s)*2 + (1-parity))*volumeCB + x] = v[s*Nc+c].imag();
       }
     }
   }
@@ -1551,9 +1553,9 @@ namespace quda {
      @return Instance of a colorspinor_wrapper that curries in access to
      this field at the above coordinates.
   */
-  __device__ __host__ inline colorspinor_wrapper<RegType,QDPJITDiracOrder<Float,Ns,Nc> >
+  __device__ __host__ inline colorspinor_wrapper<real,QDPJITDiracOrder<Float,Ns,Nc> >
     operator()(int x_cb, int parity) {
-    return colorspinor_wrapper<RegType,QDPJITDiracOrder<Float,Ns,Nc> >(*this, x_cb, parity);
+    return colorspinor_wrapper<real,QDPJITDiracOrder<Float,Ns,Nc> >(*this, x_cb, parity);
   }
 
   /**
@@ -1565,9 +1567,9 @@ namespace quda {
      @return Instance of a colorspinor_wrapper that curries in access to
      this field at the above coordinates.
   */
-  __device__ __host__ inline const colorspinor_wrapper<RegType,QDPJITDiracOrder<Float,Ns,Nc> >
+  __device__ __host__ inline const colorspinor_wrapper<real,QDPJITDiracOrder<Float,Ns,Nc> >
     operator()(int x_cb, int parity) const {
-    return colorspinor_wrapper<RegType,QDPJITDiracOrder<Float,Ns,Nc> >
+    return colorspinor_wrapper<real,QDPJITDiracOrder<Float,Ns,Nc> >
       (const_cast<QDPJITDiracOrder<Float,Ns,Nc>&>(*this), x_cb, parity);
   }
 

--- a/include/color_spinor_field_order.h
+++ b/include/color_spinor_field_order.h
@@ -533,11 +533,6 @@ namespace quda {
         }
       }
 
-      /**
-       * Destructor for the FieldOrderCB class
-       */
-      virtual ~FieldOrderCB() { ; }
-
 #ifndef DISABLE_GHOST
       void resetGhost(const ColorSpinorField &a, void * const *ghost_) const
       {
@@ -867,7 +862,6 @@ namespace quda {
     }
 #endif
   }
-  virtual ~FloatNOrder() { ; }
 
   void resetGhost(const ColorSpinorField &a, void *const *ghost_) const
   {
@@ -1028,9 +1022,9 @@ namespace quda {
   {
     real v[length_ghost];
 #pragma unroll
-    for (int i = 0; i < length_ghost; i++) {
-      v[i] = in[2 * i + 0].real();
-      v[i] = in[2 * i + 1].imag();
+    for (int i = 0; i < length_ghost / 2; i++) {
+      v[2 * i + 0] = in[i].real();
+      v[2 * i + 1] = in[i].imag();
     }
 
     if (isFixed<Float>::value) {
@@ -1132,6 +1126,7 @@ namespace quda {
 
     template <typename Float, int Ns, int Nc>
       struct SpaceColorSpinorOrder {
+        using Accessor = SpaceColorSpinorOrder<Float, Ns, Nc>;
       using real = typename mapper<Float>::type;
       using complex = complex<real>;
       static const int length = 2 * Ns * Nc;
@@ -1153,7 +1148,6 @@ namespace quda {
       faceVolumeCB[i] = a.SurfaceCB(i)*nFace;
     }
   }
-  virtual ~SpaceColorSpinorOrder() { ; }
 
   __device__ __host__ inline void load(complex v[length / 2], int x, int parity = 0) const
   {
@@ -1215,10 +1209,9 @@ namespace quda {
      @return Instance of a colorspinor_wrapper that curries in access to
      this field at the above coordinates.
   */
-  __device__ __host__ inline colorspinor_wrapper<real, SpaceColorSpinorOrder<Float, Ns, Nc>> operator()(int x_cb,
-                                                                                                        int parity)
+  __device__ __host__ inline colorspinor_wrapper<real, Accessor> operator()(int x_cb, int parity)
   {
-    return colorspinor_wrapper<real, SpaceColorSpinorOrder<Float, Ns, Nc>>(*this, x_cb, parity);
+    return colorspinor_wrapper<real, Accessor>(*this, x_cb, parity);
   }
 
   /**
@@ -1230,11 +1223,9 @@ namespace quda {
      @return Instance of a colorspinor_wrapper that curries in access to
      this field at the above coordinates.
   */
-  __device__ __host__ inline const colorspinor_wrapper<real, SpaceColorSpinorOrder<Float, Ns, Nc>>
-  operator()(int x_cb, int parity) const
+  __device__ __host__ inline const colorspinor_wrapper<real, Accessor> operator()(int x_cb, int parity) const
   {
-    return colorspinor_wrapper<real, SpaceColorSpinorOrder<Float, Ns, Nc>>(
-      const_cast<SpaceColorSpinorOrder<Float, Ns, Nc> &>(*this), x_cb, parity);
+    return colorspinor_wrapper<real, Accessor>(const_cast<Accessor &>(*this), x_cb, parity);
   }
 
   __device__ __host__ inline void loadGhost(complex v[length / 2], int x, int dim, int dir, int parity = 0) const
@@ -1262,6 +1253,7 @@ namespace quda {
 
     template <typename Float, int Ns, int Nc>
       struct SpaceSpinorColorOrder {
+      using Accessor = SpaceSpinorColorOrder<Float, Ns, Nc>;
       using real = typename mapper<Float>::type;
       using complex = complex<real>;
       static const int length = 2 * Ns * Nc;
@@ -1283,7 +1275,6 @@ namespace quda {
       faceVolumeCB[i] = a.SurfaceCB(i)*nFace;
     }
   }
-  virtual ~SpaceSpinorColorOrder() { ; }
 
   __device__ __host__ inline void load(complex v[length / 2], int x, int parity = 0) const
   {
@@ -1336,10 +1327,9 @@ namespace quda {
      @return Instance of a colorspinor_wrapper that curries in access to
      this field at the above coordinates.
   */
-  __device__ __host__ inline colorspinor_wrapper<real, SpaceSpinorColorOrder<Float, Ns, Nc>> operator()(int x_cb,
-                                                                                                        int parity)
+  __device__ __host__ inline colorspinor_wrapper<real, Accessor> operator()(int x_cb, int parity)
   {
-    return colorspinor_wrapper<real, SpaceSpinorColorOrder<Float, Ns, Nc>>(*this, x_cb, parity);
+    return colorspinor_wrapper<real, Accessor>(*this, x_cb, parity);
   }
 
   /**
@@ -1351,11 +1341,9 @@ namespace quda {
      @return Instance of a colorspinor_wrapper that curries in access to
      this field at the above coordinates.
   */
-  __device__ __host__ inline const colorspinor_wrapper<real, SpaceSpinorColorOrder<Float, Ns, Nc>>
-  operator()(int x_cb, int parity) const
+  __device__ __host__ inline const colorspinor_wrapper<real, Accessor> operator()(int x_cb, int parity) const
   {
-    return colorspinor_wrapper<real, SpaceSpinorColorOrder<Float, Ns, Nc>>(
-      const_cast<SpaceSpinorColorOrder<Float, Ns, Nc> &>(*this), x_cb, parity);
+    return colorspinor_wrapper<real, Accessor>(const_cast<Accessor &>(*this), x_cb, parity);
   }
 
   __device__ __host__ inline void loadGhost(complex v[length / 2], int x, int dim, int dir, int parity = 0) const
@@ -1384,6 +1372,7 @@ namespace quda {
     // custom accessor for TIFR z-halo padded arrays
     template <typename Float, int Ns, int Nc>
       struct PaddedSpaceSpinorColorOrder {
+      using Accessor = PaddedSpaceSpinorColorOrder<Float, Ns, Nc>;
       using real = typename mapper<Float>::type;
       using complex = complex<real>;
       static const int length = 2 * Ns * Nc;
@@ -1415,7 +1404,6 @@ namespace quda {
 
     offset = exVolumeCB*Ns*Nc*2; // compute manually since Bytes is likely wrong due to z-padding
   }
-  virtual ~PaddedSpaceSpinorColorOrder() { ; }
 
   /**
      @brief Compute the index into the padded field.  Assumes that
@@ -1486,10 +1474,9 @@ namespace quda {
      @return Instance of a colorspinor_wrapper that curries in access to
      this field at the above coordinates.
   */
-  __device__ __host__ inline colorspinor_wrapper<real, PaddedSpaceSpinorColorOrder<Float, Ns, Nc>> operator()(int x_cb,
-                                                                                                              int parity)
+  __device__ __host__ inline colorspinor_wrapper<real, Accessor> operator()(int x_cb, int parity)
   {
-    return colorspinor_wrapper<real, PaddedSpaceSpinorColorOrder<Float, Ns, Nc>>(*this, x_cb, parity);
+    return colorspinor_wrapper<real, Accessor>(*this, x_cb, parity);
   }
 
   /**
@@ -1501,11 +1488,9 @@ namespace quda {
      @return Instance of a colorspinor_wrapper that curries in access to
      this field at the above coordinates.
   */
-  __device__ __host__ inline const colorspinor_wrapper<real, PaddedSpaceSpinorColorOrder<Float, Ns, Nc>>
-  operator()(int x_cb, int parity) const
+  __device__ __host__ inline const colorspinor_wrapper<real, Accessor> operator()(int x_cb, int parity) const
   {
-    return colorspinor_wrapper<real, PaddedSpaceSpinorColorOrder<Float, Ns, Nc>>(
-      const_cast<PaddedSpaceSpinorColorOrder<Float, Ns, Nc> &>(*this), x_cb, parity);
+    return colorspinor_wrapper<real, Accessor>(const_cast<Accessor &>(*this), x_cb, parity);
   }
 
   __device__ __host__ inline void loadGhost(complex v[length / 2], int x, int dim, int dir, int parity = 0) const
@@ -1534,6 +1519,7 @@ namespace quda {
 
     template <typename Float, int Ns, int Nc>
       struct QDPJITDiracOrder {
+      using Accessor = QDPJITDiracOrder<Float, Ns, Nc>;
       using real = typename mapper<Float>::type;
       using complex = complex<real>;
       Float *field;
@@ -1543,7 +1529,6 @@ namespace quda {
       QDPJITDiracOrder(const ColorSpinorField &a, int nFace=1, Float *field_=0)
       : field(field_ ? field_ : (Float*)a.V()), volumeCB(a.VolumeCB()), stride(a.Stride()), nParity(a.SiteSubset())
   { if (volumeCB != a.Stride()) errorQuda("Stride must equal volume for this field order"); }
-  virtual ~QDPJITDiracOrder() { ; }
 
   __device__ __host__ inline void load(complex v[Ns * Nc], int x, int parity = 0) const
   {
@@ -1574,9 +1559,9 @@ namespace quda {
      @return Instance of a colorspinor_wrapper that curries in access to
      this field at the above coordinates.
   */
-  __device__ __host__ inline colorspinor_wrapper<real, QDPJITDiracOrder<Float, Ns, Nc>> operator()(int x_cb, int parity)
+  __device__ __host__ inline colorspinor_wrapper<real, Accessor> operator()(int x_cb, int parity)
   {
-    return colorspinor_wrapper<real, QDPJITDiracOrder<Float, Ns, Nc>>(*this, x_cb, parity);
+    return colorspinor_wrapper<real, Accessor>(*this, x_cb, parity);
   }
 
   /**
@@ -1588,11 +1573,9 @@ namespace quda {
      @return Instance of a colorspinor_wrapper that curries in access to
      this field at the above coordinates.
   */
-  __device__ __host__ inline const colorspinor_wrapper<real, QDPJITDiracOrder<Float, Ns, Nc>> operator()(int x_cb,
-                                                                                                         int parity) const
+  __device__ __host__ inline const colorspinor_wrapper<real, Accessor> operator()(int x_cb, int parity) const
   {
-    return colorspinor_wrapper<real, QDPJITDiracOrder<Float, Ns, Nc>>(
-      const_cast<QDPJITDiracOrder<Float, Ns, Nc> &>(*this), x_cb, parity);
+    return colorspinor_wrapper<real, Accessor>(const_cast<Accessor &>(*this), x_cb, parity);
   }
 
   size_t Bytes() const { return nParity * volumeCB * Nc * Ns * 2 * sizeof(Float); }

--- a/include/dslash.h
+++ b/include/dslash.h
@@ -19,7 +19,7 @@ protected:
 
     const int nDimComms;
 
-    char aux_base[TuneKey::aux_n];
+    char aux_base[TuneKey::aux_n - 32];
     char aux[8][TuneKey::aux_n];
 
 #ifdef JITIFY

--- a/include/gauge_field_order.h
+++ b/include/gauge_field_order.h
@@ -73,7 +73,7 @@ namespace quda {
        */
       template<typename M>
       __device__ __host__ inline void operator=(const M &a) {
-	gauge.save(a.data, x_cb, dim, parity);
+        gauge.save(a.data, x_cb, dim, parity);
       }
     };
 
@@ -139,7 +139,7 @@ namespace quda {
        */
       template<typename M>
       __device__ __host__ inline void operator=(const M &a) {
-	gauge.saveGhost(a.data, ghost_idx, dim, parity);
+        gauge.saveGhost(a.data, ghost_idx, dim, parity);
       }
     };
 
@@ -1137,39 +1137,36 @@ namespace quda {
         {
         }
 
-        __device__ __host__ inline void Pack(real out[N], const complex in[N/2], int idx) const
+        __device__ __host__ inline void Pack(real out[N], const complex in[N / 2], int idx) const
         {
           if (isFixed<Float>::value) {
 #pragma unroll
-            for (int i = 0; i < N/2; i++) {
-              out[2*i+0] = scale_inv * in[i].real();
-              out[2*i+1] = scale_inv * in[i].imag();
+            for (int i = 0; i < N / 2; i++) {
+              out[2 * i + 0] = scale_inv * in[i].real();
+              out[2 * i + 1] = scale_inv * in[i].imag();
             }
           } else {
 #pragma unroll
-            for (int i = 0; i < N/2; i++) {
-              out[2*i+0] = in[i].real();
-              out[2*i+1] = in[i].imag();
+            for (int i = 0; i < N / 2; i++) {
+              out[2 * i + 0] = in[i].real();
+              out[2 * i + 1] = in[i].imag();
             }
           }
         }
 
         template <typename I>
-        __device__ __host__ inline void Unpack(complex out[N/2], const real in[N], int idx, int dir, real phase, const I *X, const int *R) const
+        __device__ __host__ inline void Unpack(complex out[N / 2], const real in[N], int idx, int dir, real phase,
+                                               const I *X, const int *R) const
         {
           if (isFixed<Float>::value) {
 #pragma unroll
-            for (int i = 0; i < N/2; i++) {
-              out[i] = scale * complex(in[2*i+0], in[2*i+1]);
-            }
+            for (int i = 0; i < N / 2; i++) { out[i] = scale * complex(in[2 * i + 0], in[2 * i + 1]); }
           } else {
 #pragma unroll
-            for (int i = 0; i < N/2; i++) {
-              out[i] = complex(in[2*i+0], in[2*i+1]);
-            }
+            for (int i = 0; i < N / 2; i++) { out[i] = complex(in[2 * i + 0], in[2 * i + 1]); }
           }
         }
-        __device__ __host__ inline real getPhase(const complex in[N/2]) const { return 0; }
+        __device__ __host__ inline real getPhase(const complex in[N / 2]) const { return 0; }
       };
 
       /**
@@ -1247,13 +1244,13 @@ namespace quda {
         QudaGhostExchange ghostExchange;
 
         Reconstruct(const GaugeField &u) :
-            anisotropy(u.Anisotropy()),
-            tBoundary(static_cast<real>(u.TBoundary())),
-            firstTimeSliceBound(u.VolumeCB()),
-            lastTimeSliceBound((u.X()[3] - 1) * u.X()[0] * u.X()[1] * u.X()[2] / 2),
-            isFirstTimeSlice(comm_coord(3) == 0 ? true : false),
-            isLastTimeSlice(comm_coord(3) == comm_dim(3) - 1 ? true : false),
-            ghostExchange(u.GhostExchange())
+          anisotropy(u.Anisotropy()),
+          tBoundary(static_cast<real>(u.TBoundary())),
+          firstTimeSliceBound(u.VolumeCB()),
+          lastTimeSliceBound((u.X()[3] - 1) * u.X()[0] * u.X()[1] * u.X()[2] / 2),
+          isFirstTimeSlice(comm_coord(3) == 0 ? true : false),
+          isLastTimeSlice(comm_coord(3) == comm_dim(3) - 1 ? true : false),
+          ghostExchange(u.GhostExchange())
         {
         }
 
@@ -1268,24 +1265,26 @@ namespace quda {
         {
         }
 
-        __device__ __host__ inline void Pack(real out[12], const complex in[9], int idx) const {
+        __device__ __host__ inline void Pack(real out[12], const complex in[9], int idx) const
+        {
 #pragma unroll
-	  for (int i=0; i<6; i++) {
-            out[2*i+0] = in[i].real();
-            out[2*i+1] = in[i].imag();
+          for (int i = 0; i < 6; i++) {
+            out[2 * i + 0] = in[i].real();
+            out[2 * i + 1] = in[i].imag();
           }
-	}
+        }
 
-	template<typename I>
-	__device__ __host__ inline void Unpack(complex out[9], const real in[12], int idx, int dir, real phase, const I *X, const int *R) const
+        template <typename I>
+        __device__ __host__ inline void Unpack(complex out[9], const real in[12], int idx, int dir, real phase,
+                                               const I *X, const int *R) const
         {
 #pragma unroll
           for (int i = 0; i < 6; i++) out[i] = complex(in[2 * i + 0], in[2 * i + 1]);
 
           const real u0 = dir < 3 ?
-              anisotropy :
-              timeBoundary<ghostExchange_>(idx, X, R, tBoundary, static_cast<real>(1.0), firstTimeSliceBound,
-                  lastTimeSliceBound, isFirstTimeSlice, isLastTimeSlice, ghostExchange);
+            anisotropy :
+            timeBoundary<ghostExchange_>(idx, X, R, tBoundary, static_cast<real>(1.0), firstTimeSliceBound,
+                                         lastTimeSliceBound, isFirstTimeSlice, isLastTimeSlice, ghostExchange);
 
           // out[6] = u0*conj(out[1]*out[5] - out[2]*out[4]);
           out[6] = cmul(out[2], out[4]);
@@ -1320,38 +1319,40 @@ namespace quda {
         using real = typename mapper<Float>::type;
         using complex = complex<real>;
 
-	Reconstruct(const GaugeField &u) { ; }
+        Reconstruct(const GaugeField &u) { ; }
         Reconstruct(const Reconstruct<11, Float, ghostExchange_> &recon) {}
 
-        __device__ __host__ inline void Pack(real out[10], const complex in[9], int idx) const {
-#pragma unroll
-	  for (int i=0; i<2; i++) {
-            out[2*i+0] = in[i+1].real();
-            out[2*i+1] = in[i+1].imag();
-          }
-	  out[4] = in[5].real();
-	  out[5] = in[5].imag();
-          out[6] = in[0].imag();
-	  out[7] = in[4].imag();
-	  out[8] = in[8].imag();
-	  out[9] = 0.0;
-	}
-
-	template<typename I>
-	__device__ __host__ inline void Unpack(complex out[9], const real in[10], int idx, int dir, real phase, const I *X, const int *R) const
+        __device__ __host__ inline void Pack(real out[10], const complex in[9], int idx) const
         {
-	  out[0] = complex(0.0, in[6]);
+#pragma unroll
+          for (int i = 0; i < 2; i++) {
+            out[2 * i + 0] = in[i + 1].real();
+            out[2 * i + 1] = in[i + 1].imag();
+          }
+          out[4] = in[5].real();
+          out[5] = in[5].imag();
+          out[6] = in[0].imag();
+          out[7] = in[4].imag();
+          out[8] = in[8].imag();
+          out[9] = 0.0;
+        }
+
+        template <typename I>
+        __device__ __host__ inline void Unpack(complex out[9], const real in[10], int idx, int dir, real phase,
+                                               const I *X, const int *R) const
+        {
+          out[0] = complex(0.0, in[6]);
           out[1] = complex(in[0], in[1]);
           out[2] = complex(in[2], in[3]);
-	  out[3] = complex(-out[1].real(), out[1].imag());
-	  out[4] = complex(0.0, in[7]);
-	  out[5] = complex(in[4], in[5]);
-	  out[6] = complex(-out[2].real(), out[2].imag());
-	  out[7] = complex(-out[5].real(), out[5].imag());
-	  out[8] = complex(0.0, in[8]);
-	}
+          out[3] = complex(-out[1].real(), out[1].imag());
+          out[4] = complex(0.0, in[7]);
+          out[5] = complex(in[4], in[5]);
+          out[6] = complex(-out[2].real(), out[2].imag());
+          out[7] = complex(-out[5].real(), out[5].imag());
+          out[8] = complex(0.0, in[8]);
+        }
 
-	__device__ __host__ inline real getPhase(const complex in[9]) { return 0; }
+        __device__ __host__ inline real getPhase(const complex in[9]) { return 0; }
       };
 
       /**
@@ -1384,7 +1385,8 @@ namespace quda {
         }
 
         template <typename I>
-        __device__ __host__ inline void Unpack(complex out[18], const real in[12], int idx, int dir, real phase, const I *X, const int *R) const
+        __device__ __host__ inline void Unpack(complex out[18], const real in[12], int idx, int dir, real phase,
+                                               const I *X, const int *R) const
         {
 #pragma unroll
           for (int i = 0; i < 6; i++) out[i] = complex(in[2 * i + 0], in[2 * i + 1]);
@@ -1458,13 +1460,13 @@ namespace quda {
 
         // scale factor is set when using recon-9
         Reconstruct(const GaugeField &u, real scale = 1.0) :
-            anisotropy(u.Anisotropy() * scale, 1.0 / (u.Anisotropy() * scale)),
-            tBoundary(static_cast<real>(u.TBoundary()) * scale, 1.0 / (static_cast<real>(u.TBoundary()) * scale)),
-            firstTimeSliceBound(u.VolumeCB()),
-            lastTimeSliceBound((u.X()[3] - 1) * u.X()[0] * u.X()[1] * u.X()[2] / 2),
-            isFirstTimeSlice(comm_coord(3) == 0 ? true : false),
-            isLastTimeSlice(comm_coord(3) == comm_dim(3) - 1 ? true : false),
-            ghostExchange(u.GhostExchange())
+          anisotropy(u.Anisotropy() * scale, 1.0 / (u.Anisotropy() * scale)),
+          tBoundary(static_cast<real>(u.TBoundary()) * scale, 1.0 / (static_cast<real>(u.TBoundary()) * scale)),
+          firstTimeSliceBound(u.VolumeCB()),
+          lastTimeSliceBound((u.X()[3] - 1) * u.X()[0] * u.X()[1] * u.X()[2] / 2),
+          isFirstTimeSlice(comm_coord(3) == 0 ? true : false),
+          isLastTimeSlice(comm_coord(3) == comm_dim(3) - 1 ? true : false),
+          ghostExchange(u.GhostExchange())
         {
         }
 
@@ -1484,9 +1486,9 @@ namespace quda {
           out[0] = Trig<isFixed<Float>::value, real>::Atan2(in[0].imag(), in[0].real());
           out[1] = Trig<isFixed<Float>::value, real>::Atan2(in[6].imag(), in[6].real());
 #pragma unroll
-          for (int i=1; i<4; i++) {
-            out[2*i+0] = in[i].real();
-            out[2*i+1] = in[i].imag();
+          for (int i = 1; i < 4; i++) {
+            out[2 * i + 0] = in[i].real();
+            out[2 * i + 1] = in[i].imag();
           }
         }
 
@@ -1498,7 +1500,8 @@ namespace quda {
           real u0_inv = u.imag();
 
 #pragma unroll
-          for (int i = 1; i <= 3; i++) out[i] = complex(in[2 * i + 0], in[2 * i + 1]); // these elements are copied directly
+          for (int i = 1; i <= 3; i++)
+            out[i] = complex(in[2 * i + 0], in[2 * i + 1]); // these elements are copied directly
 
           real tmp[2];
           Trig<isFixed<Float>::value, real>::SinCos(in[0], &tmp[0], &tmp[1]);
@@ -1562,12 +1565,14 @@ namespace quda {
         }
 
         template <typename I>
-        __device__ __host__ inline void Unpack(complex out[18], const real in[8], int idx, int dir, real phase, const I *X,
-                                               const int *R, const complex scale = complex(static_cast<real>(1.0), static_cast<real>(1.0))) const
+        __device__ __host__ inline void
+        Unpack(complex out[18], const real in[8], int idx, int dir, real phase, const I *X, const int *R,
+               const complex scale = complex(static_cast<real>(1.0), static_cast<real>(1.0))) const
         {
-          complex u = dir < 3 ? anisotropy :
-            timeBoundary<ghostExchange_>(idx, X, R, tBoundary, scale, firstTimeSliceBound,
-                                         lastTimeSliceBound, isFirstTimeSlice, isLastTimeSlice, ghostExchange);
+          complex u = dir < 3 ?
+            anisotropy :
+            timeBoundary<ghostExchange_>(idx, X, R, tBoundary, scale, firstTimeSliceBound, lastTimeSliceBound,
+                                         isFirstTimeSlice, isLastTimeSlice, ghostExchange);
           Unpack(out, in, idx, dir, phase, X, R, scale, u);
         }
 
@@ -1611,11 +1616,11 @@ namespace quda {
             return expI3Phase.real() > 0 ? 1 : -1;
           }
 #else // phase from determinant
-          Matrix<complex,3> a;
+          Matrix<complex, 3> a;
 #pragma unroll
           for (int i = 0; i < 9; i++) a(i) = scale_inv * in[i];
-          const complex det = getDeterminant( a );
-          real phase = arg(det)/3;
+          const complex det = getDeterminant(a);
+          real phase = arg(det) / 3;
           return phase;
 #endif
         }
@@ -1641,10 +1646,10 @@ namespace quda {
         }
 
         template <typename I>
-        __device__ __host__ inline void Unpack(complex out[9], const real in[8], int idx, int dir, real phase, const I *X, const int *R) const
+        __device__ __host__ inline void Unpack(complex out[9], const real in[8], int idx, int dir, real phase,
+                                               const I *X, const int *R) const
         {
-          reconstruct_8.Unpack(out, in, idx, dir, phase, X, R,
-                               complex(static_cast<real>(1.0), static_cast<real>(1.0)),
+          reconstruct_8.Unpack(out, in, idx, dir, phase, X, R, complex(static_cast<real>(1.0), static_cast<real>(1.0)),
                                complex(static_cast<real>(1.0), static_cast<real>(1.0)));
 
           if (stag_phase == QUDA_STAGGERED_PHASE_NO) { // dynamic phase
@@ -1661,7 +1666,10 @@ namespace quda {
         }
       };
 
-      __host__ __device__ constexpr int ct_sqrt(int n, int i = 1) { return n == i ? n : (i * i < n ? ct_sqrt(n, i + 1) : i); }
+      __host__ __device__ constexpr int ct_sqrt(int n, int i = 1)
+      {
+        return n == i ? n : (i * i < n ? ct_sqrt(n, i + 1) : i);
+      }
 
       /**
          @brief Return the number of colors of the accessor based on the length of the field
@@ -1700,9 +1708,9 @@ namespace quda {
         Float *gauge;
         const AllocInt offset;
 #ifdef USE_TEXTURE_OBJECTS
-      typedef typename TexVectorType<real,N>::type TexVector;
-      cudaTextureObject_t tex;
-      const int tex_offset;
+        typedef typename TexVectorType<real, N>::type TexVector;
+        cudaTextureObject_t tex;
+        const int tex_offset;
 #endif
       Float *ghost[4];
       QudaGhostExchange ghostExchange;
@@ -1764,7 +1772,7 @@ namespace quda {
       }
       virtual ~FloatNOrder() { ; }
 
-      __device__ __host__ inline void load(complex v[length/2], int x, int dir, int parity, real inphase = 1.0) const
+      __device__ __host__ inline void load(complex v[length / 2], int x, int dir, int parity, real inphase = 1.0) const
       {
         const int M = reconLen / N;
         real tmp[reconLen];
@@ -1777,8 +1785,8 @@ namespace quda {
             TexVector vecTmp = tex1Dfetch<TexVector>(tex, parity * tex_offset + (dir * M + i) * stride + x);
             // now insert into output array
 #pragma unroll
-	    for (int j=0; j<N; j++) copy(tmp[i*N+j], reinterpret_cast<real*>(&vecTmp)[j]);
-	  } else
+            for (int j = 0; j < N; j++) copy(tmp[i * N + j], reinterpret_cast<real *>(&vecTmp)[j]);
+          } else
 #endif
 	  {
             // first load from memory
@@ -1803,7 +1811,7 @@ namespace quda {
         reconstruct.Unpack(v, tmp, x, dir, phase, X, R);
       }
 
-      __device__ __host__ inline void save(const complex v[length/2], int x, int dir, int parity)
+      __device__ __host__ inline void save(const complex v[length / 2], int x, int dir, int parity)
       {
         const int M = reconLen / N;
         real tmp[reconLen];
@@ -1820,7 +1828,8 @@ namespace quda {
         }
         if (hasPhase) {
           real phase = reconstruct.getPhase(v);
-          copy((gauge+parity*offset)[phaseOffset/sizeof(Float) + dir*stride + x], static_cast<real>(phase/(2.*M_PI)));
+          copy((gauge + parity * offset)[phaseOffset / sizeof(Float) + dir * stride + x],
+               static_cast<real>(phase / (2. * M_PI)));
         }
       }
 
@@ -1849,12 +1858,13 @@ namespace quda {
 	 @return Instance of a gauge_wrapper that curries in access to
 	 this field at the above coordinates.
        */
-      __device__ __host__ inline const gauge_wrapper<real, Accessor> operator()(int dim, int x_cb, int parity, real phase = 1.0) const
+      __device__ __host__ inline const gauge_wrapper<real, Accessor> operator()(int dim, int x_cb, int parity,
+                                                                                real phase = 1.0) const
       {
         return gauge_wrapper<real, Accessor>(const_cast<Accessor &>(*this), dim, x_cb, parity, phase);
       }
 
-      __device__ __host__ inline void loadGhost(complex v[length/2], int x, int dir, int parity, real inphase = 1.0) const
+      __device__ __host__ inline void loadGhost(complex v[length / 2], int x, int dir, int parity, real inphase = 1.0) const
       {
         if (!ghost[dir]) { // load from main field not separate array
           load(v, volumeCB + x, dir, parity, inphase); // an offset of size volumeCB puts us at the padded region
@@ -1887,7 +1897,7 @@ namespace quda {
         }
       }
 
-      __device__ __host__ inline void saveGhost(const complex v[length/2], int x, int dir, int parity)
+      __device__ __host__ inline void saveGhost(const complex v[length / 2], int x, int dir, int parity)
       {
         if (!ghost[dir]) { // store in main field not separate array
 	  save(v, volumeCB+x, dir, parity); // an offset of size volumeCB puts us at the padded region
@@ -1907,46 +1917,50 @@ namespace quda {
           }
 
 	  if (hasPhase) {
-	    real phase = reconstruct.getPhase(v);
-	    copy(ghost[dir][parity*faceVolumeCB[dir]*(M*N + 1) + faceVolumeCB[dir]*M*N + x], static_cast<real>(phase/(2.*M_PI)));
-	  }
+            real phase = reconstruct.getPhase(v);
+            copy(ghost[dir][parity * faceVolumeCB[dir] * (M * N + 1) + faceVolumeCB[dir] * M * N + x],
+                 static_cast<real>(phase / (2. * M_PI)));
+          }
 	}
       }
 
       /**
-	 @brief This accessor routine returns a gauge_ghost_wrapper to this object,
-	 allowing us to overload various operators for manipulating at
-	 the site level interms of matrix operations.
-	 @param[in] dir Which dimension are we requesting
-	 @param[in] ghost_idx Ghost index we are requesting
-	 @param[in] parity Parity we are requesting
-	 @return Instance of a gauge_ghost_wrapper that curries in access to
-	 this field at the above coordinates.
+         @brief This accessor routine returns a gauge_ghost_wrapper to this object,
+         allowing us to overload various operators for manipulating at
+         the site level interms of matrix operations.
+         @param[in] dir Which dimension are we requesting
+         @param[in] ghost_idx Ghost index we are requesting
+         @param[in] parity Parity we are requesting
+         @return Instance of a gauge_ghost_wrapper that curries in access to
+         this field at the above coordinates.
        */
-      __device__ __host__ inline gauge_ghost_wrapper<real, Accessor> Ghost(int dim, int ghost_idx, int parity, real phase = 1.0)
+      __device__ __host__ inline gauge_ghost_wrapper<real, Accessor> Ghost(int dim, int ghost_idx, int parity,
+                                                                           real phase = 1.0)
       {
         return gauge_ghost_wrapper<real, Accessor>(*this, dim, ghost_idx, parity, phase);
       }
 
       /**
-	 @brief This accessor routine returns a const gauge_ghost_wrapper to this object,
-	 allowing us to overload various operators for manipulating at
-	 the site level interms of matrix operations.
-	 @param[in] dir Which dimension are we requesting
-	 @param[in] ghost_idx Ghost index we are requesting
-	 @param[in] parity Parity we are requesting
-	 @return Instance of a gauge_ghost_wrapper that curries in access to
-	 this field at the above coordinates.
+         @brief This accessor routine returns a const gauge_ghost_wrapper to this object,
+         allowing us to overload various operators for manipulating at
+         the site level interms of matrix operations.
+         @param[in] dir Which dimension are we requesting
+         @param[in] ghost_idx Ghost index we are requesting
+         @param[in] parity Parity we are requesting
+         @return Instance of a gauge_ghost_wrapper that curries in access to
+         this field at the above coordinates.
        */
-      __device__ __host__ inline const gauge_ghost_wrapper<real, Accessor> Ghost(int dim, int ghost_idx, int parity, real phase = 1.0) const
+      __device__ __host__ inline const gauge_ghost_wrapper<real, Accessor> Ghost(int dim, int ghost_idx, int parity,
+                                                                                 real phase = 1.0) const
       {
         return gauge_ghost_wrapper<real, Accessor>(const_cast<Accessor &>(*this), dim, ghost_idx, parity, phase);
       }
 
-      __device__ __host__ inline void loadGhostEx(complex v[length/2], int buff_idx, int extended_idx, int dir,
-						  int dim, int g, int parity, const int R[]) const {
-	const int M = reconLen / N;
-	real tmp[reconLen];
+      __device__ __host__ inline void loadGhostEx(complex v[length / 2], int buff_idx, int extended_idx, int dir,
+                                                  int dim, int g, int parity, const int R[]) const
+      {
+        const int M = reconLen / N;
+        real tmp[reconLen];
 
 #pragma unroll
 	for (int i=0; i<M; i++) {
@@ -1957,19 +1971,22 @@ namespace quda {
 #pragma unroll
 	  for (int j=0; j<N; j++) copy(tmp[i*N+j], reinterpret_cast<Float*>(&vecTmp)[j]);
 	}
-	real phase=0.;
-	if (hasPhase) copy(phase, ghost[dim][((dir*2+parity)*geometry+g)*R[dim]*faceVolumeCB[dim]*(M*N + 1)
-                                             + R[dim]*faceVolumeCB[dim]*M*N + buff_idx]);
+        real phase = 0.;
+        if (hasPhase)
+          copy(phase,
+               ghost[dim][((dir * 2 + parity) * geometry + g) * R[dim] * faceVolumeCB[dim] * (M * N + 1)
+                          + R[dim] * faceVolumeCB[dim] * M * N + buff_idx]);
 
-	// use the extended_idx to determine the boundary condition
+        // use the extended_idx to determine the boundary condition
 	reconstruct.Unpack(v, tmp, extended_idx, g, 2.*M_PI*phase, X, R);
       }
 
-      __device__ __host__ inline void saveGhostEx(const complex v[length/2], int buff_idx, int extended_idx,
-						  int dir, int dim, int g, int parity, const int R[]) {
-	const int M = reconLen / N;
-	real tmp[reconLen];
-	// use the extended_idx to determine the boundary condition
+      __device__ __host__ inline void saveGhostEx(const complex v[length / 2], int buff_idx, int extended_idx, int dir,
+                                                  int dim, int g, int parity, const int R[])
+      {
+        const int M = reconLen / N;
+        real tmp[reconLen];
+        // use the extended_idx to determine the boundary condition
 	reconstruct.Pack(tmp, v, extended_idx);
 
 #pragma unroll
@@ -1983,11 +2000,12 @@ namespace quda {
 			 i*R[dim]*faceVolumeCB[dim]+buff_idx, vecTmp);
 	  }
 	  if (hasPhase) {
-	    real phase = reconstruct.getPhase(v);
-	    copy(ghost[dim][((dir*2+parity)*geometry+g)*R[dim]*faceVolumeCB[dim]*(M*N + 1) + R[dim]*faceVolumeCB[dim]*M*N + buff_idx],
-		 static_cast<real>(phase/(2.*M_PI)));
-	  }
-	}
+            real phase = reconstruct.getPhase(v);
+            copy(ghost[dim][((dir * 2 + parity) * geometry + g) * R[dim] * faceVolumeCB[dim] * (M * N + 1)
+                            + R[dim] * faceVolumeCB[dim] * M * N + buff_idx],
+                 static_cast<real>(phase / (2. * M_PI)));
+          }
+      }
 
       /**
 	 @brief Backup the field to the host when tuning
@@ -2018,11 +2036,11 @@ namespace quda {
      @param real Real number type
      @param length Number of elements in the structure
   */
-  template <typename real, int length> struct S {
-    real v[length];
-    __host__ __device__ const real& operator[](int i) const { return v[i]; }
-    __host__ __device__ real& operator[](int i) { return v[i]; }
-  };
+      template <typename real, int length> struct S {
+        real v[length];
+        __host__ __device__ const real &operator[](int i) const { return v[i]; }
+        __host__ __device__ real &operator[](int i) { return v[i]; }
+      };
 
   /**
       The LegacyOrder defines the ghost zone storage and ordering for
@@ -2030,25 +2048,29 @@ namespace quda {
   */
   template <typename Float, int length>
     struct LegacyOrder {
-      using Accessor = LegacyOrder<Float, length>;
-      using real = typename mapper<Float>::type;
-      using complex = complex<real>;
-      Float *ghost[QUDA_MAX_DIM];
-      int faceVolumeCB[QUDA_MAX_DIM];
-      const int volumeCB;
-      const int stride;
-      const int geometry;
-      const int hasPhase;
+    using Accessor = LegacyOrder<Float, length>;
+    using real = typename mapper<Float>::type;
+    using complex = complex<real>;
+    Float *ghost[QUDA_MAX_DIM];
+    int faceVolumeCB[QUDA_MAX_DIM];
+    const int volumeCB;
+    const int stride;
+    const int geometry;
+    const int hasPhase;
 
-      LegacyOrder(const GaugeField &u, Float **ghost_)
-      : volumeCB(u.VolumeCB()), stride(u.Stride()), geometry(u.Geometry()), hasPhase(0) {
-	if (geometry == QUDA_COARSE_GEOMETRY)
-	  errorQuda("This accessor does not support coarse-link fields (lacks support for bidirectional ghost zone");
+    LegacyOrder(const GaugeField &u, Float **ghost_) :
+      volumeCB(u.VolumeCB()),
+      stride(u.Stride()),
+      geometry(u.Geometry()),
+      hasPhase(0)
+    {
+      if (geometry == QUDA_COARSE_GEOMETRY)
+        errorQuda("This accessor does not support coarse-link fields (lacks support for bidirectional ghost zone");
 
-	for (int i=0; i<4; i++) {
-	  ghost[i] = (ghost_) ? ghost_[i] : (Float*)(u.Ghost()[i]);
-	  faceVolumeCB[i] = u.SurfaceCB(i)*u.Nface(); // face volume equals surface * depth
-	}
+      for (int i = 0; i < 4; i++) {
+        ghost[i] = (ghost_) ? ghost_[i] : (Float *)(u.Ghost()[i]);
+        faceVolumeCB[i] = u.SurfaceCB(i) * u.Nface(); // face volume equals surface * depth
+      }
       }
 
       LegacyOrder(const LegacyOrder &order)
@@ -2061,100 +2083,103 @@ namespace quda {
 
       virtual ~LegacyOrder() { ; }
 
-      __device__ __host__ inline void loadGhost(complex v[length/2], int x, int dir, int parity, real phase = 1.0) const
+      __device__ __host__ inline void loadGhost(complex v[length / 2], int x, int dir, int parity, real phase = 1.0) const
       {
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
 	typedef S<Float,length> structure;
 	trove::coalesced_ptr<structure> ghost_((structure*)ghost[dir]);
 	structure v_ = ghost_[parity*faceVolumeCB[dir] + x];
 #else
-        auto v_ = &ghost[dir][(parity*faceVolumeCB[dir] + x)*length];
+        auto v_ = &ghost[dir][(parity * faceVolumeCB[dir] + x) * length];
 #endif
-	for (int i=0; i<length/2; i++) v[i] = complex(v_[2*i+0], v_[2*i+1]);
+        for (int i = 0; i < length / 2; i++) v[i] = complex(v_[2 * i + 0], v_[2 * i + 1]);
       }
 
-      __device__ __host__ inline void saveGhost(const complex v[length/2], int x, int dir, int parity)
+      __device__ __host__ inline void saveGhost(const complex v[length / 2], int x, int dir, int parity)
       {
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
 	typedef S<Float,length> structure;
 	trove::coalesced_ptr<structure> ghost_((structure*)ghost[dir]);
 	structure v_;
-	for (int i=0; i<length/2; i++) {
-          v_.v[2*i+0] = (Float)v[i].real();
-          v_.v[2*i+1] = (Float)v[i].imag();
+        for (int i = 0; i < length / 2; i++) {
+          v_.v[2 * i + 0] = (Float)v[i].real();
+          v_.v[2 * i + 1] = (Float)v[i].imag();
         }
-	ghost_[parity*faceVolumeCB[dir] + x] = v_;
+        ghost_[parity*faceVolumeCB[dir] + x] = v_;
 #else
-        auto v_ = &ghost[dir][(parity*faceVolumeCB[dir] + x)*length];
-	for (int i=0; i<length/2; i++) {
-          v_[2*i+0] = (Float)v[i].real();
-          v_[2*i+1] = (Float)v[i].imag();
+        auto v_ = &ghost[dir][(parity * faceVolumeCB[dir] + x) * length];
+        for (int i = 0; i < length / 2; i++) {
+          v_[2 * i + 0] = (Float)v[i].real();
+          v_[2 * i + 1] = (Float)v[i].imag();
         }
 #endif
       }
 
       /**
-	 @brief This accessor routine returns a gauge_ghost_wrapper to this object,
-	 allowing us to overload various operators for manipulating at
-	 the site level interms of matrix operations.
-	 @param[in] dir Which dimension are we requesting
-	 @param[in] ghost_idx Ghost index we are requesting
-	 @param[in] parity Parity we are requesting
-	 @return Instance of a gauge_ghost_wrapper that curries in access to
-	 this field at the above coordinates.
+         @brief This accessor routine returns a gauge_ghost_wrapper to this object,
+         allowing us to overload various operators for manipulating at
+         the site level interms of matrix operations.
+         @param[in] dir Which dimension are we requesting
+         @param[in] ghost_idx Ghost index we are requesting
+         @param[in] parity Parity we are requesting
+         @return Instance of a gauge_ghost_wrapper that curries in access to
+         this field at the above coordinates.
        */
-      __device__ __host__ inline gauge_ghost_wrapper<real, Accessor> Ghost(int dim, int ghost_idx, int parity, real phase = 1.0)
+      __device__ __host__ inline gauge_ghost_wrapper<real, Accessor> Ghost(int dim, int ghost_idx, int parity,
+                                                                           real phase = 1.0)
       {
         return gauge_ghost_wrapper<real, Accessor>(*this, dim, ghost_idx, parity, phase);
       }
 
       /**
-	 @brief This accessor routine returns a const gauge_ghost_wrapper to this object,
-	 allowing us to overload various operators for manipulating at
-	 the site level interms of matrix operations.
-	 @param[in] dir Which dimension are we requesting
-	 @param[in] ghost_idx Ghost index we are requesting
-	 @param[in] parity Parity we are requesting
-	 @return Instance of a gauge_ghost_wrapper that curries in access to
-	 this field at the above coordinates.
+         @brief This accessor routine returns a const gauge_ghost_wrapper to this object,
+         allowing us to overload various operators for manipulating at
+         the site level interms of matrix operations.
+         @param[in] dir Which dimension are we requesting
+         @param[in] ghost_idx Ghost index we are requesting
+         @param[in] parity Parity we are requesting
+         @return Instance of a gauge_ghost_wrapper that curries in access to
+         this field at the above coordinates.
        */
-      __device__ __host__ inline const gauge_ghost_wrapper<real, Accessor> Ghost(int dim, int ghost_idx, int parity, real phase = 1.0) const
+      __device__ __host__ inline const gauge_ghost_wrapper<real, Accessor> Ghost(int dim, int ghost_idx, int parity,
+                                                                                 real phase = 1.0) const
       {
         return gauge_ghost_wrapper<real, Accessor>(const_cast<Accessor &>(*this), dim, ghost_idx, parity, phase);
       }
 
-      __device__ __host__ inline void loadGhostEx(complex v[length/2], int x, int dummy, int dir,
-						  int dim, int g, int parity, const int R[]) const {
+      __device__ __host__ inline void loadGhostEx(complex v[length / 2], int x, int dummy, int dir, int dim, int g,
+                                                  int parity, const int R[]) const
+      {
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
 	typedef S<Float,length> structure;
 	trove::coalesced_ptr<structure> ghost_((structure*)ghost[dim]);
 	structure v_ = ghost_[((dir*2+parity)*R[dim]*faceVolumeCB[dim] + x)*geometry+g];
 #else
-        auto v_ = &ghost[dim][(((dir*2+parity)*R[dim]*faceVolumeCB[dim] + x)*geometry+g)*length];
+        auto v_ = &ghost[dim][(((dir * 2 + parity) * R[dim] * faceVolumeCB[dim] + x) * geometry + g) * length];
 #endif
-	for (int i=0; i<length/2; i++) v[i] = complex(v_[2*i+0], v_[2*i+1]);
+        for (int i = 0; i < length / 2; i++) v[i] = complex(v_[2 * i + 0], v_[2 * i + 1]);
       }
 
-      __device__ __host__ inline void saveGhostEx(const complex v[length/2], int x, int dummy,
-						  int dir, int dim, int g, int parity, const int R[]) {
+      __device__ __host__ inline void saveGhostEx(const complex v[length / 2], int x, int dummy, int dir, int dim,
+                                                  int g, int parity, const int R[])
+      {
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
 	typedef S<Float,length> structure;
 	trove::coalesced_ptr<structure> ghost_((structure*)ghost[dim]);
 	structure v_;
-	for (int i=0; i<length/2; i++) {
-          v_.v[2*i+0] = (Float)v[i].real();
-          v_.v[2*i+1] = (Float)v[i].imag();
+        for (int i = 0; i < length / 2; i++) {
+          v_.v[2 * i + 0] = (Float)v[i].real();
+          v_.v[2 * i + 1] = (Float)v[i].imag();
         }
-	ghost_[((dir*2+parity)*R[dim]*faceVolumeCB[dim] + x)*geometry+g] = v_;
+        ghost_[((dir*2+parity)*R[dim]*faceVolumeCB[dim] + x)*geometry+g] = v_;
 #else
-        auto v_ = &ghost[dim][(((dir*2+parity)*R[dim]*faceVolumeCB[dim] + x)*geometry+g)*length];
-	for (int i=0; i<length/2; i++) {
-          v_[2*i+0] = (Float)v[i].real();
-          v_[2*i+1] = (Float)v[i].imag();
+        auto v_ = &ghost[dim][(((dir * 2 + parity) * R[dim] * faceVolumeCB[dim] + x) * geometry + g) * length];
+        for (int i = 0; i < length / 2; i++) {
+          v_[2 * i + 0] = (Float)v[i].real();
+          v_[2 * i + 1] = (Float)v[i].imag();
         }
 #endif
       }
-
     };
 
     /**
@@ -2174,33 +2199,34 @@ namespace quda {
       }
       virtual ~QDPOrder() { ; }
 
-      __device__ __host__ inline void load(complex v[length/2], int x, int dir, int parity, real inphase = 1.0) const
+      __device__ __host__ inline void load(complex v[length / 2], int x, int dir, int parity, real inphase = 1.0) const
       {
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
 	typedef S<Float,length> structure;
 	trove::coalesced_ptr<structure> gauge_((structure*)gauge[dir]);
 	structure v_ = gauge_[parity*volumeCB + x];
 #else
-        auto v_ = &gauge[dir][(parity*volumeCB + x)*length];
+        auto v_ = &gauge[dir][(parity * volumeCB + x) * length];
 #endif
-	for (int i=0; i<length/2; i++) v[i] = complex(v_[2*i+0], v_[2*i+1]);
+        for (int i = 0; i < length / 2; i++) v[i] = complex(v_[2 * i + 0], v_[2 * i + 1]);
       }
 
-      __device__ __host__ inline void save(const complex v[length/2], int x, int dir, int parity) {
+      __device__ __host__ inline void save(const complex v[length / 2], int x, int dir, int parity)
+      {
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
 	typedef S<Float,length> structure;
 	trove::coalesced_ptr<structure> gauge_((structure*)gauge[dir]);
 	structure v_;
-	for (int i=0; i<length/2; i++) {
-          v_.v[2*i+0] = (Float)v[i].real();
-          v_.v[2*i+1] = (Float)v[i].imag();
+        for (int i = 0; i < length / 2; i++) {
+          v_.v[2 * i + 0] = (Float)v[i].real();
+          v_.v[2 * i + 1] = (Float)v[i].imag();
         }
-	gauge_[parity*volumeCB + x] = v_;
+        gauge_[parity*volumeCB + x] = v_;
 #else
-        auto v_ = &gauge[dir][(parity*volumeCB + x)*length];
-	for (int i=0; i<length/2; i++) {
-          v_[2*i+0] = (Float)v[i].real();
-          v_[2*i+1] = (Float)v[i].imag();
+        auto v_ = &gauge[dir][(parity * volumeCB + x) * length];
+        for (int i = 0; i < length / 2; i++) {
+          v_[2 * i + 0] = (Float)v[i].real();
+          v_[2 * i + 1] = (Float)v[i].imag();
         }
 #endif
       }
@@ -2230,11 +2256,11 @@ namespace quda {
 	 @return Instance of a gauge_wrapper that curries in access to
 	 this field at the above coordinates.
        */
-      __device__ __host__ inline const gauge_wrapper<real, QDPOrder<Float, length>> operator()(
-          int dim, int x_cb, int parity) const
+      __device__ __host__ inline const gauge_wrapper<real, QDPOrder<Float, length>> operator()(int dim, int x_cb,
+                                                                                               int parity) const
       {
-        return gauge_wrapper<real, QDPOrder<Float, length>>(
-            const_cast<QDPOrder<Float, length> &>(*this), dim, x_cb, parity);
+        return gauge_wrapper<real, QDPOrder<Float, length>>(const_cast<QDPOrder<Float, length> &>(*this), dim, x_cb,
+                                                            parity);
       }
 
       size_t Bytes() const { return length * sizeof(Float); }
@@ -2257,20 +2283,20 @@ namespace quda {
       }
       virtual ~QDPJITOrder() { ; }
 
-      __device__ __host__ inline void load(complex v[length/2], int x, int dir, int parity, real inphase = 1.0) const
+      __device__ __host__ inline void load(complex v[length / 2], int x, int dir, int parity, real inphase = 1.0) const
       {
-        for (int i = 0; i < length/2; i++) {
-	  v[i].real((real)gauge[dir][((0*(length/2) + i)*2 + parity)*volumeCB + x]);
-	  v[i].imag((real)gauge[dir][((1*(length/2) + i)*2 + parity)*volumeCB + x]);
+        for (int i = 0; i < length / 2; i++) {
+          v[i].real((real)gauge[dir][((0 * (length / 2) + i) * 2 + parity) * volumeCB + x]);
+          v[i].imag((real)gauge[dir][((1 * (length / 2) + i) * 2 + parity) * volumeCB + x]);
         }
       }
 
-      __device__ __host__ inline void save(const complex v[length/2], int x, int dir, int parity)
+      __device__ __host__ inline void save(const complex v[length / 2], int x, int dir, int parity)
       {
-	for (int i=0; i<length/2; i++) {
-	  gauge[dir][((0*(length/2) + i)*2 + parity)*volumeCB + x] = v[i].real();
-	  gauge[dir][((1*(length/2) + i)*2 + parity)*volumeCB + x] = v[i].imag();
-	}
+        for (int i = 0; i < length / 2; i++) {
+          gauge[dir][((0 * (length / 2) + i) * 2 + parity) * volumeCB + x] = v[i].real();
+          gauge[dir][((1 * (length / 2) + i) * 2 + parity) * volumeCB + x] = v[i].imag();
+        }
       }
 
       /**
@@ -2283,8 +2309,7 @@ namespace quda {
 	 @return Instance of a gauge_wrapper that curries in access to
 	 this field at the above coordinates.
        */
-      __device__ __host__ inline gauge_wrapper<real, QDPJITOrder<Float, length>> operator()(
-          int dim, int x_cb, int parity)
+      __device__ __host__ inline gauge_wrapper<real, QDPJITOrder<Float, length>> operator()(int dim, int x_cb, int parity)
       {
         return gauge_wrapper<real, QDPJITOrder<Float, length>>(*this, dim, x_cb, parity);
       }
@@ -2299,10 +2324,11 @@ namespace quda {
 	 @return Instance of a gauge_wrapper that curries in access to
 	 this field at the above coordinates.
        */
-      __device__ __host__ inline const gauge_wrapper<real, QDPJITOrder<Float, length>> operator()(
-          int dim, int x_cb, int parity) const
+      __device__ __host__ inline const gauge_wrapper<real, QDPJITOrder<Float, length>> operator()(int dim, int x_cb,
+                                                                                                  int parity) const
       {
-        return gauge_wrapper<real, QDPJITOrder<Float, length>>(const_cast<QDPJITOrder<Float, length> &>(*this), dim, x_cb, parity);
+        return gauge_wrapper<real, QDPJITOrder<Float, length>>(const_cast<QDPJITOrder<Float, length> &>(*this), dim,
+                                                               x_cb, parity);
       }
 
       size_t Bytes() const { return length * sizeof(Float); }
@@ -2326,34 +2352,34 @@ namespace quda {
       { ; }
     virtual ~MILCOrder() { ; }
 
-    __device__ __host__ inline void load(complex v[length/2], int x, int dir, int parity, real inphase = 1.0) const
+    __device__ __host__ inline void load(complex v[length / 2], int x, int dir, int parity, real inphase = 1.0) const
     {
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
       typedef S<Float,length> structure;
       trove::coalesced_ptr<structure> gauge_((structure*)gauge);
       structure v_ = gauge_[(parity*volumeCB+x)*geometry + dir];
 #else
-      auto v_ = &gauge[((parity*volumeCB+x)*geometry + dir)*length];
+      auto v_ = &gauge[((parity * volumeCB + x) * geometry + dir) * length];
 #endif
-      for (int i=0; i<length/2; i++) v[i] = complex(v_[2*i+0], v_[2*i+1]);
+      for (int i = 0; i < length / 2; i++) v[i] = complex(v_[2 * i + 0], v_[2 * i + 1]);
     }
 
-    __device__ __host__ inline void save(const complex v[length/2], int x, int dir, int parity)
+    __device__ __host__ inline void save(const complex v[length / 2], int x, int dir, int parity)
     {
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
       typedef S<Float,length> structure;
       trove::coalesced_ptr<structure> gauge_((structure*)gauge);
       structure v_;
-      for (int i=0; i<length/2; i++) {
-        v_.v[2*i+0] = v[i].real();
-        v_.v[2*i+1] = v[i].imag();
+      for (int i = 0; i < length / 2; i++) {
+        v_.v[2 * i + 0] = v[i].real();
+        v_.v[2 * i + 1] = v[i].imag();
       }
       gauge_[(parity*volumeCB+x)*geometry + dir] = v_;
 #else
-      auto v_ = &gauge[((parity*volumeCB+x)*geometry + dir)*length];
-      for (int i=0; i<length/2; i++) {
-	v_[2*i+0] = v[i].real();
-	v_[2*i+1] = v[i].imag();
+      auto v_ = &gauge[((parity * volumeCB + x) * geometry + dir) * length];
+      for (int i = 0; i < length / 2; i++) {
+        v_[2 * i + 0] = v[i].real();
+        v_[2 * i + 1] = v[i].imag();
       }
 #endif
     }
@@ -2383,10 +2409,11 @@ namespace quda {
        @return Instance of a gauge_wrapper that curries in access to
        this field at the above coordinates.
     */
-    __device__ __host__ inline const gauge_wrapper<real, MILCOrder<Float, length>> operator()(
-        int dim, int x_cb, int parity) const
+    __device__ __host__ inline const gauge_wrapper<real, MILCOrder<Float, length>> operator()(int dim, int x_cb,
+                                                                                              int parity) const
     {
-      return gauge_wrapper<real, MILCOrder<Float, length>>(const_cast<MILCOrder<Float, length> &>(*this), dim, x_cb, parity);
+      return gauge_wrapper<real, MILCOrder<Float, length>>(const_cast<MILCOrder<Float, length> &>(*this), dim, x_cb,
+                                                           parity);
     }
 
     size_t Bytes() const { return length * sizeof(Float); }
@@ -2438,7 +2465,7 @@ namespace quda {
 
     virtual ~MILCSiteOrder() { ; }
 
-    __device__ __host__ inline void load(complex v[length/2], int x, int dir, int parity, real inphase = 1.0) const
+    __device__ __host__ inline void load(complex v[length / 2], int x, int dir, int parity, real inphase = 1.0) const
     {
       // get base pointer
       const Float *gauge0 = reinterpret_cast<const Float*>(reinterpret_cast<const char*>(gauge) + (parity*volumeCB+x)*size + offset);
@@ -2448,12 +2475,13 @@ namespace quda {
       trove::coalesced_ptr<structure> gauge_((structure*)gauge0);
       structure v_ = gauge_[dir];
 #else
-      auto v_ = &gauge0[dir*length];
+      auto v_ = &gauge0[dir * length];
 #endif
-      for (int i=0; i<length/2; i++) v[i] = complex(v_[2*i + 0], v_[2*i + 1]);
+      for (int i = 0; i < length / 2; i++) v[i] = complex(v_[2 * i + 0], v_[2 * i + 1]);
     }
 
-    __device__ __host__ inline void save(const complex v[length/2], int x, int dir, int parity) {
+    __device__ __host__ inline void save(const complex v[length / 2], int x, int dir, int parity)
+    {
       // get base pointer
       Float *gauge0 = reinterpret_cast<Float*>(reinterpret_cast<char*>(gauge) + (parity*volumeCB+x)*size + offset);
 
@@ -2461,15 +2489,15 @@ namespace quda {
       typedef S<Float,length> structure;
       trove::coalesced_ptr<structure> gauge_((structure*)gauge0);
       structure v_;
-      for (int i=0; i<length/2; i++) {
-        v_.v[2*i+0] = v[i].real();
-        v_.v[2*i+1] = v[i].imag();
+      for (int i = 0; i < length / 2; i++) {
+        v_.v[2 * i + 0] = v[i].real();
+        v_.v[2 * i + 1] = v[i].imag();
       }
       gauge_[dir] = v_;
 #else
-      for (int i=0; i<length/2; i++) {
-	gauge0[dir*length + 2*i + 0] = v[i].real();
-	gauge0[dir*length + 2*i + 1] = v[i].imag();
+      for (int i = 0; i < length / 2; i++) {
+        gauge0[dir * length + 2 * i + 0] = v[i].real();
+        gauge0[dir * length + 2 * i + 1] = v[i].imag();
       }
 #endif
     }
@@ -2499,10 +2527,11 @@ namespace quda {
        @return Instance of a gauge_wrapper that curries in access to
        this field at the above coordinates.
     */
-    __device__ __host__ inline const gauge_wrapper<real, MILCSiteOrder<Float, length>> operator()(
-        int dim, int x_cb, int parity) const
+    __device__ __host__ inline const gauge_wrapper<real, MILCSiteOrder<Float, length>> operator()(int dim, int x_cb,
+                                                                                                  int parity) const
     {
-      return gauge_wrapper<real, MILCSiteOrder<Float, length>>(const_cast<MILCSiteOrder<Float, length> &>(*this), dim, x_cb, parity);
+      return gauge_wrapper<real, MILCSiteOrder<Float, length>>(const_cast<MILCSiteOrder<Float, length> &>(*this), dim,
+                                                               x_cb, parity);
     }
 
     size_t Bytes() const { return length * sizeof(Float); }
@@ -2522,13 +2551,24 @@ namespace quda {
     const real anisotropy_inv;
     static constexpr int Nc = 3;
     const int geometry;
-  CPSOrder(const GaugeField &u, Float *gauge_=0, Float **ghost_=0)
-    : LegacyOrder<Float,length>(u, ghost_), gauge(gauge_ ? gauge_ : (Float*)u.Gauge_p()),
-      volumeCB(u.VolumeCB()), anisotropy(u.Anisotropy()), anisotropy_inv(1.0/anisotropy), geometry(u.Geometry())
-      { if (length != 18) errorQuda("Gauge length %d not supported", length); }
-  CPSOrder(const CPSOrder &order) : LegacyOrder<Float,length>(order), gauge(order.gauge), volumeCB(order.volumeCB),
-      anisotropy(order.anisotropy), anisotropy_inv(order.anisotropy_inv), geometry(order.geometry)
-      { ; }
+    CPSOrder(const GaugeField &u, Float *gauge_ = 0, Float **ghost_ = 0) :
+      LegacyOrder<Float, length>(u, ghost_),
+      gauge(gauge_ ? gauge_ : (Float *)u.Gauge_p()),
+      volumeCB(u.VolumeCB()),
+      anisotropy(u.Anisotropy()),
+      anisotropy_inv(1.0 / anisotropy),
+      geometry(u.Geometry())
+    {
+      if (length != 18) errorQuda("Gauge length %d not supported", length); }
+    CPSOrder(const CPSOrder &order) :
+      LegacyOrder<Float, length>(order),
+      gauge(order.gauge),
+      volumeCB(order.volumeCB),
+      anisotropy(order.anisotropy),
+      anisotropy_inv(order.anisotropy_inv),
+      geometry(order.geometry)
+    {
+      ; }
     virtual ~CPSOrder() { ; }
 
     // we need to transpose and scale for CPS ordering
@@ -2539,11 +2579,11 @@ namespace quda {
       trove::coalesced_ptr<structure> gauge_((structure*)gauge);
       structure v_ = gauge_[((parity*volumeCB+x)*geometry + dir)];
 #else
-      auto v_ = &gauge[((parity*volumeCB+x)*geometry + dir)*length];
+      auto v_ = &gauge[((parity * volumeCB + x) * geometry + dir) * length];
 #endif
       for (int i=0; i<Nc; i++) {
 	for (int j=0; j<Nc; j++) {
-          v[i*Nc+j] = complex(v_[(j*Nc+i)*2+0], v_[(j*Nc+i)*2+1]) * anisotropy_inv;
+          v[i * Nc + j] = complex(v_[(j * Nc + i) * 2 + 0], v_[(j * Nc + i) * 2 + 1]) * anisotropy_inv;
         }
       }
     }
@@ -2555,18 +2595,18 @@ namespace quda {
       trove::coalesced_ptr<structure> gauge_((structure*)gauge);
       structure v_;
       for (int i=0; i<Nc; i++)
-	for (int j=0; j<Nc; j++) {
-          v_.v[(j*Nc+i)*2+0] = anisotropy * v[i*Nc+j].real();
-          v_.v[(j*Nc+i)*2+1] = anisotropy * v[i*Nc+j].imag();
+        for (int j = 0; j < Nc; j++) {
+          v_.v[(j * Nc + i) * 2 + 0] = anisotropy * v[i * Nc + j].real();
+          v_.v[(j * Nc + i) * 2 + 1] = anisotropy * v[i * Nc + j].imag();
         }
       gauge_[((parity*volumeCB+x)*geometry + dir)] = v_;
 #else
-      auto v_ = &gauge[((parity*volumeCB+x)*geometry + dir)*length];
+      auto v_ = &gauge[((parity * volumeCB + x) * geometry + dir) * length];
       for (int i=0; i<Nc; i++) {
 	for (int j=0; j<Nc; j++) {
-          v_[(j*Nc + i)*2+0] = anisotropy * v[i*Nc+j].real();
-          v_[(j*Nc + i)*2+1] = anisotropy * v[i*Nc+j].imag();
-	}
+          v_[(j * Nc + i) * 2 + 0] = anisotropy * v[i * Nc + j].real();
+          v_[(j * Nc + i) * 2 + 1] = anisotropy * v[i * Nc + j].imag();
+        }
       }
 #endif
     }
@@ -2596,11 +2636,11 @@ namespace quda {
        @return Instance of a gauge_wrapper that curries in access to
        this field at the above coordinates.
     */
-    __device__ __host__ inline const gauge_wrapper<real, CPSOrder<Float, length>> operator()(
-        int dim, int x_cb, int parity) const
+    __device__ __host__ inline const gauge_wrapper<real, CPSOrder<Float, length>> operator()(int dim, int x_cb,
+                                                                                             int parity) const
     {
-      return gauge_wrapper<real, CPSOrder<Float, length>>(
-          const_cast<CPSOrder<Float, length> &>(*this), dim, x_cb, parity);
+      return gauge_wrapper<real, CPSOrder<Float, length>>(const_cast<CPSOrder<Float, length> &>(*this), dim, x_cb,
+                                                          parity);
     }
 
     size_t Bytes() const { return Nc * Nc * 2 * sizeof(Float); }
@@ -2620,18 +2660,23 @@ namespace quda {
       const int volumeCB;
       int exVolumeCB; // extended checkerboard volume
       static constexpr int Nc = 3;
-    BQCDOrder(const GaugeField &u, Float *gauge_=0, Float **ghost_=0)
-      : LegacyOrder<Float,length>(u, ghost_), gauge(gauge_ ? gauge_ : (Float*)u.Gauge_p()), volumeCB(u.VolumeCB())
+      BQCDOrder(const GaugeField &u, Float *gauge_ = 0, Float **ghost_ = 0) :
+        LegacyOrder<Float, length>(u, ghost_),
+        gauge(gauge_ ? gauge_ : (Float *)u.Gauge_p()),
+        volumeCB(u.VolumeCB())
       {
-	if (length != 18) errorQuda("Gauge length %d not supported", length);
+        if (length != 18) errorQuda("Gauge length %d not supported", length);
 	// compute volumeCB + halo region
 	exVolumeCB = u.X()[0]/2 + 2;
 	for (int i=1; i<4; i++) exVolumeCB *= u.X()[i] + 2;
       }
-    BQCDOrder(const BQCDOrder &order) : LegacyOrder<Float,length>(order), gauge(order.gauge),
-	volumeCB(order.volumeCB), exVolumeCB(order.exVolumeCB)
+      BQCDOrder(const BQCDOrder &order) :
+        LegacyOrder<Float, length>(order),
+        gauge(order.gauge),
+        volumeCB(order.volumeCB),
+        exVolumeCB(order.exVolumeCB)
       {
-	if (length != 18) errorQuda("Gauge length %d not supported", length);
+        if (length != 18) errorQuda("Gauge length %d not supported", length);
       }
 
       virtual ~BQCDOrder() { ; }
@@ -2640,16 +2685,14 @@ namespace quda {
       __device__ __host__ inline void load(complex v[9], int x, int dir, int parity, real inphase = 1.0) const
       {
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
-        typedef S<Float,length> structure;
-        trove::coalesced_ptr<structure> gauge_((structure*)gauge);
-        structure v_ = gauge_[(dir*2+parity)*exVolumeCB + x];
+        typedef S<Float, length> structure;
+        trove::coalesced_ptr<structure> gauge_((structure *)gauge);
+        structure v_ = gauge_[(dir * 2 + parity) * exVolumeCB + x];
 #else
-        auto v_ = &gauge[((dir*2+parity)*exVolumeCB + x)*length];
+        auto v_ = &gauge[((dir * 2 + parity) * exVolumeCB + x) * length];
 #endif
-        for (int i=0; i<Nc; i++) {
-          for (int j=0; j<Nc; j++) {
-            v[i*Nc+j] = complex(v_[(j*Nc+i)*2+0], v_[(j*Nc+i)*2+1]);
-          }
+        for (int i = 0; i < Nc; i++) {
+          for (int j = 0; j < Nc; j++) { v[i * Nc + j] = complex(v_[(j * Nc + i) * 2 + 0], v_[(j * Nc + i) * 2 + 1]); }
         }
       }
 
@@ -2660,18 +2703,18 @@ namespace quda {
 	trove::coalesced_ptr<structure> gauge_((structure*)gauge);
 	structure v_;
 	for (int i=0; i<Nc; i++)
-	  for (int j=0; j<Nc; j++) {
-            v_.v[(j*Nc+i)*2+0] = v[i*Nc+j].real();
-            v_.v[(j*Nc+i)*2+1] = v[i*Nc+j].imag();
+          for (int j = 0; j < Nc; j++) {
+            v_.v[(j * Nc + i) * 2 + 0] = v[i * Nc + j].real();
+            v_.v[(j * Nc + i) * 2 + 1] = v[i * Nc + j].imag();
           }
-	gauge_[(dir*2+parity)*exVolumeCB + x] = v_;
+        gauge_[(dir*2+parity)*exVolumeCB + x] = v_;
 #else
-        auto v_ = &gauge[((dir*2+parity)*exVolumeCB + x)*length];
-	for (int i=0; i<Nc; i++) {
+        auto v_ = &gauge[((dir * 2 + parity) * exVolumeCB + x) * length];
+        for (int i=0; i<Nc; i++) {
 	  for (int j=0; j<Nc; j++) {
-            v_[((Nc + j)*Nc + i)*2 + 0] = v[i*Nc+j].real();
-            v_[((Nc + j)*Nc + i)*2 + 1] = v[i*Nc+j].imag();
-	  }
+            v_[((Nc + j) * Nc + i) * 2 + 0] = v[i * Nc + j].real();
+            v_[((Nc + j) * Nc + i) * 2 + 1] = v[i * Nc + j].imag();
+          }
 	}
 #endif
       }
@@ -2701,11 +2744,11 @@ namespace quda {
 	 @return Instance of a gauge_wrapper that curries in access to
 	 this field at the above coordinates.
        */
-      __device__ __host__ inline const gauge_wrapper<real, BQCDOrder<Float, length>> operator()(
-          int dim, int x_cb, int parity) const
+      __device__ __host__ inline const gauge_wrapper<real, BQCDOrder<Float, length>> operator()(int dim, int x_cb,
+                                                                                                int parity) const
       {
-        return gauge_wrapper<real, BQCDOrder<Float, length>>(
-            const_cast<BQCDOrder<Float, length> &>(*this), dim, x_cb, parity);
+        return gauge_wrapper<real, BQCDOrder<Float, length>>(const_cast<BQCDOrder<Float, length> &>(*this), dim, x_cb,
+                                                             parity);
       }
 
       size_t Bytes() const { return Nc * Nc * 2 * sizeof(Float); }
@@ -2716,23 +2759,30 @@ namespace quda {
        [mu][parity][volumecb][col][row]
     */
     template <typename Float, int length> struct TIFROrder : LegacyOrder<Float,length> {
-      using real =  typename mapper<Float>::type;
+      using real = typename mapper<Float>::type;
       using complex = complex<real>;
       Float *gauge;
       const int volumeCB;
       static constexpr int Nc = 3;
       const real scale;
       const real scale_inv;
-    TIFROrder(const GaugeField &u, Float *gauge_=0, Float **ghost_=0)
-      : LegacyOrder<Float,length>(u, ghost_), gauge(gauge_ ? gauge_ : (Float*)u.Gauge_p()),
-	volumeCB(u.VolumeCB()), scale(u.Scale()), scale_inv(1.0 / scale)
+      TIFROrder(const GaugeField &u, Float *gauge_ = 0, Float **ghost_ = 0) :
+        LegacyOrder<Float, length>(u, ghost_),
+        gauge(gauge_ ? gauge_ : (Float *)u.Gauge_p()),
+        volumeCB(u.VolumeCB()),
+        scale(u.Scale()),
+        scale_inv(1.0 / scale)
       {
-	if (length != 18) errorQuda("Gauge length %d not supported", length);
+        if (length != 18) errorQuda("Gauge length %d not supported", length);
       }
-    TIFROrder(const TIFROrder &order)
-      : LegacyOrder<Float,length>(order), gauge(order.gauge), volumeCB(order.volumeCB), scale(order.scale), scale_inv(1.0 / scale)
+      TIFROrder(const TIFROrder &order) :
+        LegacyOrder<Float, length>(order),
+        gauge(order.gauge),
+        volumeCB(order.volumeCB),
+        scale(order.scale),
+        scale_inv(1.0 / scale)
       {
-	if (length != 18) errorQuda("Gauge length %d not supported", length);
+        if (length != 18) errorQuda("Gauge length %d not supported", length);
       }
 
       virtual ~TIFROrder() { ; }
@@ -2741,15 +2791,15 @@ namespace quda {
       __device__ __host__ inline void load(complex v[9], int x, int dir, int parity, real inphase = 1.0) const
       {
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
-        typedef S<Float,length> structure;
-        trove::coalesced_ptr<structure> gauge_((structure*)gauge);
-        structure v_ = gauge_[(dir*2+parity)*volumeCB + x];
+        typedef S<Float, length> structure;
+        trove::coalesced_ptr<structure> gauge_((structure *)gauge);
+        structure v_ = gauge_[(dir * 2 + parity) * volumeCB + x];
 #else
-        auto v_ = &gauge[((dir*2+parity)*volumeCB + x)*length];
+        auto v_ = &gauge[((dir * 2 + parity) * volumeCB + x) * length];
 #endif
-        for (int i=0; i<Nc; i++) {
-          for (int j=0; j<Nc; j++) {
-            v[i*Nc+j] = complex(v_[(j*Nc+i)*2+0], v_[(j*Nc+i)*2+1]) * scale_inv;
+        for (int i = 0; i < Nc; i++) {
+          for (int j = 0; j < Nc; j++) {
+            v[i * Nc + j] = complex(v_[(j * Nc + i) * 2 + 0], v_[(j * Nc + i) * 2 + 1]) * scale_inv;
           }
         }
       }
@@ -2761,18 +2811,18 @@ namespace quda {
 	trove::coalesced_ptr<structure> gauge_((structure*)gauge);
 	structure v_;
 	for (int i=0; i<Nc; i++)
-	  for (int j=0; j<Nc; j++) {
-            v_.v[(j*Nc+i)*2+0] = v[i*Nc+j].real() * scale;
-            v_.v[(j*Nc+i)*2+1] = v[i*Nc+j].imag() * scale;
+          for (int j = 0; j < Nc; j++) {
+            v_.v[(j * Nc + i) * 2 + 0] = v[i * Nc + j].real() * scale;
+            v_.v[(j * Nc + i) * 2 + 1] = v[i * Nc + j].imag() * scale;
           }
-	gauge_[(dir*2+parity)*volumeCB + x] = v_;
+        gauge_[(dir*2+parity)*volumeCB + x] = v_;
 #else
-        auto v_ = &gauge[((dir*2+parity)*volumeCB + x)*length];
-	for (int i=0; i<Nc; i++) {
+        auto v_ = &gauge[((dir * 2 + parity) * volumeCB + x) * length];
+        for (int i=0; i<Nc; i++) {
 	  for (int j=0; j<Nc; j++) {
-            v_[((Nc + j)*Nc + i)*2 + 0] = v[i*Nc+j].real() * scale;
-            v_[((Nc + j)*Nc + i)*2 + 1] = v[i*Nc+j].imag() * scale;
-	  }
+            v_[((Nc + j) * Nc + i) * 2 + 0] = v[i * Nc + j].real() * scale;
+            v_[((Nc + j) * Nc + i) * 2 + 1] = v[i * Nc + j].imag() * scale;
+          }
 	}
 #endif
       }
@@ -2802,11 +2852,11 @@ namespace quda {
 	 @return Instance of a gauge_wrapper that curries in access to
 	 this field at the above coordinates.
        */
-      __device__ __host__ inline const gauge_wrapper<real, TIFROrder<Float, length>> operator()(
-          int dim, int x_cb, int parity) const
+      __device__ __host__ inline const gauge_wrapper<real, TIFROrder<Float, length>> operator()(int dim, int x_cb,
+                                                                                                int parity) const
       {
-        return gauge_wrapper<real, TIFROrder<Float, length>>(
-            const_cast<TIFROrder<Float, length> &>(*this), dim, x_cb, parity);
+        return gauge_wrapper<real, TIFROrder<Float, length>>(const_cast<TIFROrder<Float, length> &>(*this), dim, x_cb,
+                                                             parity);
       }
 
       size_t Bytes() const { return Nc * Nc * 2 * sizeof(Float); }
@@ -2817,7 +2867,7 @@ namespace quda {
        [mu][parity][t][z+4][y][x/2][col][row]
     */
     template <typename Float, int length> struct TIFRPaddedOrder : LegacyOrder<Float,length> {
-      using real =  typename mapper<Float>::type;
+      using real = typename mapper<Float>::type;
       using complex = complex<real>;
       Float *gauge;
       const int volumeCB;
@@ -2827,25 +2877,34 @@ namespace quda {
       const real scale_inv;
       const int dim[4];
       const int exDim[4];
-    TIFRPaddedOrder(const GaugeField &u, Float *gauge_=0, Float **ghost_=0)
-      : LegacyOrder<Float,length>(u, ghost_), gauge(gauge_ ? gauge_ : (Float*)u.Gauge_p()),
-	volumeCB(u.VolumeCB()), exVolumeCB(1), scale(u.Scale()), scale_inv(1.0 / scale),
-	dim{ u.X()[0], u.X()[1], u.X()[2], u.X()[3] },
-	exDim{ u.X()[0], u.X()[1], u.X()[2] + 4, u.X()[3] } {
-	if (length != 18) errorQuda("Gauge length %d not supported", length);
+      TIFRPaddedOrder(const GaugeField &u, Float *gauge_ = 0, Float **ghost_ = 0) :
+        LegacyOrder<Float, length>(u, ghost_),
+        gauge(gauge_ ? gauge_ : (Float *)u.Gauge_p()),
+        volumeCB(u.VolumeCB()),
+        exVolumeCB(1),
+        scale(u.Scale()),
+        scale_inv(1.0 / scale),
+        dim {u.X()[0], u.X()[1], u.X()[2], u.X()[3]},
+        exDim {u.X()[0], u.X()[1], u.X()[2] + 4, u.X()[3]}
+      {
+        if (length != 18) errorQuda("Gauge length %d not supported", length);
 
 	// exVolumeCB is the padded checkboard volume
 	for (int i=0; i<4; i++) exVolumeCB *= exDim[i];
 	exVolumeCB /= 2;
       }
 
-    TIFRPaddedOrder(const TIFRPaddedOrder &order)
-      : LegacyOrder<Float,length>(order), gauge(order.gauge), volumeCB(order.volumeCB), exVolumeCB(order.exVolumeCB),
-          scale(order.scale), scale_inv(order.scale_inv),
-	  dim{order.dim[0], order.dim[1], order.dim[2], order.dim[3]},
-	  exDim{order.exDim[0], order.exDim[1], order.exDim[2], order.exDim[3]}
+      TIFRPaddedOrder(const TIFRPaddedOrder &order) :
+        LegacyOrder<Float, length>(order),
+        gauge(order.gauge),
+        volumeCB(order.volumeCB),
+        exVolumeCB(order.exVolumeCB),
+        scale(order.scale),
+        scale_inv(order.scale_inv),
+        dim {order.dim[0], order.dim[1], order.dim[2], order.dim[3]},
+        exDim {order.exDim[0], order.exDim[1], order.exDim[2], order.exDim[3]}
       {
-	if (length != 18) errorQuda("Gauge length %d not supported", length);
+        if (length != 18) errorQuda("Gauge length %d not supported", length);
       }
 
       virtual ~TIFRPaddedOrder() { ; }
@@ -2874,36 +2933,36 @@ namespace quda {
 	trove::coalesced_ptr<structure> gauge_((structure*)gauge);
 	structure v_ = gauge_[(dir*2+parity)*exVolumeCB + y];
 #else
-        auto v_ = &gauge[((dir*2+parity)*exVolumeCB + y)*length];
+        auto v_ = &gauge[((dir * 2 + parity) * exVolumeCB + y) * length];
 #endif
-        for (int i=0; i<Nc; i++) {
-          for (int j=0; j<Nc; j++) {
-            v[i*Nc+j] = complex(v_[(j*Nc+i)*2+0], v_[(j*Nc+i)*2+1]) * scale_inv;
+        for (int i = 0; i < Nc; i++) {
+          for (int j = 0; j < Nc; j++) {
+            v[i * Nc + j] = complex(v_[(j * Nc + i) * 2 + 0], v_[(j * Nc + i) * 2 + 1]) * scale_inv;
           }
         }
       }
 
       __device__ __host__ inline void save(const complex v[9], int x, int dir, int parity)
       {
-	int y = getPaddedIndex(x, parity);
+        int y = getPaddedIndex(x, parity);
 
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
 	typedef S<Float,length> structure;
 	trove::coalesced_ptr<structure> gauge_((structure*)gauge);
 	structure v_;
 	for (int i=0; i<Nc; i++)
-	  for (int j=0; j<Nc; j++) {
-            v_.v[(j*Nc+i)*2+0] = v[i*Nc+j].real() * scale;
-            v_.v[(j*Nc+i)*2+1] = v[i*Nc+j].imag() * scale;
+          for (int j = 0; j < Nc; j++) {
+            v_.v[(j * Nc + i) * 2 + 0] = v[i * Nc + j].real() * scale;
+            v_.v[(j * Nc + i) * 2 + 1] = v[i * Nc + j].imag() * scale;
           }
-        gauge_[(dir*2+parity)*exVolumeCB + y] = v_;
+        gauge_[(dir * 2 + parity) * exVolumeCB + y] = v_;
 #else
-        auto v_ = &gauge[((dir*2+parity)*exVolumeCB + y)*length];
-	for (int i=0; i<Nc; i++) {
+        auto v_ = &gauge[((dir * 2 + parity) * exVolumeCB + y) * length];
+        for (int i=0; i<Nc; i++) {
 	  for (int j=0; j<Nc; j++) {
-            v_[((Nc + j)*Nc + i)*2 + 0] = v[i*Nc+j].real() * scale;
-            v_[((Nc + j)*Nc + i)*2 + 1] = v[i*Nc+j].imag() * scale;
-	  }
+            v_[((Nc + j) * Nc + i) * 2 + 0] = v[i * Nc + j].real() * scale;
+            v_[((Nc + j) * Nc + i) * 2 + 1] = v[i * Nc + j].imag() * scale;
+          }
 	}
 #endif
       }
@@ -2918,8 +2977,8 @@ namespace quda {
 	 @return Instance of a gauge_wrapper that curries in access to
 	 this field at the above coordinates.
        */
-      __device__ __host__ inline gauge_wrapper<real, TIFRPaddedOrder<Float, length>> operator()(
-          int dim, int x_cb, int parity)
+      __device__ __host__ inline gauge_wrapper<real, TIFRPaddedOrder<Float, length>> operator()(int dim, int x_cb,
+                                                                                                int parity)
       {
         return gauge_wrapper<real, TIFRPaddedOrder<Float, length>>(*this, dim, x_cb, parity);
       }
@@ -2934,11 +2993,11 @@ namespace quda {
 	 @return Instance of a gauge_wrapper that curries in access to
 	 this field at the above coordinates.
        */
-      __device__ __host__ inline const gauge_wrapper<real, TIFRPaddedOrder<Float, length>> operator()(
-          int dim, int x_cb, int parity) const
+      __device__ __host__ inline const gauge_wrapper<real, TIFRPaddedOrder<Float, length>> operator()(int dim, int x_cb,
+                                                                                                      int parity) const
       {
-        return gauge_wrapper<real, TIFRPaddedOrder<Float, length>>(
-            const_cast<TIFRPaddedOrder<Float, length> &>(*this), dim, x_cb, parity);
+        return gauge_wrapper<real, TIFRPaddedOrder<Float, length>>(const_cast<TIFRPaddedOrder<Float, length> &>(*this),
+                                                                   dim, x_cb, parity);
       }
 
       size_t Bytes() const { return Nc * Nc * 2 * sizeof(Float); }

--- a/include/gauge_field_order.h
+++ b/include/gauge_field_order.h
@@ -1379,7 +1379,7 @@ namespace quda {
         }
 
         template <typename I>
-        __device__ __host__ inline void Unpack(complex out[18], const real in[12], int idx, int dir, real phase,
+        __device__ __host__ inline void Unpack(complex out[9], const real in[12], int idx, int dir, real phase,
                                                const I *X, const int *R) const
         {
 #pragma unroll
@@ -1560,7 +1560,7 @@ namespace quda {
 
         template <typename I>
         __device__ __host__ inline void
-        Unpack(complex out[18], const real in[8], int idx, int dir, real phase, const I *X, const int *R,
+        Unpack(complex out[9], const real in[8], int idx, int dir, real phase, const I *X, const int *R,
                const complex scale = complex(static_cast<real>(1.0), static_cast<real>(1.0))) const
         {
           complex u = dir < 3 ?

--- a/include/gauge_field_order.h
+++ b/include/gauge_field_order.h
@@ -8,12 +8,6 @@
  *
  */
 
-// trove requires the warp shuffle instructions introduced with Kepler
-#if __COMPUTE_CAPABILITY__ >= 300
-#include <trove/ptr.h>
-#else
-#define DISABLE_TROVE
-#endif
 #ifndef __CUDACC_RTC__
 #include <assert.h>
 #endif
@@ -30,6 +24,7 @@
 #include <thrust_helper.cuh>
 #include <gauge_field.h>
 #include <index_helper.cuh>
+#include <trove_helper.cuh>
 
 namespace quda {
 

--- a/include/gauge_field_order.h
+++ b/include/gauge_field_order.h
@@ -1898,7 +1898,7 @@ namespace quda {
       __device__ __host__ inline void saveGhost(const complex v[length / 2], int x, int dir, int parity)
       {
         if (!ghost[dir]) { // store in main field not separate array
-	  save(v, volumeCB + x, dir, parity); // an offset of size volumeCB puts us at the padded region
+          save(v, volumeCB + x, dir, parity); // an offset of size volumeCB puts us at the padded region
         } else {
           const int M = reconLen / N;
           real tmp[reconLen];
@@ -1976,7 +1976,7 @@ namespace quda {
                           + R[dim] * faceVolumeCB[dim] * M * N + buff_idx]);
 
         // use the extended_idx to determine the boundary condition
-        reconstruct.Unpack(v, tmp, extended_idx, g, 2.*M_PI*phase, X, R);
+        reconstruct.Unpack(v, tmp, extended_idx, g, 2. * M_PI * phase, X, R);
       }
 
       __device__ __host__ inline void saveGhostEx(const complex v[length / 2], int buff_idx, int extended_idx, int dir,
@@ -2085,9 +2085,9 @@ namespace quda {
         __device__ __host__ inline void loadGhost(complex v[length / 2], int x, int dir, int parity, real phase = 1.0) const
         {
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
-          typedef S<Float,length> structure;
-          trove::coalesced_ptr<structure> ghost_((structure*)ghost[dir]);
-          structure v_ = ghost_[parity*faceVolumeCB[dir] + x];
+          typedef S<Float, length> structure;
+          trove::coalesced_ptr<structure> ghost_((structure *)ghost[dir]);
+          structure v_ = ghost_[parity * faceVolumeCB[dir] + x];
 #else
           auto v_ = &ghost[dir][(parity * faceVolumeCB[dir] + x) * length];
 #endif
@@ -2097,8 +2097,8 @@ namespace quda {
         __device__ __host__ inline void saveGhost(const complex v[length / 2], int x, int dir, int parity)
         {
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
-          typedef S<Float,length> structure;
-          trove::coalesced_ptr<structure> ghost_((structure*)ghost[dir]);
+          typedef S<Float, length> structure;
+          trove::coalesced_ptr<structure> ghost_((structure *)ghost[dir]);
           structure v_;
           for (int i = 0; i < length / 2; i++) {
             v_[2 * i + 0] = (Float)v[i].real();
@@ -2163,8 +2163,8 @@ namespace quda {
                                                     int g, int parity, const int R[])
         {
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
-          typedef S<Float,length> structure;
-          trove::coalesced_ptr<structure> ghost_((structure*)ghost[dim]);
+          typedef S<Float, length> structure;
+          trove::coalesced_ptr<structure> ghost_((structure *)ghost[dim]);
           structure v_;
           for (int i = 0; i < length / 2; i++) {
             v_[2 * i + 0] = (Float)v[i].real();
@@ -2179,7 +2179,7 @@ namespace quda {
           }
 #endif
         }
-    };
+      };
 
     /**
        struct to define QDP ordered gauge fields:
@@ -2255,8 +2255,7 @@ namespace quda {
 	 @return Instance of a gauge_wrapper that curries in access to
 	 this field at the above coordinates.
        */
-      __device__ __host__ inline const gauge_wrapper<real, Accessor> operator()(int dim, int x_cb,
-                                                                                               int parity) const
+      __device__ __host__ inline const gauge_wrapper<real, Accessor> operator()(int dim, int x_cb, int parity) const
       {
         return gauge_wrapper<real, QDPOrder<Float, length>>(const_cast<Accessor &>(*this), dim, x_cb, parity);
       }
@@ -2348,14 +2347,14 @@ namespace quda {
       gauge(order.gauge), volumeCB(order.volumeCB), geometry(order.geometry)
       { ; }
 
-    __device__ __host__ inline void load(complex v[length / 2], int x, int dir, int parity, real inphase = 1.0) const
-    {
+      __device__ __host__ inline void load(complex v[length / 2], int x, int dir, int parity, real inphase = 1.0) const
+      {
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
       typedef S<Float,length> structure;
       trove::coalesced_ptr<structure> gauge_((structure*)gauge);
       structure v_ = gauge_[(parity*volumeCB+x)*geometry + dir];
 #else
-      auto v_ = &gauge[((parity * volumeCB + x) * geometry + dir) * length];
+        auto v_ = &gauge[((parity * volumeCB + x) * geometry + dir) * length];
 #endif
       for (int i = 0; i < length / 2; i++) v[i] = complex(v_[2 * i + 0], v_[2 * i + 1]);
     }
@@ -2659,7 +2658,7 @@ namespace quda {
       {
         if (length != 18) errorQuda("Gauge length %d not supported", length);
         // compute volumeCB + halo region
-	exVolumeCB = u.X()[0]/2 + 2;
+        exVolumeCB = u.X()[0]/2 + 2;
 	for (int i=1; i<4; i++) exVolumeCB *= u.X()[i] + 2;
       }
       BQCDOrder(const BQCDOrder &order) :
@@ -2701,7 +2700,7 @@ namespace quda {
 #else
         auto v_ = &gauge[((dir * 2 + parity) * exVolumeCB + x) * length];
         for (int i = 0; i < Nc; i++) {
-          for (int j=0; j<Nc; j++) {
+          for (int j = 0; j < Nc; j++) {
             v_[(j * Nc + i) * 2 + 0] = v[i * Nc + j].real();
             v_[(j * Nc + i) * 2 + 1] = v[i * Nc + j].imag();
           }
@@ -2806,7 +2805,7 @@ namespace quda {
 #else
         auto v_ = &gauge[((dir * 2 + parity) * volumeCB + x) * length];
         for (int i = 0; i < Nc; i++) {
-          for (int j=0; j<Nc; j++) {
+          for (int j = 0; j < Nc; j++) {
             v_[(j * Nc + i) * 2 + 0] = v[i * Nc + j].real() * scale;
             v_[(j * Nc + i) * 2 + 1] = v[i * Nc + j].imag() * scale;
           }
@@ -2876,7 +2875,7 @@ namespace quda {
         if (length != 18) errorQuda("Gauge length %d not supported", length);
 
         // exVolumeCB is the padded checkboard volume
-	for (int i=0; i<4; i++) exVolumeCB *= exDim[i];
+        for (int i=0; i<4; i++) exVolumeCB *= exDim[i];
 	exVolumeCB /= 2;
       }
 
@@ -2943,7 +2942,7 @@ namespace quda {
 #else
         auto v_ = &gauge[((dir * 2 + parity) * exVolumeCB + y) * length];
         for (int i = 0; i < Nc; i++) {
-          for (int j=0; j<Nc; j++) {
+          for (int j = 0; j < Nc; j++) {
             v_[(j * Nc + i) * 2 + 0] = v[i * Nc + j].real() * scale;
             v_[(j * Nc + i) * 2 + 1] = v[i * Nc + j].imag() * scale;
           }

--- a/include/gauge_field_order.h
+++ b/include/gauge_field_order.h
@@ -1504,10 +1504,10 @@ namespace quda {
             out[i] = complex(in[2 * i + 0], in[2 * i + 1]); // these elements are copied directly
 
           real tmp[2];
-          Trig<isFixed<Float>::value, real>::SinCos(in[0], &tmp[0], &tmp[1]);
+          Trig<isFixed<Float>::value, real>::SinCos(in[0], &tmp[1], &tmp[0]);
           out[0] = complex(tmp[0], tmp[1]);
 
-          Trig<isFixed<Float>::value, real>::SinCos(in[1], &tmp[0], &tmp[1]);
+          Trig<isFixed<Float>::value, real>::SinCos(in[1], &tmp[1], &tmp[0]);
           out[6] = complex(tmp[0], tmp[1]);
 
           // First, reconstruct first row

--- a/include/gauge_field_order.h
+++ b/include/gauge_field_order.h
@@ -2352,7 +2352,7 @@ namespace quda {
       { ; }
     virtual ~MILCOrder() { ; }
 
-    __device__ __host__ inline void load(complex v[9], int x, int dir, int parity, real inphase = 1.0) const
+    __device__ __host__ inline void load(complex v[length / 2], int x, int dir, int parity, real inphase = 1.0) const
     {
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
       typedef S<Float,length> structure;
@@ -2362,7 +2362,6 @@ namespace quda {
       auto v_ = &gauge[((parity * volumeCB + x) * geometry + dir) * length];
 #endif
       for (int i = 0; i < length / 2; i++) v[i] = complex(v_[2 * i + 0], v_[2 * i + 1]);
-      for (int i = length / 2; i < 9; i++) v[i] = complex(0.0, 0.0); // this is to surpress a compiler warning from reading from mom fields
     }
 
     __device__ __host__ inline void save(const complex v[length / 2], int x, int dir, int parity)
@@ -2466,7 +2465,7 @@ namespace quda {
 
     virtual ~MILCSiteOrder() { ; }
 
-    __device__ __host__ inline void load(complex v[9], int x, int dir, int parity, real inphase = 1.0) const
+    __device__ __host__ inline void load(complex v[length / 2], int x, int dir, int parity, real inphase = 1.0) const
     {
       // get base pointer
       const Float *gauge0 = reinterpret_cast<const Float*>(reinterpret_cast<const char*>(gauge) + (parity*volumeCB+x)*size + offset);
@@ -2479,7 +2478,6 @@ namespace quda {
       auto v_ = &gauge0[dir * length];
 #endif
       for (int i = 0; i < length / 2; i++) v[i] = complex(v_[2 * i + 0], v_[2 * i + 1]);
-      for (int i = length / 2; i < 9; i++) v[i] = complex(0.0, 0.0); // this is to surpress a compiler warning from reading from mom fields
     }
 
     __device__ __host__ inline void save(const complex v[length / 2], int x, int dir, int parity)

--- a/include/gauge_field_order.h
+++ b/include/gauge_field_order.h
@@ -73,7 +73,7 @@ namespace quda {
        */
       template<typename M>
       __device__ __host__ inline void operator=(const M &a) {
-	gauge.save((Float*)a.data, x_cb, dim, parity);
+	gauge.save(a.data, x_cb, dim, parity);
       }
     };
 
@@ -84,7 +84,7 @@ namespace quda {
   template <typename T, int N>
     template <typename S>
     __device__ __host__ inline void Matrix<T,N>::operator=(const gauge_wrapper<typename RealType<T>::type,S> &a) {
-    a.gauge.load((typename RealType<T>::type *)data, a.x_cb, a.dim, a.parity, a.phase);
+    a.gauge.load(data, a.x_cb, a.dim, a.parity, a.phase);
   }
 
   /**
@@ -94,7 +94,7 @@ namespace quda {
   template <typename T, int N>
     template <typename S>
     __device__ __host__ inline Matrix<T,N>::Matrix(const gauge_wrapper<typename RealType<T>::type,S> &a) {
-    a.gauge.load((typename RealType<T>::type *)data, a.x_cb, a.dim, a.parity, a.phase);
+    a.gauge.load(data, a.x_cb, a.dim, a.parity, a.phase);
   }
 
   /**
@@ -139,7 +139,7 @@ namespace quda {
        */
       template<typename M>
       __device__ __host__ inline void operator=(const M &a) {
-	gauge.saveGhost((Float*)a.data, ghost_idx, dim, parity);
+	gauge.saveGhost(a.data, ghost_idx, dim, parity);
       }
     };
 
@@ -150,7 +150,7 @@ namespace quda {
   template <typename T, int N>
     template <typename S>
     __device__ __host__ inline void Matrix<T,N>::operator=(const gauge_ghost_wrapper<typename RealType<T>::type,S> &a) {
-    a.gauge.loadGhost((typename RealType<T>::type *)data, a.ghost_idx, a.dim, a.parity, a.phase);
+    a.gauge.loadGhost(data, a.ghost_idx, a.dim, a.parity, a.phase);
   }
 
   /**
@@ -160,7 +160,7 @@ namespace quda {
   template <typename T, int N>
     template <typename S>
     __device__ __host__ inline Matrix<T,N>::Matrix(const gauge_ghost_wrapper<typename RealType<T>::type,S> &a) {
-    a.gauge.loadGhost((typename RealType<T>::type *)data, a.ghost_idx, a.dim, a.parity, a.phase);
+    a.gauge.loadGhost(data, a.ghost_idx, a.dim, a.parity, a.phase);
   }
 
   namespace gauge {
@@ -1128,38 +1128,48 @@ namespace quda {
       */
       template <int N, typename Float, QudaGhostExchange ghostExchange_, QudaStaggeredPhase = QUDA_STAGGERED_PHASE_NO>
       struct Reconstruct {
-        typedef typename mapper<Float>::type RegType;
-        RegType scale;
-        RegType scale_inv;
+        using real = typename mapper<Float>::type;
+        using complex = complex<real>;
+        real scale;
+        real scale_inv;
         Reconstruct(const GaugeField &u) : scale(u.LinkMax()), scale_inv(1.0 / scale) {}
         Reconstruct(const Reconstruct<N, Float, ghostExchange_> &recon) : scale(recon.scale), scale_inv(recon.scale_inv)
         {
         }
 
-        __device__ __host__ inline void Pack(RegType out[N], const RegType in[N], int idx) const
+        __device__ __host__ inline void Pack(real out[N], const complex in[N/2], int idx) const
         {
           if (isFixed<Float>::value) {
 #pragma unroll
-            for (int i = 0; i < N; i++) out[i] = scale_inv * in[i];
+            for (int i = 0; i < N/2; i++) {
+              out[2*i+0] = scale_inv * in[i].real();
+              out[2*i+1] = scale_inv * in[i].imag();
+            }
           } else {
 #pragma unroll
-            for (int i = 0; i < N; i++) out[i] = in[i];
+            for (int i = 0; i < N/2; i++) {
+              out[2*i+0] = in[i].real();
+              out[2*i+1] = in[i].imag();
+            }
           }
         }
 
         template <typename I>
-        __device__ __host__ inline void Unpack(
-            RegType out[N], const RegType in[N], int idx, int dir, const RegType phase, const I *X, const int *R) const
+        __device__ __host__ inline void Unpack(complex out[N/2], const real in[N], int idx, int dir, real phase, const I *X, const int *R) const
         {
           if (isFixed<Float>::value) {
 #pragma unroll
-            for (int i = 0; i < N; i++) out[i] = scale * in[i];
+            for (int i = 0; i < N/2; i++) {
+              out[i] = scale * complex(in[2*i+0], in[2*i+1]);
+            }
           } else {
 #pragma unroll
-            for (int i = 0; i < N; i++) out[i] = in[i];
+            for (int i = 0; i < N/2; i++) {
+              out[i] = complex(in[2*i+0], in[2*i+1]);
+            }
           }
         }
-        __device__ __host__ inline RegType getPhase(const RegType in[N]) const { return 0; }
+        __device__ __host__ inline real getPhase(const complex in[N/2]) const { return 0; }
       };
 
       /**
@@ -1226,10 +1236,10 @@ namespace quda {
          type to avoid the run-time overhead
       */
       template <typename Float, QudaGhostExchange ghostExchange_> struct Reconstruct<12, Float, ghostExchange_> {
-        typedef typename mapper<Float>::type RegType;
-        typedef complex<RegType> Complex;
-        const RegType anisotropy;
-        const RegType tBoundary;
+        using real = typename mapper<Float>::type;
+        using complex = complex<real>;
+        const real anisotropy;
+        const real tBoundary;
         const int firstTimeSliceBound;
         const int lastTimeSliceBound;
         const bool isFirstTimeSlice;
@@ -1238,7 +1248,7 @@ namespace quda {
 
         Reconstruct(const GaugeField &u) :
             anisotropy(u.Anisotropy()),
-            tBoundary(static_cast<RegType>(u.TBoundary())),
+            tBoundary(static_cast<real>(u.TBoundary())),
             firstTimeSliceBound(u.VolumeCB()),
             lastTimeSliceBound((u.X()[3] - 1) * u.X()[0] * u.X()[1] * u.X()[2] / 2),
             isFirstTimeSlice(comm_coord(3) == 0 ? true : false),
@@ -1258,46 +1268,42 @@ namespace quda {
         {
         }
 
-        __device__ __host__ inline void Pack(RegType out[12], const RegType in[18], int idx) const {
+        __device__ __host__ inline void Pack(real out[12], const complex in[9], int idx) const {
 #pragma unroll
-	  for (int i=0; i<12; i++) out[i] = in[i];
+	  for (int i=0; i<6; i++) {
+            out[2*i+0] = in[i].real();
+            out[2*i+1] = in[i].imag();
+          }
 	}
 
 	template<typename I>
-	__device__ __host__ inline void Unpack(RegType out[18], const RegType in[12], int idx, int dir,
-					       const RegType phase, const I *X, const int *R) const {
-          Complex Out[9];
+	__device__ __host__ inline void Unpack(complex out[9], const real in[12], int idx, int dir, real phase, const I *X, const int *R) const
+        {
 #pragma unroll
-          for (int i = 0; i < 6; i++) Out[i] = Complex(in[2 * i + 0], in[2 * i + 1]);
+          for (int i = 0; i < 6; i++) out[i] = complex(in[2 * i + 0], in[2 * i + 1]);
 
-          const RegType u0 = dir < 3 ?
+          const real u0 = dir < 3 ?
               anisotropy :
-              timeBoundary<ghostExchange_>(idx, X, R, tBoundary, static_cast<RegType>(1.0), firstTimeSliceBound,
+              timeBoundary<ghostExchange_>(idx, X, R, tBoundary, static_cast<real>(1.0), firstTimeSliceBound,
                   lastTimeSliceBound, isFirstTimeSlice, isLastTimeSlice, ghostExchange);
 
-          // Out[6] = u0*conj(Out[1]*Out[5] - Out[2]*Out[4]);
-          Out[6] = cmul(Out[2], Out[4]);
-          Out[6] = cmac(Out[1], Out[5], -Out[6]);
-          Out[6] = u0 * conj(Out[6]);
+          // out[6] = u0*conj(out[1]*out[5] - out[2]*out[4]);
+          out[6] = cmul(out[2], out[4]);
+          out[6] = cmac(out[1], out[5], -out[6]);
+          out[6] = u0 * conj(out[6]);
 
-          // Out[7] = u0*conj(Out[2]*Out[3] - Out[0]*Out[5]);
-          Out[7] = cmul(Out[0], Out[5]);
-          Out[7] = cmac(Out[2], Out[3], -Out[7]);
-          Out[7] = u0 * conj(Out[7]);
+          // out[7] = u0*conj(out[2]*out[3] - out[0]*out[5]);
+          out[7] = cmul(out[0], out[5]);
+          out[7] = cmac(out[2], out[3], -out[7]);
+          out[7] = u0 * conj(out[7]);
 
-          // Out[8] = u0*conj(Out[0]*Out[4] - Out[1]*Out[3]);
-          Out[8] = cmul(Out[1], Out[3]);
-          Out[8] = cmac(Out[0], Out[4], -Out[8]);
-          Out[8] = u0 * conj(Out[8]);
-
-#pragma unroll
-          for (int i = 0; i < 9; i++) {
-            out[2 * i + 0] = Out[i].real();
-            out[2 * i + 1] = Out[i].imag();
-          }
+          // out[8] = u0*conj(out[0]*out[4] - out[1]*out[3]);
+          out[8] = cmul(out[1], out[3]);
+          out[8] = cmac(out[0], out[4], -out[8]);
+          out[8] = u0 * conj(out[8]);
         }
 
-        __device__ __host__ inline RegType getPhase(const RegType in[18]) { return 0; }
+        __device__ __host__ inline real getPhase(const complex in[9]) { return 0; }
       };
 
       /**
@@ -1311,44 +1317,41 @@ namespace quda {
          type to avoid the run-time overhead
       */
       template <typename Float, QudaGhostExchange ghostExchange_> struct Reconstruct<11, Float, ghostExchange_> {
-        typedef typename mapper<Float>::type RegType;
+        using real = typename mapper<Float>::type;
+        using complex = complex<real>;
 
 	Reconstruct(const GaugeField &u) { ; }
         Reconstruct(const Reconstruct<11, Float, ghostExchange_> &recon) {}
 
-        __device__ __host__ inline void Pack(RegType out[10], const RegType in[18], int idx) const {
+        __device__ __host__ inline void Pack(real out[10], const complex in[9], int idx) const {
 #pragma unroll
-	  for (int i=0; i<4; i++) out[i] = in[i+2];
-	  out[4] = in[10];
-	  out[5] = in[11];
-	  out[6] = in[1];
-	  out[7] = in[9];
-	  out[8] = in[17];
+	  for (int i=0; i<2; i++) {
+            out[2*i+0] = in[i+1].real();
+            out[2*i+1] = in[i+1].imag();
+          }
+	  out[4] = in[5].real();
+	  out[5] = in[5].imag();
+          out[6] = in[0].imag();
+	  out[7] = in[4].imag();
+	  out[8] = in[8].imag();
 	  out[9] = 0.0;
 	}
 
 	template<typename I>
-	__device__ __host__ inline void Unpack(RegType out[18], const RegType in[10], int idx, int dir,
-					       const RegType phase, const I *X, const int *R) const {
-	  out[0] = 0.0;
-	  out[1] = in[6];
-#pragma unroll
-	  for (int i=0; i<4; i++) out[i+2] = in[i];
-	  out[6] = -out[2];
-	  out[7] =  out[3];
-	  out[8] = 0.0;
-	  out[9] = in[7];
-	  out[10] = in[4];
-	  out[11] = in[5];
-	  out[12] = -out[4];
-	  out[13] =  out[5];
-	  out[14] = -out[10];
-	  out[15] =  out[11];
-	  out[16] = 0.0;
-	  out[17] = in[8];
+	__device__ __host__ inline void Unpack(complex out[9], const real in[10], int idx, int dir, real phase, const I *X, const int *R) const
+        {
+	  out[0] = complex(0.0, in[6]);
+          out[1] = complex(in[0], in[1]);
+          out[2] = complex(in[2], in[3]);
+	  out[3] = complex(-out[1].real(), out[1].imag());
+	  out[4] = complex(0.0, in[7]);
+	  out[5] = complex(in[4], in[5]);
+	  out[6] = complex(-out[2].real(), out[2].imag());
+	  out[7] = complex(-out[5].real(), out[5].imag());
+	  out[8] = complex(0.0, in[8]);
 	}
 
-	__device__ __host__ inline RegType getPhase(const RegType in[18]) { return 0; }
+	__device__ __host__ inline real getPhase(const complex in[9]) { return 0; }
       };
 
       /**
@@ -1361,11 +1364,11 @@ namespace quda {
       */
       template <typename Float, QudaGhostExchange ghostExchange_, QudaStaggeredPhase stag_phase>
       struct Reconstruct<13, Float, ghostExchange_, stag_phase> {
-        typedef typename mapper<Float>::type RegType;
-        typedef complex<RegType> Complex;
+        using real = typename mapper<Float>::type;
+        using complex = complex<real>;
         const Reconstruct<12, Float, ghostExchange_> reconstruct_12;
-        const RegType scale;
-        const RegType scale_inv;
+        const real scale;
+        const real scale_inv;
 
         Reconstruct(const GaugeField &u) : reconstruct_12(u), scale(u.Scale()), scale_inv(1.0 / scale) {}
         Reconstruct(const Reconstruct<13, Float, ghostExchange_, stag_phase> &recon) :
@@ -1375,72 +1378,61 @@ namespace quda {
         {
         }
 
-        __device__ __host__ inline void Pack(RegType out[12], const RegType in[18], int idx) const
+        __device__ __host__ inline void Pack(real out[12], const complex in[9], int idx) const
         {
           reconstruct_12.Pack(out, in, idx);
         }
 
         template <typename I>
-        __device__ __host__ inline void Unpack(RegType out[18], const RegType in[12], int idx, int dir,
-            const RegType phase, const I *X, const int *R) const
+        __device__ __host__ inline void Unpack(complex out[18], const real in[12], int idx, int dir, real phase, const I *X, const int *R) const
         {
-          Complex Out[9];
 #pragma unroll
-          for (int i = 0; i < 6; i++) Out[i] = Complex(in[2 * i + 0], in[2 * i + 1]);
+          for (int i = 0; i < 6; i++) out[i] = complex(in[2 * i + 0], in[2 * i + 1]);
 
-          Out[6] = cmul(Out[2], Out[4]);
-          Out[6] = cmac(Out[1], Out[5], -Out[6]);
-          Out[6] = scale_inv * conj(Out[6]);
+          out[6] = cmul(out[2], out[4]);
+          out[6] = cmac(out[1], out[5], -out[6]);
+          out[6] = scale_inv * conj(out[6]);
 
-          Out[7] = cmul(Out[0], Out[5]);
-          Out[7] = cmac(Out[2], Out[3], -Out[7]);
-          Out[7] = scale_inv * conj(Out[7]);
+          out[7] = cmul(out[0], out[5]);
+          out[7] = cmac(out[2], out[3], -out[7]);
+          out[7] = scale_inv * conj(out[7]);
 
-          Out[8] = cmul(Out[1], Out[3]);
-          Out[8] = cmac(Out[0], Out[4], -Out[8]);
-          Out[8] = scale_inv * conj(Out[8]);
+          out[8] = cmul(out[1], out[3]);
+          out[8] = cmac(out[0], out[4], -out[8]);
+          out[8] = scale_inv * conj(out[8]);
 
           if (stag_phase == QUDA_STAGGERED_PHASE_NO) { // dynamic phasing
             // Multiply the third row by exp(I*3*phase), since the cross product will end up in a scale factor of exp(-I*2*phase)
-            RegType cos_sin[2];
-            Trig<isFixed<RegType>::value, RegType>::SinCos(static_cast<RegType>(3. * phase), &cos_sin[1], &cos_sin[0]);
-            Complex A(cos_sin[0], cos_sin[1]);
-            Out[6] = cmul(A, Out[6]);
-            Out[7] = cmul(A, Out[7]);
-            Out[8] = cmul(A, Out[8]);
+            real cos_sin[2];
+            Trig<isFixed<real>::value, real>::SinCos(static_cast<real>(3. * phase), &cos_sin[1], &cos_sin[0]);
+            complex A(cos_sin[0], cos_sin[1]);
+            out[6] = cmul(A, out[6]);
+            out[7] = cmul(A, out[7]);
+            out[8] = cmul(A, out[8]);
           } else { // phase is +/- 1 so real multiply is sufficient
-            Out[6] *= phase;
-            Out[7] *= phase;
-            Out[8] *= phase;
-          }
-
-#pragma unroll
-          for (int i = 0; i < 9; i++) {
-            out[2 * i + 0] = Out[i].real();
-            out[2 * i + 1] = Out[i].imag();
+            out[6] *= phase;
+            out[7] *= phase;
+            out[8] *= phase;
           }
         }
 
-        __device__ __host__ inline RegType getPhase(const RegType in[18]) const
+        __device__ __host__ inline real getPhase(const complex in[9]) const
         {
 #if 1 // phase from cross product
-          Complex In[9];
-#pragma unroll
-          for (int i = 0; i < 9; i++) In[i] = Complex(in[2 * i + 0], in[2 * i + 1]);
           // denominator = (U[0][0]*U[1][1] - U[0][1]*U[1][0])*
-          Complex denom = conj(In[0] * In[4] - In[1] * In[3]) * scale_inv;
-          Complex expI3Phase = In[8] / denom; // numerator = U[2][2]
+          complex denom = conj(in[0] * in[4] - in[1] * in[3]) * scale_inv;
+          complex expI3Phase = in[8] / denom; // numerator = U[2][2]
 
           if (stag_phase == QUDA_STAGGERED_PHASE_NO) { // dynamic phasing
-            return arg(expI3Phase) / static_cast<RegType>(3.0);
+            return arg(expI3Phase) / static_cast<real>(3.0);
           } else {
             return expI3Phase.real() > 0 ? 1 : -1;
           }
 #else // phase from determinant
-          Matrix<Complex, 3> a;
+          Matrix<complex, 3> a;
 #pragma unroll
-          for (int i = 0; i < 9; i++) a(i) = Complex(in[2 * i] * scale_inv, in[2 * i + 1] * scale_inv);
-          const Complex det = getDeterminant(a);
+          for (int i = 0; i < 9; i++) a(i) = scale_inv * in[i];
+          const complex det = getDeterminant(a);
           return phase = arg(det) / 3;
 #endif
         }
@@ -1454,10 +1446,10 @@ namespace quda {
          to avoid the run-time overhead
       */
       template <typename Float, QudaGhostExchange ghostExchange_> struct Reconstruct<8, Float, ghostExchange_> {
-        typedef typename mapper<Float>::type RegType;
-        typedef complex<RegType> Complex;
-        const Complex anisotropy; // imaginary value stores inverse
-        const Complex tBoundary;  // imaginary value stores inverse
+        using real = typename mapper<Float>::type;
+        using complex = complex<real>;
+        const complex anisotropy; // imaginary value stores inverse
+        const complex tBoundary;  // imaginary value stores inverse
         const int firstTimeSliceBound;
         const int lastTimeSliceBound;
         const bool isFirstTimeSlice;
@@ -1465,9 +1457,9 @@ namespace quda {
         QudaGhostExchange ghostExchange;
 
         // scale factor is set when using recon-9
-        Reconstruct(const GaugeField &u, RegType scale = 1.0) :
+        Reconstruct(const GaugeField &u, real scale = 1.0) :
             anisotropy(u.Anisotropy() * scale, 1.0 / (u.Anisotropy() * scale)),
-            tBoundary(static_cast<RegType>(u.TBoundary()) * scale, 1.0 / (static_cast<RegType>(u.TBoundary()) * scale)),
+            tBoundary(static_cast<real>(u.TBoundary()) * scale, 1.0 / (static_cast<real>(u.TBoundary()) * scale)),
             firstTimeSliceBound(u.VolumeCB()),
             lastTimeSliceBound((u.X()[3] - 1) * u.X()[0] * u.X()[1] * u.X()[2] / 2),
             isFirstTimeSlice(comm_coord(3) == 0 ? true : false),
@@ -1487,100 +1479,99 @@ namespace quda {
         {
         }
 
-        __device__ __host__ inline void Pack(RegType out[8], const RegType in[18], int idx) const
+        __device__ __host__ inline void Pack(real out[8], const complex in[9], int idx) const
         {
-          out[0] = Trig<isFixed<Float>::value, RegType>::Atan2(in[1], in[0]);
-          out[1] = Trig<isFixed<Float>::value, RegType>::Atan2(in[13], in[12]);
+          out[0] = Trig<isFixed<Float>::value, real>::Atan2(in[0].imag(), in[0].real());
+          out[1] = Trig<isFixed<Float>::value, real>::Atan2(in[6].imag(), in[6].real());
 #pragma unroll
-      for (int i=2; i<8; i++) out[i] = in[i];
-    }
+          for (int i=1; i<4; i++) {
+            out[2*i+0] = in[i].real();
+            out[2*i+1] = in[i].imag();
+          }
+        }
 
-    template <typename I>
-    __device__ __host__ inline void Unpack(RegType out[18], const RegType in[8], int idx, int dir, const RegType phase,
-        const I *X, const int *R, const Complex scale, const Complex u) const
-    {
-
-      RegType u0 = u.real();
-      RegType u0_inv = u.imag();
-
-      Complex Out[9];
-#pragma unroll
-      for (int i = 1; i <= 3; i++) Out[i] = Complex(in[2 * i + 0], in[2 * i + 1]); // these elements are copied directly
-
-      Trig<isFixed<Float>::value, RegType>::SinCos(in[0], &Out[0].y, &Out[0].x);
-      Trig<isFixed<Float>::value, RegType>::SinCos(in[1], &Out[6].y, &Out[6].x);
-
-      // First, reconstruct first row
-      RegType row_sum = Out[1].real() * Out[1].real();
-      row_sum += Out[1].imag() * Out[1].imag();
-      row_sum += Out[2].real() * Out[2].real();
-      row_sum += Out[2].imag() * Out[2].imag();
-      RegType row_sum_inv = static_cast<RegType>(1.0) / row_sum;
-
-      RegType diff = u0_inv * u0_inv - row_sum;
-      RegType U00_mag = diff > 0.0 ? diff * rsqrt(diff) : static_cast<RegType>(0.0);
-
-      Out[0] *= U00_mag;
-
-      // Second, reconstruct first column
-      RegType column_sum = Out[0].real() * Out[0].real();
-      column_sum += Out[0].imag() * Out[0].imag();
-      column_sum += Out[3].real() * Out[3].real();
-      column_sum += Out[3].imag() * Out[3].imag();
-
-      diff = u0_inv * u0_inv - column_sum;
-      RegType U20_mag = diff > 0.0 ? diff * rsqrt(diff) : static_cast<RegType>(0.0);
-
-      Out[6] *= U20_mag;
-
-      // Finally, reconstruct last elements from SU(2) rotation
-      RegType r_inv2 = u0_inv * row_sum_inv;
-      {
-        Complex A = cmul(conj(Out[0]), Out[3]);
-
-        // Out[4] = -(conj(Out[6])*conj(Out[2]) + u0*A*Out[1])*r_inv2; // U11
-        Out[4] = cmul(conj(Out[6]), conj(Out[2]));
-        Out[4] = cmac(u0 * A, Out[1], Out[4]);
-        Out[4] = -r_inv2 * Out[4];
-
-        // Out[5] = (conj(Out[6])*conj(Out[1]) - u0*A*Out[2])*r_inv2;  // U12
-        Out[5] = cmul(conj(Out[6]), conj(Out[1]));
-        Out[5] = cmac(-u0 * A, Out[2], Out[5]);
-        Out[5] = r_inv2 * Out[5];
-      }
-
-      {
-        Complex A = cmul(conj(Out[0]), Out[6]);
-
-        // Out[7] = (conj(Out[3])*conj(Out[2]) - u0*A*Out[1])*r_inv2;  // U21
-        Out[7] = cmul(conj(Out[3]), conj(Out[2]));
-        Out[7] = cmac(-u0 * A, Out[1], Out[7]);
-        Out[7] = r_inv2 * Out[7];
-
-        // Out[8] = -(conj(Out[3])*conj(Out[1]) + u0*A*Out[2])*r_inv2; // U12
-        Out[8] = cmul(conj(Out[3]), conj(Out[1]));
-        Out[8] = cmac(u0 * A, Out[2], Out[8]);
-        Out[8] = -r_inv2 * Out[8];
-      }
+        template <typename I>
+        __device__ __host__ inline void Unpack(complex out[9], const real in[8], int idx, int dir, real phase,
+                                               const I *X, const int *R, const complex scale, const complex u) const
+        {
+          real u0 = u.real();
+          real u0_inv = u.imag();
 
 #pragma unroll
-      for (int i = 0; i < 9; i++) {
-        out[2 * i + 0] = Out[i].real();
-        out[2 * i + 1] = Out[i].imag();
-      }
-    }
+          for (int i = 1; i <= 3; i++) out[i] = complex(in[2 * i + 0], in[2 * i + 1]); // these elements are copied directly
 
-    template <typename I>
-    __device__ __host__ inline void Unpack(RegType out[18], const RegType in[8], int idx, int dir, const RegType phase,
-        const I *X, const int *R, const Complex scale = Complex(static_cast<RegType>(1.0), static_cast<RegType>(1.0))) const
-    {
-      Complex u = dir < 3 ? anisotropy :
-                            timeBoundary<ghostExchange_>(idx, X, R, tBoundary, scale, firstTimeSliceBound,
-                                lastTimeSliceBound, isFirstTimeSlice, isLastTimeSlice, ghostExchange);
-      Unpack(out, in, idx, dir, phase, X, R, scale, u);
-    }
+          real tmp[2];
+          Trig<isFixed<Float>::value, real>::SinCos(in[0], &tmp[0], &tmp[1]);
+          out[0] = complex(tmp[0], tmp[1]);
 
-    __device__ __host__ inline RegType getPhase(const RegType in[18]){ return 0; }
+          Trig<isFixed<Float>::value, real>::SinCos(in[1], &tmp[0], &tmp[1]);
+          out[6] = complex(tmp[0], tmp[1]);
+
+          // First, reconstruct first row
+          real row_sum = out[1].real() * out[1].real();
+          row_sum += out[1].imag() * out[1].imag();
+          row_sum += out[2].real() * out[2].real();
+          row_sum += out[2].imag() * out[2].imag();
+          real row_sum_inv = static_cast<real>(1.0) / row_sum;
+
+          real diff = u0_inv * u0_inv - row_sum;
+          real U00_mag = diff > 0.0 ? diff * rsqrt(diff) : static_cast<real>(0.0);
+
+          out[0] *= U00_mag;
+
+          // Second, reconstruct first column
+          real column_sum = out[0].real() * out[0].real();
+          column_sum += out[0].imag() * out[0].imag();
+          column_sum += out[3].real() * out[3].real();
+          column_sum += out[3].imag() * out[3].imag();
+
+          diff = u0_inv * u0_inv - column_sum;
+          real U20_mag = diff > 0.0 ? diff * rsqrt(diff) : static_cast<real>(0.0);
+
+          out[6] *= U20_mag;
+
+          // Finally, reconstruct last elements from SU(2) rotation
+          real r_inv2 = u0_inv * row_sum_inv;
+          {
+            complex A = cmul(conj(out[0]), out[3]);
+
+            // out[4] = -(conj(out[6])*conj(out[2]) + u0*A*out[1])*r_inv2; // U11
+            out[4] = cmul(conj(out[6]), conj(out[2]));
+            out[4] = cmac(u0 * A, out[1], out[4]);
+            out[4] = -r_inv2 * out[4];
+
+            // out[5] = (conj(out[6])*conj(out[1]) - u0*A*out[2])*r_inv2;  // U12
+            out[5] = cmul(conj(out[6]), conj(out[1]));
+            out[5] = cmac(-u0 * A, out[2], out[5]);
+            out[5] = r_inv2 * out[5];
+          }
+
+          {
+            complex A = cmul(conj(out[0]), out[6]);
+
+            // out[7] = (conj(out[3])*conj(out[2]) - u0*A*out[1])*r_inv2;  // U21
+            out[7] = cmul(conj(out[3]), conj(out[2]));
+            out[7] = cmac(-u0 * A, out[1], out[7]);
+            out[7] = r_inv2 * out[7];
+
+            // out[8] = -(conj(out[3])*conj(out[1]) + u0*A*out[2])*r_inv2; // U12
+            out[8] = cmul(conj(out[3]), conj(out[1]));
+            out[8] = cmac(u0 * A, out[2], out[8]);
+            out[8] = -r_inv2 * out[8];
+          }
+        }
+
+        template <typename I>
+        __device__ __host__ inline void Unpack(complex out[18], const real in[8], int idx, int dir, real phase, const I *X,
+                                               const int *R, const complex scale = complex(static_cast<real>(1.0), static_cast<real>(1.0))) const
+        {
+          complex u = dir < 3 ? anisotropy :
+            timeBoundary<ghostExchange_>(idx, X, R, tBoundary, scale, firstTimeSliceBound,
+                                         lastTimeSliceBound, isFirstTimeSlice, isLastTimeSlice, ghostExchange);
+          Unpack(out, in, idx, dir, phase, X, R, scale, u);
+        }
+
+        __device__ __host__ inline real getPhase(const complex in[9]) { return 0; }
       };
 
       /**
@@ -1593,11 +1584,11 @@ namespace quda {
       */
       template <typename Float, QudaGhostExchange ghostExchange_, QudaStaggeredPhase stag_phase>
       struct Reconstruct<9, Float, ghostExchange_, stag_phase> {
-        typedef typename mapper<Float>::type RegType;
-        typedef complex<RegType> Complex;
+        using real = typename mapper<Float>::type;
+        using complex = complex<real>;
         const Reconstruct<8, Float, ghostExchange_> reconstruct_8;
-        const RegType scale;
-        const RegType scale_inv;
+        const real scale;
+        const real scale_inv;
 
         Reconstruct(const GaugeField &u) : reconstruct_8(u), scale(u.Scale()), scale_inv(1.0 / scale) {}
 
@@ -1608,73 +1599,61 @@ namespace quda {
         {
         }
 
-        __device__ __host__ inline RegType getPhase(const RegType in[18]) const
+        __device__ __host__ inline real getPhase(const complex in[9]) const
         {
 #if 1 // phase from cross product
-          Complex In[9];
-#pragma unroll
-          for (int i = 0; i < 9; i++) In[i] = Complex(in[2 * i + 0], in[2 * i + 1]);
           // denominator = (U[0][0]*U[1][1] - U[0][1]*U[1][0])*
-          Complex denom = conj(In[0] * In[4] - In[1] * In[3]) * scale_inv;
-          Complex expI3Phase = In[8] / denom; // numerator = U[2][2]
+          complex denom = conj(in[0] * in[4] - in[1] * in[3]) * scale_inv;
+          complex expI3Phase = in[8] / denom; // numerator = U[2][2]
           if (stag_phase == QUDA_STAGGERED_PHASE_NO) {
-            return arg(expI3Phase) / static_cast<RegType>(3.0);
+            return arg(expI3Phase) / static_cast<real>(3.0);
           } else {
             return expI3Phase.real() > 0 ? 1 : -1;
           }
 #else // phase from determinant
-	Matrix<Complex,3> a;
+          Matrix<complex,3> a;
 #pragma unroll
-        for (int i = 0; i < 9; i++) a(i) = Complex(in[2 * i], in[2 * i + 1]) * scale_inv;
-        const Complex det = getDeterminant( a );
-	RegType phase = arg(det)/3;
-	return phase;
+          for (int i = 0; i < 9; i++) a(i) = scale_inv * in[i];
+          const complex det = getDeterminant( a );
+          real phase = arg(det)/3;
+          return phase;
 #endif
         }
 
         // Rescale the U3 input matrix by exp(-I*phase) to obtain an SU3 matrix multiplied by a real scale factor,
-        __device__ __host__ inline void Pack(RegType out[8], const RegType in[18], int idx) const
+        __device__ __host__ inline void Pack(real out[8], const complex in[9], int idx) const
         {
-          RegType phase = getPhase(in);
-          RegType su3[18];
+          real phase = getPhase(in);
+          complex su3[9];
 
           if (stag_phase == QUDA_STAGGERED_PHASE_NO) {
-            RegType cos_sin[2];
-            Trig<isFixed<RegType>::value, RegType>::SinCos(static_cast<RegType>(-phase), &cos_sin[1], &cos_sin[0]);
-            Complex z(cos_sin[0], cos_sin[1]);
+            real cos_sin[2];
+            Trig<isFixed<real>::value, real>::SinCos(static_cast<real>(-phase), &cos_sin[1], &cos_sin[0]);
+            complex z(cos_sin[0], cos_sin[1]);
             z *= scale_inv;
 #pragma unroll
-            for (int i = 0; i < 9; i++) {
-              Complex su3_ = cmul(z, Complex(in[2 * i + 0], in[2 * i + 1]));
-              su3[2 * i + 0] = su3_.real();
-              su3[2 * i + 1] = su3_.imag();
-            }
+            for (int i = 0; i < 9; i++) su3[i] = cmul(z, in[i]);
           } else {
 #pragma unroll
-            for (int i = 0; i < 18; i++) { su3[i] = phase * in[i]; }
+            for (int i = 0; i < 9; i++) { su3[i] = phase * in[i]; }
           }
           reconstruct_8.Pack(out, su3, idx);
         }
 
         template <typename I>
-        __device__ __host__ inline void Unpack(
-            RegType out[18], const RegType in[8], int idx, int dir, const RegType phase, const I *X, const int *R) const
+        __device__ __host__ inline void Unpack(complex out[9], const real in[8], int idx, int dir, real phase, const I *X, const int *R) const
         {
           reconstruct_8.Unpack(out, in, idx, dir, phase, X, R,
-              Complex(static_cast<RegType>(1.0), static_cast<RegType>(1.0)),
-              Complex(static_cast<RegType>(1.0), static_cast<RegType>(1.0)));
+                               complex(static_cast<real>(1.0), static_cast<real>(1.0)),
+                               complex(static_cast<real>(1.0), static_cast<real>(1.0)));
 
           if (stag_phase == QUDA_STAGGERED_PHASE_NO) { // dynamic phase
-            RegType cos_sin[2];
-            Trig<isFixed<RegType>::value, RegType>::SinCos(static_cast<RegType>(phase), &cos_sin[1], &cos_sin[0]);
-            Complex z(cos_sin[0], cos_sin[1]);
+            real cos_sin[2];
+            Trig<isFixed<real>::value, real>::SinCos(static_cast<real>(phase), &cos_sin[1], &cos_sin[0]);
+            complex z(cos_sin[0], cos_sin[1]);
             z *= scale;
 #pragma unroll
-            for (int i = 0; i < 9; i++) {
-              Complex Out = cmul(z, Complex(out[2 * i + 0], out[2 * i + 1]));
-              out[2 * i + 0] = Out.real();
-              out[2 * i + 1] = Out.imag();
-            };
+            for (int i = 0; i < 9; i++) out[i] = cmul(z, out[i]);
           } else { // stagic phase
 #pragma unroll
             for (int i = 0; i < 18; i++) { out[i] *= phase; }
@@ -1682,17 +1661,14 @@ namespace quda {
         }
       };
 
-      __host__ __device__ inline constexpr int ct_sqrt(int n, int i = 1)
-      {
-        return n == i ? n : (i * i < n ? ct_sqrt(n, i + 1) : i);
-      }
+      __host__ __device__ constexpr int ct_sqrt(int n, int i = 1) { return n == i ? n : (i * i < n ? ct_sqrt(n, i + 1) : i); }
 
       /**
          @brief Return the number of colors of the accessor based on the length of the field
          @param[in] length Number of real numbers per link
          @return Number of colors (=sqrt(length/2))
        */
-      __host__ __device__ inline constexpr int Ncolor(int length) { return ct_sqrt(length / 2); }
+      __host__ __device__ constexpr int Ncolor(int length) { return ct_sqrt(length / 2); }
 
       // we default to huge allocations for gauge field (for now)
       constexpr bool default_huge_alloc = true;
@@ -1714,7 +1690,8 @@ namespace quda {
         using Accessor
             = FloatNOrder<Float, length, N, reconLenParam, stag_phase, huge_alloc, ghostExchange_, use_inphase>;
 
-        typedef typename mapper<Float>::type RegType;
+        using real = typename mapper<Float>::type;
+        using complex = complex<real>;
         typedef typename VectorType<Float, N>::type Vector;
         typedef typename AllocType<huge_alloc>::type AllocInt;
         Reconstruct<reconLenParam, Float, ghostExchange_, stag_phase> reconstruct;
@@ -1723,7 +1700,7 @@ namespace quda {
         Float *gauge;
         const AllocInt offset;
 #ifdef USE_TEXTURE_OBJECTS
-      typedef typename TexVectorType<RegType,N>::type TexVector;
+      typedef typename TexVectorType<real,N>::type TexVector;
       cudaTextureObject_t tex;
       const int tex_offset;
 #endif
@@ -1787,10 +1764,10 @@ namespace quda {
       }
       virtual ~FloatNOrder() { ; }
 
-      __device__ __host__ inline void load(RegType v[length], int x, int dir, int parity, Float inphase = 1.0) const
+      __device__ __host__ inline void load(complex v[length/2], int x, int dir, int parity, real inphase = 1.0) const
       {
         const int M = reconLen / N;
-        RegType tmp[reconLen];
+        real tmp[reconLen];
 
 #pragma unroll
         for (int i=0; i<M; i++){
@@ -1800,7 +1777,7 @@ namespace quda {
             TexVector vecTmp = tex1Dfetch<TexVector>(tex, parity * tex_offset + (dir * M + i) * stride + x);
             // now insert into output array
 #pragma unroll
-	    for (int j=0; j<N; j++) copy(tmp[i*N+j], reinterpret_cast<RegType*>(&vecTmp)[j]);
+	    for (int j=0; j<N; j++) copy(tmp[i*N+j], reinterpret_cast<real*>(&vecTmp)[j]);
 	  } else
 #endif
 	  {
@@ -1812,24 +1789,24 @@ namespace quda {
 	  }
 	}
 
-        RegType phase = 0.; // TODO - add texture support for phases
+        real phase = 0.; // TODO - add texture support for phases
 
         if (hasPhase) {
           if (static_phase<stag_phase>() && (reconLen == 13 || use_inphase)) {
             phase = inphase;
           } else {
             copy(phase, (gauge + parity * offset)[phaseOffset / sizeof(Float) + stride * dir + x]);
-            phase *= static_cast<RegType>(2.0) * static_cast<RegType>(M_PI);
+            phase *= static_cast<real>(2.0) * static_cast<real>(M_PI);
           }
         }
 
         reconstruct.Unpack(v, tmp, x, dir, phase, X, R);
       }
 
-      __device__ __host__ inline void save(const RegType v[length], int x, int dir, int parity) {
-
+      __device__ __host__ inline void save(const complex v[length/2], int x, int dir, int parity)
+      {
         const int M = reconLen / N;
-        RegType tmp[reconLen];
+        real tmp[reconLen];
         reconstruct.Pack(tmp, v, x);
 
 #pragma unroll
@@ -1841,9 +1818,9 @@ namespace quda {
 	  // second do vectorized copy into memory
           vector_store(gauge + parity * offset, x + (dir * M + i) * stride, vecTmp);
         }
-        if(hasPhase){
-          RegType phase = reconstruct.getPhase(v);
-          copy((gauge+parity*offset)[phaseOffset/sizeof(Float) + dir*stride + x], static_cast<RegType>(phase/(2.*M_PI)));
+        if (hasPhase) {
+          real phase = reconstruct.getPhase(v);
+          copy((gauge+parity*offset)[phaseOffset/sizeof(Float) + dir*stride + x], static_cast<real>(phase/(2.*M_PI)));
         }
       }
 
@@ -1857,10 +1834,9 @@ namespace quda {
 	 @return Instance of a gauge_wrapper that curries in access to
 	 this field at the above coordinates.
        */
-      __device__ __host__ inline gauge_wrapper<RegType, Accessor> operator()(
-          int dim, int x_cb, int parity, Float phase = 1.0)
+      __device__ __host__ inline gauge_wrapper<real, Accessor> operator()(int dim, int x_cb, int parity, real phase = 1.0)
       {
-        return gauge_wrapper<RegType, Accessor>(*this, dim, x_cb, parity, phase);
+        return gauge_wrapper<real, Accessor>(*this, dim, x_cb, parity, phase);
       }
 
       /**
@@ -1873,20 +1849,19 @@ namespace quda {
 	 @return Instance of a gauge_wrapper that curries in access to
 	 this field at the above coordinates.
        */
-      __device__ __host__ inline const gauge_wrapper<RegType, Accessor> operator()(
-          int dim, int x_cb, int parity, Float phase = 1.0) const
+      __device__ __host__ inline const gauge_wrapper<real, Accessor> operator()(int dim, int x_cb, int parity, real phase = 1.0) const
       {
-        return gauge_wrapper<RegType, Accessor>(const_cast<Accessor &>(*this), dim, x_cb, parity, phase);
+        return gauge_wrapper<real, Accessor>(const_cast<Accessor &>(*this), dim, x_cb, parity, phase);
       }
 
-      __device__ __host__ inline void loadGhost(RegType v[length], int x, int dir, int parity, Float inphase = 1.0) const
+      __device__ __host__ inline void loadGhost(complex v[length/2], int x, int dir, int parity, real inphase = 1.0) const
       {
         if (!ghost[dir]) { // load from main field not separate array
           load(v, volumeCB + x, dir, parity, inphase); // an offset of size volumeCB puts us at the padded region
           // This also works perfectly when phases are stored. No need to change this.
         } else {
           const int M = reconLen / N;
-          RegType tmp[reconLen];
+          real tmp[reconLen];
 
 #pragma unroll
           for (int i=0; i<M; i++) {
@@ -1897,7 +1872,7 @@ namespace quda {
 #pragma unroll
             for (int j = 0; j < N; j++) copy(tmp[i * N + j], reinterpret_cast<Float *>(&vecTmp)[j]);
           }
-          RegType phase = 0.;
+          real phase = 0.;
 
           if (hasPhase) {
 
@@ -1905,19 +1880,20 @@ namespace quda {
             //   phase = inphase < static_cast<Float>(0) ? static_cast<Float>(-1./(2.*M_PI)) : static_cast<Float>(1./2.*M_PI);
             // } else {
             copy(phase, ghost[dir][parity * faceVolumeCB[dir] * (M * N + 1) + faceVolumeCB[dir] * M * N + x]);
-            phase *= static_cast<RegType>(2.0) * static_cast<RegType>(M_PI);
+            phase *= static_cast<real>(2.0) * static_cast<real>(M_PI);
             // }
           }
           reconstruct.Unpack(v, tmp, x, dir, phase, X, R);
         }
       }
 
-      __device__ __host__ inline void saveGhost(const RegType v[length], int x, int dir, int parity) {
+      __device__ __host__ inline void saveGhost(const complex v[length/2], int x, int dir, int parity)
+      {
         if (!ghost[dir]) { // store in main field not separate array
 	  save(v, volumeCB+x, dir, parity); // an offset of size volumeCB puts us at the padded region
         } else {
           const int M = reconLen / N;
-          RegType tmp[reconLen];
+          real tmp[reconLen];
           reconstruct.Pack(tmp, v, x);
 
 #pragma unroll
@@ -1931,8 +1907,8 @@ namespace quda {
           }
 
 	  if (hasPhase) {
-	    RegType phase = reconstruct.getPhase(v);
-	    copy(ghost[dir][parity*faceVolumeCB[dir]*(M*N + 1) + faceVolumeCB[dir]*M*N + x], static_cast<RegType>(phase/(2.*M_PI)));
+	    real phase = reconstruct.getPhase(v);
+	    copy(ghost[dir][parity*faceVolumeCB[dir]*(M*N + 1) + faceVolumeCB[dir]*M*N + x], static_cast<real>(phase/(2.*M_PI)));
 	  }
 	}
       }
@@ -1944,35 +1920,33 @@ namespace quda {
 	 @param[in] dir Which dimension are we requesting
 	 @param[in] ghost_idx Ghost index we are requesting
 	 @param[in] parity Parity we are requesting
-	 @return Instance of a gauge_wrapper that curries in access to
+	 @return Instance of a gauge_ghost_wrapper that curries in access to
 	 this field at the above coordinates.
        */
-      __device__ __host__ inline gauge_ghost_wrapper<RegType, Accessor> Ghost(
-          int dim, int ghost_idx, int parity, Float phase = 1.0)
+      __device__ __host__ inline gauge_ghost_wrapper<real, Accessor> Ghost(int dim, int ghost_idx, int parity, real phase = 1.0)
       {
-        return gauge_ghost_wrapper<RegType, Accessor>(*this, dim, ghost_idx, parity, phase);
+        return gauge_ghost_wrapper<real, Accessor>(*this, dim, ghost_idx, parity, phase);
       }
 
       /**
-	 @brief This accessor routine returns a const gauge_wrapper to this object,
+	 @brief This accessor routine returns a const gauge_ghost_wrapper to this object,
 	 allowing us to overload various operators for manipulating at
 	 the site level interms of matrix operations.
 	 @param[in] dir Which dimension are we requesting
 	 @param[in] ghost_idx Ghost index we are requesting
 	 @param[in] parity Parity we are requesting
-	 @return Instance of a gauge_wrapper that curries in access to
+	 @return Instance of a gauge_ghost_wrapper that curries in access to
 	 this field at the above coordinates.
        */
-      __device__ __host__ inline const gauge_ghost_wrapper<RegType, Accessor> Ghost(
-          int dim, int ghost_idx, int parity, Float phase = 1.0) const
+      __device__ __host__ inline const gauge_ghost_wrapper<real, Accessor> Ghost(int dim, int ghost_idx, int parity, real phase = 1.0) const
       {
-        return gauge_ghost_wrapper<RegType, Accessor>(const_cast<Accessor &>(*this), dim, ghost_idx, parity, phase);
+        return gauge_ghost_wrapper<real, Accessor>(const_cast<Accessor &>(*this), dim, ghost_idx, parity, phase);
       }
 
-      __device__ __host__ inline void loadGhostEx(RegType v[length], int buff_idx, int extended_idx, int dir,
+      __device__ __host__ inline void loadGhostEx(complex v[length/2], int buff_idx, int extended_idx, int dir,
 						  int dim, int g, int parity, const int R[]) const {
 	const int M = reconLen / N;
-	RegType tmp[reconLen];
+	real tmp[reconLen];
 
 #pragma unroll
 	for (int i=0; i<M; i++) {
@@ -1983,18 +1957,18 @@ namespace quda {
 #pragma unroll
 	  for (int j=0; j<N; j++) copy(tmp[i*N+j], reinterpret_cast<Float*>(&vecTmp)[j]);
 	}
-	RegType phase=0.;
-	if(hasPhase) copy(phase, ghost[dim][((dir*2+parity)*geometry+g)*R[dim]*faceVolumeCB[dim]*(M*N + 1)
-					    + R[dim]*faceVolumeCB[dim]*M*N + buff_idx]);
+	real phase=0.;
+	if (hasPhase) copy(phase, ghost[dim][((dir*2+parity)*geometry+g)*R[dim]*faceVolumeCB[dim]*(M*N + 1)
+                                             + R[dim]*faceVolumeCB[dim]*M*N + buff_idx]);
 
 	// use the extended_idx to determine the boundary condition
 	reconstruct.Unpack(v, tmp, extended_idx, g, 2.*M_PI*phase, X, R);
       }
 
-      __device__ __host__ inline void saveGhostEx(const RegType v[length], int buff_idx, int extended_idx,
+      __device__ __host__ inline void saveGhostEx(const complex v[length/2], int buff_idx, int extended_idx,
 						  int dir, int dim, int g, int parity, const int R[]) {
 	const int M = reconLen / N;
-	RegType tmp[reconLen];
+	real tmp[reconLen];
 	// use the extended_idx to determine the boundary condition
 	reconstruct.Pack(tmp, v, extended_idx);
 
@@ -2009,9 +1983,9 @@ namespace quda {
 			 i*R[dim]*faceVolumeCB[dim]+buff_idx, vecTmp);
 	  }
 	  if (hasPhase) {
-	    RegType phase = reconstruct.getPhase(v);
+	    real phase = reconstruct.getPhase(v);
 	    copy(ghost[dim][((dir*2+parity)*geometry+g)*R[dim]*faceVolumeCB[dim]*(M*N + 1) + R[dim]*faceVolumeCB[dim]*M*N + buff_idx],
-		 static_cast<RegType>(phase/(2.*M_PI)));
+		 static_cast<real>(phase/(2.*M_PI)));
 	  }
 	}
 
@@ -2044,7 +2018,11 @@ namespace quda {
      @param real Real number type
      @param length Number of elements in the structure
   */
-  template <typename real, int length> struct S { real v[length]; };
+  template <typename real, int length> struct S {
+    real v[length];
+    __host__ __device__ const real& operator[](int i) const { return v[i]; }
+    __host__ __device__ real& operator[](int i) { return v[i]; }
+  };
 
   /**
       The LegacyOrder defines the ghost zone storage and ordering for
@@ -2052,7 +2030,9 @@ namespace quda {
   */
   template <typename Float, int length>
     struct LegacyOrder {
-      typedef typename mapper<Float>::type RegType;
+      using Accessor = LegacyOrder<Float, length>;
+      using real = typename mapper<Float>::type;
+      using complex = complex<real>;
       Float *ghost[QUDA_MAX_DIM];
       int faceVolumeCB[QUDA_MAX_DIM];
       const int volumeCB;
@@ -2081,56 +2061,97 @@ namespace quda {
 
       virtual ~LegacyOrder() { ; }
 
-      __device__ __host__ inline void loadGhost(RegType v[length], int x, int dir, int parity) const {
+      __device__ __host__ inline void loadGhost(complex v[length/2], int x, int dir, int parity, real phase = 1.0) const
+      {
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
 	typedef S<Float,length> structure;
 	trove::coalesced_ptr<structure> ghost_((structure*)ghost[dir]);
 	structure v_ = ghost_[parity*faceVolumeCB[dir] + x];
-	for (int i=0; i<length; i++) v[i] = (RegType)v_.v[i];
 #else
-	for (int i=0; i<length; i++) v[i] = (RegType)ghost[dir][(parity*faceVolumeCB[dir] + x)*length + i];
+        auto v_ = &ghost[dir][(parity*faceVolumeCB[dir] + x)*length];
 #endif
+	for (int i=0; i<length/2; i++) v[i] = complex(v_[2*i+0], v_[2*i+1]);
       }
 
-      __device__ __host__ inline void saveGhost(const RegType v[length], int x, int dir, int parity) {
+      __device__ __host__ inline void saveGhost(const complex v[length/2], int x, int dir, int parity)
+      {
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
 	typedef S<Float,length> structure;
 	trove::coalesced_ptr<structure> ghost_((structure*)ghost[dir]);
 	structure v_;
-	for (int i=0; i<length; i++) v_.v[i] = (Float)v[i];
+	for (int i=0; i<length/2; i++) {
+          v_.v[2*i+0] = (Float)v[i].real();
+          v_.v[2*i+1] = (Float)v[i].imag();
+        }
 	ghost_[parity*faceVolumeCB[dir] + x] = v_;
 #else
-	for (int i=0; i<length; i++) ghost[dir][(parity*faceVolumeCB[dir] + x)*length + i] = (Float)v[i];
+        auto v_ = &ghost[dir][(parity*faceVolumeCB[dir] + x)*length];
+	for (int i=0; i<length/2; i++) {
+          v_[2*i+0] = (Float)v[i].real();
+          v_[2*i+1] = (Float)v[i].imag();
+        }
 #endif
       }
 
-      __device__ __host__ inline void loadGhostEx(RegType v[length], int x, int dummy, int dir,
+      /**
+	 @brief This accessor routine returns a gauge_ghost_wrapper to this object,
+	 allowing us to overload various operators for manipulating at
+	 the site level interms of matrix operations.
+	 @param[in] dir Which dimension are we requesting
+	 @param[in] ghost_idx Ghost index we are requesting
+	 @param[in] parity Parity we are requesting
+	 @return Instance of a gauge_ghost_wrapper that curries in access to
+	 this field at the above coordinates.
+       */
+      __device__ __host__ inline gauge_ghost_wrapper<real, Accessor> Ghost(int dim, int ghost_idx, int parity, real phase = 1.0)
+      {
+        return gauge_ghost_wrapper<real, Accessor>(*this, dim, ghost_idx, parity, phase);
+      }
+
+      /**
+	 @brief This accessor routine returns a const gauge_ghost_wrapper to this object,
+	 allowing us to overload various operators for manipulating at
+	 the site level interms of matrix operations.
+	 @param[in] dir Which dimension are we requesting
+	 @param[in] ghost_idx Ghost index we are requesting
+	 @param[in] parity Parity we are requesting
+	 @return Instance of a gauge_ghost_wrapper that curries in access to
+	 this field at the above coordinates.
+       */
+      __device__ __host__ inline const gauge_ghost_wrapper<real, Accessor> Ghost(int dim, int ghost_idx, int parity, real phase = 1.0) const
+      {
+        return gauge_ghost_wrapper<real, Accessor>(const_cast<Accessor &>(*this), dim, ghost_idx, parity, phase);
+      }
+
+      __device__ __host__ inline void loadGhostEx(complex v[length/2], int x, int dummy, int dir,
 						  int dim, int g, int parity, const int R[]) const {
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
 	typedef S<Float,length> structure;
 	trove::coalesced_ptr<structure> ghost_((structure*)ghost[dim]);
 	structure v_ = ghost_[((dir*2+parity)*R[dim]*faceVolumeCB[dim] + x)*geometry+g];
-	for (int i=0; i<length; i++) v[i] = (RegType)v_.v[i];
 #else
-	for (int i=0; i<length; i++) {
-	  v[i] = (RegType)ghost[dim][(((dir*2+parity)*R[dim]*faceVolumeCB[dim] + x)*geometry+g)*length + i];
-	}
+        auto v_ = &ghost[dim][(((dir*2+parity)*R[dim]*faceVolumeCB[dim] + x)*geometry+g)*length];
 #endif
+	for (int i=0; i<length/2; i++) v[i] = complex(v_[2*i+0], v_[2*i+1]);
       }
 
-      __device__ __host__ inline void saveGhostEx(const RegType v[length], int x, int dummy,
+      __device__ __host__ inline void saveGhostEx(const complex v[length/2], int x, int dummy,
 						  int dir, int dim, int g, int parity, const int R[]) {
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
 	typedef S<Float,length> structure;
 	trove::coalesced_ptr<structure> ghost_((structure*)ghost[dim]);
 	structure v_;
-	for (int i=0; i<length; i++) v_.v[i] = (Float)v[i];
+	for (int i=0; i<length/2; i++) {
+          v_.v[2*i+0] = (Float)v[i].real();
+          v_.v[2*i+1] = (Float)v[i].imag();
+        }
 	ghost_[((dir*2+parity)*R[dim]*faceVolumeCB[dim] + x)*geometry+g] = v_;
 #else
-	for (int i=0; i<length; i++) {
-	  ghost[dim]
-	    [(((dir*2+parity)*R[dim]*faceVolumeCB[dim] + x)*geometry+g)*length + i] = (Float)v[i];
-	}
+        auto v_ = &ghost[dim][(((dir*2+parity)*R[dim]*faceVolumeCB[dim] + x)*geometry+g)*length];
+	for (int i=0; i<length/2; i++) {
+          v_[2*i+0] = (Float)v[i].real();
+          v_[2*i+1] = (Float)v[i].imag();
+        }
 #endif
       }
 
@@ -2141,7 +2162,8 @@ namespace quda {
        [[dim]] [[parity][volumecb][row][col]]
     */
     template <typename Float, int length> struct QDPOrder : public LegacyOrder<Float,length> {
-      typedef typename mapper<Float>::type RegType;
+      using real = typename mapper<Float>::type;
+      using complex = complex<real>;
       Float *gauge[QUDA_MAX_DIM];
       const int volumeCB;
     QDPOrder(const GaugeField &u, Float *gauge_=0, Float **ghost_=0)
@@ -2152,31 +2174,34 @@ namespace quda {
       }
       virtual ~QDPOrder() { ; }
 
-      __device__ __host__ inline void load(RegType v[length], int x, int dir, int parity, Float inphase = 1.0) const
+      __device__ __host__ inline void load(complex v[length/2], int x, int dir, int parity, real inphase = 1.0) const
       {
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
 	typedef S<Float,length> structure;
 	trove::coalesced_ptr<structure> gauge_((structure*)gauge[dir]);
 	structure v_ = gauge_[parity*volumeCB + x];
-	for (int i=0; i<length; i++) v[i] = (RegType)v_.v[i];
 #else
-	for (int i=0; i<length; i++) {
-	  v[i] = (RegType)gauge[dir][(parity*volumeCB + x)*length + i];
-	}
+        auto v_ = &gauge[dir][(parity*volumeCB + x)*length];
 #endif
+	for (int i=0; i<length/2; i++) v[i] = complex(v_[2*i+0], v_[2*i+1]);
       }
 
-      __device__ __host__ inline void save(const RegType v[length], int x, int dir, int parity) {
+      __device__ __host__ inline void save(const complex v[length/2], int x, int dir, int parity) {
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
 	typedef S<Float,length> structure;
 	trove::coalesced_ptr<structure> gauge_((structure*)gauge[dir]);
 	structure v_;
-	for (int i=0; i<length; i++) v_.v[i] = (Float)v[i];
+	for (int i=0; i<length/2; i++) {
+          v_.v[2*i+0] = (Float)v[i].real();
+          v_.v[2*i+1] = (Float)v[i].imag();
+        }
 	gauge_[parity*volumeCB + x] = v_;
 #else
-	for (int i=0; i<length; i++) {
-	  gauge[dir][(parity*volumeCB + x)*length + i] = (Float)v[i];
-	}
+        auto v_ = &gauge[dir][(parity*volumeCB + x)*length];
+	for (int i=0; i<length/2; i++) {
+          v_[2*i+0] = (Float)v[i].real();
+          v_[2*i+1] = (Float)v[i].imag();
+        }
 #endif
       }
 
@@ -2190,9 +2215,9 @@ namespace quda {
 	 @return Instance of a gauge_wrapper that curries in access to
 	 this field at the above coordinates.
        */
-      __device__ __host__ inline gauge_wrapper<RegType, QDPOrder<Float, length>> operator()(int dim, int x_cb, int parity)
+      __device__ __host__ inline gauge_wrapper<real, QDPOrder<Float, length>> operator()(int dim, int x_cb, int parity)
       {
-        return gauge_wrapper<RegType, QDPOrder<Float, length>>(*this, dim, x_cb, parity);
+        return gauge_wrapper<real, QDPOrder<Float, length>>(*this, dim, x_cb, parity);
       }
 
       /**
@@ -2205,10 +2230,10 @@ namespace quda {
 	 @return Instance of a gauge_wrapper that curries in access to
 	 this field at the above coordinates.
        */
-      __device__ __host__ inline const gauge_wrapper<RegType, QDPOrder<Float, length>> operator()(
+      __device__ __host__ inline const gauge_wrapper<real, QDPOrder<Float, length>> operator()(
           int dim, int x_cb, int parity) const
       {
-        return gauge_wrapper<RegType, QDPOrder<Float, length>>(
+        return gauge_wrapper<real, QDPOrder<Float, length>>(
             const_cast<QDPOrder<Float, length> &>(*this), dim, x_cb, parity);
       }
 
@@ -2220,7 +2245,8 @@ namespace quda {
        [[dim]] [[parity][complex][row][col][volumecb]]
     */
     template <typename Float, int length> struct QDPJITOrder : public LegacyOrder<Float,length> {
-      typedef typename mapper<Float>::type RegType;
+      using real = typename mapper<Float>::type;
+      using complex = complex<real>;
       Float *gauge[QUDA_MAX_DIM];
       const int volumeCB;
     QDPJITOrder(const GaugeField &u, Float *gauge_=0, Float **ghost_=0)
@@ -2231,20 +2257,19 @@ namespace quda {
       }
       virtual ~QDPJITOrder() { ; }
 
-      __device__ __host__ inline void load(RegType v[length], int x, int dir, int parity, Float inphase = 1.0) const
+      __device__ __host__ inline void load(complex v[length/2], int x, int dir, int parity, real inphase = 1.0) const
       {
-        for (int i = 0; i < length; i++) {
-          int z = i % 2;
-          int rolcol = i/2;
-	  v[i] = (RegType)gauge[dir][((z*(length/2) + rolcol)*2 + parity)*volumeCB + x];
+        for (int i = 0; i < length/2; i++) {
+	  v[i].real((real)gauge[dir][((0*(length/2) + i)*2 + parity)*volumeCB + x]);
+	  v[i].imag((real)gauge[dir][((1*(length/2) + i)*2 + parity)*volumeCB + x]);
         }
       }
 
-      __device__ __host__ inline void save(const RegType v[length], int x, int dir, int parity) {
-	for (int i=0; i<length; i++) {
-	  int z = i%2;
-	  int rolcol = i/2;
-	  gauge[dir][((z*(length/2) + rolcol)*2 + parity)*volumeCB + x] = (Float)v[i];
+      __device__ __host__ inline void save(const complex v[length/2], int x, int dir, int parity)
+      {
+	for (int i=0; i<length/2; i++) {
+	  gauge[dir][((0*(length/2) + i)*2 + parity)*volumeCB + x] = v[i].real();
+	  gauge[dir][((1*(length/2) + i)*2 + parity)*volumeCB + x] = v[i].imag();
 	}
       }
 
@@ -2258,10 +2283,10 @@ namespace quda {
 	 @return Instance of a gauge_wrapper that curries in access to
 	 this field at the above coordinates.
        */
-      __device__ __host__ inline gauge_wrapper<RegType, QDPJITOrder<Float, length>> operator()(
+      __device__ __host__ inline gauge_wrapper<real, QDPJITOrder<Float, length>> operator()(
           int dim, int x_cb, int parity)
       {
-        return gauge_wrapper<RegType, QDPJITOrder<Float, length>>(*this, dim, x_cb, parity);
+        return gauge_wrapper<real, QDPJITOrder<Float, length>>(*this, dim, x_cb, parity);
       }
 
       /**
@@ -2274,11 +2299,10 @@ namespace quda {
 	 @return Instance of a gauge_wrapper that curries in access to
 	 this field at the above coordinates.
        */
-      __device__ __host__ inline const gauge_wrapper<RegType, QDPJITOrder<Float, length>> operator()(
+      __device__ __host__ inline const gauge_wrapper<real, QDPJITOrder<Float, length>> operator()(
           int dim, int x_cb, int parity) const
       {
-        return gauge_wrapper<RegType, QDPJITOrder<Float, length>>(
-            const_cast<QDPJITOrder<Float, length> &>(*this), dim, x_cb, parity);
+        return gauge_wrapper<real, QDPJITOrder<Float, length>>(const_cast<QDPJITOrder<Float, length> &>(*this), dim, x_cb, parity);
       }
 
       size_t Bytes() const { return length * sizeof(Float); }
@@ -2289,7 +2313,8 @@ namespace quda {
      [parity][dim][volumecb][row][col]
   */
   template <typename Float, int length> struct MILCOrder : public LegacyOrder<Float,length> {
-    typedef typename mapper<Float>::type RegType;
+    using real = typename mapper<Float>::type;
+    using complex = complex<real>;
     Float *gauge;
     const int volumeCB;
     const int geometry;
@@ -2301,30 +2326,34 @@ namespace quda {
       { ; }
     virtual ~MILCOrder() { ; }
 
-    __device__ __host__ inline void load(RegType v[length], int x, int dir, int parity, Float inphase = 1.0) const
+    __device__ __host__ inline void load(complex v[length/2], int x, int dir, int parity, real inphase = 1.0) const
     {
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
       typedef S<Float,length> structure;
       trove::coalesced_ptr<structure> gauge_((structure*)gauge);
       structure v_ = gauge_[(parity*volumeCB+x)*geometry + dir];
-      for (int i=0; i<length; i++) v[i] = (RegType)v_.v[i];
 #else
-      for (int i=0; i<length; i++) {
-	v[i] = (RegType)gauge[((parity*volumeCB+x)*geometry + dir)*length + i];
-      }
+      auto v_ = &gauge[((parity*volumeCB+x)*geometry + dir)*length];
 #endif
+      for (int i=0; i<length/2; i++) v[i] = complex(v_[2*i+0], v_[2*i+1]);
     }
 
-    __device__ __host__ inline void save(const RegType v[length], int x, int dir, int parity) {
+    __device__ __host__ inline void save(const complex v[length/2], int x, int dir, int parity)
+    {
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
       typedef S<Float,length> structure;
       trove::coalesced_ptr<structure> gauge_((structure*)gauge);
       structure v_;
-      for (int i=0; i<length; i++) v_.v[i] = (Float)v[i];
+      for (int i=0; i<length/2; i++) {
+        v_.v[2*i+0] = v[i].real();
+        v_.v[2*i+1] = v[i].imag();
+      }
       gauge_[(parity*volumeCB+x)*geometry + dir] = v_;
 #else
-      for (int i=0; i<length; i++) {
-	gauge[((parity*volumeCB+x)*geometry + dir)*length + i] = (Float)v[i];
+      auto v_ = &gauge[((parity*volumeCB+x)*geometry + dir)*length];
+      for (int i=0; i<length/2; i++) {
+	v_[2*i+0] = v[i].real();
+	v_[2*i+1] = v[i].imag();
       }
 #endif
     }
@@ -2339,9 +2368,9 @@ namespace quda {
        @return Instance of a gauge_wrapper that curries in access to
        this field at the above coordinates.
     */
-    __device__ __host__ inline gauge_wrapper<RegType, MILCOrder<Float, length>> operator()(int dim, int x_cb, int parity)
+    __device__ __host__ inline gauge_wrapper<real, MILCOrder<Float, length>> operator()(int dim, int x_cb, int parity)
     {
-      return gauge_wrapper<RegType, MILCOrder<Float, length>>(*this, dim, x_cb, parity);
+      return gauge_wrapper<real, MILCOrder<Float, length>>(*this, dim, x_cb, parity);
     }
 
     /**
@@ -2354,11 +2383,10 @@ namespace quda {
        @return Instance of a gauge_wrapper that curries in access to
        this field at the above coordinates.
     */
-    __device__ __host__ inline const gauge_wrapper<RegType, MILCOrder<Float, length>> operator()(
+    __device__ __host__ inline const gauge_wrapper<real, MILCOrder<Float, length>> operator()(
         int dim, int x_cb, int parity) const
     {
-      return gauge_wrapper<RegType, MILCOrder<Float, length>>(
-          const_cast<MILCOrder<Float, length> &>(*this), dim, x_cb, parity);
+      return gauge_wrapper<real, MILCOrder<Float, length>>(const_cast<MILCOrder<Float, length> &>(*this), dim, x_cb, parity);
     }
 
     size_t Bytes() const { return length * sizeof(Float); }
@@ -2380,7 +2408,8 @@ namespace quda {
      allocation in MILC.
   */
   template <typename Float, int length> struct MILCSiteOrder : public LegacyOrder<Float,length> {
-    typedef typename mapper<Float>::type RegType;
+    using real = typename mapper<Float>::type;
+    using complex = complex<real>;
     Float *gauge;
     const int volumeCB;
     const int geometry;
@@ -2409,7 +2438,7 @@ namespace quda {
 
     virtual ~MILCSiteOrder() { ; }
 
-    __device__ __host__ inline void load(RegType v[length], int x, int dir, int parity, Float inphase = 1.0) const
+    __device__ __host__ inline void load(complex v[length/2], int x, int dir, int parity, real inphase = 1.0) const
     {
       // get base pointer
       const Float *gauge0 = reinterpret_cast<const Float*>(reinterpret_cast<const char*>(gauge) + (parity*volumeCB+x)*size + offset);
@@ -2418,15 +2447,13 @@ namespace quda {
       typedef S<Float,length> structure;
       trove::coalesced_ptr<structure> gauge_((structure*)gauge0);
       structure v_ = gauge_[dir];
-      for (int i=0; i<length; i++) v[i] = (RegType)v_.v[i];
 #else
-      for (int i=0; i<length; i++) {
-	v[i] = (RegType)gauge0[dir*length + i];
-      }
+      auto v_ = &gauge0[dir*length];
 #endif
+      for (int i=0; i<length/2; i++) v[i] = complex(v_[2*i + 0], v_[2*i + 1]);
     }
 
-    __device__ __host__ inline void save(const RegType v[length], int x, int dir, int parity) {
+    __device__ __host__ inline void save(const complex v[length/2], int x, int dir, int parity) {
       // get base pointer
       Float *gauge0 = reinterpret_cast<Float*>(reinterpret_cast<char*>(gauge) + (parity*volumeCB+x)*size + offset);
 
@@ -2434,13 +2461,48 @@ namespace quda {
       typedef S<Float,length> structure;
       trove::coalesced_ptr<structure> gauge_((structure*)gauge0);
       structure v_;
-      for (int i=0; i<length; i++) v_.v[i] = (Float)v[i];
+      for (int i=0; i<length/2; i++) {
+        v_.v[2*i+0] = v[i].real();
+        v_.v[2*i+1] = v[i].imag();
+      }
       gauge_[dir] = v_;
 #else
-      for (int i=0; i<length; i++) {
-	gauge0[dir*length + i] = (Float)v[i];
+      for (int i=0; i<length/2; i++) {
+	gauge0[dir*length + 2*i + 0] = v[i].real();
+	gauge0[dir*length + 2*i + 1] = v[i].imag();
       }
 #endif
+    }
+
+    /**
+       @brief This accessor routine returns a gauge_wrapper to this object,
+       allowing us to overload various operators for manipulating at
+       the site level interms of matrix operations.
+       @param[in] dir Which dimension are we requesting
+       @param[in] x_cb Checkerboarded space-time index we are requesting
+       @param[in] parity Parity we are requesting
+       @return Instance of a gauge_wrapper that curries in access to
+       this field at the above coordinates.
+    */
+    __device__ __host__ inline gauge_wrapper<real, MILCSiteOrder<Float, length>> operator()(int dim, int x_cb, int parity)
+    {
+      return gauge_wrapper<real, MILCSiteOrder<Float, length>>(*this, dim, x_cb, parity);
+    }
+
+    /**
+       @brief This accessor routine returns a const gauge_wrapper to this object,
+       allowing us to overload various operators for manipulating at
+       the site level interms of matrix operations.
+       @param[in] dir Which dimension are we requesting
+       @param[in] x_cb Checkerboarded space-time index we are requesting
+       @param[in] parity Parity we are requesting
+       @return Instance of a gauge_wrapper that curries in access to
+       this field at the above coordinates.
+    */
+    __device__ __host__ inline const gauge_wrapper<real, MILCSiteOrder<Float, length>> operator()(
+        int dim, int x_cb, int parity) const
+    {
+      return gauge_wrapper<real, MILCSiteOrder<Float, length>>(const_cast<MILCSiteOrder<Float, length> &>(*this), dim, x_cb, parity);
     }
 
     size_t Bytes() const { return length * sizeof(Float); }
@@ -2452,61 +2514,58 @@ namespace quda {
      [parity][dim][volumecb][col][row]
   */
   template <typename Float, int length> struct CPSOrder : LegacyOrder<Float,length> {
-    typedef typename mapper<Float>::type RegType;
+    using real = typename mapper<Float>::type;
+    using complex = complex<real>;
     Float *gauge;
     const int volumeCB;
-    const Float anisotropy;
+    const real anisotropy;
+    const real anisotropy_inv;
     static constexpr int Nc = 3;
     const int geometry;
   CPSOrder(const GaugeField &u, Float *gauge_=0, Float **ghost_=0)
     : LegacyOrder<Float,length>(u, ghost_), gauge(gauge_ ? gauge_ : (Float*)u.Gauge_p()),
-      volumeCB(u.VolumeCB()), anisotropy(u.Anisotropy()), geometry(u.Geometry())
+      volumeCB(u.VolumeCB()), anisotropy(u.Anisotropy()), anisotropy_inv(1.0/anisotropy), geometry(u.Geometry())
       { if (length != 18) errorQuda("Gauge length %d not supported", length); }
-  CPSOrder(const CPSOrder &order) : LegacyOrder<Float,length>(order), gauge(order.gauge),
-      volumeCB(order.volumeCB), anisotropy(order.anisotropy), geometry(order.geometry)
+  CPSOrder(const CPSOrder &order) : LegacyOrder<Float,length>(order), gauge(order.gauge), volumeCB(order.volumeCB),
+      anisotropy(order.anisotropy), anisotropy_inv(order.anisotropy_inv), geometry(order.geometry)
       { ; }
     virtual ~CPSOrder() { ; }
 
     // we need to transpose and scale for CPS ordering
-    __device__ __host__ inline void load(RegType v[18], int x, int dir, int parity, Float inphase = 1.0) const
+    __device__ __host__ inline void load(complex v[9], int x, int dir, int parity, Float inphase = 1.0) const
     {
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
       typedef S<Float,length> structure;
       trove::coalesced_ptr<structure> gauge_((structure*)gauge);
       structure v_ = gauge_[((parity*volumeCB+x)*geometry + dir)];
-      for (int i=0; i<Nc; i++)
-	for (int j=0; j<Nc; j++)
-	  for (int z=0; z<2; z++)
-	    v[(i*Nc+j)*2+z] = (RegType)v_.v[(j*Nc+i)*2+z] / anisotropy;
 #else
+      auto v_ = &gauge[((parity*volumeCB+x)*geometry + dir)*length];
+#endif
       for (int i=0; i<Nc; i++) {
 	for (int j=0; j<Nc; j++) {
-	  for (int z=0; z<2; z++) {
-	    v[(i*Nc+j)*2+z] =
-	      (RegType)(gauge[((((parity*volumeCB+x)*geometry + dir)*Nc + j)*Nc + i)*2 + z] / anisotropy);
-	  }
-	}
+          v[i*Nc+j] = complex(v_[(j*Nc+i)*2+0], v_[(j*Nc+i)*2+1]) * anisotropy_inv;
+        }
       }
-#endif
     }
 
-    __device__ __host__ inline void save(const RegType v[18], int x, int dir, int parity) {
+    __device__ __host__ inline void save(const complex v[9], int x, int dir, int parity)
+    {
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
       typedef S<Float,length> structure;
       trove::coalesced_ptr<structure> gauge_((structure*)gauge);
       structure v_;
       for (int i=0; i<Nc; i++)
-	for (int j=0; j<Nc; j++)
-	  for (int z=0; z<2; z++)
-	    v_.v[(j*Nc+i)*2+z] = (Float)(anisotropy * v[(i*Nc+j)*2+z]);
+	for (int j=0; j<Nc; j++) {
+          v_.v[(j*Nc+i)*2+0] = anisotropy * v[i*Nc+j].real();
+          v_.v[(j*Nc+i)*2+1] = anisotropy * v[i*Nc+j].imag();
+        }
       gauge_[((parity*volumeCB+x)*geometry + dir)] = v_;
 #else
+      auto v_ = &gauge[((parity*volumeCB+x)*geometry + dir)*length];
       for (int i=0; i<Nc; i++) {
 	for (int j=0; j<Nc; j++) {
-	  for (int z=0; z<2; z++) {
-	    gauge[((((parity*volumeCB+x)*geometry + dir)*Nc + j)*Nc + i)*2 + z] =
-	      (Float)(anisotropy * v[(i*Nc+j)*2+z]);
-	  }
+          v_[(j*Nc + i)*2+0] = anisotropy * v[i*Nc+j].real();
+          v_[(j*Nc + i)*2+1] = anisotropy * v[i*Nc+j].imag();
 	}
       }
 #endif
@@ -2522,9 +2581,9 @@ namespace quda {
        @return Instance of a gauge_wrapper that curries in access to
        this field at the above coordinates.
     */
-    __device__ __host__ inline gauge_wrapper<RegType, CPSOrder<Float, length>> operator()(int dim, int x_cb, int parity)
+    __device__ __host__ inline gauge_wrapper<real, CPSOrder<Float, length>> operator()(int dim, int x_cb, int parity)
     {
-      return gauge_wrapper<RegType, CPSOrder<Float, length>>(*this, dim, x_cb, parity);
+      return gauge_wrapper<real, CPSOrder<Float, length>>(*this, dim, x_cb, parity);
     }
 
     /**
@@ -2537,10 +2596,10 @@ namespace quda {
        @return Instance of a gauge_wrapper that curries in access to
        this field at the above coordinates.
     */
-    __device__ __host__ inline const gauge_wrapper<RegType, CPSOrder<Float, length>> operator()(
+    __device__ __host__ inline const gauge_wrapper<real, CPSOrder<Float, length>> operator()(
         int dim, int x_cb, int parity) const
     {
-      return gauge_wrapper<RegType, CPSOrder<Float, length>>(
+      return gauge_wrapper<real, CPSOrder<Float, length>>(
           const_cast<CPSOrder<Float, length> &>(*this), dim, x_cb, parity);
     }
 
@@ -2555,63 +2614,63 @@ namespace quda {
        [mu][parity][volumecb+halos][col][row]
     */
     template <typename Float, int length> struct BQCDOrder : LegacyOrder<Float,length> {
-      typedef typename mapper<Float>::type RegType;
+      using real = typename mapper<Float>::type;
+      using complex = complex<real>;
       Float *gauge;
       const int volumeCB;
       int exVolumeCB; // extended checkerboard volume
       static constexpr int Nc = 3;
     BQCDOrder(const GaugeField &u, Float *gauge_=0, Float **ghost_=0)
-      : LegacyOrder<Float,length>(u, ghost_), gauge(gauge_ ? gauge_ : (Float*)u.Gauge_p()), volumeCB(u.VolumeCB()) {
+      : LegacyOrder<Float,length>(u, ghost_), gauge(gauge_ ? gauge_ : (Float*)u.Gauge_p()), volumeCB(u.VolumeCB())
+      {
 	if (length != 18) errorQuda("Gauge length %d not supported", length);
 	// compute volumeCB + halo region
 	exVolumeCB = u.X()[0]/2 + 2;
 	for (int i=1; i<4; i++) exVolumeCB *= u.X()[i] + 2;
       }
     BQCDOrder(const BQCDOrder &order) : LegacyOrder<Float,length>(order), gauge(order.gauge),
-	volumeCB(order.volumeCB), exVolumeCB(order.exVolumeCB) {
+	volumeCB(order.volumeCB), exVolumeCB(order.exVolumeCB)
+      {
 	if (length != 18) errorQuda("Gauge length %d not supported", length);
       }
 
       virtual ~BQCDOrder() { ; }
 
       // we need to transpose for BQCD ordering
-      __device__ __host__ inline void load(RegType v[18], int x, int dir, int parity, Float inphase = 1.0) const
+      __device__ __host__ inline void load(complex v[9], int x, int dir, int parity, real inphase = 1.0) const
       {
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
-      typedef S<Float,length> structure;
-      trove::coalesced_ptr<structure> gauge_((structure*)gauge);
-      structure v_ = gauge_[(dir*2+parity)*exVolumeCB + x];
-      for (int i=0; i<Nc; i++)
-	for (int j=0; j<Nc; j++)
-	  for (int z=0; z<2; z++)
-	    v[(i*Nc+j)*2+z] = (RegType)v_.v[(j*Nc+i)*2+z];
+        typedef S<Float,length> structure;
+        trove::coalesced_ptr<structure> gauge_((structure*)gauge);
+        structure v_ = gauge_[(dir*2+parity)*exVolumeCB + x];
 #else
-	for (int i=0; i<Nc; i++) {
-	  for (int j=0; j<Nc; j++) {
-	    for (int z=0; z<2; z++) {
-	      v[(i*Nc+j)*2+z] = (RegType)gauge[((((dir*2+parity)*exVolumeCB + x)*Nc + j)*Nc + i)*2 + z];
-	    }
-	  }
-	}
+        auto v_ = &gauge[((dir*2+parity)*exVolumeCB + x)*length];
 #endif
+        for (int i=0; i<Nc; i++) {
+          for (int j=0; j<Nc; j++) {
+            v[i*Nc+j] = complex(v_[(j*Nc+i)*2+0], v_[(j*Nc+i)*2+1]);
+          }
+        }
       }
 
-      __device__ __host__ inline void save(const RegType v[18], int x, int dir, int parity) {
+      __device__ __host__ inline void save(const complex v[9], int x, int dir, int parity)
+      {
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
 	typedef S<Float,length> structure;
 	trove::coalesced_ptr<structure> gauge_((structure*)gauge);
 	structure v_;
 	for (int i=0; i<Nc; i++)
-	  for (int j=0; j<Nc; j++)
-	    for (int z=0; z<2; z++)
-	      v_.v[(j*Nc+i)*2+z] = (Float)(v[(i*Nc+j)*2+z]);
+	  for (int j=0; j<Nc; j++) {
+            v_.v[(j*Nc+i)*2+0] = v[i*Nc+j].real();
+            v_.v[(j*Nc+i)*2+1] = v[i*Nc+j].imag();
+          }
 	gauge_[(dir*2+parity)*exVolumeCB + x] = v_;
 #else
+        auto v_ = &gauge[((dir*2+parity)*exVolumeCB + x)*length];
 	for (int i=0; i<Nc; i++) {
 	  for (int j=0; j<Nc; j++) {
-	    for (int z=0; z<2; z++) {
-	      gauge[((((dir*2+parity)*exVolumeCB + x)*Nc + j)*Nc + i)*2 + z] = (Float)v[(i*Nc+j)*2+z];
-	    }
+            v_[((Nc + j)*Nc + i)*2 + 0] = v[i*Nc+j].real();
+            v_[((Nc + j)*Nc + i)*2 + 1] = v[i*Nc+j].imag();
 	  }
 	}
 #endif
@@ -2627,9 +2686,9 @@ namespace quda {
 	 @return Instance of a gauge_wrapper that curries in access to
 	 this field at the above coordinates.
        */
-      __device__ __host__ inline gauge_wrapper<RegType, BQCDOrder<Float, length>> operator()(int dim, int x_cb, int parity)
+      __device__ __host__ inline gauge_wrapper<real, BQCDOrder<Float, length>> operator()(int dim, int x_cb, int parity)
       {
-        return gauge_wrapper<RegType, BQCDOrder<Float, length>>(*this, dim, x_cb, parity);
+        return gauge_wrapper<real, BQCDOrder<Float, length>>(*this, dim, x_cb, parity);
       }
 
       /**
@@ -2642,10 +2701,10 @@ namespace quda {
 	 @return Instance of a gauge_wrapper that curries in access to
 	 this field at the above coordinates.
        */
-      __device__ __host__ inline const gauge_wrapper<RegType, BQCDOrder<Float, length>> operator()(
+      __device__ __host__ inline const gauge_wrapper<real, BQCDOrder<Float, length>> operator()(
           int dim, int x_cb, int parity) const
       {
-        return gauge_wrapper<RegType, BQCDOrder<Float, length>>(
+        return gauge_wrapper<real, BQCDOrder<Float, length>>(
             const_cast<BQCDOrder<Float, length> &>(*this), dim, x_cb, parity);
       }
 
@@ -2653,65 +2712,66 @@ namespace quda {
     };
 
     /**
-       struct to define TIFR ordered gauge fields:
+       @brief struct to define TIFR ordered gauge fields:
        [mu][parity][volumecb][col][row]
     */
     template <typename Float, int length> struct TIFROrder : LegacyOrder<Float,length> {
-      typedef typename mapper<Float>::type RegType;
+      using real =  typename mapper<Float>::type;
+      using complex = complex<real>;
       Float *gauge;
       const int volumeCB;
       static constexpr int Nc = 3;
-      const Float scale;
+      const real scale;
+      const real scale_inv;
     TIFROrder(const GaugeField &u, Float *gauge_=0, Float **ghost_=0)
       : LegacyOrder<Float,length>(u, ghost_), gauge(gauge_ ? gauge_ : (Float*)u.Gauge_p()),
-	volumeCB(u.VolumeCB()), scale(u.Scale()) {
+	volumeCB(u.VolumeCB()), scale(u.Scale()), scale_inv(1.0 / scale)
+      {
 	if (length != 18) errorQuda("Gauge length %d not supported", length);
       }
     TIFROrder(const TIFROrder &order)
-      : LegacyOrder<Float,length>(order), gauge(order.gauge), volumeCB(order.volumeCB), scale(order.scale) {
+      : LegacyOrder<Float,length>(order), gauge(order.gauge), volumeCB(order.volumeCB), scale(order.scale), scale_inv(1.0 / scale)
+      {
 	if (length != 18) errorQuda("Gauge length %d not supported", length);
       }
 
       virtual ~TIFROrder() { ; }
 
       // we need to transpose for TIFR ordering
-      __device__ __host__ inline void load(RegType v[18], int x, int dir, int parity, Float inphase = 1.0) const
+      __device__ __host__ inline void load(complex v[9], int x, int dir, int parity, real inphase = 1.0) const
       {
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
-      typedef S<Float,length> structure;
-      trove::coalesced_ptr<structure> gauge_((structure*)gauge);
-      structure v_ = gauge_[(dir*2+parity)*volumeCB + x];
-      for (int i=0; i<Nc; i++)
-	for (int j=0; j<Nc; j++)
-	  for (int z=0; z<2; z++)
-	    v[(i*Nc+j)*2+z] = (RegType)v_.v[(j*Nc+i)*2+z] / scale;
+        typedef S<Float,length> structure;
+        trove::coalesced_ptr<structure> gauge_((structure*)gauge);
+        structure v_ = gauge_[(dir*2+parity)*volumeCB + x];
 #else
-	for (int i=0; i<Nc; i++) {
-	  for (int j=0; j<Nc; j++) {
-	    for (int z=0; z<2; z++) {
-	      v[(i*Nc+j)*2+z] = (RegType)gauge[((((dir*2+parity)*volumeCB + x)*Nc + j)*Nc + i)*2 + z] / scale;
-	    }
-	  }
-	}
+        auto v_ = &gauge[((dir*2+parity)*volumeCB + x)*length];
 #endif
+        for (int i=0; i<Nc; i++) {
+          for (int j=0; j<Nc; j++) {
+            v[i*Nc+j] = complex(v_[(j*Nc+i)*2+0], v_[(j*Nc+i)*2+1]) * scale_inv;
+          }
+        }
       }
 
-      __device__ __host__ inline void save(const RegType v[18], int x, int dir, int parity) {
+      __device__ __host__ inline void save(const complex v[9], int x, int dir, int parity)
+      {
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
 	typedef S<Float,length> structure;
 	trove::coalesced_ptr<structure> gauge_((structure*)gauge);
 	structure v_;
 	for (int i=0; i<Nc; i++)
-	  for (int j=0; j<Nc; j++)
-	    for (int z=0; z<2; z++)
-	      v_.v[(j*Nc+i)*2+z] = (Float)(v[(i*Nc+j)*2+z]) * scale;
+	  for (int j=0; j<Nc; j++) {
+            v_.v[(j*Nc+i)*2+0] = v[i*Nc+j].real() * scale;
+            v_.v[(j*Nc+i)*2+1] = v[i*Nc+j].imag() * scale;
+          }
 	gauge_[(dir*2+parity)*volumeCB + x] = v_;
 #else
+        auto v_ = &gauge[((dir*2+parity)*volumeCB + x)*length];
 	for (int i=0; i<Nc; i++) {
 	  for (int j=0; j<Nc; j++) {
-	    for (int z=0; z<2; z++) {
-	      gauge[((((dir*2+parity)*volumeCB + x)*Nc + j)*Nc + i)*2 + z] = (Float)v[(i*Nc+j)*2+z] * scale;
-	    }
+            v_[((Nc + j)*Nc + i)*2 + 0] = v[i*Nc+j].real() * scale;
+            v_[((Nc + j)*Nc + i)*2 + 1] = v[i*Nc+j].imag() * scale;
 	  }
 	}
 #endif
@@ -2727,9 +2787,9 @@ namespace quda {
 	 @return Instance of a gauge_wrapper that curries in access to
 	 this field at the above coordinates.
        */
-      __device__ __host__ inline gauge_wrapper<RegType, TIFROrder<Float, length>> operator()(int dim, int x_cb, int parity)
+      __device__ __host__ inline gauge_wrapper<real, TIFROrder<Float, length>> operator()(int dim, int x_cb, int parity)
       {
-        return gauge_wrapper<RegType, TIFROrder<Float, length>>(*this, dim, x_cb, parity);
+        return gauge_wrapper<real, TIFROrder<Float, length>>(*this, dim, x_cb, parity);
       }
 
       /**
@@ -2742,10 +2802,10 @@ namespace quda {
 	 @return Instance of a gauge_wrapper that curries in access to
 	 this field at the above coordinates.
        */
-      __device__ __host__ inline const gauge_wrapper<RegType, TIFROrder<Float, length>> operator()(
+      __device__ __host__ inline const gauge_wrapper<real, TIFROrder<Float, length>> operator()(
           int dim, int x_cb, int parity) const
       {
-        return gauge_wrapper<RegType, TIFROrder<Float, length>>(
+        return gauge_wrapper<real, TIFROrder<Float, length>>(
             const_cast<TIFROrder<Float, length> &>(*this), dim, x_cb, parity);
       }
 
@@ -2757,17 +2817,19 @@ namespace quda {
        [mu][parity][t][z+4][y][x/2][col][row]
     */
     template <typename Float, int length> struct TIFRPaddedOrder : LegacyOrder<Float,length> {
-      typedef typename mapper<Float>::type RegType;
+      using real =  typename mapper<Float>::type;
+      using complex = complex<real>;
       Float *gauge;
       const int volumeCB;
       int exVolumeCB;
       static constexpr int Nc = 3;
-      const Float scale;
+      const real scale;
+      const real scale_inv;
       const int dim[4];
       const int exDim[4];
     TIFRPaddedOrder(const GaugeField &u, Float *gauge_=0, Float **ghost_=0)
       : LegacyOrder<Float,length>(u, ghost_), gauge(gauge_ ? gauge_ : (Float*)u.Gauge_p()),
-	volumeCB(u.VolumeCB()), exVolumeCB(1), scale(u.Scale()),
+	volumeCB(u.VolumeCB()), exVolumeCB(1), scale(u.Scale()), scale_inv(1.0 / scale),
 	dim{ u.X()[0], u.X()[1], u.X()[2], u.X()[3] },
 	exDim{ u.X()[0], u.X()[1], u.X()[2] + 4, u.X()[3] } {
 	if (length != 18) errorQuda("Gauge length %d not supported", length);
@@ -2778,9 +2840,11 @@ namespace quda {
       }
 
     TIFRPaddedOrder(const TIFRPaddedOrder &order)
-      : LegacyOrder<Float,length>(order), gauge(order.gauge), volumeCB(order.volumeCB), exVolumeCB(order.exVolumeCB), scale(order.scale),
+      : LegacyOrder<Float,length>(order), gauge(order.gauge), volumeCB(order.volumeCB), exVolumeCB(order.exVolumeCB),
+          scale(order.scale), scale_inv(order.scale_inv),
 	  dim{order.dim[0], order.dim[1], order.dim[2], order.dim[3]},
-	  exDim{order.exDim[0], order.exDim[1], order.exDim[2], order.exDim[3]} {
+	  exDim{order.exDim[0], order.exDim[1], order.exDim[2], order.exDim[3]}
+      {
 	if (length != 18) errorQuda("Gauge length %d not supported", length);
       }
 
@@ -2801,32 +2865,26 @@ namespace quda {
       }
 
       // we need to transpose for TIFR ordering
-      __device__ __host__ inline void load(RegType v[18], int x, int dir, int parity, Float inphase = 1.0) const
+      __device__ __host__ inline void load(complex v[9], int x, int dir, int parity, real inphase = 1.0) const
       {
-
         int y = getPaddedIndex(x, parity);
 
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
 	typedef S<Float,length> structure;
 	trove::coalesced_ptr<structure> gauge_((structure*)gauge);
 	structure v_ = gauge_[(dir*2+parity)*exVolumeCB + y];
-	for (int i=0; i<Nc; i++)
-	  for (int j=0; j<Nc; j++)
-	    for (int z=0; z<2; z++)
-	      v[(i*Nc+j)*2+z] = (RegType)v_.v[(j*Nc+i)*2+z] / scale;
 #else
-	for (int i=0; i<Nc; i++) {
-	  for (int j=0; j<Nc; j++) {
-	    for (int z=0; z<2; z++) {
-	      v[(i*Nc+j)*2+z] = (RegType)gauge[((((dir*2+parity)*exVolumeCB + y)*Nc + j)*Nc + i)*2 + z] / scale;
-	    }
-	  }
-	}
+        auto v_ = &gauge[((dir*2+parity)*exVolumeCB + y)*length];
 #endif
+        for (int i=0; i<Nc; i++) {
+          for (int j=0; j<Nc; j++) {
+            v[i*Nc+j] = complex(v_[(j*Nc+i)*2+0], v_[(j*Nc+i)*2+1]) * scale_inv;
+          }
+        }
       }
 
-      __device__ __host__ inline void save(const RegType v[18], int x, int dir, int parity) {
-
+      __device__ __host__ inline void save(const complex v[9], int x, int dir, int parity)
+      {
 	int y = getPaddedIndex(x, parity);
 
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
@@ -2834,16 +2892,17 @@ namespace quda {
 	trove::coalesced_ptr<structure> gauge_((structure*)gauge);
 	structure v_;
 	for (int i=0; i<Nc; i++)
-	  for (int j=0; j<Nc; j++)
-	    for (int z=0; z<2; z++)
-	      v_.v[(j*Nc+i)*2+z] = (Float)(v[(i*Nc+j)*2+z]) * scale;
-  gauge_[(dir*2+parity)*exVolumeCB + y] = v_;
+	  for (int j=0; j<Nc; j++) {
+            v_.v[(j*Nc+i)*2+0] = v[i*Nc+j].real() * scale;
+            v_.v[(j*Nc+i)*2+1] = v[i*Nc+j].imag() * scale;
+          }
+        gauge_[(dir*2+parity)*exVolumeCB + y] = v_;
 #else
+        auto v_ = &gauge[((dir*2+parity)*exVolumeCB + y)*length];
 	for (int i=0; i<Nc; i++) {
 	  for (int j=0; j<Nc; j++) {
-	    for (int z=0; z<2; z++) {
-	      gauge[((((dir*2+parity)*exVolumeCB + y)*Nc + j)*Nc + i)*2 + z] = (Float)v[(i*Nc+j)*2+z] * scale;
-	    }
+            v_[((Nc + j)*Nc + i)*2 + 0] = v[i*Nc+j].real() * scale;
+            v_[((Nc + j)*Nc + i)*2 + 1] = v[i*Nc+j].imag() * scale;
 	  }
 	}
 #endif
@@ -2859,10 +2918,10 @@ namespace quda {
 	 @return Instance of a gauge_wrapper that curries in access to
 	 this field at the above coordinates.
        */
-      __device__ __host__ inline gauge_wrapper<RegType, TIFRPaddedOrder<Float, length>> operator()(
+      __device__ __host__ inline gauge_wrapper<real, TIFRPaddedOrder<Float, length>> operator()(
           int dim, int x_cb, int parity)
       {
-        return gauge_wrapper<RegType, TIFRPaddedOrder<Float, length>>(*this, dim, x_cb, parity);
+        return gauge_wrapper<real, TIFRPaddedOrder<Float, length>>(*this, dim, x_cb, parity);
       }
 
       /**
@@ -2875,10 +2934,10 @@ namespace quda {
 	 @return Instance of a gauge_wrapper that curries in access to
 	 this field at the above coordinates.
        */
-      __device__ __host__ inline const gauge_wrapper<RegType, TIFRPaddedOrder<Float, length>> operator()(
+      __device__ __host__ inline const gauge_wrapper<real, TIFRPaddedOrder<Float, length>> operator()(
           int dim, int x_cb, int parity) const
       {
-        return gauge_wrapper<RegType, TIFRPaddedOrder<Float, length>>(
+        return gauge_wrapper<real, TIFRPaddedOrder<Float, length>>(
             const_cast<TIFRPaddedOrder<Float, length> &>(*this), dim, x_cb, parity);
       }
 

--- a/include/gauge_field_order.h
+++ b/include/gauge_field_order.h
@@ -2043,8 +2043,8 @@ namespace quda {
       };
 
   /**
-      The LegacyOrder defines the ghost zone storage and ordering for
-      all cpuGaugeFields, which use the same ghost zone storage.
+     @brief The LegacyOrder defines the ghost zone storage and ordering for
+     all cpuGaugeFields, which use the same ghost zone storage.
   */
   template <typename Float, int length>
     struct LegacyOrder {
@@ -2352,7 +2352,7 @@ namespace quda {
       { ; }
     virtual ~MILCOrder() { ; }
 
-    __device__ __host__ inline void load(complex v[length / 2], int x, int dir, int parity, real inphase = 1.0) const
+    __device__ __host__ inline void load(complex v[9], int x, int dir, int parity, real inphase = 1.0) const
     {
 #if defined( __CUDA_ARCH__) && !defined(DISABLE_TROVE)
       typedef S<Float,length> structure;
@@ -2362,6 +2362,7 @@ namespace quda {
       auto v_ = &gauge[((parity * volumeCB + x) * geometry + dir) * length];
 #endif
       for (int i = 0; i < length / 2; i++) v[i] = complex(v_[2 * i + 0], v_[2 * i + 1]);
+      for (int i = length / 2; i < 9; i++) v[i] = complex(0.0, 0.0); // this is to surpress a compiler warning from reading from mom fields
     }
 
     __device__ __host__ inline void save(const complex v[length / 2], int x, int dir, int parity)
@@ -2465,7 +2466,7 @@ namespace quda {
 
     virtual ~MILCSiteOrder() { ; }
 
-    __device__ __host__ inline void load(complex v[length / 2], int x, int dir, int parity, real inphase = 1.0) const
+    __device__ __host__ inline void load(complex v[9], int x, int dir, int parity, real inphase = 1.0) const
     {
       // get base pointer
       const Float *gauge0 = reinterpret_cast<const Float*>(reinterpret_cast<const char*>(gauge) + (parity*volumeCB+x)*size + offset);
@@ -2478,6 +2479,7 @@ namespace quda {
       auto v_ = &gauge0[dir * length];
 #endif
       for (int i = 0; i < length / 2; i++) v[i] = complex(v_[2 * i + 0], v_[2 * i + 1]);
+      for (int i = length / 2; i < 9; i++) v[i] = complex(0.0, 0.0); // this is to surpress a compiler warning from reading from mom fields
     }
 
     __device__ __host__ inline void save(const complex v[length / 2], int x, int dir, int parity)

--- a/include/invert_quda.h
+++ b/include/invert_quda.h
@@ -1085,7 +1085,7 @@ public:
     virtual ~PreconditionedSolver() { delete solver; }
 
     void operator()(ColorSpinorField &x, ColorSpinorField &b) {
-      setOutputPrefix(prefix);
+      pushOutputPrefix(prefix);
 
       QudaSolutionType solution_type = b.SiteSubset() == QUDA_FULL_SITE_SUBSET ? QUDA_MAT_SOLUTION : QUDA_MATPC_SOLUTION;
 
@@ -1096,7 +1096,7 @@ public:
       (*solver)(*out, *in);
       dirac.reconstruct(x, b, solution_type);
 
-      setOutputPrefix("");
+      popOutputPrefix();
     }
   };
 

--- a/include/kernels/clover_deriv.cuh
+++ b/include/kernels/clover_deriv.cuh
@@ -366,10 +366,9 @@ namespace quda
 #endif
 
     // Write to array
-    Link F;
-    arg.force.load((real *)(F.data), index, mu, yIndex == 0 ? arg.parity : 1 - arg.parity);
+    Link F = arg.force(mu, index, yIndex == 0 ? arg.parity : 1 - arg.parity);
     axpy(arg.coeff, force, F);
-    arg.force.save((real *)(F.data), index, mu, yIndex == 0 ? arg.parity : 1 - arg.parity);
+    arg.force(mu, index, yIndex == 0 ? arg.parity : 1 - arg.parity) = F;
 
     return;
   } // cloverDerivativeKernel

--- a/include/kernels/clover_sigma_outer_product.cuh
+++ b/include/kernels/clover_sigma_outer_product.cuh
@@ -58,10 +58,9 @@ namespace quda
 
     result -= conj(result);
 
-    Matrix<Complex, 3> temp;
-    arg.oprod.load(reinterpret_cast<real *>(temp.data), idx, (mu - 1) * mu / 2 + nu, parity);
+    Matrix<Complex, 3> temp = arg.oprod((mu - 1) * mu / 2 + nu, idx, parity);
     temp = result + temp;
-    arg.oprod.save(reinterpret_cast<real *>(temp.data), idx, (mu - 1) * mu / 2 + nu, parity);
+    arg.oprod((mu - 1) * mu / 2 + nu, idx, parity) = temp;
   }
 
   template <int nvector, typename real, typename Arg> __global__ void sigmaOprodKernel(Arg arg)

--- a/include/kernels/copy_gauge.cuh
+++ b/include/kernels/copy_gauge.cuh
@@ -44,8 +44,10 @@ namespace quda {
 	      arg.out(d, parity, x, i, j) = arg.in(d, parity, x, i, j);
 	    }
 #else
-	  Matrix<complex<RegTypeIn>, nColor> in = arg.in(d, x, parity);
-	  Matrix<complex<RegTypeOut>, nColor> out = in;
+	  Matrix<complex<RegTypeIn>, nColor> in;
+	  Matrix<complex<RegTypeOut>, nColor> out;
+          in = arg.in(d, x, parity);
+          out = in;
 	  arg.out(d, x, parity) = out;
 #endif
 	}
@@ -109,8 +111,10 @@ namespace quda {
     if (i >= nColor) return;
     for (int j=0; j<nColor; j++) arg.out(d, parity, x, i, j) = arg.in(d, parity, x, i, j);
 #else
-    Matrix<complex<RegTypeIn>, nColor> in = arg.in(d, x, parity);
-    Matrix<complex<RegTypeOut>, nColor> out = in;
+    Matrix<complex<RegTypeIn>, nColor> in;
+    Matrix<complex<RegTypeOut>, nColor> out;
+    in = arg.in(d, x, parity);
+    out = in;
     arg.out(d, x, parity) = out;
 #endif
   }
@@ -133,8 +137,10 @@ namespace quda {
             for (int j=0; j<nColor; j++)
               arg.out.Ghost(d+arg.out_offset, parity, x, i, j) = arg.in.Ghost(d+arg.in_offset, parity, x, i, j);
 #else
-          Matrix<complex<RegTypeIn>, nColor> in = arg.in.Ghost(d+arg.in_offset, x, parity); // assumes we are loading
-          Matrix<complex<RegTypeOut>, nColor> out = in;
+          Matrix<complex<RegTypeIn>, nColor> in;
+          Matrix<complex<RegTypeOut>, nColor> out;
+          in = arg.in.Ghost(d+arg.in_offset, x, parity);
+          out = in;
           arg.out.Ghost(d+arg.out_offset, x, parity) = out;
 #endif
         }
@@ -166,8 +172,10 @@ namespace quda {
       for (int j=0; j<nColor; j++)
         arg.out.Ghost(d+arg.out_offset, parity, x, i, j) = arg.in.Ghost(d+arg.in_offset, parity, x, i, j);
 #else
-      Matrix<complex<RegTypeIn>, nColor> in = arg.in.Ghost(d+arg.in_offset, x, parity); // assumes we are loading
-      Matrix<complex<RegTypeOut>, nColor> out = in;
+      Matrix<complex<RegTypeIn>, nColor> in;
+      Matrix<complex<RegTypeOut>, nColor> out;
+      in = arg.in.Ghost(d+arg.in_offset, x, parity);
+      out = in;
       arg.out.Ghost(d+arg.out_offset, x, parity) = out;
 #endif
     }

--- a/include/kernels/dslash_wilson_clover.cuh
+++ b/include/kernels/dslash_wilson_clover.cuh
@@ -13,7 +13,7 @@ namespace quda
     static constexpr int length = (nSpin / (nSpin / 2)) * 2 * nColor * nColor * (nSpin / 2) * (nSpin / 2) / 2;
     static constexpr bool twist = twist_;
 
-    typedef typename clover_mapper<Float, length>::type C;
+    typedef typename clover_mapper<Float, length, true>::type C;
     typedef typename mapper<Float>::type real;
     const C A;    /** the clover field */
     const real a; /** xpay scale factor */

--- a/include/quda_matrix.h
+++ b/include/quda_matrix.h
@@ -89,12 +89,13 @@ namespace quda {
           for (int i = 0; i < N * N; i++) data[i] = a.data[i];
         }
 
-        __device__ __host__ inline Matrix(const T data_[]) {
+        __device__ __host__ inline Matrix(const T data_[])
+        {
 #pragma unroll
 	  for (int i=0; i<N*N; i++) data[i] = data_[i];
-	}
+        }
 
-	__device__ __host__ inline Matrix(const HMatrix<real,N> &a);
+        __device__ __host__ inline Matrix(const HMatrix<real,N> &a);
 
         __device__ __host__ inline T const & operator()(int i, int j) const {
           return data[index(i,j)];

--- a/include/quda_matrix.h
+++ b/include/quda_matrix.h
@@ -83,6 +83,12 @@ namespace quda {
 	  for (int i=0; i<N*N; i++) data[i] = a.data[i];
 	}
 
+        template <class U>
+	__device__ __host__ inline Matrix(const Matrix<U,N> &a) {
+#pragma unroll
+	  for (int i=0; i<N*N; i++) data[i] = a.data[i];
+	}
+
 	__device__ __host__ inline Matrix(const T data_[]) {
 #pragma unroll
 	  for (int i=0; i<N*N; i++) data[i] = data_[i];

--- a/include/quda_matrix.h
+++ b/include/quda_matrix.h
@@ -95,7 +95,7 @@ namespace quda {
 	  for (int i=0; i<N*N; i++) data[i] = data_[i];
         }
 
-        __device__ __host__ inline Matrix(const HMatrix<real,N> &a);
+        __device__ __host__ inline Matrix(const HMatrix<real, N> &a);
 
         __device__ __host__ inline T const & operator()(int i, int j) const {
           return data[index(i,j)];

--- a/include/quda_matrix.h
+++ b/include/quda_matrix.h
@@ -83,13 +83,13 @@ namespace quda {
 	  for (int i=0; i<N*N; i++) data[i] = a.data[i];
 	}
 
-        template <class U>
-	__device__ __host__ inline Matrix(const Matrix<U,N> &a) {
+        template <class U> __device__ __host__ inline Matrix(const Matrix<U, N> &a)
+        {
 #pragma unroll
-	  for (int i=0; i<N*N; i++) data[i] = a.data[i];
-	}
+          for (int i = 0; i < N * N; i++) data[i] = a.data[i];
+        }
 
-	__device__ __host__ inline Matrix(const T data_[]) {
+        __device__ __host__ inline Matrix(const T data_[]) {
 #pragma unroll
 	  for (int i=0; i<N*N; i++) data[i] = data_[i];
 	}

--- a/include/trove_helper.cuh
+++ b/include/trove_helper.cuh
@@ -1,0 +1,11 @@
+#pragma once
+
+// ensure that we include the quda_define.h file to ensure that __COMPUTE_CAPABILITY__ is set
+#include <quda_define.h>
+
+// trove requires the warp shuffle instructions introduced with Kepler and has issues with device debug
+#if __COMPUTE_CAPABILITY__ >= 300 && !defined(DEVICE_DEBUG)
+#include <trove/ptr.h>
+#else
+#define DISABLE_TROVE
+#endif

--- a/include/tune_quda.h
+++ b/include/tune_quda.h
@@ -209,8 +209,9 @@ namespace quda {
         case 5: return 64 * 1024;
         }
       default:
-	errorQuda("Unknown SM architecture %d.%d\n", deviceProp.major, deviceProp.minor);
-	return 0;
+        warningQuda("Unknown SM architecture %d.%d - assuming limit of 48 KiB per SM\n",
+                    deviceProp.major, deviceProp.minor);
+        return 48 * 1024;
       }
     }
 

--- a/include/tune_quda.h
+++ b/include/tune_quda.h
@@ -165,7 +165,10 @@ namespace quda {
         case 2: return 32;
         case 5: return 16;
         }
-      default: errorQuda("Unknown SM architecture %d.%d\n", deviceProp.major, deviceProp.minor); return 0;
+      default:
+        warningQuda("Unknown SM architecture %d.%d - assuming limit of 32 blocks per SM\n",
+                    deviceProp.major, deviceProp.minor);
+        return 32;
       }
     }
 

--- a/lib/clover_outer_product.cu
+++ b/lib/clover_outer_product.cu
@@ -251,10 +251,10 @@ namespace quda {
 	  D_shift = (D_shift.project(dim,-1)).reconstruct(dim,-1);
 	  result += outerProdSpinTrace(D_shift,C);
 
-	  arg.force.load(reinterpret_cast<real*>(temp.data), idx, dim, arg.parity);
-	  arg.gauge.load(reinterpret_cast<real*>(U.data), idx, dim, arg.parity);
+	  temp = arg.force(dim, idx, arg.parity);
+	  U = arg.gauge(dim, idx, arg.parity);
 	  result = temp + U*result*arg.coeff;
-	  arg.force.save(reinterpret_cast<real*>(result.data), idx, dim, arg.parity);
+	  arg.force(dim, idx, arg.parity) = result;
 	}
       } // dim
 
@@ -289,10 +289,10 @@ namespace quda {
       D_shift = projected_tmp.reconstruct(dim,-1);
       result += outerProdSpinTrace(D_shift,C);
 
-      arg.force.load(reinterpret_cast<real*>(temp.data), bulk_cb_idx, dim, arg.parity);
-      arg.gauge.load(reinterpret_cast<real*>(U.data), bulk_cb_idx, dim, arg.parity);
+      temp = arg.force(dim, bulk_cb_idx, arg.parity);
+      U = arg.gauge(dim, bulk_cb_idx, arg.parity);
       result = temp + U*result*arg.coeff;
-      arg.force.save(reinterpret_cast<real*>(result.data), bulk_cb_idx, dim, arg.parity);
+      arg.force(dim, bulk_cb_idx, arg.parity) = result;
 
       cb_idx += gridDim.x*blockDim.x;
     }

--- a/lib/clover_trace_quda.cu
+++ b/lib/clover_trace_quda.cu
@@ -139,7 +139,7 @@ namespace quda {
 	  }
 
 	  mat *= arg.coeff;
-	  arg.gauge.save((Float*)(mat.data), x, (mu-1)*mu/2 + nu, parity);
+	  arg.gauge((mu-1)*mu/2 + nu, x, parity) = mat;
 	} // nu
       } // mu
 

--- a/lib/color_spinor_wuppertal.cu
+++ b/lib/color_spinor_wuppertal.cu
@@ -106,8 +106,7 @@ namespace quda {
 
     computeNeighborSum<Float,Nc>(out, arg, x_cb, parity);
 
-    Vector in;
-    arg.in.load((Float*)in.data, x_cb, parity);
+    Vector in = arg.in(x_cb, parity);
     out = arg.A*in + arg.B*out;
     
     arg.out(x_cb, parity) = out;

--- a/lib/comm_common.cpp
+++ b/lib/comm_common.cpp
@@ -610,7 +610,9 @@ void comm_finalize(void)
   comm_set_default_topology(NULL);
 }
 
-
+static char partition_string[16]; /** string that contains the job partitioning */
+static char topology_string[128]; /** string that contains the job topology */
+static char partition_override_string[16]; /** string that contains any overridden partitioning */
 static int manual_set_partition[QUDA_MAX_DIM] = {0};
 
 void comm_dim_partitioned_set(int dim)
@@ -618,10 +620,16 @@ void comm_dim_partitioned_set(int dim)
 #ifdef MULTI_GPU
   manual_set_partition[dim] = 1;
 #endif
+
+  snprintf(partition_string, 16, ",comm=%d%d%d%d", comm_dim_partitioned(0),
+           comm_dim_partitioned(1), comm_dim_partitioned(2), comm_dim_partitioned(3));
 }
 
 void comm_dim_partitioned_reset(){
   for (int i = 0; i < QUDA_MAX_DIM; i++) manual_set_partition[i] = 0;
+
+  snprintf(partition_string, 16, ",comm=%d%d%d%d", comm_dim_partitioned(0),
+           comm_dim_partitioned(1), comm_dim_partitioned(2), comm_dim_partitioned(3));
 }
 
 int comm_dim_partitioned(int dim)
@@ -686,11 +694,6 @@ bool comm_gdr_blacklist() {
 
   return blacklist;
 }
-
-static char partition_string[16]; /** static string that contains a string of the machine partition */
-static char topology_string[128]; /** static string that contains a string of the machine partition */
-static char
-  partition_override_string[16]; /** static string that contains a string of overridden communication partitioning */
 
 static bool deterministic_reduce = false;
 

--- a/lib/comm_common.cpp
+++ b/lib/comm_common.cpp
@@ -402,8 +402,8 @@ void comm_set_neighbor_ranks(Topology *topo){
   }
      
   for(int d=0; d<4; ++d){
-    int pos_displacement[4] = {0,0,0,0};
-    int neg_displacement[4] = {0,0,0,0};
+    int pos_displacement[QUDA_MAX_DIM] = { };
+    int neg_displacement[QUDA_MAX_DIM] = { };
     pos_displacement[d] = +1;
     neg_displacement[d] = -1;
     neighbor_rank[0][d] = comm_rank_displaced(topology, neg_displacement);

--- a/lib/copy_color_spinor.cuh
+++ b/lib/copy_color_spinor.cuh
@@ -27,8 +27,12 @@ namespace quda {
 
   using namespace colorspinor;
 
-  template <typename Out, typename In>
+  template <typename FloatOut, typename FloatIn, int nSpin_, int nColor_, typename Out, typename In>
   struct CopyColorSpinorArg {
+    using realOut = typename mapper<FloatOut>::type;
+    using realIn = typename mapper<FloatIn>::type;
+    static constexpr int nSpin = nSpin_;
+    static constexpr int nColor = nColor_;
     Out out;
     const In in;
     const int volumeCB;
@@ -42,8 +46,10 @@ namespace quda {
   };
 
   /** Straight copy with no basis change */
-  template <int Ns, int Nc>
+  template <typename Arg>
   struct PreserveBasis {
+    static constexpr int Ns = Arg::nSpin;
+    static constexpr int Nc = Arg::nColor;
     template <typename FloatOut, typename FloatIn>
     __device__ __host__ inline void operator()(complex<FloatOut> out[Ns*Nc], const complex<FloatIn> in[Ns*Nc]) const {
       for (int s=0; s<Ns; s++) for (int c=0; c<Nc; c++) out[s*Nc+c] = in[s*Nc+c];
@@ -51,8 +57,10 @@ namespace quda {
   };
 
   /** Transform from relativistic into non-relavisitic basis */
-  template <int Ns, int Nc>
+  template <typename Arg>
   struct NonRelBasis {
+    static constexpr int Ns = Arg::nSpin;
+    static constexpr int Nc = Arg::nColor;
     template <typename FloatOut, typename FloatIn>
     __device__ __host__ inline void operator()(complex<FloatOut> out[Ns*Nc], const complex<FloatIn> in[Ns*Nc]) const {
       int s1[4] = {1, 2, 3, 0};
@@ -68,8 +76,10 @@ namespace quda {
   };
 
   /** Transform from non-relativistic into relavisitic basis */
-  template <int Ns, int Nc>
+  template <typename Arg>
   struct RelBasis {
+    static constexpr int Ns = Arg::nSpin;
+    static constexpr int Nc = Arg::nColor;
     template <typename FloatOut, typename FloatIn>
     __device__ __host__ inline void operator()(complex<FloatOut> out[Ns*Nc], const complex<FloatIn> in[Ns*Nc]) const {
       int s1[4] = {1, 2, 3, 0};
@@ -85,8 +95,10 @@ namespace quda {
   };
 
   /** Transform from chiral into non-relavisitic basis */
-  template <int Ns, int Nc>
+  template <typename Arg>
   struct ChiralToNonRelBasis {
+    static constexpr int Ns = Arg::nSpin;
+    static constexpr int Nc = Arg::nColor;
     template <typename FloatOut, typename FloatIn>
     __device__ __host__ inline void operator()(complex<FloatOut> out[Ns*Nc], const complex<FloatIn> in[Ns*Nc]) const {
       int s1[4] = {0, 1, 0, 1};
@@ -102,8 +114,10 @@ namespace quda {
   };
 
   /** Transform from non-relativistic into chiral basis */
-  template <int Ns, int Nc>
+  template <typename Arg>
   struct NonRelToChiralBasis {
+    static constexpr int Ns = Arg::nSpin;
+    static constexpr int Nc = Arg::nColor;
     template <typename FloatOut, typename FloatIn>
     __device__ __host__ inline void operator()(complex<FloatOut> out[Ns*Nc], const complex<FloatIn> in[Ns*Nc]) const {
       int s1[4] = {0, 1, 0, 1};
@@ -119,15 +133,12 @@ namespace quda {
   };
 
   /** CPU function to reorder spinor fields.  */
-  template <typename FloatOut, typename FloatIn, int Ns, int Nc, typename Arg, typename Basis>
-  void copyColorSpinor(Arg &arg, const Basis &basis) {
-    typedef typename mapper<FloatIn>::type RegTypeIn;
-    typedef typename mapper<FloatOut>::type RegTypeOut;
-
+  template <typename Arg, typename Basis> void copyColorSpinor(Arg &arg, const Basis &basis)
+  {
     for (int parity = 0; parity<arg.nParity; parity++) {
       for (int x=0; x<arg.volumeCB; x++) {
-	ColorSpinor<RegTypeIn, Nc, Ns> in = arg.in(x, (parity+arg.inParity)&1);
-	ColorSpinor<RegTypeOut, Nc, Ns> out;
+        ColorSpinor<typename Arg::realIn, Arg::nColor, Arg::nSpin> in = arg.in(x, (parity+arg.inParity)&1);
+        ColorSpinor<typename Arg::realOut, Arg::nColor, Arg::nSpin> out;
 	basis(out.data, in.data);
 	arg.out(x, (parity+arg.outParity)&1) = out;
       }
@@ -135,22 +146,19 @@ namespace quda {
   }
 
   /** CUDA kernel to reorder spinor fields.  Adopts a similar form as the CPU version, using the same inlined functions. */
-  template <typename FloatOut, typename FloatIn, int Ns, int Nc, typename Arg, typename Basis>
-  __global__ void copyColorSpinorKernel(Arg arg, Basis basis) {
-    typedef typename mapper<FloatIn>::type RegTypeIn;
-    typedef typename mapper<FloatOut>::type RegTypeOut;
-
+  template <typename Arg, typename Basis> __global__ void copyColorSpinorKernel(Arg arg, Basis basis)
+  {
     int x = blockIdx.x * blockDim.x + threadIdx.x;
     if (x >= arg.volumeCB) return;
     int parity = blockIdx.y * blockDim.y + threadIdx.y;
 
-    ColorSpinor<RegTypeIn, Nc, Ns> in = arg.in(x, (parity+arg.inParity)&1);
-    ColorSpinor<RegTypeOut, Nc, Ns> out;
+    ColorSpinor<typename Arg::realIn, Arg::nColor, Arg::nSpin> in = arg.in(x, (parity+arg.inParity)&1);
+    ColorSpinor<typename Arg::realOut, Arg::nColor, Arg::nSpin> out;
     basis(out.data, in.data);
     arg.out(x, (parity+arg.outParity)&1) = out;
   }
 
-  template <typename FloatOut, typename FloatIn, int Ns, int Nc, typename Arg>
+  template <int Ns, typename Arg>
     class CopyColorSpinor : TunableVectorY {
     Arg &arg;
     const ColorSpinorField &meta;
@@ -174,11 +182,10 @@ namespace quda {
   
     void apply(const cudaStream_t &stream) {
       if (location == QUDA_CPU_FIELD_LOCATION) {
-	copyColorSpinor<FloatOut, FloatIn, Ns, Nc>(arg, PreserveBasis<Ns,Nc>());
+	copyColorSpinor(arg, PreserveBasis<Arg>());
       } else {
 	TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
-	copyColorSpinorKernel<FloatOut, FloatIn, Ns, Nc>
-	  <<<tp.grid, tp.block, tp.shared_bytes, stream>>> (arg, PreserveBasis<Ns,Nc>());
+	copyColorSpinorKernel<<<tp.grid, tp.block, tp.shared_bytes, stream>>>(arg, PreserveBasis<Arg>());
       }
     }
 
@@ -187,8 +194,8 @@ namespace quda {
     long long bytes() const { return arg.in.Bytes() + arg.out.Bytes(); }
   };
 
-  template <typename FloatOut, typename FloatIn, int Nc, typename Arg>
-  class CopyColorSpinor<FloatOut,FloatIn,4,Nc,Arg> : TunableVectorY {
+  template <typename Arg>
+  class CopyColorSpinor<4,Arg> : TunableVectorY {
     static constexpr int Ns = 4;
     Arg &arg;
     const ColorSpinorField &out;
@@ -226,33 +233,28 @@ namespace quda {
     void apply(const cudaStream_t &stream) {
       if (location == QUDA_CPU_FIELD_LOCATION) {
 	if (out.GammaBasis()==in.GammaBasis()) {
-	  copyColorSpinor<FloatOut, FloatIn, Ns, Nc>(arg, PreserveBasis<Ns,Nc>());
+          copyColorSpinor(arg, PreserveBasis<Arg>());
 	} else if (out.GammaBasis() == QUDA_UKQCD_GAMMA_BASIS && in.GammaBasis() == QUDA_DEGRAND_ROSSI_GAMMA_BASIS) {
-	  copyColorSpinor<FloatOut, FloatIn, Ns, Nc>(arg, NonRelBasis<Ns,Nc>());
+	  copyColorSpinor(arg, NonRelBasis<Arg>());
 	} else if (in.GammaBasis() == QUDA_UKQCD_GAMMA_BASIS && out.GammaBasis() == QUDA_DEGRAND_ROSSI_GAMMA_BASIS) {
-	  copyColorSpinor<FloatOut, FloatIn, Ns, Nc>(arg, RelBasis<Ns,Nc>());
+	  copyColorSpinor(arg, RelBasis<Arg>());
 	} else if (out.GammaBasis() == QUDA_UKQCD_GAMMA_BASIS && in.GammaBasis() == QUDA_CHIRAL_GAMMA_BASIS) {
-	  copyColorSpinor<FloatOut, FloatIn, Ns, Nc>(arg, ChiralToNonRelBasis<Ns,Nc>());
+	  copyColorSpinor(arg, ChiralToNonRelBasis<Arg>());
 	} else if (in.GammaBasis() == QUDA_UKQCD_GAMMA_BASIS && out.GammaBasis() == QUDA_CHIRAL_GAMMA_BASIS) {
-	  copyColorSpinor<FloatOut, FloatIn, Ns, Nc>(arg, NonRelToChiralBasis<Ns,Nc>());
+	  copyColorSpinor(arg, NonRelToChiralBasis<Arg>());
 	}
       } else {
 	TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
 	if (out.GammaBasis()==in.GammaBasis()) {
-	  copyColorSpinorKernel<FloatOut, FloatIn, Ns, Nc>
-	    <<<tp.grid, tp.block, tp.shared_bytes, stream>>> (arg, PreserveBasis<Ns,Nc>());
+	  copyColorSpinorKernel<<<tp.grid, tp.block, tp.shared_bytes, stream>>> (arg, PreserveBasis<Arg>());
 	} else if (out.GammaBasis() == QUDA_UKQCD_GAMMA_BASIS && in.GammaBasis() == QUDA_DEGRAND_ROSSI_GAMMA_BASIS) {
-	  copyColorSpinorKernel<FloatOut, FloatIn, Ns, Nc>
-	    <<<tp.grid, tp.block, tp.shared_bytes, stream>>> (arg, NonRelBasis<Ns,Nc>());
+	  copyColorSpinorKernel<<<tp.grid, tp.block, tp.shared_bytes, stream>>> (arg, NonRelBasis<Arg>());
 	} else if (in.GammaBasis() == QUDA_UKQCD_GAMMA_BASIS && out.GammaBasis() == QUDA_DEGRAND_ROSSI_GAMMA_BASIS) {
-	  copyColorSpinorKernel<FloatOut, FloatIn, Ns, Nc>
-	    <<<tp.grid, tp.block, tp.shared_bytes, stream>>> (arg, RelBasis<Ns,Nc>());
+	  copyColorSpinorKernel<<<tp.grid, tp.block, tp.shared_bytes, stream>>> (arg, RelBasis<Arg>());
 	} else if (out.GammaBasis() == QUDA_UKQCD_GAMMA_BASIS && in.GammaBasis() == QUDA_CHIRAL_GAMMA_BASIS) {
-	  copyColorSpinorKernel<FloatOut, FloatIn, Ns, Nc>
-	    <<<tp.grid, tp.block, tp.shared_bytes, stream>>> (arg, ChiralToNonRelBasis<Ns,Nc>());
+	  copyColorSpinorKernel<<<tp.grid, tp.block, tp.shared_bytes, stream>>> (arg, ChiralToNonRelBasis<Arg>());
 	} else if (in.GammaBasis() == QUDA_UKQCD_GAMMA_BASIS && out.GammaBasis() == QUDA_CHIRAL_GAMMA_BASIS) {
-	  copyColorSpinorKernel<FloatOut, FloatIn, Ns, Nc>
-	    <<<tp.grid, tp.block, tp.shared_bytes, stream>>> (arg, NonRelToChiralBasis<Ns,Nc>());
+	  copyColorSpinorKernel<<<tp.grid, tp.block, tp.shared_bytes, stream>>> (arg, NonRelToChiralBasis<Arg>());
 	}
       }
     }
@@ -266,13 +268,11 @@ namespace quda {
   /** Decide whether we are changing basis or not */
   template <typename FloatOut, typename FloatIn, int Ns, int Nc, typename Out, typename In>
   void genericCopyColorSpinor(Out &outOrder, const In &inOrder, const ColorSpinorField &out,
-			      const ColorSpinorField &in, QudaFieldLocation location) {
-
-    typedef CopyColorSpinorArg<Out,In> Arg;
-    Arg arg(outOrder, inOrder, out, in);
-    CopyColorSpinor<FloatOut, FloatIn, Ns, Nc, Arg> copy(arg, out, in, location);
+			      const ColorSpinorField &in, QudaFieldLocation location)
+  {
+    CopyColorSpinorArg<FloatOut, FloatIn, Ns, Nc, Out, In> arg(outOrder, inOrder, out, in);
+    CopyColorSpinor<Ns, decltype(arg)> copy(arg, out, in, location);
     copy.apply(0);
-
   }
 
   /** Decide on the output order*/

--- a/lib/copy_gauge_extended.cu
+++ b/lib/copy_gauge_extended.cu
@@ -1,5 +1,6 @@
 #include <tune_quda.h>
 #include <gauge_field_order.h>
+#include <quda_matrix.h>
 
 namespace quda {
 
@@ -49,6 +50,7 @@ namespace quda {
   __device__ __host__ void copyGaugeEx(CopyGaugeExArg<OutOrder,InOrder> &arg, int X, int parity) {
     typedef typename mapper<FloatIn>::type RegTypeIn;
     typedef typename mapper<FloatOut>::type RegTypeOut;
+    constexpr int nColor = Ncolor(length);
 
     int x[4];
     int R[4];
@@ -80,12 +82,10 @@ namespace quda {
       xin = ((((x[3]+R[3])*arg.Xin[2] + (x[2]+R[2]))*arg.Xin[1] + (x[1]+R[1]))*arg.Xin[0]+(x[0]+R[0])) >> 1;
       xout = X;
     }
-    for (int d=0; d<arg.geometry; d++){
-      RegTypeIn in[length];
-      RegTypeOut out[length];
-      arg.in.load(in, xin, d, parity);
-      for (int i=0; i<length; i++) out[i] = in[i];
-      arg.out.save(out, xout, d, parity);
+    for (int d=0; d<arg.geometry; d++) {
+      const Matrix<complex<RegTypeIn>,nColor> in = arg.in(d, xin, parity);
+      Matrix<complex<RegTypeOut>,nColor> out = in;
+      arg.out(d, xout, parity) = out;
     }//dir
   }
 
@@ -93,7 +93,7 @@ namespace quda {
   void copyGaugeEx(CopyGaugeExArg<OutOrder,InOrder> arg) {
     for (int parity=0; parity<2; parity++) {
       for(int X=0; X<arg.volume/2; X++){
-  copyGaugeEx<FloatOut, FloatIn, length, OutOrder, InOrder, regularToextended>(arg, X, parity);
+        copyGaugeEx<FloatOut, FloatIn, length, OutOrder, InOrder, regularToextended>(arg, X, parity);
       }
     }
   }

--- a/lib/extended_color_spinor_utilities.cu
+++ b/lib/extended_color_spinor_utilities.cu
@@ -82,19 +82,16 @@ namespace quda {
   }
 
 
-
   /** Straight copy with no basis change */
   template <typename FloatOut, typename FloatIn, int Ns, int Nc>
     class PreserveBasis {
       typedef typename mapper<FloatIn>::type RegTypeIn;
       typedef typename mapper<FloatOut>::type RegTypeOut;
       public:
-      __device__ __host__ inline void operator()(RegTypeOut out[Ns*Nc*2], const RegTypeIn in[Ns*Nc*2]) {
+      __device__ __host__ inline void operator()(ColorSpinor<RegTypeOut,Nc,Ns> &out, const ColorSpinor<RegTypeIn,Nc,Ns> &in) {
         for (int s=0; s<Ns; s++) {
           for (int c=0; c<Nc; c++) {
-            for (int z=0; z<2; z++) {
-              out[(s*Nc+c)*2+z] = in[(s*Nc+c)*2+z];
-            }
+            out(s,c) = in(s,c);
           }
         }
       }
@@ -105,7 +102,7 @@ namespace quda {
     struct NonRelBasis {
       typedef typename mapper<FloatIn>::type RegTypeIn;
       typedef typename mapper<FloatOut>::type RegTypeOut;
-      __device__ __host__ inline void operator()(RegTypeOut out[Ns*Nc*2], const RegTypeIn in[Ns*Nc*2]) {
+      __device__ __host__ inline void operator()(ColorSpinor<RegTypeOut,Nc,Ns> &out, const ColorSpinor<RegTypeIn,Nc,Ns> &in) {
         int s1[4] = {1, 2, 3, 0};
         int s2[4] = {3, 0, 1, 2};
         RegTypeOut K1[4] = {static_cast<RegTypeOut>(kP), static_cast<RegTypeOut>(-kP),
@@ -114,21 +111,19 @@ namespace quda {
 			    static_cast<RegTypeOut>(kP), static_cast<RegTypeOut>(kP)};
         for (int s=0; s<Ns; s++) {
           for (int c=0; c<Nc; c++) {
-            for (int z=0; z<2; z++) {
-              out[(s*Nc+c)*2+z] = K1[s]*in[(s1[s]*Nc+c)*2+z] + K2[s]*in[(s2[s]*Nc+c)*2+z];
-            }
+            out(s,c).real(K1[s]*in(s1[s],c).real() + K2[s]*in(s2[s],c).real());
+            out(s,c).imag(K1[s]*in(s1[s],c).imag() + K2[s]*in(s2[s],c).imag());
           }
         }
       }
     };
-
 
   /** Transform from non-relativistic into relavisitic basis */
   template <typename FloatOut, typename FloatIn, int Ns, int Nc>
     struct RelBasis {
       typedef typename mapper<FloatIn>::type RegTypeIn;
       typedef typename mapper<FloatOut>::type RegTypeOut;
-      __device__ __host__ inline void operator()(RegTypeOut out[Ns*Nc*2], const RegTypeIn in[Ns*Nc*2]) {
+      __device__ __host__ inline void operator()(ColorSpinor<RegTypeOut,Nc,Ns> &out, const ColorSpinor<RegTypeIn,Nc,Ns> &in) {
         int s1[4] = {1, 2, 3, 0};
         int s2[4] = {3, 0, 1, 2};
         RegTypeOut K1[4] = {static_cast<RegTypeOut>(-kU), static_cast<RegTypeOut>(kU),
@@ -137,16 +132,12 @@ namespace quda {
 			    static_cast<RegTypeOut>(-kU), static_cast<RegTypeOut>(-kU)};
         for (int s=0; s<Ns; s++) {
           for (int c=0; c<Nc; c++) {
-            for (int z=0; z<2; z++) {
-              out[(s*Nc+c)*2+z] = K1[s]*in[(s1[s]*Nc+c)*2+z] + K2[s]*in[(s2[s]*Nc+c)*2+z];
-            }
+            out(s,c).real(K1[s]*in(s1[s],c).real() + K2[s]*in(s2[s],c).real());
+            out(s,c).imag(K1[s]*in(s1[s],c).imag() + K2[s]*in(s2[s],c).imag());
           }
         }
       }
     };
-
-
-
 
   template<typename OutOrder, typename InOrder, typename Basis>
     struct CopySpinorExArg{
@@ -192,17 +183,18 @@ namespace quda {
       typedef typename mapper<FloatIn>::type RegTypeIn;
       typedef typename mapper<FloatOut>::type RegTypeOut;
 
-      RegTypeIn   in[Ns*Nc*2] = { };
-      RegTypeOut  out[Ns*Nc*2] = { };
+      ColorSpinor<RegTypeIn,Nc,Ns> in;
+      ColorSpinor<RegTypeOut,Nc,Ns> out;
+      int parity = 0;
 
       if(extend){
-        arg.in.load(in, X);
+        in = arg.in(X, parity);
         arg.basis(out, in);
-        arg.out.save(out, Y);
+        arg.out(Y, parity) = out;
       }else{
-        arg.in.load(in, Y);
-        arg.basis(out,in);
-        arg.out.save(out, Y);
+        in = arg.in(Y, parity);
+        arg.basis(out, in);
+        arg.out(Y, parity) = out;
       }
     }
 

--- a/lib/extract_gauge_ghost_extended.cu
+++ b/lib/extract_gauge_ghost_extended.cu
@@ -1,6 +1,7 @@
 #include <quda_internal.h>
 #include <tune_quda.h>
 #include <gauge_field_order.h>
+#include <quda_matrix.h>
 
 namespace quda {
 
@@ -54,26 +55,26 @@ namespace quda {
   template <typename Float, int length, int dim, typename Arg>
   __device__ __host__ void extractor(Arg &arg, int dir, int a, int b, 
 				     int c, int d, int g, int parity) {
-    typename mapper<Float>::type u[length];
     int srcIdx = (a*arg.fBody[dim][0] + b*arg.fBody[dim][1] + 
 		  c*arg.fBody[dim][2] + d*arg.fBody[dim][3]) >> 1;
     
     int dstIdx = (a*arg.fBuf[dim][0] + b*arg.fBuf[dim][1] + 
 		  c*arg.fBuf[dim][2] + (d-(dir?arg.X[dim]:arg.R[dim]))*arg.fBuf[dim][3]) >> 1;
     
+    Matrix<complex<typename mapper<Float>::type>, Ncolor(length)> u;
+
     // load the ghost element from the bulk
-    arg.order.load(u, srcIdx, g, parity); 
+    u = arg.order(g, srcIdx, parity); 
 
     // need dir dependence in write
     // srcIdx is used here to determine boundary condition
-    arg.order.saveGhostEx(u, dstIdx, srcIdx, dir, dim, g, (parity+arg.localParity[dim])&1, arg.R);
+    arg.order.saveGhostEx(u.data, dstIdx, srcIdx, dir, dim, g, (parity+arg.localParity[dim])&1, arg.R);
   }
 
 
   template <typename Float, int length, int dim, typename Arg>
   __device__ __host__ void injector(Arg &arg, int dir, int a, int b, 
 				    int c, int d, int g, int parity) {
-    typename mapper<Float>::type u[length];
     int srcIdx = (a*arg.fBuf[dim][0] + b*arg.fBuf[dim][1] + 
 		  c*arg.fBuf[dim][2] + (d-dir*(arg.X[dim]+arg.R[dim]))*arg.fBuf[dim][3]) >> 1;
     
@@ -82,11 +83,13 @@ namespace quda {
 
     int oddness = (parity+arg.localParity[dim])&1;
     
+    Matrix<complex<typename mapper<Float>::type>, Ncolor(length)> u;
+
     // need dir dependence in read
     // dstIdx is used here to determine boundary condition
-    arg.order.loadGhostEx(u, srcIdx, dstIdx, dir, dim, g, oddness, arg.R);
+    arg.order.loadGhostEx(u.data, srcIdx, dstIdx, dir, dim, g, oddness, arg.R);
     
-    arg.order.save(u, dstIdx, g, parity); // save the ghost element into the bulk
+    arg.order(g, dstIdx, parity) = u; // save the ghost element into the bulk
   }
   
   /**
@@ -94,9 +97,8 @@ namespace quda {
      NB This routines is specialized to four dimensions
   */
   template <typename Float, int length, int nDim, int dim, typename Order, bool extract>
-  void extractGhostEx(ExtractGhostExArg<Order,nDim,dim> arg) {  
-    typedef typename mapper<Float>::type RegType;
-
+  void extractGhostEx(ExtractGhostExArg<Order,nDim,dim> arg)
+  {
     for (int parity=0; parity<2; parity++) {
 
       // the following 4-way loop means this is specialized for 4 dimensions 
@@ -139,9 +141,8 @@ namespace quda {
      NB This routines is specialized to four dimensions
   */
   template <typename Float, int length, int nDim, int dim, typename Order, bool extract>
-  __global__ void extractGhostExKernel(ExtractGhostExArg<Order,nDim,dim> arg) {  
-    typedef typename mapper<Float>::type RegType;
-
+  __global__ void extractGhostExKernel(ExtractGhostExArg<Order,nDim,dim> arg)
+  {
     // parallelize over parity and dir using block or grid 
     /*for (int parity=0; parity<2; parity++) {*/
     {

--- a/lib/extract_gauge_ghost_helper.cuh
+++ b/lib/extract_gauge_ghost_helper.cuh
@@ -7,8 +7,9 @@ namespace quda {
 
   using namespace gauge;
 
-  template <typename Order, int nDim>
+  template <typename Float, typename Order, int nDim>
   struct ExtractGhostArg {
+    using real = typename mapper<Float>::type;
     Order order;
     const unsigned char nFace;
     unsigned short X[nDim];
@@ -29,7 +30,7 @@ namespace quda {
 	B[d] = B_[d];
 	C[d] = C_[d];
 	for (int e=0; e<nDim; e++) f[d][e] = f_[d][e];
-	localParity[d] = localParity_[d]; 
+	localParity[d] = localParity_[d];
 	commDim[d] = comm_dim_partitioned(d);
 	faceVolumeCB[d] = u.SurfaceCB(d)*u.Nface();
       }
@@ -40,9 +41,10 @@ namespace quda {
      Generic CPU gauge ghost extraction and packing
      NB This routines is specialized to four dimensions
   */
-  template <typename Float, int length, int nDim, typename Order, bool extract>
-  void extractGhost(ExtractGhostArg<Order,nDim> arg) {  
-    using real = typename mapper<Float>::type;
+  template <int length, int nDim, bool extract, typename Arg>
+  void extractGhost(Arg &arg)
+  {
+    using real = typename Arg::real;
     constexpr int nColor = Ncolor(length);
 
     for (int parity=0; parity<2; parity++) {
@@ -54,7 +56,7 @@ namespace quda {
 
 	// linear index used for reading/writing into ghost buffer
 	int indexGhost = 0;
-	// the following 4-way loop means this is specialized for 4 dimensions 
+	// the following 4-way loop means this is specialized for 4 dimensions
 
 	// FIXME redefine a, b, c, d such that we always optimize for locality
 	for (int d=arg.X[dim]-arg.nFace; d<arg.X[dim]; d++) { // loop over last nFace faces in this dimension
@@ -107,9 +109,10 @@ namespace quda {
      NB This routines is specialized to four dimensions
      FIXME this implementation will have two-way warp divergence
   */
-  template <typename Float, int length, int nDim, typename Order, bool extract>
-  __global__ void extractGhostKernel(ExtractGhostArg<Order,nDim> arg) {  
-    using real = typename mapper<Float>::type;
+  template <int length, int nDim, bool extract, typename Arg>
+  __global__ void extractGhostKernel(Arg arg)
+  {
+    using real = typename Arg::real;
     constexpr int nColor = Ncolor(length);
 
     int parity_dim = blockIdx.z * blockDim.z + threadIdx.z; //parity_dim = parity*nDim + dim
@@ -154,19 +157,18 @@ namespace quda {
       if (extract) {
         // load the ghost element from the bulk
         Matrix<complex<real>, nColor> u = arg.order(dim+arg.offset, indexCB, parity);
-        arg.order.Ghost(dim, X>>1, (parity+arg.localParity[dim])&1) = u;
+        //arg.order.Ghost(dim, X>>1, (parity+arg.localParity[dim])&1) = u;
       } else { // injection
-        Matrix <complex<real>, nColor> u = arg.order.Ghost(dim, X>>1, (parity+arg.localParity[dim])&1);
-        arg.order(dim+arg.offset, indexCB, parity) = u; // save the ghost element to the bulk
+        Matrix <complex<real>, nColor> u;// = arg.order.Ghost(dim, X>>1, (parity+arg.localParity[dim])&1);
+        //arg.order(dim+arg.offset, indexCB, parity) = u; // save the ghost element to the bulk
       }
 #endif
     } // oddness == parity
-
   }
 
-  template <typename Float, int length, int nDim, typename Order>
+  template <int length, int nDim, typename Arg>
   class ExtractGhost : TunableVectorYZ {
-    ExtractGhostArg<Order,nDim> arg;
+    Arg &arg;
     int size;
     const GaugeField &meta;
     QudaFieldLocation location;
@@ -180,15 +182,14 @@ namespace quda {
     unsigned int minThreads() const { return size; }
 
   public:
-    ExtractGhost(ExtractGhostArg<Order,nDim> &arg, const GaugeField &meta,
-		 QudaFieldLocation location, bool extract)
+    ExtractGhost(Arg &arg, const GaugeField &meta, QudaFieldLocation location, bool extract)
 #ifndef FINE_GRAINED_ACCESS
       : TunableVectorYZ(1, 2*nDim), arg(arg), meta(meta), location(location), extract(extract) {
 #else
       : TunableVectorYZ(gauge::Ncolor(length), 2*nDim), arg(arg), meta(meta), location(location), extract(extract) {
 #endif
       int faceMax = 0;
-      for (int d=0; d<nDim; d++) 
+      for (int d=0; d<nDim; d++)
 	faceMax = (arg.faceVolumeCB[d] > faceMax ) ? arg.faceVolumeCB[d] : faceMax;
       size = 2 * faceMax; // factor of comes from parity
 
@@ -200,31 +201,29 @@ namespace quda {
     }
 
     virtual ~ExtractGhost() { ; }
-  
+
     void apply(const cudaStream_t &stream) {
       if (location==QUDA_CPU_FIELD_LOCATION) {
-	if (extract) extractGhost<Float,length,nDim,Order,true>(arg);
-	else extractGhost<Float,length,nDim,Order,false>(arg);
+	if (extract) extractGhost<length,nDim,true>(arg);
+	else extractGhost<length,nDim,false>(arg);
       } else {
 	TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
 	if (extract) {
-	  extractGhostKernel<Float, length, nDim, Order, true>
-	    <<<tp.grid, tp.block, tp.shared_bytes, stream>>>(arg);
+	  extractGhostKernel<length, nDim, true> <<<tp.grid, tp.block, tp.shared_bytes, stream>>>(arg);
 	} else {
-	  extractGhostKernel<Float, length, nDim, Order, false>
-	    <<<tp.grid, tp.block, tp.shared_bytes, stream>>>(arg);
+	  extractGhostKernel<length, nDim, false> <<<tp.grid, tp.block, tp.shared_bytes, stream>>>(arg);
 	}
       }
     }
 
     TuneKey tuneKey() const { return TuneKey(meta.VolString(), typeid(*this).name(), aux); }
 
-    long long flops() const { return 0; } 
-    long long bytes() const { 
+    long long flops() const { return 0; }
+    long long bytes() const {
       int sites = 0;
       for (int d=0; d<nDim; d++) sites += arg.faceVolumeCB[d];
       return 2 * sites * 2 * arg.order.Bytes(); // parity * sites * i/o * vec size
-    } 
+    }
   };
 
 
@@ -235,7 +234,7 @@ namespace quda {
   template <typename Float, int length, typename Order>
   void extractGhost(Order order, const GaugeField &u, QudaFieldLocation location, bool extract, int offset) {
     const int *X = u.X();
-    const int nDim = 4;
+    constexpr int nDim = 4;
     //loop variables: a, b, c with a the most signifcant and c the least significant
     //A, B, C the maximum value
     //we need to loop in d as well, d's vlaue dims[dir]-3, dims[dir]-2, dims[dir]-1
@@ -243,7 +242,7 @@ namespace quda {
     A[0] = X[3]; B[0] = X[2]; C[0] = X[1]; // X dimension face
     A[1] = X[3]; B[1] = X[2]; C[1] = X[0]; // Y dimension face
     A[2] = X[3]; B[2] = X[1]; C[2] = X[0]; // Z dimension face
-    A[3] = X[2]; B[3] = X[1]; C[3] = X[0]; // T dimension face    
+    A[3] = X[2]; B[3] = X[1]; C[3] = X[0]; // T dimension face
 
     //multiplication factor to compute index in original cpu memory
     int f[nDim][nDim]={
@@ -253,19 +252,18 @@ namespace quda {
       {     X[0]*X[1],       X[0],    1,  X[0]*X[1]*X[2]}
     };
 
-    //set the local processor parity 
+    //set the local processor parity
     //switching odd and even ghost gauge when that dimension size is odd
     //only switch if X[dir] is odd and the gridsize in that dimension is greater than 1
     // FIXME - I don't understand this, shouldn't it be commDim(dim) == 0 ?
     int localParity[nDim];
-    for (int dim=0; dim<nDim; dim++) 
+    for (int dim=0; dim<nDim; dim++)
       //localParity[dim] = (X[dim]%2==0 || commDim(dim)) ? 0 : 1;
       localParity[dim] = ((X[dim] % 2 ==1) && (commDim(dim) > 1)) ? 1 : 0;
 
-    ExtractGhostArg<Order, nDim> arg(order, u, A, B, C, f, localParity, offset);
-    ExtractGhost<Float,length,nDim,Order> extractor(arg, u, location, extract);
+    ExtractGhostArg<Float, Order, nDim> arg(order, u, A, B, C, f, localParity, offset);
+    ExtractGhost<length, nDim, decltype(arg)> extractor(arg, u, location, extract);
     extractor.apply(0);
-
   }
 
 } // namespace quda

--- a/lib/extract_gauge_ghost_helper.cuh
+++ b/lib/extract_gauge_ghost_helper.cuh
@@ -158,10 +158,10 @@ namespace quda {
       if (extract) {
         // load the ghost element from the bulk
         Matrix<complex<real>, nColor> u = arg.order(dim+arg.offset, indexCB, parity);
-        //arg.order.Ghost(dim, X>>1, (parity+arg.localParity[dim])&1) = u;
+        arg.order.Ghost(dim, X>>1, (parity+arg.localParity[dim])&1) = u;
       } else { // injection
-        Matrix <complex<real>, nColor> u;// = arg.order.Ghost(dim, X>>1, (parity+arg.localParity[dim])&1);
-        //arg.order(dim+arg.offset, indexCB, parity) = u; // save the ghost element to the bulk
+        Matrix <complex<real>, nColor> u = arg.order.Ghost(dim, X>>1, (parity+arg.localParity[dim])&1);
+        arg.order(dim+arg.offset, indexCB, parity) = u; // save the ghost element to the bulk
       }
 #endif
     } // oddness == parity

--- a/lib/gauge_fix_fft.cu
+++ b/lib/gauge_fix_fft.cu
@@ -261,16 +261,14 @@ namespace quda {
       setZero(&delta);
       //idx = linkIndex(x,X);
       for ( int mu = 0; mu < gauge_dir; mu++ ) {
-        Matrix<Cmplx,3> U;
-        argQ.dataOr.load((Float *)(U.data), idx_cb, mu, parity);
+        Matrix<Cmplx,3> U = argQ.dataOr(mu, idx_cb, parity);
         delta -= U;
       }
       //18*gauge_dir
       data.x += -delta(0, 0).x - delta(1, 1).x - delta(2, 2).x;
       //2
       for ( int mu = 0; mu < gauge_dir; mu++ ) {
-        Matrix<Cmplx,3> U;
-        argQ.dataOr.load((Float*)(U.data),linkIndexM1(x,argQ.X,mu), mu, 1 - parity);
+        Matrix<Cmplx,3> U = argQ.dataOr(mu, linkIndexM1(x,argQ.X,mu), 1 - parity);
         delta += U;
       }
       //18*gauge_dir
@@ -596,9 +594,8 @@ namespace quda {
 
 
     for ( int mu = 0; mu < 4; mu++ ) {
-      Matrix<Cmplx,3> U;
+      Matrix<Cmplx,3> U = dataOr(mu, id, parity);
       Matrix<Cmplx,3> g0;
-      dataOr.load((Float*)(U.data),id, mu, parity);
       U = g * U;
       //198
       idx = linkNormalIndexP1(x,arg.X,mu);
@@ -630,7 +627,7 @@ namespace quda {
 
       U = U * conj(g0);
       //198
-      dataOr.save((Float*)(U.data),id, mu, parity);
+      dataOr(mu, id, parity) = U;
     }
   }
 
@@ -838,9 +835,8 @@ namespace quda {
     int x[4];
     getCoords(x, id, arg.X, parity);
     for ( int mu = 0; mu < 4; mu++ ) {
-      Matrix<Cmplx,3> U;
+      Matrix<Cmplx,3> U = dataOr(mu, id, parity);
       Matrix<Cmplx,3> g0;
-      dataOr.load((Float*)(U.data),id, mu, parity);
       U = g * U;
       //198
       int idm1 = linkIndexP1(x,arg.X,mu);
@@ -861,7 +857,7 @@ namespace quda {
       }
       U = U * conj(g0);
       //198
-      dataOr.save((Float*)(U.data),id, mu, parity);
+      dataOr.save(mu, id, parity) = U;
     }
     //T=42+4*(198*2+42) Elems=6
     //T=4*(198*2) Elems=9

--- a/lib/gauge_fix_ovr.cu
+++ b/lib/gauge_fix_ovr.cu
@@ -138,8 +138,7 @@ namespace quda {
       setZero(&delta);
       //load upward links
       for ( int mu = 0; mu < gauge_dir; mu++ ) {
-        Matrix<Cmplx,3> U;
-        argQ.dataOr.load((Float *)(U.data), linkIndex(x, X), mu, parity);
+        Matrix<Cmplx,3> U = argQ.dataOr(mu, linkIndex(x, X), parity);
         delta -= U;
       }
       //18*gauge_dir
@@ -147,8 +146,7 @@ namespace quda {
       //2
       //load downward links
       for ( int mu = 0; mu < gauge_dir; mu++ ) {
-        Matrix<Cmplx,3> U;
-        argQ.dataOr.load((Float*)(U.data),linkIndexM1(x,X,mu), mu, 1 - parity);
+        Matrix<Cmplx,3> U = argQ.dataOr(mu, linkIndexM1(x,X,mu), 1 - parity);
         delta += U;
       }
       //18*gauge_dir
@@ -244,7 +242,7 @@ namespace quda {
 
 
   /**
-   * @brief Kernel to perform gauge fixing with overrelaxation for single-GPU  
+   * @brief Kernel to perform gauge fixing with overrelaxation for single-GPU
    */
   template<int ImplementationType, int blockSize, typename Float, typename Gauge, int gauge_dir>
   __global__ void computeFix(GaugeFixArg<Float, Gauge> arg, int parity){
@@ -278,17 +276,16 @@ namespace quda {
         oddbit = 1 - parity;
       }
       idx = (((x[3] * X[2] + x[2]) * X[1] + x[1]) * X[0] + x[0]) >> 1;
-      Matrix<Cmplx,3> link;
-      arg.dataOr.load((Float*)(link.data),idx, mu, oddbit);
+      Matrix<Cmplx,3> link = arg.dataOr(mu, idx, oddbit);
       // 8 treads per lattice site, the reduction is performed by shared memory without using atomicadd.
-      // this implementation needs 8x more shared memory than the implementation using atomicadd 
+      // this implementation needs 8x more shared memory than the implementation using atomicadd
       if ( ImplementationType == 0 ) GaugeFixHit_NoAtomicAdd<blockSize, Float, gauge_dir, 3>(link, arg.relax_boost, tid);
       // 8 treads per lattice site, the reduction is performed by shared memory using atomicadd
       if ( ImplementationType == 1 ) GaugeFixHit_AtomicAdd<blockSize, Float, gauge_dir, 3>(link, arg.relax_boost, tid);
-      // 8 treads per lattice site, the reduction is performed by shared memory without using atomicadd. 
-      // uses the same amount of shared memory as the atomicadd implementation with more thread block synchronization 
+      // 8 treads per lattice site, the reduction is performed by shared memory without using atomicadd.
+      // uses the same amount of shared memory as the atomicadd implementation with more thread block synchronization
       if ( ImplementationType == 2 ) GaugeFixHit_NoAtomicAdd_LessSM<blockSize, Float, gauge_dir, 3>(link, arg.relax_boost, tid);
-      arg.dataOr.save((Float*)(link.data),idx, mu, oddbit);
+      arg.dataOr(mu, idx, oddbit) = link;
     }
     // 4 threads per lattice site
     else{
@@ -307,28 +304,25 @@ namespace quda {
   #endif
       int mu = (threadIdx.x / blockSize);
       idx = (((x[3] * X[2] + x[2]) * X[1] + x[1]) * X[0] + x[0]) >> 1;
-      Matrix<Cmplx,3> link;
       //load upward link
-      arg.dataOr.load((Float*)(link.data),idx, mu, parity);
-
+      Matrix<Cmplx,3> link = arg.dataOr(mu, idx, parity);
 
       x[mu] = (x[mu] - 1 + X[mu]) % X[mu];
       int idx1 = (((x[3] * X[2] + x[2]) * X[1] + x[1]) * X[0] + x[0]) >> 1;
-      Matrix<Cmplx,3> link1;
       //load downward link
-      arg.dataOr.load((Float*)(link1.data),idx1, mu, 1 - parity);
+      Matrix<Cmplx,3> link1 = arg.dataOr(mu, idx1, 1 - parity);
 
       // 4 treads per lattice site, the reduction is performed by shared memory without using atomicadd.
-      // this implementation needs 4x more shared memory than the implementation using atomicadd 
+      // this implementation needs 4x more shared memory than the implementation using atomicadd
       if ( ImplementationType == 3 ) GaugeFixHit_NoAtomicAdd<blockSize, Float, gauge_dir, 3>(link, link1, arg.relax_boost, tid);
       // 4 treads per lattice site, the reduction is performed by shared memory using atomicadd
       if ( ImplementationType == 4 ) GaugeFixHit_AtomicAdd<blockSize, Float, gauge_dir, 3>(link, link1, arg.relax_boost, tid);
-      // 4 treads per lattice site, the reduction is performed by shared memory without using atomicadd. 
-      // uses the same amount of shared memory as the atomicadd implementation with more thread block synchronization 
+      // 4 treads per lattice site, the reduction is performed by shared memory without using atomicadd.
+      // uses the same amount of shared memory as the atomicadd implementation with more thread block synchronization
       if ( ImplementationType == 5 ) GaugeFixHit_NoAtomicAdd_LessSM<blockSize, Float, gauge_dir, 3>(link, link1, arg.relax_boost, tid);
 
-      arg.dataOr.save((Float*)(link.data),idx, mu, parity);
-      arg.dataOr.save((Float*)(link1.data),idx1, mu, 1 - parity);
+      arg.dataOr(mu, idx, parity) = link;
+      arg.dataOr(mu, idx1, 1 - parity) = link1;
 
     }
   }
@@ -563,42 +557,38 @@ public:
         parity = 1 - parity;
       }
       idx = (((x[3] * X[2] + x[2]) * X[1] + x[1]) * X[0] + x[0]) >> 1;
-      Matrix<Complex,3> link;
-      arg.dataOr.load((Float*)(link.data),idx, mu, parity);
+      Matrix<Complex,3> link = arg.dataOr(mu, idx, parity);
       // 8 treads per lattice site, the reduction is performed by shared memory without using atomicadd.
-      // this implementation needs 8x more shared memory than the implementation using atomicadd 
+      // this implementation needs 8x more shared memory than the implementation using atomicadd
       if ( ImplementationType == 0 ) GaugeFixHit_NoAtomicAdd<blockSize, Float, gauge_dir, 3>(link, arg.relax_boost, tid);
       // 8 treads per lattice site, the reduction is performed by shared memory using atomicadd
       if ( ImplementationType == 1 ) GaugeFixHit_AtomicAdd<blockSize, Float, gauge_dir, 3>(link, arg.relax_boost, tid);
-      // 8 treads per lattice site, the reduction is performed by shared memory without using atomicadd. 
-      // uses the same amount of shared memory as the atomicadd implementation with more thread block synchronization 
+      // 8 treads per lattice site, the reduction is performed by shared memory without using atomicadd.
+      // uses the same amount of shared memory as the atomicadd implementation with more thread block synchronization
       if ( ImplementationType == 2 ) GaugeFixHit_NoAtomicAdd_LessSM<blockSize, Float, gauge_dir, 3>(link, arg.relax_boost, tid);
-      arg.dataOr.save((Float*)(link.data),idx, mu, parity);
+      arg.dataOr(mu, idx, parity) = link;
     }
     // 4 threads per lattice site
     else{
       idx = (((x[3] * X[2] + x[2]) * X[1] + x[1]) * X[0] + x[0]) >> 1;
-      Matrix<Complex,3> link;
-      arg.dataOr.load((Float*)(link.data),idx, mu, parity);
+      Matrix<Complex,3> link = arg.dataOr(mu, idx, parity);
 
 
       x[mu] = (x[mu] - 1 + X[mu]) % X[mu];
       int idx1 = (((x[3] * X[2] + x[2]) * X[1] + x[1]) * X[0] + x[0]) >> 1;
-      Matrix<Complex,3> link1;
-      arg.dataOr.load((Float*)(link1.data),idx1, mu, 1 - parity);
+      Matrix<Complex,3> link1 = arg.dataOr(mu, idx1, 1 - parity);
 
       // 4 treads per lattice site, the reduction is performed by shared memory without using atomicadd.
-      // this implementation needs 4x more shared memory than the implementation using atomicadd 
+      // this implementation needs 4x more shared memory than the implementation using atomicadd
       if ( ImplementationType == 3 ) GaugeFixHit_NoAtomicAdd<blockSize, Float, gauge_dir, 3>(link, link1, arg.relax_boost, tid);
       // 4 treads per lattice site, the reduction is performed by shared memory using atomicadd
       if ( ImplementationType == 4 ) GaugeFixHit_AtomicAdd<blockSize, Float, gauge_dir, 3>(link, link1, arg.relax_boost, tid);
-      // 4 treads per lattice site, the reduction is performed by shared memory without using atomicadd. 
-      // uses the same amount of shared memory as the atomicadd implementation with more thread block synchronization 
+      // 4 treads per lattice site, the reduction is performed by shared memory without using atomicadd.
+      // uses the same amount of shared memory as the atomicadd implementation with more thread block synchronization
       if ( ImplementationType == 5 ) GaugeFixHit_NoAtomicAdd_LessSM<blockSize, Float, gauge_dir, 3>(link, link1, arg.relax_boost, tid);
 
-      arg.dataOr.save((Float*)(link.data),idx, mu, parity);
-      arg.dataOr.save((Float*)(link1.data),idx1, mu, 1 - parity);
-
+      arg.dataOr(mu, idx, parity) = link;
+      arg.dataOr(mu, idx1, 1 - parity) = link1;
     }
   }
 
@@ -822,41 +812,38 @@ public:
         parity = 1 - parity;
       }
       idx = (((x[3] * X[2] + x[2]) * X[1] + x[1]) * X[0] + x[0]) >> 1;
-      Matrix<Cmplx,3> link;
-      arg.dataOr.load((Float*)(link.data),idx, mu, parity);
+      Matrix<Cmplx,3> link = arg.dataOr(mu, idx, parity);
       // 8 treads per lattice site, the reduction is performed by shared memory without using atomicadd.
-      // this implementation needs 8x more shared memory than the implementation using atomicadd 
+      // this implementation needs 8x more shared memory than the implementation using atomicadd
       if ( ImplementationType == 0 ) GaugeFixHit_NoAtomicAdd<blockSize, Float, gauge_dir, 3>(link, arg.relax_boost, tid);
       // 8 treads per lattice site, the reduction is performed by shared memory using atomicadd
       if ( ImplementationType == 1 ) GaugeFixHit_AtomicAdd<blockSize, Float, gauge_dir, 3>(link, arg.relax_boost, tid);
-      // 8 treads per lattice site, the reduction is performed by shared memory without using atomicadd. 
-      // uses the same amount of shared memory as the atomicadd implementation with more thread block synchronization 
+      // 8 treads per lattice site, the reduction is performed by shared memory without using atomicadd.
+      // uses the same amount of shared memory as the atomicadd implementation with more thread block synchronization
       if ( ImplementationType == 2 ) GaugeFixHit_NoAtomicAdd_LessSM<blockSize, Float, gauge_dir, 3>(link, arg.relax_boost, tid);
-      arg.dataOr.save((Float*)(link.data),idx, mu, parity);
+      arg.dataOr(mu, idx, parity) = link;
     }
     // 4 threads per lattice site
     else{
       idx = (((x[3] * X[2] + x[2]) * X[1] + x[1]) * X[0] + x[0]) >> 1;
-      Matrix<Cmplx,3> link;
-      arg.dataOr.load((Float*)(link.data),idx, mu, parity);
+      Matrix<Cmplx,3> link = arg.dataOr(mu, idx, parity);
 
 
       x[mu] = (x[mu] - 1 + X[mu]) % X[mu];
       int idx1 = (((x[3] * X[2] + x[2]) * X[1] + x[1]) * X[0] + x[0]) >> 1;
-      Matrix<Cmplx,3> link1;
-      arg.dataOr.load((Float*)(link1.data),idx1, mu, 1 - parity);
+      Matrix<Cmplx,3> link1 = arg.dataOr(mu, idx1, 1 - parity);
 
       // 4 treads per lattice site, the reduction is performed by shared memory without using atomicadd.
-      // this implementation needs 4x more shared memory than the implementation using atomicadd 
+      // this implementation needs 4x more shared memory than the implementation using atomicadd
       if ( ImplementationType == 3 ) GaugeFixHit_NoAtomicAdd<blockSize, Float, gauge_dir, 3>(link, link1, arg.relax_boost, tid);
       // 4 treads per lattice site, the reduction is performed by shared memory using atomicadd
       if ( ImplementationType == 4 ) GaugeFixHit_AtomicAdd<blockSize, Float, gauge_dir, 3>(link, link1, arg.relax_boost, tid);
-      // 4 treads per lattice site, the reduction is performed by shared memory without using atomicadd. 
-      // uses the same amount of shared memory as the atomicadd implementation with more thread block synchronization 
+      // 4 treads per lattice site, the reduction is performed by shared memory without using atomicadd.
+      // uses the same amount of shared memory as the atomicadd implementation with more thread block synchronization
       if ( ImplementationType == 5 ) GaugeFixHit_NoAtomicAdd_LessSM<blockSize, Float, gauge_dir, 3>(link, link1, arg.relax_boost, tid);
 
-      arg.dataOr.save((Float*)(link.data),idx, mu, parity);
-      arg.dataOr.save((Float*)(link1.data),idx1, mu, 1 - parity);
+      arg.dataOr(mu, idx, parity) = link;
+      arg.dataOr(mu, idx1, 1 - parity) = link1;
     }
   }
 
@@ -1107,20 +1094,22 @@ public:
     typedef complex<Float> Cmplx;
     typedef typename mapper<Float>::type RegType;
     RegType tmp[NElems];
-    RegType data[18];
+    Cmplx data[9];
     if ( pack ) {
       arg.dataOr.load(data, id, dir, parity);
       arg.dataOr.reconstruct.Pack(tmp, data, id);
-      for ( int i = 0; i < NElems / 2; ++i ) array[idx + size * i] = ((Cmplx*)tmp)[i];
-    }
-    else{
-      for ( int i = 0; i < NElems / 2; ++i ) ((Cmplx*)tmp)[i] = array[idx + size * i];
+      for ( int i = 0; i < NElems / 2; ++i ) {
+        array[idx + size * i] = Cmplx(tmp[2*i+0], tmp[2*i+1]);
+      }
+    } else {
+      for ( int i = 0; i < NElems / 2; ++i ) {
+        tmp[2*i+0] = array[idx + size * i].real();
+        tmp[2*i+1] = array[idx + size * i].imag();
+      }
       arg.dataOr.reconstruct.Unpack(data, tmp, id, dir, 0, arg.dataOr.X, arg.dataOr.R);
       arg.dataOr.save(data, id, dir, parity);
     }
   }
-
-
 
 
   template<int NElems, typename Float, typename Gauge, bool pack>
@@ -1174,35 +1163,22 @@ public:
     typedef complex<Float> Cmplx;
     typedef typename mapper<Float>::type RegType;
     RegType tmp[NElems];
-    RegType data[18];
+    Cmplx data[9];
     if ( pack ) {
       arg.dataOr.load(data, id, dir, parity);
       arg.dataOr.reconstruct.Pack(tmp, data, id);
-      for ( int i = 0; i < NElems / 2; ++i ) array[idx + size * i] = ((Cmplx*)tmp)[i];
+      for ( int i = 0; i < NElems / 2; ++i ) array[idx + size * i] = Cmplx(tmp[2*i+0], tmp[2*i+1]);
     }
     else{
-      for ( int i = 0; i < NElems / 2; ++i ) ((Cmplx*)tmp)[i] = array[idx + size * i];
+      for ( int i = 0; i < NElems / 2; ++i ) {
+        tmp[2*i+0] = array[idx + size * i].real();
+        tmp[2*i+1] = array[idx + size * i].imag();
+      }
       arg.dataOr.reconstruct.Unpack(data, tmp, id, dir, 0, arg.dataOr.X, arg.dataOr.R);
       arg.dataOr.save(data, id, dir, parity);
     }
   }
 #endif
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
   template<typename Float, typename Gauge, int NElems, int gauge_dir>

--- a/lib/gauge_update_quda.cu
+++ b/lib/gauge_update_quda.cu
@@ -33,8 +33,8 @@ namespace quda {
 
     Matrix<Complex,3> link, result, mom;
     for(int dir=0; dir<arg.nDim; ++dir){
-      arg.in.load((Float*)(link.data), x, dir, parity);
-      arg.momentum.load((Float*)(mom.data), x, dir, parity);
+      link = arg.in(dir, x, parity);
+      mom = arg.momentum(dir, x, parity);
 
       Complex trace = getTrace(mom);
       mom(0,0) -= trace/static_cast<Float>(3.0);
@@ -65,7 +65,7 @@ namespace quda {
         result = link;
       }
 
-      arg.out.save((Float*)(result.data), x, dir, parity);
+      arg.out(dir, x, parity) = result;
     } // dir
 
   }

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -112,7 +112,6 @@ void closeMagma(){
     printfQuda("\nMAGMA library was not initialized..\n");
   }
 
-  return;
 }
 
 cudaGaugeField *gaugePrecise = nullptr;
@@ -706,6 +705,7 @@ static cudaGaugeField* createExtendedGauge(cudaGaugeField &in, const int *R, Tim
   gParamEx.t_boundary = in.TBoundary();
   gParamEx.nFace = 1;
   gParamEx.tadpole = in.Tadpole();
+  gParamEx.anisotropy = in.Anisotropy();
   for (int d=0; d<4; d++) gParamEx.r[d] = R[d];
 
   auto *out = new cudaGaugeField(gParamEx);
@@ -4056,8 +4056,6 @@ void computeKSLinkQuda(void* fatlink, void* longlink, void* ulink, void* inlink,
 #else
   errorQuda("Fat-link has not been built");
 #endif // GPU_FATLINK
-
-  return;
 }
 
 int getGaugePadding(GaugeFieldParam& param){
@@ -4226,8 +4224,6 @@ void createCloverQuda(QudaInvertParam* invertParam)
 
   // FIXME always preserve the extended gauge
   extendedGaugeResident = gauge;
-
-  return;
 }
 
 void* createGaugeFieldQuda(void* gauge, int geometry, QudaGaugeParam* param)
@@ -4432,7 +4428,6 @@ void computeStaggeredForceQuda(void* h_mom, double dt, double delta, void *h_for
   profileStaggeredForce.TPSTOP(QUDA_PROFILE_TOTAL);
 
   checkCudaError();
-  return;
 }
 
 void computeHISQForceQuda(void* const milc_momentum,
@@ -4681,7 +4676,6 @@ void computeHISQForceQuda(void* const milc_momentum,
 
   profileHISQForce.TPSTOP(QUDA_PROFILE_TOTAL);
 
-  return;
 #else
   errorQuda("HISQ force has not been built");
 #endif
@@ -4868,7 +4862,6 @@ void computeCloverForceQuda(void *h_mom, double dt, void **h_x, void **h_p,
 
   checkCudaError();
   profileCloverForce.TPSTOP(QUDA_PROFILE_TOTAL);
-  return;
 }
 
 
@@ -4973,7 +4966,6 @@ void updateGaugeFieldQuda(void* gauge,
   checkCudaError();
 
   profileGaugeUpdate.TPSTOP(QUDA_PROFILE_TOTAL);
-  return;
 }
 
  void projectSU3Quda(void *gauge_h, double tol, QudaGaugeParam *param) {
@@ -5426,7 +5418,6 @@ void plaq_quda_(double plaq[3]) {
 
 void plaqQuda(double plaq[3])
 {
-
   profilePlaq.TPSTART(QUDA_PROFILE_TOTAL);
 
   if (!gaugePrecise) errorQuda("Cannot compute plaquette as there is no resident gauge field");
@@ -5442,7 +5433,6 @@ void plaqQuda(double plaq[3])
   profilePlaq.TPSTOP(QUDA_PROFILE_COMPUTE);
 
   profilePlaq.TPSTOP(QUDA_PROFILE_TOTAL);
-  return;
 }
 
 /*
@@ -5462,7 +5452,6 @@ void copyExtendedResidentGaugeQuda(void* resident_gauge, QudaFieldLocation loc)
   copyExtendedGauge(*io_gauge, *extendedGaugeResident, loc);
 
   //profilePlaq.TPSTOP(QUDA_PROFILE_TOTAL);
-  return;
 }
 
 void performWuppertalnStep(void *h_out, void *h_in, QudaInvertParam *inv_param, unsigned int nSteps, double alpha)

--- a/lib/momentum.cu
+++ b/lib/momentum.cu
@@ -90,8 +90,14 @@ using namespace gauge;
     while (x < arg.threads) {
       // loop over direction
       for (int mu=0; mu<4; mu++) {
-	Float v[10];
-	arg.mom.load(v, x, mu, parity);
+        // FIXME should understand what this does exactly and cleanup (matches MILC)
+	complex<Float> v_[5];
+	arg.mom.load(v_, x, mu, parity);
+        Float v[10];
+        for (int i=0; i<5; i++) {
+          v[2*i+0] = v_[i].real();
+          v[2*i+1] = v_[i].imag();
+        }
 
 	double local_sum = 0.0;
 	for (int j=0; j<6; j++) local_sum += v[j]*v[j];
@@ -366,12 +372,12 @@ using namespace gauge;
 
     while (x<arg.threads) {
       for (int d=0; d<4; d++) {
-	arg.force.load(reinterpret_cast<Float*>(f.data), x, d, parity);
-	arg.U.load(reinterpret_cast<Float*>(u.data), x, d, parity);
+	f = arg.force(d, x, parity);
+	u = arg.U(d, x, parity);
 
 	f = u * f;
 
-	arg.force.save(reinterpret_cast<Float*>(f.data), x, d, parity);
+	arg.force(d, x, parity) = f;
       }
 
       x += gridDim.x*blockDim.x;

--- a/lib/multigrid.cpp
+++ b/lib/multigrid.cpp
@@ -877,9 +877,7 @@ namespace quda
   }
 
   void MG::operator()(ColorSpinorField &x, ColorSpinorField &b) {
-    char prefix_bkup[100];
-    strncpy(prefix_bkup, prefix, 100);
-    setOutputPrefix(prefix);
+    pushOutputPrefix(prefix);
 
     if (param.level < param.Nlevel - 1) { // set parity for the solver in the transfer operator
       QudaSiteSubset site_subset
@@ -954,7 +952,6 @@ namespace quda
 
         // recurse to the next lower level
         (*coarse_solver)(*x_coarse, *r_coarse);
-        setOutputPrefix(prefix); // restore prefix after return from coarse grid
         if (debug) printfQuda("after coarse solve x_coarse2 = %e r_coarse2 = %e\n", norm2(*x_coarse), norm2(*r_coarse));
 
         // prolongate back to this grid
@@ -997,7 +994,7 @@ namespace quda
       printfQuda("leaving V-cycle with x2=%e, r2=%e\n", norm2(x), r2);
     }
 
-    setOutputPrefix(param.level == 0 ? "" : prefix_bkup);
+    popOutputPrefix();
   }
 
   // supports separate reading or single file read

--- a/lib/pgauge_det_trace.cu
+++ b/lib/pgauge_det_trace.cu
@@ -63,8 +63,7 @@ __global__ void compute_Value(KernelArg<Gauge> arg){
   #endif
 #pragma unroll
     for (int mu = 0; mu < 4; mu++) {
-      Matrix<complex<Float>,NCOLORS> U;
-      arg.dataOr.load((Float*)(U.data), idx, mu, parity);
+      Matrix<complex<Float>,NCOLORS> U = arg.dataOr(mu, idx, parity);
       if(functiontype == 0) val += getDeterminant(U);
       if(functiontype == 1) val += getTrace(U);
     }

--- a/lib/pgauge_exchange.cu
+++ b/lib/pgauge_exchange.cu
@@ -117,14 +117,17 @@ namespace quda {
     typedef complex<Float> Complex;
     typedef typename mapper<Float>::type RegType;
     RegType tmp[NElems];
-    RegType data[18];
+    Complex data[9];
     if ( pack ) {
       arg.dataOr.load(data, id, dir, parity);
       arg.dataOr.reconstruct.Pack(tmp, data, id);
-      for ( int i = 0; i < NElems / 2; ++i ) array[idx + size * i] = ((Complex*)tmp)[i];
+      for ( int i = 0; i < NElems / 2; ++i ) array[idx + size * i] = Complex(tmp[2*i+0], tmp[2*i+1]);
     }
     else{
-      for ( int i = 0; i < NElems / 2; ++i ) ((Complex*)tmp)[i] = array[idx + size * i];
+      for ( int i = 0; i < NElems / 2; ++i ) {
+        tmp[2*i+0] = array[idx + size * i].real();
+        tmp[2*i+1] = array[idx + size * i].imag();
+      }
       arg.dataOr.reconstruct.Unpack(data, tmp, id, dir, 0, arg.dataOr.X, arg.dataOr.R);
       arg.dataOr.save(data, id, dir, parity);
     }

--- a/lib/pgauge_heatbath.cu
+++ b/lib/pgauge_heatbath.cu
@@ -626,27 +626,26 @@ namespace quda {
     Matrix<complex<Float>,NCOLORS> U;
     for ( int nu = 0; nu < 4; nu++ ) if ( mu != nu ) {
         int dx[4] = { 0, 0, 0, 0 };
-        Matrix<complex<Float>,NCOLORS> link;
-        arg.dataOr.load((Float*)(link.data), idx, nu, parity);
+        Matrix<complex<Float>,NCOLORS> link = arg.dataOr(nu, idx, parity);
         dx[nu]++;
-        arg.dataOr.load((Float*)(U.data), linkIndexShift(x,dx,X), mu, 1 - parity);
+        U = arg.dataOr(mu, linkIndexShift(x,dx,X), 1 - parity);
         link *= U;
         dx[nu]--;
         dx[mu]++;
-        arg.dataOr.load((Float*)(U.data), linkIndexShift(x,dx,X), nu, 1 - parity);
+        U = arg.dataOr(nu, linkIndexShift(x,dx,X), 1 - parity);
         link *= conj(U);
         staple += link;
         dx[mu]--;
         dx[nu]--;
-        arg.dataOr.load((Float*)(link.data), linkIndexShift(x,dx,X), nu, 1 - parity);
-        arg.dataOr.load((Float*)(U.data), linkIndexShift(x,dx,X), mu, 1 - parity);
+        link = arg.dataOr(nu, linkIndexShift(x,dx,X), 1 - parity);
+        U = arg.dataOr(mu, linkIndexShift(x,dx,X), 1 - parity);
         link = conj(link) * U;
         dx[mu]++;
-        arg.dataOr.load((Float*)(U.data), linkIndexShift(x,dx,X), nu, parity);
+        U = arg.dataOr(nu, linkIndexShift(x,dx,X), parity);
         link *= U;
         staple += link;
       }
-    arg.dataOr.load((Float*)(U.data), idx, mu, parity);
+    U = arg.dataOr(mu, idx, parity);
     if ( HeatbathOrRelax ) {
       cuRNGState localState = arg.rngstate.State()[ id ];
       heatBathSUN<Float, NCOLORS>( U, conj(staple), localState, arg.BetaOverNc );
@@ -655,7 +654,7 @@ namespace quda {
     else{
       overrelaxationSUN<Float, NCOLORS>( U, conj(staple) );
     }
-    arg.dataOr.save((Float*)(U.data), idx, mu, parity);
+    arg.dataOr(mu, idx, parity) = U;
   }
 
 

--- a/lib/pgauge_init.cu
+++ b/lib/pgauge_init.cu
@@ -49,8 +49,7 @@ namespace quda {
     }
     Matrix<complex<Float>,NCOLORS> U;
     setIdentity(&U);
-    for ( int d = 0; d < 4; d++ )
-      arg.dataOr.save((Float*)(U.data),idx, d, parity);
+    for ( int d = 0; d < 4; d++ ) arg.dataOr(d, idx, parity) = U;
   }
 
 
@@ -343,7 +342,7 @@ namespace quda {
       for ( int d = 0; d < 4; d++ ) {
         Matrix<complex<Float>,NCOLORS> U;
         U = randomize<Float, NCOLORS>(localState);
-        arg.dataOr.save((Float*)(U.data),idx, d, parity);
+        arg.dataOr(d, idx, parity) = U;
       }
     }
   #ifdef MULTI_GPU

--- a/lib/staggered_oprod.cu
+++ b/lib/staggered_oprod.cu
@@ -182,15 +182,14 @@ namespace quda {
   template<typename real, typename Output, typename InputA, typename InputB>
   __global__ void interiorOprodKernel(StaggeredOprodArg<real, Output, InputA, InputB> arg)
     {
+      using complex = complex<real>;
+      using matrix = Matrix<complex,3>;
+
       unsigned int idx = blockIdx.x*blockDim.x + threadIdx.x;
       const unsigned int gridSize = gridDim.x*blockDim.x;
 
-      typedef complex<real> Complex;
-      Complex x[3];
-      Complex y[3];
-      Complex z[3];
-      Matrix<Complex,3> result;
-      Matrix<Complex,3> tempA, tempB; // input
+      complex x[3], y[3], z[3];
+      matrix result;
 
       while(idx<arg.length){
         arg.inA.load(x, idx);
@@ -203,20 +202,20 @@ namespace quda {
           if(first_nbr_idx >= 0){
             arg.inB.load(y, first_nbr_idx);
             outerProd(y,x,&result);
-            arg.outA.load(reinterpret_cast<real*>(tempA.data), idx, dim, arg.parity); 
+            matrix tempA = arg.outA(dim, idx, arg.parity);
             result = tempA + result*arg.coeff[0];
     
-	    arg.outA.save(reinterpret_cast<real*>(result.data), idx, dim, arg.parity); 
+	    arg.outA(dim, idx, arg.parity) = result;
 
 	    if (arg.nFace == 3) {
 	      shift[dim] = 3;
 	      const int third_nbr_idx = neighborIndex(idx, shift, arg.partitioned, arg.parity, arg.X);
-	      if(third_nbr_idx >= 0){
+	      if (third_nbr_idx >= 0) {
 		arg.inB.load(z, third_nbr_idx);
 		outerProd(z, x, &result);
-		arg.outB.load(reinterpret_cast<real*>(tempB.data), idx, dim, arg.parity); 
+		matrix tempB = arg.outB(dim, idx, arg.parity);
 		result = tempB + result*arg.coeff[1];
-		arg.outB.save(reinterpret_cast<real*>(result.data), idx, dim, arg.parity); 
+		arg.outB(dim, idx, arg.parity) = result;
 	      }
 	    }
           }
@@ -231,33 +230,32 @@ namespace quda {
   template<int dim, typename real, typename Output, typename InputA, typename InputB>
   __global__ void exteriorOprodKernel(StaggeredOprodArg<real, Output, InputA, InputB> arg)
     {
-      typedef complex<real> Complex;
+      using complex = complex<real>;
+      using matrix = Matrix<complex,3>;
 
       unsigned int cb_idx = blockIdx.x*blockDim.x + threadIdx.x;
       const unsigned int gridSize = gridDim.x*blockDim.x;
 
-      Complex a[3];
-      Complex b[3];
-      Matrix<Complex,3> result;
-      Matrix<Complex,3> inmatrix; // input
+      complex a[3], b[3];
+      matrix result;
 
       Output& out = (arg.displacement == 1) ? arg.outA : arg.outB;
       real coeff = (arg.displacement == 1) ? arg.coeff[0] : arg.coeff[1];
 
       int x[4];
       while(cb_idx<arg.length){
-        coordsFromIndex(x, cb_idx, arg.X, arg.dir, arg.displacement, arg.parity); 
+        coordsFromIndex(x, cb_idx, arg.X, arg.dir, arg.displacement, arg.parity);
         const unsigned int bulk_cb_idx = ((((x[3]*arg.X[2] + x[2])*arg.X[1] + x[1])*arg.X[0] + x[0]) >> 1);
 
-        out.load(reinterpret_cast<real*>(inmatrix.data), bulk_cb_idx, arg.dir, arg.parity); 
+        matrix inmatrix = out(arg.dir, bulk_cb_idx, arg.parity);
         arg.inA.load(a, bulk_cb_idx);
 
         const unsigned int ghost_idx = arg.ghostOffset[dim] + cb_idx;
         arg.inB.loadGhost(b, ghost_idx, arg.dir);
 
-        outerProd(b,a,&result);
-        result = inmatrix + result*coeff; 
-        out.save(reinterpret_cast<real*>(result.data), bulk_cb_idx, arg.dir, arg.parity); 
+        outerProd(b, a, &result);
+        result = inmatrix + result*coeff;
+        out(arg.dir, bulk_cb_idx, arg.parity) = result;
 
         cb_idx += gridSize;
       }

--- a/lib/tune.cpp
+++ b/lib/tune.cpp
@@ -225,8 +225,8 @@ namespace quda {
       TuneKey key = q.top().first;
       TuneParam param = q.top().second;
 
-      char tmp[14] = { };
-      strncpy(tmp, key.aux, 13);
+      char tmp[TuneKey::aux_n] = { };
+      strncpy(tmp, key.aux, TuneKey::aux_n);
       bool is_policy_kernel = strncmp(tmp, "policy_kernel", 13) == 0 ? true : false;
       bool is_policy = (strncmp(tmp, "policy", 6) == 0 && !is_policy_kernel) ? true : false;
 
@@ -265,8 +265,8 @@ namespace quda {
       TuneKey &key = it->key;
 
       // special case kernel members of a policy
-      char tmp[14] = { };
-      strncpy(tmp, key.aux, 13);
+      char tmp[TuneKey::aux_n] = { };
+      strncpy(tmp, key.aux, TuneKey::aux_n);
       bool is_policy_kernel = strcmp(tmp, "policy_kernel") == 0 ? true : false;
 
       out << std::setw(12) << it->time << "\t";
@@ -567,8 +567,8 @@ namespace quda {
 	int n_policy = 0;
 	for (map::iterator entry = tunecache.begin(); entry != tunecache.end(); entry++) {
 	  // if a policy entry, then we can ignore
-	  char tmp[7] = { };
-	  strncpy(tmp, entry->first.aux, 6);
+	  char tmp[TuneKey::aux_n] = { };
+	  strncpy(tmp, entry->first.aux, TuneKey::aux_n);
 	  TuneParam param = entry->second;
 	  bool is_policy = strcmp(tmp, "policy") == 0 ? true : false;
 	  if (param.n_calls > 0 && !is_policy) n_entry++;

--- a/lib/unitarize_force_quda.cu
+++ b/lib/unitarize_force_quda.cu
@@ -488,15 +488,15 @@ namespace quda{
       Matrix<complex<Float>,3> v_tmp, result_tmp, oprod_tmp;
 
       for(int dir=0; dir<4; ++dir){
-	arg.force_old.load((Float*)(oprod_tmp.data), idx, dir, parity);
-	arg.gauge.load((Float*)(v_tmp.data), idx, dir, parity);
+	oprod_tmp = arg.force_old(dir, idx, parity);
+	v_tmp = arg.gauge(dir, idx, parity);
 	v = v_tmp;
 	oprod = oprod_tmp;
 
 	getUnitarizeForceSite<double>(result, v, oprod, arg);
 	result_tmp = result;
 
-	arg.force.save((Float*)(result_tmp.data), idx, dir, parity);
+	arg.force(dir, idx, parity) = result_tmp;
       } // 4*4528 flops per site
       return;
     } // getUnitarizeForceField
@@ -510,15 +510,15 @@ namespace quda{
       for (int parity=0; parity<2; parity++) {
 	for (int i=0; i<arg.threads/2; i++) {
 	  for (int dir=0; dir<4; dir++) {
-	    arg.force_old.load((Float*)(oprod_tmp.data), i, dir, parity);
-	    arg.gauge.load((Float*)(v_tmp.data), i, dir, parity);
+	    oprod_tmp = arg.force_old(dir, i, parity);
+	    v_tmp = arg.gauge(dir, i, parity);
 	    v = v_tmp;
 	    oprod = oprod_tmp;
 
 	    getUnitarizeForceSite<double>(result, v, oprod, arg);
 
 	    result_tmp = result;
-	    arg.force.save((Float*)(result_tmp.data), i, dir, parity);
+	    arg.force(dir, i, parity) = result_tmp;
 	  }
 	}
       }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,7 +47,7 @@ endif()
 # define tests
 
 # if we build with QDP JIT the tests cannot run anyway
-if(QUDA_INTERFACE_QDPJIT)
+if(QUDA_QDPJIT)
   set(QUDA_BUILD_ALL_TESTS OFF)
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -501,7 +501,7 @@ foreach(pol IN LISTS DSLASH_POLICIES)
 
   if(QUDA_COVDEV)
     add_test(NAME covdev_-policy${pol2}
-             COMMAND ${QUDA_CTEST_LAUNC} $<TARGET_FILE:covdev_test> ${MPIEXEEC_POSTFLAGS}
+             COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:covdev_test> ${MPIEXEEC_POSTFLAGS}
                      --dim 6 8 10 12
                      --gtest_output=xml:covdev_test_pol${pol2}.xml)
    endif()

--- a/tests/plaq_test.cpp
+++ b/tests/plaq_test.cpp
@@ -78,8 +78,9 @@ void setGaugeParam(QudaGaugeParam &gauge_param)
   pad_size = MAX(pad_size, z_face_size);
   pad_size = MAX(pad_size, t_face_size);
   gauge_param.ga_pad = pad_size;
-#endif
+#else
   gauge_param.ga_pad = 0;
+#endif
 }
 
 extern void usage(char **);

--- a/tests/plaq_test.cpp
+++ b/tests/plaq_test.cpp
@@ -79,6 +79,7 @@ void setGaugeParam(QudaGaugeParam &gauge_param)
   pad_size = MAX(pad_size, t_face_size);
   gauge_param.ga_pad = pad_size;
 #endif
+  gauge_param.ga_pad = 0;
 }
 
 extern void usage(char **);


### PR DESCRIPTION
This is a bug fix pull request:
* Changed function signatures of gauge-accessor `load`/`save` functions to use complex-valued arrays instead of real-valued arrays: this avoids casting to a real array that causes undefined behaviour and lead to bad code being generated by the compiler.
* Switched all uses of `load`/`save` to use `operator=` overloading to remove any pointer casting from kernel code to accommodate the above change.
* Minor fix to CMake build (don't build tests if building with `QUDA_QDPJIT` enabled, rather than if `QUDA_INTERFACE_QDPJIT` is enabled)