### PR TITLE
Hotfix/boolean

### DIFF
--- a/include/dirac_quda.h
+++ b/include/dirac_quda.h
@@ -48,7 +48,7 @@ namespace quda {
     // for multigrid only
     Transfer *transfer; 
     Dirac *dirac;
-    QudaBoolean need_bidirectional; // whether or not we need to force a bi-directional build
+    bool need_bidirectional; // whether or not we need to force a bi-directional build
 
     DiracParam() :
       type(QUDA_INVALID_DIRAC),
@@ -64,7 +64,7 @@ namespace quda {
       tmp1(0),
       tmp2(0),
       halo_precision(QUDA_INVALID_PRECISION),
-      need_bidirectional(QUDA_BOOLEAN_INVALID)
+      need_bidirectional(false)
     {
       for (int i=0; i<QUDA_MAX_DIM; i++) commDim[i] = 1;
     }
@@ -813,7 +813,7 @@ public:
     double mu_factor;
     const Transfer *transfer; /** restrictor / prolongator defined here */
     const Dirac *dirac; /** Parent Dirac operator */
-    const QudaBoolean need_bidirectional; /** Whether or not to force a bi-directional build */
+    const bool need_bidirectional; /** Whether or not to force a bi-directional build */
 
     mutable cpuGaugeField *Y_h; /** CPU copy of the coarse link field */
     mutable cpuGaugeField *X_h; /** CPU copy of the coarse clover term */

--- a/include/enum_quda.h
+++ b/include/enum_quda.h
@@ -449,10 +449,14 @@ extern "C" {
   } QudaSetupType;
 
   typedef enum QudaBoolean_s {
-    QUDA_BOOLEAN_NO = 0,
-    QUDA_BOOLEAN_YES = 1,
+    QUDA_BOOLEAN_FALSE = 0,
+    QUDA_BOOLEAN_TRUE = 1,
     QUDA_BOOLEAN_INVALID = QUDA_INVALID_ENUM
   } QudaBoolean;
+
+  // define these for backwards compatibility
+#define QUDA_BOOLEAN_NO QUDA_BOOLEAN_FALSE
+#define QUDA_BOOLEAN_YES QUDA_BOOLEAN_TRUE
 
   typedef enum QudaDirection_s {
     QUDA_BACKWARDS = -1,

--- a/include/enum_quda_fortran.h
+++ b/include/enum_quda_fortran.h
@@ -400,9 +400,11 @@
 #define QUDA_INVALID_SETUP_TYPE QUDA_INVALID_ENUM
 
 #define QudaBoolean integer(4)
-#define QUDA_BOOLEAN_NO 0
-#define QUDA_BOOLEAN_YES 1
+#define QUDA_BOOLEAN_FALSE 0
+#define QUDA_BOOLEAN_TRUE 1
 #define QUDA_BOOLEAN_INVALID QUDA_INVALID_ENUM
+#define QUDA_BOOLEAN_NO QUDA_BOOLEAN_FALSE // backwards compatibility
+#define QUDA_BOOLEAN_YES QUDA_BOOLEAN_TRUE // backwards compatibility
 
 #define QudaDirection integer(4)
 #define QUDA_BACKWARDS -1

--- a/include/multigrid.h
+++ b/include/multigrid.h
@@ -446,7 +446,7 @@ public:
    */
   void CoarseCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T, const GaugeField &gauge,
                       const GaugeField &clover, const GaugeField &cloverInv, double kappa, double mu, double mu_factor,
-                      QudaDiracType dirac, QudaMatPCType matpc, QudaBoolean need_bidirectional);
+                      QudaDiracType dirac, QudaMatPCType matpc, bool need_bidirectional);
 
   /**
      @brief Calculate preconditioned coarse links and coarse clover inverse field

--- a/lib/check_params.h
+++ b/lib/check_params.h
@@ -145,14 +145,14 @@ void printQudaEigParam(QudaEigParam *param) {
 #endif
 
 #if defined INIT_PARAM
-  P(use_poly_acc, QUDA_BOOLEAN_NO);
+  P(use_poly_acc, QUDA_BOOLEAN_FALSE);
   P(poly_deg, 0);
   P(a_min, 0.0);
   P(a_max, 0.0);
-  P(use_dagger, QUDA_BOOLEAN_NO);
-  P(use_norm_op, QUDA_BOOLEAN_NO);
-  P(compute_svd, QUDA_BOOLEAN_NO);
-  P(require_convergence, QUDA_BOOLEAN_YES);
+  P(use_dagger, QUDA_BOOLEAN_FALSE);
+  P(use_norm_op, QUDA_BOOLEAN_FALSE);
+  P(compute_svd, QUDA_BOOLEAN_FALSE);
+  P(require_convergence, QUDA_BOOLEAN_TRUE);
   P(spectrum, QUDA_SPECTRUM_LR_EIG);
   P(nEv, 0);
   P(nKr, 0);
@@ -160,7 +160,7 @@ void printQudaEigParam(QudaEigParam *param) {
   P(tol, 0.0);
   P(check_interval, 0);
   P(max_restarts, 0);
-  P(arpack_check, QUDA_BOOLEAN_NO);
+  P(arpack_check, QUDA_BOOLEAN_FALSE);
   P(nk, 0);
   P(np, 0);
   P(eig_type, QUDA_EIG_TR_LANCZOS);
@@ -622,13 +622,13 @@ void printQudaMultigridParam(QudaMultigridParam *param) {
 #endif
 
 #ifdef INIT_PARAM
-  P(pre_orthonormalize, QUDA_BOOLEAN_NO);
+  P(pre_orthonormalize, QUDA_BOOLEAN_FALSE);
 #else
   P(pre_orthonormalize, QUDA_BOOLEAN_INVALID);
 #endif
 
 #ifdef INIT_PARAM
-  P(post_orthonormalize, QUDA_BOOLEAN_YES);
+  P(post_orthonormalize, QUDA_BOOLEAN_TRUE);
 #else
   P(post_orthonormalize, QUDA_BOOLEAN_INVALID);
 #endif
@@ -650,7 +650,7 @@ void printQudaMultigridParam(QudaMultigridParam *param) {
     P(num_setup_iter[i], INVALID_INT);
 #endif
 #ifdef INIT_PARAM
-    P(use_eig_solver[i], QUDA_BOOLEAN_NO);
+    P(use_eig_solver[i], QUDA_BOOLEAN_FALSE);
 #else
     P(use_eig_solver[i], QUDA_BOOLEAN_INVALID);
 #endif
@@ -740,7 +740,7 @@ void printQudaMultigridParam(QudaMultigridParam *param) {
     P(coarse_solver_tol[i], INVALID_DOUBLE);
     P(smoother_tol[i], INVALID_DOUBLE);
 #ifdef INIT_PARAM
-    P(global_reduction[i], QUDA_BOOLEAN_YES);
+    P(global_reduction[i], QUDA_BOOLEAN_TRUE);
 #else
     P(global_reduction[i], QUDA_BOOLEAN_INVALID);
 #endif
@@ -756,7 +756,7 @@ void printQudaMultigridParam(QudaMultigridParam *param) {
   }
 
 #ifdef INIT_PARAM
-  P(setup_minimize_memory, QUDA_BOOLEAN_NO);
+  P(setup_minimize_memory, QUDA_BOOLEAN_FALSE);
 #else
   P(setup_minimize_memory, QUDA_BOOLEAN_INVALID);
 #endif
@@ -767,7 +767,7 @@ void printQudaMultigridParam(QudaMultigridParam *param) {
 #ifdef CHECK_PARAM
   // if only doing top-level null-space generation, check that n_vec
   // is equal on all levels
-  if (param->generate_all_levels == QUDA_BOOLEAN_NO && param->compute_null_vector == QUDA_COMPUTE_NULL_VECTOR_YES) {
+  if (param->generate_all_levels == QUDA_BOOLEAN_FALSE && param->compute_null_vector == QUDA_COMPUTE_NULL_VECTOR_YES) {
     for (int i=1; i<n_level-1; i++)
       if (param->n_vec[0] != param->n_vec[i])
 	errorQuda("n_vec %d != %d must be equal on all levels if generate_all_levels == false",
@@ -778,9 +778,9 @@ void printQudaMultigridParam(QudaMultigridParam *param) {
   P(run_verify, QUDA_BOOLEAN_INVALID);
 
 #ifdef INIT_PARAM
-  P(run_low_mode_check, QUDA_BOOLEAN_NO);
-  P(run_oblique_proj_check, QUDA_BOOLEAN_NO);
-  P(coarse_guess, QUDA_BOOLEAN_NO);
+  P(run_low_mode_check, QUDA_BOOLEAN_FALSE);
+  P(run_oblique_proj_check, QUDA_BOOLEAN_FALSE);
+  P(coarse_guess, QUDA_BOOLEAN_FALSE);
 #else
   P(run_low_mode_check, QUDA_BOOLEAN_INVALID);
   P(run_oblique_proj_check, QUDA_BOOLEAN_INVALID);
@@ -792,8 +792,8 @@ void printQudaMultigridParam(QudaMultigridParam *param) {
     P(vec_load[i], QUDA_BOOLEAN_INVALID);
     P(vec_store[i], QUDA_BOOLEAN_INVALID);
 #else
-    P(vec_load[i], QUDA_BOOLEAN_NO);
-    P(vec_store[i], QUDA_BOOLEAN_NO);
+    P(vec_load[i], QUDA_BOOLEAN_FALSE);
+    P(vec_store[i], QUDA_BOOLEAN_FALSE);
 #endif
   }
 

--- a/lib/check_params.h
+++ b/lib/check_params.h
@@ -776,12 +776,14 @@ void printQudaMultigridParam(QudaMultigridParam *param) {
 #endif
 
   P(run_verify, QUDA_BOOLEAN_INVALID);
-  P(run_low_mode_check, QUDA_BOOLEAN_INVALID);
-  P(run_oblique_proj_check, QUDA_BOOLEAN_INVALID);
 
 #ifdef INIT_PARAM
+  P(run_low_mode_check, QUDA_BOOLEAN_NO);
+  P(run_oblique_proj_check, QUDA_BOOLEAN_NO);
   P(coarse_guess, QUDA_BOOLEAN_NO);
 #else
+  P(run_low_mode_check, QUDA_BOOLEAN_INVALID);
+  P(run_oblique_proj_check, QUDA_BOOLEAN_INVALID);
   P(coarse_guess, QUDA_BOOLEAN_INVALID);
 #endif
 

--- a/lib/coarse_op.cu
+++ b/lib/coarse_op.cu
@@ -18,8 +18,8 @@ namespace quda {
 
     QudaFieldLocation location = Y.Location();
 
-    QudaBoolean need_bidirectional = QUDA_BOOLEAN_NO;
-    if (dirac == QUDA_CLOVERPC_DIRAC || dirac == QUDA_TWISTED_MASSPC_DIRAC || dirac == QUDA_TWISTED_CLOVERPC_DIRAC) { need_bidirectional = QUDA_BOOLEAN_YES; }
+    bool need_bidirectional = false;
+    if (dirac == QUDA_CLOVERPC_DIRAC || dirac == QUDA_TWISTED_MASSPC_DIRAC || dirac == QUDA_TWISTED_CLOVERPC_DIRAC) { need_bidirectional = QUDA_BOOLEAN_TRUE; }
 
     if (location == QUDA_CPU_FIELD_LOCATION) {
 

--- a/lib/coarse_op.cuh
+++ b/lib/coarse_op.cuh
@@ -872,7 +872,7 @@ namespace quda {
 		  GaugeField &Y_, GaugeField &X_, GaugeField &Y_atomic_, GaugeField &X_atomic_,
                   ColorSpinorField &uv, ColorSpinorField &av, const ColorSpinorField &v,
 		  double kappa, double mu, double mu_factor, QudaDiracType dirac, QudaMatPCType matpc,
-		  QudaBoolean need_bidirectional, const int *fine_to_coarse, const int *coarse_to_fine) {
+		  bool need_bidirectional, const int *fine_to_coarse, const int *coarse_to_fine) {
 
     // sanity checks
     if (matpc == QUDA_MATPC_EVEN_EVEN_ASYMMETRIC || matpc == QUDA_MATPC_ODD_ODD_ASYMMETRIC)
@@ -904,7 +904,7 @@ namespace quda {
     // If doing a preconditioned operator with a clover term then we
     // have bi-directional links, though we can do the bidirectional setup for all operators for debugging
     bool bidirectional_links = (dirac == QUDA_CLOVERPC_DIRAC || dirac == QUDA_COARSEPC_DIRAC || bidirectional_debug ||
-				dirac == QUDA_TWISTED_MASSPC_DIRAC || dirac == QUDA_TWISTED_CLOVERPC_DIRAC || need_bidirectional == QUDA_BOOLEAN_YES);
+				dirac == QUDA_TWISTED_MASSPC_DIRAC || dirac == QUDA_TWISTED_CLOVERPC_DIRAC || need_bidirectional);
 
     if (getVerbosity() >= QUDA_VERBOSE) {
       if (bidirectional_links) printfQuda("Doing bi-directional link coarsening\n");

--- a/lib/coarsecoarse_op.cu
+++ b/lib/coarsecoarse_op.cu
@@ -14,7 +14,7 @@ namespace quda {
   void calculateYcoarse(GaugeField &Y, GaugeField &X, GaugeField &Yatomic, GaugeField &Xatomic,
 			ColorSpinorField &uv, const Transfer &T, const GaugeField &g, const GaugeField &clover,
 			const GaugeField &cloverInv, double kappa, double mu, double mu_factor, QudaDiracType dirac, QudaMatPCType matpc,
-                        QudaBoolean need_bidirectional) {
+                        bool need_bidirectional) {
 
     if (Y.Location() == QUDA_CPU_FIELD_LOCATION) {
 
@@ -92,7 +92,7 @@ namespace quda {
   template <typename Float, typename vFloat, int fineColor, int fineSpin>
   void calculateYcoarse(GaugeField &Y, GaugeField &X, GaugeField &Yatomic, GaugeField &Xatomic,
 			ColorSpinorField &uv, const Transfer &T, const GaugeField &g, const GaugeField &clover,
-			const GaugeField &cloverInv, double kappa, double mu, double mu_factor, QudaDiracType dirac, QudaMatPCType matpc, QudaBoolean need_bidirectional) {
+			const GaugeField &cloverInv, double kappa, double mu, double mu_factor, QudaDiracType dirac, QudaMatPCType matpc, bool need_bidirectional) {
     if (T.Vectors().Nspin()/T.Spin_bs() != 2) 
       errorQuda("Unsupported number of coarse spins %d\n",T.Vectors().Nspin()/T.Spin_bs());
     const int coarseSpin = 2;
@@ -119,7 +119,7 @@ namespace quda {
   template <typename Float, typename vFloat, int fineColor>
   void calculateYcoarse(GaugeField &Y, GaugeField &X, GaugeField &Yatomic, GaugeField &Xatomic,
 			ColorSpinorField &uv, const Transfer &T, const GaugeField &g, const GaugeField &clover,
-			const GaugeField &cloverInv, double kappa, double mu, double mu_factor, QudaDiracType dirac, QudaMatPCType matpc, QudaBoolean need_bidirectional) {
+			const GaugeField &cloverInv, double kappa, double mu, double mu_factor, QudaDiracType dirac, QudaMatPCType matpc, bool need_bidirectional) {
     if (T.Vectors().Nspin() == 2) {
       calculateYcoarse<Float,vFloat,fineColor,2>(Y, X, Yatomic, Xatomic, uv, T, g, clover, cloverInv, kappa, mu, mu_factor, dirac, matpc, need_bidirectional);
     } else {
@@ -131,7 +131,7 @@ namespace quda {
   template <typename Float, typename vFloat>
   void calculateYcoarse(GaugeField &Y, GaugeField &X, GaugeField &Yatomic, GaugeField &Xatomic,
 			ColorSpinorField &uv, const Transfer &T, const GaugeField &g, const GaugeField &clover,
-			const GaugeField &cloverInv, double kappa, double mu, double mu_factor, QudaDiracType dirac, QudaMatPCType matpc, QudaBoolean need_bidirectional) {
+			const GaugeField &cloverInv, double kappa, double mu, double mu_factor, QudaDiracType dirac, QudaMatPCType matpc, bool need_bidirectional) {
     if (g.Ncolor()/T.Vectors().Nspin() == 6) { // free field Wilson
       calculateYcoarse<Float,vFloat,6>(Y, X, Yatomic, Xatomic, uv, T, g, clover, cloverInv, kappa, mu, mu_factor, dirac, matpc, need_bidirectional);
 #if 0
@@ -152,7 +152,7 @@ namespace quda {
   //Does the heavy lifting of creating the coarse color matrices Y
   void calculateYcoarse(GaugeField &Y, GaugeField &X, GaugeField &Yatomic, GaugeField &Xatomic, ColorSpinorField &uv,
 			const Transfer &T, const GaugeField &g, const GaugeField &clover, const GaugeField &cloverInv,
-			double kappa, double mu, double mu_factor, QudaDiracType dirac, QudaMatPCType matpc, QudaBoolean need_bidirectional) {
+			double kappa, double mu, double mu_factor, QudaDiracType dirac, QudaMatPCType matpc, bool need_bidirectional) {
     checkPrecision(X, Y, g, clover, cloverInv, uv, T.Vectors(X.Location()));
     checkPrecision(Xatomic, Yatomic);
 
@@ -192,7 +192,7 @@ namespace quda {
   void CoarseCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T,
 		      const GaugeField &gauge, const GaugeField &clover, const GaugeField &cloverInv,
 		      double kappa, double mu, double mu_factor, QudaDiracType dirac, QudaMatPCType matpc,
-                      QudaBoolean need_bidirectional) {
+                      bool need_bidirectional) {
 
 #ifdef GPU_MULTIGRID
     QudaPrecision precision = Y.Precision();

--- a/lib/dirac_coarse.cpp
+++ b/lib/dirac_coarse.cpp
@@ -39,7 +39,7 @@ namespace quda {
     mu_factor(param.mu_factor),
     transfer(nullptr),
     dirac(nullptr),
-    need_bidirectional(QUDA_BOOLEAN_NO),
+    need_bidirectional(false),
     Y_h(Y_h),
     X_h(X_h),
     Xinv_h(Xinv_h),
@@ -527,11 +527,11 @@ namespace quda {
     if (checkLocation(Y, X) == QUDA_CPU_FIELD_LOCATION) {
       initializeLazy(QUDA_CPU_FIELD_LOCATION);
       CoarseCoarseOp(Y, X, T, *(this->Yhat_h), *(this->X_h), *(this->Xinv_h), kappa, a, -mu_factor, QUDA_COARSEPC_DIRAC,
-                     matpcType, QUDA_BOOLEAN_YES);
+                     matpcType, true);
     } else {
       initializeLazy(QUDA_CUDA_FIELD_LOCATION);
       CoarseCoarseOp(Y, X, T, *(this->Yhat_d), *(this->X_d), *(this->Xinv_d), kappa, a, -mu_factor, QUDA_COARSEPC_DIRAC,
-                     matpcType, QUDA_BOOLEAN_YES);
+                     matpcType, true);
     }
   }
 

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -2606,7 +2606,7 @@ multigrid_solver::multigrid_solver(QudaMultigridParam &mg_param, TimeProfile &pr
   Bprec = (mg_param.setup_location[0] == QUDA_CPU_FIELD_LOCATION && Bprec < QUDA_SINGLE_PRECISION ? QUDA_SINGLE_PRECISION : Bprec);
   csParam.setPrecision(Bprec);
   csParam.fieldOrder = mg_param.setup_location[0] == QUDA_CUDA_FIELD_LOCATION ? QUDA_FLOAT2_FIELD_ORDER : QUDA_SPACE_SPIN_COLOR_FIELD_ORDER;
-  csParam.mem_type = mg_param.setup_minimize_memory == QUDA_BOOLEAN_YES ? QUDA_MEMORY_MAPPED : QUDA_MEMORY_DEVICE;
+  csParam.mem_type = mg_param.setup_minimize_memory == QUDA_BOOLEAN_TRUE ? QUDA_MEMORY_MAPPED : QUDA_MEMORY_DEVICE;
   B.resize(mg_param.n_vec[0]);
   for (int i = 0; i < mg_param.n_vec[0]; i++) { B[i] = ColorSpinorField::Create(csParam); }
 

--- a/lib/inv_mr_quda.cpp
+++ b/lib/inv_mr_quda.cpp
@@ -114,7 +114,7 @@ namespace quda {
 	commGlobalReductionSet(param.global_reduction); // use local reductions for DD solver
 
 	blas::zero(xSloppy);  // can get rid of this for a special first update kernel
-	double c2 = param.global_reduction == QUDA_BOOLEAN_YES ? r2 : blas::norm2(r);  // c2 holds the initial r2
+	double c2 = param.global_reduction == QUDA_BOOLEAN_TRUE ? r2 : blas::norm2(r);  // c2 holds the initial r2
 	scale = c2 > 0.0 ? sqrt(c2) : 1.0;
 
 	// domain-wise normalization of the initial residual to prevent underflow

--- a/lib/milc_interface.cpp
+++ b/lib/milc_interface.cpp
@@ -761,14 +761,14 @@ void setDeflationParam(QudaPrecision ritz_prec, QudaFieldLocation location_ritz,
                        QudaExtLibType deflation_ext_lib, char vec_infile[], char vec_outfile[], QudaEigParam *df_param)
 {
 
-  df_param->import_vectors = strcmp(vec_infile,"") ? QUDA_BOOLEAN_YES : QUDA_BOOLEAN_NO;
+  df_param->import_vectors = strcmp(vec_infile,"") ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
 
   df_param->cuda_prec_ritz = ritz_prec;
   df_param->location       = location_ritz;
   df_param->mem_type_ritz  = mem_type_ritz;
 
 
-  df_param->run_verify     = QUDA_BOOLEAN_NO;
+  df_param->run_verify     = QUDA_BOOLEAN_FALSE;
 
   df_param->nk       = df_param->invert_param->nev;
   df_param->np       = df_param->invert_param->nev*df_param->invert_param->deflation_grid;

--- a/lib/multigrid.cpp
+++ b/lib/multigrid.cpp
@@ -78,7 +78,7 @@ namespace quda
 
     if (param.level < param.Nlevel-1) {
       if (param.mg_global.compute_null_vector == QUDA_COMPUTE_NULL_VECTOR_YES) {
-        if (param.mg_global.generate_all_levels == QUDA_BOOLEAN_YES || param.level == 0) {
+        if (param.mg_global.generate_all_levels == QUDA_BOOLEAN_TRUE || param.level == 0) {
 
           // Initializing to random vectors
           for(int i=0; i<(int)param.B.size(); i++) {
@@ -100,7 +100,7 @@ namespace quda
       } else if (strcmp(param.mg_global.vec_infile[param.level], "")
                  != 0) { // only load if infile is defined and not computing
         if ( param.mg_global.num_setup_iter[param.level] > 0 ) generateNullVectors(param.B);
-      } else if (param.mg_global.vec_load[param.level] == QUDA_BOOLEAN_YES) { // only conditional load of null vectors
+      } else if (param.mg_global.vec_load[param.level] == QUDA_BOOLEAN_TRUE) { // only conditional load of null vectors
 
         loadVectors(param.B);
       } else { // generate free field vectors
@@ -172,7 +172,7 @@ namespace quda
           (*B_coarse)[i] = param.B[0]->CreateCoarse(param.geoBlockSize, param.spinBlockSize, param.Nvec, B_coarse_precision, param.mg_global.setup_location[param.level+1]);
 
         // if we're not generating on all levels then we need to propagate the vectors down
-        if (param.mg_global.generate_all_levels == QUDA_BOOLEAN_NO) {
+        if (param.mg_global.generate_all_levels == QUDA_BOOLEAN_FALSE) {
           if (getVerbosity() >= QUDA_VERBOSE) printfQuda("Restricting null space vectors\n");
           for (int i=0; i<param.Nvec; i++) {
             zero(*(*B_coarse)[i]);
@@ -350,11 +350,11 @@ namespace quda
 
     // Need to figure out if we need to force bi-directional build. If any previous level (incl this one) was
     // preconditioned, we have to force bi-directional builds.
-    diracParam.need_bidirectional = QUDA_BOOLEAN_NO;
+    diracParam.need_bidirectional = QUDA_BOOLEAN_FALSE;
     for (int i = 0; i <= param.level; i++) {
       if (param.mg_global.coarse_grid_solution_type[i] == QUDA_MATPC_SOLUTION
           && param.mg_global.smoother_solve_type[i] == QUDA_DIRECT_PC_SOLVE) {
-        diracParam.need_bidirectional = QUDA_BOOLEAN_YES;
+        diracParam.need_bidirectional = QUDA_BOOLEAN_TRUE;
       }
     }
 
@@ -370,7 +370,7 @@ namespace quda
     // use even-odd preconditioning for the coarse grid solver
     if (diracCoarseResidual) delete diracCoarseResidual;
     diracCoarseResidual = new DiracCoarse(diracParam, param.setup_location == QUDA_CUDA_FIELD_LOCATION ? true : false,
-                                          param.mg_global.setup_minimize_memory == QUDA_BOOLEAN_YES ? true : false);
+                                          param.mg_global.setup_minimize_memory == QUDA_BOOLEAN_TRUE ? true : false);
 
     // create smoothing operators
     diracParam.dirac = const_cast<Dirac*>(param.matSmooth->Expose());
@@ -457,10 +457,10 @@ namespace quda
       // on the coarsest level, and we are on the next to coarsest level.
       if (param.mg_global.use_eig_solver[param.Nlevel - 1] && (param.level == param.Nlevel - 2)) {
         param_coarse_solver->eig_param = *param.mg_global.eig_param[param.Nlevel - 1];
-        param_coarse_solver->deflate = QUDA_BOOLEAN_YES;
+        param_coarse_solver->deflate = QUDA_BOOLEAN_TRUE;
         // Due to coherence between these levels, an initial guess
         // might be beneficial.
-        if (param.mg_global.coarse_guess == QUDA_BOOLEAN_YES) {
+        if (param.mg_global.coarse_guess == QUDA_BOOLEAN_TRUE) {
           param_coarse_solver->use_init_guess = QUDA_USE_INIT_GUESS_YES;
         }
 
@@ -473,7 +473,7 @@ namespace quda
         }
 
         if (strcmp(param_coarse_solver->eig_param.vec_infile, "") == 0 && // check that input file not already set
-            param.mg_global.vec_load[param.level + 1] == QUDA_BOOLEAN_YES
+            param.mg_global.vec_load[param.level + 1] == QUDA_BOOLEAN_TRUE
             && (strcmp(param.mg_global.vec_infile[param.level + 1], "") != 0)) {
           std::string vec_infile(param.mg_global.vec_infile[param.level + 1]);
           vec_infile += "_level_";
@@ -484,7 +484,7 @@ namespace quda
         }
 
         if (strcmp(param_coarse_solver->eig_param.vec_outfile, "") == 0 && // check that output file not already set
-            param.mg_global.vec_store[param.level + 1] == QUDA_BOOLEAN_YES
+            param.mg_global.vec_store[param.level + 1] == QUDA_BOOLEAN_TRUE
             && (strcmp(param.mg_global.vec_outfile[param.level + 1], "") != 0)) {
           std::string vec_outfile(param.mg_global.vec_outfile[param.level + 1]);
           vec_outfile += "_level_";
@@ -1193,7 +1193,7 @@ namespace quda
           resetTransfer = true;
           reset();
           if ( param.level < param.Nlevel-2 ) {
-            if ( param.mg_global.generate_all_levels == QUDA_BOOLEAN_YES ) {
+            if ( param.mg_global.generate_all_levels == QUDA_BOOLEAN_TRUE ) {
               coarse->generateNullVectors(*B_coarse, refresh);
             } else {
               if (getVerbosity() >= QUDA_VERBOSE) printfQuda("Restricting null space vectors\n");
@@ -1229,7 +1229,7 @@ namespace quda
       diracSmootherSloppy->setCommDim(commDim);
     }
 
-    if (param.mg_global.vec_store[param.level] == QUDA_BOOLEAN_YES) { // conditional store of null vectors
+    if (param.mg_global.vec_store[param.level] == QUDA_BOOLEAN_TRUE) { // conditional store of null vectors
       saveVectors(B);
     }
 

--- a/lib/quda_fortran.F90
+++ b/lib/quda_fortran.F90
@@ -217,6 +217,8 @@ module quda_fortran
 
      integer(8) :: deflation_op ! pointer to deflation instance
 
+     integer(8) :: eig_param ! pointer to eig parameter instance
+
      ! Dslash used in the inner Krylov solver
      QudaDslashType :: dslash_type_precondition
 

--- a/tests/deflated_invert_test.cpp
+++ b/tests/deflated_invert_test.cpp
@@ -286,8 +286,8 @@ void setInvertParam(QudaInvertParam &inv_param) {
 
 void setDeflationParam(QudaEigParam &df_param) {
 
-  df_param.import_vectors = QUDA_BOOLEAN_NO;
-  df_param.run_verify     = QUDA_BOOLEAN_NO;
+  df_param.import_vectors = QUDA_BOOLEAN_FALSE;
+  df_param.run_verify     = QUDA_BOOLEAN_FALSE;
 
   df_param.nk             = df_param.invert_param->nev;
   df_param.np             = df_param.invert_param->nev*df_param.invert_param->deflation_grid;

--- a/tests/eigensolve_test.cpp
+++ b/tests/eigensolve_test.cpp
@@ -304,25 +304,25 @@ void setEigParam(QudaEigParam &eig_param)
   eig_param.nEv = eig_nEv;
   eig_param.nKr = eig_nKr;
   eig_param.tol = eig_tol;
-  eig_param.require_convergence = eig_require_convergence ? QUDA_BOOLEAN_YES : QUDA_BOOLEAN_NO;
+  eig_param.require_convergence = eig_require_convergence ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
   eig_param.check_interval = eig_check_interval;
   eig_param.max_restarts = eig_max_restarts;
   eig_param.cuda_prec_ritz = cuda_prec;
 
-  eig_param.use_norm_op = eig_use_normop ? QUDA_BOOLEAN_YES : QUDA_BOOLEAN_NO;
-  eig_param.use_dagger = eig_use_dagger ? QUDA_BOOLEAN_YES : QUDA_BOOLEAN_NO;
-  eig_param.compute_svd = eig_compute_svd ? QUDA_BOOLEAN_YES : QUDA_BOOLEAN_NO;
+  eig_param.use_norm_op = eig_use_normop ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
+  eig_param.use_dagger = eig_use_dagger ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
+  eig_param.compute_svd = eig_compute_svd ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
   if (eig_compute_svd) {
-    eig_param.use_dagger = QUDA_BOOLEAN_NO;
-    eig_param.use_norm_op = QUDA_BOOLEAN_YES;
+    eig_param.use_dagger = QUDA_BOOLEAN_FALSE;
+    eig_param.use_norm_op = QUDA_BOOLEAN_TRUE;
   }
 
-  eig_param.use_poly_acc = eig_use_poly_acc ? QUDA_BOOLEAN_YES : QUDA_BOOLEAN_NO;
+  eig_param.use_poly_acc = eig_use_poly_acc ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
   eig_param.poly_deg = eig_poly_deg;
   eig_param.a_min = eig_amin;
   eig_param.a_max = eig_amax;
 
-  eig_param.arpack_check = eig_arpack_check ? QUDA_BOOLEAN_YES : QUDA_BOOLEAN_NO;
+  eig_param.arpack_check = eig_arpack_check ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
   strcpy(eig_param.arpack_logfile, eig_arpack_logfile);
   strcpy(eig_param.QUDA_logfile, eig_QUDA_logfile);
 

--- a/tests/multigrid_evolve_test.cpp
+++ b/tests/multigrid_evolve_test.cpp
@@ -330,7 +330,7 @@ void setMultigridParam(QudaMultigridParam &mg_param) {
     mg_param.smoother_schwarz_type[i] = schwarz_type[i];
 
     // if using Schwarz preconditioning then use local reductions only
-    mg_param.global_reduction[i] = (schwarz_type[i] == QUDA_INVALID_SCHWARZ) ? QUDA_BOOLEAN_YES : QUDA_BOOLEAN_NO;
+    mg_param.global_reduction[i] = (schwarz_type[i] == QUDA_INVALID_SCHWARZ) ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
 
     // set number of Schwarz cycles to apply
     mg_param.smoother_schwarz_cycle[i] = schwarz_cycle[i];
@@ -413,22 +413,22 @@ void setMultigridParam(QudaMultigridParam &mg_param) {
   mg_param.spin_block_size[0] = 2;
 
   mg_param.setup_type = setup_type;
-  mg_param.pre_orthonormalize = pre_orthonormalize ? QUDA_BOOLEAN_YES :  QUDA_BOOLEAN_NO;
-  mg_param.post_orthonormalize = post_orthonormalize ? QUDA_BOOLEAN_YES :  QUDA_BOOLEAN_NO;
+  mg_param.pre_orthonormalize = pre_orthonormalize ? QUDA_BOOLEAN_TRUE :  QUDA_BOOLEAN_FALSE;
+  mg_param.post_orthonormalize = post_orthonormalize ? QUDA_BOOLEAN_TRUE :  QUDA_BOOLEAN_FALSE;
 
   mg_param.compute_null_vector = generate_nullspace ? QUDA_COMPUTE_NULL_VECTOR_YES
     : QUDA_COMPUTE_NULL_VECTOR_NO;
 
-  mg_param.generate_all_levels = generate_all_levels ? QUDA_BOOLEAN_YES :  QUDA_BOOLEAN_NO;
+  mg_param.generate_all_levels = generate_all_levels ? QUDA_BOOLEAN_TRUE :  QUDA_BOOLEAN_FALSE;
 
-  mg_param.run_verify = verify_results ? QUDA_BOOLEAN_YES : QUDA_BOOLEAN_NO;
+  mg_param.run_verify = verify_results ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
 
   // set file i/o parameters
   for (int i = 0; i < mg_param.n_level; i++) {
     strcpy(mg_param.vec_infile[i], mg_vec_infile[i]);
     strcpy(mg_param.vec_outfile[i], mg_vec_outfile[i]);
-    if (strcmp(mg_param.vec_infile[i], "") != 0) mg_param.vec_load[i] = QUDA_BOOLEAN_YES;
-    if (strcmp(mg_param.vec_outfile[i], "") != 0) mg_param.vec_store[i] = QUDA_BOOLEAN_YES;
+    if (strcmp(mg_param.vec_infile[i], "") != 0) mg_param.vec_load[i] = QUDA_BOOLEAN_TRUE;
+    if (strcmp(mg_param.vec_outfile[i], "") != 0) mg_param.vec_store[i] = QUDA_BOOLEAN_TRUE;
   }
 
   // these need to tbe set for now but are actually ignored by the MG setup

--- a/tests/multigrid_invert_test.cpp
+++ b/tests/multigrid_invert_test.cpp
@@ -246,18 +246,18 @@ void setEigParam(QudaEigParam &mg_eig_param, int level)
   mg_eig_param.nEv = mg_eig_nEv[level];
   mg_eig_param.nKr = mg_eig_nKr[level];
   mg_eig_param.nConv = nvec[level];
-  mg_eig_param.require_convergence = mg_eig_require_convergence[level] ? QUDA_BOOLEAN_YES : QUDA_BOOLEAN_NO;
+  mg_eig_param.require_convergence = mg_eig_require_convergence[level] ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
 
   mg_eig_param.tol = mg_eig_tol[level];
   mg_eig_param.check_interval = mg_eig_check_interval[level];
   mg_eig_param.max_restarts = mg_eig_max_restarts[level];
   mg_eig_param.cuda_prec_ritz = cuda_prec;
 
-  mg_eig_param.compute_svd = QUDA_BOOLEAN_NO;
-  mg_eig_param.use_norm_op = mg_eig_use_normop[level] ? QUDA_BOOLEAN_YES : QUDA_BOOLEAN_NO;
-  mg_eig_param.use_dagger = mg_eig_use_dagger[level] ? QUDA_BOOLEAN_YES : QUDA_BOOLEAN_NO;
+  mg_eig_param.compute_svd = QUDA_BOOLEAN_FALSE;
+  mg_eig_param.use_norm_op = mg_eig_use_normop[level] ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
+  mg_eig_param.use_dagger = mg_eig_use_dagger[level] ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
 
-  mg_eig_param.use_poly_acc = mg_eig_use_poly_acc[level] ? QUDA_BOOLEAN_YES : QUDA_BOOLEAN_NO;
+  mg_eig_param.use_poly_acc = mg_eig_use_poly_acc[level] ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
   mg_eig_param.poly_deg = mg_eig_poly_deg[level];
   mg_eig_param.a_min = mg_eig_amin[level];
   mg_eig_param.a_max = mg_eig_amax[level];
@@ -337,7 +337,7 @@ void setMultigridParam(QudaMultigridParam &mg_param)
       // if not defined use 4
       mg_param.geo_block_size[i][j] = geo_block_size[i][j] ? geo_block_size[i][j] : 4;
     }
-    mg_param.use_eig_solver[i] = mg_eig[i] ? QUDA_BOOLEAN_YES : QUDA_BOOLEAN_NO;
+    mg_param.use_eig_solver[i] = mg_eig[i] ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
     mg_param.verbosity[i] = mg_verbosity[i];
     mg_param.setup_inv_type[i] = setup_inv[i];
     mg_param.num_setup_iter[i] = num_setup_iter[i];
@@ -393,7 +393,7 @@ void setMultigridParam(QudaMultigridParam &mg_param)
     mg_param.smoother_schwarz_type[i] = schwarz_type[i];
 
     // if using Schwarz preconditioning then use local reductions only
-    mg_param.global_reduction[i] = (schwarz_type[i] == QUDA_INVALID_SCHWARZ) ? QUDA_BOOLEAN_YES : QUDA_BOOLEAN_NO;
+    mg_param.global_reduction[i] = (schwarz_type[i] == QUDA_INVALID_SCHWARZ) ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
 
     // set number of Schwarz cycles to apply
     mg_param.smoother_schwarz_cycle[i] = schwarz_cycle[i];
@@ -473,33 +473,33 @@ void setMultigridParam(QudaMultigridParam &mg_param)
   }
 
   // whether to run GPU setup but putting temporaries into mapped (slow CPU) memory
-  mg_param.setup_minimize_memory = QUDA_BOOLEAN_NO;
+  mg_param.setup_minimize_memory = QUDA_BOOLEAN_FALSE;
 
   // only coarsen the spin on the first restriction
   mg_param.spin_block_size[0] = 2;
 
   mg_param.setup_type = setup_type;
-  mg_param.pre_orthonormalize = pre_orthonormalize ? QUDA_BOOLEAN_YES :  QUDA_BOOLEAN_NO;
-  mg_param.post_orthonormalize = post_orthonormalize ? QUDA_BOOLEAN_YES :  QUDA_BOOLEAN_NO;
+  mg_param.pre_orthonormalize = pre_orthonormalize ? QUDA_BOOLEAN_TRUE :  QUDA_BOOLEAN_FALSE;
+  mg_param.post_orthonormalize = post_orthonormalize ? QUDA_BOOLEAN_TRUE :  QUDA_BOOLEAN_FALSE;
 
   mg_param.compute_null_vector = generate_nullspace ? QUDA_COMPUTE_NULL_VECTOR_YES
     : QUDA_COMPUTE_NULL_VECTOR_NO;
 
-  mg_param.generate_all_levels = generate_all_levels ? QUDA_BOOLEAN_YES :  QUDA_BOOLEAN_NO;
+  mg_param.generate_all_levels = generate_all_levels ? QUDA_BOOLEAN_TRUE :  QUDA_BOOLEAN_FALSE;
 
-  mg_param.run_verify = verify_results ? QUDA_BOOLEAN_YES : QUDA_BOOLEAN_NO;
-  mg_param.run_low_mode_check = low_mode_check ? QUDA_BOOLEAN_YES : QUDA_BOOLEAN_NO;
-  mg_param.run_oblique_proj_check = oblique_proj_check ? QUDA_BOOLEAN_YES : QUDA_BOOLEAN_NO;
+  mg_param.run_verify = verify_results ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
+  mg_param.run_low_mode_check = low_mode_check ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
+  mg_param.run_oblique_proj_check = oblique_proj_check ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
 
   // set file i/o parameters
   for (int i = 0; i < mg_param.n_level; i++) {
     strcpy(mg_param.vec_infile[i], mg_vec_infile[i]);
     strcpy(mg_param.vec_outfile[i], mg_vec_outfile[i]);
-    if (strcmp(mg_param.vec_infile[i], "") != 0) mg_param.vec_load[i] = QUDA_BOOLEAN_YES;
-    if (strcmp(mg_param.vec_outfile[i], "") != 0) mg_param.vec_store[i] = QUDA_BOOLEAN_YES;
+    if (strcmp(mg_param.vec_infile[i], "") != 0) mg_param.vec_load[i] = QUDA_BOOLEAN_TRUE;
+    if (strcmp(mg_param.vec_outfile[i], "") != 0) mg_param.vec_store[i] = QUDA_BOOLEAN_TRUE;
   }
 
-  mg_param.coarse_guess = mg_eig_coarse_guess ? QUDA_BOOLEAN_YES : QUDA_BOOLEAN_NO;
+  mg_param.coarse_guess = mg_eig_coarse_guess ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
 
   // these need to tbe set for now but are actually ignored by the MG setup
   // needed to make it pass the initialization test
@@ -634,14 +634,14 @@ int main(int argc, char **argv)
     // Default eigensolver params
     mg_eig[i] = false;
     mg_eig_tol[i] = 1e-3;
-    mg_eig_require_convergence[i] = QUDA_BOOLEAN_YES;
+    mg_eig_require_convergence[i] = QUDA_BOOLEAN_TRUE;
     mg_eig_type[i] = QUDA_EIG_TR_LANCZOS;
     mg_eig_spectrum[i] = QUDA_SPECTRUM_SR_EIG;
     mg_eig_check_interval[i] = 5;
     mg_eig_max_restarts[i] = 100;
-    mg_eig_use_normop[i] = QUDA_BOOLEAN_NO;
-    mg_eig_use_dagger[i] = QUDA_BOOLEAN_NO;
-    mg_eig_use_poly_acc[i] = QUDA_BOOLEAN_YES;
+    mg_eig_use_normop[i] = QUDA_BOOLEAN_FALSE;
+    mg_eig_use_dagger[i] = QUDA_BOOLEAN_FALSE;
+    mg_eig_use_poly_acc[i] = QUDA_BOOLEAN_TRUE;
     mg_eig_poly_deg[i] = 100;
     mg_eig_amin[i] = 1.0;
     mg_eig_amax[i] = 5.0;

--- a/tests/staggered_eigensolve_test.cpp
+++ b/tests/staggered_eigensolve_test.cpp
@@ -295,25 +295,25 @@ void setEigParam(QudaEigParam &eig_param)
   eig_param.nEv = eig_nEv;
   eig_param.nKr = eig_nKr;
   eig_param.tol = eig_tol;
-  eig_param.require_convergence = eig_require_convergence ? QUDA_BOOLEAN_YES : QUDA_BOOLEAN_NO;
+  eig_param.require_convergence = eig_require_convergence ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
   eig_param.check_interval = eig_check_interval;
   eig_param.max_restarts = eig_max_restarts;
   eig_param.cuda_prec_ritz = prec;
 
-  eig_param.use_norm_op = eig_use_normop ? QUDA_BOOLEAN_YES : QUDA_BOOLEAN_NO;
-  eig_param.use_dagger = eig_use_dagger ? QUDA_BOOLEAN_YES : QUDA_BOOLEAN_NO;
-  eig_param.compute_svd = eig_compute_svd ? QUDA_BOOLEAN_YES : QUDA_BOOLEAN_NO;
+  eig_param.use_norm_op = eig_use_normop ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
+  eig_param.use_dagger = eig_use_dagger ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
+  eig_param.compute_svd = eig_compute_svd ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
   if (eig_compute_svd) {
-    eig_param.use_dagger = QUDA_BOOLEAN_NO;
-    eig_param.use_norm_op = QUDA_BOOLEAN_YES;
+    eig_param.use_dagger = QUDA_BOOLEAN_FALSE;
+    eig_param.use_norm_op = QUDA_BOOLEAN_TRUE;
   }
 
-  eig_param.use_poly_acc = eig_use_poly_acc ? QUDA_BOOLEAN_YES : QUDA_BOOLEAN_NO;
+  eig_param.use_poly_acc = eig_use_poly_acc ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
   eig_param.poly_deg = eig_poly_deg;
   eig_param.a_min = eig_amin;
   eig_param.a_max = eig_amax;
 
-  eig_param.arpack_check = eig_arpack_check ? QUDA_BOOLEAN_YES : QUDA_BOOLEAN_NO;
+  eig_param.arpack_check = eig_arpack_check ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
   strcpy(eig_param.arpack_logfile, eig_arpack_logfile);
   strcpy(eig_param.QUDA_logfile, eig_QUDA_logfile);
 


### PR DESCRIPTION
* Added valid default values for `QudaMultigridParam::run_low_mode_check` and `QudaMultigridParam::run_oblique_proj_check` to ensure these do not need to be set by the caller
* Fix Fortran interface (missing `eig_param` pointer in `QudaInvertParam`).  With this change in place, TIFR RHMC is now confirmed to work with QUDA 1.0.
* Renamed `QUDA_BOOLEAN_NO`->`QUDA_BOOLEAN_FALSE` and `QUDA_BOOLEAN_YES` to `QUDA_BOOLEAN_TRUE` with macros aliasing the old names to new names to preserve interface compatibility.

With this pull request, we may be done with QUDA 1.0.