### PR TITLE
Hotfix/persistent defl fixes

### DIFF
--- a/lib/inv_cg_quda.cpp
+++ b/lib/inv_cg_quda.cpp
@@ -330,7 +330,7 @@ namespace quda {
     const double u = param.precision_sloppy == 8 ?
       std::numeric_limits<double>::epsilon() / 2. :
       param.precision_sloppy == 4 ? std::numeric_limits<float>::epsilon() / 2. :
-                                    param.precision == 2 ? pow(2., -13) : pow(2., -6);
+                                    param.precision_sloppy == 2 ? pow(2., -13) : pow(2., -6);
     const double uhigh = param.precision == 8 ? std::numeric_limits<double>::epsilon() / 2. :
                                                 param.precision == 4 ? std::numeric_limits<float>::epsilon() / 2. :
                                                                        param.precision == 2 ? pow(2., -13) : pow(2., -6);

--- a/lib/solver.cpp
+++ b/lib/solver.cpp
@@ -260,21 +260,22 @@ namespace quda {
   void Solver::injectDeflationSpace(std::vector<ColorSpinorField *> &defl_space)
   {
     if (!evecs.empty()) errorQuda("Solver deflation space should be empty, instead size=%lu\n", defl_space.size());
-    int size = defl_space.size();
+    // Create space for the eigenvalues
+    evals.resize(defl_space.size());
+    // Create space for the eigenvectors, destroy defl_space
     for (auto &e : defl_space) { evecs.push_back(e); }
     defl_space.resize(0);
-    // Create space for the eigenvalues
-    evals.reserve(size);
-    for (int i = 0; i < size; i++) evals.push_back(0.0);
+
   }
 
   void Solver::extractDeflationSpace(std::vector<ColorSpinorField *> &defl_space)
   {
     if (!defl_space.empty()) errorQuda("Container deflation space should be empty, instead size=%lu\n", defl_space.size());
-    for (auto &e : evecs ) { defl_space.push_back(e); }
-    evecs.resize(0);
     // We do not care about the eigenvalues, they will be recomputed.
     evals.resize(0);
+    // Create space for the eigenvectors, destroy evecs
+    for (auto &e : evecs ) { defl_space.push_back(e); }
+    evecs.resize(0);
   }
 
   void Solver::extendSVDDeflationSpace()

--- a/lib/solver.cpp
+++ b/lib/solver.cpp
@@ -265,9 +265,9 @@ namespace quda {
     defl_space.resize(0);
     // Create space for the eigenvalues
     evals.reserve(size);
-    for(int i=0; i<size; i++) evals.push_back(0.0);
+    for (int i = 0; i < size; i++) evals.push_back(0.0);
   }
-  
+
   void Solver::extractDeflationSpace(std::vector<ColorSpinorField *> &defl_space)
   {
     if (!defl_space.empty()) errorQuda("Container deflation space should be empty, instead size=%lu\n", defl_space.size());

--- a/lib/solver.cpp
+++ b/lib/solver.cpp
@@ -260,15 +260,21 @@ namespace quda {
   void Solver::injectDeflationSpace(std::vector<ColorSpinorField *> &defl_space)
   {
     if (!evecs.empty()) errorQuda("Solver deflation space should be empty, instead size=%lu\n", defl_space.size());
+    int size = defl_space.size();
     for (auto &e : defl_space) { evecs.push_back(e); }
     defl_space.resize(0);
+    // Create space for the eigenvalues
+    evals.reserve(size);
+    for(int i=0; i<size; i++) evals.push_back(0.0);
   }
-
+  
   void Solver::extractDeflationSpace(std::vector<ColorSpinorField *> &defl_space)
   {
     if (!defl_space.empty()) errorQuda("Container deflation space should be empty, instead size=%lu\n", defl_space.size());
     for (auto &e : evecs ) { defl_space.push_back(e); }
     evecs.resize(0);
+    // We do not care about the eigenvalues, they will be recomputed.
+    evals.resize(0);
   }
 
   void Solver::extendSVDDeflationSpace()

--- a/lib/solver.cpp
+++ b/lib/solver.cpp
@@ -265,7 +265,6 @@ namespace quda {
     // Create space for the eigenvectors, destroy defl_space
     for (auto &e : defl_space) { evecs.push_back(e); }
     defl_space.resize(0);
-
   }
 
   void Solver::extractDeflationSpace(std::vector<ColorSpinorField *> &defl_space)

--- a/tests/multigrid_evolve_test.cpp
+++ b/tests/multigrid_evolve_test.cpp
@@ -907,7 +907,7 @@ int main(int argc, char **argv)
         inv_param2.mass = 0.5 / (kappa - 0.001 * step) - (1 + 3 / anisotropy);
       }
       if (dslash_type == QUDA_TWISTED_MASS_DSLASH || dslash_type == QUDA_TWISTED_CLOVER_DSLASH) {
-	// Multiply by -1.0 to emulate twist switch
+        // Multiply by -1.0 to emulate twist switch
         inv_param.mu = -1.0 * mu + 0.01 * step;
         inv_param2.mu = -1.0 * mu + 0.01 * step;
         mg_param.invert_param->mu = inv_param.mu;

--- a/tests/multigrid_evolve_test.cpp
+++ b/tests/multigrid_evolve_test.cpp
@@ -907,8 +907,9 @@ int main(int argc, char **argv)
         inv_param2.mass = 0.5 / (kappa - 0.001 * step) - (1 + 3 / anisotropy);
       }
       if (dslash_type == QUDA_TWISTED_MASS_DSLASH || dslash_type == QUDA_TWISTED_CLOVER_DSLASH) {
-        inv_param.mu = mu + 0.01 * step;
-        inv_param2.mu = mu + 0.01 * step;
+	// Multiply by -1.0 to emulate twist switch
+        inv_param.mu = -1.0 * mu + 0.01 * step;
+        inv_param2.mu = -1.0 * mu + 0.01 * step;
         mg_param.invert_param->mu = inv_param.mu;
       }
 


### PR DESCRIPTION
This is primarily a bug-fix pull:
* fixes a bug with persistent eigenvector reuse (closes #929)
* fixes a bug with CG with the reliable update threshold
* adds twisted mass evolution to multigrid_evolve_test, enhancing its testing capabilities

@cpviolator gets all the credit for finding the bug with the persistent eigenvectors