### PR TITLE
fix linking of tests which require cufft or curand

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,7 +22,7 @@ if(QUDA_QMP AND QUDA_DOWNLOAD_USQCD AND NOT QMP_FOUND)
   add_dependencies(quda_test QMP)
 endif()
 
-set(TEST_LIBS quda quda_test)
+set(TEST_LIBS quda quda_test ${QUDA_LIBS})
 
 macro(QUDA_CHECKBUILDTEST mytarget qudabuildtests)
   if(NOT ${qudabuildtests})


### PR DESCRIPTION
When `QUDA_BUILD_ALL_TESTS` is set and one wants to specifically build `multigrid_evolve_test` by setting `QUDA_MULTIGRID` and `QUDA_GAUGE_ALG`, a dependency on `libcufft` and `libcurand` is obtained. While this is added to `QUDA_LIBS`, it is not propagated to `TEST_LIBS`, resulting in missing references upon linking.

The proposed change propagates `QUDA_LIBS` fully to `TEST_LIBS`. Not sure if that's the right way to go, however...