### PR TITLE
Feature/hermitian check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,6 +176,7 @@ set(QUDA_CTEST_SEP_DSLASH_POLICIES
     CACHE BOOL "Test Dslash policies separately in ctest instead of only autotuning them.")
 
 set(QUDA_REDUCE_SINGLE_WARP OFF CACHE BOOL "enable single warp per CTA for reduction kernels to reduce compile time")
+set(QUDA_DSLASH_FAST_COMPILE OFF CACHE BOOL "enable fast compilation in dslash kernels to reduce compile time (~20% perf impact)")
 
 set(QUDA_OPENMP OFF CACHE BOOL "enable OpenMP")
 set(QUDA_CXX_STANDARD 14 CACHE STRING "set the CXX Standard (14 or 17)")
@@ -206,6 +207,7 @@ mark_as_advanced(QUDA_PROPAGATE_CXX_FLAGS)
 mark_as_advanced(QUDA_TEX)
 mark_as_advanced(QUDA_FLOAT8)
 mark_as_advanced(QUDA_REDUCE_SINGLE_WARP)
+mark_as_advanced(QUDA_DSLASH_FAST_COMPILE)
 mark_as_advanced(QUDA_NVML)
 mark_as_advanced(QUDA_NUMA_NVML)
 mark_as_advanced(QUDA_VERBOSE_BUILD)
@@ -652,6 +654,10 @@ add_definitions(-DQUDA_PRECISION=${QUDA_PRECISION})
 
 if(QUDA_REDUCE_SINGLE_WARP)
 add_definitions(-DQUDA_REDUCE_SINGLE_WARP)
+endif()
+
+if(QUDA_DSLASH_FAST_COMPILE)
+add_definitions(-DQUDA_DSLASH_FAST_COMPILE)
 endif()
 
 # set which precisions to enable

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,8 +175,8 @@ set(QUDA_CTEST_SEP_DSLASH_POLICIES
     OFF
     CACHE BOOL "Test Dslash policies separately in ctest instead of only autotuning them.")
 
-set(QUDA_REDUCE_SINGLE_WARP OFF CACHE BOOL "enable single warp per CTA for reduction kernels to reduce compile time")
-set(QUDA_DSLASH_FAST_COMPILE OFF CACHE BOOL "enable fast compilation in dslash kernels to reduce compile time (~20% perf impact)")
+set(QUDA_FAST_COMPILE_REDUCE OFF CACHE BOOL "enable fast compilation in blas and reduction kernels (single warp per reduction)")
+set(QUDA_FAST_COMPILE_DSLASH OFF CACHE BOOL "enable fast compilation in dslash kernels (~20% perf impact)")
 
 set(QUDA_OPENMP OFF CACHE BOOL "enable OpenMP")
 set(QUDA_CXX_STANDARD 14 CACHE STRING "set the CXX Standard (14 or 17)")
@@ -206,8 +206,8 @@ mark_as_advanced(QUDA_BUILD_ALL_TESTS)
 mark_as_advanced(QUDA_PROPAGATE_CXX_FLAGS)
 mark_as_advanced(QUDA_TEX)
 mark_as_advanced(QUDA_FLOAT8)
-mark_as_advanced(QUDA_REDUCE_SINGLE_WARP)
-mark_as_advanced(QUDA_DSLASH_FAST_COMPILE)
+mark_as_advanced(QUDA_FAST_COMPILE_REDUCE)
+mark_as_advanced(QUDA_FAST_COMPILE_DSLASH)
 mark_as_advanced(QUDA_NVML)
 mark_as_advanced(QUDA_NUMA_NVML)
 mark_as_advanced(QUDA_VERBOSE_BUILD)
@@ -652,12 +652,12 @@ endif(QUDA_ARPACK)
 # set which precisions to enable
 add_definitions(-DQUDA_PRECISION=${QUDA_PRECISION})
 
-if(QUDA_REDUCE_SINGLE_WARP)
-add_definitions(-DQUDA_REDUCE_SINGLE_WARP)
+if(QUDA_FAST_COMPILE_REDUCE)
+add_definitions(-DQUDA_FAST_COMPILE_REDUCE)
 endif()
 
-if(QUDA_DSLASH_FAST_COMPILE)
-add_definitions(-DQUDA_DSLASH_FAST_COMPILE)
+if(QUDA_FAST_COMPILE_DSLASH)
+add_definitions(-DQUDA_FAST_COMPILE_DSLASH)
 endif()
 
 # set which precisions to enable

--- a/include/dirac_quda.h
+++ b/include/dirac_quda.h
@@ -1025,6 +1025,8 @@ public:
 			 const QudaSolutionType) const;
     virtual void reconstruct(ColorSpinorField &x, const ColorSpinorField &b,
 			     const QudaSolutionType) const;
+
+    virtual bool hermitian() const { return true; }
   };
 
   // Full staggered
@@ -1108,6 +1110,8 @@ public:
 			 const QudaSolutionType) const;
     virtual void reconstruct(ColorSpinorField &x, const ColorSpinorField &b,
 			     const QudaSolutionType) const;
+
+    virtual bool hermitian() const { return true; }
   };
 
   /**

--- a/include/dirac_quda.h
+++ b/include/dirac_quda.h
@@ -260,6 +260,9 @@ namespace quda {
     /** Flips value of daggered */
     void flipDagger() const { dagger = (dagger == QUDA_DAG_YES) ? QUDA_DAG_NO : QUDA_DAG_YES; }
 
+    /** @return is operator hermitian */
+    virtual bool hermitian() const { return false; }
+
     /**
      * @brief Create the coarse operator (virtual parent)
      *
@@ -1363,6 +1366,7 @@ public:
 			 const QudaSolutionType) const;
     virtual void reconstruct(ColorSpinorField &x, const ColorSpinorField &b,
 			     const QudaSolutionType) const;
+    virtual bool hermitian() const { return true; }
   };
 
   /**
@@ -1383,6 +1387,7 @@ public:
 		 ColorSpinorField &x, ColorSpinorField &b,
 		 const QudaSolutionType) const;
     void reconstruct(ColorSpinorField &x, const ColorSpinorField &b, const QudaSolutionType) const;
+    virtual bool hermitian() const { return true; }
   };
 
   /**
@@ -1459,6 +1464,8 @@ public:
 	      Type() == typeid(DiracImprovedStaggered).name()) ? true : false;
     }
 
+    virtual bool hermitian() const { return dirac->hermitian(); }
+
     const Dirac *Expose() const { return dirac; }
 
     //! Shift term added onto operator (M/M^dag M/M M^dag + shift)
@@ -1525,8 +1532,6 @@ public:
     DiracMdagM(const Dirac &d) : DiracMatrix(d) { }
     DiracMdagM(const Dirac *d) : DiracMatrix(d) { }
 
-    
-
     void operator()(ColorSpinorField &out, const ColorSpinorField &in) const
     {
       dirac->MdagM(out, in);
@@ -1556,6 +1561,8 @@ public:
     {
       return 2*dirac->getStencilSteps(); // 2 for M and M dagger
     }
+
+    virtual bool hermitian() const { return true; } // normal op is always Hermitian
   };
 
   /* Gloms onto a DiracMatrix and provides an operator() forward to its MMdag method */
@@ -1594,6 +1601,8 @@ public:
     {
       return 2*dirac->getStencilSteps(); // 2 for M and M dagger
     }
+
+    virtual bool hermitian() const { return true; } // normal op is always Hermitian
   };
 
   /* Gloms onto a DiracMatrix and provides an  operator() for its Mdag method */

--- a/include/dslash_helper.cuh
+++ b/include/dslash_helper.cuh
@@ -438,10 +438,14 @@ namespace quda
       int x_cb = (blockIdx.x - dslash_block_offset) * blockDim.x + threadIdx.x;
       if (x_cb >= arg.threads) return;
 
+#ifdef QUDA_DSLASH_FAST_COMPILE
+      dslash(x_cb, s, parity);
+#else
       switch (parity) {
       case 0: dslash(x_cb, s, 0); break;
       case 1: dslash(x_cb, s, 1); break;
       }
+#endif
     }
   }
 

--- a/include/eigensolve_quda.h
+++ b/include/eigensolve_quda.h
@@ -13,10 +13,10 @@ namespace quda
 
   class EigenSolver
   {
-
-protected:
     using range = std::pair<int, int>;
 
+protected:
+    const DiracMatrix &mat;
     QudaEigParam *eig_param;
     TimeProfile &profile;
 
@@ -61,12 +61,17 @@ public:
        @param eig_param MGParam struct that defines all meta data
        @param profile Timeprofile instance used to profile
     */
-    EigenSolver(QudaEigParam *eig_param, TimeProfile &profile);
+    EigenSolver(const DiracMatrix &mat, QudaEigParam *eig_param, TimeProfile &profile);
 
     /**
        Destructor for EigenSolver class.
     */
     virtual ~EigenSolver();
+
+    /**
+       @return Whether the solver is only for Hermitian systems
+     */
+    virtual bool hermitian() = 0;
 
     /**
        @brief Computes the eigen decomposition for the operator passed to create.
@@ -281,19 +286,20 @@ public:
   {
 
 public:
-    const DiracMatrix &mat;
     /**
        @brief Constructor for Thick Restarted Eigensolver class
        @param eig_param The eigensolver parameters
        @param mat The operator to solve
        @param profile Time Profile
     */
-    TRLM(QudaEigParam *eig_param, const DiracMatrix &mat, TimeProfile &profile);
+    TRLM(const DiracMatrix &mat, QudaEigParam *eig_param, TimeProfile &profile);
 
     /**
        @brief Destructor for Thick Restarted Eigensolver class
     */
     virtual ~TRLM();
+
+    virtual bool hermitian() { return true; } /** TRLM is only for Hermitian systems */
 
     // Variable size matrix
     std::vector<double> ritz_mat;

--- a/include/invert_quda.h
+++ b/include/invert_quda.h
@@ -137,7 +137,7 @@ namespace quda {
 
     /**< The precision used by the QUDA sloppy operator */
     QudaPrecision precision_sloppy;
-    
+
     /**< The precision used by the QUDA sloppy operator for multishift refinement */
     QudaPrecision precision_refinement_sloppy;
 
@@ -457,6 +457,10 @@ namespace quda {
   class Solver {
 
   protected:
+    const DiracMatrix &mat;
+    const DiracMatrix &matSloppy;
+    const DiracMatrix &matPrecon;
+
     SolverParam &param;
     TimeProfile &profile;
     int node_parity;
@@ -468,18 +472,28 @@ namespace quda {
     std::vector<Complex> evals;                /** Holds the eigenvalues. */
 
   public:
-    Solver(SolverParam &param, TimeProfile &profile);
+    Solver(const DiracMatrix &mat, const DiracMatrix &matSloppy, const DiracMatrix &matPrecon,
+           SolverParam &param, TimeProfile &profile);
     virtual ~Solver();
 
     virtual void operator()(ColorSpinorField &out, ColorSpinorField &in) = 0;
 
     virtual void blocksolve(ColorSpinorField &out, ColorSpinorField &in);
 
+    const DiracMatrix& M() { return mat; }
+    const DiracMatrix& Msloppy() { return matSloppy; }
+    const DiracMatrix& Mprecon() { return matPrecon; }
+
+    /**
+       @return Whether the solver is only for Hermitian systems
+     */
+    virtual bool hermitian() = 0;
+
     /**
        @brief Solver factory
     */
-    static Solver* create(SolverParam &param, DiracMatrix &mat, DiracMatrix &matSloppy,
-			  DiracMatrix &matPrecon, TimeProfile &profile);
+    static Solver* create(SolverParam &param, const DiracMatrix &mat, const DiracMatrix &matSloppy,
+			  const DiracMatrix &matPrecon, TimeProfile &profile);
 
     /**
        @brief Set the solver L2 stopping condition
@@ -611,16 +625,13 @@ namespace quda {
   class CG : public Solver {
 
   private:
-    const DiracMatrix &mat;
-    const DiracMatrix &matSloppy;
-    const DiracMatrix &matPrecon;
     // pointers to fields to avoid multiple creation overhead
     ColorSpinorField *yp, *rp, *rnewp, *pp, *App, *tmpp, *tmp2p, *tmp3p, *rSloppyp, *xSloppyp;
     std::vector<ColorSpinorField*> p;
     bool init;
 
   public:
-    CG(DiracMatrix &mat, DiracMatrix &matSloppy, DiracMatrix &matPrecon, SolverParam &param, TimeProfile &profile);
+    CG(const DiracMatrix &mat, const DiracMatrix &matSloppy, const DiracMatrix &matPrecon, SolverParam &param, TimeProfile &profile);
     virtual ~CG();
     /**
      * @brief Run CG.
@@ -642,43 +653,43 @@ namespace quda {
     void operator()(ColorSpinorField &out, ColorSpinorField &in, ColorSpinorField *p_init, double r2_old_init);
 
     void blocksolve(ColorSpinorField& out, ColorSpinorField& in);
-  };
 
+    virtual bool hermitian() { return true; } /** CG is only for Hermitian systems */
+  };
 
 
   class CG3 : public Solver {
 
   private:
-    const DiracMatrix &mat;
-    const DiracMatrix &matSloppy;
     // pointers to fields to avoid multiple creation overhead
     ColorSpinorField *yp, *rp, *tmpp, *ArSp, *rSp, *xSp, *xS_oldp, *tmpSp, *rS_oldp, *tmp2Sp;
     bool init;
 
   public:
-    CG3(DiracMatrix &mat, DiracMatrix &matSloppy, SolverParam &param, TimeProfile &profile);
+    CG3(const DiracMatrix &mat, const DiracMatrix &matSloppy, SolverParam &param, TimeProfile &profile);
     virtual ~CG3();
 
     void operator()(ColorSpinorField &out, ColorSpinorField &in);
-  };
 
+    virtual bool hermitian() { return true; } /** CG is only for Hermitian systems */
+  };
 
 
   class CG3NE : public Solver {
 
   private:
-    const DiracMatrix &mat;
-    const DiracMatrix &matSloppy;
     DiracDagger matDagSloppy;
     // pointers to fields to avoid multiple creation overhead
     ColorSpinorField *yp, *rp, *AdagrSp, *AAdagrSp, *rSp, *xSp, *xS_oldp, *tmpSp, *rS_oldp;
     bool init;
 
   public:
-    CG3NE(DiracMatrix &mat, DiracMatrix &matSloppy, SolverParam &param, TimeProfile &profile);
+    CG3NE(const DiracMatrix &mat, const DiracMatrix &matSloppy, SolverParam &param, TimeProfile &profile);
     virtual ~CG3NE();
 
     void operator()(ColorSpinorField &out, ColorSpinorField &in);
+
+    virtual bool hermitian() { return true; } /** CGNE is for any system */
   };
 
   class CGNE : public CG {
@@ -692,10 +703,12 @@ namespace quda {
     bool init;
 
   public:
-    CGNE(DiracMatrix &mat, DiracMatrix &matSloppy, DiracMatrix &matPrecon, SolverParam &param, TimeProfile &profile);
+    CGNE(const DiracMatrix &mat, const DiracMatrix &matSloppy, const DiracMatrix &matPrecon, SolverParam &param, TimeProfile &profile);
     virtual ~CGNE();
 
     void operator()(ColorSpinorField &out, ColorSpinorField &in);
+
+    virtual bool hermitian() { return false; } /** CGNE is for any Hermitian system */
   };
 
   class CGNR : public CG {
@@ -708,161 +721,154 @@ namespace quda {
     bool init;
 
   public:
-    CGNR(DiracMatrix &mat, DiracMatrix &matSloppy, DiracMatrix &matPrecon, SolverParam &param, TimeProfile &profile);
+    CGNR(const DiracMatrix &mat, const DiracMatrix &matSloppy, const DiracMatrix &matPrecon, SolverParam &param, TimeProfile &profile);
     virtual ~CGNR();
 
     void operator()(ColorSpinorField &out, ColorSpinorField &in);
+
+    virtual bool hermitian() { return false; } /** CGNR is for any Hermitian system */
   };
 
   class MPCG : public Solver {
     private:
-      const DiracMatrix &mat;
       void computeMatrixPowers(cudaColorSpinorField out[], cudaColorSpinorField &in, int nvec);
       void computeMatrixPowers(std::vector<cudaColorSpinorField>& out, std::vector<cudaColorSpinorField>& in, int nsteps);
 
-
     public:
-      MPCG(DiracMatrix &mat, SolverParam &param, TimeProfile &profile);
+      MPCG(const DiracMatrix &mat, SolverParam &param, TimeProfile &profile);
       virtual ~MPCG();
 
       void operator()(ColorSpinorField &out, ColorSpinorField &in);
+      virtual bool hermitian() { return true; } /** MPCG is only Hermitian system */
   };
-
 
 
   class PreconCG : public Solver {
     private:
-      const DiracMatrix &mat;
-      const DiracMatrix &matSloppy;
-      const DiracMatrix &matPrecon;
-
       Solver *K;
       SolverParam Kparam; // parameters for preconditioner solve
 
     public:
-      PreconCG(DiracMatrix &mat, DiracMatrix &matSloppy, DiracMatrix &matPrecon, SolverParam &param, TimeProfile &profile);
+      PreconCG(const DiracMatrix &mat, const DiracMatrix &matSloppy, const DiracMatrix &matPrecon, SolverParam &param, TimeProfile &profile);
 
       virtual ~PreconCG();
 
       void operator()(ColorSpinorField &out, ColorSpinorField &in);
+      virtual bool hermitian() { return true; } /** MPCG is only Hermitian system */
   };
 
 
   class BiCGstab : public Solver {
 
   private:
-    DiracMatrix &mat;
-    const DiracMatrix &matSloppy;
-    const DiracMatrix &matPrecon;
-
     // pointers to fields to avoid multiple creation overhead
     ColorSpinorField *yp, *rp, *pp, *vp, *tmpp, *tp;
     bool init;
 
   public:
-    BiCGstab(DiracMatrix &mat, DiracMatrix &matSloppy, DiracMatrix &matPrecon,
+    BiCGstab(const DiracMatrix &mat, const DiracMatrix &matSloppy, const DiracMatrix &matPrecon,
 	     SolverParam &param, TimeProfile &profile);
     virtual ~BiCGstab();
 
     void operator()(ColorSpinorField &out, ColorSpinorField &in);
+
+    virtual bool hermitian() { return false; } /** BiCGStab is for any linear system */
   };
 
   class SimpleBiCGstab : public Solver {
 
   private:
-    DiracMatrix &mat;
 
     // pointers to fields to avoid multiple creation overhead
     cudaColorSpinorField *yp, *rp, *pp, *vp, *tmpp, *tp;
     bool init;
 
   public:
-    SimpleBiCGstab(DiracMatrix &mat, SolverParam &param, TimeProfile &profile);
+    SimpleBiCGstab(const DiracMatrix &mat, SolverParam &param, TimeProfile &profile);
     virtual ~SimpleBiCGstab();
 
     void operator()(ColorSpinorField &out, ColorSpinorField &in);
+
+    virtual bool hermitian() { return false; } /** BiCGStab is for any linear system */
   };
 
   class MPBiCGstab : public Solver {
 
   private:
-    DiracMatrix &mat;
     void computeMatrixPowers(std::vector<cudaColorSpinorField>& pr, cudaColorSpinorField& p, cudaColorSpinorField& r, int nsteps);
 
   public:
-    MPBiCGstab(DiracMatrix &mat, SolverParam &param, TimeProfile &profile);
+    MPBiCGstab(const DiracMatrix &mat, SolverParam &param, TimeProfile &profile);
     virtual ~MPBiCGstab();
 
     void operator()(ColorSpinorField &out, ColorSpinorField &in);
+
+    virtual bool hermitian() { return false; } /** BiCGStab is for any linear system */
   };
 
   class BiCGstabL : public Solver {
 
   private:
-    DiracMatrix &mat;
-    const DiracMatrix &matSloppy;
-
     /**
        The size of the Krylov space that BiCGstabL uses.
      */
     int nKrylov; // in the language of BiCGstabL, this is L.
-    
+
     // Various coefficients and params needed on each iteration.
-    Complex rho0, rho1, alpha, omega, beta; // Various coefficients for the BiCG part of BiCGstab-L. 
+    Complex rho0, rho1, alpha, omega, beta; // Various coefficients for the BiCG part of BiCGstab-L.
     Complex *gamma, *gamma_prime, *gamma_prime_prime; // Parameters for MR part of BiCGstab-L. (L+1) length.
     Complex **tau; // Parameters for MR part of BiCGstab-L. Tech. modified Gram-Schmidt coeffs. (L+1)x(L+1) length.
     double *sigma; // Parameters for MR part of BiCGstab-L. Tech. the normalization part of Gram-Scmidt. (L+1) length.
-    
+
     // pointers to fields to avoid multiple creation overhead
     // full precision fields
     ColorSpinorField *r_fullp;   //! Full precision residual.
     ColorSpinorField *yp;        //! Full precision temporary.
     // sloppy precision fields
-    ColorSpinorField *tempp;     //! Sloppy temporary vector. 
+    ColorSpinorField *tempp;     //! Sloppy temporary vector.
     std::vector<ColorSpinorField*> r; // Current residual + intermediate residual values, along the MR.
     std::vector<ColorSpinorField*> u; // Search directions.
-    
+
     // Saved, preallocated vectors. (may or may not get used depending on precision.)
     ColorSpinorField *x_sloppy_saved_p; //! Sloppy solution vector.
     ColorSpinorField *r0_saved_p;       //! Shadow residual, in BiCG language.
     ColorSpinorField *r_sloppy_saved_p; //! Current residual, in BiCG language.
-    
+
     /**
        Internal routine for reliable updates. Made to not conflict with BiCGstab's implementation.
      */
     int reliable(double &rNorm, double &maxrx, double &maxrr, const double &r2, const double &delta);
-    
+
     /**
        Internal routines for pipelined Gram-Schmidt. Made to not conflict with GCR's implementation.
      */
     void computeTau(Complex **tau, double *sigma, std::vector<ColorSpinorField*> r, int begin, int size, int j);
     void updateR(Complex **tau, std::vector<ColorSpinorField*> r, int begin, int size, int j);
     void orthoDir(Complex **tau, double* sigma, std::vector<ColorSpinorField*> r, int j, int pipeline);
-    
+
     void updateUend(Complex* gamma, std::vector<ColorSpinorField*> u, int nKrylov);
     void updateXRend(Complex* gamma, Complex* gamma_prime, Complex* gamma_prime_prime,
                                 std::vector<ColorSpinorField*> r, ColorSpinorField& x, int nKrylov);
-    
+
     /**
        Solver uses lazy allocation: this flag determines whether we have allocated or not.
      */
-    bool init; 
-    
+    bool init;
+
     std::string solver_name; // holds BiCGstab-l, where 'l' literally equals nKrylov.
 
   public:
-    BiCGstabL(DiracMatrix &mat, DiracMatrix &matSloppy, SolverParam &param, TimeProfile &profile);
+    BiCGstabL(const DiracMatrix &mat, const DiracMatrix &matSloppy, SolverParam &param, TimeProfile &profile);
     virtual ~BiCGstabL();
 
     void operator()(ColorSpinorField &out, ColorSpinorField &in);
+
+    virtual bool hermitian() { return false; } /** BiCGStab is for any linear system */
   };
 
   class GCR : public Solver {
 
   private:
-    const DiracMatrix &mat;
-    const DiracMatrix &matSloppy;
-    const DiracMatrix &matPrecon;
     const DiracMdagM matMdagM; // used by the eigensolver
 
     Solver *K;
@@ -891,24 +897,24 @@ namespace quda {
     std::vector<ColorSpinorField*> Ap; // mat * direction vectors
 
   public:
-    GCR(DiracMatrix &mat, DiracMatrix &matSloppy, DiracMatrix &matPrecon,
+    GCR(const DiracMatrix &mat, const DiracMatrix &matSloppy, const DiracMatrix &matPrecon,
 	SolverParam &param, TimeProfile &profile);
 
     /**
        @param K Preconditioner
     */
-    GCR(DiracMatrix &mat, Solver &K, DiracMatrix &matSloppy, DiracMatrix &matPrecon, SolverParam &param,
+    GCR(const DiracMatrix &mat, Solver &K, const DiracMatrix &matSloppy, const DiracMatrix &matPrecon, SolverParam &param,
         TimeProfile &profile);
     virtual ~GCR();
 
     void operator()(ColorSpinorField &out, ColorSpinorField &in);
+
+    virtual bool hermitian() { return false; } /** GCR is for any linear system */
   };
 
   class MR : public Solver {
 
   private:
-    const DiracMatrix &mat;
-    const DiracMatrix &matSloppy;
     ColorSpinorField *rp;
     ColorSpinorField *r_sloppy;
     ColorSpinorField *Arp;
@@ -918,10 +924,12 @@ namespace quda {
     bool init;
 
   public:
-    MR(DiracMatrix &mat, DiracMatrix &matSloppy, SolverParam &param, TimeProfile &profile);
+    MR(const DiracMatrix &mat, const DiracMatrix &matSloppy, SolverParam &param, TimeProfile &profile);
     virtual ~MR();
 
     void operator()(ColorSpinorField &out, ColorSpinorField &in);
+
+    virtual bool hermitian() { return false; } /** MR is for any linear system */
   };
 
   /**
@@ -935,9 +943,6 @@ namespace quda {
   class CACG : public Solver {
 
   private:
-    const DiracMatrix &mat;
-    const DiracMatrix &matSloppy;
-    const DiracMatrix &matPrecon;
     bool init;
 
     bool lambda_init;
@@ -988,10 +993,12 @@ namespace quda {
     int reliable(double &rNorm,  double &maxrr, int &rUpdate, const double &r2, const double &delta);
 
   public:
-    CACG(DiracMatrix &mat, DiracMatrix &matSloppy, DiracMatrix &matPrecon, SolverParam &param, TimeProfile &profile);
+    CACG(const DiracMatrix &mat, const DiracMatrix &matSloppy, const DiracMatrix &matPrecon, SolverParam &param, TimeProfile &profile);
     virtual ~CACG();
 
     void operator()(ColorSpinorField &out, ColorSpinorField &in);
+
+    virtual bool hermitian() { return true; } /** CG is only for Hermitian systems */
   };
 
   class CACGNE : public CACG {
@@ -1005,10 +1012,12 @@ namespace quda {
     bool init;
 
   public:
-    CACGNE(DiracMatrix &mat, DiracMatrix &matSloppy, DiracMatrix &matPrecon, SolverParam &param, TimeProfile &profile);
+    CACGNE(const DiracMatrix &mat, const DiracMatrix &matSloppy, const DiracMatrix &matPrecon, SolverParam &param, TimeProfile &profile);
     virtual ~CACGNE();
 
     void operator()(ColorSpinorField &out, ColorSpinorField &in);
+
+    virtual bool hermitian() { return false; } /** CGNE is for any linear system */
   };
 
   class CACGNR : public CACG {
@@ -1021,10 +1030,12 @@ namespace quda {
     bool init;
 
   public:
-    CACGNR(DiracMatrix &mat, DiracMatrix &matSloppy, DiracMatrix &matPrecon, SolverParam &param, TimeProfile &profile);
+    CACGNR(const DiracMatrix &mat, const DiracMatrix &matSloppy, const DiracMatrix &matPrecon, SolverParam &param, TimeProfile &profile);
     virtual ~CACGNR();
 
     void operator()(ColorSpinorField &out, ColorSpinorField &in);
+
+    virtual bool hermitian() { return false; } /** CGNE is for any linear system */
   };
 
   /**
@@ -1037,9 +1048,6 @@ namespace quda {
   class CAGCR : public Solver {
 
   private:
-    const DiracMatrix &mat;
-    const DiracMatrix &matSloppy;
-    const DiracMatrix &matPrecon;
     const DiracMdagM matMdagM; // used by the eigensolver
     bool init;
     const bool use_source; // whether we can reuse the source vector
@@ -1075,32 +1083,35 @@ namespace quda {
     void solve(Complex *psi_, std::vector<ColorSpinorField*> &q, ColorSpinorField &b);
 
 public:
-  CAGCR(DiracMatrix &mat, DiracMatrix &matSloppy, DiracMatrix &matPrecon, SolverParam &param, TimeProfile &profile);
-  virtual ~CAGCR();
+    CAGCR(const DiracMatrix &mat, const DiracMatrix &matSloppy, const DiracMatrix &matPrecon, SolverParam &param, TimeProfile &profile);
+    virtual ~CAGCR();
 
-  void operator()(ColorSpinorField &out, ColorSpinorField &in);
+    void operator()(ColorSpinorField &out, ColorSpinorField &in);
+
+    virtual bool hermitian() { return false; } /** GCR is for any linear system */
   };
 
   // Steepest descent solver used as a preconditioner
   class SD : public Solver {
     private:
-      const DiracMatrix &mat;
       cudaColorSpinorField *Ar;
       cudaColorSpinorField *r;
       cudaColorSpinorField *y;
       bool init;
 
     public:
-      SD(DiracMatrix &mat, SolverParam &param, TimeProfile &profile);
+      SD(const DiracMatrix &mat, SolverParam &param, TimeProfile &profile);
       virtual ~SD();
 
       void operator()(ColorSpinorField &out, ColorSpinorField &in);
+
+      virtual bool hermitian() { return false; } /** CGNE is for any linear system */
   };
 
   // Extended Steepest Descent solver used for overlapping DD preconditioning
-  class XSD : public Solver {
+  class XSD : public Solver
+  {
     private:
-      const DiracMatrix &mat;
       cudaColorSpinorField *xx;
       cudaColorSpinorField *bx;
       SD *sd; // extended sd is implemented using standard sd
@@ -1108,15 +1119,16 @@ public:
       int R[4];
 
     public:
-      XSD(DiracMatrix &mat, SolverParam &param, TimeProfile &profile);
+      XSD(const DiracMatrix &mat, SolverParam &param, TimeProfile &profile);
       virtual ~XSD();
 
       void operator()(ColorSpinorField &out, ColorSpinorField &in);
+
+      virtual bool hermitian() { return false; } /** CGNE is for any linear system */
   };
 
   class PreconditionedSolver : public Solver
   {
-
 private:
     Solver *solver;
     const Dirac &dirac;
@@ -1125,7 +1137,7 @@ private:
 public:
     PreconditionedSolver(Solver &solver, const Dirac &dirac, SolverParam &param, TimeProfile &profile,
                          const char *prefix) :
-      Solver(param, profile),
+      Solver(solver.M(), solver.Msloppy(), solver.Mprecon(), param, profile),
       solver(&solver),
       dirac(dirac),
       prefix(prefix)
@@ -1154,17 +1166,21 @@ public:
      *        rescaling an MG instance
      */
     Solver &ExposeSolver() const { return *solver; }
+
+    virtual bool hermitian() { return solver->hermitian(); } /** Use the inner solver */
   };
 
   class MultiShiftSolver {
 
   protected:
+    const DiracMatrix &mat;
+    const DiracMatrix &matSloppy;
     SolverParam &param;
     TimeProfile &profile;
 
   public:
-    MultiShiftSolver(SolverParam &param, TimeProfile &profile) :
-    param(param), profile(profile) { ; }
+    MultiShiftSolver(const DiracMatrix &mat, const DiracMatrix &matSloppy, SolverParam &param, TimeProfile &profile) :
+      mat(mat), matSloppy(matSloppy), param(param), profile(profile) { ; }
     virtual ~MultiShiftSolver() { ; }
 
     virtual void operator()(std::vector<ColorSpinorField*> out, ColorSpinorField &in) = 0;
@@ -1176,16 +1192,12 @@ public:
  */
   class MultiShiftCG : public MultiShiftSolver {
 
-  protected:
-    const DiracMatrix &mat;
-    const DiracMatrix &matSloppy;
-
   public:
-    MultiShiftCG(DiracMatrix &mat, DiracMatrix &matSloppy, SolverParam &param, TimeProfile &profile);
+    MultiShiftCG(const DiracMatrix &mat, const DiracMatrix &matSloppy, SolverParam &param, TimeProfile &profile);
     virtual ~MultiShiftCG();
 /**
  * @brief Run multi-shift and return Krylov-space at the end of the solve in p and r2_old_arry.
- * 
+ *
  * @param out std::vector of pointer to solutions for all the shifts.
  * @param in right-hand side.
  * @param p std::vector of pointers to hold search directions. Note this will be resized as necessary.
@@ -1195,7 +1207,7 @@ public:
 
 /**
  * @brief Run multi-shift and return Krylov-space at the end of the solve in p and r2_old_arry.
- * 
+ *
  * @param out std::vector of pointer to solutions for all the shifts.
  * @param in right-hand side.
  */
@@ -1205,11 +1217,10 @@ public:
 
       (*this)(out, in, p, r2_old.get());
 
-      for (auto& pp : p) delete pp;   
+      for (auto& pp : p) delete pp;
     }
 
   };
-
 
 
   /**
@@ -1251,7 +1262,7 @@ public:
        @param apply_mat Whether to apply the operator in place or assume q already contains this
        @profile Timing profile to use
     */
-    MinResExt(DiracMatrix &mat, bool orthogonal, bool apply_mat, bool hermitian, TimeProfile &profile);
+    MinResExt(const DiracMatrix &mat, bool orthogonal, bool apply_mat, bool hermitian, TimeProfile &profile);
     virtual ~MinResExt();
 
     /**
@@ -1281,10 +1292,6 @@ public:
   class IncEigCG : public Solver {
 
   private:
-    DiracMatrix &mat;
-    DiracMatrix &matSloppy;
-    DiracMatrix &matPrecon;
-
     Solver *K;
     SolverParam Kparam; // parameters for preconditioner solve
 
@@ -1295,7 +1302,7 @@ public:
     ColorSpinorField* p;  // conjugate vector
     ColorSpinorField* Ap; // mat * conjugate vector
     ColorSpinorField *tmpp;     //! temporary for mat-vec
-    ColorSpinorField* Az; // mat * conjugate vector from the previous iteration 
+    ColorSpinorField* Az; // mat * conjugate vector from the previous iteration
     ColorSpinorField *r_pre;    //! residual passed to preconditioner
     ColorSpinorField *p_pre;    //! preconditioner result
 
@@ -1306,7 +1313,7 @@ public:
     bool init;
 
 public:
-    IncEigCG(DiracMatrix &mat, DiracMatrix &matSloppy, DiracMatrix &matPrecon, SolverParam &param, TimeProfile &profile);
+    IncEigCG(const DiracMatrix &mat, const DiracMatrix &matSloppy, const DiracMatrix &matPrecon, SolverParam &param, TimeProfile &profile);
 
     virtual ~IncEigCG();
 
@@ -1318,13 +1325,15 @@ public:
     void increment(ColorSpinorField &V, int nev);
 
     void RestartVT(const double beta, const double rho);
-    void UpdateVm(ColorSpinorField &res, double beta, double sqrtr2); 
+    void UpdateVm(ColorSpinorField &res, double beta, double sqrtr2);
     //EigCG solver:
     int eigCGsolve(ColorSpinorField &out, ColorSpinorField &in);
     //InitCG solver:
     int initCGsolve(ColorSpinorField &out, ColorSpinorField &in);
     //Incremental eigCG solver (for eigcg and initcg calls)
     void operator()(ColorSpinorField &out, ColorSpinorField &in);
+
+    bool hermitian() { return true; } // EigCG is only for Hermitian systems
   };
 
 //forward declaration
@@ -1333,11 +1342,6 @@ public:
  class GMResDR : public Solver {
 
   private:
-
-    DiracMatrix &mat;
-    DiracMatrix &matSloppy;
-    DiracMatrix &matPrecon;
-
     Solver *K;
     SolverParam Kparam; // parameters for preconditioner solve
 
@@ -1359,8 +1363,8 @@ public:
 
   public:
 
-    GMResDR(DiracMatrix &mat, DiracMatrix &matSloppy, DiracMatrix &matPrecon, SolverParam &param, TimeProfile &profile);
-    GMResDR(DiracMatrix &mat, Solver &K, DiracMatrix &matSloppy, DiracMatrix &matPrecon, SolverParam &param, TimeProfile &profile);
+    GMResDR(const DiracMatrix &mat, const DiracMatrix &matSloppy, const DiracMatrix &matPrecon, SolverParam &param, TimeProfile &profile);
+    GMResDR(const DiracMatrix &mat, Solver &K, const DiracMatrix &matSloppy, const DiracMatrix &matPrecon, SolverParam &param, TimeProfile &profile);
 
     virtual ~GMResDR();
 
@@ -1376,7 +1380,8 @@ public:
 
     void UpdateSolution(ColorSpinorField *x, ColorSpinorField *r, bool do_gels);
 
-  };
+    bool hermitian() { return false; } // GMRESDR for any linear system
+ };
 
   /**
      @brief This is an object that captures the state required for a
@@ -1389,4 +1394,3 @@ public:
   };
 
 } // namespace quda
-

--- a/include/invert_quda.h
+++ b/include/invert_quda.h
@@ -708,7 +708,7 @@ namespace quda {
 
     void operator()(ColorSpinorField &out, ColorSpinorField &in);
 
-    virtual bool hermitian() { return false; } /** CGNE is for any Hermitian system */
+    virtual bool hermitian() { return false; } /** CGNE is for any system */
   };
 
   class CGNR : public CG {
@@ -726,7 +726,7 @@ namespace quda {
 
     void operator()(ColorSpinorField &out, ColorSpinorField &in);
 
-    virtual bool hermitian() { return false; } /** CGNR is for any Hermitian system */
+    virtual bool hermitian() { return false; } /** CGNR is for any system */
   };
 
   class MPCG : public Solver {

--- a/include/kernels/dslash_wilson.cuh
+++ b/include/kernels/dslash_wilson.cuh
@@ -95,7 +95,7 @@ namespace quda
             ghostFaceIndex<1, Arg::nDim>(coord, arg.dim, d, arg.nFace) : idx;
 
           Link U = arg.U(d, gauge_idx, gauge_parity);
-          HalfVector in = arg.in.Ghost(d, 1, ghost_idx + coord.s * arg.dc.ghostFaceCB[d], parity);
+          HalfVector in = arg.in.Ghost(d, 1, ghost_idx + coord.s * arg.dc.ghostFaceCB[d], their_spinor_parity);
           if (d == 3) in *= arg.t_proj_scale; // put this in the Ghost accessor and merge with any rescaling?
 
           out += (U * in).reconstruct(d, proj_dir);

--- a/include/kernels/multi_blas_core.cuh
+++ b/include/kernels/multi_blas_core.cuh
@@ -6,7 +6,7 @@
 #include <multi_blas_helper.cuh>
 #include <float_vector.h>
 
-#if (__COMPUTE_CAPABILITY__ >= 300 || __CUDA_ARCH__ >= 300)
+#if (__COMPUTE_CAPABILITY__ >= 300 || __CUDA_ARCH__ >= 300) && !defined(QUDA_FAST_COMPILE_REDUCE)
 #define WARP_SPLIT
 #include <generics/shfl.h>
 #endif

--- a/include/launch_kernel.cuh
+++ b/include/launch_kernel.cuh
@@ -1,4 +1,4 @@
-#ifdef QUDA_REDUCE_SINGLE_WARP
+#ifdef QUDA_FAST_COMPILE_REDUCE
 // only compile block size with a single warp
 #define LAUNCH_KERNEL(kernel, tunable, tp, stream, arg, ...)            \
   switch (tp.block.x) {							\
@@ -179,9 +179,9 @@ default:								\
     errorQuda("%s not implemented for %d threads", #kernel, tp.block.x); \
     }
 
-#endif // REDUCE_SINGLE_WARP
+#endif // QUDA_FAST_COMPILE_REDUCE
 
-#ifdef QUDA_REDUCE_SINGLE_WARP
+#ifdef QUDA_FAST_COMPILE_REDUCE
 
 // only compile block size with a single warp
 #define LAUNCH_KERNEL_LOCAL_PARITY(kernel, tunable, tp, stream, arg, ...) \
@@ -317,7 +317,7 @@ default:								\
   default: errorQuda("%s block size %d not instantiated", #kernel, tp.block.x);                                        \
   }
 
-#ifdef QUDA_REDUCE_SINGLE_WARP
+#ifdef QUDA_FAST_COMPILE_REDUCE
 
  // only compile block size with a single warp
 #define LAUNCH_KERNEL_REDUCE(kernel, tunable, tp, stream, arg, ...)                                                    \

--- a/include/multigrid.h
+++ b/include/multigrid.h
@@ -298,6 +298,11 @@ public:
     virtual ~MG();
 
     /**
+       @return MG can solve non-Hermitian systems
+     */
+    bool hermitian() { return false; };
+
+    /**
        @brief This method resets the solver, e.g., when a parameter has changed such as the mass.
        @param Whether we are refreshing the null-space components or just updating the operators
      */

--- a/lib/eigensolve_quda.cpp
+++ b/lib/eigensolve_quda.cpp
@@ -109,8 +109,6 @@ namespace quda
     default: errorQuda("Invalid eig solver type");
     }
 
-    std::cout << mat.hermitian() << " " << eig_solver->hermitian() << std::endl;
-
     if (!mat.hermitian() && eig_solver->hermitian()) errorQuda("Cannot solve non-Hermitian system with Hermitian eigensolver");
     return eig_solver;
   }

--- a/lib/inv_bicgstab_quda.cpp
+++ b/lib/inv_bicgstab_quda.cpp
@@ -14,8 +14,8 @@ namespace quda {
   // set the required parameters for the inner solver
   void fillInnerSolveParam(SolverParam &inner, const SolverParam &outer);
 
-  BiCGstab::BiCGstab(DiracMatrix &mat, DiracMatrix &matSloppy, DiracMatrix &matPrecon, SolverParam &param, TimeProfile &profile) :
-    Solver(param, profile), mat(mat), matSloppy(matSloppy), matPrecon(matPrecon), init(false) {
+  BiCGstab::BiCGstab(const DiracMatrix &mat, const DiracMatrix &matSloppy, const DiracMatrix &matPrecon, SolverParam &param, TimeProfile &profile) :
+    Solver(mat, matSloppy, matPrecon, param, profile), init(false) {
 
   }
 

--- a/lib/inv_bicgstabl_quda.cpp
+++ b/lib/inv_bicgstabl_quda.cpp
@@ -252,8 +252,8 @@ namespace quda {
     extern Worker* aux_worker;
   } 
   
-  BiCGstabL::BiCGstabL(DiracMatrix &mat, DiracMatrix &matSloppy, SolverParam &param, TimeProfile &profile) :
-    Solver(param, profile), mat(mat), matSloppy(matSloppy), nKrylov(param.Nkrylov), init(false)
+  BiCGstabL::BiCGstabL(const DiracMatrix &mat, const DiracMatrix &matSloppy, SolverParam &param, TimeProfile &profile) :
+    Solver(mat, matSloppy, matSloppy, param, profile), nKrylov(param.Nkrylov), init(false)
   {
     r.resize(nKrylov+1);
     u.resize(nKrylov+1);

--- a/lib/inv_ca_cg.cpp
+++ b/lib/inv_ca_cg.cpp
@@ -12,11 +12,8 @@
 
 namespace quda {
 
-  CACG::CACG(DiracMatrix &mat, DiracMatrix &matSloppy, DiracMatrix &matPrecon, SolverParam &param, TimeProfile &profile) :
-    Solver(param, profile),
-    mat(mat),
-    matSloppy(matSloppy),
-    matPrecon(matPrecon),
+  CACG::CACG(const DiracMatrix &mat, const DiracMatrix &matSloppy, const DiracMatrix &matPrecon, SolverParam &param, TimeProfile &profile) :
+    Solver(mat, matSloppy, matPrecon, param, profile),
     init(false),
     lambda_init(false),
     basis(param.ca_basis),
@@ -67,7 +64,7 @@ namespace quda {
     if (!param.is_preconditioner) profile.TPSTOP(QUDA_PROFILE_FREE);
   }
 
-  CACGNE::CACGNE(DiracMatrix &mat, DiracMatrix &matSloppy, DiracMatrix &matPrecon, SolverParam &param,
+  CACGNE::CACGNE(const DiracMatrix &mat, const DiracMatrix &matSloppy, const DiracMatrix &matPrecon, SolverParam &param,
                  TimeProfile &profile) :
     CACG(mmdag, mmdagSloppy, mmdagPrecon, param, profile),
     mmdag(mat.Expose()),
@@ -156,7 +153,7 @@ namespace quda {
 
   }
 
-  CACGNR::CACGNR(DiracMatrix &mat, DiracMatrix &matSloppy, DiracMatrix &matPrecon, SolverParam &param,
+  CACGNR::CACGNR(const DiracMatrix &mat, const DiracMatrix &matSloppy, const DiracMatrix &matPrecon, SolverParam &param,
                  TimeProfile &profile) :
     CACG(mdagm, mdagmSloppy, mdagmPrecon, param, profile),
     mdagm(mat.Expose()),

--- a/lib/inv_ca_gcr.cpp
+++ b/lib/inv_ca_gcr.cpp
@@ -4,12 +4,9 @@
 
 namespace quda {
 
-  CAGCR::CAGCR(DiracMatrix &mat, DiracMatrix &matSloppy, DiracMatrix &matPrecon, SolverParam &param,
+  CAGCR::CAGCR(const DiracMatrix &mat, const DiracMatrix &matSloppy, const DiracMatrix &matPrecon, SolverParam &param,
                TimeProfile &profile) :
-    Solver(param, profile),
-    mat(mat),
-    matSloppy(matSloppy),
-    matPrecon(matPrecon),
+    Solver(mat, matSloppy, matPrecon, param, profile),
     matMdagM(matPrecon.Expose()),
     init(false),
     use_source(param.preserve_source == QUDA_PRESERVE_SOURCE_NO && param.precision == param.precision_sloppy

--- a/lib/inv_cg3_quda.cpp
+++ b/lib/inv_cg3_quda.cpp
@@ -13,8 +13,8 @@
 
 namespace quda {
 
-  CG3::CG3(DiracMatrix &mat, DiracMatrix &matSloppy, SolverParam &param, TimeProfile &profile) :
-    Solver(param, profile), mat(mat), matSloppy(matSloppy), init(false)
+  CG3::CG3(const DiracMatrix &mat, const DiracMatrix &matSloppy, SolverParam &param, TimeProfile &profile) :
+    Solver(mat, matSloppy, matSloppy, param, profile), init(false)
   {
   }
 

--- a/lib/inv_cg3ne_quda.cpp
+++ b/lib/inv_cg3ne_quda.cpp
@@ -13,8 +13,8 @@
 
 namespace quda {
 
-  CG3NE::CG3NE(DiracMatrix &mat, DiracMatrix &matSloppy, SolverParam &param, TimeProfile &profile) :
-    Solver(param, profile), mat(mat), matSloppy(matSloppy), matDagSloppy(matSloppy), init(false)
+  CG3NE::CG3NE(const DiracMatrix &mat, const DiracMatrix &matSloppy, SolverParam &param, TimeProfile &profile) :
+    Solver(mat, matSloppy, matSloppy, param, profile), matDagSloppy(matSloppy), init(false)
   {
   }
 

--- a/lib/inv_cg_quda.cpp
+++ b/lib/inv_cg_quda.cpp
@@ -19,11 +19,8 @@
 
 namespace quda {
 
-  CG::CG(DiracMatrix &mat, DiracMatrix &matSloppy, DiracMatrix &matPrecon, SolverParam &param, TimeProfile &profile) :
-    Solver(param, profile),
-    mat(mat),
-    matSloppy(matSloppy),
-    matPrecon(matPrecon),
+  CG::CG(const DiracMatrix &mat, const DiracMatrix &matSloppy, const DiracMatrix &matPrecon, SolverParam &param, TimeProfile &profile) :
+    Solver(mat, matSloppy, matPrecon, param, profile),
     yp(nullptr),
     rp(nullptr),
     rnewp(nullptr),
@@ -64,7 +61,7 @@ namespace quda {
     if (!param.is_preconditioner) profile.TPSTOP(QUDA_PROFILE_FREE);
   }
 
-  CGNE::CGNE(DiracMatrix &mat, DiracMatrix &matSloppy, DiracMatrix &matPrecon, SolverParam &param, TimeProfile &profile) :
+  CGNE::CGNE(const DiracMatrix &mat, const DiracMatrix &matSloppy, const DiracMatrix &matPrecon, SolverParam &param, TimeProfile &profile) :
     CG(mmdag, mmdagSloppy, mmdagPrecon, param, profile),
     mmdag(mat.Expose()),
     mmdagSloppy(matSloppy.Expose()),
@@ -152,7 +149,7 @@ namespace quda {
 
   }
 
-  CGNR::CGNR(DiracMatrix &mat, DiracMatrix &matSloppy, DiracMatrix &matPrecon, SolverParam &param, TimeProfile &profile) :
+  CGNR::CGNR(const DiracMatrix &mat, const DiracMatrix &matSloppy, const DiracMatrix &matPrecon, SolverParam &param, TimeProfile &profile) :
     CG(mdagm, mdagmSloppy, mdagmPrecon, param, profile),
     mdagm(mat.Expose()),
     mdagmSloppy(matSloppy.Expose()),

--- a/lib/inv_eigcg_quda.cpp
+++ b/lib/inv_eigcg_quda.cpp
@@ -267,8 +267,8 @@ namespace quda {
   }
 
 
-  IncEigCG::IncEigCG(DiracMatrix &mat, DiracMatrix &matSloppy, DiracMatrix &matPrecon, SolverParam &param, TimeProfile &profile) :
-    Solver(param, profile), mat(mat), matSloppy(matSloppy), matPrecon(matPrecon), K(nullptr), Kparam(param), Vm(nullptr), r_pre(nullptr), p_pre(nullptr), eigcg_args(nullptr), profile(profile), init(false)
+  IncEigCG::IncEigCG(const DiracMatrix &mat, const DiracMatrix &matSloppy, const DiracMatrix &matPrecon, SolverParam &param, TimeProfile &profile) :
+    Solver(mat, matSloppy, matPrecon, param, profile), K(nullptr), Kparam(param), Vm(nullptr), r_pre(nullptr), p_pre(nullptr), eigcg_args(nullptr), profile(profile), init(false)
   {
 
     if (2 * param.nev >= param.m)

--- a/lib/inv_gcr_quda.cpp
+++ b/lib/inv_gcr_quda.cpp
@@ -160,11 +160,8 @@ namespace quda {
     delete []delta;
   }
 
-  GCR::GCR(DiracMatrix &mat, DiracMatrix &matSloppy, DiracMatrix &matPrecon, SolverParam &param, TimeProfile &profile) :
-    Solver(param, profile),
-    mat(mat),
-    matSloppy(matSloppy),
-    matPrecon(matPrecon),
+  GCR::GCR(const DiracMatrix &mat, const DiracMatrix &matSloppy, const DiracMatrix &matPrecon, SolverParam &param, TimeProfile &profile) :
+    Solver(mat, matSloppy, matPrecon, param, profile),
     matMdagM(DiracMdagM(matPrecon.Expose())),
     K(0),
     Kparam(param),
@@ -201,12 +198,9 @@ namespace quda {
     gamma = new double[nKrylov];
   }
 
-  GCR::GCR(DiracMatrix &mat, Solver &K, DiracMatrix &matSloppy, DiracMatrix &matPrecon, SolverParam &param,
+  GCR::GCR(const DiracMatrix &mat, Solver &K, const DiracMatrix &matSloppy, const DiracMatrix &matPrecon, SolverParam &param,
            TimeProfile &profile) :
-    Solver(param, profile),
-    mat(mat),
-    matSloppy(matSloppy),
-    matPrecon(matPrecon),
+    Solver(mat, matSloppy, matPrecon, param, profile),
     matMdagM(matPrecon.Expose()),
     K(&K),
     Kparam(param),

--- a/lib/inv_gmresdr_quda.cpp
+++ b/lib/inv_gmresdr_quda.cpp
@@ -208,9 +208,9 @@ namespace quda {
     }
 
 
- GMResDR::GMResDR(DiracMatrix &mat, DiracMatrix &matSloppy, DiracMatrix &matPrecon, SolverParam &param, TimeProfile &profile) :
-    Solver(param, profile), mat(mat), matSloppy(matSloppy), matPrecon(matPrecon), K(nullptr), Kparam(param),
-    Vm(nullptr), Zm(nullptr), profile(profile), gmresdr_args(nullptr), init(false)
+ GMResDR::GMResDR(const DiracMatrix &mat, const DiracMatrix &matSloppy, const DiracMatrix &matPrecon, SolverParam &param, TimeProfile &profile) :
+   Solver(mat, matSloppy, matPrecon, param, profile), K(nullptr), Kparam(param),
+   Vm(nullptr), Zm(nullptr), profile(profile), gmresdr_args(nullptr), init(false)
  {
      fillFGMResDRInnerSolveParam(Kparam, param);
 
@@ -226,21 +226,17 @@ namespace quda {
        K = nullptr;
      else
        errorQuda("Unsupported preconditioner %d\n", param.inv_type_precondition);
-
-
-     return;
  }
 
- GMResDR::GMResDR(DiracMatrix &mat, Solver &K, DiracMatrix &matSloppy, DiracMatrix &matPrecon, SolverParam &param, TimeProfile &profile) :
-    Solver(param, profile), mat(mat), matSloppy(matSloppy), matPrecon(matPrecon), K(&K), Kparam(param),
+  GMResDR::GMResDR(const DiracMatrix &mat, Solver &K, const DiracMatrix &matSloppy, const DiracMatrix &matPrecon, SolverParam &param, TimeProfile &profile) :
+   Solver(mat, matSloppy, matPrecon, param, profile), K(&K), Kparam(param),
     Vm(nullptr), Zm(nullptr), profile(profile), gmresdr_args(nullptr), init(false) { }
 
 
  GMResDR::~GMResDR() {
     profile.TPSTART(QUDA_PROFILE_FREE);
 
-    if(init)
-    {
+    if (init) {
       delete Vm;
       Vm = nullptr;
 

--- a/lib/inv_mpbicgstab_quda.cpp
+++ b/lib/inv_mpbicgstab_quda.cpp
@@ -12,8 +12,8 @@
 
 namespace quda {
 
-  MPBiCGstab::MPBiCGstab(DiracMatrix &mat, SolverParam &param, TimeProfile &profile) :
-    Solver(param, profile), mat(mat)
+  MPBiCGstab::MPBiCGstab(const DiracMatrix &mat, SolverParam &param, TimeProfile &profile) :
+    Solver(mat, mat, mat, param, profile)
   {
   }
 

--- a/lib/inv_mpcg_quda.cpp
+++ b/lib/inv_mpcg_quda.cpp
@@ -90,8 +90,8 @@ namespace quda {
 
 
 
-  MPCG::MPCG(DiracMatrix &mat, SolverParam &param, TimeProfile &profile) :
-    Solver(param, profile), mat(mat)
+  MPCG::MPCG(const DiracMatrix &mat, SolverParam &param, TimeProfile &profile) :
+    Solver(mat, mat, mat, param, profile)
   {
 
   }

--- a/lib/inv_mr_quda.cpp
+++ b/lib/inv_mr_quda.cpp
@@ -13,8 +13,8 @@
 
 namespace quda {
 
-  MR::MR(DiracMatrix &mat, DiracMatrix &matSloppy, SolverParam &param, TimeProfile &profile) :
-    Solver(param, profile), mat(mat), matSloppy(matSloppy), rp(nullptr), r_sloppy(nullptr),
+  MR::MR(const DiracMatrix &mat, const DiracMatrix &matSloppy, SolverParam &param, TimeProfile &profile) :
+    Solver(mat, matSloppy, matSloppy, param, profile), rp(nullptr), r_sloppy(nullptr),
     Arp(nullptr), tmpp(nullptr), tmp_sloppy(nullptr), x_sloppy(nullptr), init(false)
   {
     if (param.schwarz_type == QUDA_MULTIPLICATIVE_SCHWARZ && param.Nsteps % 2 == 1) {

--- a/lib/inv_mre.cpp
+++ b/lib/inv_mre.cpp
@@ -4,7 +4,7 @@
 
 namespace quda {
 
-  MinResExt::MinResExt(DiracMatrix &mat, bool orthogonal, bool apply_mat, bool hermitian, TimeProfile &profile)
+  MinResExt::MinResExt(const DiracMatrix &mat, bool orthogonal, bool apply_mat, bool hermitian, TimeProfile &profile)
     : mat(mat), orthogonal(orthogonal), apply_mat(apply_mat), hermitian(hermitian), profile(profile){
 
   }

--- a/lib/inv_multi_cg_quda.cpp
+++ b/lib/inv_multi_cg_quda.cpp
@@ -112,15 +112,11 @@ namespace quda {
     extern Worker* aux_worker;
   }  
 
-  MultiShiftCG::MultiShiftCG(DiracMatrix &mat, DiracMatrix &matSloppy, SolverParam &param,
-			     TimeProfile &profile) 
-    : MultiShiftSolver(param, profile), mat(mat), matSloppy(matSloppy) {
+  MultiShiftCG::MultiShiftCG(const DiracMatrix &mat, const DiracMatrix &matSloppy, SolverParam &param,
+			     TimeProfile &profile) :
+    MultiShiftSolver(mat, matSloppy, param, profile) { }
 
-  }
-
-  MultiShiftCG::~MultiShiftCG() {
-
-  }
+  MultiShiftCG::~MultiShiftCG() { }
 
   /**
      Compute the new values of alpha and zeta

--- a/lib/inv_pcg_quda.cpp
+++ b/lib/inv_pcg_quda.cpp
@@ -36,10 +36,9 @@ namespace quda {
   }
 
 
-  PreconCG::PreconCG(DiracMatrix &mat, DiracMatrix &matSloppy, DiracMatrix &matPrecon, SolverParam &param, TimeProfile &profile) :
-    Solver(param, profile), mat(mat), matSloppy(matSloppy), matPrecon(matPrecon), K(0), Kparam(param)
+  PreconCG::PreconCG(const DiracMatrix &mat, const DiracMatrix &matSloppy, const DiracMatrix &matPrecon, SolverParam &param, TimeProfile &profile) :
+    Solver(mat, matSloppy, matPrecon, param, profile), K(0), Kparam(param)
   {
-
     fillInnerSolverParam(Kparam, param);
 
     if(param.inv_type_precondition == QUDA_CG_INVERTER){

--- a/lib/inv_sd_quda.cpp
+++ b/lib/inv_sd_quda.cpp
@@ -14,8 +14,8 @@ namespace quda {
 
   using namespace blas;
   
-  SD::SD(DiracMatrix &mat, SolverParam &param, TimeProfile &profile) :
-    Solver(param,profile), mat(mat), init(false)
+  SD::SD(const DiracMatrix &mat, SolverParam &param, TimeProfile &profile) :
+    Solver(mat, mat, mat, param, profile), init(false)
   {
 
   }

--- a/lib/inv_xsd_quda.cpp
+++ b/lib/inv_xsd_quda.cpp
@@ -13,8 +13,8 @@
 
 namespace quda {
 
-  XSD::XSD(DiracMatrix &mat, SolverParam &param, TimeProfile &profile) :
-    Solver(param,profile), mat(mat)
+  XSD::XSD(const DiracMatrix &mat, SolverParam &param, TimeProfile &profile) :
+    Solver(mat, mat, mat, param, profile)
   {
     sd = new SD(mat,param,profile);
     for(int i=0; i<4; ++i) R[i] = param.overlap_precondition*comm_dim_partitioned(i);

--- a/lib/multi_blas_quda.cu
+++ b/lib/multi_blas_quda.cu
@@ -167,8 +167,10 @@ namespace quda {
 
         switch (tp.aux.x) {
         case 1: multiBlasKernel<FloatN, M, NXZ, 1><<<tp.grid, tp.block, tp.shared_bytes, stream>>>(arg); break;
+#ifdef WARP_SPLIT
         case 2: multiBlasKernel<FloatN, M, NXZ, 2><<<tp.grid, tp.block, tp.shared_bytes, stream>>>(arg); break;
         case 4: multiBlasKernel<FloatN, M, NXZ, 4><<<tp.grid, tp.block, tp.shared_bytes, stream>>>(arg); break;
+#endif
         default: errorQuda("warp-split factor %d not instantiated", tp.aux.x);
         }
 

--- a/lib/multigrid.cpp
+++ b/lib/multigrid.cpp
@@ -12,7 +12,7 @@ namespace quda
   static bool debug = false;
 
   MG::MG(MGParam &param, TimeProfile &profile_global) :
-    Solver(param, profile),
+    Solver(*param.matResidual, *param.matSmooth, *param.matSmoothSloppy, param, profile),
     param(param),
     transfer(0),
     resetTransfer(false),

--- a/lib/solver.cpp
+++ b/lib/solver.cpp
@@ -10,7 +10,11 @@ namespace quda {
     if (getVerbosity() >= QUDA_VERBOSE) printfQuda("Creating a %s solver\n", type);
   }
 
-  Solver::Solver(SolverParam &param, TimeProfile &profile) :
+  Solver::Solver(const DiracMatrix &mat, const DiracMatrix &matSloppy, const DiracMatrix &matPrecon,
+                 SolverParam &param, TimeProfile &profile) :
+    mat(mat),
+    matSloppy(matSloppy),
+    matPrecon(matPrecon),
     param(param),
     profile(profile),
     node_parity(0),
@@ -33,8 +37,8 @@ namespace quda {
   }
 
   // solver factory
-  Solver* Solver::create(SolverParam &param, DiracMatrix &mat, DiracMatrix &matSloppy,
-			 DiracMatrix &matPrecon, TimeProfile &profile)
+  Solver* Solver::create(SolverParam &param, const DiracMatrix &mat, const DiracMatrix &matSloppy,
+			 const DiracMatrix &matPrecon, TimeProfile &profile)
   {
     Solver *solver = nullptr;
 
@@ -156,6 +160,7 @@ namespace quda {
       errorQuda("Invalid solver type %d", param.inv_type);
     }
 
+    if (!mat.hermitian() && solver->hermitian()) errorQuda("Cannot solve non-Hermitian system with Hermitian solver");
     return solver;
   }
 

--- a/tests/invert_test.cpp
+++ b/tests/invert_test.cpp
@@ -22,42 +22,44 @@
 // In a typical application, quda.h is the only QUDA header required.
 #include <quda.h>
 
-
 void display_test_info()
 {
   printfQuda("running the following test:\n");
     
-  printfQuda("prec    prec_sloppy   multishift  matpc_type  recon  recon_sloppy S_dimension T_dimension Ls_dimension   dslash_type  normalization\n");
-  printfQuda("%6s   %6s          %d     %12s     %2s     %2s         %3d/%3d/%3d     %3d         %2d       %14s  %8s\n",
+  printfQuda("prec    prec_sloppy   multishift  matpc_type  recon  recon_sloppy solve_type S_dimension T_dimension Ls_dimension   dslash_type  normalization\n");
+  printfQuda("%6s   %6s          %d     %12s     %2s     %2s         %10s %3d/%3d/%3d     %3d         %2d       %14s  %8s\n",
              get_prec_str(prec), get_prec_str(prec_sloppy), multishift, get_matpc_str(matpc_type),
-             get_recon_str(link_recon), get_recon_str(link_recon_sloppy), xdim, ydim, zdim, tdim, Lsdim,
+             get_recon_str(link_recon), get_recon_str(link_recon_sloppy),
+             get_solve_str(solve_type), xdim, ydim, zdim, tdim, Lsdim,
              get_dslash_str(dslash_type), get_mass_normalization_str(normalization));
 
-  printfQuda("\n   Eigensolver parameters\n");
-  printfQuda(" - solver mode %s\n", get_eig_type_str(eig_type));
-  printfQuda(" - spectrum requested %s\n", get_eig_spectrum_str(eig_spectrum));
-  printfQuda(" - number of eigenvectors requested %d\n", eig_nConv);
-  printfQuda(" - size of eigenvector search space %d\n", eig_nEv);
-  printfQuda(" - size of Krylov space %d\n", eig_nKr);
-  printfQuda(" - solver tolerance %e\n", eig_tol);
-  printfQuda(" - convergence required (%s)\n", eig_require_convergence ? "true" : "false");
-  if (eig_compute_svd) {
-    printfQuda(" - Operator: MdagM. Will compute SVD of M\n");
-    printfQuda(" - ***********************************************************\n");
-    printfQuda(" - **** Overriding any previous choices of operator type. ****\n");
-    printfQuda(" - ****    SVD demands normal operator, will use MdagM    ****\n");
-    printfQuda(" - ***********************************************************\n");
-  } else {
-    printfQuda(" - Operator: daggered (%s) , norm-op (%s)\n", eig_use_dagger ? "true" : "false",
-               eig_use_normop ? "true" : "false");
-  }
-  if (eig_use_poly_acc) {
-    printfQuda(" - Chebyshev polynomial degree %d\n", eig_poly_deg);
-    printfQuda(" - Chebyshev polynomial minumum %e\n", eig_amin);
-    if (eig_amax <= 0)
-      printfQuda(" - Chebyshev polynomial maximum will be computed\n");
-    else
-      printfQuda(" - Chebyshev polynomial maximum %e\n\n", eig_amax);
+  if (inv_deflate) {
+    printfQuda("\n   Eigensolver parameters\n");
+    printfQuda(" - solver mode %s\n", get_eig_type_str(eig_type));
+    printfQuda(" - spectrum requested %s\n", get_eig_spectrum_str(eig_spectrum));
+    printfQuda(" - number of eigenvectors requested %d\n", eig_nConv);
+    printfQuda(" - size of eigenvector search space %d\n", eig_nEv);
+    printfQuda(" - size of Krylov space %d\n", eig_nKr);
+    printfQuda(" - solver tolerance %e\n", eig_tol);
+    printfQuda(" - convergence required (%s)\n", eig_require_convergence ? "true" : "false");
+    if (eig_compute_svd) {
+      printfQuda(" - Operator: MdagM. Will compute SVD of M\n");
+      printfQuda(" - ***********************************************************\n");
+      printfQuda(" - **** Overriding any previous choices of operator type. ****\n");
+      printfQuda(" - ****    SVD demands normal operator, will use MdagM    ****\n");
+      printfQuda(" - ***********************************************************\n");
+    } else {
+      printfQuda(" - Operator: daggered (%s) , norm-op (%s)\n", eig_use_dagger ? "true" : "false",
+                 eig_use_normop ? "true" : "false");
+    }
+    if (eig_use_poly_acc) {
+      printfQuda(" - Chebyshev polynomial degree %d\n", eig_poly_deg);
+      printfQuda(" - Chebyshev polynomial minumum %e\n", eig_amin);
+      if (eig_amax <= 0)
+        printfQuda(" - Chebyshev polynomial maximum will be computed\n");
+      else
+        printfQuda(" - Chebyshev polynomial maximum %e\n\n", eig_amax);
+    }
   }
 
   printfQuda("Grid partition info:     X  Y  Z  T\n"); 

--- a/tests/invert_test.cpp
+++ b/tests/invert_test.cpp
@@ -22,8 +22,8 @@
 // In a typical application, quda.h is the only QUDA header required.
 #include <quda.h>
 
-void
-display_test_info()
+
+void display_test_info()
 {
   printfQuda("running the following test:\n");
     
@@ -66,9 +66,6 @@ display_test_info()
 	     dimPartitioned(1),
 	     dimPartitioned(2),
 	     dimPartitioned(3)); 
-  
-  return ;
-  
 }
 
 // Parameters defining the eigensolver

--- a/tests/staggered_invert_test.cpp
+++ b/tests/staggered_invert_test.cpp
@@ -244,7 +244,6 @@ void setInvertParam(QudaInvertParam &inv_param)
 
 int invert_test()
 {
-
   // Ensure that the default is improved staggered
   if (dslash_type != QUDA_ASQTAD_DSLASH && dslash_type != QUDA_STAGGERED_DSLASH && dslash_type != QUDA_LAPLACE_DSLASH)
     dslash_type = QUDA_ASQTAD_DSLASH;
@@ -720,31 +719,33 @@ void display_test_info()
       get_prec_str(prec_sloppy), get_recon_str(link_recon), get_recon_str(link_recon_sloppy),
       get_staggered_test_type(test_type), xdim, ydim, zdim, tdim);
 
-  printfQuda("\n   Eigensolver parameters\n");
-  printfQuda(" - solver mode %s\n", get_eig_type_str(eig_type));
-  printfQuda(" - spectrum requested %s\n", get_eig_spectrum_str(eig_spectrum));
-  printfQuda(" - number of eigenvectors requested %d\n", eig_nConv);
-  printfQuda(" - size of eigenvector search space %d\n", eig_nEv);
-  printfQuda(" - size of Krylov space %d\n", eig_nKr);
-  printfQuda(" - solver tolerance %e\n", eig_tol);
-  printfQuda(" - convergence required (%s)\n", eig_require_convergence ? "true" : "false");
-  if (eig_compute_svd) {
-    printfQuda(" - Operator: MdagM. Will compute SVD of M\n");
-    printfQuda(" - ***********************************************************\n");
-    printfQuda(" - **** Overriding any previous choices of operator type. ****\n");
-    printfQuda(" - ****    SVD demands normal operator, will use MdagM    ****\n");
-    printfQuda(" - ***********************************************************\n");
-  } else {
-    printfQuda(" - Operator: daggered (%s) , norm-op (%s)\n", eig_use_dagger ? "true" : "false",
-               eig_use_normop ? "true" : "false");
-  }
-  if (eig_use_poly_acc) {
-    printfQuda(" - Chebyshev polynomial degree %d\n", eig_poly_deg);
-    printfQuda(" - Chebyshev polynomial minumum %e\n", eig_amin);
-    if (eig_amax < 0)
-      printfQuda(" - Chebyshev polynomial maximum will be computed\n");
-    else
-      printfQuda(" - Chebyshev polynomial maximum %e\n\n", eig_amax);
+  if (inv_deflate) {
+    printfQuda("\n   Eigensolver parameters\n");
+    printfQuda(" - solver mode %s\n", get_eig_type_str(eig_type));
+    printfQuda(" - spectrum requested %s\n", get_eig_spectrum_str(eig_spectrum));
+    printfQuda(" - number of eigenvectors requested %d\n", eig_nConv);
+    printfQuda(" - size of eigenvector search space %d\n", eig_nEv);
+    printfQuda(" - size of Krylov space %d\n", eig_nKr);
+    printfQuda(" - solver tolerance %e\n", eig_tol);
+    printfQuda(" - convergence required (%s)\n", eig_require_convergence ? "true" : "false");
+    if (eig_compute_svd) {
+      printfQuda(" - Operator: MdagM. Will compute SVD of M\n");
+      printfQuda(" - ***********************************************************\n");
+      printfQuda(" - **** Overriding any previous choices of operator type. ****\n");
+      printfQuda(" - ****    SVD demands normal operator, will use MdagM    ****\n");
+      printfQuda(" - ***********************************************************\n");
+    } else {
+      printfQuda(" - Operator: daggered (%s) , norm-op (%s)\n", eig_use_dagger ? "true" : "false",
+                 eig_use_normop ? "true" : "false");
+    }
+    if (eig_use_poly_acc) {
+      printfQuda(" - Chebyshev polynomial degree %d\n", eig_poly_deg);
+      printfQuda(" - Chebyshev polynomial minumum %e\n", eig_amin);
+      if (eig_amax < 0)
+        printfQuda(" - Chebyshev polynomial maximum will be computed\n");
+      else
+        printfQuda(" - Chebyshev polynomial maximum %e\n\n", eig_amax);
+    }
   }
 
   printfQuda("Grid partition info:     X  Y  Z  T\n");

--- a/tests/test_util.cpp
+++ b/tests/test_util.cpp
@@ -44,6 +44,18 @@ int mySpinorSiteSize;
 
 extern float fat_link_max;
 
+extern "C" {
+  /**
+     @brief Set the default ASAN options.  This ensures that QUDA just
+     works when SANITIZE is enabled without requiring ASAN_OPTIONS to
+     be set.
+   */
+  const char *__asan_default_options()
+  {
+    return "protect_shadow_gap=0";
+  }
+}
+
 /**
  * For MPI, the default node mapping is lexicographical with t varying fastest.
  */


### PR DESCRIPTION
This is a minor pull request that improves quality of life:
* All Dirac operators and solvers now have a `hermitian()` method that returns whether said operator/solver is Hermitian or not.  This is then used to provide a run-time check that we are not trying to solve a non-Hermitian system with a Hermitian solver.  E.g., if the command-line used in issue #966 were to be used, the following error message is given
```
Source: CPU = 524156, CUDA copy = 524156
Prepared source = 524156
Prepared solution = 0
Prepared source post mass rescale = 524156
Creating a CG solver
ERROR: Cannot solve non-Hermitian system with Hermitian solver (rank 0, host nvsocal2, /home/kate/github/quda-bug/lib/solver.cpp:163 in create())
       last kernel called was (name=N4quda4blas5Norm2Id7double2S2_EE,volume=16x16x16x16x8,aux=vol=524288,stride=262144,precision=8,Ns=4,Nc=3)
```
* Add new advanced cmake option `QUDA_DSLASH_FAST_COMPILE`.  This removes the parity specialization used in the dslash kernel: this has the effect of halving the compilation time, at the cost up to 20% in performance (depending on the action).  The cmake wiki page https://github.com/lattice/quda/wiki/QUDA-Build-With-CMake has been updated accordingly.
* When compiled with `SANITIZE` enabled, the QUDA tests will now run out of the box without needing to set `ASAN_OPTIONS`.  The minimum ASAN settings to enable address sanitizer to work with CUDA are now set by default in test_util.cpp.  I have updated the instructions at https://github.com/lattice/quda/wiki/QUDA-Debugging accordingly.
