### PR TITLE
Bi-directional coarse link build check

### DIFF
--- a/include/dirac_quda.h
+++ b/include/dirac_quda.h
@@ -50,10 +50,21 @@ namespace quda {
     Dirac *dirac;
     QudaBoolean need_bidirectional; // whether or not we need to force a bi-directional build
 
-  DiracParam() 
-    : type(QUDA_INVALID_DIRAC), kappa(0.0), m5(0.0), matpcType(QUDA_MATPC_INVALID),
-      dagger(QUDA_DAG_INVALID), gauge(0), clover(0), mu(0.0), mu_factor(0.0), epsilon(0.0),
-      tmp1(0), tmp2(0), halo_precision(QUDA_INVALID_PRECISION), need_bidirectional(QUDA_BOOLEAN_INVALID)
+    DiracParam() :
+      type(QUDA_INVALID_DIRAC),
+      kappa(0.0),
+      m5(0.0),
+      matpcType(QUDA_MATPC_INVALID),
+      dagger(QUDA_DAG_INVALID),
+      gauge(0),
+      clover(0),
+      mu(0.0),
+      mu_factor(0.0),
+      epsilon(0.0),
+      tmp1(0),
+      tmp2(0),
+      halo_precision(QUDA_INVALID_PRECISION),
+      need_bidirectional(QUDA_BOOLEAN_INVALID)
     {
       for (int i=0; i<QUDA_MAX_DIM; i++) commDim[i] = 1;
     }

--- a/include/dirac_quda.h
+++ b/include/dirac_quda.h
@@ -48,11 +48,12 @@ namespace quda {
     // for multigrid only
     Transfer *transfer; 
     Dirac *dirac;
+    QudaBoolean need_bidirectional; // whether or not we need to force a bi-directional build
 
   DiracParam() 
     : type(QUDA_INVALID_DIRAC), kappa(0.0), m5(0.0), matpcType(QUDA_MATPC_INVALID),
       dagger(QUDA_DAG_INVALID), gauge(0), clover(0), mu(0.0), mu_factor(0.0), epsilon(0.0),
-      tmp1(0), tmp2(0), halo_precision(QUDA_INVALID_PRECISION)
+      tmp1(0), tmp2(0), halo_precision(QUDA_INVALID_PRECISION), need_bidirectional(QUDA_BOOLEAN_INVALID)
     {
       for (int i=0; i<QUDA_MAX_DIM; i++) commDim[i] = 1;
     }
@@ -801,6 +802,7 @@ public:
     double mu_factor;
     const Transfer *transfer; /** restrictor / prolongator defined here */
     const Dirac *dirac; /** Parent Dirac operator */
+    const QudaBoolean need_bidirectional; /** Whether or not to force a bi-directional build */
 
     mutable cpuGaugeField *Y_h; /** CPU copy of the coarse link field */
     mutable cpuGaugeField *X_h; /** CPU copy of the coarse clover term */

--- a/include/multigrid.h
+++ b/include/multigrid.h
@@ -440,10 +440,14 @@ public:
      operator we are constructing the coarse grid operator from.  If
      matpc==QUDA_MATPC_INVALID then we assume the operator is not
      even-odd preconditioned and we coarsen the full operator.
+     @param need_bidirectional[in] Whether or not we need to force a bi-directional
+     build, even if the given level isn't preconditioned---if any previous level is
+     preconditioned, we've violated that symmetry.
    */
   void CoarseCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T,
 		      const GaugeField &gauge, const GaugeField &clover, const GaugeField &cloverInv,
-		      double kappa, double mu, double mu_factor, QudaDiracType dirac, QudaMatPCType matpc);
+		      double kappa, double mu, double mu_factor, QudaDiracType dirac, QudaMatPCType matpc,
+                      QudaBoolean need_bidirectional);
 
   /**
      @brief Calculate preconditioned coarse links and coarse clover inverse field

--- a/include/multigrid.h
+++ b/include/multigrid.h
@@ -444,10 +444,9 @@ public:
      build, even if the given level isn't preconditioned---if any previous level is
      preconditioned, we've violated that symmetry.
    */
-  void CoarseCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T,
-		      const GaugeField &gauge, const GaugeField &clover, const GaugeField &cloverInv,
-		      double kappa, double mu, double mu_factor, QudaDiracType dirac, QudaMatPCType matpc,
-                      QudaBoolean need_bidirectional);
+  void CoarseCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T, const GaugeField &gauge,
+                      const GaugeField &clover, const GaugeField &cloverInv, double kappa, double mu, double mu_factor,
+                      QudaDiracType dirac, QudaMatPCType matpc, QudaBoolean need_bidirectional);
 
   /**
      @brief Calculate preconditioned coarse links and coarse clover inverse field

--- a/lib/coarse_op.cu
+++ b/lib/coarse_op.cu
@@ -18,6 +18,9 @@ namespace quda {
 
     QudaFieldLocation location = Y.Location();
 
+    QudaBoolean need_bidirectional = QUDA_BOOLEAN_NO;
+    if (dirac == QUDA_CLOVERPC_DIRAC || dirac == QUDA_TWISTED_MASSPC_DIRAC || dirac == QUDA_TWISTED_CLOVERPC_DIRAC) { need_bidirectional = QUDA_BOOLEAN_YES; }
+
     if (location == QUDA_CPU_FIELD_LOCATION) {
 
       constexpr QudaFieldOrder csOrder = QUDA_SPACE_SPIN_COLOR_FIELD_ORDER;
@@ -49,9 +52,10 @@ namespace quda {
       cFine cAccessor(const_cast<CloverField&>(c), false);
       cFine cInvAccessor(const_cast<CloverField&>(c), true);
 
+
       calculateY<false,Float,fineSpin,fineColor,coarseSpin,coarseColor>
 	(yAccessor, xAccessor, yAccessorAtomic, xAccessorAtomic, uvAccessor,
-	 avAccessor, vAccessor, gAccessor, cAccessor, cInvAccessor, Y, X, Yatomic, Xatomic, uv, av, v, kappa, mu, mu_factor, dirac, matpc,
+	 avAccessor, vAccessor, gAccessor, cAccessor, cInvAccessor, Y, X, Yatomic, Xatomic, uv, av, v, kappa, mu, mu_factor, dirac, matpc, need_bidirectional,
 	 T.fineToCoarse(location), T.coarseToFine(location));
 
     } else {
@@ -87,7 +91,7 @@ namespace quda {
 
       calculateY<false,Float,fineSpin,fineColor,coarseSpin,coarseColor>
 	(yAccessor, xAccessor, yAccessorAtomic, xAccessorAtomic, uvAccessor,
-	 avAccessor, vAccessor, gAccessor, cAccessor, cInvAccessor, Y, X, Yatomic, Xatomic, uv, av, v, kappa, mu, mu_factor, dirac, matpc,
+	 avAccessor, vAccessor, gAccessor, cAccessor, cInvAccessor, Y, X, Yatomic, Xatomic, uv, av, v, kappa, mu, mu_factor, dirac, matpc, need_bidirectional,
 	 T.fineToCoarse(location), T.coarseToFine(location));
 
     }

--- a/lib/coarse_op.cuh
+++ b/lib/coarse_op.cuh
@@ -861,6 +861,8 @@ namespace quda {
      @param kappa[in] Kappa parameter
      @param mu[in] Twisted-mass parameter
      @param matpc[in] The type of preconditioning of the source fine-grid operator
+     @param need_bidirectional[in] If we need to force bi-directional build or not. Required
+     if some previous level was preconditioned, even if this one isn't
    */
   template<bool from_coarse, typename Float, int fineSpin, int fineColor, int coarseSpin, int coarseColor, typename F,
 	   typename Ftmp, typename Vt, typename coarseGauge, typename coarseGaugeAtomic, typename fineGauge, typename fineClover>
@@ -870,7 +872,7 @@ namespace quda {
 		  GaugeField &Y_, GaugeField &X_, GaugeField &Y_atomic_, GaugeField &X_atomic_,
                   ColorSpinorField &uv, ColorSpinorField &av, const ColorSpinorField &v,
 		  double kappa, double mu, double mu_factor, QudaDiracType dirac, QudaMatPCType matpc,
-		  const int *fine_to_coarse, const int *coarse_to_fine) {
+		  QudaBoolean need_bidirectional, const int *fine_to_coarse, const int *coarse_to_fine) {
 
     // sanity checks
     if (matpc == QUDA_MATPC_EVEN_EVEN_ASYMMETRIC || matpc == QUDA_MATPC_ODD_ODD_ASYMMETRIC)
@@ -902,7 +904,7 @@ namespace quda {
     // If doing a preconditioned operator with a clover term then we
     // have bi-directional links, though we can do the bidirectional setup for all operators for debugging
     bool bidirectional_links = (dirac == QUDA_CLOVERPC_DIRAC || dirac == QUDA_COARSEPC_DIRAC || bidirectional_debug ||
-				dirac == QUDA_TWISTED_MASSPC_DIRAC || dirac == QUDA_TWISTED_CLOVERPC_DIRAC);
+				dirac == QUDA_TWISTED_MASSPC_DIRAC || dirac == QUDA_TWISTED_CLOVERPC_DIRAC || need_bidirectional == QUDA_BOOLEAN_YES);
 
     if (getVerbosity() >= QUDA_VERBOSE) {
       if (bidirectional_links) printfQuda("Doing bi-directional link coarsening\n");

--- a/lib/coarsecoarse_op.cu
+++ b/lib/coarsecoarse_op.cu
@@ -13,7 +13,8 @@ namespace quda {
   template <typename Float, typename vFloat, int fineColor, int fineSpin, int coarseColor, int coarseSpin>
   void calculateYcoarse(GaugeField &Y, GaugeField &X, GaugeField &Yatomic, GaugeField &Xatomic,
 			ColorSpinorField &uv, const Transfer &T, const GaugeField &g, const GaugeField &clover,
-			const GaugeField &cloverInv, double kappa, double mu, double mu_factor, QudaDiracType dirac, QudaMatPCType matpc) {
+			const GaugeField &cloverInv, double kappa, double mu, double mu_factor, QudaDiracType dirac, QudaMatPCType matpc,
+                        QudaBoolean need_bidirectional) {
 
     if (Y.Location() == QUDA_CPU_FIELD_LOCATION) {
 
@@ -46,7 +47,7 @@ namespace quda {
       calculateY<true,Float,fineSpin,fineColor,coarseSpin,coarseColor>
 	(yAccessor, xAccessor, yAccessorAtomic, xAccessorAtomic,
 	 uvAccessor, vAccessor, vAccessor, gAccessor, cAccessor, cInvAccessor,
-	 Y, X, Yatomic, Xatomic, uv, const_cast<ColorSpinorField&>(v), v, kappa, mu, mu_factor, dirac, matpc,
+	 Y, X, Yatomic, Xatomic, uv, const_cast<ColorSpinorField&>(v), v, kappa, mu, mu_factor, dirac, matpc, need_bidirectional,
 	 T.fineToCoarse(Y.Location()), T.coarseToFine(Y.Location()));
 
     } else {
@@ -80,7 +81,7 @@ namespace quda {
       calculateY<true,Float,fineSpin,fineColor,coarseSpin,coarseColor>
 	(yAccessor, xAccessor, yAccessorAtomic, xAccessorAtomic,
 	 uvAccessor, vAccessor, vAccessor, gAccessor, cAccessor, cInvAccessor,
-	 Y, X, Yatomic, Xatomic, uv, const_cast<ColorSpinorField&>(v), v, kappa, mu, mu_factor, dirac, matpc,
+	 Y, X, Yatomic, Xatomic, uv, const_cast<ColorSpinorField&>(v), v, kappa, mu, mu_factor, dirac, matpc, need_bidirectional,
 	 T.fineToCoarse(Y.Location()), T.coarseToFine(Y.Location()));
 
     }
@@ -91,24 +92,24 @@ namespace quda {
   template <typename Float, typename vFloat, int fineColor, int fineSpin>
   void calculateYcoarse(GaugeField &Y, GaugeField &X, GaugeField &Yatomic, GaugeField &Xatomic,
 			ColorSpinorField &uv, const Transfer &T, const GaugeField &g, const GaugeField &clover,
-			const GaugeField &cloverInv, double kappa, double mu, double mu_factor, QudaDiracType dirac, QudaMatPCType matpc) {
+			const GaugeField &cloverInv, double kappa, double mu, double mu_factor, QudaDiracType dirac, QudaMatPCType matpc, QudaBoolean need_bidirectional) {
     if (T.Vectors().Nspin()/T.Spin_bs() != 2) 
       errorQuda("Unsupported number of coarse spins %d\n",T.Vectors().Nspin()/T.Spin_bs());
     const int coarseSpin = 2;
     const int coarseColor = Y.Ncolor() / coarseSpin;
 
     if (coarseColor == 6) {
-      calculateYcoarse<Float,vFloat,fineColor,fineSpin,6,coarseSpin>(Y, X, Yatomic, Xatomic, uv, T, g, clover, cloverInv, kappa, mu, mu_factor, dirac, matpc);
+      calculateYcoarse<Float,vFloat,fineColor,fineSpin,6,coarseSpin>(Y, X, Yatomic, Xatomic, uv, T, g, clover, cloverInv, kappa, mu, mu_factor, dirac, matpc, need_bidirectional);
 #if 0
     } else if (coarseColor == 8) {
-      calculateYcoarse<Float,vFloat,fineColor,fineSpin,8,coarseSpin>(Y, X, Yatomic, Xatomic, uv, T, g, clover, cloverInv, kappa, mu, mu_factor, dirac, matpc);
+      calculateYcoarse<Float,vFloat,fineColor,fineSpin,8,coarseSpin>(Y, X, Yatomic, Xatomic, uv, T, g, clover, cloverInv, kappa, mu, mu_factor, dirac, matpc, need_bidirectional);
     } else if (coarseColor == 16) {
-      calculateYcoarse<Float,vFloat,fineColor,fineSpin,16,coarseSpin>(Y, X, Yatomic, Xatomic, uv, T, g, clover, cloverInv, kappa, mu, mu_factor, dirac, matpc);
+      calculateYcoarse<Float,vFloat,fineColor,fineSpin,16,coarseSpin>(Y, X, Yatomic, Xatomic, uv, T, g, clover, cloverInv, kappa, mu, mu_factor, dirac, matpc, need_bidirectional);
 #endif
     } else if (coarseColor == 24) {
-      calculateYcoarse<Float,vFloat,fineColor,fineSpin,24,coarseSpin>(Y, X, Yatomic, Xatomic, uv, T, g, clover, cloverInv, kappa, mu, mu_factor, dirac, matpc);
+      calculateYcoarse<Float,vFloat,fineColor,fineSpin,24,coarseSpin>(Y, X, Yatomic, Xatomic, uv, T, g, clover, cloverInv, kappa, mu, mu_factor, dirac, matpc, need_bidirectional);
     } else if (coarseColor == 32) {
-      calculateYcoarse<Float,vFloat,fineColor,fineSpin,32,coarseSpin>(Y, X, Yatomic, Xatomic, uv, T, g, clover, cloverInv, kappa, mu, mu_factor, dirac, matpc);
+      calculateYcoarse<Float,vFloat,fineColor,fineSpin,32,coarseSpin>(Y, X, Yatomic, Xatomic, uv, T, g, clover, cloverInv, kappa, mu, mu_factor, dirac, matpc, need_bidirectional);
     } else {
       errorQuda("Unsupported number of coarse dof %d\n", Y.Ncolor());
     }
@@ -118,9 +119,9 @@ namespace quda {
   template <typename Float, typename vFloat, int fineColor>
   void calculateYcoarse(GaugeField &Y, GaugeField &X, GaugeField &Yatomic, GaugeField &Xatomic,
 			ColorSpinorField &uv, const Transfer &T, const GaugeField &g, const GaugeField &clover,
-			const GaugeField &cloverInv, double kappa, double mu, double mu_factor, QudaDiracType dirac, QudaMatPCType matpc) {
+			const GaugeField &cloverInv, double kappa, double mu, double mu_factor, QudaDiracType dirac, QudaMatPCType matpc, QudaBoolean need_bidirectional) {
     if (T.Vectors().Nspin() == 2) {
-      calculateYcoarse<Float,vFloat,fineColor,2>(Y, X, Yatomic, Xatomic, uv, T, g, clover, cloverInv, kappa, mu, mu_factor, dirac, matpc);
+      calculateYcoarse<Float,vFloat,fineColor,2>(Y, X, Yatomic, Xatomic, uv, T, g, clover, cloverInv, kappa, mu, mu_factor, dirac, matpc, need_bidirectional);
     } else {
       errorQuda("Unsupported number of spins %d\n", T.Vectors().Nspin());
     }
@@ -130,19 +131,19 @@ namespace quda {
   template <typename Float, typename vFloat>
   void calculateYcoarse(GaugeField &Y, GaugeField &X, GaugeField &Yatomic, GaugeField &Xatomic,
 			ColorSpinorField &uv, const Transfer &T, const GaugeField &g, const GaugeField &clover,
-			const GaugeField &cloverInv, double kappa, double mu, double mu_factor, QudaDiracType dirac, QudaMatPCType matpc) {
+			const GaugeField &cloverInv, double kappa, double mu, double mu_factor, QudaDiracType dirac, QudaMatPCType matpc, QudaBoolean need_bidirectional) {
     if (g.Ncolor()/T.Vectors().Nspin() == 6) { // free field Wilson
-      calculateYcoarse<Float,vFloat,6>(Y, X, Yatomic, Xatomic, uv, T, g, clover, cloverInv, kappa, mu, mu_factor, dirac, matpc);
+      calculateYcoarse<Float,vFloat,6>(Y, X, Yatomic, Xatomic, uv, T, g, clover, cloverInv, kappa, mu, mu_factor, dirac, matpc, need_bidirectional);
 #if 0
     } else if (g.Ncolor()/T.Vectors().Nspin() == 8) {
-      calculateYcoarse<Float,vFloat,8>(Y, X, Yatomic, Xatomic, uv, T, g, clover, cloverInv, kappa, mu, mu_factor, dirac, matpc);
+      calculateYcoarse<Float,vFloat,8>(Y, X, Yatomic, Xatomic, uv, T, g, clover, cloverInv, kappa, mu, mu_factor, dirac, matpc, need_bidirectional);
     } else if (g.Ncolor()/T.Vectors().Nspin() == 16) {
-      calculateYcoarse<Float,vFloat,16>(Y, X, Yatomic, Xatomic, uv, T, g, clover, cloverInv, kappa, mu, mu_factor, dirac, matpc);
+      calculateYcoarse<Float,vFloat,16>(Y, X, Yatomic, Xatomic, uv, T, g, clover, cloverInv, kappa, mu, mu_factor, dirac, matpc, need_bidirectional);
 #endif
     } else if (g.Ncolor()/T.Vectors().Nspin() == 24) {
-      calculateYcoarse<Float,vFloat,24>(Y, X, Yatomic, Xatomic, uv, T, g, clover, cloverInv, kappa, mu, mu_factor, dirac, matpc);
+      calculateYcoarse<Float,vFloat,24>(Y, X, Yatomic, Xatomic, uv, T, g, clover, cloverInv, kappa, mu, mu_factor, dirac, matpc, need_bidirectional);
     } else if (g.Ncolor()/T.Vectors().Nspin() == 32) {
-      calculateYcoarse<Float,vFloat,32>(Y, X, Yatomic, Xatomic, uv, T, g, clover, cloverInv, kappa, mu, mu_factor, dirac, matpc);
+      calculateYcoarse<Float,vFloat,32>(Y, X, Yatomic, Xatomic, uv, T, g, clover, cloverInv, kappa, mu, mu_factor, dirac, matpc, need_bidirectional);
     } else {
       errorQuda("Unsupported number of colors %d\n", g.Ncolor());
     }
@@ -151,7 +152,7 @@ namespace quda {
   //Does the heavy lifting of creating the coarse color matrices Y
   void calculateYcoarse(GaugeField &Y, GaugeField &X, GaugeField &Yatomic, GaugeField &Xatomic, ColorSpinorField &uv,
 			const Transfer &T, const GaugeField &g, const GaugeField &clover, const GaugeField &cloverInv,
-			double kappa, double mu, double mu_factor, QudaDiracType dirac, QudaMatPCType matpc) {
+			double kappa, double mu, double mu_factor, QudaDiracType dirac, QudaMatPCType matpc, QudaBoolean need_bidirectional) {
     checkPrecision(X, Y, g, clover, cloverInv, uv, T.Vectors(X.Location()));
     checkPrecision(Xatomic, Yatomic);
 
@@ -159,7 +160,7 @@ namespace quda {
     if (Y.Precision() == QUDA_DOUBLE_PRECISION) {
 #ifdef GPU_MULTIGRID_DOUBLE
       if (T.Vectors(X.Location()).Precision() == QUDA_DOUBLE_PRECISION) {
-	calculateYcoarse<double,double>(Y, X, Yatomic, Xatomic, uv, T, g, clover, cloverInv, kappa, mu, mu_factor, dirac, matpc);
+	calculateYcoarse<double,double>(Y, X, Yatomic, Xatomic, uv, T, g, clover, cloverInv, kappa, mu, mu_factor, dirac, matpc, need_bidirectional);
       } else {
 	errorQuda("Unsupported precision %d\n", Y.Precision());
       }
@@ -168,13 +169,13 @@ namespace quda {
 #endif
     } else if (Y.Precision() == QUDA_SINGLE_PRECISION) {
       if (T.Vectors(X.Location()).Precision() == QUDA_SINGLE_PRECISION) {
-	calculateYcoarse<float,float>(Y, X, Yatomic, Xatomic, uv, T, g, clover, cloverInv, kappa, mu, mu_factor, dirac, matpc);
+	calculateYcoarse<float,float>(Y, X, Yatomic, Xatomic, uv, T, g, clover, cloverInv, kappa, mu, mu_factor, dirac, matpc, need_bidirectional);
       } else {
 	errorQuda("Unsupported precision %d\n", T.Vectors(X.Location()).Precision());
       }
     } else if (Y.Precision() == QUDA_HALF_PRECISION) {
       if (T.Vectors(X.Location()).Precision() == QUDA_HALF_PRECISION) {
-	calculateYcoarse<float,short>(Y, X, Yatomic, Xatomic, uv, T, g, clover, cloverInv, kappa, mu, mu_factor, dirac, matpc);
+	calculateYcoarse<float,short>(Y, X, Yatomic, Xatomic, uv, T, g, clover, cloverInv, kappa, mu, mu_factor, dirac, matpc, need_bidirectional);
       } else {
 	errorQuda("Unsupported precision %d\n", T.Vectors(X.Location()).Precision());
       }
@@ -190,7 +191,8 @@ namespace quda {
   //N.B. Assumes Y, X have been allocated.
   void CoarseCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T,
 		      const GaugeField &gauge, const GaugeField &clover, const GaugeField &cloverInv,
-		      double kappa, double mu, double mu_factor, QudaDiracType dirac, QudaMatPCType matpc) {
+		      double kappa, double mu, double mu_factor, QudaDiracType dirac, QudaMatPCType matpc,
+                      QudaBoolean need_bidirectional) {
 
 #ifdef GPU_MULTIGRID
     QudaPrecision precision = Y.Precision();
@@ -222,7 +224,7 @@ namespace quda {
       Xatomic = GaugeField::Create(param);
     }
 
-    calculateYcoarse(Y, X, *Yatomic, *Xatomic, *uv, T, gauge, clover, cloverInv, kappa, mu, mu_factor, dirac, matpc);
+    calculateYcoarse(Y, X, *Yatomic, *Xatomic, *uv, T, gauge, clover, cloverInv, kappa, mu, mu_factor, dirac, matpc, need_bidirectional);
 
     if (Yatomic != &Y) delete Yatomic;
     if (Xatomic != &X) delete Xatomic;

--- a/lib/dirac_coarse.cpp
+++ b/lib/dirac_coarse.cpp
@@ -4,35 +4,81 @@
 
 namespace quda {
 
-  DiracCoarse::DiracCoarse(const DiracParam &param, bool gpu_setup, bool mapped)
-    : Dirac(param), mu(param.mu), mu_factor(param.mu_factor), transfer(param.transfer), dirac(param.dirac), need_bidirectional(param.need_bidirectional),
-      Y_h(nullptr), X_h(nullptr), Xinv_h(nullptr), Yhat_h(nullptr),
-      Y_d(nullptr), X_d(nullptr), Xinv_d(nullptr), Yhat_d(nullptr),
-      enable_gpu(false), enable_cpu(false), gpu_setup(gpu_setup),
-      init_gpu(gpu_setup), init_cpu(!gpu_setup), mapped(mapped)
+  DiracCoarse::DiracCoarse(const DiracParam &param, bool gpu_setup, bool mapped) :
+    Dirac(param),
+    mu(param.mu),
+    mu_factor(param.mu_factor),
+    transfer(param.transfer),
+    dirac(param.dirac),
+    need_bidirectional(param.need_bidirectional),
+    Y_h(nullptr),
+    X_h(nullptr),
+    Xinv_h(nullptr),
+    Yhat_h(nullptr),
+    Y_d(nullptr),
+    X_d(nullptr),
+    Xinv_d(nullptr),
+    Yhat_d(nullptr),
+    enable_gpu(false),
+    enable_cpu(false),
+    gpu_setup(gpu_setup),
+    init_gpu(gpu_setup),
+    init_cpu(!gpu_setup),
+    mapped(mapped)
   {
     initializeCoarse();
   }
 
-  DiracCoarse::DiracCoarse(const DiracParam &param,
-			   cpuGaugeField *Y_h, cpuGaugeField *X_h, cpuGaugeField *Xinv_h, cpuGaugeField *Yhat_h,   // cpu link fields
-			   cudaGaugeField *Y_d, cudaGaugeField *X_d, cudaGaugeField *Xinv_d, cudaGaugeField *Yhat_d) // gpu link field
-    : Dirac(param), mu(param.mu), mu_factor(param.mu_factor), transfer(nullptr), dirac(nullptr), need_bidirectional(QUDA_BOOLEAN_NO),
-      Y_h(Y_h), X_h(X_h), Xinv_h(Xinv_h), Yhat_h(Yhat_h),
-      Y_d(Y_d), X_d(X_d), Xinv_d(Xinv_d), Yhat_d(Yhat_d),
-      enable_gpu( Y_d ? true : false), enable_cpu(Y_h ? true : false), gpu_setup(true),
-      init_gpu(enable_gpu ? false : true), init_cpu(enable_cpu ? false : true), mapped(Y_d->MemType() == QUDA_MEMORY_MAPPED)
+  DiracCoarse::DiracCoarse(const DiracParam &param, cpuGaugeField *Y_h, cpuGaugeField *X_h, cpuGaugeField *Xinv_h,
+                           cpuGaugeField *Yhat_h, // cpu link fields
+                           cudaGaugeField *Y_d, cudaGaugeField *X_d, cudaGaugeField *Xinv_d,
+                           cudaGaugeField *Yhat_d) // gpu link field
+    :
+    Dirac(param),
+    mu(param.mu),
+    mu_factor(param.mu_factor),
+    transfer(nullptr),
+    dirac(nullptr),
+    need_bidirectional(QUDA_BOOLEAN_NO),
+    Y_h(Y_h),
+    X_h(X_h),
+    Xinv_h(Xinv_h),
+    Yhat_h(Yhat_h),
+    Y_d(Y_d),
+    X_d(X_d),
+    Xinv_d(Xinv_d),
+    Yhat_d(Yhat_d),
+    enable_gpu(Y_d ? true : false),
+    enable_cpu(Y_h ? true : false),
+    gpu_setup(true),
+    init_gpu(enable_gpu ? false : true),
+    init_cpu(enable_cpu ? false : true),
+    mapped(Y_d->MemType() == QUDA_MEMORY_MAPPED)
   {
 
   }
 
-  DiracCoarse::DiracCoarse(const DiracCoarse &dirac, const DiracParam &param)
-    : Dirac(param), mu(param.mu), mu_factor(param.mu_factor), transfer(param.transfer), dirac(param.dirac), need_bidirectional(param.need_bidirectional),
-      Y_h(dirac.Y_h), X_h(dirac.X_h), Xinv_h(dirac.Xinv_h), Yhat_h(dirac.Yhat_h),
-      Y_d(dirac.Y_d), X_d(dirac.X_d), Xinv_d(dirac.Xinv_d), Yhat_d(dirac.Yhat_d),
-      enable_gpu(dirac.enable_gpu), enable_cpu(dirac.enable_cpu), gpu_setup(dirac.gpu_setup),
-      init_gpu(enable_gpu ? false : true), init_cpu(enable_cpu ? false : true),
-      mapped(dirac.mapped)
+  DiracCoarse::DiracCoarse(const DiracCoarse &dirac, const DiracParam &param) :
+    Dirac(param),
+    mu(param.mu),
+    mu_factor(param.mu_factor),
+    transfer(param.transfer),
+    dirac(param.dirac),
+    need_bidirectional(param.need_bidirectional),
+    Y_h(dirac.Y_h),
+    X_h(dirac.X_h),
+    Xinv_h(dirac.Xinv_h),
+    Yhat_h(dirac.Yhat_h),
+    Y_d(dirac.Y_d),
+    X_d(dirac.X_d),
+    Xinv_d(dirac.Xinv_d),
+    Yhat_d(dirac.Yhat_d),
+    enable_gpu(dirac.enable_gpu),
+    enable_cpu(dirac.enable_cpu),
+    gpu_setup(dirac.gpu_setup),
+    init_gpu(enable_gpu ? false : true),
+    init_cpu(enable_cpu ? false : true),
+    mapped(dirac.mapped)
   {
 
   }
@@ -298,10 +344,12 @@ namespace quda {
     double a = 2.0 * kappa * mu * T.Vectors().TwistFlavor();
     if (checkLocation(Y, X) == QUDA_CPU_FIELD_LOCATION) {
       initializeLazy(QUDA_CPU_FIELD_LOCATION);
-      CoarseCoarseOp(Y, X, T, *(this->Y_h), *(this->X_h), *(this->Xinv_h), kappa, a, mu_factor, QUDA_COARSE_DIRAC, QUDA_MATPC_INVALID, need_bidirectional);
+      CoarseCoarseOp(Y, X, T, *(this->Y_h), *(this->X_h), *(this->Xinv_h), kappa, a, mu_factor, QUDA_COARSE_DIRAC,
+                     QUDA_MATPC_INVALID, need_bidirectional);
     } else {
       initializeLazy(QUDA_CUDA_FIELD_LOCATION);
-      CoarseCoarseOp(Y, X, T, *(this->Y_d), *(this->X_d), *(this->Xinv_d), kappa, a, mu_factor, QUDA_COARSE_DIRAC, QUDA_MATPC_INVALID, need_bidirectional);
+      CoarseCoarseOp(Y, X, T, *(this->Y_d), *(this->X_d), *(this->Xinv_d), kappa, a, mu_factor, QUDA_COARSE_DIRAC,
+                     QUDA_MATPC_INVALID, need_bidirectional);
     }
   }
 
@@ -478,10 +526,12 @@ namespace quda {
     double a = -2.0 * kappa * mu * T.Vectors().TwistFlavor();
     if (checkLocation(Y, X) == QUDA_CPU_FIELD_LOCATION) {
       initializeLazy(QUDA_CPU_FIELD_LOCATION);
-      CoarseCoarseOp(Y, X, T, *(this->Yhat_h), *(this->X_h), *(this->Xinv_h), kappa, a, -mu_factor, QUDA_COARSEPC_DIRAC, matpcType, QUDA_BOOLEAN_YES);
+      CoarseCoarseOp(Y, X, T, *(this->Yhat_h), *(this->X_h), *(this->Xinv_h), kappa, a, -mu_factor, QUDA_COARSEPC_DIRAC,
+                     matpcType, QUDA_BOOLEAN_YES);
     } else {
       initializeLazy(QUDA_CUDA_FIELD_LOCATION);
-      CoarseCoarseOp(Y, X, T, *(this->Yhat_d), *(this->X_d), *(this->Xinv_d), kappa, a, -mu_factor, QUDA_COARSEPC_DIRAC, matpcType, QUDA_BOOLEAN_YES);
+      CoarseCoarseOp(Y, X, T, *(this->Yhat_d), *(this->X_d), *(this->Xinv_d), kappa, a, -mu_factor, QUDA_COARSEPC_DIRAC,
+                     matpcType, QUDA_BOOLEAN_YES);
     }
   }
 

--- a/lib/dirac_coarse.cpp
+++ b/lib/dirac_coarse.cpp
@@ -5,7 +5,7 @@
 namespace quda {
 
   DiracCoarse::DiracCoarse(const DiracParam &param, bool gpu_setup, bool mapped)
-    : Dirac(param), mu(param.mu), mu_factor(param.mu_factor), transfer(param.transfer), dirac(param.dirac),
+    : Dirac(param), mu(param.mu), mu_factor(param.mu_factor), transfer(param.transfer), dirac(param.dirac), need_bidirectional(param.need_bidirectional),
       Y_h(nullptr), X_h(nullptr), Xinv_h(nullptr), Yhat_h(nullptr),
       Y_d(nullptr), X_d(nullptr), Xinv_d(nullptr), Yhat_d(nullptr),
       enable_gpu(false), enable_cpu(false), gpu_setup(gpu_setup),
@@ -17,7 +17,7 @@ namespace quda {
   DiracCoarse::DiracCoarse(const DiracParam &param,
 			   cpuGaugeField *Y_h, cpuGaugeField *X_h, cpuGaugeField *Xinv_h, cpuGaugeField *Yhat_h,   // cpu link fields
 			   cudaGaugeField *Y_d, cudaGaugeField *X_d, cudaGaugeField *Xinv_d, cudaGaugeField *Yhat_d) // gpu link field
-    : Dirac(param), mu(param.mu), mu_factor(param.mu_factor), transfer(nullptr), dirac(nullptr),
+    : Dirac(param), mu(param.mu), mu_factor(param.mu_factor), transfer(nullptr), dirac(nullptr), need_bidirectional(QUDA_BOOLEAN_NO),
       Y_h(Y_h), X_h(X_h), Xinv_h(Xinv_h), Yhat_h(Yhat_h),
       Y_d(Y_d), X_d(X_d), Xinv_d(Xinv_d), Yhat_d(Yhat_d),
       enable_gpu( Y_d ? true : false), enable_cpu(Y_h ? true : false), gpu_setup(true),
@@ -27,7 +27,7 @@ namespace quda {
   }
 
   DiracCoarse::DiracCoarse(const DiracCoarse &dirac, const DiracParam &param)
-    : Dirac(param), mu(param.mu), mu_factor(param.mu_factor), transfer(param.transfer), dirac(param.dirac),
+    : Dirac(param), mu(param.mu), mu_factor(param.mu_factor), transfer(param.transfer), dirac(param.dirac), need_bidirectional(param.need_bidirectional),
       Y_h(dirac.Y_h), X_h(dirac.X_h), Xinv_h(dirac.Xinv_h), Yhat_h(dirac.Yhat_h),
       Y_d(dirac.Y_d), X_d(dirac.X_d), Xinv_d(dirac.Xinv_d), Yhat_d(dirac.Yhat_d),
       enable_gpu(dirac.enable_gpu), enable_cpu(dirac.enable_cpu), gpu_setup(dirac.gpu_setup),
@@ -298,10 +298,10 @@ namespace quda {
     double a = 2.0 * kappa * mu * T.Vectors().TwistFlavor();
     if (checkLocation(Y, X) == QUDA_CPU_FIELD_LOCATION) {
       initializeLazy(QUDA_CPU_FIELD_LOCATION);
-      CoarseCoarseOp(Y, X, T, *(this->Y_h), *(this->X_h), *(this->Xinv_h), kappa, a, mu_factor, QUDA_COARSE_DIRAC, QUDA_MATPC_INVALID);
+      CoarseCoarseOp(Y, X, T, *(this->Y_h), *(this->X_h), *(this->Xinv_h), kappa, a, mu_factor, QUDA_COARSE_DIRAC, QUDA_MATPC_INVALID, need_bidirectional);
     } else {
       initializeLazy(QUDA_CUDA_FIELD_LOCATION);
-      CoarseCoarseOp(Y, X, T, *(this->Y_d), *(this->X_d), *(this->Xinv_d), kappa, a, mu_factor, QUDA_COARSE_DIRAC, QUDA_MATPC_INVALID);
+      CoarseCoarseOp(Y, X, T, *(this->Y_d), *(this->X_d), *(this->Xinv_d), kappa, a, mu_factor, QUDA_COARSE_DIRAC, QUDA_MATPC_INVALID, need_bidirectional);
     }
   }
 
@@ -478,10 +478,10 @@ namespace quda {
     double a = -2.0 * kappa * mu * T.Vectors().TwistFlavor();
     if (checkLocation(Y, X) == QUDA_CPU_FIELD_LOCATION) {
       initializeLazy(QUDA_CPU_FIELD_LOCATION);
-      CoarseCoarseOp(Y, X, T, *(this->Yhat_h), *(this->X_h), *(this->Xinv_h), kappa, a, -mu_factor, QUDA_COARSEPC_DIRAC, matpcType);
+      CoarseCoarseOp(Y, X, T, *(this->Yhat_h), *(this->X_h), *(this->Xinv_h), kappa, a, -mu_factor, QUDA_COARSEPC_DIRAC, matpcType, QUDA_BOOLEAN_YES);
     } else {
       initializeLazy(QUDA_CUDA_FIELD_LOCATION);
-      CoarseCoarseOp(Y, X, T, *(this->Yhat_d), *(this->X_d), *(this->Xinv_d), kappa, a, -mu_factor, QUDA_COARSEPC_DIRAC, matpcType);
+      CoarseCoarseOp(Y, X, T, *(this->Yhat_d), *(this->X_d), *(this->Xinv_d), kappa, a, -mu_factor, QUDA_COARSEPC_DIRAC, matpcType, QUDA_BOOLEAN_YES);
     }
   }
 

--- a/lib/multigrid.cpp
+++ b/lib/multigrid.cpp
@@ -352,7 +352,8 @@ namespace quda
     // preconditioned, we have to force bi-directional builds.
     diracParam.need_bidirectional = QUDA_BOOLEAN_NO;
     for (int i = 0; i <= param.level; i++) {
-      if (param.mg_global.coarse_grid_solution_type[i] == QUDA_MATPC_SOLUTION && param.mg_global.smoother_solve_type[i] == QUDA_DIRECT_PC_SOLVE) {
+      if (param.mg_global.coarse_grid_solution_type[i] == QUDA_MATPC_SOLUTION
+          && param.mg_global.smoother_solve_type[i] == QUDA_DIRECT_PC_SOLVE) {
         diracParam.need_bidirectional = QUDA_BOOLEAN_YES;
       }
     }
@@ -774,7 +775,8 @@ namespace quda
     if (deviation > tol) errorQuda("failed, deviation = %e (tol=%e)", deviation, tol);
 
     // check the preconditioned operator construction on the lower level if applicable
-    bool coarse_was_preconditioned = (param.mg_global.coarse_grid_solution_type[param.level+1] == QUDA_MATPC_SOLUTION && param.mg_global.smoother_solve_type[param.level+1] == QUDA_DIRECT_PC_SOLVE);
+    bool coarse_was_preconditioned = (param.mg_global.coarse_grid_solution_type[param.level + 1] == QUDA_MATPC_SOLUTION
+                                      && param.mg_global.smoother_solve_type[param.level + 1] == QUDA_DIRECT_PC_SOLVE);
     if (coarse_was_preconditioned) {
       // check eo
       if (getVerbosity() >= QUDA_SUMMARIZE)


### PR DESCRIPTION
This PR fixes two logic bugs related to coarse link builds and verification.

* Corrected the logic check for bi-directional coarse construct: bi-directional builds need to be performed if the operator being coarsened is the precondition op, or if any subsequent op (in a recursive setup) was preconditioned.
* Corrected the logic for checking the preconditioned op construct: the coarse preconditioned op construct on level `i+1` was incorrectly only being verified if the level `i` operator was preconditioned as opposed to if `i+1` was preconditioned.

With these fixes, `direct` and `direct-pc` solves can be freely interleaved within an MG solve (relevant for some staggered cases) and verified during the construct.

Since these bugs effect `develop`, we should merge `release/1.0.x` into `develop` after this is merged (or after Kate's other PR).