### PR TITLE
Feature/mg misc

### DIFF
--- a/include/atomic.cuh
+++ b/include/atomic.cuh
@@ -152,3 +152,19 @@ static inline __device__ float atomicMax(float *addr, float val){
 
   return __uint_as_float(old);
 }
+
+/**
+   @brief Implementation of single-precision atomic max specialized
+   for positive-definite numbers.  Here we take advantage of the
+   property that when positive floating point numbers are
+   reinterpretted as unsigned integers, they have the same unique
+   sorted order.
+
+   @param addr Address that stores the atomic variable to be updated
+   @param val Value to be added to the atomic
+*/
+static inline __device__ float atomicAbsMax(float *addr, float val){
+  uint32_t val_ = __float_as_uint(val);
+  uint32_t *addr_ = reinterpret_cast<uint32_t*>(addr);
+  return atomicMax(addr_, val_);
+}

--- a/include/clover_field.h
+++ b/include/clover_field.h
@@ -162,7 +162,6 @@ namespace quda {
        @return Absolute minimum value
      */
     double abs_min(bool inverse = false) const;
-
   };
 
   class cudaCloverField : public CloverField {

--- a/include/clover_field.h
+++ b/include/clover_field.h
@@ -143,25 +143,25 @@ namespace quda {
        @brief Compute the L1 norm of the field
        @return L1 norm
      */
-    double norm1() const;
+    double norm1(bool inverse = false) const;
 
     /**
        @brief Compute the L2 norm squared of the field
        @return L2 norm squared
      */
-    double norm2() const;
+    double norm2(bool inverse = false) const;
 
     /**
        @brief Compute the absolute maximum of the field (Linfinity norm)
        @return Absolute maximum value
      */
-    double abs_max() const;
+    double abs_max(bool inverse = false) const;
 
     /**
        @brief Compute the absolute minimum of the field
        @return Absolute minimum value
      */
-    double abs_min() const;
+    double abs_min(bool inverse = false) const;
 
   };
 

--- a/include/cub_helper.cuh
+++ b/include/cub_helper.cuh
@@ -11,6 +11,11 @@ using namespace quda;
 #define CUB_USE_COOPERATIVE_GROUPS
 #endif
 
+#ifdef __CUDACC_RTC__
+// WAR for CUDA < 11 which prevents the use of cuda_fp16.h in cub with nvrtc
+struct __half { };
+#endif
+
 #include <cub/block/block_reduce.cuh>
 
 #if __COMPUTE_CAPABILITY__ >= 300

--- a/include/gauge_field.h
+++ b/include/gauge_field.h
@@ -358,28 +358,28 @@ namespace quda {
        @param[in] dim Which dimension we are taking the norm of (dim=-1 mean all dimensions)
        @return L1 norm
      */
-    double norm1(int dim=-1) const;
+    double norm1(int dim = -1, bool fixed = false) const;
 
     /**
        @brief Compute the L2 norm squared of the field
        @param[in] dim Which dimension we are taking the norm of (dim=-1 mean all dimensions)
        @return L2 norm squared
      */
-    double norm2(int dim=-1) const;
+    double norm2(int dim = -1, bool fixed = false) const;
 
     /**
        @brief Compute the absolute maximum of the field (Linfinity norm)
        @param[in] dim Which dimension we are taking the norm of (dim=-1 mean all dimensions)
        @return Absolute maximum value
      */
-    double abs_max(int dim=-1) const;
+    double abs_max(int dim = -1, bool fixed = false) const;
 
     /**
        @brief Compute the absolute minimum of the field
        @param[in] dim Which dimension we are taking the norm of (dim=-1 mean all dimensions)
        @return Absolute minimum value
      */
-    double abs_min(int dim=-1) const;
+    double abs_min(int dim = -1, bool fixed = false) const;
 
     /**
        Compute checksum of this gauge field: this uses a XOR-based checksum method
@@ -389,7 +389,7 @@ namespace quda {
        a field has changed with a global update algorithm.
        @return checksum value
      */
-    uint64_t checksum(bool mini=false) const;
+    uint64_t checksum(bool mini = false) const;
 
     /**
        @brief Create the gauge field, with meta data specified in the

--- a/include/kernels/coarse_op_kernel.cuh
+++ b/include/kernels/coarse_op_kernel.cuh
@@ -82,7 +82,9 @@ namespace quda {
     Float max_h; // scalar that stores the maximum element of the dynamic clover inverse
     Float *max_d; // array that stores the maximum element per lattice site of the dynamic clover inverse
 
-    int dim_index; // which direction / dimension we are working on
+    int dim;           // which dimension are we working on
+    QudaDirection dir; // which direction are working on
+    int dim_index;     // which direction / dimension we are working on
 
     CalculateYArg(coarseGauge &Y, coarseGauge &X,
 		  coarseGaugeAtomic &Y_atomic, coarseGaugeAtomic &X_atomic,

--- a/include/kernels/coarse_op_preconditioned.cuh
+++ b/include/kernels/coarse_op_preconditioned.cuh
@@ -3,7 +3,9 @@
 
 namespace quda {
 
-  template <typename Float, typename PreconditionedGauge, typename Gauge, int n> struct CalculateYhatArg {
+  template <typename Float_, typename PreconditionedGauge, typename Gauge, int n_> struct CalculateYhatArg {
+    using Float = Float_;
+    static constexpr int n = n_;
     PreconditionedGauge Yhat;
     const Gauge Y;
     const Gauge Xinv;
@@ -32,9 +34,10 @@ namespace quda {
     }
   };
 
-  template <typename Float, int n, bool compute_max_only, typename Arg>
-  inline __device__ __host__ Float computeYhat(Arg &arg, int d, int x_cb, int parity, int i, int j)
+  template <bool compute_max_only, typename Arg>
+  inline __device__ __host__ typename Arg::Float computeYhat(Arg &arg, int d, int x_cb, int parity, int i, int j)
   {
+    using Float = typename Arg::Float;
     constexpr int nDim = 4;
     int coord[nDim];
     getCoords(coord, x_cb, arg.dim, parity);
@@ -48,7 +51,7 @@ namespace quda {
 
       complex<Float> yHat = 0.0;
 #pragma unroll
-      for (int k = 0; k<n; k++) {
+      for (int k = 0; k<Arg::n; k++) {
         yHat = cmac(arg.Y.Ghost(d,1-parity,ghost_idx,i,k), conj(arg.Xinv(0,parity,x_cb,j,k)), yHat);
       }
       if (compute_max_only) {
@@ -62,7 +65,7 @@ namespace quda {
 
       complex<Float> yHat = 0.0;
 #pragma unroll
-      for (int k = 0; k<n; k++) {
+      for (int k = 0; k<Arg::n; k++) {
         yHat = cmac(arg.Y(d,1-parity,back_idx,i,k), conj(arg.Xinv(0,parity,x_cb,j,k)), yHat);
       }
       if (compute_max_only) {
@@ -75,7 +78,7 @@ namespace quda {
     // now do the forwards links X^{-1} * Y^{-\mu}
     complex<Float> yHat = 0.0;
 #pragma unroll
-    for (int k = 0; k<n; k++) {
+    for (int k = 0; k<Arg::n; k++) {
       yHat = cmac(arg.Xinv(0,parity,x_cb,i,k), arg.Y(d+4,parity,x_cb,k,j), yHat);
     }
     if (compute_max_only) {
@@ -87,16 +90,16 @@ namespace quda {
     return yHatMax;
   }
 
-  template <typename Float, int n, bool compute_max_only, typename Arg> void CalculateYhatCPU(Arg &arg)
+  template <bool compute_max_only, typename Arg> void CalculateYhatCPU(Arg &arg)
   {
-    Float max = 0.0;
+    typename Arg::Float max = 0.0;
     for (int d=0; d<4; d++) {
       for (int parity=0; parity<2; parity++) {
 #pragma omp parallel for
         for (int x_cb = 0; x_cb < arg.Y.VolumeCB(); x_cb++) {
-          for (int i = 0; i < n; i++)
-            for (int j = 0; j < n; j++) {
-              Float max_x = computeYhat<Float, n, compute_max_only>(arg, d, x_cb, parity, i, j);
+          for (int i = 0; i < Arg::n; i++)
+            for (int j = 0; j < Arg::n; j++) {
+              typename Arg::Float max_x = computeYhat<compute_max_only>(arg, d, x_cb, parity, i, j);
               if (compute_max_only) max = max > max_x ? max : max_x;
             }
         }
@@ -105,8 +108,9 @@ namespace quda {
     if (compute_max_only) *arg.max_h = max;
   }
 
-  template <typename Float, int n, bool compute_max_only, typename Arg> __global__ void CalculateYhatGPU(Arg arg)
+  template <bool compute_max_only, typename Arg> __global__ void CalculateYhatGPU(Arg arg)
   {
+    constexpr auto n = Arg::n;
     int x_cb = blockDim.x*blockIdx.x + threadIdx.x;
     if (x_cb >= arg.coarseVolumeCB) return;
     int i_parity = blockDim.y*blockIdx.y + threadIdx.y;
@@ -119,8 +123,8 @@ namespace quda {
     int j = j_d % n;
     int d = j_d / n;
 
-    Float max = computeYhat<Float, n, compute_max_only>(arg, d, x_cb, parity, i, j);
-    if (compute_max_only) atomicMax(arg.max_d, max);
+    typename Arg::Float max = computeYhat<compute_max_only>(arg, d, x_cb, parity, i, j);
+    if (compute_max_only) atomicAbsMax(arg.max_d, max);
   }
 
 } // namespace quda

--- a/include/kernels/dslash_staggered.cuh
+++ b/include/kernels/dslash_staggered.cuh
@@ -46,6 +46,8 @@ namespace quda
     const bool is_last_time_slice; /** are we on the last (global) time slice */
     static constexpr bool improved = improved_;
 
+    const real dagger_scale;
+
     StaggeredArg(ColorSpinorField &out, const ColorSpinorField &in, const GaugeField &U, const GaugeField &L, double a,
                  const ColorSpinorField &x, int parity, bool dagger, const int *comm_override) :
       DslashArg<Float, nDim>(in, U, parity, dagger, a == 0.0 ? false : true, improved_ ? 3 : 1, spin_project,
@@ -58,7 +60,8 @@ namespace quda
       a(a),
       tboundary(U.TBoundary()),
       is_first_time_slice(comm_coord(3) == 0 ? true : false),
-      is_last_time_slice(comm_coord(3) == comm_dim(3) - 1 ? true : false)
+      is_last_time_slice(comm_coord(3) == comm_dim(3) - 1 ? true : false),
+      dagger_scale(dagger ? static_cast<real>(-1.0) : static_cast<real>(1.0))
     {
       if (!out.isNative() || !x.isNative() || !in.isNative() || !U.isNative())
         errorQuda("Unsupported field order colorspinor=%d gauge=%d combination\n", in.FieldOrder(), U.FieldOrder());
@@ -75,7 +78,7 @@ namespace quda
      @param[in] parity The site parity
      @param[in] x_cb The checkerboarded site index
   */
-  template <int nParity, bool dagger, KernelType kernel_type, typename Arg, typename Vector>
+  template <int nParity, KernelType kernel_type, typename Arg, typename Vector>
   __device__ __host__ inline void applyStaggered(Vector &out, Arg &arg, int coord[Arg::nDim], int x_cb, int parity,
                                                  int idx, int thread_dim, bool &active)
   {
@@ -163,7 +166,7 @@ namespace quda
   }
 
   // out(x) = M*in = (-D + m) * in(x-mu)
-  template <int nParity, bool dagger, bool xpay, KernelType kernel_type, typename Arg>
+  template <int nParity, bool dummy, bool xpay, KernelType kernel_type, typename Arg>
   struct staggered : dslash_default {
 
     Arg &arg;
@@ -186,9 +189,9 @@ namespace quda
 
       Vector out;
 
-      applyStaggered<nParity, dagger, kernel_type>(out, arg, coord, x_cb, parity, idx, thread_dim, active);
+      applyStaggered<nParity, kernel_type>(out, arg, coord, x_cb, parity, idx, thread_dim, active);
 
-      if (dagger) { out = -out; }
+      out *= arg.dagger_scale;
 
       if (xpay && kernel_type == INTERIOR_KERNEL) {
         Vector x = arg.x(x_cb, my_spinor_parity);

--- a/include/kernels/dslash_staggered.cuh
+++ b/include/kernels/dslash_staggered.cuh
@@ -83,7 +83,7 @@ namespace quda
     typedef Matrix<complex<real>, Arg::nColor> Link;
     const int their_spinor_parity = (arg.nParity == 2) ? 1 - parity : 0;
 
-#pragma unroll 4
+#pragma unroll
     for (int d = 0; d < 4; d++) { // loop over dimension
 
       // standard - forward direction

--- a/include/kernels/dslash_twisted_mass_preconditioned.cuh
+++ b/include/kernels/dslash_twisted_mass_preconditioned.cuh
@@ -56,7 +56,7 @@ namespace quda
     typedef Matrix<complex<real>, Arg::nColor> Link;
     const int their_spinor_parity = nParity == 2 ? 1 - parity : 0;
 
-#pragma unroll Arg::nDim
+#pragma unroll
     for (int d = 0; d < Arg::nDim; d++) { // loop over dimension
       {                              // Forward gather - compute fwd offset for vector fetch
         const int fwd_idx = getNeighborIndexCB(coord, d, +1, arg.dc);

--- a/include/kernels/dslash_wilson.cuh
+++ b/include/kernels/dslash_wilson.cuh
@@ -73,7 +73,6 @@ namespace quda
     // parity for gauge field - include residual parity from 5-d => 4-d checkerboarding
     const int gauge_parity = (Arg::nDim == 5 ? (x_cb / arg.dc.volume_4d_cb + parity) % 2 : parity);
 
-#pragma unroll 4
     for (int d = 0; d < 4; d++) { // loop over dimension - 4 and not nDim since this is used for DWF as well
       {                           // Forward gather - compute fwd offset for vector fetch
         const int fwd_idx = getNeighborIndexCB<Arg::nDim>(coord, d, +1, arg.dc);

--- a/include/multigrid.h
+++ b/include/multigrid.h
@@ -226,7 +226,7 @@ namespace quda {
     /** Residual vector */
     ColorSpinorField *r;
 
-    /** Projected source vector for preconditioned syste, else just points to source */
+    /** Projected source vector for preconditioned system, else just points to source */
     ColorSpinorField *b_tilde;
 
     /** Coarse residual vector */

--- a/include/tune_key.h
+++ b/include/tune_key.h
@@ -8,7 +8,7 @@ namespace quda {
   struct TuneKey {
 
     static const int volume_n = 32;
-    static const int name_n = 384;
+    static const int name_n = 512;
     static const int aux_n = 256;
     char volume[volume_n];
     char name[name_n];

--- a/lib/blas_cublas.cu
+++ b/lib/blas_cublas.cu
@@ -81,11 +81,11 @@ namespace quda {
 	  errorQuda("\nError in LU decomposition (cublasCgetrfBatched), error code = %d\n", error);
 
 	qudaMemcpy(info_array, dinfo_array, batch*sizeof(int), cudaMemcpyDeviceToHost);
-	for (int i=0; i<batch; i++) {
+	for (uint64_t i=0; i<batch; i++) {
 	  if (info_array[i] < 0) {
-	    errorQuda("%d argument had an illegal value or another error occured, such as memory allocation failed", i);
+	    errorQuda("%lu argument had an illegal value or another error occured, such as memory allocation failed", i);
 	  } else if (info_array[i] > 0) {
-	    errorQuda("%d factorization completed but the factor U is exactly singular", i);
+	    errorQuda("%lu factorization completed but the factor U is exactly singular", i);
 	  }
 	}
     
@@ -97,11 +97,11 @@ namespace quda {
 
 	qudaMemcpy(info_array, dinfo_array, batch*sizeof(int), cudaMemcpyDeviceToHost);
 
-	for (int i=0; i<batch; i++) {
+	for (uint64_t i=0; i<batch; i++) {
 	  if (info_array[i] < 0) {
-	    errorQuda("%d argument had an illegal value or another error occured, such as memory allocation failed", i);
+	    errorQuda("%lu argument had an illegal value or another error occured, such as memory allocation failed", i);
 	  } else if (info_array[i] > 0) {
-	    errorQuda("%d factorization completed but the factor U is exactly singular", i);
+	    errorQuda("%lu factorization completed but the factor U is exactly singular", i);
 	  }
 	}
 

--- a/lib/blas_cublas.cu
+++ b/lib/blas_cublas.cu
@@ -66,6 +66,7 @@ namespace quda {
       int *dipiv = static_cast<int*>(pool_device_malloc(batch*n*sizeof(int)));
       int *dinfo_array = static_cast<int*>(pool_device_malloc(batch*sizeof(int)));
       int *info_array = static_cast<int*>(pool_pinned_malloc(batch*sizeof(int)));
+      memset(info_array, '0', batch*sizeof(int)); // silence memcheck warnings
 
       if (prec == QUDA_SINGLE_PRECISION) {
 	typedef cuFloatComplex C;

--- a/lib/block_orthogonalize.cu
+++ b/lib/block_orthogonalize.cu
@@ -4,25 +4,13 @@
 #include <typeinfo>
 #include <vector>
 #include <assert.h>
-
-// ensure compatibilty with C++11
-#if __cplusplus >= 201402L
 #include <utility>
-#else
-#include <integer_sequence.hpp> // C++11 version of this C++14 feature
-#endif
 
 #include <launch_kernel.cuh>
-
 #include <jitify_helper.cuh>
-
-#ifdef GPU_MULTIGRID
 #include <kernels/block_orthogonalize.cuh>
-#endif
 
 namespace quda {
-
-#ifdef GPU_MULTIGRID
 
   using namespace quda::colorspinor;
 
@@ -87,8 +75,6 @@ namespace quda {
       int chiralBlocks = (nSpin==1) ? 2 : V.Nspin() / spinBlockSize; //always 2 for staggered.
       nBlock = (V.Volume()/geoBlockSize) * chiralBlocks;
       }
-
-    virtual ~BlockOrtho() { }
 
     /**
        @brief Helper function for expanding the std::vector into a
@@ -227,116 +213,99 @@ namespace quda {
     checkCudaError();
   }
 
-  template <typename vFloat, typename bFloat, int nSpin, int spinBlockSize>
+  template <typename vFloat, typename bFloat>
   void BlockOrthogonalize(ColorSpinorField &V, const std::vector<ColorSpinorField *> &B, const int *fine_to_coarse,
-                          const int *coarse_to_fine, const int *geo_bs, const int n_block_ortho)
+                          const int *coarse_to_fine, const int *geo_bs, int spin_bs, int n_block_ortho)
   {
     const int Nvec = B.size();
     if (V.Ncolor()/Nvec == 3) {
-
-      constexpr int nColor = 3;
+      if (V.Nspin() != 4) errorQuda("Unexpected nSpin = %d", V.Nspin());
 #ifdef NSPIN4
+      constexpr int nSpin = 4;
+      if (spin_bs != 2) errorQuda("Unexpected spin block size = %d", spin_bs);
+      constexpr int spinBlockSize = 2;
+      constexpr int nColor = 3;
+
       if (Nvec == 6) { // for Wilson free field
         BlockOrthogonalize<vFloat, bFloat, nSpin, spinBlockSize, nColor, 6>(V, B, fine_to_coarse, coarse_to_fine,
                                                                             geo_bs, n_block_ortho);
-      } else
-#endif
-      if (Nvec == 24) {
+      } else if (Nvec == 24) {
         BlockOrthogonalize<vFloat, bFloat, nSpin, spinBlockSize, nColor, 24>(V, B, fine_to_coarse, coarse_to_fine,
                                                                              geo_bs, n_block_ortho);
-#ifdef NSPIN4
       } else if (Nvec == 32) {
         BlockOrthogonalize<vFloat, bFloat, nSpin, spinBlockSize, nColor, 32>(V, B, fine_to_coarse, coarse_to_fine,
                                                                              geo_bs, n_block_ortho);
-#endif // NSPIN4
-      } else {
-        errorQuda("Unsupported nVec %d\n", Nvec);
-      }
-#ifdef NSPIN4
-    } else if (V.Ncolor()/Nvec == 6) {
-
-      constexpr int nColor = 6;
-      if (Nvec == 6) {
-        BlockOrthogonalize<vFloat, bFloat, nSpin, spinBlockSize, nColor, 6>(V, B, fine_to_coarse, coarse_to_fine,
-                                                                            geo_bs, n_block_ortho);
       } else {
         errorQuda("Unsupported nVec %d\n", Nvec);
       }
 #endif // NSPIN4
-    } else if (V.Ncolor()/Nvec == 24) {
 
-      constexpr int nColor = 24;
-      if (Nvec == 24) {
-        BlockOrthogonalize<vFloat,bFloat,nSpin,spinBlockSize,nColor,24>(V, B, fine_to_coarse, coarse_to_fine, geo_bs, n_block_ortho);
+    } else { // Nc != 3
+      if (V.Nspin() != 2) errorQuda("Unexpected nSpin = %d", V.Nspin());
+      constexpr int nSpin = 2;
+      if (spin_bs != 1) errorQuda("Unexpected spin block size = %d", spin_bs);
+      constexpr int spinBlockSize = 1;
+
 #ifdef NSPIN4
-      } else if (Nvec == 32) {
-        BlockOrthogonalize<vFloat,bFloat,nSpin,spinBlockSize,nColor,32>(V, B, fine_to_coarse, coarse_to_fine, geo_bs, n_block_ortho);
+      if (V.Ncolor()/Nvec == 6) {
+        constexpr int nColor = 6;
+        if (Nvec == 6) {
+          BlockOrthogonalize<vFloat, bFloat, nSpin, spinBlockSize, nColor, 6>(V, B, fine_to_coarse, coarse_to_fine,
+                                                                              geo_bs, n_block_ortho);
+        } else {
+          errorQuda("Unsupported nVec %d\n", Nvec);
+        }
+      } else
 #endif // NSPIN4
-#ifdef NSPIN1
-      } else if (Nvec == 64) {
-        BlockOrthogonalize<vFloat,bFloat,nSpin,spinBlockSize,nColor,64>(V, B, fine_to_coarse, coarse_to_fine, geo_bs, n_block_ortho);
-      } else if (Nvec == 96) {
-        BlockOrthogonalize<vFloat,bFloat,nSpin,spinBlockSize,nColor,96>(V, B, fine_to_coarse, coarse_to_fine, geo_bs, n_block_ortho);
-#endif // NSPIN1
-      } else {
-        errorQuda("Unsupported nVec %d\n", Nvec);
-      }
+      if (V.Ncolor()/Nvec == 24) {
+        constexpr int nColor = 24;
+        if (Nvec == 24) {
+          BlockOrthogonalize<vFloat,bFloat,nSpin,spinBlockSize,nColor,24>(V, B, fine_to_coarse, coarse_to_fine, geo_bs, n_block_ortho);
 #ifdef NSPIN4
-    } else if (V.Ncolor()/Nvec == 32) {
-
-      constexpr int nColor = 32;
-      if (Nvec == 32) {
-        BlockOrthogonalize<vFloat,bFloat,nSpin,spinBlockSize,nColor,32>(V, B, fine_to_coarse, coarse_to_fine, geo_bs, n_block_ortho);
-      } else {
-        errorQuda("Unsupported nVec %d\n", Nvec);
-      }
+        } else if (Nvec == 32) {
+          BlockOrthogonalize<vFloat,bFloat,nSpin,spinBlockSize,nColor,32>(V, B, fine_to_coarse, coarse_to_fine, geo_bs, n_block_ortho);
 #endif // NSPIN4
 #ifdef NSPIN1
-    } else if (V.Ncolor()/Nvec == 64) {
-
-      constexpr int nColor = 64;
-      if (Nvec == 64) {
-        BlockOrthogonalize<vFloat,bFloat,nSpin,spinBlockSize,nColor,64>(V, B, fine_to_coarse, coarse_to_fine, geo_bs, n_block_ortho);
-      } else if (Nvec == 96) {
-        BlockOrthogonalize<vFloat,bFloat,nSpin,spinBlockSize,nColor,96>(V, B, fine_to_coarse, coarse_to_fine, geo_bs, n_block_ortho);
-      } else {
-        errorQuda("Unsupported nVec %d\n", Nvec);
-      }
-    } else if (V.Ncolor()/Nvec == 96) {
-
-      constexpr int nColor = 96;
-      if (Nvec == 96) {
-        BlockOrthogonalize<vFloat,bFloat,nSpin,spinBlockSize,nColor,96>(V, B, fine_to_coarse, coarse_to_fine, geo_bs, n_block_ortho);
-      } else {
-        errorQuda("Unsupported nVec %d\n", Nvec);
-      }
+        } else if (Nvec == 64) {
+          BlockOrthogonalize<vFloat,bFloat,nSpin,spinBlockSize,nColor,64>(V, B, fine_to_coarse, coarse_to_fine, geo_bs, n_block_ortho);
+        } else if (Nvec == 96) {
+          BlockOrthogonalize<vFloat,bFloat,nSpin,spinBlockSize,nColor,96>(V, B, fine_to_coarse, coarse_to_fine, geo_bs, n_block_ortho);
 #endif // NSPIN1
-    } else {
-      errorQuda("Unsupported nColor %d\n", V.Ncolor()/Nvec);
-    }
-  }
-
-  template <typename vFloat, typename bFloat>
-  void BlockOrthogonalize(ColorSpinorField &V, const std::vector<ColorSpinorField *> &B, const int *fine_to_coarse,
-                          const int *coarse_to_fine, const int *geo_bs, const int spin_bs, const int n_block_ortho)
-  {
-    if(V.Nspin() ==2 && spin_bs == 1) { //coarsening coarse fermions w/ chirality.
-      BlockOrthogonalize<vFloat, bFloat, 2, 1>(V, B, fine_to_coarse, coarse_to_fine, geo_bs, n_block_ortho);
+        } else {
+          errorQuda("Unsupported nVec %d\n", Nvec);
+        }
 #ifdef NSPIN4
-    } else if (V.Nspin() == 4 && spin_bs == 2) { // coarsening Wilson-like fermions.
-      BlockOrthogonalize<vFloat, bFloat, 4, 2>(V, B, fine_to_coarse, coarse_to_fine, geo_bs, n_block_ortho);
-#endif
-#if 0 // not needed until we add Laplace MG. Not necessary for staggered MG Lanczos.
-//#ifdef NSPIN1
-    } else if (V.Nspin() == 1 && spin_bs == 1) { // coarsening Laplace-like operators.
-      BlockOrthogonalize<vFloat, bFloat, 1, 1>(V, B, fine_to_coarse, coarse_to_fine, geo_bs, n_block_ortho);
-#endif
-    } else {
-      errorQuda("Unsupported nSpin %d and spinBlockSize %d combination.\n", V.Nspin(), spin_bs);
-    }
+      } else if (V.Ncolor()/Nvec == 32) {
+        constexpr int nColor = 32;
+        if (Nvec == 32) {
+          BlockOrthogonalize<vFloat,bFloat,nSpin,spinBlockSize,nColor,32>(V, B, fine_to_coarse, coarse_to_fine, geo_bs, n_block_ortho);
+        } else {
+          errorQuda("Unsupported nVec %d\n", Nvec);
+        }
+#endif // NSPIN4
+#ifdef NSPIN1
+      } else if (V.Ncolor()/Nvec == 64) {
+        constexpr int nColor = 64;
+        if (Nvec == 64) {
+          BlockOrthogonalize<vFloat,bFloat,nSpin,spinBlockSize,nColor,64>(V, B, fine_to_coarse, coarse_to_fine, geo_bs, n_block_ortho);
+        } else if (Nvec == 96) {
+          BlockOrthogonalize<vFloat,bFloat,nSpin,spinBlockSize,nColor,96>(V, B, fine_to_coarse, coarse_to_fine, geo_bs, n_block_ortho);
+        } else {
+          errorQuda("Unsupported nVec %d\n", Nvec);
+        }
+      } else if (V.Ncolor()/Nvec == 96) {
+        constexpr int nColor = 96;
+        if (Nvec == 96) {
+          BlockOrthogonalize<vFloat,bFloat,nSpin,spinBlockSize,nColor,96>(V, B, fine_to_coarse, coarse_to_fine, geo_bs, n_block_ortho);
+        } else {
+          errorQuda("Unsupported nVec %d\n", Nvec);
+        }
+#endif // NSPIN1
+      } else {
+        errorQuda("Unsupported nColor %d\n", V.Ncolor()/Nvec);
+      }
+    } // Nc != 3
   }
-
-#endif // GPU_MULTIGRID
 
   void BlockOrthogonalize(ColorSpinorField &V, const std::vector<ColorSpinorField *> &B, const int *fine_to_coarse,
                           const int *coarse_to_fine, const int *geo_bs, const int spin_bs, const int n_block_ortho)

--- a/lib/coarse_op.cuh
+++ b/lib/coarse_op.cuh
@@ -27,7 +27,381 @@ namespace quda {
     COMPUTE_INVALID
   };
 
-  template <bool from_coarse, typename Float, int fineSpin,
+  /**
+     @brief Launcher for CPU instantiations of coarse-link construction
+   */
+  template <QudaFieldLocation location, bool from_coarse, typename Float, int fineSpin,
+            int fineColor, int coarseSpin, int coarseColor, typename Arg> struct Launch {
+    Launch(Arg &arg, CUresult &error, TuneParam &tp, ComputeType type, const cudaStream_t &stream)
+    {
+      if (type == COMPUTE_UV) {
+        if (arg.dir == QUDA_BACKWARDS) {
+          if      (arg.dim==0) ComputeUVCPU<from_coarse,Float,0,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor>(arg);
+          else if (arg.dim==1) ComputeUVCPU<from_coarse,Float,1,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor>(arg);
+          else if (arg.dim==2) ComputeUVCPU<from_coarse,Float,2,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor>(arg);
+          else if (arg.dim==3) ComputeUVCPU<from_coarse,Float,3,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor>(arg);
+        } else if (arg.dir == QUDA_FORWARDS) {
+          if      (arg.dim==0) ComputeUVCPU<from_coarse,Float,0,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor>(arg);
+          else if (arg.dim==1) ComputeUVCPU<from_coarse,Float,1,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor>(arg);
+          else if (arg.dim==2) ComputeUVCPU<from_coarse,Float,2,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor>(arg);
+          else if (arg.dim==3) ComputeUVCPU<from_coarse,Float,3,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor>(arg);
+        } else {
+          errorQuda("Undefined direction %d", arg.dir);
+        }
+      } else if (type == COMPUTE_AV) {
+        if (from_coarse) errorQuda("ComputeAV should only be called from the fine grid");
+
+#if defined(GPU_CLOVER_DIRAC) && !defined(COARSECOARSE)
+        ComputeAVCPU<Float,fineSpin,fineColor,coarseColor>(arg);
+#else
+        errorQuda("Clover dslash has not been built");
+#endif
+
+      } else if (type == COMPUTE_TMAV) {
+        if (from_coarse) errorQuda("ComputeTMAV should only be called from the fine grid");
+
+#if defined(GPU_TWISTED_MASS_DIRAC) && !defined(COARSECOARSE)
+        ComputeTMAVCPU<Float,fineSpin,fineColor,coarseColor>(arg);
+#else
+        errorQuda("Twisted mass dslash has not been built");
+#endif
+
+      } else if (type == COMPUTE_TMCAV) {
+        if (from_coarse) errorQuda("ComputeTMCAV should only be called from the fine grid");
+
+#if defined(GPU_TWISTED_CLOVER_DIRAC) && !defined(COARSECOARSE)
+        ComputeTMCAVCPU<Float,fineSpin,fineColor,coarseColor>(arg);
+#else
+        errorQuda("Twisted clover dslash has not been built");
+#endif
+
+      } else if (type == COMPUTE_CLOVER_INV_MAX) {
+        if (from_coarse) errorQuda("ComputeInvCloverMax should only be called from the fine grid");
+
+#if defined(DYNAMIC_CLOVER) && !defined(COARSECOARSE)
+        ComputeCloverInvMaxCPU<Float, false>(arg);
+#else
+        errorQuda("ComputeInvCloverMax only enabled with dynamic clover");
+#endif
+
+      } else if (type == COMPUTE_TWISTED_CLOVER_INV_MAX) {
+        if (from_coarse) errorQuda("ComputeInvCloverMax should only be called from the fine grid");
+
+#if defined(DYNAMIC_CLOVER) && !defined(COARSECOARSE)
+        ComputeCloverInvMaxCPU<Float, true>(arg);
+#else
+        errorQuda("ComputeInvCloverMax only enabled with dynamic clover");
+#endif
+
+      } else if (type == COMPUTE_VUV) {
+        if (arg.dir == QUDA_BACKWARDS) {
+          if      (arg.dim==0) ComputeVUVCPU<from_coarse,Float,0,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor>(arg);
+          else if (arg.dim==1) ComputeVUVCPU<from_coarse,Float,1,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor>(arg);
+          else if (arg.dim==2) ComputeVUVCPU<from_coarse,Float,2,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor>(arg);
+          else if (arg.dim==3) ComputeVUVCPU<from_coarse,Float,3,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor>(arg);
+        } else if (arg.dir == QUDA_FORWARDS) {
+          if      (arg.dim==0) ComputeVUVCPU<from_coarse,Float,0,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor>(arg);
+          else if (arg.dim==1) ComputeVUVCPU<from_coarse,Float,1,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor>(arg);
+          else if (arg.dim==2) ComputeVUVCPU<from_coarse,Float,2,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor>(arg);
+          else if (arg.dim==3) ComputeVUVCPU<from_coarse,Float,3,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor>(arg);
+        } else {
+          errorQuda("Undefined direction %d", arg.dir);
+        }
+      } else if (type == COMPUTE_COARSE_CLOVER) {
+        ComputeCoarseCloverCPU<from_coarse,Float,fineSpin,coarseSpin,fineColor,coarseColor>(arg);
+      } else if (type == COMPUTE_REVERSE_Y) {
+        ComputeYReverseCPU<Float,coarseSpin,coarseColor>(arg);
+      } else if (type == COMPUTE_DIAGONAL) {
+        AddCoarseDiagonalCPU<Float,coarseSpin,coarseColor>(arg);
+      } else if (type == COMPUTE_TMDIAGONAL) {
+        AddCoarseTmDiagonalCPU<Float,coarseSpin,coarseColor>(arg);
+      } else if (type == COMPUTE_CONVERT) {
+        ConvertCPU<Float,coarseSpin,coarseColor>(arg);
+      } else if (type == COMPUTE_RESCALE) {
+        RescaleYCPU<Float,coarseSpin,coarseColor>(arg);
+      } else {
+        errorQuda("Undefined compute type %d", type);
+      }
+    }
+  };
+
+  /**
+     @brief Launcher for GPU instantiations of coarse-link construction
+  */
+  template <bool from_coarse, typename Float, int fineSpin, int fineColor, int coarseSpin, int coarseColor, typename Arg>
+  struct Launch<QUDA_CUDA_FIELD_LOCATION, from_coarse, Float, fineSpin, fineColor, coarseSpin, coarseColor, Arg> {
+    Launch(Arg &arg, CUresult &error, TuneParam &tp, ComputeType type, const cudaStream_t &stream)
+    {
+#ifdef JITIFY
+      using namespace jitify::reflection;
+#endif
+      if (type == COMPUTE_UV) {
+
+        if (arg.dir != QUDA_BACKWARDS && arg.dir != QUDA_FORWARDS) errorQuda("Undefined direction %d", arg.dir);
+#ifdef JITIFY
+        error = program->kernel("quda::ComputeUVGPU")
+          .instantiate(from_coarse,Type<Float>(),arg.dim,arg.dir,fineSpin,fineColor,coarseSpin,coarseColor,Type<Arg>())
+          .configure(tp.grid,tp.block,tp.shared_bytes,stream).launch(arg);
+#else
+        if (arg.dir == QUDA_BACKWARDS) {
+          if      (arg.dim==0) ComputeUVGPU<from_coarse,Float,0,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+          else if (arg.dim==1) ComputeUVGPU<from_coarse,Float,1,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+          else if (arg.dim==2) ComputeUVGPU<from_coarse,Float,2,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+          else if (arg.dim==3) ComputeUVGPU<from_coarse,Float,3,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+        } else if (arg.dir == QUDA_FORWARDS) {
+          if      (arg.dim==0) ComputeUVGPU<from_coarse,Float,0,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+          else if (arg.dim==1) ComputeUVGPU<from_coarse,Float,1,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+          else if (arg.dim==2) ComputeUVGPU<from_coarse,Float,2,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+          else if (arg.dim==3) ComputeUVGPU<from_coarse,Float,3,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+        }
+#endif
+
+      } else if (type == COMPUTE_AV) {
+
+        if (from_coarse) errorQuda("ComputeAV should only be called from the fine grid");
+#ifdef JITIFY
+        error = program->kernel("quda::ComputeAVGPU")
+          .instantiate(Type<Float>(),fineSpin,fineColor,coarseColor,Type<Arg>())
+          .configure(tp.grid,tp.block,tp.shared_bytes,stream).launch(arg);
+#else
+#if defined(GPU_CLOVER_DIRAC) && !defined(COARSECOARSE)
+          ComputeAVGPU<Float,fineSpin,fineColor,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+#else
+          errorQuda("Clover dslash has not been built");
+#endif
+#endif
+
+      } else if (type == COMPUTE_TMAV) {
+
+        if (from_coarse) errorQuda("ComputeTMAV should only be called from the fine grid");
+#ifdef JITIFY
+        error = program->kernel("quda::ComputeTMAVGPU")
+          .instantiate(Type<Float>(),fineSpin,fineColor,coarseColor,Type<Arg>())
+          .configure(tp.grid,tp.block,tp.shared_bytes,stream).launch(arg);
+#else
+#if defined(GPU_TWISTED_MASS_DIRAC) && !defined(COARSECOARSE)
+        ComputeTMAVGPU<Float,fineSpin,fineColor,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+#else
+        errorQuda("Twisted mass dslash has not been built");
+#endif
+#endif
+
+      } else if (type == COMPUTE_TMCAV) {
+
+        if (from_coarse) errorQuda("ComputeTMCAV should only be called from the fine grid");
+#ifdef JITIFY
+        error = program->kernel("quda::ComputeTMCAVGPU")
+          .instantiate(Type<Float>(),fineSpin,fineColor,coarseColor,Type<Arg>())
+          .configure(tp.grid,tp.block,tp.shared_bytes,stream).launch(arg);
+#else
+#if defined(GPU_TWISTED_CLOVER_DIRAC) && !defined(COARSECOARSE)
+        ComputeTMCAVGPU<Float,fineSpin,fineColor,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+#else
+        errorQuda("Twisted clover dslash has not been built");
+#endif
+#endif
+
+      } else if (type == COMPUTE_CLOVER_INV_MAX) {
+
+        if (from_coarse) errorQuda("ComputeCloverInvMax should only be called from the fine grid");
+        arg.max_d = static_cast<Float*>(pool_device_malloc(2 * arg.fineVolumeCB *sizeof(Float)));
+
+#ifdef JITIFY
+        error = program->kernel("quda::ComputeCloverInvMaxGPU")
+          .instantiate(Type<Float>(), false, Type<Arg>())
+          .configure(tp.grid, tp.block, tp.shared_bytes, stream)
+          .launch(arg);
+#else
+#if defined(DYNAMIC_CLOVER) && !defined(COARSECOARSE)
+        ComputeCloverInvMaxGPU<Float, false><<<tp.grid, tp.block, tp.shared_bytes>>>(arg);
+#else
+        errorQuda("ComputeCloverInvMax only enabled with dynamic clover");
+#endif
+#endif
+
+        if (!activeTuning()) { // only do reduction once tuning is done else thrust will catch tuning failures
+          thrust_allocator alloc;
+          thrust::device_ptr<Float> ptr(arg.max_d);
+          arg.max_h = thrust::reduce(thrust::cuda::par(alloc), ptr, ptr + 2 * arg.fineVolumeCB,
+                                     static_cast<Float>(0.0), thrust::maximum<Float>());
+        }
+        pool_device_free(arg.max_d);
+
+      } else if (type == COMPUTE_TWISTED_CLOVER_INV_MAX) {
+
+        if (from_coarse) errorQuda("ComputeCloverInvMax should only be called from the fine grid");
+        arg.max_d = static_cast<Float *>(pool_device_malloc(2 * arg.fineVolumeCB * sizeof(Float)));
+
+#ifdef JITIFY
+        error = program->kernel("quda::ComputeCloverInvMaxGPU")
+          .instantiate(Type<Float>(), true, Type<Arg>())
+          .configure(tp.grid, tp.block, tp.shared_bytes, stream)
+          .launch(arg);
+#else
+#if defined(DYNAMIC_CLOVER) && !defined(COARSECOARSE)
+        ComputeCloverInvMaxGPU<Float, true><<<tp.grid, tp.block, tp.shared_bytes>>>(arg);
+#else
+        errorQuda("ComputeCloverInvMax only enabled with dynamic clover");
+#endif
+#endif
+
+        if (!activeTuning()) { // only do reduction once tuning is done else thrust will catch tuning failures
+          thrust_allocator alloc;
+          thrust::device_ptr<Float> ptr(arg.max_d);
+          arg.max_h = thrust::reduce(thrust::cuda::par(alloc), ptr, ptr+2*arg.fineVolumeCB, static_cast<Float>(0.0), thrust::maximum<Float>());
+        }
+        pool_device_free(arg.max_d);
+
+      } else if (type == COMPUTE_VUV) {
+
+        // need to resize the grid since we don't tune over the entire coarseColor dimension
+        // factor of two comes from parity onto different blocks (e.g. in the grid)
+        tp.grid.y = (2*coarseColor + tp.block.y - 1) / tp.block.y;
+        tp.grid.z = (coarseColor + tp.block.z - 1) / tp.block.z;
+
+        arg.shared_atomic = tp.aux.y;
+        arg.parity_flip = tp.aux.z;
+
+        if (arg.shared_atomic) {
+          // check we have a valid problem size for shared atomics
+          // constrint is due to how shared memory initialization and global store are done
+          int block_size = arg.fineVolumeCB/arg.coarseVolumeCB;
+          if (block_size/2 < coarseSpin*coarseSpin)
+            errorQuda("Block size %d not supported in shared-memory atomic coarsening", block_size);
+
+          arg.aggregates_per_block = tp.aux.x;
+          tp.block.x *= tp.aux.x;
+          tp.grid.x /= tp.aux.x;
+        }
+
+        if (arg.coarse_color_wave) {
+          // swap x and y grids
+          std::swap(tp.grid.y,tp.grid.x);
+          // augment x grid with coarseColor row grid (z grid)
+          arg.grid_z = tp.grid.z;
+          arg.coarse_color_grid_z = coarseColor*tp.grid.z;
+          tp.grid.x *= tp.grid.z;
+          tp.grid.z = 1;
+        }
+
+#ifdef JITIFY
+        error = program->kernel("quda::ComputeVUVGPU")
+          .instantiate(arg.shared_atomic,arg.parity_flip,from_coarse,Type<Float>(),arg.dim,arg.dir,fineSpin,fineColor,coarseSpin,coarseColor,Type<Arg>())
+          .configure(tp.grid,tp.block,tp.shared_bytes,stream).launch(arg);
+#else
+        if (arg.shared_atomic) {
+          if (arg.parity_flip != true) errorQuda("parity_flip = %d not instantiated", arg.parity_flip);
+          constexpr bool parity_flip = true;
+
+          if (arg.dir == QUDA_BACKWARDS) {
+            if      (arg.dim==0) ComputeVUVGPU<true,parity_flip,from_coarse,Float,0,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+            else if (arg.dim==1) ComputeVUVGPU<true,parity_flip,from_coarse,Float,1,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+            else if (arg.dim==2) ComputeVUVGPU<true,parity_flip,from_coarse,Float,2,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+            else if (arg.dim==3) ComputeVUVGPU<true,parity_flip,from_coarse,Float,3,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+          } else if (arg.dir == QUDA_FORWARDS) {
+            if      (arg.dim==0) ComputeVUVGPU<true,parity_flip,from_coarse,Float,0,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+            else if (arg.dim==1) ComputeVUVGPU<true,parity_flip,from_coarse,Float,1,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+            else if (arg.dim==2) ComputeVUVGPU<true,parity_flip,from_coarse,Float,2,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+            else if (arg.dim==3) ComputeVUVGPU<true,parity_flip,from_coarse,Float,3,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+          } else {
+            errorQuda("Undefined direction %d", arg.dir);
+          }
+        } else {
+          if (arg.parity_flip != false) errorQuda("parity_flip = %d not instantiated", arg.parity_flip);
+          constexpr bool parity_flip = false;
+
+          if (arg.dir == QUDA_BACKWARDS) {
+            if      (arg.dim==0) ComputeVUVGPU<false,parity_flip,from_coarse,Float,0,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+            else if (arg.dim==1) ComputeVUVGPU<false,parity_flip,from_coarse,Float,1,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+            else if (arg.dim==2) ComputeVUVGPU<false,parity_flip,from_coarse,Float,2,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+            else if (arg.dim==3) ComputeVUVGPU<false,parity_flip,from_coarse,Float,3,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+          } else if (arg.dir == QUDA_FORWARDS) {
+            if      (arg.dim==0) ComputeVUVGPU<false,parity_flip,from_coarse,Float,0,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+            else if (arg.dim==1) ComputeVUVGPU<false,parity_flip,from_coarse,Float,1,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+            else if (arg.dim==2) ComputeVUVGPU<false,parity_flip,from_coarse,Float,2,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+            else if (arg.dim==3) ComputeVUVGPU<false,parity_flip,from_coarse,Float,3,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+          } else {
+            errorQuda("Undefined direction %d", arg.dir);
+          }
+        }
+#endif
+
+        if (arg.coarse_color_wave) {
+          // revert the grids
+          tp.grid.z = arg.grid_z;
+          tp.grid.x /= tp.grid.z;
+          std::swap(tp.grid.x,tp.grid.y);
+        }
+
+        if (arg.shared_atomic) {
+          tp.block.x /= tp.aux.x;
+          tp.grid.x *= tp.aux.x;
+        }
+
+      } else if (type == COMPUTE_COARSE_CLOVER) {
+
+#ifdef JITIFY
+        error = program->kernel("quda::ComputeCoarseCloverGPU")
+          .instantiate(from_coarse,Type<Float>(),fineSpin,coarseSpin,fineColor,coarseColor,Type<Arg>())
+          .configure(tp.grid,tp.block,tp.shared_bytes,stream).launch(arg);
+#else
+        ComputeCoarseCloverGPU<from_coarse,Float,fineSpin,coarseSpin,fineColor,coarseColor>
+          <<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+#endif
+
+      } else if (type == COMPUTE_REVERSE_Y) {
+
+#ifdef JITIFY
+        error = program->kernel("quda::ComputeYReverseGPU")
+          .instantiate(Type<Float>(),coarseSpin,coarseColor,Type<Arg>())
+          .configure(tp.grid,tp.block,tp.shared_bytes,stream).launch(arg);
+#else
+        ComputeYReverseGPU<Float,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+#endif
+      } else if (type == COMPUTE_DIAGONAL) {
+
+#ifdef JITIFY
+        error = program->kernel("quda::AddCoarseDiagonalGPU")
+          .instantiate(Type<Float>(),coarseSpin,coarseColor,Type<Arg>())
+          .configure(tp.grid,tp.block,tp.shared_bytes,stream).launch(arg);
+#else
+        AddCoarseDiagonalGPU<Float,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+#endif
+      } else if (type == COMPUTE_TMDIAGONAL) {
+
+#ifdef JITIFY
+        error = program->kernel("quda::AddCoarseTmDiagonalGPU")
+          .instantiate(Type<Float>(),coarseSpin,coarseColor,Type<Arg>())
+          .configure(tp.grid,tp.block,tp.shared_bytes,stream).launch(arg);
+#else
+        AddCoarseTmDiagonalGPU<Float,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+#endif
+      } else if (type == COMPUTE_CONVERT) {
+
+#ifdef JITIFY
+        error = program->kernel("quda::ConvertGPU")
+          .instantiate(Type<Float>(),coarseSpin,coarseColor,Type<Arg>())
+          .configure(tp.grid,tp.block,tp.shared_bytes,stream).launch(arg);
+#else
+        ConvertGPU<Float,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+#endif
+      } else if (type == COMPUTE_RESCALE) {
+
+#ifdef JITIFY
+        error = program->kernel("quda::RescaleYGPU")
+          .instantiate(Type<Float>(),coarseSpin,coarseColor,Type<Arg>())
+          .configure(tp.grid,tp.block,tp.shared_bytes,stream).launch(arg);
+#else
+        RescaleYGPU<Float,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+#endif
+
+      } else {
+        errorQuda("Undefined compute type %d", type);
+      }
+    }
+  };
+
+  template <QudaFieldLocation location, bool from_coarse, typename Float, int fineSpin,
 	    int fineColor, int coarseSpin, int coarseColor, typename Arg>
   class CalculateY : public TunableVectorYZ {
   public:
@@ -191,408 +565,18 @@ namespace quda {
       strcat(aux, comm_dim_partitioned_string());
       if (meta.Location() == QUDA_CPU_FIELD_LOCATION) strcat(aux, getOmpThreadStr());
     }
-    virtual ~CalculateY() { }
 
-    void apply(const cudaStream_t &stream) {
+    void apply(const cudaStream_t &stream)
+    {
       TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
-
-      if (meta.Location() == QUDA_CPU_FIELD_LOCATION) {
-
-	if (type == COMPUTE_UV) {
-
-	  if (dir == QUDA_BACKWARDS) {
-	    if      (dim==0) ComputeUVCPU<from_coarse,Float,0,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor>(arg);
-	    else if (dim==1) ComputeUVCPU<from_coarse,Float,1,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor>(arg);
-	    else if (dim==2) ComputeUVCPU<from_coarse,Float,2,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor>(arg);
-	    else if (dim==3) ComputeUVCPU<from_coarse,Float,3,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor>(arg);
-	  } else if (dir == QUDA_FORWARDS) {
-	    if      (dim==0) ComputeUVCPU<from_coarse,Float,0,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor>(arg);
-	    else if (dim==1) ComputeUVCPU<from_coarse,Float,1,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor>(arg);
-	    else if (dim==2) ComputeUVCPU<from_coarse,Float,2,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor>(arg);
-	    else if (dim==3) ComputeUVCPU<from_coarse,Float,3,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor>(arg);
-	  } else {
-	    errorQuda("Undefined direction %d", dir);
-	  }
-
-	} else if (type == COMPUTE_AV) {
-
-	  if (from_coarse) errorQuda("ComputeAV should only be called from the fine grid");
-#if defined(GPU_CLOVER_DIRAC) && !defined(COARSECOARSE)
-          ComputeAVCPU<Float,fineSpin,fineColor,coarseColor>(arg);
-#else
-          errorQuda("Clover dslash has not been built");
-#endif
-
-	} else if (type == COMPUTE_TMAV) {
-
-	  if (from_coarse) errorQuda("ComputeTMAV should only be called from the fine grid");
-#if defined(GPU_TWISTED_MASS_DIRAC) && !defined(COARSECOARSE)
-          ComputeTMAVCPU<Float,fineSpin,fineColor,coarseColor>(arg);
-#else
-          errorQuda("Twisted mass dslash has not been built");
-#endif
-
-	} else if (type == COMPUTE_TMCAV) {
-
-	  if (from_coarse) errorQuda("ComputeTMCAV should only be called from the fine grid");
-#if defined(GPU_TWISTED_CLOVER_DIRAC) && !defined(COARSECOARSE)
-          ComputeTMCAVCPU<Float,fineSpin,fineColor,coarseColor>(arg);
-#else
-          errorQuda("Twisted clover dslash has not been built");
-#endif
-
-	} else if (type == COMPUTE_CLOVER_INV_MAX) {
-
-	  if (from_coarse) errorQuda("ComputeInvCloverMax should only be called from the fine grid");
-#if defined(DYNAMIC_CLOVER) && !defined(COARSECOARSE)
-          ComputeCloverInvMaxCPU<Float, false>(arg);
-#else
-          errorQuda("ComputeInvCloverMax only enabled with dynamic clover");
-#endif
-
-        } else if (type == COMPUTE_TWISTED_CLOVER_INV_MAX) {
-
-          if (from_coarse) errorQuda("ComputeInvCloverMax should only be called from the fine grid");
-#if defined(DYNAMIC_CLOVER) && !defined(COARSECOARSE)
-          ComputeCloverInvMaxCPU<Float, true>(arg);
-#else
-	  errorQuda("ComputeInvCloverMax only enabled with dynamic clover");
-#endif
-
-        } else if (type == COMPUTE_VUV) {
-
-          arg.dim_index = 4*(dir==QUDA_BACKWARDS ? 0 : 1) + dim;
-
-          if (dir == QUDA_BACKWARDS) {
-	    if      (dim==0) ComputeVUVCPU<from_coarse,Float,0,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor>(arg);
-	    else if (dim==1) ComputeVUVCPU<from_coarse,Float,1,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor>(arg);
-	    else if (dim==2) ComputeVUVCPU<from_coarse,Float,2,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor>(arg);
-	    else if (dim==3) ComputeVUVCPU<from_coarse,Float,3,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor>(arg);
-	  } else if (dir == QUDA_FORWARDS) {
-	    if      (dim==0) ComputeVUVCPU<from_coarse,Float,0,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor>(arg);
-	    else if (dim==1) ComputeVUVCPU<from_coarse,Float,1,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor>(arg);
-	    else if (dim==2) ComputeVUVCPU<from_coarse,Float,2,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor>(arg);
-	    else if (dim==3) ComputeVUVCPU<from_coarse,Float,3,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor>(arg);
-	  } else {
-	    errorQuda("Undefined direction %d", dir);
-	  }
-
-        } else if (type == COMPUTE_COARSE_CLOVER) {
-
-          ComputeCoarseCloverCPU<from_coarse,Float,fineSpin,coarseSpin,fineColor,coarseColor>(arg);
-
-        } else if (type == COMPUTE_REVERSE_Y) {
-
-          ComputeYReverseCPU<Float,coarseSpin,coarseColor>(arg);
-
-        } else if (type == COMPUTE_DIAGONAL) {
-
-          AddCoarseDiagonalCPU<Float,coarseSpin,coarseColor>(arg);
-
-        } else if (type == COMPUTE_TMDIAGONAL) {
-
-          AddCoarseTmDiagonalCPU<Float,coarseSpin,coarseColor>(arg);
-
-        } else if (type == COMPUTE_CONVERT) {
-
-          arg.dim_index = 4*(dir==QUDA_BACKWARDS ? 0 : 1) + dim;
-	  ConvertCPU<Float,coarseSpin,coarseColor>(arg);
-
-        } else if (type == COMPUTE_RESCALE) {
-
-          arg.dim_index = 4*(dir==QUDA_BACKWARDS ? 0 : 1) + dim;
-	  RescaleYCPU<Float,coarseSpin,coarseColor>(arg);
-
-        } else {
-          errorQuda("Undefined compute type %d", type);
-        }
-      } else {
-
-	if (type == COMPUTE_UV) {
-
-          if (dir != QUDA_BACKWARDS && dir != QUDA_FORWARDS) errorQuda("Undefined direction %d", dir);
-#ifdef JITIFY
-          using namespace jitify::reflection;
-          jitify_error = program->kernel("quda::ComputeUVGPU")
-            .instantiate(from_coarse,Type<Float>(),dim,dir,fineSpin,fineColor,coarseSpin,coarseColor,Type<Arg>())
-            .configure(tp.grid,tp.block,tp.shared_bytes,stream).launch(arg);
-#else
-          if (dir == QUDA_BACKWARDS) {
-	    if      (dim==0) ComputeUVGPU<from_coarse,Float,0,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
-	    else if (dim==1) ComputeUVGPU<from_coarse,Float,1,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
-	    else if (dim==2) ComputeUVGPU<from_coarse,Float,2,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
-	    else if (dim==3) ComputeUVGPU<from_coarse,Float,3,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
-	  } else if (dir == QUDA_FORWARDS) {
-	    if      (dim==0) ComputeUVGPU<from_coarse,Float,0,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
-	    else if (dim==1) ComputeUVGPU<from_coarse,Float,1,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
-	    else if (dim==2) ComputeUVGPU<from_coarse,Float,2,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
-	    else if (dim==3) ComputeUVGPU<from_coarse,Float,3,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
-	  }
-#endif
-
-	} else if (type == COMPUTE_AV) {
-
-	  if (from_coarse) errorQuda("ComputeAV should only be called from the fine grid");
-#ifdef JITIFY
-          using namespace jitify::reflection;
-          jitify_error = program->kernel("quda::ComputeAVGPU")
-            .instantiate(Type<Float>(),fineSpin,fineColor,coarseColor,Type<Arg>())
-            .configure(tp.grid,tp.block,tp.shared_bytes,stream).launch(arg);
-#else
-#if defined(GPU_CLOVER_DIRAC) && !defined(COARSECOARSE)
-          ComputeAVGPU<Float,fineSpin,fineColor,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
-#else
-          errorQuda("Clover dslash has not been built");
-#endif
-#endif
-
-	} else if (type == COMPUTE_TMAV) {
-
-	  if (from_coarse) errorQuda("ComputeTMAV should only be called from the fine grid");
-#ifdef JITIFY
-          using namespace jitify::reflection;
-          jitify_error = program->kernel("quda::ComputeTMAVGPU")
-            .instantiate(Type<Float>(),fineSpin,fineColor,coarseColor,Type<Arg>())
-            .configure(tp.grid,tp.block,tp.shared_bytes,stream).launch(arg);
-#else
-#if defined(GPU_TWISTED_MASS_DIRAC) && !defined(COARSECOARSE)
-          ComputeTMAVGPU<Float,fineSpin,fineColor,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
-#else
-          errorQuda("Twisted mass dslash has not been built");
-#endif
-#endif
-
-	} else if (type == COMPUTE_TMCAV) {
-
-	  if (from_coarse) errorQuda("ComputeTMCAV should only be called from the fine grid");
-#ifdef JITIFY
-          using namespace jitify::reflection;
-          jitify_error = program->kernel("quda::ComputeTMCAVGPU")
-            .instantiate(Type<Float>(),fineSpin,fineColor,coarseColor,Type<Arg>())
-            .configure(tp.grid,tp.block,tp.shared_bytes,stream).launch(arg);
-#else
-#if defined(GPU_TWISTED_CLOVER_DIRAC) && !defined(COARSECOARSE)
-          ComputeTMCAVGPU<Float,fineSpin,fineColor,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
-#else
-          errorQuda("Twisted clover dslash has not been built");
-#endif
-#endif
-
-	} else if (type == COMPUTE_CLOVER_INV_MAX) {
-
-	  if (from_coarse) errorQuda("ComputeCloverInvMax should only be called from the fine grid");
-	  arg.max_d = static_cast<Float*>(pool_device_malloc(2 * arg.fineVolumeCB *sizeof(Float)));
-
-#ifdef JITIFY
-          using namespace jitify::reflection;
-          jitify_error = program->kernel("quda::ComputeCloverInvMaxGPU")
-                             .instantiate(Type<Float>(), false, Type<Arg>())
-                             .configure(tp.grid, tp.block, tp.shared_bytes, stream)
-                             .launch(arg);
-#else
-#if defined(DYNAMIC_CLOVER) && !defined(COARSECOARSE)
-          ComputeCloverInvMaxGPU<Float, false><<<tp.grid, tp.block, tp.shared_bytes>>>(arg);
-#else
-          errorQuda("ComputeCloverInvMax only enabled with dynamic clover");
-#endif
-#endif
-
-          if (!activeTuning()) { // only do reduction once tuning is done else thrust will catch tuning failures
-            thrust_allocator alloc;
-            thrust::device_ptr<Float> ptr(arg.max_d);
-            arg.max_h = thrust::reduce(thrust::cuda::par(alloc), ptr, ptr + 2 * arg.fineVolumeCB,
-                static_cast<Float>(0.0), thrust::maximum<Float>());
-          }
-          pool_device_free(arg.max_d);
-
-        } else if (type == COMPUTE_TWISTED_CLOVER_INV_MAX) {
-
-          if (from_coarse) errorQuda("ComputeCloverInvMax should only be called from the fine grid");
-          arg.max_d = static_cast<Float *>(pool_device_malloc(2 * arg.fineVolumeCB * sizeof(Float)));
-
-#ifdef JITIFY
-          using namespace jitify::reflection;
-          jitify_error = program->kernel("quda::ComputeCloverInvMaxGPU")
-                             .instantiate(Type<Float>(), true, Type<Arg>())
-                             .configure(tp.grid, tp.block, tp.shared_bytes, stream)
-                             .launch(arg);
-#else
-#if defined(DYNAMIC_CLOVER) && !defined(COARSECOARSE)
-          ComputeCloverInvMaxGPU<Float, true><<<tp.grid, tp.block, tp.shared_bytes>>>(arg);
-#else
-	  errorQuda("ComputeCloverInvMax only enabled with dynamic clover");
-#endif
-#endif
-
-          if (!activeTuning()) { // only do reduction once tuning is done else thrust will catch tuning failures
-            thrust_allocator alloc;
-            thrust::device_ptr<Float> ptr(arg.max_d);
-            arg.max_h = thrust::reduce(thrust::cuda::par(alloc), ptr, ptr+2*arg.fineVolumeCB, static_cast<Float>(0.0), thrust::maximum<Float>());
-          }
-          pool_device_free(arg.max_d);
-
-        } else if (type == COMPUTE_VUV) {
-
-          arg.dim_index = 4*(dir==QUDA_BACKWARDS ? 0 : 1) + dim;
-
-          // need to resize the grid since we don't tune over the entire coarseColor dimension
-          // factor of two comes from parity onto different blocks (e.g. in the grid)
-          tp.grid.y = (2*coarseColor + tp.block.y - 1) / tp.block.y;
-          tp.grid.z = (coarseColor + tp.block.z - 1) / tp.block.z;
-
-          arg.shared_atomic = tp.aux.y;
-          arg.parity_flip = tp.aux.z;
-
-          if (arg.shared_atomic) {
-            // check we have a valid problem size for shared atomics
-            // constrint is due to how shared memory initialization and global store are done
-            int block_size = arg.fineVolumeCB/arg.coarseVolumeCB;
-            if (block_size/2 < coarseSpin*coarseSpin)
-              errorQuda("Block size %d not supported in shared-memory atomic coarsening", block_size);
-
-            arg.aggregates_per_block = tp.aux.x;
-            tp.block.x *= tp.aux.x;
-            tp.grid.x /= tp.aux.x;
-          }
-
-          if (arg.coarse_color_wave) {
-            // swap x and y grids
-            std::swap(tp.grid.y,tp.grid.x);
-            // augment x grid with coarseColor row grid (z grid)
-            arg.grid_z = tp.grid.z;
-            arg.coarse_color_grid_z = coarseColor*tp.grid.z;
-            tp.grid.x *= tp.grid.z;
-            tp.grid.z = 1;
-          }
-
-          tp.shared_bytes -= sharedBytesPerBlock(tp); // shared memory is static so don't include it in launch
-
-#ifdef JITIFY
-          using namespace jitify::reflection;
-          jitify_error = program->kernel("quda::ComputeVUVGPU")
-            .instantiate(arg.shared_atomic,arg.parity_flip,from_coarse,Type<Float>(),dim,dir,fineSpin,fineColor,coarseSpin,coarseColor,Type<Arg>())
-            .configure(tp.grid,tp.block,tp.shared_bytes,stream).launch(arg);
-#else
-          if (arg.shared_atomic) {
-            if (arg.parity_flip != true) errorQuda("parity_flip = %d not instantiated", arg.parity_flip);
-            constexpr bool parity_flip = true;
-
-            if (dir == QUDA_BACKWARDS) {
-              if      (dim==0) ComputeVUVGPU<true,parity_flip,from_coarse,Float,0,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
-              else if (dim==1) ComputeVUVGPU<true,parity_flip,from_coarse,Float,1,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
-              else if (dim==2) ComputeVUVGPU<true,parity_flip,from_coarse,Float,2,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
-              else if (dim==3) ComputeVUVGPU<true,parity_flip,from_coarse,Float,3,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
-            } else if (dir == QUDA_FORWARDS) {
-              if      (dim==0) ComputeVUVGPU<true,parity_flip,from_coarse,Float,0,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
-              else if (dim==1) ComputeVUVGPU<true,parity_flip,from_coarse,Float,1,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
-              else if (dim==2) ComputeVUVGPU<true,parity_flip,from_coarse,Float,2,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
-              else if (dim==3) ComputeVUVGPU<true,parity_flip,from_coarse,Float,3,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
-            } else {
-              errorQuda("Undefined direction %d", dir);
-            }
-          } else {
-            if (arg.parity_flip != false) errorQuda("parity_flip = %d not instantiated", arg.parity_flip);
-            constexpr bool parity_flip = false;
-
-            if (dir == QUDA_BACKWARDS) {
-              if      (dim==0) ComputeVUVGPU<false,parity_flip,from_coarse,Float,0,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
-              else if (dim==1) ComputeVUVGPU<false,parity_flip,from_coarse,Float,1,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
-              else if (dim==2) ComputeVUVGPU<false,parity_flip,from_coarse,Float,2,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
-              else if (dim==3) ComputeVUVGPU<false,parity_flip,from_coarse,Float,3,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
-            } else if (dir == QUDA_FORWARDS) {
-              if      (dim==0) ComputeVUVGPU<false,parity_flip,from_coarse,Float,0,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
-              else if (dim==1) ComputeVUVGPU<false,parity_flip,from_coarse,Float,1,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
-              else if (dim==2) ComputeVUVGPU<false,parity_flip,from_coarse,Float,2,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
-              else if (dim==3) ComputeVUVGPU<false,parity_flip,from_coarse,Float,3,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
-            } else {
-              errorQuda("Undefined direction %d", dir);
-            }
-          }
-#endif
-          tp.shared_bytes += sharedBytesPerBlock(tp); // restore shared memory
-
-          if (arg.coarse_color_wave) {
-            // revert the grids
-            tp.grid.z = arg.grid_z;
-            tp.grid.x /= tp.grid.z;
-            std::swap(tp.grid.x,tp.grid.y);
-          }
-
-          if (arg.shared_atomic) {
-            tp.block.x /= tp.aux.x;
-            tp.grid.x *= tp.aux.x;
-          }
-
-        } else if (type == COMPUTE_COARSE_CLOVER) {
-
-#ifdef JITIFY
-          using namespace jitify::reflection;
-          jitify_error = program->kernel("quda::ComputeCoarseCloverGPU")
-            .instantiate(from_coarse,Type<Float>(),fineSpin,coarseSpin,fineColor,coarseColor,Type<Arg>())
-            .configure(tp.grid,tp.block,tp.shared_bytes,stream).launch(arg);
-#else
-	  ComputeCoarseCloverGPU<from_coarse,Float,fineSpin,coarseSpin,fineColor,coarseColor>
-	    <<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
-#endif
-
-        } else if (type == COMPUTE_REVERSE_Y) {
-
-#ifdef JITIFY
-          using namespace jitify::reflection;
-          jitify_error = program->kernel("quda::ComputeYReverseGPU")
-            .instantiate(Type<Float>(),coarseSpin,coarseColor,Type<Arg>())
-            .configure(tp.grid,tp.block,tp.shared_bytes,stream).launch(arg);
-#else
-	  ComputeYReverseGPU<Float,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
-#endif
-        } else if (type == COMPUTE_DIAGONAL) {
-
-#ifdef JITIFY
-          using namespace jitify::reflection;
-          jitify_error = program->kernel("quda::AddCoarseDiagonalGPU")
-            .instantiate(Type<Float>(),coarseSpin,coarseColor,Type<Arg>())
-            .configure(tp.grid,tp.block,tp.shared_bytes,stream).launch(arg);
-#else
-	  AddCoarseDiagonalGPU<Float,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
-#endif
-        } else if (type == COMPUTE_TMDIAGONAL) {
-
-#ifdef JITIFY
-          using namespace jitify::reflection;
-          jitify_error = program->kernel("quda::AddCoarseTmDiagonalGPU")
-            .instantiate(Type<Float>(),coarseSpin,coarseColor,Type<Arg>())
-            .configure(tp.grid,tp.block,tp.shared_bytes,stream).launch(arg);
-#else
-          AddCoarseTmDiagonalGPU<Float,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
-#endif
-        } else if (type == COMPUTE_CONVERT) {
-
-          arg.dim_index = 4*(dir==QUDA_BACKWARDS ? 0 : 1) + dim;
-#ifdef JITIFY
-          using namespace jitify::reflection;
-          jitify_error = program->kernel("quda::ConvertGPU")
-            .instantiate(Type<Float>(),coarseSpin,coarseColor,Type<Arg>())
-            .configure(tp.grid,tp.block,tp.shared_bytes,stream).launch(arg);
-#else
-	  ConvertGPU<Float,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
-#endif
-        } else if (type == COMPUTE_RESCALE) {
-
-          arg.dim_index = 4*(dir==QUDA_BACKWARDS ? 0 : 1) + dim;
-#ifdef JITIFY
-          using namespace jitify::reflection;
-          jitify_error = program->kernel("quda::RescaleYGPU")
-            .instantiate(Type<Float>(),coarseSpin,coarseColor,Type<Arg>())
-            .configure(tp.grid,tp.block,tp.shared_bytes,stream).launch(arg);
-#else
-	  RescaleYGPU<Float,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
-#endif
-
-        } else {
-          errorQuda("Undefined compute type %d", type);
-        }
-      }
-    }
+      arg.dim = dim;
+      arg.dir = dir;
+      if (type == COMPUTE_VUV || type == COMPUTE_CONVERT || type == COMPUTE_RESCALE) arg.dim_index = 4*(dir==QUDA_BACKWARDS ? 0 : 1) + dim;
+
+      if (type == COMPUTE_VUV) tp.shared_bytes -= sharedBytesPerBlock(tp); // shared memory is static so don't include it in launch
+      Launch<location, from_coarse, Float, fineSpin, fineColor, coarseSpin, coarseColor, Arg>(arg, jitify_error, tp, type, stream);
+      if (type == COMPUTE_VUV) tp.shared_bytes += sharedBytesPerBlock(tp); // restore shared memory
+    };
 
     /**
        Set which dimension we are working on (where applicable)
@@ -839,8 +823,6 @@ namespace quda {
     }
   };
 
-
-
   /**
      @brief Calculate the coarse-link field, including the coarse clover field.
 
@@ -864,14 +846,15 @@ namespace quda {
      @param need_bidirectional[in] If we need to force bi-directional build or not. Required
      if some previous level was preconditioned, even if this one isn't
    */
-  template<bool from_coarse, typename Float, int fineSpin, int fineColor, int coarseSpin, int coarseColor, typename F,
+  template<QudaFieldLocation location, bool from_coarse, typename Float, int fineSpin, int fineColor, int coarseSpin, int coarseColor, typename F,
 	   typename Ftmp, typename Vt, typename coarseGauge, typename coarseGaugeAtomic, typename fineGauge, typename fineClover>
   void calculateY(coarseGauge &Y, coarseGauge &X,
 		  coarseGaugeAtomic &Y_atomic, coarseGaugeAtomic &X_atomic,
 		  Ftmp &UV, F &AV, Vt &V, fineGauge &G, fineClover &C, fineClover &Cinv,
 		  GaugeField &Y_, GaugeField &X_, GaugeField &Y_atomic_, GaugeField &X_atomic_,
                   ColorSpinorField &uv, ColorSpinorField &av, const ColorSpinorField &v,
-		  double kappa, double mu, double mu_factor, QudaDiracType dirac, QudaMatPCType matpc,
+		  const GaugeField &G_, const CloverField &C_,
+                  double kappa, double mu, double mu_factor, QudaDiracType dirac, QudaMatPCType matpc,
 		  bool need_bidirectional, const int *fine_to_coarse, const int *coarse_to_fine) {
 
     // sanity checks
@@ -916,10 +899,10 @@ namespace quda {
     typedef CalculateYArg<Float,fineSpin,coarseSpin,fineColor,coarseColor,coarseGauge,coarseGaugeAtomic,fineGauge,F,Ftmp,Vt,fineClover> Arg;
     Arg arg(Y, X, Y_atomic, X_atomic, UV, AV, G, V, C, Cinv, kappa,
 	    mu, mu_factor, x_size, xc_size, geo_bs, spin_bs, fine_to_coarse, coarse_to_fine, bidirectional_links);
-    CalculateY<from_coarse, Float, fineSpin, fineColor, coarseSpin, coarseColor, Arg> y(arg, v, Y_, X_, Y_atomic_, X_atomic_);
+    CalculateY<location, from_coarse, Float, fineSpin, fineColor, coarseSpin, coarseColor, Arg> y(arg, v, Y_, X_, Y_atomic_, X_atomic_);
 
-    QudaFieldLocation location = checkLocation(Y_, X_, av, v);
-    if (getVerbosity() >= QUDA_VERBOSE) printfQuda("Running link coarsening on the %s\n", location == QUDA_CUDA_FIELD_LOCATION ? "GPU" : "CPU");
+    QudaFieldLocation location_ = checkLocation(Y_, X_, av, v);
+    if (getVerbosity() >= QUDA_VERBOSE) printfQuda("Running link coarsening on the %s\n", location_ == QUDA_CUDA_FIELD_LOCATION ? "GPU" : "CPU");
 
     // do exchange of null-space vectors
     const int nFace = 1;
@@ -942,7 +925,7 @@ namespace quda {
         y.apply(0);
         double max = 6 * arg.max_h;
 #else
-        double max = 6*arg.Cinv.abs_max(0);
+        double max = 6*C_.abs_max(true);
 #endif
         if (getVerbosity() >= QUDA_DEBUG_VERBOSE) printfQuda("clover max %e\n", max);
 	av.Scale(max);
@@ -990,7 +973,7 @@ namespace quda {
         y.apply(0);
 	double max = 6*sqrt(arg.max_h);
 #else
-	double max = 6*sqrt(arg.Cinv.abs_max(0));
+	double max = 6*sqrt(C_.abs_max(true));
 #endif
 	if (getVerbosity() >= QUDA_DEBUG_VERBOSE) printfQuda("tmc max %e\n", max);
 	av.Scale(max);
@@ -1006,7 +989,9 @@ namespace quda {
     // work out what to set the scales to
     if (coarseGaugeAtomic::fixedPoint()) {
       double max = 500.0; // Should be more than sufficient
+      Y_atomic_.Scale(max);
       arg.Y_atomic.resetScale(max);
+      X_atomic_.Scale(max);
       arg.X_atomic.resetScale(max);
     }
 
@@ -1024,7 +1009,7 @@ namespace quda {
 	if (getVerbosity() >= QUDA_VERBOSE) printfQuda("Computing forward %d UV and VUV\n", d);
 
 	if (uv.Precision() == QUDA_HALF_PRECISION) {
-	  double U_max = 3.0*arg.U.abs_max(from_coarse ? d+4 : d);
+	  double U_max = 3.0*G_.abs_max(from_coarse ? d+4 : d);
 	  double uv_max = U_max * v.Scale();
 	  uv.Scale(uv_max);
 	  arg.UV.resetScale(uv_max);
@@ -1036,18 +1021,19 @@ namespace quda {
 	y.apply(0);
 	if (getVerbosity() >= QUDA_VERBOSE) printfQuda("UV2[%d] = %e\n", d, arg.UV.norm2());
 
-      // if we are writing to a temporary, we need to zero it before each computation
+        // if we are writing to a temporary, we need to zero it before each computation
         if (Y_atomic.Geometry() == 1) Y_atomic_.zero();
 
         y.setComputeType(COMPUTE_VUV); // compute Y += VUV
         y.apply(0);
-        if (getVerbosity() >= QUDA_VERBOSE) printfQuda("Y2[%d] (atomic) = %e\n", 4+d, arg.Y_atomic.norm2( (4+d) % arg.Y_atomic.geometry ));
+        if (getVerbosity() >= QUDA_VERBOSE)
+          printfQuda("Y2[%d] (atomic) = %e\n", 4+d, Y_atomic_.norm2((4+d) % arg.Y_atomic.geometry, coarseGaugeAtomic::fixedPoint()));
 
         // now convert from atomic to application computation format if necessary for Y[d]
         if (coarseGaugeAtomic::fixedPoint() || coarseGauge::fixedPoint()) {
 
           if (coarseGauge::fixedPoint()) {
-            double y_max = arg.Y_atomic.abs_max( (4+d) % arg.Y_atomic.geometry );
+            double y_max = Y_atomic_.abs_max((4+d) % arg.Y_atomic.geometry, coarseGaugeAtomic::fixedPoint());
 
             if (getVerbosity() >= QUDA_DEBUG_VERBOSE) printfQuda("Y[%d] (atomic) max = %e Y[%d] scale = %e\n", 4+d, y_max, 4+d, Y_.Scale());
             if (!set_scale) {
@@ -1073,7 +1059,7 @@ namespace quda {
           y.setComputeType(COMPUTE_CONVERT);
           y.apply(0);
 
-          if (getVerbosity() >= QUDA_VERBOSE) printfQuda("Y2[%d] = %e\n", 4+d, arg.Y.norm2( 4+d ));
+          if (getVerbosity() >= QUDA_VERBOSE) printfQuda("Y2[%d] = %e\n", 4+d, Y_.norm2( 4+d ));
         }
 
       }
@@ -1093,7 +1079,7 @@ namespace quda {
       if (getVerbosity() >= QUDA_VERBOSE) printfQuda("Computing backward %d UV and VUV\n", d);
 
       if (uv.Precision() == QUDA_HALF_PRECISION) {
-	double U_max = 3.0*arg.U.abs_max(d);
+	double U_max = 3.0*G_.abs_max(d);
 	double uv_max = U_max * av.Scale();
 	uv.Scale(uv_max);
 	arg.UV.resetScale(uv_max);
@@ -1110,13 +1096,14 @@ namespace quda {
 
       y.setComputeType(COMPUTE_VUV); // compute Y += VUV
       y.apply(0);
-      if (getVerbosity() >= QUDA_VERBOSE) printfQuda("Y2[%d] (atomic) = %e\n", d, arg.Y_atomic.norm2( d%arg.Y_atomic.geometry ));
+      if (getVerbosity() >= QUDA_VERBOSE)
+        printfQuda("Y2[%d] (atomic) = %e\n", d, Y_atomic_.norm2(d%arg.Y_atomic.geometry, coarseGaugeAtomic::fixedPoint()));
 
       // now convert from atomic to application computation format if necessary for Y[d]
       if (coarseGaugeAtomic::fixedPoint() || coarseGauge::fixedPoint() ) {
 
         if (coarseGauge::fixedPoint()) {
-          double y_max = arg.Y_atomic.abs_max( d % arg.Y_atomic.geometry );
+          double y_max = Y_atomic_.abs_max(d % arg.Y_atomic.geometry, coarseGaugeAtomic::fixedPoint());
           if (getVerbosity() >= QUDA_DEBUG_VERBOSE) printfQuda("Y[%d] (atomic) max = %e Y[%d] scale = %e\n", d, y_max, d, Y_.Scale());
 
           if (!set_scale) {
@@ -1152,12 +1139,12 @@ namespace quda {
         y.setComputeType(COMPUTE_CONVERT);
         y.apply(0);
 
-        if (getVerbosity() >= QUDA_VERBOSE) printfQuda("Y2[%d] = %e\n", d, arg.Y.norm2( d ));
+        if (getVerbosity() >= QUDA_VERBOSE) printfQuda("Y2[%d] = %e\n", d, Y_.norm2( d ));
       }
 
     }
 
-    if (getVerbosity() >= QUDA_VERBOSE) printfQuda("X2 = %e\n", arg.X_atomic.norm2(0));
+    if (getVerbosity() >= QUDA_VERBOSE) printfQuda("X2 = %e\n", X_atomic_.norm2(0, coarseGaugeAtomic::fixedPoint()));
 
     // if not doing a preconditioned operator then we can trivially
     // construct the forward links from the backward links
@@ -1193,7 +1180,7 @@ namespace quda {
       y.setDirection(QUDA_BACKWARDS);
 
       if (coarseGauge::fixedPoint()) {
-        double x_max = arg.X_atomic.abs_max(0);
+        double x_max = X_atomic_.abs_max(0, coarseGaugeAtomic::fixedPoint());
         X_.Scale(x_max);
         arg.X.resetScale(x_max);
       }
@@ -1202,9 +1189,7 @@ namespace quda {
       y.apply(0);
     }
 
-    if (getVerbosity() >= QUDA_VERBOSE) printfQuda("X2 = %e\n", arg.X.norm2(0));
-
+    if (getVerbosity() >= QUDA_VERBOSE) printfQuda("X2 = %e\n", X_.norm2(0));
   }
-
 
 } // namespace quda

--- a/lib/coarse_op_preconditioned.cu
+++ b/lib/coarse_op_preconditioned.cu
@@ -10,10 +10,58 @@ namespace quda {
 
 #ifdef GPU_MULTIGRID
 
-  template <typename Float, int n, typename Arg>
+  /**
+     @brief Launcher for CPU instantiations of preconditioned coarse-link construction
+  */
+  template <QudaFieldLocation location, typename Arg>
+  struct Launch {
+    Launch(Arg &arg, bool compute_max_only, TuneParam &tp, const cudaStream_t &stream)
+    {
+      if (compute_max_only)
+        CalculateYhatCPU<true, Arg>(arg);
+      else
+        CalculateYhatCPU<false, Arg>(arg);
+    }
+  };
+
+  /**
+     @brief Launcher for GPU instantiations of preconditioned coarse-link construction
+  */
+  template <typename Arg>
+  struct Launch<QUDA_CUDA_FIELD_LOCATION, Arg> {
+    Launch(Arg &arg, bool compute_max_only, TuneParam &tp, const cudaStream_t &stream)
+    {
+      if (compute_max_only) {
+        if (!activeTuning()) {
+          qudaMemsetAsync(arg.max_d, 0, sizeof(typename Arg::Float), stream);
+        }
+      }
+#ifdef JITIFY
+      using namespace jitify::reflection;
+      jitify_error = program->kernel("quda::CalculateYhatGPU")
+        .instantiate(compute_max_only, Type<Arg>())
+        .configure(tp.grid, tp.block, tp.shared_bytes, stream)
+        .launch(arg);
+#else
+      if (compute_max_only)
+        CalculateYhatGPU<true, Arg><<<tp.grid, tp.block, tp.shared_bytes, stream>>>(arg);
+      else
+        CalculateYhatGPU<false, Arg><<<tp.grid, tp.block, tp.shared_bytes, stream>>>(arg);
+#endif
+      if (compute_max_only) {
+        if (!activeTuning()) { // only do copy once tuning is done
+          qudaMemcpyAsync(arg.max_h, arg.max_d, sizeof(typename Arg::Float), cudaMemcpyDeviceToHost, stream);
+          qudaStreamSynchronize(const_cast<cudaStream_t&>(stream));
+        }
+      }
+    }
+  };
+
+  template <QudaFieldLocation location, typename Arg>
   class CalculateYhat : public TunableVectorYZ {
 
-  protected:
+    using Float = typename Arg::Float;
+    static constexpr int n = Arg::n;
     Arg &arg;
     const LatticeField &meta;
 
@@ -37,7 +85,7 @@ namespace quda {
       {
         if (meta.Location() == QUDA_CUDA_FIELD_LOCATION) {
 #ifdef JITIFY
-        create_jitify_program("kernels/coarse_op_preconditioned.cuh");
+          create_jitify_program("kernels/coarse_op_preconditioned.cuh");
 #endif
           arg.max_d = static_cast<Float*>(pool_device_malloc(sizeof(Float)));
         }
@@ -45,6 +93,7 @@ namespace quda {
       strcpy(aux, compile_type_str(meta));
       strcat(aux, comm_dim_partitioned_string());
       }
+
     virtual ~CalculateYhat() {
       if (meta.Location() == QUDA_CUDA_FIELD_LOCATION) {
         pool_device_free(arg.max_d);
@@ -52,41 +101,10 @@ namespace quda {
       pool_pinned_free(arg.max_h);
     }
 
-    void apply(const cudaStream_t &stream) {
+    void apply(const cudaStream_t &stream)
+    {
       TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
-      if (meta.Location() == QUDA_CPU_FIELD_LOCATION) {
-
-        if (compute_max_only)
-          CalculateYhatCPU<Float, n, true, Arg>(arg);
-        else
-          CalculateYhatCPU<Float, n, false, Arg>(arg);
-
-      } else {
-        if (compute_max_only) {
-          if (!activeTuning())
-          {
-            qudaMemsetAsync(arg.max_d, 0, sizeof(Float), stream);
-          }
-        }
-#ifdef JITIFY
-        using namespace jitify::reflection;
-        jitify_error = program->kernel("quda::CalculateYhatGPU")
-                         .instantiate(Type<Float>(), n, compute_max_only, Type<Arg>())
-                         .configure(tp.grid, tp.block, tp.shared_bytes, stream)
-                         .launch(arg);
-#else
-        if (compute_max_only)
-          CalculateYhatGPU<Float, n, true, Arg><<<tp.grid, tp.block, tp.shared_bytes, stream>>>(arg);
-        else
-          CalculateYhatGPU<Float, n, false, Arg><<<tp.grid, tp.block, tp.shared_bytes, stream>>>(arg);
-#endif
-        if (compute_max_only) {
-          if (!activeTuning()) { // only do copy once tuning is done
-            qudaMemcpyAsync(arg.max_h, arg.max_d, sizeof(Float), cudaMemcpyDeviceToHost, stream);
-            qudaStreamSynchronize(const_cast<cudaStream_t&>(stream));
-          }
-        }
-      }
+      Launch<location, Arg>(arg, compute_max_only, tp, stream);
     }
 
     /**
@@ -124,7 +142,7 @@ namespace quda {
      @param Y[out] Coarse link field
      @param X[out] Coarse clover field
    */
-  template<typename storeFloat, typename Float, int N, QudaGaugeFieldOrder gOrder>
+  template<QudaFieldLocation location, typename storeFloat, typename Float, int N, QudaGaugeFieldOrder gOrder>
   void calculateYhat(GaugeField &Yhat, GaugeField &Xinv, const GaugeField &Y, const GaugeField &X)
   {
     // invert the clover matrix field
@@ -175,7 +193,7 @@ namespace quda {
       typedef CalculateYhatArg<Float, gPreconditionedCoarse, gCoarse, N> yHatArg;
       yHatArg arg(yHatAccessor, yAccessor, xInvAccessor, xc_size, comm_dim, 1);
 
-      CalculateYhat<Float, N, yHatArg> yHat(arg, Y);
+      CalculateYhat<location, yHatArg> yHat(arg, Y);
       if (Yhat.Precision() == QUDA_HALF_PRECISION || Yhat.Precision() == QUDA_QUARTER_PRECISION) {
         yHat.setComputeMaxOnly(true);
         yHat.apply(0);
@@ -215,11 +233,11 @@ namespace quda {
     if (Y.Location() == QUDA_CPU_FIELD_LOCATION) {
       constexpr QudaGaugeFieldOrder gOrder = QUDA_QDP_GAUGE_ORDER;
       if (Y.FieldOrder() != gOrder) errorQuda("Unsupported field order %d\n", Y.FieldOrder());
-      calculateYhat<storeFloat,Float,N,gOrder>(Yhat, Xinv, Y, X);
+      calculateYhat<QUDA_CPU_FIELD_LOCATION,storeFloat,Float,N,gOrder>(Yhat, Xinv, Y, X);
     } else {
       constexpr QudaGaugeFieldOrder gOrder = QUDA_FLOAT2_GAUGE_ORDER;
       if (Y.FieldOrder() != gOrder) errorQuda("Unsupported field order %d\n", Y.FieldOrder());
-      calculateYhat<storeFloat,Float,N,gOrder>(Yhat, Xinv, Y, X);
+      calculateYhat<QUDA_CUDA_FIELD_LOCATION,storeFloat,Float,N,gOrder>(Yhat, Xinv, Y, X);
     }
   }
 

--- a/lib/coarsecoarse_op.cu
+++ b/lib/coarsecoarse_op.cu
@@ -7,7 +7,7 @@
 
 namespace quda {
 
-  static CloverField* dummyClover()
+  inline CloverField* dummyClover()
   {
     CloverFieldParam cf_param;
     cf_param.nDim = 4;

--- a/lib/color_spinor_pack.cu
+++ b/lib/color_spinor_pack.cu
@@ -258,13 +258,11 @@ namespace quda {
       errorQuda("Ncolor = %d not supported for double precision fields", a.Ncolor());
 #endif
 
-    if (a.Ncolor() == 2) {
-      genericPackGhost<Float,ghostFloat,order,Ns,precision_spin_color_mapper<Float,ghostFloat,Ns,2>::nColor>(ghost, a, parity, nFace, dagger, destination);
-    } else if (a.Ncolor() == 3) {
+    if (a.Ncolor() == 3) {
       genericPackGhost<Float,ghostFloat,order,Ns,precision_spin_color_mapper<Float,ghostFloat,Ns,3>::nColor>(ghost, a, parity, nFace, dagger, destination);
 #ifdef GPU_MULTIGRID
-    } else if (a.Ncolor() == 4) {
-      genericPackGhost<Float,ghostFloat,order,Ns,precision_spin_color_mapper<Float,ghostFloat,Ns,4>::nColor>(ghost, a, parity, nFace, dagger, destination);
+    } else if (a.Ncolor() == 6) {
+      genericPackGhost<Float,ghostFloat,order,Ns,precision_spin_color_mapper<Float,ghostFloat,Ns,6>::nColor>(ghost, a, parity, nFace, dagger, destination);
     } else if (a.Ncolor() == 18) { // Needed for two level free field Wilson
       genericPackGhost<Float,ghostFloat,order,Ns,precision_spin_color_mapper<Float,ghostFloat,Ns,18>::nColor>(ghost, a, parity, nFace, dagger, destination);
     } else if (a.Ncolor() == 24) { // Needed for K-D staggered Wilson

--- a/lib/copy_color_spinor_mg.cuh
+++ b/lib/copy_color_spinor_mg.cuh
@@ -215,19 +215,7 @@ namespace quda {
 #ifdef GPU_STAGGERED_DIRAC
 #define INSTANTIATE_COLOR           \
   switch(src.Ncolor()) {            \
-  case 1: CopyGenericColorSpinor<1>(dst, src, location, dst_ptr, src_ptr);  \
-    break;                \
-  case 2: CopyGenericColorSpinor<2>(dst, src, location, dst_ptr, src_ptr);  \
-    break;                \
-  case 4: CopyGenericColorSpinor<4>(dst, src, location, dst_ptr, src_ptr);  \
-    break;                \
   case 6: CopyGenericColorSpinor<6>(dst, src, location, dst_ptr, src_ptr);  \
-    break;                \
-  case 9: CopyGenericColorSpinor<9>(dst, src, location, dst_ptr, src_ptr);  \
-    break;                \
-  case 12: CopyGenericColorSpinor<12>(dst, src, location, dst_ptr, src_ptr); \
-    break;                \
-  case 16: CopyGenericColorSpinor<16>(dst, src, location, dst_ptr, src_ptr); \
     break;                \
   case 18: CopyGenericColorSpinor<18>(dst, src, location, dst_ptr, src_ptr); \
     break;                \
@@ -237,19 +225,11 @@ namespace quda {
     break;                \
   case 36: CopyGenericColorSpinor<36>(dst, src, location, dst_ptr, src_ptr); \
     break;                \
-  case 48: CopyGenericColorSpinor<48>(dst, src, location, dst_ptr, src_ptr); \
-    break;                \
   case 64: CopyGenericColorSpinor<64>(dst, src, location, dst_ptr, src_ptr); \
     break;                \
   case 72: CopyGenericColorSpinor<72>(dst, src, location, dst_ptr, src_ptr); \
     break;                \
   case 96: CopyGenericColorSpinor<96>(dst, src, location, dst_ptr, src_ptr); \
-    break;                \
-  case 128: CopyGenericColorSpinor<128>(dst, src, location, dst_ptr, src_ptr); \
-    break;                \
-  case 192: CopyGenericColorSpinor<192>(dst, src, location, dst_ptr, src_ptr); \
-    break;                \
-  case 256: CopyGenericColorSpinor<256>(dst, src, location, dst_ptr, src_ptr);  \
     break;                \
   case 576: CopyGenericColorSpinor<576>(dst, src, location, dst_ptr, src_ptr);  \
     break;                \
@@ -274,21 +254,13 @@ namespace quda {
 
 #define INSTANTIATE_COLOR                                                                                              \
   switch (src.Ncolor()) {                                                                                              \
-  case 1: CopyGenericColorSpinor<1>(dst, src, location, dst_ptr, src_ptr); break;                                      \
-  case 2: CopyGenericColorSpinor<2>(dst, src, location, dst_ptr, src_ptr); break;                                      \
-  case 4: CopyGenericColorSpinor<4>(dst, src, location, dst_ptr, src_ptr); break;                                      \
   case 6: CopyGenericColorSpinor<6>(dst, src, location, dst_ptr, src_ptr); break;                                      \
-  case 9: CopyGenericColorSpinor<9>(dst, src, location, dst_ptr, src_ptr); break;                                      \
-  case 12: CopyGenericColorSpinor<12>(dst, src, location, dst_ptr, src_ptr); break;                                    \
-  case 16: CopyGenericColorSpinor<16>(dst, src, location, dst_ptr, src_ptr); break;                                    \
   case 18: CopyGenericColorSpinor<18>(dst, src, location, dst_ptr, src_ptr); break;                                    \
   case 24: CopyGenericColorSpinor<24>(dst, src, location, dst_ptr, src_ptr); break;                                    \
   case 32: CopyGenericColorSpinor<32>(dst, src, location, dst_ptr, src_ptr); break;                                    \
   case 36: CopyGenericColorSpinor<36>(dst, src, location, dst_ptr, src_ptr); break;                                    \
-  case 48: CopyGenericColorSpinor<48>(dst, src, location, dst_ptr, src_ptr); break;                                    \
   case 72: CopyGenericColorSpinor<72>(dst, src, location, dst_ptr, src_ptr); break;                                    \
   case 96: CopyGenericColorSpinor<96>(dst, src, location, dst_ptr, src_ptr); break;                                    \
-  case 256: CopyGenericColorSpinor<256>(dst, src, location, dst_ptr, src_ptr); break;                                  \
   case 576: CopyGenericColorSpinor<576>(dst, src, location, dst_ptr, src_ptr); break;                                  \
   case 768: CopyGenericColorSpinor<768>(dst, src, location, dst_ptr, src_ptr); break;                                  \
   case 1024: CopyGenericColorSpinor<1024>(dst, src, location, dst_ptr, src_ptr); break;                                \

--- a/lib/copy_color_spinor_mg_hh.cu
+++ b/lib/copy_color_spinor_mg_hh.cu
@@ -6,13 +6,13 @@ namespace quda {
 				  QudaFieldLocation location, void *Dst, void *Src, 
 				  void *dstNorm, void *srcNorm) {
 
-#if defined(GPU_MULTIGRID)
+#if defined(GPU_MULTIGRID) && (QUDA_PRECISION & 2)
     short *dst_ptr = static_cast<short*>(Dst);
     short *src_ptr = static_cast<short*>(Src);
 
     INSTANTIATE_COLOR;
 #else
-    errorQuda("Double precision multigrid has not been enabled");
+    errorQuda("Half precision has not been enabled");
 #endif
 
   }

--- a/lib/copy_color_spinor_mg_hq.cu
+++ b/lib/copy_color_spinor_mg_hq.cu
@@ -6,13 +6,13 @@ namespace quda {
 				  QudaFieldLocation location, void *Dst, void *Src, 
 				  void *dstNorm, void *srcNorm) {
 
-#if defined(GPU_MULTIGRID)
+#if defined(GPU_MULTIGRID) && (QUDA_PRECISION & 2) && (QUDA_PRECISION & 1)
     short *dst_ptr = static_cast<short*>(Dst);
     char *src_ptr = static_cast<char*>(Src);
 
     INSTANTIATE_COLOR;
 #else
-    errorQuda("Double precision multigrid has not been enabled");
+    errorQuda("Half and quarter precision have not been enabled");
 #endif
 
   }

--- a/lib/copy_color_spinor_mg_hs.cu
+++ b/lib/copy_color_spinor_mg_hs.cu
@@ -6,13 +6,13 @@ namespace quda {
 				  QudaFieldLocation location, void *Dst, void *Src, 
 				  void *dstNorm, void *srcNorm) {
 
-#if defined(GPU_MULTIGRID)
+#if defined(GPU_MULTIGRID) && (QUDA_PRECISION & 2)
     short *dst_ptr = static_cast<short*>(Dst);
     float *src_ptr = static_cast<float*>(Src);
 
     INSTANTIATE_COLOR;
 #else
-    errorQuda("Double precision multigrid has not been enabled");
+    errorQuda("Half precision has not been enabled");
 #endif
 
   }

--- a/lib/copy_color_spinor_mg_qh.cu
+++ b/lib/copy_color_spinor_mg_qh.cu
@@ -6,13 +6,13 @@ namespace quda {
 				  QudaFieldLocation location, void *Dst, void *Src, 
 				  void *dstNorm, void *srcNorm) {
 
-#if defined(GPU_MULTIGRID)
+#if defined(GPU_MULTIGRID) && (QUDA_PRECISION & 2) && (QUDA_PRECISION & 1)
     char *dst_ptr = static_cast<char*>(Dst);
     short *src_ptr = static_cast<short*>(Src);
 
     INSTANTIATE_COLOR;
 #else
-    errorQuda("Double precision multigrid has not been enabled");
+    errorQuda("Half and quarter precision have not been enabled");
 #endif
 
   }

--- a/lib/copy_color_spinor_mg_qq.cu
+++ b/lib/copy_color_spinor_mg_qq.cu
@@ -6,13 +6,13 @@ namespace quda {
 				  QudaFieldLocation location, void *Dst, void *Src, 
 				  void *dstNorm, void *srcNorm) {
 
-#if defined(GPU_MULTIGRID)
+#if defined(GPU_MULTIGRID) && (QUDA_PRECISION & 1)
     char *dst_ptr = static_cast<char*>(Dst);
     char *src_ptr = static_cast<char*>(Src);
 
     INSTANTIATE_COLOR;
 #else
-    errorQuda("Double precision multigrid has not been enabled");
+    errorQuda("Quarter precision has not been enabled");
 #endif
 
   }

--- a/lib/copy_color_spinor_mg_qs.cu
+++ b/lib/copy_color_spinor_mg_qs.cu
@@ -6,13 +6,13 @@ namespace quda {
 				  QudaFieldLocation location, void *Dst, void *Src, 
 				  void *dstNorm, void *srcNorm) {
 
-#if defined(GPU_MULTIGRID)
+#if defined(GPU_MULTIGRID) && (QUDA_PRECISION & 1)
     char *dst_ptr = static_cast<char*>(Dst);
     float *src_ptr = static_cast<float*>(Src);
 
     INSTANTIATE_COLOR;
 #else
-    errorQuda("Double precision multigrid has not been enabled");
+    errorQuda("Quarter precision has not been enabled");
 #endif
 
   }

--- a/lib/copy_gauge_mg.cu
+++ b/lib/copy_gauge_mg.cu
@@ -6,12 +6,11 @@
 
 namespace quda {
   
-  template <typename sFloatOut, typename sFloatIn, int Nc, typename InOrder>
+  template <typename sFloatOut, typename FloatIn, int Nc, typename InOrder>
   void copyGaugeMG(const InOrder &inOrder, GaugeField &out, const GaugeField &in,
-		   QudaFieldLocation location, sFloatOut *Out, sFloatOut **outGhost, int type) {
-
+		   QudaFieldLocation location, sFloatOut *Out, sFloatOut **outGhost, int type)
+  {
     typedef typename mapper<sFloatOut>::type FloatOut;
-    typedef typename mapper<sFloatIn>::type FloatIn;
     constexpr int length = 2*Nc*Nc;
 
     if (out.Reconstruct() != QUDA_RECONSTRUCT_NO)
@@ -72,8 +71,8 @@ namespace quda {
 
   template <typename sFloatOut, typename sFloatIn, int Nc>
     void copyGaugeMG(GaugeField &out, const GaugeField &in, QudaFieldLocation location,
-		     sFloatOut *Out, sFloatIn *In, sFloatOut **outGhost, sFloatIn **inGhost, int type) {
-
+		     sFloatOut *Out, sFloatIn *In, sFloatOut **outGhost, sFloatIn **inGhost, int type)
+  {
     typedef typename mapper<sFloatOut>::type FloatOut;
     typedef typename mapper<sFloatIn>::type FloatIn;
 #ifndef FINE_GRAINED_ACCESS
@@ -87,10 +86,10 @@ namespace quda {
 #ifdef FINE_GRAINED_ACCESS
       if (inGhost) {
 	typedef typename gauge::FieldOrder<FloatIn,Nc,1,QUDA_FLOAT2_GAUGE_ORDER,false,sFloatIn> G;
-	copyGaugeMG<sFloatOut,sFloatIn,Nc> (G(const_cast<GaugeField&>(in),(void*)In,(void**)inGhost), out, in, location, Out, outGhost, type);
+	copyGaugeMG<sFloatOut,FloatIn,Nc> (G(const_cast<GaugeField&>(in),(void*)In,(void**)inGhost), out, in, location, Out, outGhost, type);
       } else {
 	typedef typename gauge::FieldOrder<FloatIn,Nc,1,QUDA_FLOAT2_GAUGE_ORDER,true,sFloatIn> G;
-	copyGaugeMG<sFloatOut,sFloatIn,Nc> (G(const_cast<GaugeField&>(in),(void*)In,(void**)inGhost), out, in, location, Out, outGhost, type);
+	copyGaugeMG<sFloatOut,FloatIn,Nc> (G(const_cast<GaugeField&>(in),(void*)In,(void**)inGhost), out, in, location, Out, outGhost, type);
       }
 #else
       typedef typename gauge_mapper<FloatIn,QUDA_RECONSTRUCT_NO,length>::type G;
@@ -100,7 +99,7 @@ namespace quda {
 
 #ifdef FINE_GRAINED_ACCESS
       typedef typename gauge::FieldOrder<FloatIn,Nc,1,QUDA_QDP_GAUGE_ORDER,true,sFloatIn> G;
-      copyGaugeMG<sFloatOut,sFloatIn,Nc>(G(const_cast<GaugeField&>(in),(void*)In,(void**)inGhost), out, in, location, Out, outGhost, type);
+      copyGaugeMG<sFloatOut,FloatIn,Nc>(G(const_cast<GaugeField&>(in),(void*)In,(void**)inGhost), out, in, location, Out, outGhost, type);
 #else
       typedef typename QDPOrder<FloatIn,length> G;
       copyGaugeMG<FloatOut,FloatIn,Nc>(G(in, In, inGhost), out, in, location, Out, outGhost, type);
@@ -110,7 +109,7 @@ namespace quda {
 
 #ifdef FINE_GRAINED_ACCESS
       typedef typename gauge::FieldOrder<FloatIn,Nc,1,QUDA_MILC_GAUGE_ORDER,true,sFloatIn> G;
-      copyGaugeMG<sFloatOut,sFloatIn,Nc>(G(const_cast<GaugeField&>(in),(void*)In,(void**)inGhost), out, in, location, Out, outGhost, type);
+      copyGaugeMG<sFloatOut,FloatIn,Nc>(G(const_cast<GaugeField&>(in),(void*)In,(void**)inGhost), out, in, location, Out, outGhost, type);
 #else
       typedef typename MILCOrder<FloatIn,length> G;
       copyGaugeMG<FloatOut,FloatIn,Nc>(G(in, In, inGhost), out, in, location, Out, outGhost, type);
@@ -124,21 +123,16 @@ namespace quda {
 
   template <typename FloatOut, typename FloatIn>
   void copyGaugeMG(GaugeField &out, const GaugeField &in, QudaFieldLocation location, FloatOut *Out, 
-		   FloatIn *In, FloatOut **outGhost, FloatIn **inGhost, int type) {
-
-    switch(in.Ncolor()) {
+		   FloatIn *In, FloatOut **outGhost, FloatIn **inGhost, int type)
+  {
+    switch (in.Ncolor()) {
 #ifdef GPU_MULTIGRID
-    case  8: copyGaugeMG<FloatOut,FloatIn, 8>(out, in, location, Out, In, outGhost, inGhost, type); break;
-    case 12: copyGaugeMG<FloatOut,FloatIn,12>(out, in, location, Out, In, outGhost, inGhost, type); break;
-    case 16: copyGaugeMG<FloatOut,FloatIn,16>(out, in, location, Out, In, outGhost, inGhost, type); break;
-    case 24: copyGaugeMG<FloatOut,FloatIn,24>(out, in, location, Out, In, outGhost, inGhost, type); break;
-    case 32: copyGaugeMG<FloatOut,FloatIn,32>(out, in, location, Out, In, outGhost, inGhost, type); break;
-    case 40: copyGaugeMG<FloatOut,FloatIn,40>(out, in, location, Out, In, outGhost, inGhost, type); break;
     case 48: copyGaugeMG<FloatOut,FloatIn,48>(out, in, location, Out, In, outGhost, inGhost, type); break;
-    case 56: copyGaugeMG<FloatOut,FloatIn,56>(out, in, location, Out, In, outGhost, inGhost, type); break;
+#ifdef NSPIN4
+    case 12: copyGaugeMG<FloatOut,FloatIn,12>(out, in, location, Out, In, outGhost, inGhost, type); break;
     case 64: copyGaugeMG<FloatOut,FloatIn,64>(out, in, location, Out, In, outGhost, inGhost, type); break;
-#ifdef GPU_STAGGERED_DIRAC
-    case 96: copyGaugeMG<FloatOut,FloatIn,96>(out, in, location, Out, In, outGhost, inGhost, type); break;
+#endif
+#ifdef NSPIN1
     case 128: copyGaugeMG<FloatOut,FloatIn,128>(out, in, location, Out, In, outGhost, inGhost, type); break;
     case 192: copyGaugeMG<FloatOut,FloatIn,192>(out, in, location, Out, In, outGhost, inGhost, type); break;
 #endif
@@ -149,8 +143,8 @@ namespace quda {
 
   // this is the function that is actually called, from here on down we instantiate all required templates
   void copyGenericGaugeMG(GaugeField &out, const GaugeField &in, QudaFieldLocation location,
-			  void *Out, void *In, void **ghostOut, void **ghostIn, int type) {
-
+			  void *Out, void *In, void **ghostOut, void **ghostIn, int type)
+  {
 #ifndef FINE_GRAINED_ACCESS
     if (out.Precision() == QUDA_HALF_PRECISION || in.Precision() == QUDA_HALF_PRECISION)
       errorQuda("Precision format not supported");
@@ -202,7 +196,5 @@ namespace quda {
       errorQuda("Precision %d not supported", out.Precision());
     } 
   } 
-
-
 
 } // namespace quda

--- a/lib/cuda_color_spinor_field.cpp
+++ b/lib/cuda_color_spinor_field.cpp
@@ -230,8 +230,7 @@ namespace quda {
         // check for special metadata wrapper (look at reference comments in
         // createTexObject() below)
         if (!((uint64_t)v == (uint64_t)(void *)std::numeric_limits<uint64_t>::max()
-              || (uint64_t)norm == (uint64_t)(void *)std::numeric_limits<uint64_t>::max())) {
-
+              || (precision == QUDA_HALF_PRECISION && (uint64_t)norm == (uint64_t)(void *)std::numeric_limits<uint64_t>::max()) )) {
           (dynamic_cast<cudaColorSpinorField *>(odd))->v = (void *)((char *)v + bytes / 2);
           if (precision == QUDA_HALF_PRECISION || precision == QUDA_QUARTER_PRECISION)
             (dynamic_cast<cudaColorSpinorField *>(odd))->norm = (void *)((char *)norm + norm_bytes / 2);

--- a/lib/dslash_improved_staggered.cu
+++ b/lib/dslash_improved_staggered.cu
@@ -31,7 +31,18 @@ namespace quda
     {
       TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
       Dslash::setParam(tp);
-      Dslash::template instantiate<packStaggeredShmem>(tp, stream);
+      // operator is anti-Hermitian so do not instantiate dagger
+      if (arg.nParity == 1) {
+        if (arg.xpay)
+          Dslash::template instantiate<packStaggeredShmem, 1, false, true>(tp, stream);
+        else
+          Dslash::template instantiate<packStaggeredShmem, 1, false, false>(tp, stream);
+      } else if (arg.nParity == 2) {
+        if (arg.xpay)
+          Dslash::template instantiate<packStaggeredShmem, 2, false, true>(tp, stream);
+        else
+          Dslash::template instantiate<packStaggeredShmem, 2, false, false>(tp, stream);
+      }
     }
 
     /*

--- a/lib/dslash_staggered.cu
+++ b/lib/dslash_staggered.cu
@@ -21,6 +21,7 @@ namespace quda
   template <typename Arg> class Staggered : public Dslash<staggered, Arg>
   {
     using Dslash = Dslash<staggered, Arg>;
+    using Dslash::arg;
 
   public:
     Staggered(Arg &arg, const ColorSpinorField &out, const ColorSpinorField &in) : Dslash(arg, out, in) {}
@@ -29,7 +30,18 @@ namespace quda
     {
       TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
       Dslash::setParam(tp);
-      Dslash::template instantiate<packStaggeredShmem>(tp, stream);
+      // operator is anti-Hermitian so do not instantiate dagger
+      if (arg.nParity == 1) {
+        if (arg.xpay)
+          Dslash::template instantiate<packStaggeredShmem, 1, false, true>(tp, stream);
+        else
+          Dslash::template instantiate<packStaggeredShmem, 1, false, false>(tp, stream);
+      } else if (arg.nParity == 2) {
+        if (arg.xpay)
+          Dslash::template instantiate<packStaggeredShmem, 2, false, true>(tp, stream);
+        else
+          Dslash::template instantiate<packStaggeredShmem, 2, false, false>(tp, stream);
+      }
     }
   };
 

--- a/lib/extract_gauge_ghost_mg.cu
+++ b/lib/extract_gauge_ghost_mg.cu
@@ -59,13 +59,11 @@ namespace quda {
     if (u.LinkType() != QUDA_COARSE_LINKS)
       errorQuda("Link type %d not supported", u.LinkType());
 
-    if (u.Ncolor() == 12) { // free field Wilson
-      extractGhostMG<Float, 12>(u, Ghost, extract, offset);
-    } else if (u.Ncolor() == 32) {
-      extractGhostMG<Float, 32>(u, Ghost, extract, offset);
-    } else if (u.Ncolor() == 48) {
+    if (u.Ncolor() == 48) {
       extractGhostMG<Float, 48>(u, Ghost, extract, offset);
 #ifdef NSPIN4
+    } else if (u.Ncolor() == 12) { // free field Wilson
+      extractGhostMG<Float, 12>(u, Ghost, extract, offset);
     } else if (u.Ncolor() == 64) {
       extractGhostMG<Float, 64>(u, Ghost, extract, offset);
 #endif // NSPIN4

--- a/lib/generic_blas.cuh
+++ b/lib/generic_blas.cuh
@@ -5,7 +5,6 @@ template <typename Float, int writeX, int writeY, int writeZ, int writeW, int wr
     typename SpinorY, typename SpinorZ, typename SpinorW, typename SpinorV, typename Functor>
 void genericBlas(SpinorX &X, SpinorY &Y, SpinorZ &Z, SpinorW &W, SpinorV &V, Functor f)
 {
-
   for (int parity = 0; parity < X.Nparity(); parity++) {
     for (int x = 0; x < X.VolumeCB(); x++) {
       for (int s = 0; s < X.Nspin(); s++) {
@@ -42,32 +41,25 @@ template <typename Float, typename yFloat, int nSpin, QudaFieldOrder order, int 
 void genericBlas(
     ColorSpinorField &x, ColorSpinorField &y, ColorSpinorField &z, ColorSpinorField &w, ColorSpinorField &v, Functor f)
 {
+  if (x.Ncolor() != 3 && x.Nspin() != 2) errorQuda("Unsupported nSpin = %d and nColor = %d combination", x.Ncolor(), x.Nspin());
   if (x.Ncolor() == 3) {
     genericBlas<Float, yFloat, nSpin, 3, order, writeX, writeY, writeZ, writeW, writeV, Functor>(x, y, z, w, v, f);
 #ifdef GPU_MULTIGRID
-  } else if (x.Ncolor() == 4) {
-    genericBlas<Float, yFloat, nSpin, 4, order, writeX, writeY, writeZ, writeW, writeV, Functor>(x, y, z, w, v, f);
+#ifdef NSPIN4
   } else if (x.Ncolor() == 6) { // free field Wilson
-    genericBlas<Float, yFloat, nSpin, 6, order, writeX, writeY, writeZ, writeW, writeV, Functor>(x, y, z, w, v, f);
-  } else if (x.Ncolor() == 8) {
-    genericBlas<Float, yFloat, nSpin, 8, order, writeX, writeY, writeZ, writeW, writeV, Functor>(x, y, z, w, v, f);
-  } else if (x.Ncolor() == 12) {
-    genericBlas<Float, yFloat, nSpin, 12, order, writeX, writeY, writeZ, writeW, writeV, Functor>(x, y, z, w, v, f);
-  } else if (x.Ncolor() == 16) {
-    genericBlas<Float, yFloat, nSpin, 16, order, writeX, writeY, writeZ, writeW, writeV, Functor>(x, y, z, w, v, f);
-  } else if (x.Ncolor() == 20) {
-    genericBlas<Float, yFloat, nSpin, 20, order, writeX, writeY, writeZ, writeW, writeV, Functor>(x, y, z, w, v, f);
+    genericBlas<Float, yFloat, 2, 6, order, writeX, writeY, writeZ, writeW, writeV, Functor>(x, y, z, w, v, f);
+#endif
   } else if (x.Ncolor() == 24) {
-    genericBlas<Float, yFloat, nSpin, 24, order, writeX, writeY, writeZ, writeW, writeV, Functor>(x, y, z, w, v, f);
+    genericBlas<Float, yFloat, 2, 24, order, writeX, writeY, writeZ, writeW, writeV, Functor>(x, y, z, w, v, f);
 #ifdef NSPIN4
   } else if (x.Ncolor() == 32) {
-    genericBlas<Float, yFloat, nSpin, 32, order, writeX, writeY, writeZ, writeW, writeV, Functor>(x, y, z, w, v, f);
+    genericBlas<Float, yFloat, 2, 32, order, writeX, writeY, writeZ, writeW, writeV, Functor>(x, y, z, w, v, f);
 #endif // NSPIN4
 #ifdef NSPIN1
   } else if (x.Ncolor() == 64) {
-    genericBlas<Float, yFloat, nSpin, 64, order, writeX, writeY, writeZ, writeW, writeV, Functor>(x, y, z, w, v, f);
+    genericBlas<Float, yFloat, 2, 64, order, writeX, writeY, writeZ, writeW, writeV, Functor>(x, y, z, w, v, f);
   } else if (x.Ncolor() == 96) {
-    genericBlas<Float, yFloat, nSpin, 96, order, writeX, writeY, writeZ, writeW, writeV, Functor>(x, y, z, w, v, f);
+    genericBlas<Float, yFloat, 2, 96, order, writeX, writeY, writeZ, writeW, writeV, Functor>(x, y, z, w, v, f);
 #endif // NSPIN1
 #endif
   } else {

--- a/lib/generic_reduce.cuh
+++ b/lib/generic_reduce.cuh
@@ -5,7 +5,6 @@ template <typename ReduceType, typename Float, int writeX, int writeY, int write
     typename SpinorX, typename SpinorY, typename SpinorZ, typename SpinorW, typename SpinorV, typename Reducer>
 ReduceType genericReduce(SpinorX &X, SpinorY &Y, SpinorZ &Z, SpinorW &W, SpinorV &V, Reducer r)
 {
-
   ReduceType sum;
   ::quda::zero(sum);
 
@@ -49,53 +48,33 @@ template <typename ReduceType, typename Float, typename zFloat, int nSpin, QudaF
 ReduceType genericReduce(
     ColorSpinorField &x, ColorSpinorField &y, ColorSpinorField &z, ColorSpinorField &w, ColorSpinorField &v, R r)
 {
+  if (x.Ncolor() != 3 && x.Nspin() != 2) errorQuda("Unsupported nSpin = %d and nColor = %d combination", x.Ncolor(), x.Nspin());
   ReduceType value;
   if (x.Ncolor() == 3) {
     value = genericReduce<ReduceType, Float, zFloat, nSpin, 3, order, writeX, writeY, writeZ, writeW, writeV, R>(
         x, y, z, w, v, r);
 #ifdef GPU_MULTIGRID
-  } else if (x.Ncolor() == 4) {
-    value = genericReduce<ReduceType, Float, zFloat, nSpin, 4, order, writeX, writeY, writeZ, writeW, writeV, R>(
-        x, y, z, w, v, r);
+#ifdef NSPIN4
   } else if (x.Ncolor() == 6) { // free field Wilson
-    value = genericReduce<ReduceType, Float, zFloat, nSpin, 6, order, writeX, writeY, writeZ, writeW, writeV, R>(
+    value = genericReduce<ReduceType, Float, zFloat, 2, 6, order, writeX, writeY, writeZ, writeW, writeV, R>(
         x, y, z, w, v, r);
-  } else if (x.Ncolor() == 8) {
-    value = genericReduce<ReduceType, Float, zFloat, nSpin, 8, order, writeX, writeY, writeZ, writeW, writeV, R>(
-        x, y, z, w, v, r);
-  } else if (x.Ncolor() == 12) {
-    value = genericReduce<ReduceType, Float, zFloat, nSpin, 12, order, writeX, writeY, writeZ, writeW, writeV, R>(
-        x, y, z, w, v, r);
-  } else if (x.Ncolor() == 16) {
-    value = genericReduce<ReduceType, Float, zFloat, nSpin, 16, order, writeX, writeY, writeZ, writeW, writeV, R>(
-        x, y, z, w, v, r);
-  } else if (x.Ncolor() == 20) {
-    value = genericReduce<ReduceType, Float, zFloat, nSpin, 20, order, writeX, writeY, writeZ, writeW, writeV, R>(
-        x, y, z, w, v, r);
+#endif
   } else if (x.Ncolor() == 24) {
-    value = genericReduce<ReduceType, Float, zFloat, nSpin, 24, order, writeX, writeY, writeZ, writeW, writeV, R>(
+    value = genericReduce<ReduceType, Float, zFloat, 2, 24, order, writeX, writeY, writeZ, writeW, writeV, R>(
         x, y, z, w, v, r);
 #ifdef NSPIN4
   } else if (x.Ncolor() == 32) {
-    value = genericReduce<ReduceType, Float, zFloat, nSpin, 32, order, writeX, writeY, writeZ, writeW, writeV, R>(
+    value = genericReduce<ReduceType, Float, zFloat, 2, 32, order, writeX, writeY, writeZ, writeW, writeV, R>(
         x, y, z, w, v, r);
 #endif // NSPIN4
 #ifdef NSPIN1
   } else if (x.Ncolor() == 64) {
-    value = genericReduce<ReduceType, Float, zFloat, nSpin, 64, order, writeX, writeY, writeZ, writeW, writeV, R>(
+    value = genericReduce<ReduceType, Float, zFloat, 2, 64, order, writeX, writeY, writeZ, writeW, writeV, R>(
         x, y, z, w, v, r);
-#endif // NSPIN1
-  } else if (x.Ncolor() == 72) {
-    value = genericReduce<ReduceType, Float, zFloat, nSpin, 72, order, writeX, writeY, writeZ, writeW, writeV, R>(
-        x, y, z, w, v, r);
-#ifdef NSPIN1
   } else if (x.Ncolor() == 96) {
-    value = genericReduce<ReduceType, Float, zFloat, nSpin, 96, order, writeX, writeY, writeZ, writeW, writeV, R>(
+    value = genericReduce<ReduceType, Float, zFloat, 2, 96, order, writeX, writeY, writeZ, writeW, writeV, R>(
         x, y, z, w, v, r);
 #endif // NSPIN1
-  } else if (x.Ncolor() == 576) {
-    value = genericReduce<ReduceType, Float, zFloat, nSpin, 576, order, writeX, writeY, writeZ, writeW, writeV, R>(
-        x, y, z, w, v, r);
 #endif
   } else {
     ::quda::zero(value);

--- a/lib/laplace.cu
+++ b/lib/laplace.cu
@@ -32,7 +32,19 @@ namespace quda
     {
       TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
       Dslash::setParam(tp);
-      Dslash::template instantiate<packStaggeredShmem>(tp, stream);
+
+      // operator is Hermitian so do not instantiate dagger
+      if (arg.nParity == 1) {
+        if (arg.xpay)
+          Dslash::template instantiate<packStaggeredShmem, 1, false, true>(tp, stream);
+        else
+          Dslash::template instantiate<packStaggeredShmem, 1, false, false>(tp, stream);
+      } else if (arg.nParity == 2) {
+        if (arg.xpay)
+          Dslash::template instantiate<packStaggeredShmem, 2, false, true>(tp, stream);
+        else
+          Dslash::template instantiate<packStaggeredShmem, 2, false, false>(tp, stream);
+      }
     }
 
     long long flops() const
@@ -167,7 +179,7 @@ namespace quda
           in.GhostFaceCB(), profile);
         policy.apply(0);
 #else
-        errorQuda("nSpin=4 Laplace operator required wilsondslash to be enabled");
+        errorQuda("nSpin=4 Laplace operator required wilson dslash to be enabled");
 #endif
       } else {
         errorQuda("Unsupported nSpin= %d", in.Nspin());

--- a/lib/max_clover.cu
+++ b/lib/max_clover.cu
@@ -12,47 +12,47 @@ namespace quda {
   };
 
   template<typename real, int Nc, QudaCloverFieldOrder order>
-  double norm(const CloverField &u, norm_type_ type) {
+  double norm(const CloverField &u, bool inverse, norm_type_ type) {
     constexpr int Ns = 4;
     typedef typename mapper<real>::type reg_type;
     double norm_ = 0.0;
     switch(type) {
-    case   NORM1: norm_ = FieldOrder<reg_type,Nc,Ns,order>(const_cast<CloverField &>(u)).norm1();   break;
-    case   NORM2: norm_ = FieldOrder<reg_type,Nc,Ns,order>(const_cast<CloverField &>(u)).norm2();   break;
-    case ABS_MAX: norm_ = FieldOrder<reg_type,Nc,Ns,order>(const_cast<CloverField &>(u)).abs_max(); break;
-    case ABS_MIN: norm_ = FieldOrder<reg_type,Nc,Ns,order>(const_cast<CloverField &>(u)).abs_min(); break;
+    case   NORM1: norm_ = FieldOrder<reg_type,Nc,Ns,order>(const_cast<CloverField &>(u), inverse).norm1();   break;
+    case   NORM2: norm_ = FieldOrder<reg_type,Nc,Ns,order>(const_cast<CloverField &>(u), inverse).norm2();   break;
+    case ABS_MAX: norm_ = FieldOrder<reg_type,Nc,Ns,order>(const_cast<CloverField &>(u), inverse).abs_max(); break;
+    case ABS_MIN: norm_ = FieldOrder<reg_type,Nc,Ns,order>(const_cast<CloverField &>(u), inverse).abs_min(); break;
     }
     return norm_;
   }
 
   template<typename real, int Nc>
-  double norm(const CloverField &u, norm_type_ type) {
+  double norm(const CloverField &u, bool inverse, norm_type_ type) {
     double norm_ = 0.0;
     switch (u.Order()) {
-    case QUDA_FLOAT2_CLOVER_ORDER: norm_ = norm<real,Nc,QUDA_FLOAT2_CLOVER_ORDER>(u, type); break;
-    case QUDA_FLOAT4_CLOVER_ORDER: norm_ = norm<real,Nc,QUDA_FLOAT4_CLOVER_ORDER>(u, type); break;
+    case QUDA_FLOAT2_CLOVER_ORDER: norm_ = norm<real,Nc,QUDA_FLOAT2_CLOVER_ORDER>(u, inverse, type); break;
+    case QUDA_FLOAT4_CLOVER_ORDER: norm_ = norm<real,Nc,QUDA_FLOAT4_CLOVER_ORDER>(u, inverse, type); break;
     default: errorQuda("Clover field %d order not supported", u.Order());
     }
     return norm_;
   }
 
   template<typename real>
-  double _norm(const CloverField &u, norm_type_ type) {
+  double _norm(const CloverField &u, bool inverse, norm_type_ type) {
     double norm_ = 0.0;
     switch(u.Ncolor()) {
-    case  3: norm_ = norm<real, 3>(u, type); break;
+    case  3: norm_ = norm<real, 3>(u, inverse, type); break;
     default: errorQuda("Unsupported color %d", u.Ncolor());
     }
     return norm_;
   }
 
-  double _norm(const CloverField &u, norm_type_ type)
+  double _norm(const CloverField &u, bool inverse, norm_type_ type)
   {
     double nrm = 0.0;
 #ifdef GPU_CLOVER_DIRAC
     switch(u.Precision()) {
-    case QUDA_DOUBLE_PRECISION: nrm = _norm<double>(u, type); break;
-    case QUDA_SINGLE_PRECISION: nrm = _norm< float>(u, type); break;
+    case QUDA_DOUBLE_PRECISION: nrm = _norm<double>(u, inverse, type); break;
+    case QUDA_SINGLE_PRECISION: nrm = _norm< float>(u, inverse, type); break;
     default: errorQuda("Unsupported precision %d", u.Precision());
     }
 #else
@@ -61,20 +61,20 @@ namespace quda {
     return nrm;
   }
 
-  double CloverField::norm1() const {
-    return _norm(*this, NORM1);
+  double CloverField::norm1(bool inverse) const {
+    return _norm(*this, inverse, NORM1);
   }
 
-  double CloverField::norm2() const {
-    return _norm(*this, NORM2);
+  double CloverField::norm2(bool inverse) const {
+    return _norm(*this, inverse, NORM2);
   }
 
-  double CloverField::abs_max() const {
-    return _norm(*this, ABS_MAX);
+  double CloverField::abs_max(bool inverse) const {
+    return _norm(*this, inverse, ABS_MAX);
   }
 
-  double CloverField::abs_min() const {
-    return _norm(*this, ABS_MIN);
+  double CloverField::abs_min(bool inverse) const {
+    return _norm(*this, inverse, ABS_MIN);
   }
 
 } // namespace quda

--- a/lib/max_gauge.cu
+++ b/lib/max_gauge.cu
@@ -11,9 +11,8 @@ namespace quda {
     ABS_MIN
   };
 
-  template<typename real, int Nc, QudaGaugeFieldOrder order>
+  template <typename reg_type, typename real, int Nc, QudaGaugeFieldOrder order>
   double norm(const GaugeField &u, int d, norm_type_ type) {
-    typedef typename mapper<real>::type reg_type;
     double norm_ = 0.0;
     switch(type) {
     case   NORM1: norm_ = FieldOrder<reg_type,Nc,1,order,true,real>(const_cast<GaugeField &>(u)).norm1(d);   break;
@@ -24,37 +23,37 @@ namespace quda {
     return norm_;
   }
 
-  template<typename real, int Nc>
+  template <typename reg_type, typename real, int Nc>
   double norm(const GaugeField &u, int d, norm_type_ type) {
     double norm_ = 0.0;
     switch (u.FieldOrder()) {
-    case QUDA_FLOAT2_GAUGE_ORDER: norm_ = norm<real,Nc,QUDA_FLOAT2_GAUGE_ORDER>(u, d, type); break;
-    case QUDA_QDP_GAUGE_ORDER:    norm_ = norm<real,Nc,   QUDA_QDP_GAUGE_ORDER>(u, d, type); break;
-    case QUDA_MILC_GAUGE_ORDER:   norm_ = norm<real,Nc,  QUDA_MILC_GAUGE_ORDER>(u, d, type); break;
+    case QUDA_FLOAT2_GAUGE_ORDER: norm_ = norm<reg_type, real,Nc,QUDA_FLOAT2_GAUGE_ORDER>(u, d, type); break;
+    case QUDA_QDP_GAUGE_ORDER:    norm_ = norm<reg_type, real,Nc,   QUDA_QDP_GAUGE_ORDER>(u, d, type); break;
+    case QUDA_MILC_GAUGE_ORDER:   norm_ = norm<reg_type, real,Nc,  QUDA_MILC_GAUGE_ORDER>(u, d, type); break;
     default: errorQuda("Gauge field %d order not supported", u.Order());
     }
     return norm_;
   }
 
-  template<typename real>
+  template <typename reg_type, typename real>
   double norm(const GaugeField &u, int d, norm_type_ type) {
     double norm_ = 0.0;
     switch(u.Ncolor()) {
-    case  3: norm_ = norm<real, 3>(u, d, type); break;
+    case  3: norm_ = norm<reg_type, real, 3>(u, d, type); break;
 #ifdef GPU_MULTIGRID
-    case  8: norm_ = norm<real, 8>(u, d, type); break;
-    case 12: norm_ = norm<real,12>(u, d, type); break;
-    case 16: norm_ = norm<real,16>(u, d, type); break;
-    case 24: norm_ = norm<real,24>(u, d, type); break;
-    case 32: norm_ = norm<real,32>(u, d, type); break;
-    case 40: norm_ = norm<real,40>(u, d, type); break;
-    case 48: norm_ = norm<real,48>(u, d, type); break;
-    case 56: norm_ = norm<real,56>(u, d, type); break;
-    case 64: norm_ = norm<real,64>(u, d, type); break;
+    case  8: norm_ = norm<reg_type, real, 8>(u, d, type); break;
+    case 12: norm_ = norm<reg_type, real,12>(u, d, type); break;
+    case 16: norm_ = norm<reg_type, real,16>(u, d, type); break;
+    case 24: norm_ = norm<reg_type, real,24>(u, d, type); break;
+    case 32: norm_ = norm<reg_type, real,32>(u, d, type); break;
+    case 40: norm_ = norm<reg_type, real,40>(u, d, type); break;
+    case 48: norm_ = norm<reg_type, real,48>(u, d, type); break;
+    case 56: norm_ = norm<reg_type, real,56>(u, d, type); break;
+    case 64: norm_ = norm<reg_type, real,64>(u, d, type); break;
 #ifdef NSPIN1
-    case 96: norm_ = norm<real,96>(u, d, type); break;
-    case 128: norm_ = norm<real,128>(u, d, type); break;
-    case 192: norm_ = norm<real,192>(u, d, type); break;
+    case 96: norm_ = norm<reg_type, real,96>(u, d, type); break;
+    case 128: norm_ = norm<reg_type, real,128>(u, d, type); break;
+    case 192: norm_ = norm<reg_type, real,192>(u, d, type); break;
 #endif // NSPIN1
 #endif // GPU_MULTIGRID
     default: errorQuda("Unsupported color %d", u.Ncolor());
@@ -62,26 +61,29 @@ namespace quda {
     return norm_;
   }
 
-  double norm(const GaugeField &u, int d, norm_type_ type) {
+  double norm(const GaugeField &u, int d, bool fixed, norm_type_ type) {
+    if (fixed && u.Precision() > QUDA_SINGLE_PRECISION)
+      errorQuda("Fixed point override only enabled for 8-bit, 16-bit and 32-bit fields");
+
     double nrm = 0.0;
     switch(u.Precision()) {
     case QUDA_DOUBLE_PRECISION:
-      nrm = norm<double>(u, d, type); break;
+      nrm = norm<typename mapper<double>::type, double>(u, d, type); break;
     case QUDA_SINGLE_PRECISION:
 #if QUDA_PRECISION & 4
-      nrm = norm<float>(u, d, type); break;
+      nrm = fixed ? norm<float, int>(u, d, type) : norm<typename mapper<float>::type, float>(u, d, type); break;
 #else
       errorQuda("QUDA_PRECISION=%d does not enable single precision", QUDA_PRECISION);
 #endif
     case QUDA_HALF_PRECISION:
 #if QUDA_PRECISION & 2
-      nrm = norm<short>(u, d, type); break;
+      nrm = norm<typename mapper<short>::type, short>(u, d, type); break;
 #else
       errorQuda("QUDA_PRECISION=%d does not enable half precision", QUDA_PRECISION);
 #endif
     case QUDA_QUARTER_PRECISION:
 #if QUDA_PRECISION & 1
-      nrm = norm<char>(u, d, type); break;
+      nrm = norm<typename mapper<char>::type, char>(u, d, type); break;
 #else
       errorQuda("QUDA_PRECISION=%d does not enable quarter precision", QUDA_PRECISION);
 #endif
@@ -90,24 +92,24 @@ namespace quda {
     return nrm;
   }
 
-  double GaugeField::norm1(int d) const {
+  double GaugeField::norm1(int d, bool fixed) const {
     if (reconstruct != QUDA_RECONSTRUCT_NO) errorQuda("Unsupported reconstruct=%d", reconstruct);
-    return norm(*this, d, NORM1);
+    return norm(*this, d, fixed, NORM1);
   }
 
-  double GaugeField::norm2(int d) const {
+  double GaugeField::norm2(int d, bool fixed) const {
     if (reconstruct != QUDA_RECONSTRUCT_NO) errorQuda("Unsupported reconstruct=%d", reconstruct);
-    return norm(*this, d, NORM1);
+    return norm(*this, d, fixed, NORM1);
   }
 
-  double GaugeField::abs_max(int d) const {
+  double GaugeField::abs_max(int d, bool fixed) const {
     if (reconstruct != QUDA_RECONSTRUCT_NO) errorQuda("Unsupported reconstruct=%d", reconstruct);
-    return norm(*this, d, ABS_MAX);
+    return norm(*this, d, fixed, ABS_MAX);
   }
 
-  double GaugeField::abs_min(int d) const {
+  double GaugeField::abs_min(int d, bool fixed) const {
     if (reconstruct != QUDA_RECONSTRUCT_NO) errorQuda("Unsupported reconstruct=%d", reconstruct);
-    return norm(*this, d, ABS_MIN);
+    return norm(*this, d, fixed, ABS_MIN);
   }
 
 } // namespace quda

--- a/lib/max_gauge.cu
+++ b/lib/max_gauge.cu
@@ -41,19 +41,14 @@ namespace quda {
     switch(u.Ncolor()) {
     case  3: norm_ = norm<reg_type, real, 3>(u, d, type); break;
 #ifdef GPU_MULTIGRID
-    case  8: norm_ = norm<reg_type, real, 8>(u, d, type); break;
-    case 12: norm_ = norm<reg_type, real,12>(u, d, type); break;
-    case 16: norm_ = norm<reg_type, real,16>(u, d, type); break;
-    case 24: norm_ = norm<reg_type, real,24>(u, d, type); break;
-    case 32: norm_ = norm<reg_type, real,32>(u, d, type); break;
-    case 40: norm_ = norm<reg_type, real,40>(u, d, type); break;
-    case 48: norm_ = norm<reg_type, real,48>(u, d, type); break;
-    case 56: norm_ = norm<reg_type, real,56>(u, d, type); break;
-    case 64: norm_ = norm<reg_type, real,64>(u, d, type); break;
+#ifdef NSPIN4
+    case 12: norm_ = norm<reg_type, real, 12>(u, d, type); break;
+    case 48: norm_ = norm<reg_type, real, 48>(u, d, type); break;
+    case 64: norm_ = norm<reg_type, real, 64>(u, d, type); break;
+#endif // NSPIN4
 #ifdef NSPIN1
-    case 96: norm_ = norm<reg_type, real,96>(u, d, type); break;
-    case 128: norm_ = norm<reg_type, real,128>(u, d, type); break;
-    case 192: norm_ = norm<reg_type, real,192>(u, d, type); break;
+    case 128: norm_ = norm<reg_type, real, 128>(u, d, type); break;
+    case 192: norm_ = norm<reg_type, real, 192>(u, d, type); break;
 #endif // NSPIN1
 #endif // GPU_MULTIGRID
     default: errorQuda("Unsupported color %d", u.Ncolor());
@@ -99,7 +94,7 @@ namespace quda {
 
   double GaugeField::norm2(int d, bool fixed) const {
     if (reconstruct != QUDA_RECONSTRUCT_NO) errorQuda("Unsupported reconstruct=%d", reconstruct);
-    return norm(*this, d, fixed, NORM1);
+    return norm(*this, d, fixed, NORM2);
   }
 
   double GaugeField::abs_max(int d, bool fixed) const {

--- a/lib/max_gauge.cu
+++ b/lib/max_gauge.cu
@@ -41,9 +41,9 @@ namespace quda {
     switch(u.Ncolor()) {
     case  3: norm_ = norm<reg_type, real, 3>(u, d, type); break;
 #ifdef GPU_MULTIGRID
+    case 48: norm_ = norm<reg_type, real, 48>(u, d, type); break;
 #ifdef NSPIN4
     case 12: norm_ = norm<reg_type, real, 12>(u, d, type); break;
-    case 48: norm_ = norm<reg_type, real, 48>(u, d, type); break;
     case 64: norm_ = norm<reg_type, real, 64>(u, d, type); break;
 #endif // NSPIN4
 #ifdef NSPIN1

--- a/lib/multigrid.cpp
+++ b/lib/multigrid.cpp
@@ -27,6 +27,7 @@ namespace quda
     param_postsmooth(nullptr),
     param_coarse_solver(nullptr),
     r(nullptr),
+    b_tilde(nullptr),
     r_coarse(nullptr),
     x_coarse(nullptr),
     tmp_coarse(nullptr),

--- a/lib/restrictor.cu
+++ b/lib/restrictor.cu
@@ -8,8 +8,6 @@
 
 namespace quda {
 
-#ifdef GPU_MULTIGRID
-
   template <typename Float, typename vFloat, int fineSpin, int fineColor, int coarseSpin, int coarseColor,
             int coarse_colors_per_thread>
   class RestrictLaunch : public Tunable {
@@ -51,7 +49,6 @@ namespace quda {
       strcat(vol, ",");
       strcat(vol, in.VolString());
     } // block size is checkerboard fine length / full coarse length
-    virtual ~RestrictLaunch() { }
 
     void apply(const cudaStream_t &stream) {
       if (location == QUDA_CPU_FIELD_LOCATION) {
@@ -183,119 +180,111 @@ namespace quda {
     if (checkLocation(out, in, v) == QUDA_CUDA_FIELD_LOCATION) checkCudaError();
   }
 
-  template <typename Float, int fineSpin>
+  template <typename Float>
   void Restrict(ColorSpinorField &out, const ColorSpinorField &in, const ColorSpinorField &v,
                 int nVec, const int *fine_to_coarse, const int *coarse_to_fine, const int * const * spin_map, int parity)
   {
     if (out.Nspin() != 2) errorQuda("Unsupported nSpin %d", out.Nspin());
-    const int coarseSpin = 2;
-
-    // first check that the spin_map matches the spin_mapper
-    spin_mapper<fineSpin,coarseSpin> mapper;
-    for (int s=0; s<fineSpin; s++) 
-      for (int p=0; p<2; p++)
-        if (mapper(s,p) != spin_map[s][p]) errorQuda("Spin map does not match spin_mapper");
+    constexpr int coarseSpin = 2;
 
     // Template over fine color
     if (in.Ncolor() == 3) { // standard QCD
-      const int fineColor = 3;
+      if (in.Nspin() != 4) errorQuda("Unexpected nSpin = %d", in.Nspin());
+      constexpr int fineSpin = 4;
+      constexpr int fineColor = 3;
+
+      // first check that the spin_map matches the spin_mapper
+      spin_mapper<fineSpin,coarseSpin> mapper;
+      for (int s=0; s<fineSpin; s++)
+        for (int p=0; p<2; p++)
+          if (mapper(s,p) != spin_map[s][p]) errorQuda("Spin map does not match spin_mapper");
+
 #ifdef NSPIN4
       if (nVec == 6) { // free field Wilson
         Restrict<Float,fineSpin,fineColor,coarseSpin,6>(out, in, v, fine_to_coarse, coarse_to_fine, parity);
+      } else if (nVec == 24) {
+        Restrict<Float,fineSpin,fineColor,coarseSpin,24>(out, in, v, fine_to_coarse, coarse_to_fine, parity);
+      } else if (nVec == 32) {
+        Restrict<Float,fineSpin,fineColor,coarseSpin,32>(out, in, v, fine_to_coarse, coarse_to_fine, parity);
+      } else {
+        errorQuda("Unsupported nVec %d", nVec);
+      }
+#endif // NSPIN4
+
+    } else { // Nc != 3
+
+      if (in.Nspin() != 2) errorQuda("Unexpected nSpin = %d", in.Nspin());
+      constexpr int fineSpin = 2;
+
+      // first check that the spin_map matches the spin_mapper
+      spin_mapper<fineSpin,coarseSpin> mapper;
+      for (int s=0; s<fineSpin; s++)
+        for (int p=0; p<2; p++)
+          if (mapper(s,p) != spin_map[s][p]) errorQuda("Spin map does not match spin_mapper");
+
+#ifdef NSPIN4
+      if (in.Ncolor() == 6) { // Coarsen coarsened Wilson free field
+        const int fineColor = 6;
+        if (nVec == 6) {
+          Restrict<Float,fineSpin,fineColor,coarseSpin,6>(out, in, v, fine_to_coarse, coarse_to_fine, parity);
+        } else {
+          errorQuda("Unsupported nVec %d", nVec);
+        }
       } else
 #endif // NSPIN4
-      if (nVec == 24) {
-        Restrict<Float,fineSpin,fineColor,coarseSpin,24>(out, in, v, fine_to_coarse, coarse_to_fine, parity);
+      if (in.Ncolor() == 24) { // to keep compilation under control coarse grids have same or more colors
+        const int fineColor = 24;
+        if (nVec == 24) {
+          Restrict<Float,fineSpin,fineColor,coarseSpin,24>(out, in, v, fine_to_coarse, coarse_to_fine, parity);
 #ifdef NSPIN4
-      } else if (nVec == 32) {
-        Restrict<Float,fineSpin,fineColor,coarseSpin,32>(out, in, v, fine_to_coarse, coarse_to_fine, parity);
-#endif // NSPIN4
-      } else {
-        errorQuda("Unsupported nVec %d", nVec);
-      }
-#ifdef NSPIN4
-    } else if (in.Ncolor() == 6) { // Coarsen coarsened Wilson free field
-      const int fineColor = 6;
-      if (nVec == 6) { 
-        Restrict<Float,fineSpin,fineColor,coarseSpin,6>(out, in, v, fine_to_coarse, coarse_to_fine, parity);
-      } else {
-        errorQuda("Unsupported nVec %d", nVec);
-      }
-#endif // NSPIN4
-    } else if (in.Ncolor() == 24) { // to keep compilation under control coarse grids have same or more colors
-      const int fineColor = 24;
-      if (nVec == 24) {
-        Restrict<Float,fineSpin,fineColor,coarseSpin,24>(out, in, v, fine_to_coarse, coarse_to_fine, parity);
-#ifdef NSPIN4
-      } else if (nVec == 32) {
-        Restrict<Float,fineSpin,fineColor,coarseSpin,32>(out, in, v, fine_to_coarse, coarse_to_fine, parity);
+        } else if (nVec == 32) {
+          Restrict<Float,fineSpin,fineColor,coarseSpin,32>(out, in, v, fine_to_coarse, coarse_to_fine, parity);
 #endif // NSPIN4
 #ifdef NSPIN1
-      } else if (nVec == 64) {
-        Restrict<Float,fineSpin,fineColor,coarseSpin,64>(out, in, v, fine_to_coarse, coarse_to_fine, parity);
-      } else if (nVec == 96) {
-        Restrict<Float,fineSpin,fineColor,coarseSpin,96>(out, in, v, fine_to_coarse, coarse_to_fine, parity);
+        } else if (nVec == 64) {
+          Restrict<Float,fineSpin,fineColor,coarseSpin,64>(out, in, v, fine_to_coarse, coarse_to_fine, parity);
+        } else if (nVec == 96) {
+          Restrict<Float,fineSpin,fineColor,coarseSpin,96>(out, in, v, fine_to_coarse, coarse_to_fine, parity);
 #endif // NSPIN1
-      } else {
-        errorQuda("Unsupported nVec %d", nVec);
-      }
+        } else {
+          errorQuda("Unsupported nVec %d", nVec);
+        }
 #ifdef NSPIN4
-    } else if (in.Ncolor() == 32) {
-      const int fineColor = 32;
-      if (nVec == 32) {
-        Restrict<Float,fineSpin,fineColor,coarseSpin,32>(out, in, v, fine_to_coarse, coarse_to_fine, parity);
-      } else {
-        errorQuda("Unsupported nVec %d", nVec);
-      }
+      } else if (in.Ncolor() == 32) {
+        const int fineColor = 32;
+        if (nVec == 32) {
+          Restrict<Float,fineSpin,fineColor,coarseSpin,32>(out, in, v, fine_to_coarse, coarse_to_fine, parity);
+        } else {
+          errorQuda("Unsupported nVec %d", nVec);
+        }
 #endif // NSPIN4
 #ifdef NSPIN1
-    } else if (in.Ncolor() == 64) {
-      const int fineColor = 64;
-      if (nVec == 64) {
-        Restrict<Float,fineSpin,fineColor,coarseSpin,64>(out, in, v, fine_to_coarse, coarse_to_fine, parity);
-      } else if (nVec == 96) {
-        Restrict<Float,fineSpin,fineColor,coarseSpin,96>(out, in, v, fine_to_coarse, coarse_to_fine, parity);
-      } else {
-        errorQuda("Unsupported nVec %d", nVec);
-      }
-    } else if (in.Ncolor() == 96) {
-      const int fineColor = 96;
-      if (nVec == 96) {
-        Restrict<Float,fineSpin,fineColor,coarseSpin,96>(out, in, v, fine_to_coarse, coarse_to_fine, parity);
-      } else {
-        errorQuda("Unsupported nVec %d", nVec);
-      }
+      } else if (in.Ncolor() == 64) {
+        const int fineColor = 64;
+        if (nVec == 64) {
+          Restrict<Float,fineSpin,fineColor,coarseSpin,64>(out, in, v, fine_to_coarse, coarse_to_fine, parity);
+        } else if (nVec == 96) {
+          Restrict<Float,fineSpin,fineColor,coarseSpin,96>(out, in, v, fine_to_coarse, coarse_to_fine, parity);
+        } else {
+          errorQuda("Unsupported nVec %d", nVec);
+        }
+      } else if (in.Ncolor() == 96) {
+        const int fineColor = 96;
+        if (nVec == 96) {
+          Restrict<Float,fineSpin,fineColor,coarseSpin,96>(out, in, v, fine_to_coarse, coarse_to_fine, parity);
+        } else {
+          errorQuda("Unsupported nVec %d", nVec);
+        }
 #endif // NSPIN1
-    } else {
-      errorQuda("Unsupported nColor %d", in.Ncolor());
-    }
+      } else {
+        errorQuda("Unsupported nColor %d", in.Ncolor());
+      }
+    } // Nc != 3
   }
 
-  template <typename Float>
   void Restrict(ColorSpinorField &out, const ColorSpinorField &in, const ColorSpinorField &v,
-                int Nvec, const int *fine_to_coarse, const int *coarse_to_fine, const int * const * spin_map, int parity) {
-
-    if (in.Nspin() == 2) {
-      Restrict<Float,2>(out, in, v, Nvec, fine_to_coarse, coarse_to_fine, spin_map, parity);
-#ifdef NSPIN4
-    } else if (in.Nspin() == 4) {
-      Restrict<Float,4>(out, in, v, Nvec, fine_to_coarse, coarse_to_fine, spin_map, parity);
-#endif
-#if 0 // not needed until we have Laplace MG or staggered MG Lanczos
-//#ifdef NSPIN1
-    } else if (in.Nspin() == 1) {
-      Restrict<Float,1>(out, in, v, Nvec, fine_to_coarse, coarse_to_fine, spin_map, parity);
-#endif
-    } else {
-      errorQuda("Unsupported nSpin %d", in.Nspin());
-    }
-  }
-
-#endif // GPU_MULTIGRID
-
-  void Restrict(ColorSpinorField &out, const ColorSpinorField &in, const ColorSpinorField &v,
-                int Nvec, const int *fine_to_coarse, const int *coarse_to_fine, const int * const * spin_map, int parity) {
-
+                int Nvec, const int *fine_to_coarse, const int *coarse_to_fine, const int * const * spin_map, int parity)
+  {
 #ifdef GPU_MULTIGRID
     if (out.FieldOrder() != in.FieldOrder() ||        out.FieldOrder() != v.FieldOrder())
       errorQuda("Field orders do not match (out=%d, in=%d, v=%d)",

--- a/lib/restrictor.cu
+++ b/lib/restrictor.cu
@@ -190,6 +190,7 @@ namespace quda {
     // Template over fine color
     if (in.Ncolor() == 3) { // standard QCD
       if (in.Nspin() != 4) errorQuda("Unexpected nSpin = %d", in.Nspin());
+#ifdef NSPIN4
       constexpr int fineSpin = 4;
       constexpr int fineColor = 3;
 
@@ -199,7 +200,6 @@ namespace quda {
         for (int p=0; p<2; p++)
           if (mapper(s,p) != spin_map[s][p]) errorQuda("Spin map does not match spin_mapper");
 
-#ifdef NSPIN4
       if (nVec == 6) { // free field Wilson
         Restrict<Float,fineSpin,fineColor,coarseSpin,6>(out, in, v, fine_to_coarse, coarse_to_fine, parity);
       } else if (nVec == 24) {

--- a/lib/staggered_coarse_op.cu
+++ b/lib/staggered_coarse_op.cu
@@ -136,7 +136,7 @@ namespace quda {
     if (getVerbosity() >= QUDA_VERBOSE) printfQuda("Running link coarsening on the %s\n", location == QUDA_CUDA_FIELD_LOCATION ? "GPU" : "CPU");
 
     // We know exactly what the scale should be: the max of all of the (fat) links.
-    double max_scale = arg.U.abs_max();
+    double max_scale = G_.abs_max();
     if (getVerbosity() >= QUDA_VERBOSE) printfQuda("Global U_max = %e\n", max_scale);
 
     if (coarseGauge::fixedPoint()) {
@@ -154,11 +154,11 @@ namespace quda {
     y.apply(0);
 
     if (getVerbosity() >= QUDA_VERBOSE) {
-      for (int d = 0; d < nDim; d++) printfQuda("Y2[%d] = %e\n", 4+d, arg.Y.norm2( 4+d ));
-      for (int d = 0; d < nDim; d++) printfQuda("Y2[%d] = %e\n", d, arg.Y.norm2( d ));
+      for (int d = 0; d < nDim; d++) printfQuda("Y2[%d] = %e\n", 4+d, Y_.norm2( 4+d ));
+      for (int d = 0; d < nDim; d++) printfQuda("Y2[%d] = %e\n", d, Y_.norm2( d ));
     }
 
-    if (getVerbosity() >= QUDA_VERBOSE) printfQuda("X2 = %e\n", arg.X.norm2(0));
+    if (getVerbosity() >= QUDA_VERBOSE) printfQuda("X2 = %e\n", X_.norm2(0));
   }
 
   template <typename Float, typename vFloat, int fineColor, int fineSpin, int coarseColor, int coarseSpin>

--- a/lib/transfer.cpp
+++ b/lib/transfer.cpp
@@ -68,11 +68,8 @@ namespace quda {
     }
 
     if (ndim > 4) {
-      if (geo_bs[4] != 1) {
-        geo_bs[4] = 1;
-        warningQuda(
-          "5th dimension block size is being set to 1. This is a benign side effect of staggered fermions.\n");
-      }
+      geo_bs[4] = 1;
+      warningQuda("5th dimension block size is being set to 1. This is a benign side effect of staggered fermions");
     }
 
     this->geo_bs = new int[ndim];


### PR DESCRIPTION
Quality of life improvement for multigrid to reduce unnecessary template instantiations and some Jitify fixes:
* Significantly reduced compilation time for multigrid-related kernels (setup kernels, copy, restrictor and block_orthogonalize kernels)
* Fix Jitify with CUB 1.8
* Increase `TuneKey::name_n` to prevent buffer overflow
* Add new `atomicAbsMax` function for floats to atomic.cuh which uses native integer atomic `atomicMax`
* Optimization of `compute_max` kernel for Yhat calculation to use `atomicAbsMax`
* Halved number of templates instantiated for Laplace and staggered operators (do not instantiate unnecessary dagger templates)
