### PR TITLE
WAR for segfaults when loading some Chroma-generated gauge fields

### DIFF
--- a/lib/qio_field.cpp
+++ b/lib/qio_field.cpp
@@ -109,7 +109,9 @@ int read_field(QIO_Reader *infile, int count, void *field_in[], QudaPrecision cp
     errorQuda("QIO_get_typesize %d does not match expected datasize %d", in_typesize, file_prec * len);
 
   // Print the XML string.
-  if (QIO_string_length(xml_record_in) > 0) printfQuda("QIO string: %s\n", QIO_string_ptr(xml_record_in));
+  // The len != 18 is a WAR for this line segfaulting on some Chroma configs.
+  // Tracked on github via #936 
+  if (len != 18 && QIO_string_length(xml_record_in) > 0) printfQuda("QIO string: %s\n", QIO_string_ptr(xml_record_in));
 
   // Get total size. Could probably check the filesize better, but tbd.
   size_t rec_size = file_prec * count * len;


### PR DESCRIPTION
Progress making this a formal fix tracked on github via #936 

Should be a non-controversial WAR. `len == 18` corresponds to a gauge field (9 elements * 2 for complex). I've never seen issues with spinor fields, and MILC can verifiably load spinor fields generated by QUDA, so I didn't want to do a blanket comment out of the line.

@cpviolator @alexstrel if one of you can verify, let's get this merged in once it passes build tests.