### PR TITLE
Hotfix/partition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ endif()
 #
 # PROJECT is QUDA
 #
-project("QUDA" VERSION 0.9.0 LANGUAGES)
+project("QUDA" VERSION 1.0.0 LANGUAGES)
 
 message(STATUS "")
 message(STATUS "${PROJECT_NAME} ${PROJECT_VERSION} (${GITVERSION}) **")

--- a/lib/comm_common.cpp
+++ b/lib/comm_common.cpp
@@ -634,7 +634,7 @@ void comm_dim_partitioned_reset(){
 
 int comm_dim_partitioned(int dim)
 {
-  return (manual_set_partition[dim] || (comm_dim(dim) > 1));
+  return (manual_set_partition[dim] || (default_topo && comm_dim(dim) > 1));
 }
 
 int comm_partitioned()


### PR DESCRIPTION
* Fix bug with setting the partitioning before the communications topology has been set.
* Bump CMakeLists.txt version to 1.0.0 in preparation of imminent 1.0 release.