### PR TITLE
Expose createDirac to the user via dirac_quda.h

### DIFF
--- a/include/dirac_quda.h
+++ b/include/dirac_quda.h
@@ -1686,27 +1686,6 @@ public:
     }
   };
 
-  /**
-   * Create the Dirac operator
-   * @param[in] d        User prec
-   * @param[in] dSloppy  Sloppy prec
-   * @param[in] dPre     Preconditioner prec
-   * @param[in] param    Invert param container
-   * @param[in] pc_solve Whether or not to perform an even/odd preconditioned solve
-   */
-  void createDirac(Dirac *&d, Dirac *&dSloppy, Dirac *&dPre, QudaInvertParam &param, const bool pc_solve);
-
-  /**
-   * Create the Dirac operator
-   * @param[in] d        User prec
-   * @param[in] dSloppy  Sloppy prec
-   * @param[in] dPre     Preconditioner prec
-   * @param[in] dRef     Reference prec (EigCG and deflation)
-   * @param[in] param    Invert param container
-   * @param[in] pc_solve Whether or not to perform an even/odd preconditioned solve
-   */
-  void createDirac(Dirac *&d, Dirac *&dSloppy, Dirac *&dPre, Dirac *&dRef, QudaInvertParam &param, const bool pc_solve);
-  
 } // namespace quda
 
 #endif // _DIRAC_QUDA_H

--- a/include/dirac_quda.h
+++ b/include/dirac_quda.h
@@ -1686,6 +1686,27 @@ public:
     }
   };
 
+  /**
+   * Create the Dirac operator
+   * @param[in] d        User prec
+   * @param[in] dSloppy  Sloppy prec
+   * @param[in] dPre     Preconditioner prec
+   * @param[in] param    Invert param container
+   * @param[in] pc_solve Whether or not to perform an even/odd preconditioned solve
+   */
+  void createDirac(Dirac *&d, Dirac *&dSloppy, Dirac *&dPre, QudaInvertParam &param, const bool pc_solve);
+
+  /**
+   * Create the Dirac operator
+   * @param[in] d        User prec
+   * @param[in] dSloppy  Sloppy prec
+   * @param[in] dPre     Preconditioner prec
+   * @param[in] dRef     Reference prec (EigCG and deflation)
+   * @param[in] param    Invert param container
+   * @param[in] pc_solve Whether or not to perform an even/odd preconditioned solve
+   */
+  void createDirac(Dirac *&d, Dirac *&dSloppy, Dirac *&dPre, Dirac *&dRef, QudaInvertParam &param, const bool pc_solve);
+  
 } // namespace quda
 
 #endif // _DIRAC_QUDA_H

--- a/include/dirac_quda.h
+++ b/include/dirac_quda.h
@@ -1706,7 +1706,7 @@ public:
    * @param[in] pc_solve Whether or not to perform an even/odd preconditioned solve
    */
   void createDirac(Dirac *&d, Dirac *&dSloppy, Dirac *&dPre, Dirac *&dRef, QudaInvertParam &param, const bool pc_solve);
-  
+
 } // namespace quda
 
 #endif // _DIRAC_QUDA_H

--- a/include/dirac_quda.h
+++ b/include/dirac_quda.h
@@ -1686,7 +1686,6 @@ public:
     }
   };
 
-<<<<<<< HEAD
   /**
    * Create the Dirac operator
    * @param[in] d        User prec
@@ -1707,9 +1706,6 @@ public:
    * @param[in] pc_solve Whether or not to perform an even/odd preconditioned solve
    */
   void createDirac(Dirac *&d, Dirac *&dSloppy, Dirac *&dPre, Dirac *&dRef, QudaInvertParam &param, const bool pc_solve);
-
-=======
->>>>>>> parent of 42faa3103... Expose create_dirac to the user via dirac_quda.h
 } // namespace quda
 
 #endif // _DIRAC_QUDA_H

--- a/include/dirac_quda.h
+++ b/include/dirac_quda.h
@@ -1686,6 +1686,7 @@ public:
     }
   };
 
+<<<<<<< HEAD
   /**
    * Create the Dirac operator
    * @param[in] d        User prec
@@ -1707,6 +1708,8 @@ public:
    */
   void createDirac(Dirac *&d, Dirac *&dSloppy, Dirac *&dPre, Dirac *&dRef, QudaInvertParam &param, const bool pc_solve);
 
+=======
+>>>>>>> parent of 42faa3103... Expose create_dirac to the user via dirac_quda.h
 } // namespace quda
 
 #endif // _DIRAC_QUDA_H

--- a/lib/dirac.cpp
+++ b/lib/dirac.cpp
@@ -302,7 +302,7 @@ namespace quda {
     if (tmp2) tmp2->prefetch(mem_space, stream);
   }
 
-  // Some dirac helper functions for creating dirac objects  
+  // Some dirac helper functions for creating dirac objects
   void createDirac(Dirac *&d, Dirac *&dSloppy, Dirac *&dPre, QudaInvertParam &param, const bool pc_solve)
   {
     DiracParam diracParam;

--- a/lib/dirac.cpp
+++ b/lib/dirac.cpp
@@ -302,4 +302,41 @@ namespace quda {
     if (tmp2) tmp2->prefetch(mem_space, stream);
   }
 
+  // Some dirac helper functions for creating dirac objects  
+  void createDirac(Dirac *&d, Dirac *&dSloppy, Dirac *&dPre, QudaInvertParam &param, const bool pc_solve)
+  {
+    DiracParam diracParam;
+    DiracParam diracSloppyParam;
+    DiracParam diracPreParam;
+
+    setDiracParam(diracParam, &param, pc_solve);
+    setDiracSloppyParam(diracSloppyParam, &param, pc_solve);
+    // eigCG and deflation need 2 sloppy precisions and do not use Schwarz
+    bool comms_flag = (param.inv_type == QUDA_INC_EIGCG_INVERTER || param.eig_param) ? true : false;
+    setDiracPreParam(diracPreParam, &param, pc_solve, comms_flag);
+
+    d = Dirac::create(diracParam); // create the Dirac operator
+    dSloppy = Dirac::create(diracSloppyParam);
+    dPre = Dirac::create(diracPreParam);
+  }
+
+  void createDirac(Dirac *&d, Dirac *&dSloppy, Dirac *&dPre, Dirac *&dRef, QudaInvertParam &param, const bool pc_solve)
+  {
+    DiracParam diracParam;
+    DiracParam diracSloppyParam;
+    DiracParam diracPreParam;
+    DiracParam diracRefParam;
+
+    setDiracParam(diracParam, &param, pc_solve);
+    setDiracSloppyParam(diracSloppyParam, &param, pc_solve);
+    setDiracRefineParam(diracRefParam, &param, pc_solve);
+    // eigCG and deflation need 2 sloppy precisions and do not use Schwarz
+    bool comms_flag = (param.inv_type == QUDA_INC_EIGCG_INVERTER || param.eig_param) ? true : false;
+    setDiracPreParam(diracPreParam, &param, pc_solve, comms_flag);
+
+    d = Dirac::create(diracParam); // create the Dirac operator
+    dSloppy = Dirac::create(diracSloppyParam);
+    dPre = Dirac::create(diracPreParam);
+    dRef = Dirac::create(diracRefParam);
+  }
 } // namespace quda

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -1746,44 +1746,6 @@ namespace quda {
                 inv_param->cuda_prec_precondition);
   }
 
-
-  void createDirac(Dirac *&d, Dirac *&dSloppy, Dirac *&dPre, QudaInvertParam &param, const bool pc_solve)
-  {
-    DiracParam diracParam;
-    DiracParam diracSloppyParam;
-    DiracParam diracPreParam;
-
-    setDiracParam(diracParam, &param, pc_solve);
-    setDiracSloppyParam(diracSloppyParam, &param, pc_solve);
-    // eigCG and deflation need 2 sloppy precisions and do not use Schwarz
-    bool comms_flag = (param.inv_type == QUDA_INC_EIGCG_INVERTER || param.eig_param) ? true : false;
-    setDiracPreParam(diracPreParam, &param, pc_solve, comms_flag);
-
-    d = Dirac::create(diracParam); // create the Dirac operator
-    dSloppy = Dirac::create(diracSloppyParam);
-    dPre = Dirac::create(diracPreParam);
-  }
-
-  void createDirac(Dirac *&d, Dirac *&dSloppy, Dirac *&dPre, Dirac *&dRef, QudaInvertParam &param, const bool pc_solve)
-  {
-    DiracParam diracParam;
-    DiracParam diracSloppyParam;
-    DiracParam diracPreParam;
-    DiracParam diracRefParam;
-
-    setDiracParam(diracParam, &param, pc_solve);
-    setDiracSloppyParam(diracSloppyParam, &param, pc_solve);
-    setDiracRefineParam(diracRefParam, &param, pc_solve);
-    // eigCG and deflation need 2 sloppy precisions and do not use Schwarz
-    bool comms_flag = (param.inv_type == QUDA_INC_EIGCG_INVERTER || param.eig_param) ? true : false;
-    setDiracPreParam(diracPreParam, &param, pc_solve, comms_flag);
-
-    d = Dirac::create(diracParam); // create the Dirac operator
-    dSloppy = Dirac::create(diracSloppyParam);
-    dPre = Dirac::create(diracPreParam);
-    dRef = Dirac::create(diracRefParam);
-  }
-
   static double unscaled_shifts[QUDA_MAX_MULTI_SHIFT];
 
   void massRescale(cudaColorSpinorField &b, QudaInvertParam &param) {


### PR DESCRIPTION
This hot fix simply adds forward declarations to the two `createDirac` functions in `interface_quda.cpp` so that users may create solvers outside of `invertQuda()` 