### PR TITLE
Fix refresh of preconditioned long and fat links

### DIFF
--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -1371,8 +1371,8 @@ void loadSloppyGaugeQuda(const QudaPrecision *prec, const QudaReconstructType *r
                && gauge_param.reconstruct == gaugeFatSloppy->Reconstruct()) {
       gaugeFatPrecondition = gaugeFatSloppy;
     } else {
-      gaugePrecondition = new cudaGaugeField(gauge_param);
-      gaugePrecondition->copy(*gaugeFatPrecise);
+      gaugeFatPrecondition = new cudaGaugeField(gauge_param);
+      gaugeFatPrecondition->copy(*gaugeFatPrecise);
     }
 
     // switch the parameters for creating the mirror refinement cuda gauge field
@@ -1419,8 +1419,8 @@ void loadSloppyGaugeQuda(const QudaPrecision *prec, const QudaReconstructType *r
                && gauge_param.reconstruct == gaugeLongSloppy->Reconstruct()) {
       gaugeLongPrecondition = gaugeLongSloppy;
     } else {
-      gaugePrecondition = new cudaGaugeField(gauge_param);
-      gaugePrecondition->copy(*gaugeLongPrecise);
+      gaugeLongPrecondition = new cudaGaugeField(gauge_param);
+      gaugeLongPrecondition->copy(*gaugeLongPrecise);
     }
 
     // switch the parameters for creating the mirror refinement cuda gauge field


### PR DESCRIPTION
This hotfix fixes a copy+paste bug in `loadSloppyGaugeQuda` which caused the preconditioned long and fat links to not be correctly initialized depending on the preconditioned recon and precision.

This routine only gets triggered when updating the fat and long links when there are already resident links, which is a workflow we'd never tested internally, but is common in MILC workflows due to the Naik correction for the charm quark. 

Thank you to @detar for pointing us towards this bug via a MILC workload and helping me reproduce it. I verified that the MILC workload now goes through and behaves sanely with this fix.

As an FYI, this bug doesn't exist in `release/1.0.x`, so nothing to worry about there.