### PR TITLE
Intermediately saving the tunecache during an MG setup

### DIFF
--- a/include/blas_cublas.h
+++ b/include/blas_cublas.h
@@ -25,7 +25,8 @@ namespace quda {
        @param[in] Location of the input/output data
        @return Number of flops done in this computation
     */
-    long long BatchInvertMatrix(void *Ainv, void* A, const int n, const uint64_t batch, QudaPrecision precision, QudaFieldLocation location);
+    long long BatchInvertMatrix(void *Ainv, void *A, const int n, const uint64_t batch, QudaPrecision precision,
+                                QudaFieldLocation location);
 
   } // namespace cublas
 

--- a/include/blas_cublas.h
+++ b/include/blas_cublas.h
@@ -25,7 +25,7 @@ namespace quda {
        @param[in] Location of the input/output data
        @return Number of flops done in this computation
     */
-    long long BatchInvertMatrix(void *Ainv, void* A, const int n, const int batch, QudaPrecision precision, QudaFieldLocation location);
+    long long BatchInvertMatrix(void *Ainv, void* A, const int n, const uint64_t batch, QudaPrecision precision, QudaFieldLocation location);
 
   } // namespace cublas
 

--- a/lib/blas_cublas.cu
+++ b/lib/blas_cublas.cu
@@ -51,7 +51,7 @@ namespace quda {
     }
 
     // FIXME do this in pipelined fashion to reduce memory overhead.
-    long long BatchInvertMatrix(void *Ainv, void* A, const int n, const int batch, QudaPrecision prec, QudaFieldLocation location)
+    long long BatchInvertMatrix(void *Ainv, void* A, const int n, const uint64_t batch, QudaPrecision prec, QudaFieldLocation location)
     {
       long long flops = 0;
 #ifdef CUBLAS_LIB

--- a/lib/blas_magma_nopiv.cu
+++ b/lib/blas_magma_nopiv.cu
@@ -93,7 +93,7 @@ void CloseMagma(){
 #define FLOPS_ZGETRI(n_) (6. * FMULS_GETRI((double)(n_)) + 2.0 * FADDS_GETRI((double)(n_)) )
 #define FLOPS_CGETRI(n_) (6. * FMULS_GETRI((double)(n_)) + 2.0 * FADDS_GETRI((double)(n_)) )
 
-void BlasMagmaArgs::BatchInvertMatrix(void *Ainv_h, void* A_h, const int n, const int batch, const int prec)
+void BlasMagmaArgs::BatchInvertMatrix(void *Ainv_h, void* A_h, const int n, const uint64_t batch, const int prec)
 {
 #ifdef MAGMA_LIB
   printfQuda("%s with n=%d and batch=%d\n", __func__, n, batch);

--- a/lib/dirac_coarse.cpp
+++ b/lib/dirac_coarse.cpp
@@ -194,6 +194,9 @@ namespace quda {
     if (gpu_setup) dirac->createCoarseOp(*Y_d,*X_d,*transfer,kappa,mass,Mu(),MuFactor());
     else dirac->createCoarseOp(*Y_h,*X_h,*transfer,kappa,mass,Mu(),MuFactor());
 
+    // save the intermediate tunecache after the UV and VUV tune
+    saveTuneCache();
+
     if (getVerbosity() >= QUDA_VERBOSE) printfQuda("About to build the preconditioned coarse clover\n");
 
     createYhat(gpu_setup);
@@ -205,6 +208,9 @@ namespace quda {
     else createPreconditionedCoarseOp(*Yhat_h,*Xinv_h,*Y_h,*X_h);
 
     if (getVerbosity() >= QUDA_VERBOSE) printfQuda("Finished creating the preconditioned coarse op\n");
+
+    // save the intermediate tunecache after the Yhat tune
+    saveTuneCache();
 
     if (gpu_setup) {
       enable_gpu = true;

--- a/lib/multigrid.cpp
+++ b/lib/multigrid.cpp
@@ -368,7 +368,7 @@ namespace quda
     if (diracCoarseResidual) delete diracCoarseResidual;
     diracCoarseResidual = new DiracCoarse(diracParam, param.setup_location == QUDA_CUDA_FIELD_LOCATION ? true : false,
                                           param.mg_global.setup_minimize_memory == QUDA_BOOLEAN_TRUE ? true : false);
-  
+
     // create smoothing operators
     diracParam.dirac = const_cast<Dirac*>(param.matSmooth->Expose());
     diracParam.halo_precision = param.mg_global.smoother_halo_precision[param.level+1];

--- a/lib/multigrid.cpp
+++ b/lib/multigrid.cpp
@@ -368,7 +368,7 @@ namespace quda
     if (diracCoarseResidual) delete diracCoarseResidual;
     diracCoarseResidual = new DiracCoarse(diracParam, param.setup_location == QUDA_CUDA_FIELD_LOCATION ? true : false,
                                           param.mg_global.setup_minimize_memory == QUDA_BOOLEAN_TRUE ? true : false);
-
+  
     // create smoothing operators
     diracParam.dirac = const_cast<Dirac*>(param.matSmooth->Expose());
     diracParam.halo_precision = param.mg_global.smoother_halo_precision[param.level+1];

--- a/tests/invert_test.cpp
+++ b/tests/invert_test.cpp
@@ -439,25 +439,30 @@ int main(int argc, char **argv)
   rng->Release();
   delete rng;
 
-  auto mean_time = 0.0;
-  auto mean_time2 = 0.0;
-  auto mean_gflops = 0.0;
-  auto mean_gflops2 = 0.0;
-  for (int i = 0; i < Nsrc; i++) {
-    mean_time += time[i];
-    mean_time2 += time[i] * time[i];
-    mean_gflops += gflops[i];
-    mean_gflops2 += gflops[i] * gflops[i];
-  }
+  if (Nsrc > 1) {
+    auto mean_time = 0.0;
+    auto mean_time2 = 0.0;
+    auto mean_gflops = 0.0;
+    auto mean_gflops2 = 0.0;
+    // skip first solve due to allocations, potential UVM swapping overhead
+    for (int i = 1; i < Nsrc; i++) {
+      mean_time += time[i];
+      mean_time2 += time[i] * time[i];
+      mean_gflops += gflops[i];
+      mean_gflops2 += gflops[i] * gflops[i];
+    }
 
-  mean_time /= Nsrc;
-  mean_time2 /= Nsrc;
-  auto stddev_time = Nsrc > 1 ? sqrt((Nsrc / ((double)Nsrc - 1.0)) * (mean_time2 - mean_time * mean_time)) : std::numeric_limits<double>::infinity();
-  mean_gflops /= Nsrc;
-  mean_gflops2 /= Nsrc;
-  auto stddev_gflops = Nsrc > 1 ? sqrt((Nsrc / ((double)Nsrc - 1.0)) * (mean_gflops2 - mean_gflops * mean_gflops)) : std::numeric_limits<double>::infinity();
-  printfQuda("%d solves, with mean solve time %g (stddev = %g), mean GFLOPS %g (stddev = %g)\n", Nsrc, mean_time,
+    auto NsrcM1 = Nsrc-1;
+
+    mean_time /= NsrcM1;
+    mean_time2 /= NsrcM1;
+    auto stddev_time = NsrcM1 > 1 ? sqrt((NsrcM1 / ((double)NsrcM1 - 1.0)) * (mean_time2 - mean_time * mean_time)) : std::numeric_limits<double>::infinity();
+    mean_gflops /= NsrcM1;
+    mean_gflops2 /= NsrcM1;
+    auto stddev_gflops = NsrcM1 > 1 ? sqrt((NsrcM1 / ((double)NsrcM1 - 1.0)) * (mean_gflops2 - mean_gflops * mean_gflops)) : std::numeric_limits<double>::infinity();
+    printfQuda("%d solves, with mean solve time %g (stddev = %g), mean GFLOPS %g (stddev = %g) [excluding first solve]\n", Nsrc, mean_time,
              stddev_time, mean_gflops, stddev_gflops);
+  }
 
   delete[] time;
   delete[] gflops;

--- a/tests/invert_test.cpp
+++ b/tests/invert_test.cpp
@@ -452,16 +452,20 @@ int main(int argc, char **argv)
       mean_gflops2 += gflops[i] * gflops[i];
     }
 
-    auto NsrcM1 = Nsrc-1;
+    auto NsrcM1 = Nsrc - 1;
 
     mean_time /= NsrcM1;
     mean_time2 /= NsrcM1;
-    auto stddev_time = NsrcM1 > 1 ? sqrt((NsrcM1 / ((double)NsrcM1 - 1.0)) * (mean_time2 - mean_time * mean_time)) : std::numeric_limits<double>::infinity();
+    auto stddev_time = NsrcM1 > 1 ? sqrt((NsrcM1 / ((double)NsrcM1 - 1.0)) * (mean_time2 - mean_time * mean_time)) :
+                                    std::numeric_limits<double>::infinity();
     mean_gflops /= NsrcM1;
     mean_gflops2 /= NsrcM1;
-    auto stddev_gflops = NsrcM1 > 1 ? sqrt((NsrcM1 / ((double)NsrcM1 - 1.0)) * (mean_gflops2 - mean_gflops * mean_gflops)) : std::numeric_limits<double>::infinity();
-    printfQuda("%d solves, with mean solve time %g (stddev = %g), mean GFLOPS %g (stddev = %g) [excluding first solve]\n", Nsrc, mean_time,
-             stddev_time, mean_gflops, stddev_gflops);
+    auto stddev_gflops = NsrcM1 > 1 ?
+      sqrt((NsrcM1 / ((double)NsrcM1 - 1.0)) * (mean_gflops2 - mean_gflops * mean_gflops)) :
+      std::numeric_limits<double>::infinity();
+    printfQuda(
+      "%d solves, with mean solve time %g (stddev = %g), mean GFLOPS %g (stddev = %g) [excluding first solve]\n", Nsrc,
+      mean_time, stddev_time, mean_gflops, stddev_gflops);
   }
 
   delete[] time;

--- a/tests/multigrid_invert_test.cpp
+++ b/tests/multigrid_invert_test.cpp
@@ -706,25 +706,31 @@ int main(int argc, char **argv)
   // free the multigrid solver
   destroyMultigridQuda(mg_preconditioner);
 
-  auto mean_time = 0.0;
-  auto mean_time2 = 0.0;
-  auto mean_gflops = 0.0;
-  auto mean_gflops2 = 0.0;
-  for (int i = 0; i < Nsrc; i++) {
-    mean_time += time[i];
-    mean_time2 += time[i] * time[i];
-    mean_gflops += gflops[i];
-    mean_gflops2 += gflops[i] * gflops[i];
-  }
+  // Compute timings
+  if (Nsrc > 1) {
+    auto mean_time = 0.0;
+    auto mean_time2 = 0.0;
+    auto mean_gflops = 0.0;
+    auto mean_gflops2 = 0.0;
+    // skip first solve due to allocations, potential UVM swapping overhead
+    for (int i = 1; i < Nsrc; i++) {
+      mean_time += time[i];
+      mean_time2 += time[i] * time[i];
+      mean_gflops += gflops[i];
+      mean_gflops2 += gflops[i] * gflops[i];
+    }
 
-  mean_time /= Nsrc;
-  mean_time2 /= Nsrc;
-  auto stddev_time = Nsrc > 1 ? sqrt((Nsrc / ((double)Nsrc - 1.0)) * (mean_time2 - mean_time * mean_time)) : std::numeric_limits<double>::infinity();
-  mean_gflops /= Nsrc;
-  mean_gflops2 /= Nsrc;
-  auto stddev_gflops = Nsrc > 1 ? sqrt((Nsrc / ((double)Nsrc - 1.0)) * (mean_gflops2 - mean_gflops * mean_gflops)) : std::numeric_limits<double>::infinity();
-  printfQuda("%d solves, with mean solve time %g (stddev = %g), mean GFLOPS %g (stddev = %g)\n", Nsrc, mean_time,
-             stddev_time, mean_gflops, stddev_gflops);
+    auto NsrcM1 = Nsrc-1;
+
+    mean_time /= NsrcM1;
+    mean_time2 /= NsrcM1;
+    auto stddev_time = NsrcM1 > 1 ? sqrt((NsrcM1 / ((double)NsrcM1 - 1.0)) * (mean_time2 - mean_time * mean_time)) : std::numeric_limits<double>::infinity();
+    mean_gflops /= NsrcM1;
+    mean_gflops2 /= NsrcM1;
+    auto stddev_gflops = NsrcM1 > 1 ? sqrt((NsrcM1 / ((double)NsrcM1 - 1.0)) * (mean_gflops2 - mean_gflops * mean_gflops)) : std::numeric_limits<double>::infinity();
+    printfQuda("%d solves, with mean solve time %g (stddev = %g), mean GFLOPS %g (stddev = %g) [excluding first solve]\n", Nsrc, mean_time,
+           stddev_time, mean_gflops, stddev_gflops);
+  }
 
   delete[] time;
   delete[] gflops;

--- a/tests/multigrid_invert_test.cpp
+++ b/tests/multigrid_invert_test.cpp
@@ -720,16 +720,20 @@ int main(int argc, char **argv)
       mean_gflops2 += gflops[i] * gflops[i];
     }
 
-    auto NsrcM1 = Nsrc-1;
+    auto NsrcM1 = Nsrc - 1;
 
     mean_time /= NsrcM1;
     mean_time2 /= NsrcM1;
-    auto stddev_time = NsrcM1 > 1 ? sqrt((NsrcM1 / ((double)NsrcM1 - 1.0)) * (mean_time2 - mean_time * mean_time)) : std::numeric_limits<double>::infinity();
+    auto stddev_time = NsrcM1 > 1 ? sqrt((NsrcM1 / ((double)NsrcM1 - 1.0)) * (mean_time2 - mean_time * mean_time)) :
+                                    std::numeric_limits<double>::infinity();
     mean_gflops /= NsrcM1;
     mean_gflops2 /= NsrcM1;
-    auto stddev_gflops = NsrcM1 > 1 ? sqrt((NsrcM1 / ((double)NsrcM1 - 1.0)) * (mean_gflops2 - mean_gflops * mean_gflops)) : std::numeric_limits<double>::infinity();
-    printfQuda("%d solves, with mean solve time %g (stddev = %g), mean GFLOPS %g (stddev = %g) [excluding first solve]\n", Nsrc, mean_time,
-           stddev_time, mean_gflops, stddev_gflops);
+    auto stddev_gflops = NsrcM1 > 1 ?
+      sqrt((NsrcM1 / ((double)NsrcM1 - 1.0)) * (mean_gflops2 - mean_gflops * mean_gflops)) :
+      std::numeric_limits<double>::infinity();
+    printfQuda(
+      "%d solves, with mean solve time %g (stddev = %g), mean GFLOPS %g (stddev = %g) [excluding first solve]\n", Nsrc,
+      mean_time, stddev_time, mean_gflops, stddev_gflops);
   }
 
   delete[] time;

--- a/tests/staggered_invert_test.cpp
+++ b/tests/staggered_invert_test.cpp
@@ -508,16 +508,20 @@ int invert_test()
         mean_gflops2 += gflops[i] * gflops[i];
       }
 
-      auto NsrcM1 = Nsrc-1;
+      auto NsrcM1 = Nsrc - 1;
 
       mean_time /= NsrcM1;
       mean_time2 /= NsrcM1;
-      auto stddev_time = NsrcM1 > 1 ? sqrt((NsrcM1 / ((double)NsrcM1 - 1.0)) * (mean_time2 - mean_time * mean_time)) : std::numeric_limits<double>::infinity();
+      auto stddev_time = NsrcM1 > 1 ? sqrt((NsrcM1 / ((double)NsrcM1 - 1.0)) * (mean_time2 - mean_time * mean_time)) :
+                                      std::numeric_limits<double>::infinity();
       mean_gflops /= NsrcM1;
       mean_gflops2 /= NsrcM1;
-      auto stddev_gflops = NsrcM1 > 1 ? sqrt((NsrcM1 / ((double)NsrcM1 - 1.0)) * (mean_gflops2 - mean_gflops * mean_gflops)) : std::numeric_limits<double>::infinity();
-      printfQuda("%d solves, with mean solve time %g (stddev = %g), mean GFLOPS %g (stddev = %g) [excluding first solve]\n", Nsrc, mean_time,
-             stddev_time, mean_gflops, stddev_gflops);
+      auto stddev_gflops = NsrcM1 > 1 ?
+        sqrt((NsrcM1 / ((double)NsrcM1 - 1.0)) * (mean_gflops2 - mean_gflops * mean_gflops)) :
+        std::numeric_limits<double>::infinity();
+      printfQuda(
+        "%d solves, with mean solve time %g (stddev = %g), mean GFLOPS %g (stddev = %g) [excluding first solve]\n",
+        Nsrc, mean_time, stddev_time, mean_gflops, stddev_gflops);
     }
     break;
 
@@ -570,16 +574,20 @@ int invert_test()
         mean_gflops2 += gflops[i] * gflops[i];
       }
 
-      auto NsrcM1 = Nsrc-1;
+      auto NsrcM1 = Nsrc - 1;
 
       mean_time /= NsrcM1;
       mean_time2 /= NsrcM1;
-      auto stddev_time = NsrcM1 > 1 ? sqrt((NsrcM1 / ((double)NsrcM1 - 1.0)) * (mean_time2 - mean_time * mean_time)) : std::numeric_limits<double>::infinity();
+      auto stddev_time = NsrcM1 > 1 ? sqrt((NsrcM1 / ((double)NsrcM1 - 1.0)) * (mean_time2 - mean_time * mean_time)) :
+                                      std::numeric_limits<double>::infinity();
       mean_gflops /= NsrcM1;
       mean_gflops2 /= NsrcM1;
-      auto stddev_gflops = NsrcM1 > 1 ? sqrt((NsrcM1 / ((double)NsrcM1 - 1.0)) * (mean_gflops2 - mean_gflops * mean_gflops)) : std::numeric_limits<double>::infinity();
-      printfQuda("%d solves, with mean solve time %g (stddev = %g), mean GFLOPS %g (stddev = %g) [excluding first solve]\n", Nsrc, mean_time,
-             stddev_time, mean_gflops, stddev_gflops);
+      auto stddev_gflops = NsrcM1 > 1 ?
+        sqrt((NsrcM1 / ((double)NsrcM1 - 1.0)) * (mean_gflops2 - mean_gflops * mean_gflops)) :
+        std::numeric_limits<double>::infinity();
+      printfQuda(
+        "%d solves, with mean solve time %g (stddev = %g), mean GFLOPS %g (stddev = %g) [excluding first solve]\n",
+        Nsrc, mean_time, stddev_time, mean_gflops, stddev_gflops);
     }
 
     break;

--- a/tests/staggered_multigrid_invert_test.cpp
+++ b/tests/staggered_multigrid_invert_test.cpp
@@ -884,27 +884,30 @@ int main(int argc, char **argv)
              inv_param.tol, inv_param.true_res, l2r, inv_param.tol_hq, inv_param.true_res_hq, hqr);
 
   // Compute timings
-  auto mean_time = 0.0;
-  auto mean_time2 = 0.0;
-  auto mean_gflops = 0.0;
-  auto mean_gflops2 = 0.0;
-  for (int i = 0; i < Nsrc; i++) {
-    mean_time += time[i];
-    mean_time2 += time[i] * time[i];
-    mean_gflops += gflops[i];
-    mean_gflops2 += gflops[i] * gflops[i];
-  }
+  if (Nsrc > 1) {
+    auto mean_time = 0.0;
+    auto mean_time2 = 0.0;
+    auto mean_gflops = 0.0;
+    auto mean_gflops2 = 0.0;
+    // skip first solve due to allocations, potential UVM swapping overhead
+    for (int i = 1; i < Nsrc; i++) {
+      mean_time += time[i];
+      mean_time2 += time[i] * time[i];
+      mean_gflops += gflops[i];
+      mean_gflops2 += gflops[i] * gflops[i];
+    }
 
-  mean_time /= Nsrc;
-  mean_time2 /= Nsrc;
-  auto stddev_time = Nsrc > 1 ? sqrt((Nsrc / ((double)Nsrc - 1.0)) * (mean_time2 - mean_time * mean_time)) :
-                                std::numeric_limits<double>::infinity();
-  mean_gflops /= Nsrc;
-  mean_gflops2 /= Nsrc;
-  auto stddev_gflops = Nsrc > 1 ? sqrt((Nsrc / ((double)Nsrc - 1.0)) * (mean_gflops2 - mean_gflops * mean_gflops)) :
-                                  std::numeric_limits<double>::infinity();
-  printfQuda("%d solves, with mean solve time %g (stddev = %g), mean GFLOPS %g (stddev = %g)\n", Nsrc, mean_time,
-             stddev_time, mean_gflops, stddev_gflops);
+    auto NsrcM1 = Nsrc-1;
+
+    mean_time /= NsrcM1;
+    mean_time2 /= NsrcM1;
+    auto stddev_time = NsrcM1 > 1 ? sqrt((NsrcM1 / ((double)NsrcM1 - 1.0)) * (mean_time2 - mean_time * mean_time)) : std::numeric_limits<double>::infinity();
+    mean_gflops /= NsrcM1;
+    mean_gflops2 /= NsrcM1;
+    auto stddev_gflops = NsrcM1 > 1 ? sqrt((NsrcM1 / ((double)NsrcM1 - 1.0)) * (mean_gflops2 - mean_gflops * mean_gflops)) : std::numeric_limits<double>::infinity();
+    printfQuda("%d solves, with mean solve time %g (stddev = %g), mean GFLOPS %g (stddev = %g) [excluding first solve]\n", Nsrc, mean_time,
+           stddev_time, mean_gflops, stddev_gflops);
+  }
 
   delete[] time;
   delete[] gflops;

--- a/tests/staggered_multigrid_invert_test.cpp
+++ b/tests/staggered_multigrid_invert_test.cpp
@@ -897,16 +897,20 @@ int main(int argc, char **argv)
       mean_gflops2 += gflops[i] * gflops[i];
     }
 
-    auto NsrcM1 = Nsrc-1;
+    auto NsrcM1 = Nsrc - 1;
 
     mean_time /= NsrcM1;
     mean_time2 /= NsrcM1;
-    auto stddev_time = NsrcM1 > 1 ? sqrt((NsrcM1 / ((double)NsrcM1 - 1.0)) * (mean_time2 - mean_time * mean_time)) : std::numeric_limits<double>::infinity();
+    auto stddev_time = NsrcM1 > 1 ? sqrt((NsrcM1 / ((double)NsrcM1 - 1.0)) * (mean_time2 - mean_time * mean_time)) :
+                                    std::numeric_limits<double>::infinity();
     mean_gflops /= NsrcM1;
     mean_gflops2 /= NsrcM1;
-    auto stddev_gflops = NsrcM1 > 1 ? sqrt((NsrcM1 / ((double)NsrcM1 - 1.0)) * (mean_gflops2 - mean_gflops * mean_gflops)) : std::numeric_limits<double>::infinity();
-    printfQuda("%d solves, with mean solve time %g (stddev = %g), mean GFLOPS %g (stddev = %g) [excluding first solve]\n", Nsrc, mean_time,
-           stddev_time, mean_gflops, stddev_gflops);
+    auto stddev_gflops = NsrcM1 > 1 ?
+      sqrt((NsrcM1 / ((double)NsrcM1 - 1.0)) * (mean_gflops2 - mean_gflops * mean_gflops)) :
+      std::numeric_limits<double>::infinity();
+    printfQuda(
+      "%d solves, with mean solve time %g (stddev = %g), mean GFLOPS %g (stddev = %g) [excluding first solve]\n", Nsrc,
+      mean_time, stddev_time, mean_gflops, stddev_gflops);
   }
 
   delete[] time;


### PR DESCRIPTION
This PR adds explicit saves of the tunecache to `dirac_coarse.cpp` after building the coarse operator and the preconditioned coarse operator. This is motivated by wall time constraints on some systems. Both tuning `UV`/`VUV` and tuning the matrix multiply to build `Yhat` can be very expensive, especially for staggered MG.

As a bonus, this modifies the `BatchInvertMatrix` routine to accept a `uint64_t` batch size instead of `int`, which avoids some integer overflow issues for large local volumes.

This does not address issues while tuning the staggered compute VUV with exceptionally large local volumes (96 x 24 x 24 x 32)---this is lower priority because this large of a volume cannot be run without excessive UVM swapping.

Edit: Removes the first run in the average over time per solve and gflops in `*_invert_test`.