### PR TITLE
Hotfix/ls dim qio

### DIFF
--- a/include/color_spinor_field.h
+++ b/include/color_spinor_field.h
@@ -197,7 +197,7 @@ namespace quda {
         nDim++;
         x[4] = inv_param.Ls;
       } else {
-	x[4] = 1;
+        x[4] = 1;
       }
 
       if (inv_param.dirac_order == QUDA_INTERNAL_DIRAC_ORDER) {
@@ -227,7 +227,7 @@ namespace quda {
     // normally used to create cuda param from a cpu param
     ColorSpinorParam(ColorSpinorParam &cpuParam, QudaInvertParam &inv_param,
                      QudaFieldLocation location = QUDA_CUDA_FIELD_LOCATION) :
-	//LatticeFieldParam(cpuParam.nDim, cpuParam.x, inv_param.sp_pad, inv_param.cuda_prec),
+      // LatticeFieldParam(cpuParam.nDim, cpuParam.x, inv_param.sp_pad, inv_param.cuda_prec),
       LatticeFieldParam(cpuParam.nDim, cpuParam.x, 0, inv_param.cuda_prec),
       location(location),
       nColor(cpuParam.nColor),

--- a/include/color_spinor_field.h
+++ b/include/color_spinor_field.h
@@ -196,6 +196,8 @@ namespace quda {
       } else if (inv_param.dslash_type == QUDA_STAGGERED_DSLASH || inv_param.dslash_type == QUDA_ASQTAD_DSLASH) {
         nDim++;
         x[4] = inv_param.Ls;
+      } else {
+	x[4] = 1;
       }
 
       if (inv_param.dirac_order == QUDA_INTERNAL_DIRAC_ORDER) {
@@ -225,7 +227,8 @@ namespace quda {
     // normally used to create cuda param from a cpu param
     ColorSpinorParam(ColorSpinorParam &cpuParam, QudaInvertParam &inv_param,
                      QudaFieldLocation location = QUDA_CUDA_FIELD_LOCATION) :
-      LatticeFieldParam(cpuParam.nDim, cpuParam.x, inv_param.sp_pad, inv_param.cuda_prec),
+	//LatticeFieldParam(cpuParam.nDim, cpuParam.x, inv_param.sp_pad, inv_param.cuda_prec),
+      LatticeFieldParam(cpuParam.nDim, cpuParam.x, 0, inv_param.cuda_prec),
       location(location),
       nColor(cpuParam.nColor),
       nSpin(cpuParam.nSpin),
@@ -245,6 +248,7 @@ namespace quda {
     {
       siteSubset = cpuParam.siteSubset;
       fieldOrder = (precision == QUDA_DOUBLE_PRECISION || nSpin == 1 || nSpin == 2) ? QUDA_FLOAT2_FIELD_ORDER : QUDA_FLOAT4_FIELD_ORDER;
+      for (int d = 0; d < QUDA_MAX_DIM; d++) x[d] = cpuParam.x[d];
     }
 
     /**

--- a/include/qio_field.h
+++ b/include/qio_field.h
@@ -22,15 +22,15 @@ inline void write_gauge_field(const char *filename, void *gauge[], QudaPrecision
   exit(-1);
 }
 inline void read_spinor_field(const char *filename, void *V[], QudaPrecision precision, const int *X,
-                              QudaSiteSubset subset, QudaParity parity, int nColor, int nSpin, int Ls, int Nvec, int argc,
-                              char *argv[])
+                              QudaSiteSubset subset, QudaParity parity, int nColor, int nSpin, int Ls, int Nvec,
+                              int argc, char *argv[])
 {
   printf("QIO support has not been enabled\n");
   exit(-1);
 }
 inline void write_spinor_field(const char *filename, void *V[], QudaPrecision precision, const int *X,
-                               QudaSiteSubset subset, QudaParity parity, int nColor, int nSpin, int Ls, int Nvec, int argc,
-                               char *argv[])
+                               QudaSiteSubset subset, QudaParity parity, int nColor, int nSpin, int Ls, int Nvec,
+                               int argc, char *argv[])
 {
   printf("QIO support has not been enabled\n");
   exit(-1);

--- a/include/qio_field.h
+++ b/include/qio_field.h
@@ -7,9 +7,9 @@ void read_gauge_field(const char *filename, void *gauge[], QudaPrecision prec, c
 void write_gauge_field(const char *filename, void* gauge[], QudaPrecision prec, const int *X,
           int argc, char* argv[]);
 void read_spinor_field(const char *filename, void *V[], QudaPrecision precision, const int *X, QudaSiteSubset subset,
-                       QudaParity parity, int nColor, int nSpin, int Nvec, int argc, char *argv[]);
+                       QudaParity parity, int nColor, int nSpin, int Ls, int Nvec, int argc, char *argv[]);
 void write_spinor_field(const char *filename, void *V[], QudaPrecision precision, const int *X, QudaSiteSubset subset,
-                        QudaParity parity, int nColor, int nSpin, int Nvec, int argc, char *argv[]);
+                        QudaParity parity, int nColor, int nSpin, int Ls, int Nvec, int argc, char *argv[]);
 #else
 inline void read_gauge_field(const char *filename, void *gauge[], QudaPrecision prec,
 		      const int *X, int argc, char *argv[]) {
@@ -22,14 +22,14 @@ inline void write_gauge_field(const char *filename, void *gauge[], QudaPrecision
   exit(-1);
 }
 inline void read_spinor_field(const char *filename, void *V[], QudaPrecision precision, const int *X,
-                              QudaSiteSubset subset, QudaParity parity, int nColor, int nSpin, int Nvec, int argc,
+                              QudaSiteSubset subset, QudaParity parity, int nColor, int nSpin, int Ls, int Nvec, int argc,
                               char *argv[])
 {
   printf("QIO support has not been enabled\n");
   exit(-1);
 }
 inline void write_spinor_field(const char *filename, void *V[], QudaPrecision precision, const int *X,
-                               QudaSiteSubset subset, QudaParity parity, int nColor, int nSpin, int Nvec, int argc,
+                               QudaSiteSubset subset, QudaParity parity, int nColor, int nSpin, int Ls, int Nvec, int argc,
                                char *argv[])
 {
   printf("QIO support has not been enabled\n");

--- a/lib/color_spinor_field.cpp
+++ b/lib/color_spinor_field.cpp
@@ -193,13 +193,13 @@ namespace quda {
 
     precision = Prec;
     // Copy all data in X
-    for (int d=0; d<QUDA_MAX_DIM; d++) x[d] = X[d];
+    for (int d = 0; d < QUDA_MAX_DIM; d++) x[d] = X[d];
     volume = 1;
     for (int d=0; d<nDim; d++) {
       volume *= x[d];
     }
     volumeCB = siteSubset == QUDA_PARITY_SITE_SUBSET ? volume : volume/2;
-    
+
    if((twistFlavor == QUDA_TWIST_NONDEG_DOUBLET || twistFlavor == QUDA_TWIST_DEG_DOUBLET) && x[4] != 2)
      errorQuda("Must be two flavors for non-degenerate twisted mass spinor (while provided with %d number of components)\n", x[4]);//two flavors
 

--- a/lib/color_spinor_field.cpp
+++ b/lib/color_spinor_field.cpp
@@ -192,13 +192,14 @@ namespace quda {
     this->suggested_parity = suggested_parity;
 
     precision = Prec;
+    // Copy all data in X
+    for (int d=0; d<QUDA_MAX_DIM; d++) x[d] = X[d];
     volume = 1;
     for (int d=0; d<nDim; d++) {
-      x[d] = X[d];
       volume *= x[d];
     }
     volumeCB = siteSubset == QUDA_PARITY_SITE_SUBSET ? volume : volume/2;
-
+    
    if((twistFlavor == QUDA_TWIST_NONDEG_DOUBLET || twistFlavor == QUDA_TWIST_DEG_DOUBLET) && x[4] != 2)
      errorQuda("Must be two flavors for non-degenerate twisted mass spinor (while provided with %d number of components)\n", x[4]);//two flavors
 

--- a/lib/deflation.cpp
+++ b/lib/deflation.cpp
@@ -373,7 +373,7 @@ namespace quda
     if (strcmp(vec_infile.c_str(),"")!=0) {
       auto parity = (B[0]->SiteSubset() == QUDA_FULL_SITE_SUBSET ? QUDA_INVALID_PARITY : QUDA_EVEN_PARITY);
       read_spinor_field(vec_infile.c_str(), &V[0], B[0]->Precision(), B[0]->X(), B[0]->SiteSubset(), parity,
-                        B[0]->Ncolor(), B[0]->Nspin(), Nvec, 0, (char **)0);
+                        B[0]->Ncolor(), B[0]->Nspin(), B[0]->X()[4], Nvec, 0, (char **)0);
     } else {
       errorQuda("No eigenspace file defined");
     }
@@ -408,7 +408,7 @@ namespace quda
       // assumes even parity if a single-parity field...
       auto parity = (B[0]->SiteSubset() == QUDA_FULL_SITE_SUBSET ? QUDA_INVALID_PARITY : QUDA_EVEN_PARITY);
       write_spinor_field(vec_outfile.c_str(), &V[0], B[0]->Precision(), B[0]->X(), B[0]->SiteSubset(), parity,
-                         B[0]->Ncolor(), B[0]->Nspin(), Nvec, 0, (char **)0);
+                         B[0]->Ncolor(), B[0]->Nspin(), B[0]->X()[4], Nvec, 0, (char **)0);
 
       host_free(V);
       printfQuda("Done saving vectors\n");

--- a/lib/eigensolve_quda.cpp
+++ b/lib/eigensolve_quda.cpp
@@ -548,7 +548,7 @@ namespace quda
       }
 
       read_spinor_field(vec_infile.c_str(), &V[0], tmp[0]->Precision(), tmp[0]->X(), tmp[0]->SiteSubset(),
-                        spinor_parity, tmp[0]->Ncolor(), tmp[0]->Nspin(), Nvec, 0, (char **)0);
+                        spinor_parity, tmp[0]->Ncolor(), tmp[0]->Nspin(), tmp[0]->X()[4], Nvec, 0, (char **)0);
 
       host_free(V);
       if (eig_vecs[0]->Location() == QUDA_CUDA_FIELD_LOCATION) {
@@ -685,7 +685,7 @@ namespace quda
     }
 
     write_spinor_field(vec_outfile.c_str(), &V[0], tmp[0]->Precision(), tmp[0]->X(), eig_vecs[0]->SiteSubset(),
-                       spinor_parity, tmp[0]->Ncolor(), tmp[0]->Nspin(), Nvec, 0, (char **)0);
+                       spinor_parity, tmp[0]->Ncolor(), tmp[0]->Nspin(), tmp[0]->X()[4], Nvec, 0, (char **)0);
 
     host_free(V);
     if (getVerbosity() >= QUDA_SUMMARIZE) printfQuda("Done saving vectors\n");
@@ -762,6 +762,7 @@ namespace quda
   {
     // In case we are deflating an operator, save the tunechache from the inverter
     saveTuneCache();
+
     // Check to see if we are loading eigenvectors
     if (strcmp(eig_param->vec_infile, "") != 0) {
       printfQuda("Loading evecs from file name %s\n", eig_param->vec_infile);

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -2335,7 +2335,7 @@ void eigensolveQuda(void **host_evecs, double _Complex *host_evals, QudaEigParam
     cpuParam.v = host_evecs[i];
     host_evecs_.push_back(ColorSpinorField::Create(cpuParam));
   }
-
+  
   ColorSpinorParam cudaParam(cpuParam);
   cudaParam.location = QUDA_CUDA_FIELD_LOCATION;
   cudaParam.create = QUDA_ZERO_FIELD_CREATE;

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -2335,7 +2335,7 @@ void eigensolveQuda(void **host_evecs, double _Complex *host_evals, QudaEigParam
     cpuParam.v = host_evecs[i];
     host_evecs_.push_back(ColorSpinorField::Create(cpuParam));
   }
-  
+
   ColorSpinorParam cudaParam(cpuParam);
   cudaParam.location = QUDA_CUDA_FIELD_LOCATION;
   cudaParam.create = QUDA_ZERO_FIELD_CREATE;

--- a/lib/qio_field.cpp
+++ b/lib/qio_field.cpp
@@ -159,7 +159,7 @@ void set_layout(const int *X)
   for (int d=0; d<4; d++) {
     lattice_size[d] = comm_dim(d)*X[d];
     lattice_volume *= lattice_size[d];
-  }
+  }  
 
   /* Set the mapping of coordinates to nodes */
   if (setup_layout(lattice_size, 4, QMP_get_number_of_nodes()) != 0) { errorQuda("Setup layout failed\n"); }
@@ -210,7 +210,9 @@ int read_field(QIO_Reader *infile, int Ninternal, int count, void *field_in[], Q
   case 24: status = read_field<24>(infile, count, field_in, cpu_prec, subset, parity, nSpin, nColor); break;
   case 96: status = read_field<96>(infile, count, field_in, cpu_prec, subset, parity, nSpin, nColor); break;
   case 128: status = read_field<128>(infile, count, field_in, cpu_prec, subset, parity, nSpin, nColor); break;
+  case 192: status = read_field<192>(infile, count, field_in, cpu_prec, subset, parity, nSpin, nColor); break;    
   case 256: status = read_field<256>(infile, count, field_in, cpu_prec, subset, parity, nSpin, nColor); break;
+  case 288: status = read_field<288>(infile, count, field_in, cpu_prec, subset, parity, nSpin, nColor); break;
   case 384: status = read_field<384>(infile, count, field_in, cpu_prec, subset, parity, nSpin, nColor); break;
   default:
     errorQuda("Undefined %d", Ninternal);
@@ -219,7 +221,7 @@ int read_field(QIO_Reader *infile, int Ninternal, int count, void *field_in[], Q
 }
 
 void read_spinor_field(const char *filename, void *V[], QudaPrecision precision, const int *X, QudaSiteSubset subset,
-                       QudaParity parity, int nColor, int nSpin, int Nvec, int argc, char *argv[])
+                       QudaParity parity, int nColor, int nSpin, int Ls, int Nvec, int argc, char *argv[])
 {
   this_node = mynode();
 
@@ -231,9 +233,9 @@ void read_spinor_field(const char *filename, void *V[], QudaPrecision precision,
 
   /* Read the spinor field record */
   printfQuda("%s: reading %d vector fields\n", __func__, Nvec); fflush(stdout);
-  int status = read_field(infile, 2 * nSpin * nColor, Nvec, V, precision, subset, parity, nSpin, nColor);
+  int status = read_field(infile, Ls * 2 * nSpin * nColor, Nvec, V, precision, subset, parity, nSpin, nColor);
   if (status) { errorQuda("read_spinor_fields failed %d\n", status); }
-
+  
   /* Close the file */
   QIO_close_read(infile);
   printfQuda("%s: Closed file for reading\n",__func__);
@@ -241,21 +243,36 @@ void read_spinor_field(const char *filename, void *V[], QudaPrecision precision,
 
 template <int len>
 int write_field(QIO_Writer *outfile, int count, void *field_out[], QudaPrecision file_prec, QudaPrecision cpu_prec,
-                QudaSiteSubset subset, QudaParity parity, int nSpin, int nColor, const char *type)
+                QudaSiteSubset subset, QudaParity parity, int nSpin, int nColor, int Ls, const char *type)
 {
 
   // Prepare a string.
   std::string xml_record = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><quda";
-  switch (len) {
-  case 6: xml_record += "StaggeredColorSpinorField>"; break; // SU(3) staggered
-  case 18: xml_record += "GaugeFieldFile>"; break;           // SU(3) gauge field
-  case 24: xml_record += "WilsonColorSpinorField>"; break;   // SU(3) Wilson
-  case 96:
-  case 128:
-  case 256:
-  case 384: xml_record += "MGColorSpinorField>"; break; // Color spinor vector
-  default: errorQuda("Invalid element length for QIO writing."); break;
+  if(Ls==1) {
+    switch (len) {
+    case 6: xml_record += "StaggeredColorSpinorField>"; break; // SU(3) staggered
+    case 18: xml_record += "GaugeFieldFile>"; break;           // SU(3) gauge field
+    case 24: xml_record += "WilsonColorSpinorField>"; break;   // SU(3) Wilson
+    case 96:
+    case 128:
+    case 256:
+    case 384: xml_record += "MGColorSpinorField>"; break; // Color spinor vector
+    default: errorQuda("Invalid element length for QIO writing."); break;
+    }
+  } else {
+    int len_spinor = len/Ls;
+    switch (len_spinor) {
+    case 6: xml_record += "StaggeredColorSpinorField>"; break; // SU(3) staggered
+    case 18: xml_record += "GaugeFieldFile>"; break;           // SU(3) gauge field
+    case 24: xml_record += "WilsonColorSpinorField>"; break;   // SU(3) Wilson
+    case 96:
+    case 128:
+    case 256:
+    case 384: xml_record += "MGColorSpinorField>"; break; // Color spinor vector
+    default: errorQuda("Invalid element length for QIO writing."); break;
+    }
   }
+  
   xml_record += "<version>BETA</version>";
   xml_record += "<type>" + std::string(type) + "</type><info>";
 
@@ -280,19 +297,34 @@ int write_field(QIO_Writer *outfile, int count, void *field_out[], QudaPrecision
 
   // A lot of this is redundant of the record info, but eh.
   xml_record += "<nColor>" + std::to_string(nColor) + "</nColor>";
-  xml_record += "<nSpin>" + std::to_string(nSpin) + "</nSpin>";
+  xml_record += "<nSpin>" + std::to_string(nSpin) + "</nSpin>";  
+  xml_record += "<Ls>" + std::to_string(Ls) + "</Ls>";
   xml_record += "</info></quda";
-  switch (len) {
-  case 6: xml_record += "StaggeredColorSpinorField>"; break; // SU(3) staggered
-  case 18: xml_record += "GaugeFieldFile>"; break;           // SU(3) gauge field
-  case 24: xml_record += "WilsonColorSpinorField>"; break;   // SU(3) Wilson
-  case 96:
-  case 128:
-  case 256:
-  case 384: xml_record += "MGColorSpinorField>"; break; // Color spinor vector
-  default: errorQuda("Invalid element length for QIO writing."); break;
+  if(Ls==1) {
+    switch (len) {
+    case 6: xml_record += "StaggeredColorSpinorField>"; break; // SU(3) staggered
+    case 18: xml_record += "GaugeFieldFile>"; break;           // SU(3) gauge field
+    case 24: xml_record += "WilsonColorSpinorField>"; break;   // SU(3) Wilson
+    case 96:
+    case 128:
+    case 256:
+    case 384: xml_record += "MGColorSpinorField>"; break; // Color spinor vector
+    default: errorQuda("Invalid element length for QIO writing."); break;
+    }
+  } else {
+    int len_spinor = len/Ls;
+    switch (len_spinor) {
+    case 6: xml_record += "StaggeredColorSpinorField>"; break; // SU(3) staggered
+    case 18: xml_record += "GaugeFieldFile>"; break;           // SU(3) gauge field
+    case 24: xml_record += "WilsonColorSpinorField>"; break;   // SU(3) Wilson
+    case 96:
+    case 128:
+    case 256:
+    case 384: xml_record += "MGColorSpinorField>"; break; // Color spinor vector
+    default: errorQuda("Invalid element length for QIO writing."); break;
+    }
   }
-
+  
   int status;
 
   // Create the record info for the field
@@ -345,7 +377,7 @@ int write_su3_field(QIO_Writer *outfile, int count, void *field_out[],
     QudaPrecision file_prec, QudaPrecision cpu_prec, const char* type)
 {
   return write_field<18>(outfile, count, field_out, file_prec, cpu_prec, QUDA_FULL_SITE_SUBSET, QUDA_INVALID_PARITY, 0,
-                         3, type);
+                         3, 1, type);
 }
 
 void write_gauge_field(const char *filename, void *gauge[], QudaPrecision precision, const int *X, int argc, char *argv[])
@@ -376,27 +408,33 @@ void write_gauge_field(const char *filename, void *gauge[], QudaPrecision precis
 // count is the number of vectors
 // Ninternal is the size of the "inner struct" (24 for Wilson spinor)
 int write_field(QIO_Writer *outfile, int Ninternal, int count, void *field_out[], QudaPrecision file_prec,
-                QudaPrecision cpu_prec, QudaSiteSubset subset, QudaParity parity, int nSpin, int nColor, const char *type)
+                QudaPrecision cpu_prec, QudaSiteSubset subset, QudaParity parity, int nSpin, int nColor, int Ls, const char *type)
 {
   int status = 0;
   switch (Ninternal) {
   case 6:
-    status = write_field<6>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, type);
+    status = write_field<6>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type);
     break;
   case 24:
-    status = write_field<24>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, type);
-    break;
+    status = write_field<24>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type);
+    break;    
   case 96:
-    status = write_field<96>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, type);
+    status = write_field<96>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type);
     break;
   case 128:
-    status = write_field<128>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, type);
+    status = write_field<128>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type);
     break;
   case 256:
-    status = write_field<256>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, type);
+    status = write_field<256>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type);
+    break;
+  case 192:
+    status = write_field<192>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type);
+    break;
+  case 288:
+    status = write_field<288>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type);
     break;
   case 384:
-    status = write_field<384>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, type);
+    status = write_field<384>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type);
     break;
   default:
     errorQuda("Undefined %d", Ninternal);
@@ -405,7 +443,7 @@ int write_field(QIO_Writer *outfile, int Ninternal, int count, void *field_out[]
 }
 
 void write_spinor_field(const char *filename, void *V[], QudaPrecision precision, const int *X, QudaSiteSubset subset,
-                        QudaParity parity, int nColor, int nSpin, int Nvec, int argc, char *argv[])
+                        QudaParity parity, int nColor, int nSpin, int Ls, int Nvec, int argc, char *argv[])
 {
   this_node = mynode();
 
@@ -414,7 +452,7 @@ void write_spinor_field(const char *filename, void *V[], QudaPrecision precision
   QudaPrecision file_prec = precision;
 
   char type[128];
-  sprintf(type, "QUDA_%sNs%dNc%d_ColorSpinorField", (file_prec == QUDA_DOUBLE_PRECISION) ? "D" : "F", nSpin, nColor);
+  sprintf(type, "QUDA_%sNs%dNc%dLs%d_ColorSpinorField", (file_prec == QUDA_DOUBLE_PRECISION) ? "D" : "F", nSpin, nColor, Ls);
 
   /* Open the test file for reading */
   QIO_Writer *outfile = open_test_output(filename, QIO_SINGLEFILE, QIO_PARALLEL, QIO_ILDGNO);
@@ -423,7 +461,7 @@ void write_spinor_field(const char *filename, void *V[], QudaPrecision precision
   /* Read the spinor field record */
   printfQuda("%s: writing %d vector fields\n", __func__, Nvec); fflush(stdout);
   int status
-    = write_field(outfile, 2 * nSpin * nColor, Nvec, V, precision, precision, subset, parity, nSpin, nColor, type);
+    = write_field(outfile, Ls * 2 * nSpin * nColor, Nvec, V, precision, precision, subset, parity, nSpin, nColor, Ls, type);
   if (status) { errorQuda("write_spinor_fields failed %d\n", status); }
 
   /* Close the file */

--- a/lib/qio_field.cpp
+++ b/lib/qio_field.cpp
@@ -202,7 +202,7 @@ void read_gauge_field(const char *filename, void *gauge[], QudaPrecision precisi
 // count is the number of vectors
 // Ninternal is the size of the "inner struct" (24 for Wilson spinor)
 int read_field(QIO_Reader *infile, int Ninternal, int count, void *field_in[], QudaPrecision cpu_prec,
-               QudaSiteSubset subset, QudaParity parity, int nSpin, int nColor)
+               QudaSiteSubset subset, QudaParity parity, int nSpin, int nColor, int Ls)
 {
   int status = 0;
   switch (Ninternal) {
@@ -211,11 +211,19 @@ int read_field(QIO_Reader *infile, int Ninternal, int count, void *field_in[], Q
   case 96: status = read_field<96>(infile, count, field_in, cpu_prec, subset, parity, nSpin, nColor); break;
   case 128: status = read_field<128>(infile, count, field_in, cpu_prec, subset, parity, nSpin, nColor); break;
   case 192: status = read_field<192>(infile, count, field_in, cpu_prec, subset, parity, nSpin, nColor); break;
+  case 240: status = read_field<240>(infile, count, field_in, cpu_prec, subset, parity, nSpin, nColor); break;    
   case 256: status = read_field<256>(infile, count, field_in, cpu_prec, subset, parity, nSpin, nColor); break;
   case 288: status = read_field<288>(infile, count, field_in, cpu_prec, subset, parity, nSpin, nColor); break;
+  case 336: status = read_field<336>(infile, count, field_in, cpu_prec, subset, parity, nSpin, nColor); break;
   case 384: status = read_field<384>(infile, count, field_in, cpu_prec, subset, parity, nSpin, nColor); break;
+  case 432: status = read_field<432>(infile, count, field_in, cpu_prec, subset, parity, nSpin, nColor); break;
+  case 480: status = read_field<480>(infile, count, field_in, cpu_prec, subset, parity, nSpin, nColor); break;
+  case 528: status = read_field<528>(infile, count, field_in, cpu_prec, subset, parity, nSpin, nColor); break;
+  case 576: status = read_field<576>(infile, count, field_in, cpu_prec, subset, parity, nSpin, nColor); break;
   default:
-    errorQuda("Undefined %d", Ninternal);
+    if(Ls != 1) {      
+      errorQuda("Undefined data lenth %d. You need to instantiate case %d for your value of Ls=%d", Ninternal, Ninternal, Ls);
+    } else errorQuda("Undefined data lenth %d", Ninternal);
   }
   return status;
 }
@@ -226,14 +234,14 @@ void read_spinor_field(const char *filename, void *V[], QudaPrecision precision,
   this_node = mynode();
 
   set_layout(X);
-
+  
   /* Open the test file for reading */
   QIO_Reader *infile = open_test_input(filename, QIO_UNKNOWN, QIO_PARALLEL);
   if (infile == NULL) { errorQuda("Open file failed\n"); }
 
   /* Read the spinor field record */
   printfQuda("%s: reading %d vector fields\n", __func__, Nvec); fflush(stdout);
-  int status = read_field(infile, Ls * 2 * nSpin * nColor, Nvec, V, precision, subset, parity, nSpin, nColor);
+  int status = read_field(infile, Ls * 2 * nSpin * nColor, Nvec, V, precision, subset, parity, nSpin, nColor, Ls);
   if (status) { errorQuda("read_spinor_fields failed %d\n", status); }
 
   /* Close the file */
@@ -245,31 +253,34 @@ template <int len>
 int write_field(QIO_Writer *outfile, int count, void *field_out[], QudaPrecision file_prec, QudaPrecision cpu_prec,
                 QudaSiteSubset subset, QudaParity parity, int nSpin, int nColor, int Ls, const char *type)
 {
-
   // Prepare a string.
   std::string xml_record = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><quda";
   if (Ls == 1) {
     switch (len) {
     case 6: xml_record += "StaggeredColorSpinorField>"; break; // SU(3) staggered
     case 18: xml_record += "GaugeFieldFile>"; break;           // SU(3) gauge field
-    case 24: xml_record += "WilsonColorSpinorField>"; break;   // SU(3) Wilson
+    case 24: xml_record += "WilsonColorSpinorField>"; break;   // SU(3) Wilson            
     case 96:
-    case 128:
-    case 256:
-    case 384: xml_record += "MGColorSpinorField>"; break; // Color spinor vector
-    default: errorQuda("Invalid element length for QIO writing."); break;
+    case 128: 
+    case 192: 
+    case 240: 
+    case 256: 
+    case 288: 
+    case 336: 
+    case 384: 
+    case 432: 
+    case 480: 
+    case 528: 
+    case 576: xml_record += "MGColorSpinorField>"; break; // Color spinor vector
+    default: errorQuda("Invalid element length %d for QIO writing.", len); break;
     }
   } else {
+    // This must be some spinor, deduce which kind
     int len_spinor = len / Ls;
     switch (len_spinor) {
     case 6: xml_record += "StaggeredColorSpinorField>"; break; // SU(3) staggered
-    case 18: xml_record += "GaugeFieldFile>"; break;           // SU(3) gauge field
     case 24: xml_record += "WilsonColorSpinorField>"; break;   // SU(3) Wilson
-    case 96:
-    case 128:
-    case 256:
-    case 384: xml_record += "MGColorSpinorField>"; break; // Color spinor vector
-    default: errorQuda("Invalid element length for QIO writing."); break;
+    default: errorQuda("Invalid element length %d for QIO writing with Ls=%d.", len_spinor, Ls); break;
     }
   }
 
@@ -300,31 +311,35 @@ int write_field(QIO_Writer *outfile, int count, void *field_out[], QudaPrecision
   xml_record += "<nSpin>" + std::to_string(nSpin) + "</nSpin>";
   xml_record += "<Ls>" + std::to_string(Ls) + "</Ls>";
   xml_record += "</info></quda";
+  
   if (Ls == 1) {
     switch (len) {
     case 6: xml_record += "StaggeredColorSpinorField>"; break; // SU(3) staggered
     case 18: xml_record += "GaugeFieldFile>"; break;           // SU(3) gauge field
-    case 24: xml_record += "WilsonColorSpinorField>"; break;   // SU(3) Wilson
+    case 24: xml_record += "WilsonColorSpinorField>"; break;   // SU(3) Wilson            
     case 96:
-    case 128:
-    case 256:
-    case 384: xml_record += "MGColorSpinorField>"; break; // Color spinor vector
-    default: errorQuda("Invalid element length for QIO writing."); break;
+    case 128: 
+    case 192: 
+    case 240: 
+    case 256: 
+    case 288: 
+    case 336: 
+    case 384: 
+    case 432: 
+    case 480: 
+    case 528: 
+    case 576: xml_record += "MGColorSpinorField>"; break; // Color spinor vector
+    default: errorQuda("Invalid element length %d for QIO writing.", len); break;
     }
   } else {
+    // This must be some spinor, deduce which kind
     int len_spinor = len / Ls;
     switch (len_spinor) {
     case 6: xml_record += "StaggeredColorSpinorField>"; break; // SU(3) staggered
-    case 18: xml_record += "GaugeFieldFile>"; break;           // SU(3) gauge field
     case 24: xml_record += "WilsonColorSpinorField>"; break;   // SU(3) Wilson
-    case 96:
-    case 128:
-    case 256:
-    case 384: xml_record += "MGColorSpinorField>"; break; // Color spinor vector
-    default: errorQuda("Invalid element length for QIO writing."); break;
+    default: errorQuda("Invalid element length %d for QIO writing with Ls=%d.", len_spinor, Ls); break;
     }
-  }
-
+  }    
   int status;
 
   // Create the record info for the field
@@ -412,33 +427,25 @@ int write_field(QIO_Writer *outfile, int Ninternal, int count, void *field_out[]
                 const char *type)
 {
   int status = 0;
-  switch (Ninternal) {
-  case 6:
-    status = write_field<6>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type);
-    break;
-  case 24:
-    status = write_field<24>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type);
-    break;
-  case 96:
-    status = write_field<96>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type);
-    break;
-  case 128:
-    status = write_field<128>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type);
-    break;
-  case 256:
-    status = write_field<256>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type);
-    break;
-  case 192:
-    status = write_field<192>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type);
-    break;
-  case 288:
-    status = write_field<288>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type);
-    break;
-  case 384:
-    status = write_field<384>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type);
-    break;
+  switch (Ninternal) {    
+  case 6: status = write_field<6>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type); break;
+  case 24: status = write_field<24>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type); break;
+  case 96: status = write_field<96>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type); break;
+  case 128: status = write_field<128>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type); break;
+  case 192: status = write_field<192>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type); break;
+  case 240: status = write_field<240>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type); break;    
+  case 256: status = write_field<256>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type); break;
+  case 288: status = write_field<288>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type); break;
+  case 336: status = write_field<336>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type); break;
+  case 384: status = write_field<384>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type); break;
+  case 432: status = write_field<432>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type); break;
+  case 480: status = write_field<480>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type); break;
+  case 528: status = write_field<528>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type); break;
+  case 576: status = write_field<576>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type); break;
   default:
-    errorQuda("Undefined %d", Ninternal);
+    if(Ls != 1) {      
+      errorQuda("Undefined data lenth %d. You need to instantiate case %d for your value of Ls=%d", Ninternal, Ninternal, Ls);
+    } else errorQuda("Undefined data lenth %d", Ninternal);
   }
   return status;
 }

--- a/lib/qio_field.cpp
+++ b/lib/qio_field.cpp
@@ -159,7 +159,7 @@ void set_layout(const int *X)
   for (int d=0; d<4; d++) {
     lattice_size[d] = comm_dim(d)*X[d];
     lattice_volume *= lattice_size[d];
-  }  
+  }
 
   /* Set the mapping of coordinates to nodes */
   if (setup_layout(lattice_size, 4, QMP_get_number_of_nodes()) != 0) { errorQuda("Setup layout failed\n"); }
@@ -210,7 +210,7 @@ int read_field(QIO_Reader *infile, int Ninternal, int count, void *field_in[], Q
   case 24: status = read_field<24>(infile, count, field_in, cpu_prec, subset, parity, nSpin, nColor); break;
   case 96: status = read_field<96>(infile, count, field_in, cpu_prec, subset, parity, nSpin, nColor); break;
   case 128: status = read_field<128>(infile, count, field_in, cpu_prec, subset, parity, nSpin, nColor); break;
-  case 192: status = read_field<192>(infile, count, field_in, cpu_prec, subset, parity, nSpin, nColor); break;    
+  case 192: status = read_field<192>(infile, count, field_in, cpu_prec, subset, parity, nSpin, nColor); break;
   case 256: status = read_field<256>(infile, count, field_in, cpu_prec, subset, parity, nSpin, nColor); break;
   case 288: status = read_field<288>(infile, count, field_in, cpu_prec, subset, parity, nSpin, nColor); break;
   case 384: status = read_field<384>(infile, count, field_in, cpu_prec, subset, parity, nSpin, nColor); break;
@@ -235,7 +235,7 @@ void read_spinor_field(const char *filename, void *V[], QudaPrecision precision,
   printfQuda("%s: reading %d vector fields\n", __func__, Nvec); fflush(stdout);
   int status = read_field(infile, Ls * 2 * nSpin * nColor, Nvec, V, precision, subset, parity, nSpin, nColor);
   if (status) { errorQuda("read_spinor_fields failed %d\n", status); }
-  
+
   /* Close the file */
   QIO_close_read(infile);
   printfQuda("%s: Closed file for reading\n",__func__);
@@ -248,7 +248,7 @@ int write_field(QIO_Writer *outfile, int count, void *field_out[], QudaPrecision
 
   // Prepare a string.
   std::string xml_record = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><quda";
-  if(Ls==1) {
+  if (Ls == 1) {
     switch (len) {
     case 6: xml_record += "StaggeredColorSpinorField>"; break; // SU(3) staggered
     case 18: xml_record += "GaugeFieldFile>"; break;           // SU(3) gauge field
@@ -260,7 +260,7 @@ int write_field(QIO_Writer *outfile, int count, void *field_out[], QudaPrecision
     default: errorQuda("Invalid element length for QIO writing."); break;
     }
   } else {
-    int len_spinor = len/Ls;
+    int len_spinor = len / Ls;
     switch (len_spinor) {
     case 6: xml_record += "StaggeredColorSpinorField>"; break; // SU(3) staggered
     case 18: xml_record += "GaugeFieldFile>"; break;           // SU(3) gauge field
@@ -272,7 +272,7 @@ int write_field(QIO_Writer *outfile, int count, void *field_out[], QudaPrecision
     default: errorQuda("Invalid element length for QIO writing."); break;
     }
   }
-  
+
   xml_record += "<version>BETA</version>";
   xml_record += "<type>" + std::string(type) + "</type><info>";
 
@@ -297,10 +297,10 @@ int write_field(QIO_Writer *outfile, int count, void *field_out[], QudaPrecision
 
   // A lot of this is redundant of the record info, but eh.
   xml_record += "<nColor>" + std::to_string(nColor) + "</nColor>";
-  xml_record += "<nSpin>" + std::to_string(nSpin) + "</nSpin>";  
+  xml_record += "<nSpin>" + std::to_string(nSpin) + "</nSpin>";
   xml_record += "<Ls>" + std::to_string(Ls) + "</Ls>";
   xml_record += "</info></quda";
-  if(Ls==1) {
+  if (Ls == 1) {
     switch (len) {
     case 6: xml_record += "StaggeredColorSpinorField>"; break; // SU(3) staggered
     case 18: xml_record += "GaugeFieldFile>"; break;           // SU(3) gauge field
@@ -312,7 +312,7 @@ int write_field(QIO_Writer *outfile, int count, void *field_out[], QudaPrecision
     default: errorQuda("Invalid element length for QIO writing."); break;
     }
   } else {
-    int len_spinor = len/Ls;
+    int len_spinor = len / Ls;
     switch (len_spinor) {
     case 6: xml_record += "StaggeredColorSpinorField>"; break; // SU(3) staggered
     case 18: xml_record += "GaugeFieldFile>"; break;           // SU(3) gauge field
@@ -324,7 +324,7 @@ int write_field(QIO_Writer *outfile, int count, void *field_out[], QudaPrecision
     default: errorQuda("Invalid element length for QIO writing."); break;
     }
   }
-  
+
   int status;
 
   // Create the record info for the field
@@ -408,7 +408,8 @@ void write_gauge_field(const char *filename, void *gauge[], QudaPrecision precis
 // count is the number of vectors
 // Ninternal is the size of the "inner struct" (24 for Wilson spinor)
 int write_field(QIO_Writer *outfile, int Ninternal, int count, void *field_out[], QudaPrecision file_prec,
-                QudaPrecision cpu_prec, QudaSiteSubset subset, QudaParity parity, int nSpin, int nColor, int Ls, const char *type)
+                QudaPrecision cpu_prec, QudaSiteSubset subset, QudaParity parity, int nSpin, int nColor, int Ls,
+                const char *type)
 {
   int status = 0;
   switch (Ninternal) {
@@ -417,7 +418,7 @@ int write_field(QIO_Writer *outfile, int Ninternal, int count, void *field_out[]
     break;
   case 24:
     status = write_field<24>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type);
-    break;    
+    break;
   case 96:
     status = write_field<96>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type);
     break;
@@ -452,7 +453,8 @@ void write_spinor_field(const char *filename, void *V[], QudaPrecision precision
   QudaPrecision file_prec = precision;
 
   char type[128];
-  sprintf(type, "QUDA_%sNs%dNc%dLs%d_ColorSpinorField", (file_prec == QUDA_DOUBLE_PRECISION) ? "D" : "F", nSpin, nColor, Ls);
+  sprintf(type, "QUDA_%sNs%dNc%dLs%d_ColorSpinorField", (file_prec == QUDA_DOUBLE_PRECISION) ? "D" : "F", nSpin, nColor,
+          Ls);
 
   /* Open the test file for reading */
   QIO_Writer *outfile = open_test_output(filename, QIO_SINGLEFILE, QIO_PARALLEL, QIO_ILDGNO);
@@ -460,8 +462,8 @@ void write_spinor_field(const char *filename, void *V[], QudaPrecision precision
 
   /* Read the spinor field record */
   printfQuda("%s: writing %d vector fields\n", __func__, Nvec); fflush(stdout);
-  int status
-    = write_field(outfile, Ls * 2 * nSpin * nColor, Nvec, V, precision, precision, subset, parity, nSpin, nColor, Ls, type);
+  int status = write_field(outfile, Ls * 2 * nSpin * nColor, Nvec, V, precision, precision, subset, parity, nSpin,
+                           nColor, Ls, type);
   if (status) { errorQuda("write_spinor_fields failed %d\n", status); }
 
   /* Close the file */

--- a/lib/qio_field.cpp
+++ b/lib/qio_field.cpp
@@ -211,7 +211,7 @@ int read_field(QIO_Reader *infile, int Ninternal, int count, void *field_in[], Q
   case 96: status = read_field<96>(infile, count, field_in, cpu_prec, subset, parity, nSpin, nColor); break;
   case 128: status = read_field<128>(infile, count, field_in, cpu_prec, subset, parity, nSpin, nColor); break;
   case 192: status = read_field<192>(infile, count, field_in, cpu_prec, subset, parity, nSpin, nColor); break;
-  case 240: status = read_field<240>(infile, count, field_in, cpu_prec, subset, parity, nSpin, nColor); break;    
+  case 240: status = read_field<240>(infile, count, field_in, cpu_prec, subset, parity, nSpin, nColor); break;
   case 256: status = read_field<256>(infile, count, field_in, cpu_prec, subset, parity, nSpin, nColor); break;
   case 288: status = read_field<288>(infile, count, field_in, cpu_prec, subset, parity, nSpin, nColor); break;
   case 336: status = read_field<336>(infile, count, field_in, cpu_prec, subset, parity, nSpin, nColor); break;
@@ -221,9 +221,11 @@ int read_field(QIO_Reader *infile, int Ninternal, int count, void *field_in[], Q
   case 528: status = read_field<528>(infile, count, field_in, cpu_prec, subset, parity, nSpin, nColor); break;
   case 576: status = read_field<576>(infile, count, field_in, cpu_prec, subset, parity, nSpin, nColor); break;
   default:
-    if(Ls != 1) {      
-      errorQuda("Undefined data lenth %d. You need to instantiate case %d for your value of Ls=%d", Ninternal, Ninternal, Ls);
-    } else errorQuda("Undefined data lenth %d", Ninternal);
+    if (Ls != 1) {
+      errorQuda("Undefined data lenth %d. You need to instantiate case %d for your value of Ls=%d", Ninternal,
+                Ninternal, Ls);
+    } else
+      errorQuda("Undefined data lenth %d", Ninternal);
   }
   return status;
 }
@@ -234,7 +236,7 @@ void read_spinor_field(const char *filename, void *V[], QudaPrecision precision,
   this_node = mynode();
 
   set_layout(X);
-  
+
   /* Open the test file for reading */
   QIO_Reader *infile = open_test_input(filename, QIO_UNKNOWN, QIO_PARALLEL);
   if (infile == NULL) { errorQuda("Open file failed\n"); }
@@ -259,18 +261,18 @@ int write_field(QIO_Writer *outfile, int count, void *field_out[], QudaPrecision
     switch (len) {
     case 6: xml_record += "StaggeredColorSpinorField>"; break; // SU(3) staggered
     case 18: xml_record += "GaugeFieldFile>"; break;           // SU(3) gauge field
-    case 24: xml_record += "WilsonColorSpinorField>"; break;   // SU(3) Wilson            
+    case 24: xml_record += "WilsonColorSpinorField>"; break;   // SU(3) Wilson
     case 96:
-    case 128: 
-    case 192: 
-    case 240: 
-    case 256: 
-    case 288: 
-    case 336: 
-    case 384: 
-    case 432: 
-    case 480: 
-    case 528: 
+    case 128:
+    case 192:
+    case 240:
+    case 256:
+    case 288:
+    case 336:
+    case 384:
+    case 432:
+    case 480:
+    case 528:
     case 576: xml_record += "MGColorSpinorField>"; break; // Color spinor vector
     default: errorQuda("Invalid element length %d for QIO writing.", len); break;
     }
@@ -311,23 +313,23 @@ int write_field(QIO_Writer *outfile, int count, void *field_out[], QudaPrecision
   xml_record += "<nSpin>" + std::to_string(nSpin) + "</nSpin>";
   xml_record += "<Ls>" + std::to_string(Ls) + "</Ls>";
   xml_record += "</info></quda";
-  
+
   if (Ls == 1) {
     switch (len) {
     case 6: xml_record += "StaggeredColorSpinorField>"; break; // SU(3) staggered
     case 18: xml_record += "GaugeFieldFile>"; break;           // SU(3) gauge field
-    case 24: xml_record += "WilsonColorSpinorField>"; break;   // SU(3) Wilson            
+    case 24: xml_record += "WilsonColorSpinorField>"; break;   // SU(3) Wilson
     case 96:
-    case 128: 
-    case 192: 
-    case 240: 
-    case 256: 
-    case 288: 
-    case 336: 
-    case 384: 
-    case 432: 
-    case 480: 
-    case 528: 
+    case 128:
+    case 192:
+    case 240:
+    case 256:
+    case 288:
+    case 336:
+    case 384:
+    case 432:
+    case 480:
+    case 528:
     case 576: xml_record += "MGColorSpinorField>"; break; // Color spinor vector
     default: errorQuda("Invalid element length %d for QIO writing.", len); break;
     }
@@ -339,7 +341,7 @@ int write_field(QIO_Writer *outfile, int count, void *field_out[], QudaPrecision
     case 24: xml_record += "WilsonColorSpinorField>"; break;   // SU(3) Wilson
     default: errorQuda("Invalid element length %d for QIO writing with Ls=%d.", len_spinor, Ls); break;
     }
-  }    
+  }
   int status;
 
   // Create the record info for the field
@@ -427,25 +429,55 @@ int write_field(QIO_Writer *outfile, int Ninternal, int count, void *field_out[]
                 const char *type)
 {
   int status = 0;
-  switch (Ninternal) {    
-  case 6: status = write_field<6>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type); break;
-  case 24: status = write_field<24>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type); break;
-  case 96: status = write_field<96>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type); break;
-  case 128: status = write_field<128>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type); break;
-  case 192: status = write_field<192>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type); break;
-  case 240: status = write_field<240>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type); break;    
-  case 256: status = write_field<256>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type); break;
-  case 288: status = write_field<288>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type); break;
-  case 336: status = write_field<336>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type); break;
-  case 384: status = write_field<384>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type); break;
-  case 432: status = write_field<432>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type); break;
-  case 480: status = write_field<480>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type); break;
-  case 528: status = write_field<528>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type); break;
-  case 576: status = write_field<576>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type); break;
+  switch (Ninternal) {
+  case 6:
+    status = write_field<6>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type);
+    break;
+  case 24:
+    status = write_field<24>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type);
+    break;
+  case 96:
+    status = write_field<96>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type);
+    break;
+  case 128:
+    status = write_field<128>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type);
+    break;
+  case 192:
+    status = write_field<192>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type);
+    break;
+  case 240:
+    status = write_field<240>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type);
+    break;
+  case 256:
+    status = write_field<256>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type);
+    break;
+  case 288:
+    status = write_field<288>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type);
+    break;
+  case 336:
+    status = write_field<336>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type);
+    break;
+  case 384:
+    status = write_field<384>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type);
+    break;
+  case 432:
+    status = write_field<432>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type);
+    break;
+  case 480:
+    status = write_field<480>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type);
+    break;
+  case 528:
+    status = write_field<528>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type);
+    break;
+  case 576:
+    status = write_field<576>(outfile, count, field_out, file_prec, cpu_prec, subset, parity, nSpin, nColor, Ls, type);
+    break;
   default:
-    if(Ls != 1) {      
-      errorQuda("Undefined data lenth %d. You need to instantiate case %d for your value of Ls=%d", Ninternal, Ninternal, Ls);
-    } else errorQuda("Undefined data lenth %d", Ninternal);
+    if (Ls != 1) {
+      errorQuda("Undefined data lenth %d. You need to instantiate case %d for your value of Ls=%d", Ninternal,
+                Ninternal, Ls);
+    } else
+      errorQuda("Undefined data lenth %d", Ninternal);
   }
   return status;
 }


### PR DESCRIPTION
In the previous code, QIO had no knowledge of the Ls dim. When saving/loading DWF deflation spaces, It would write/read a fraction (1/Ls) of the total deflation space.

This hot fix adds rudimentary support for Ls=8,10,...,24 to the read/write spinor QIO routines. It also ensures that the ColorSpinorField objects inherit ALL the x[] data, and that Wilson type fermions have x[4] = 1. The QIO routines query x[4] to deduce how large Ls should be.

To illustrate, run the following on current develop:
```
./invert_test --sdim 8 --tdim 8 --inv-deflate true --eig-save-vec test --verbosity verbose --eig-use-poly-acc false --eig-spectrum SR --dslash-type mobius --Lsdim 16 --solve-type normop-pc --solution-type mat
```
Make a note of the eigenvalues and their residua. Then run:
```
./invert_test --sdim 8 --tdim 8 --inv-deflate true --eig-load-vec test --verbosity verbose --eig-use-poly-acc false --eig-spectrum SR --dslash-type mobius --Lsdim 16 --solve-type normop-pc --solution-type mat
```
You will see that the eigenvalues are different, and the residua are poor. Also note that for the above command, the size of the eigenvector file is 1/16th the size you would expect. Run the same commands for this PR to see the corrections.

