### PR TITLE
Hotfix/gauge memset

### DIFF
--- a/lib/cpu_gauge_field.cpp
+++ b/lib/cpu_gauge_field.cpp
@@ -173,7 +173,7 @@ namespace quda {
     if (link_direction != QUDA_LINK_BACKWARDS)
       errorQuda("link_direction = %d not supported", link_direction);
 
-    void *recv[QUDA_MAX_DIM];
+    void *recv[2*QUDA_MAX_DIM];
     for (int d=0; d<nDim; d++) recv[d] = safe_malloc(nFace*surface[d]*nInternal*precision);
 
     // communicate between nodes

--- a/lib/cpu_gauge_field.cpp
+++ b/lib/cpu_gauge_field.cpp
@@ -379,7 +379,11 @@ namespace quda {
   }
 
   void cpuGaugeField::zero() {
-    memset(gauge, 0, bytes);
+    if (order != QUDA_QDP_GAUGE_ORDER) {
+      memset(gauge, 0, bytes);
+    } else {
+      for (int g=0; g<geometry; g++) memset(gauge[g], 0, volume * nInternal * precision);
+    }
   }
 
 /*template <typename Float>


### PR DESCRIPTION
Bugfix pull
* Fix `cpuGaugeField::zero()` when using qdp-ordered fields
* Silence ASAN warning about invalid memory read when using bi-directional gauge fields on the CPU