### PR TITLE
Hotfix/expose create dirac

### DIFF
--- a/include/dirac_quda.h
+++ b/include/dirac_quda.h
@@ -15,7 +15,7 @@ namespace quda {
   // Forward declare: MG Transfer Class
   class Transfer;
 
-  // Forward declar: Dirac Op Base Class
+  // Forward declare: Dirac Op Base Class
   class Dirac;
 
   // Params for Dirac operator
@@ -92,7 +92,6 @@ namespace quda {
         printfQuda(
             "b_5[%d] = %e %e \t c_5[%d] = %e %e\n", i, b_5[i].real(), b_5[i].imag(), i, c_5[i].real(), c_5[i].imag());
     }
-
   };
 
   // This is a free function:
@@ -1701,7 +1700,7 @@ public:
    * @param[in/out] d        User prec
    * @param[in/out] dSloppy  Sloppy prec
    * @param[in/out] dPre     Preconditioner prec
-   * @param[in] dRef         Reference prec (EigCG and deflation)
+   * @param[in] dRef         Refine prec (EigCG and deflation)
    * @param[in] param        Invert param container
    * @param[in] pc_solve     Whether or not to perform an even/odd preconditioned solve
    */

--- a/include/dirac_quda.h
+++ b/include/dirac_quda.h
@@ -1695,7 +1695,7 @@ public:
    * @param[in] pc_solve     Whether or not to perform an even/odd preconditioned solve
    */
   void createDirac(Dirac *&d, Dirac *&dSloppy, Dirac *&dPre, QudaInvertParam &param, const bool pc_solve);
-  
+
   /**
    * Create the Dirac operator
    * @param[in/out] d        User prec
@@ -1706,7 +1706,7 @@ public:
    * @param[in] pc_solve     Whether or not to perform an even/odd preconditioned solve
    */
   void createDirac(Dirac *&d, Dirac *&dSloppy, Dirac *&dPre, Dirac *&dRef, QudaInvertParam &param, const bool pc_solve);
-  
+
 } // namespace quda
 
 #endif // _DIRAC_QUDA_H

--- a/include/dirac_quda.h
+++ b/include/dirac_quda.h
@@ -1686,6 +1686,27 @@ public:
     }
   };
 
+  /**
+   * Create the Dirac operator
+   * @param[in/out] d        User prec
+   * @param[in/out] dSloppy  Sloppy prec
+   * @param[in/out] dPre     Preconditioner prec
+   * @param[in] param        Invert param container
+   * @param[in] pc_solve     Whether or not to perform an even/odd preconditioned solve
+   */
+  void createDirac(Dirac *&d, Dirac *&dSloppy, Dirac *&dPre, QudaInvertParam &param, const bool pc_solve);
+  
+  /**
+   * Create the Dirac operator
+   * @param[in/out] d        User prec
+   * @param[in/out] dSloppy  Sloppy prec
+   * @param[in/out] dPre     Preconditioner prec
+   * @param[in] dRef         Reference prec (EigCG and deflation)
+   * @param[in] param        Invert param container
+   * @param[in] pc_solve     Whether or not to perform an even/odd preconditioned solve
+   */
+  void createDirac(Dirac *&d, Dirac *&dSloppy, Dirac *&dPre, Dirac *&dRef, QudaInvertParam &param, const bool pc_solve);
+  
 } // namespace quda
 
 #endif // _DIRAC_QUDA_H

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -1746,9 +1746,6 @@ namespace quda {
                 inv_param->cuda_prec_precondition);
   }
 
-
-
-  
   static double unscaled_shifts[QUDA_MAX_MULTI_SHIFT];
 
   void massRescale(cudaColorSpinorField &b, QudaInvertParam &param) {

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -1746,8 +1746,45 @@ namespace quda {
                 inv_param->cuda_prec_precondition);
   }
 
-  static double unscaled_shifts[QUDA_MAX_MULTI_SHIFT];
+  void createDirac(Dirac *&d, Dirac *&dSloppy, Dirac *&dPre, QudaInvertParam &param, const bool pc_solve)
+  {
+    DiracParam diracParam;
+    DiracParam diracSloppyParam;
+    DiracParam diracPreParam;
+    
+    setDiracParam(diracParam, &param, pc_solve);
+    setDiracSloppyParam(diracSloppyParam, &param, pc_solve);
+    // eigCG and deflation need 2 sloppy precisions and do not use Schwarz
+    bool comms_flag = (param.inv_type == QUDA_INC_EIGCG_INVERTER || param.eig_param) ? true : false;
+    setDiracPreParam(diracPreParam, &param, pc_solve, comms_flag);
+    
+    d = Dirac::create(diracParam); // create the Dirac operator
+    dSloppy = Dirac::create(diracSloppyParam);
+    dPre = Dirac::create(diracPreParam);
+  }
 
+  void createDirac(Dirac *&d, Dirac *&dSloppy, Dirac *&dPre, Dirac *&dRef, QudaInvertParam &param, const bool pc_solve)
+  {
+    DiracParam diracParam;
+    DiracParam diracSloppyParam;
+    DiracParam diracPreParam;
+    DiracParam diracRefParam;
+    
+    setDiracParam(diracParam, &param, pc_solve);
+    setDiracSloppyParam(diracSloppyParam, &param, pc_solve);
+    setDiracRefineParam(diracRefParam, &param, pc_solve);
+    // eigCG and deflation need 2 sloppy precisions and do not use Schwarz
+    bool comms_flag = (param.inv_type == QUDA_INC_EIGCG_INVERTER || param.eig_param) ? true : false;
+    setDiracPreParam(diracPreParam, &param, pc_solve, comms_flag);
+    
+    d = Dirac::create(diracParam); // create the Dirac operator
+    dSloppy = Dirac::create(diracSloppyParam);
+    dPre = Dirac::create(diracPreParam);
+    dRef = Dirac::create(diracRefParam);
+  }
+  
+  static double unscaled_shifts[QUDA_MAX_MULTI_SHIFT];
+  
   void massRescale(cudaColorSpinorField &b, QudaInvertParam &param) {
 
     double kappa5 = (0.5/(5.0 + param.m5));

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -1747,43 +1747,8 @@ namespace quda {
   }
 
 
-  void createDirac(Dirac *&d, Dirac *&dSloppy, Dirac *&dPre, QudaInvertParam &param, const bool pc_solve)
-  {
-    DiracParam diracParam;
-    DiracParam diracSloppyParam;
-    DiracParam diracPreParam;
 
-    setDiracParam(diracParam, &param, pc_solve);
-    setDiracSloppyParam(diracSloppyParam, &param, pc_solve);
-    // eigCG and deflation need 2 sloppy precisions and do not use Schwarz
-    bool comms_flag = (param.inv_type == QUDA_INC_EIGCG_INVERTER || param.eig_param) ? true : false;
-    setDiracPreParam(diracPreParam, &param, pc_solve, comms_flag);
-
-    d = Dirac::create(diracParam); // create the Dirac operator
-    dSloppy = Dirac::create(diracSloppyParam);
-    dPre = Dirac::create(diracPreParam);
-  }
-
-  void createDirac(Dirac *&d, Dirac *&dSloppy, Dirac *&dPre, Dirac *&dRef, QudaInvertParam &param, const bool pc_solve)
-  {
-    DiracParam diracParam;
-    DiracParam diracSloppyParam;
-    DiracParam diracPreParam;
-    DiracParam diracRefParam;
-
-    setDiracParam(diracParam, &param, pc_solve);
-    setDiracSloppyParam(diracSloppyParam, &param, pc_solve);
-    setDiracRefineParam(diracRefParam, &param, pc_solve);
-    // eigCG and deflation need 2 sloppy precisions and do not use Schwarz
-    bool comms_flag = (param.inv_type == QUDA_INC_EIGCG_INVERTER || param.eig_param) ? true : false;
-    setDiracPreParam(diracPreParam, &param, pc_solve, comms_flag);
-
-    d = Dirac::create(diracParam); // create the Dirac operator
-    dSloppy = Dirac::create(diracSloppyParam);
-    dPre = Dirac::create(diracPreParam);
-    dRef = Dirac::create(diracRefParam);
-  }
-
+  
   static double unscaled_shifts[QUDA_MAX_MULTI_SHIFT];
 
   void massRescale(cudaColorSpinorField &b, QudaInvertParam &param) {


### PR DESCRIPTION
This hot fix simply exposes the createDirac helper functions to the user via dirac.h. This is sufficient for users to construct solvers and operators.