### PR TITLE
Feature/matrix tile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,7 +301,7 @@ endif()
 set(CMAKE_CXX_STANDARD ${QUDA_CXX_STANDARD})
 # define CXX FLAGS
 set(CMAKE_CXX_FLAGS_DEVEL
-    "${OpenMP_CXX_FLAGS} -g -O3 -Wall ${CLANG_FORCE_COLOR}"
+    "${OpenMP_CXX_FLAGS} -g -O3 -Wall -DDEVEL ${CLANG_FORCE_COLOR}"
     CACHE STRING "Flags used by the C++ compiler during regular development builds.")
 set(CMAKE_CXX_FLAGS_STRICT
     "${OpenMP_CXX_FLAGS} -O3 -Wall -Werror ${CLANG_NOERROR}"
@@ -326,7 +326,7 @@ set(
 enable_language(CXX)
 
 # define C FLAGS
-set(CMAKE_C_FLAGS_DEVEL "-Wall -g -O3" CACHE STRING "Flags used by the C compiler during regular development builds.")
+set(CMAKE_C_FLAGS_DEVEL "-Wall -g -O3" CACHE STRING -DDEVEL"Flags used by the C compiler during regular development builds.")
 set(CMAKE_C_FLAGS_STRICT
     "-Wall -O3 -Werror -Wno-error=unused-private-field"
     CACHE STRING "Flags used by the C compiler during strict jenkins builds.")
@@ -829,7 +829,7 @@ endif(QUDA_VERBOSE_BUILD)
 set(CMAKE_CUDA_DISABLE_XCOMPILER_WARNINGS
     "-Wno-unknown-pragmas,-Wno-unused-function,-Wno-unused-local-typedef,-Wno-unused-private-field")
 set(CMAKE_CUDA_FLAGS_DEVEL
-    "${QUDA_NVCC_FLAGS} -lineinfo -g -O3 -Xcompiler ${CMAKE_CUDA_DISABLE_XCOMPILER_WARNINGS}"
+    "${QUDA_NVCC_FLAGS} -lineinfo -DDEVEL -g -O3 -Xcompiler ${CMAKE_CUDA_DISABLE_XCOMPILER_WARNINGS}"
     CACHE STRING "Flags used by the CUDA compiler during regular development builds.")
 set(CMAKE_CUDA_FLAGS_STRICT
     "${CMAKE_CUDA_FLAGS_DEVEL}"

--- a/include/clover_field_order.h
+++ b/include/clover_field_order.h
@@ -11,11 +11,11 @@
 #include <convert.h>
 #include <clover_field.h>
 #include <complex_quda.h>
-#include <thrust_helper.cuh>
 #include <quda_matrix.h>
 #include <color_spinor.h>
 #include <trove_helper.cuh>
 #include <texture_helper.cuh>
+#include <transform_reduce.h>
 
 namespace quda {
 
@@ -178,7 +178,7 @@ namespace quda {
       }
 
       template<typename helper, typename reducer>
-        __host__ double transform_reduce(QudaFieldLocation location, helper h, reducer r, double i) const
+        __host__ double transform_reduce(QudaFieldLocation location, helper h, double i, reducer r) const
       {
         return 0.0;
       }
@@ -223,17 +223,10 @@ namespace quda {
       }
 
       template<typename helper, typename reducer>
-        __host__ double transform_reduce(QudaFieldLocation location, helper h, reducer r, double init) const {
-        double result = init;
-        if (location == QUDA_CUDA_FIELD_LOCATION) {
-          thrust_allocator alloc;
-          thrust::device_ptr<complex<Float> > ptr(reinterpret_cast<complex<Float>*>(a));
-          result = thrust::transform_reduce(thrust::cuda::par(alloc), ptr, ptr+offset_cb, h, result, r);
-        } else {
-          // just use offset_cb, since factor of two from parity is equivalent to complexity
-          complex<Float> *ptr = reinterpret_cast<complex<Float>*>(a);
-          result = thrust::transform_reduce(thrust::seq, ptr, ptr+offset_cb, h, result, r);
-        }
+        __host__ double transform_reduce(QudaFieldLocation location, helper h, double init, reducer r) const
+      {
+        // just use offset_cb, since factor of two from parity is equivalent to complexity
+        double result = ::quda::transform_reduce(location, reinterpret_cast<complex<Float>*>(a), offset_cb, h, init, r);
         return 2.0 * result; // factor of two is normalization
       }
 
@@ -288,17 +281,10 @@ namespace quda {
       }
 
       template<typename helper, typename reducer>
-        __host__ double transform_reduce(QudaFieldLocation location, helper h, reducer r, double init) const {
-        double result = init;
-        if (location == QUDA_CUDA_FIELD_LOCATION) {
-          thrust_allocator alloc;
-          thrust::device_ptr<complex<Float> > ptr(reinterpret_cast<complex<Float>*>(a));
-          result = thrust::transform_reduce(thrust::cuda::par(alloc), ptr, ptr+offset_cb, h, result, r);
-        } else {
-          // just use offset_cb, since factor of two from parity is equivalent to complexity
-          complex<Float> *ptr = reinterpret_cast<complex<Float>*>(a);
-          result = thrust::transform_reduce(thrust::seq, ptr, ptr+offset_cb, h, result, r);
-        }
+        __host__ double transform_reduce(QudaFieldLocation location, helper h, double init, reducer r) const
+      {
+        // just use offset_cb, since factor of two from parity is equivalent to complexity
+        double result = ::quda::transform_reduce(location, reinterpret_cast<complex<Float>*>(a), offset_cb, h, init, r);
         return 2.0 * result; // factor of two is normalization
       }
 
@@ -343,7 +329,7 @@ namespace quda {
       }
 
       template <typename helper, typename reducer>
-      __host__ double transform_reduce(QudaFieldLocation location, helper h, reducer r, double init) const
+        __host__ double transform_reduce(QudaFieldLocation location, helper h, double init, reducer r) const
       {
         errorQuda("Not implemented");
 	return 0.0;
@@ -482,8 +468,7 @@ namespace quda {
 	 * @return L1 norm
 	 */
 	__host__ double norm1(int dim=-1, bool global=true) const {
-          double nrm1 = accessor.transform_reduce(location, abs_<double,Float>(),
-                                                  thrust::plus<double>(), 0.0);
+          double nrm1 = accessor.transform_reduce(location, abs_<double,Float>(), 0.0, plus<double>());
 	  if (global) comm_allreduce(&nrm1);
 	  return nrm1;
 	}
@@ -494,8 +479,7 @@ namespace quda {
 	 * @return L1 norm
 	 */
 	__host__ double norm2(int dim=-1, bool global=true) const {
-          double nrm2 = accessor.transform_reduce(location, square_<double,Float>(),
-                                                  thrust::plus<double>(), 0.0);
+          double nrm2 = accessor.transform_reduce(location, square_<double,Float>(), 0.0, plus<double>());
 	  if (global) comm_allreduce(&nrm2);
 	  return nrm2;
 	}
@@ -506,8 +490,7 @@ namespace quda {
 	 * @return Linfinity norm
 	 */
 	__host__ double abs_max(int dim=-1, bool global=true) const {
-	  double absmax = accessor.transform_reduce(location, abs_<Float,Float>(),
-                                                    thrust::maximum<Float>(), 0.0);
+	  double absmax = accessor.transform_reduce(location, abs_<Float,Float>(), 0.0, maximum<Float>());
 	  if (global) comm_allreduce_max(&absmax);
 	  return absmax;
 	}
@@ -519,7 +502,7 @@ namespace quda {
 	 */
 	__host__ double abs_min(int dim=-1, bool global=true) const {
 	  double absmax = accessor.transform_reduce(location, abs_<Float,Float>(),
-                                                    thrust::minimum<Float>(), std::numeric_limits<double>::max());
+                                                    std::numeric_limits<double>::max(), minimum<Float>());
 	  if (global) comm_allreduce_min(&absmax);
 	  return absmax;
 	}

--- a/include/clover_field_order.h
+++ b/include/clover_field_order.h
@@ -177,8 +177,8 @@ namespace quda {
 	return dummy;
       }
 
-      template<typename helper, typename reducer>
-        __host__ double transform_reduce(QudaFieldLocation location, helper h, double i, reducer r) const
+      template <typename helper, typename reducer>
+      __host__ double transform_reduce(QudaFieldLocation location, helper h, double i, reducer r) const
       {
         return 0.0;
       }
@@ -222,14 +222,13 @@ namespace quda {
 
       }
 
-      template<typename helper, typename reducer>
-        __host__ double transform_reduce(QudaFieldLocation location, helper h, double init, reducer r) const
+      template <typename helper, typename reducer>
+      __host__ double transform_reduce(QudaFieldLocation location, helper h, double init, reducer r) const
       {
         // just use offset_cb, since factor of two from parity is equivalent to complexity
-        double result = ::quda::transform_reduce(location, reinterpret_cast<complex<Float>*>(a), offset_cb, h, init, r);
+        double result = ::quda::transform_reduce(location, reinterpret_cast<complex<Float> *>(a), offset_cb, h, init, r);
         return 2.0 * result; // factor of two is normalization
       }
-
     };
 
     template<int N>
@@ -280,14 +279,13 @@ namespace quda {
 
       }
 
-      template<typename helper, typename reducer>
-        __host__ double transform_reduce(QudaFieldLocation location, helper h, double init, reducer r) const
+      template <typename helper, typename reducer>
+      __host__ double transform_reduce(QudaFieldLocation location, helper h, double init, reducer r) const
       {
         // just use offset_cb, since factor of two from parity is equivalent to complexity
-        double result = ::quda::transform_reduce(location, reinterpret_cast<complex<Float>*>(a), offset_cb, h, init, r);
+        double result = ::quda::transform_reduce(location, reinterpret_cast<complex<Float> *>(a), offset_cb, h, init, r);
         return 2.0 * result; // factor of two is normalization
       }
-
     };
 
     template<typename Float, int nColor, int nSpin> 
@@ -329,7 +327,7 @@ namespace quda {
       }
 
       template <typename helper, typename reducer>
-        __host__ double transform_reduce(QudaFieldLocation location, helper h, double init, reducer r) const
+      __host__ double transform_reduce(QudaFieldLocation location, helper h, double init, reducer r) const
       {
         errorQuda("Not implemented");
 	return 0.0;
@@ -468,8 +466,8 @@ namespace quda {
 	 * @return L1 norm
 	 */
 	__host__ double norm1(int dim=-1, bool global=true) const {
-          double nrm1 = accessor.transform_reduce(location, abs_<double,Float>(), 0.0, plus<double>());
-	  if (global) comm_allreduce(&nrm1);
+          double nrm1 = accessor.transform_reduce(location, abs_<double, Float>(), 0.0, plus<double>());
+          if (global) comm_allreduce(&nrm1);
 	  return nrm1;
 	}
 
@@ -479,8 +477,8 @@ namespace quda {
 	 * @return L1 norm
 	 */
 	__host__ double norm2(int dim=-1, bool global=true) const {
-          double nrm2 = accessor.transform_reduce(location, square_<double,Float>(), 0.0, plus<double>());
-	  if (global) comm_allreduce(&nrm2);
+          double nrm2 = accessor.transform_reduce(location, square_<double, Float>(), 0.0, plus<double>());
+          if (global) comm_allreduce(&nrm2);
 	  return nrm2;
 	}
 
@@ -490,8 +488,8 @@ namespace quda {
 	 * @return Linfinity norm
 	 */
 	__host__ double abs_max(int dim=-1, bool global=true) const {
-	  double absmax = accessor.transform_reduce(location, abs_<Float,Float>(), 0.0, maximum<Float>());
-	  if (global) comm_allreduce_max(&absmax);
+          double absmax = accessor.transform_reduce(location, abs_<Float, Float>(), 0.0, maximum<Float>());
+          if (global) comm_allreduce_max(&absmax);
 	  return absmax;
 	}
 
@@ -501,9 +499,9 @@ namespace quda {
 	 * @return Minimum norm
 	 */
 	__host__ double abs_min(int dim=-1, bool global=true) const {
-	  double absmax = accessor.transform_reduce(location, abs_<Float,Float>(),
-                                                    std::numeric_limits<double>::max(), minimum<Float>());
-	  if (global) comm_allreduce_min(&absmax);
+          double absmax = accessor.transform_reduce(location, abs_<Float, Float>(), std::numeric_limits<double>::max(),
+                                                    minimum<Float>());
+          if (global) comm_allreduce_min(&absmax);
 	  return absmax;
 	}
 

--- a/include/color_spinor_field_order.h
+++ b/include/color_spinor_field_order.h
@@ -18,10 +18,10 @@
 #include <complex_quda.h>
 #include <index_helper.cuh>
 #include <color_spinor.h>
-#include <thrust_helper.cuh>
 #include <color_spinor_field.h>
 #include <trove_helper.cuh>
 #include <texture_helper.cuh>
+#include <transform_reduce.h>
 
 namespace quda {
 
@@ -745,17 +745,10 @@ namespace quda {
        * @param[in] global Whether to do a global or process local norm2 reduction
        * @return L2 norm squared
       */
-      __host__ double norm2(bool global=true) const {
-        double nrm2 = 0;
-        if (location == QUDA_CUDA_FIELD_LOCATION) {
-          thrust_allocator alloc;
-          thrust::device_ptr<complex<storeFloat> > ptr(v);
-          nrm2 = thrust::transform_reduce(thrust::cuda::par(alloc), ptr, ptr+nParity*volumeCB*nSpin*nColor*nVec,
-          square_<double,storeFloat>(scale_inv), 0.0, thrust::plus<double>());
-        } else {
-          nrm2 = thrust::transform_reduce(thrust::seq, v, v+nParity*volumeCB*nSpin*nColor*nVec,
-          square_<double,storeFloat>(scale_inv), 0.0, thrust::plus<double>());
-        }
+      __host__ double norm2(bool global=true) const
+      {
+        double nrm2 = ::quda::transform_reduce(location, v, nParity*volumeCB*nSpin*nColor*nVec,
+                                               square_<double,storeFloat>(scale_inv), 0.0, plus<double>());
         if (global) comm_allreduce(&nrm2);
         return nrm2;
       }
@@ -765,18 +758,10 @@ namespace quda {
        * @param[in] global Whether to do a global or process local Linfinity reduction
        * @return Linfinity norm
       */
-      __host__ double abs_max(bool global=true) const {
-
-	double absmax = 0;
-	if (location == QUDA_CUDA_FIELD_LOCATION) {
-	  thrust_allocator alloc;
-	  thrust::device_ptr<complex<storeFloat> > ptr(v);
-	  absmax = thrust::transform_reduce(thrust::cuda::par(alloc), ptr, ptr+nParity*volumeCB*nSpin*nColor*nVec,
-					    abs_<double,storeFloat>(scale_inv), 0.0, thrust::maximum<double>());
-	} else {
-	  absmax = thrust::transform_reduce(thrust::seq, v, v+nParity*volumeCB*nSpin*nColor*nVec,
-					    abs_<double,storeFloat>(scale_inv), 0.0, thrust::maximum<double>());
-	}
+      __host__ double abs_max(bool global=true) const
+      {
+	double absmax = ::quda::transform_reduce(location, v, nParity*volumeCB*nSpin*nColor*nVec,
+                                                 abs_<double,storeFloat>(scale_inv), 0.0, maximum<double>());
 	if (global) comm_allreduce_max(&absmax);
 	return absmax;
       }

--- a/include/color_spinor_field_order.h
+++ b/include/color_spinor_field_order.h
@@ -745,10 +745,10 @@ namespace quda {
        * @param[in] global Whether to do a global or process local norm2 reduction
        * @return L2 norm squared
       */
-      __host__ double norm2(bool global=true) const
+      __host__ double norm2(bool global = true) const
       {
-        double nrm2 = ::quda::transform_reduce(location, v, nParity*volumeCB*nSpin*nColor*nVec,
-                                               square_<double,storeFloat>(scale_inv), 0.0, plus<double>());
+        double nrm2 = ::quda::transform_reduce(location, v, nParity * volumeCB * nSpin * nColor * nVec,
+                                               square_<double, storeFloat>(scale_inv), 0.0, plus<double>());
         if (global) comm_allreduce(&nrm2);
         return nrm2;
       }
@@ -758,11 +758,11 @@ namespace quda {
        * @param[in] global Whether to do a global or process local Linfinity reduction
        * @return Linfinity norm
       */
-      __host__ double abs_max(bool global=true) const
+      __host__ double abs_max(bool global = true) const
       {
-	double absmax = ::quda::transform_reduce(location, v, nParity*volumeCB*nSpin*nColor*nVec,
-                                                 abs_<double,storeFloat>(scale_inv), 0.0, maximum<double>());
-	if (global) comm_allreduce_max(&absmax);
+        double absmax = ::quda::transform_reduce(location, v, nParity * volumeCB * nSpin * nColor * nVec,
+                                                 abs_<double, storeFloat>(scale_inv), 0.0, maximum<double>());
+        if (global) comm_allreduce_max(&absmax);
 	return absmax;
       }
 

--- a/include/externals/jitify.hpp
+++ b/include/externals/jitify.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2017-2019, NVIDIA CORPORATION. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -42,7 +42,7 @@
   --------------------------------------
   Embedding source files into executable
   --------------------------------------
-  g++  ... -ldl -rdynamic
+  g++  ... -ldl -rdynamic -DJITIFY_ENABLE_EMBEDDED_FILES=1
   -Wl,-b,binary,my_kernel.cu,include/my_header.cuh,-b,default nvcc ... -ldl
   -Xcompiler "-rdynamic
   -Wl\,-b\,binary\,my_kernel.cu\,include/my_header.cuh\,-b\,default"
@@ -85,9 +85,12 @@
 #define JITIFY_THREAD_SAFE 1
 #endif
 
+#if JITIFY_ENABLE_EMBEDDED_FILES
 #include <dlfcn.h>
+#endif
 #include <stdint.h>
 #include <algorithm>
+#include <cctype>
 #include <cstring>  // For strtok_r etc.
 #include <deque>
 #include <fstream>
@@ -99,26 +102,11 @@
 #include <stdexcept>
 #include <string>
 #include <typeinfo>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 #if JITIFY_THREAD_SAFE
 #include <mutex>
-#endif
-#if __cplusplus >= 201103L
-#define JITIFY_UNIQUE_PTR std::unique_ptr
-#define JITIFY_DEFINE_AUTO_PTR_COPY_WAR(cls)
-#else
-#define JITIFY_UNIQUE_PTR std::auto_ptr
-template <class C>
-class RefWrapper {
-  C* _this;
-
- public:
-  RefWrapper(C* this_) : _this(this_) {}
-  C& ref() { return *_this; }
-};
-#define JITIFY_DEFINE_AUTO_PTR_COPY_WAR(cls)               \
-  cls(RefWrapper<cls> other) : _impl(other.ref()._impl) {} \
-  operator RefWrapper<cls>() { return this; }
 #endif
 
 #include <cuda.h>
@@ -127,6 +115,31 @@ class RefWrapper {
 #define NVRTC_GET_TYPE_NAME 1
 #endif
 #include <nvrtc.h>
+
+// For use by get_current_executable_path().
+#ifdef __linux__
+#include <linux/limits.h>  // For PATH_MAX
+
+#include <cstdlib>  // For realpath
+#define JITIFY_PATH_MAX PATH_MAX
+#elif defined(_WIN32) || defined(_WIN64)
+#include <windows.h>
+#define JITIFY_PATH_MAX MAX_PATH
+#else
+#error "Unsupported platform"
+#endif
+
+#if defined(_WIN32) || defined(_WIN64)
+// WAR for strtok_r being called strtok_s on Windows
+#pragma push_macro("strtok_r")
+#undef strtok_r
+#define strtok_r strtok_s
+// WAR for min and max possibly being macros defined by windows.h
+#pragma push_macro("min")
+#pragma push_macro("max")
+#undef min
+#undef max
+#endif
 
 #ifndef JITIFY_PRINT_LOG
 #define JITIFY_PRINT_LOG 1
@@ -137,18 +150,22 @@ class RefWrapper {
 #define JITIFY_PRINT_SOURCE 1
 #define JITIFY_PRINT_LOG 1
 #define JITIFY_PRINT_PTX 1
+#define JITIFY_PRINT_LINKER_LOG 1
 #define JITIFY_PRINT_LAUNCH 1
+#define JITIFY_PRINT_HEADER_PATHS 1
 #endif
 
+#if JITIFY_ENABLE_EMBEDDED_FILES
 #define JITIFY_FORCE_UNDEFINED_SYMBOL(x) void* x##_forced = (void*)&x
 /*! Include a source file that has been embedded into the executable using the
  *    GCC linker.
  * \param name The name of the source file (<b>not</b> as a string), which must
  * be sanitized by replacing non-alpha-numeric characters with underscores.
  * E.g., \code{.cpp}JITIFY_INCLUDE_EMBEDDED_FILE(my_header_h)\endcode will
- * include the embedded file "my_header.h". \note Files declared with this macro
- * can be referenced using their original (unsanitized) filenames when creating
- * a \p jitify::Program instance.
+ * include the embedded file "my_header.h".
+ * \note Files declared with this macro can be referenced using
+ * their original (unsanitized) filenames when creating a \p
+ * jitify::Program instance.
  */
 #define JITIFY_INCLUDE_EMBEDDED_FILE(name)                                \
   extern "C" uint8_t _jitify_binary_##name##_start[] asm("_binary_" #name \
@@ -157,6 +174,7 @@ class RefWrapper {
                                                        "_end");           \
   JITIFY_FORCE_UNDEFINED_SYMBOL(_jitify_binary_##name##_start);           \
   JITIFY_FORCE_UNDEFINED_SYMBOL(_jitify_binary_##name##_end)
+#endif  // JITIFY_ENABLE_EMBEDDED_FILES
 
 /*! Jitify library namespace
  */
@@ -209,7 +227,9 @@ class ObjectCache {
     _capacity = capacity;
     this->discard_old();
   }
-  inline bool contains(const key_type& k) const { return _objects.count(k); }
+  inline bool contains(const key_type& k) const {
+    return (bool)_objects.count(k);
+  }
   inline void touch(const key_type& k) {
     if (!this->contains(k)) {
       throw std::runtime_error("Key not found in cache");
@@ -237,7 +257,11 @@ class ObjectCache {
   template <typename... Args>
   inline value_type& emplace(const key_type& k, Args&&... args) {
     this->discard_old(1);
-    auto iter = _objects.emplace(k, value_type{args...}).first;
+    // Note: Use of piecewise_construct allows non-movable non-copyable types
+    auto iter = _objects
+                    .emplace(std::piecewise_construct, std::forward_as_tuple(k),
+                             std::forward_as_tuple(args...))
+                    .first;
     _ranked_keys.push_front(iter->first);
     return iter->second;
   }
@@ -256,10 +280,8 @@ class vector : public std::vector<T> {
   vector(std::vector<T> const& vals) : super_type(vals) {}
   template <int N>
   vector(T const (&vals)[N]) : super_type(vals, vals + N) {}
-#if defined __cplusplus && __cplusplus >= 201103L
   vector(std::vector<T>&& vals) : super_type(vals) {}
   vector(std::initializer_list<T> vals) : super_type(vals) {}
-#endif
 };
 
 // Helper functions for parsing/manipulating source code
@@ -278,6 +300,7 @@ inline std::string sanitize_filename(std::string name) {
   return replace_characters(name, "/\\.-: ?%*|\"<>", '_');
 }
 
+#if JITIFY_ENABLE_EMBEDDED_FILES
 class EmbeddedData {
   void* _app;
   EmbeddedData(EmbeddedData const&);
@@ -310,6 +333,7 @@ class EmbeddedData {
   }
   const uint8_t* end(std::string key) const { return (*this)[key + "_end"]; }
 };
+#endif  // JITIFY_ENABLE_EMBEDDED_FILES
 
 inline bool is_tokenchar(char c) {
   return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
@@ -360,6 +384,41 @@ inline std::string path_join(std::string p1, std::string p2) {
   }
   return p1 + p2;
 }
+// Elides "/." and "/.." tokens from path.
+inline std::string path_simplify(const std::string& path) {
+  std::vector<std::string> dirs;
+  std::string cur_dir;
+  bool after_slash = false;
+  for (int i = 0; i < (int)path.size(); ++i) {
+    if (path[i] == '/') {
+      if (after_slash) continue;  // Ignore repeat slashes
+      after_slash = true;
+      if (cur_dir == ".." && !dirs.empty() && dirs.back() != "..") {
+        if (dirs.size() == 1 && dirs.front().empty()) {
+          throw std::runtime_error(
+              "Invalid path: back-traversals exceed depth of absolute path");
+        }
+        dirs.pop_back();
+      } else if (cur_dir != ".") {  // Ignore /./
+        dirs.push_back(cur_dir);
+      }
+      cur_dir.clear();
+    } else {
+      after_slash = false;
+      cur_dir.push_back(path[i]);
+    }
+  }
+  if (!after_slash) {
+    dirs.push_back(cur_dir);
+  }
+  std::stringstream ss;
+  for (int i = 0; i < (int)dirs.size() - 1; ++i) {
+    ss << dirs[i] << "/";
+  }
+  if (!dirs.empty()) ss << dirs.back();
+  if (after_slash) ss << "/";
+  return ss.str();
+}
 inline unsigned long long hash_larson64(const char* s,
                                         unsigned long long seed = 0) {
   unsigned long long hash = seed;
@@ -378,27 +437,46 @@ inline bool extract_include_info_from_compile_error(std::string log,
                                                     std::string& name,
                                                     std::string& parent,
                                                     int& line_num) {
-  static const std::string pattern = "cannot open source file \"";
-  size_t beg = log.find(pattern);
-  if (beg == std::string::npos) {
-    return false;
-  }
-  beg += pattern.size();
-  size_t end = log.find("\"", beg);
-  name = log.substr(beg, end - beg);
+  static const std::vector<std::string> pattern = {
+      "could not open source file \"", "cannot open source file \""};
 
-  size_t line_beg = log.rfind("\n", beg);
-  if (line_beg == std::string::npos) {
-    line_beg = 0;
-  } else {
-    line_beg += 1;
+  for (auto& p : pattern) {
+    size_t beg = log.find(p);
+    if (beg != std::string::npos) {
+      beg += p.size();
+      size_t end = log.find("\"", beg);
+      name = log.substr(beg, end - beg);
+
+      size_t line_beg = log.rfind("\n", beg);
+      if (line_beg == std::string::npos) {
+        line_beg = 0;
+      } else {
+        line_beg += 1;
+      }
+
+      size_t split = log.find("(", line_beg);
+      parent = log.substr(line_beg, split - line_beg);
+      line_num =
+          atoi(log.substr(split + 1, log.find(")", split + 1) - (split + 1))
+                   .c_str());
+
+      return true;
+    }
   }
 
-  size_t split = log.find("(", line_beg);
-  parent = log.substr(line_beg, split - line_beg);
-  line_num = atoi(
-      log.substr(split + 1, log.find(")", split + 1) - (split + 1)).c_str());
-  return true;
+  return false;
+}
+
+inline bool is_include_directive_with_quotes(const std::string& source,
+                                             int line_num) {
+  // TODO: Check each find() for failure.
+  size_t beg = 0;
+  for (int i = 1; i < line_num; ++i) {
+    beg = source.find("\n", beg) + 1;
+  }
+  beg = source.find("include", beg) + 7;
+  beg = source.find_first_of("\"<", beg);
+  return source[beg] == '"';
 }
 
 inline std::string comment_out_code_line(int line_num, std::string source) {
@@ -443,7 +521,7 @@ inline std::vector<std::string> split_string(std::string str,
   std::vector<char> v_str(str.c_str(), str.c_str() + (str.size() + 1));
   char* c_str = v_str.data();
   char* saveptr = c_str;
-  char* token;
+  char* token = nullptr;
   for (long i = 0; i != maxsplit; ++i) {
     token = ::strtok_r(c_str, delims.c_str(), &saveptr);
     c_str = 0;
@@ -464,11 +542,15 @@ inline std::vector<std::string> split_string(std::string str,
   return results;
 }
 
+static const std::map<std::string, std::string>& get_jitsafe_headers_map();
+
 inline bool load_source(
     std::string filename, std::map<std::string, std::string>& sources,
     std::string current_dir = "",
     std::vector<std::string> include_paths = std::vector<std::string>(),
-    file_callback_type file_callback = 0, bool remove_missing_headers = true) {
+    file_callback_type file_callback = 0,
+    std::map<std::string, std::string>* fullpaths = nullptr,
+    bool search_current_dir = true) {
   std::istream* source_stream = 0;
   std::stringstream string_stream;
   std::ifstream file_stream;
@@ -489,6 +571,7 @@ inline bool load_source(
     // Try loading from callback
     if (!file_callback ||
         !(source_stream = file_callback(fullpath, string_stream))) {
+#if JITIFY_ENABLE_EMBEDDED_FILES
       // Try loading as embedded file
       EmbeddedData embedded;
       std::string source;
@@ -496,25 +579,46 @@ inline bool load_source(
         source.assign(embedded.begin(fullpath), embedded.end(fullpath));
         string_stream << source;
         source_stream = &string_stream;
-      } catch (std::runtime_error) {
-        // Finally, try loading from filesystem
-        file_stream.open(fullpath.c_str());
-        if (!file_stream) {
-          bool found_file = false;
+      } catch (std::runtime_error const&)
+#endif  // JITIFY_ENABLE_EMBEDDED_FILES
+      {
+        // Try loading from filesystem
+        bool found_file = false;
+        if (search_current_dir) {
+          file_stream.open(fullpath.c_str());
+          if (file_stream) {
+            source_stream = &file_stream;
+            found_file = true;
+          }
+        }
+        // Search include directories
+        if (!found_file) {
           for (int i = 0; i < (int)include_paths.size(); ++i) {
             fullpath = path_join(include_paths[i], filename);
             file_stream.open(fullpath.c_str());
             if (file_stream) {
+              source_stream = &file_stream;
               found_file = true;
               break;
             }
           }
           if (!found_file) {
-            return false;
+            // Try loading from builtin headers
+            fullpath = path_join("__jitify_builtin", filename);
+            auto it = get_jitsafe_headers_map().find(filename);
+            if (it != get_jitsafe_headers_map().end()) {
+              string_stream << it->second;
+              source_stream = &string_stream;
+            } else {
+              return false;
+            }
           }
         }
-        source_stream = &file_stream;
       }
+    }
+    if (fullpaths) {
+      // Record the full file path corresponding to this include name.
+      (*fullpaths)[filename] = path_simplify(fullpath);
     }
   }
   sources[filename] = std::string();
@@ -612,10 +716,7 @@ namespace reflection {
  */
 template <typename T, T VALUE_>
 struct NonType {
-#if defined __cplusplus && __cplusplus >= 201103L
-  constexpr
-#endif
-      static T VALUE = VALUE_;
+  constexpr static T VALUE = VALUE_;
 };
 
 // Forward declaration
@@ -664,59 +765,73 @@ inline std::string value_string<bool>(const bool& x) {
 }
 
 //#if CUDA_VERSION < 8000
-#ifdef _WIN32
-#include <DbgHelp.h>
-inline std::string demangle(const char* mangled_name) {
-  enum { BUFSIZE = 1024 };
-  char buf[BUFSIZE];
-  if (!UnDecorateSymbolName(mangled_name, buf, BUFSIZE, UNDNAME_COMPLETE)) {
-    return "";
-  }
-  return buf;
+#ifdef _MSC_VER  // MSVC compiler
+inline std::string demangle(const char* verbose_name) {
+  // Strips annotations from the verbose name returned by typeid(X).name()
+  std::string result = verbose_name;
+  result = jitify::detail::replace_token(result, "__ptr64", "");
+  result = jitify::detail::replace_token(result, "__cdecl", "");
+  result = jitify::detail::replace_token(result, "class", "");
+  result = jitify::detail::replace_token(result, "struct", "");
+  return result;
 }
-#else  // not Windows
+#else  // not MSVC
 #include <cxxabi.h>
 inline std::string demangle(const char* mangled_name) {
-  size_t bufsize = 1024;
-  char* buf = (char*)malloc(bufsize);
+  size_t bufsize = 0;
+  char* buf = nullptr;
   std::string demangled_name;
   int status;
-  char *demangled_ptr = abi::__cxa_demangle(mangled_name, buf, &bufsize, &status);
+  auto demangled_ptr = std::unique_ptr<char, decltype(free)*>(
+      abi::__cxa_demangle(mangled_name, buf, &bufsize, &status), free);
   if (status == 0) {
-    demangled_name = demangled_ptr; // all worked as expected
+    demangled_name = demangled_ptr.get();  // all worked as expected
   } else if (status == -2) {
     demangled_name = mangled_name;  // we interpret this as plain C name
   } else if (status == -1) {
-    throw std::runtime_error(std::string("memory allocation failure in __cxa_demangle"));
+    throw std::runtime_error(
+        std::string("memory allocation failure in __cxa_demangle"));
   } else if (status == -3) {
     throw std::runtime_error(std::string("invalid argument to __cxa_demangle"));
   }
-  free(buf);
   return demangled_name;
 }
-#endif
+#endif  // not MSVC
 //#endif // CUDA_VERSION < 8000
 
 template <typename T>
 struct type_reflection {
   inline static std::string name() {
     //#if CUDA_VERSION < 8000
-    // const char* mangled_name = typeid(T).name();
     // WAR for typeid discarding cv qualifiers on value-types
-    //   (crops off 'P' from beginning of mangled pointer type).
-    const char* mangled_name = typeid(T*).name() + 1;
-    return demangle(mangled_name);
+    // We use a pointer type to maintain cv qualifiers, then strip out the '*'
+    std::string no_cv_name = demangle(typeid(T).name());
+    std::string ptr_name = demangle(typeid(T*).name());
+    // Find the right '*' by diffing the type name and ptr name
+    // Note that the '*' will also be prefixed with the cv qualifiers
+    size_t diff_begin =
+        std::mismatch(no_cv_name.begin(), no_cv_name.end(), ptr_name.begin())
+            .first -
+        no_cv_name.begin();
+    size_t star_begin = ptr_name.find("*", diff_begin);
+    if (star_begin == std::string::npos) {
+      throw std::runtime_error("Type reflection failed: " + ptr_name);
+    }
+    std::string name =
+        ptr_name.substr(0, star_begin) + ptr_name.substr(star_begin + 1);
+    return name;
     //#else
-    // std::string ret;
-    // nvrtcResult status = nvrtcGetTypeName<T>(&ret);
-    // if ( status != NVRTC_SUCCESS ) {
-    //  throw std::runtime_error(std::string("nvrtcGetTypeName failed:") +
-    //                           nvrtcGetErrorString(status));
-    //}
-    // return ret;
+    //         std::string ret;
+    //         nvrtcResult status = nvrtcGetTypeName<T>(&ret);
+    //         if( status != NVRTC_SUCCESS ) {
+    //                 throw std::runtime_error(std::string("nvrtcGetTypeName
+    // failed:
+    //")+ nvrtcGetErrorString(status));
+    //         }
+    //         return ret;
     //#endif
   }
-};
+};  // namespace detail
 template <typename T, T VALUE>
 struct type_reflection<NonType<T, VALUE> > {
   inline static std::string name() {
@@ -741,7 +856,8 @@ struct Instance {
 };
 
 /*! Create an Instance object from which we can extract the value's run-time
- * type. \param value The const value to be captured.
+ * type.
+ *  \param value The const value to be captured.
  */
 template <typename T>
 inline Instance<T const> instance_of(T const& value) {
@@ -777,9 +893,9 @@ inline std::string reflect(T const& value) {
 /*! Generate a code-string for an integer non-type template argument.
  *  \code{.cpp}reflect<7>() --> "(int64_t)7"\endcode
  */
-template <long long N>
+template <int64_t N>
 inline std::string reflect() {
-  return reflect<NonType<int, N> >();
+  return reflect<NonType<int64_t, N> >();
 }
 // Non-type template arg reflection (explicit type)
 // E.g., reflect<int,7>() -> "(int)7"
@@ -829,13 +945,11 @@ inline Type<T const> type_of(T const& value) {
   return Type<T const>();
 }
 
-#if __cplusplus >= 201103L
 // Multiple value reflections one call, returning list of strings
 template <typename... Args>
 inline std::vector<std::string> reflect_all(Args... args) {
   return {reflect(args)...};
 }
-#endif  // __cplusplus >= 201103L
 
 inline std::string reflect_list(jitify::detail::vector<std::string> const& args,
                                 std::string opener = "",
@@ -857,14 +971,12 @@ inline std::string reflect_template(
   // Note: The space in " >" is a WAR to avoid '>>' appearing
   return reflect_list(args, "<", " >");
 }
-#if __cplusplus >= 201103L
 // TODO: See if can make this evaluate completely at compile-time
 template <typename... Ts>
 inline std::string reflect_template() {
   return reflect_template({reflect<Ts>()...});
   // return reflect_template<sizeof...(Ts)>({reflect<Ts>()...});
 }
-#endif
 
 }  // namespace reflection
 
@@ -872,14 +984,102 @@ inline std::string reflect_template() {
 
 namespace detail {
 
+// Demangles nested variable names using the PTX name mangling scheme
+// (which follows the Itanium64 ABI). E.g., _ZN1a3Foo2bcE -> a::Foo::bc.
+inline std::string demangle_ptx_variable_name(const char* name) {
+  std::stringstream ss;
+  const char* c = name;
+  if (*c++ != '_' || *c++ != 'Z') return name;  // Non-mangled name
+  if (*c++ != 'N') return "";  // Not a nested name, unsupported
+  while (true) {
+    // Parse identifier length.
+    int n = 0;
+    while (std::isdigit(*c)) {
+      n = n * 10 + (*c - '0');
+      c++;
+    }
+    if (!n) return "";  // Invalid or unsupported mangled name
+    // Parse identifier.
+    const char* c0 = c;
+    while (n-- && *c) c++;
+    if (!*c) return "";  // Mangled name is truncated
+    std::string id(c0, c);
+    // Identifiers starting with "_GLOBAL" are anonymous namespaces.
+    ss << (id.substr(0, 7) == "_GLOBAL" ? "(anonymous namespace)" : id);
+    // Nested name specifiers end with 'E'.
+    if (*c == 'E') break;
+    // There are more identifiers to come, add join token.
+    ss << "::";
+  }
+  return ss.str();
+}
+
+static const char* get_current_executable_path() {
+  static const char* path = []() -> const char* {
+    static char buffer[JITIFY_PATH_MAX] = {};
+#ifdef __linux__
+    if (!::realpath("/proc/self/exe", buffer)) return nullptr;
+#elif defined(_WIN32) || defined(_WIN64)
+    if (!GetModuleFileNameA(nullptr, buffer, JITIFY_PATH_MAX)) return nullptr;
+#endif
+    return buffer;
+  }();
+  return path;
+}
+
+inline bool endswith(const std::string& str, const std::string& suffix) {
+  return str.size() >= suffix.size() &&
+         str.substr(str.size() - suffix.size()) == suffix;
+}
+
+// Infers the JIT input type from the filename suffix. If no known suffix is
+// present, the filename is assumed to refer to a library, and the associated
+// suffix (and possibly prefix) is automatically added to the filename.
+inline CUjitInputType get_cuda_jit_input_type(std::string* filename) {
+  if (endswith(*filename, ".ptx")) {
+    return CU_JIT_INPUT_PTX;
+  } else if (endswith(*filename, ".cubin")) {
+    return CU_JIT_INPUT_CUBIN;
+  } else if (endswith(*filename, ".fatbin")) {
+    return CU_JIT_INPUT_FATBINARY;
+  } else if (endswith(*filename,
+#if defined _WIN32 || defined _WIN64
+                      ".obj"
+#else  // Linux
+                      ".o"
+#endif
+                      )) {
+    return CU_JIT_INPUT_OBJECT;
+  } else {  // Assume library
+#if defined _WIN32 || defined _WIN64
+    if (!endswith(*filename, ".lib")) {
+      *filename += ".lib";
+    }
+#else  // Linux
+    if (!endswith(*filename, ".a")) {
+      *filename = "lib" + *filename + ".a";
+    }
+#endif
+    return CU_JIT_INPUT_LIBRARY;
+  }
+}
+
 class CUDAKernel {
+  std::vector<std::string> _link_files;
+  std::vector<std::string> _link_paths;
   CUlinkState _link_state;
   CUmodule _module;
   CUfunction _kernel;
   std::string _func_name;
   std::string _ptx;
-  std::map<std::string,std::string> _constant;
+  std::map<std::string, std::string> _global_map;
   std::vector<CUjit_option> _opts;
+  std::vector<void*> _optvals;
+#ifdef JITIFY_PRINT_LINKER_LOG
+  static const unsigned int _log_size = 8192;
+  char _error_log[_log_size];
+  char _info_log[_log_size];
+#endif
 
   inline void cuda_safe_call(CUresult res) const {
     if (res != CUDA_SUCCESS) {
@@ -889,47 +1089,80 @@ class CUDAKernel {
     }
   }
   inline void create_module(std::vector<std::string> link_files,
-                            std::vector<std::string> link_paths,
-                            void** optvals = 0) {
+                            std::vector<std::string> link_paths) {
+    CUresult result;
+#ifndef JITIFY_PRINT_LINKER_LOG
+    // WAR since linker log does not seem to be constructed using a single call
+    // to cuModuleLoadDataEx.
     if (link_files.empty()) {
-      cuda_safe_call(cuModuleLoadDataEx(&_module, _ptx.c_str(), _opts.size(),
-                                        _opts.data(), optvals));
-    } else {
-      cuda_safe_call(
-          cuLinkCreate(_opts.size(), _opts.data(), optvals, &_link_state));
+      result =
+          cuModuleLoadDataEx(&_module, _ptx.c_str(), (unsigned)_opts.size(),
+                             _opts.data(), _optvals.data());
+    } else
+#endif
+    {
+      cuda_safe_call(cuLinkCreate((unsigned)_opts.size(), _opts.data(),
+                                  _optvals.data(), &_link_state));
       cuda_safe_call(cuLinkAddData(_link_state, CU_JIT_INPUT_PTX,
                                    (void*)_ptx.c_str(), _ptx.size(),
                                    "jitified_source.ptx", 0, 0, 0));
       for (int i = 0; i < (int)link_files.size(); ++i) {
         std::string link_file = link_files[i];
-#if defined _WIN32 || defined _WIN64
-        link_file = link_file + ".lib";
-#else
-        link_file = "lib" + link_file + ".a";
-#endif
-        CUresult result = cuLinkAddFile(_link_state, CU_JIT_INPUT_LIBRARY,
+        CUjitInputType jit_input_type;
+        if (link_file == ".") {
+          // Special case for linking to current executable.
+          link_file = get_current_executable_path();
+          jit_input_type = CU_JIT_INPUT_OBJECT;
+        } else {
+          // Infer based on filename.
+          jit_input_type = get_cuda_jit_input_type(&link_file);
+        }
+        CUresult result = cuLinkAddFile(_link_state, jit_input_type,
                                         link_file.c_str(), 0, 0, 0);
         int path_num = 0;
         while (result == CUDA_ERROR_FILE_NOT_FOUND &&
                path_num < (int)link_paths.size()) {
           std::string filename = path_join(link_paths[path_num++], link_file);
-          result = cuLinkAddFile(_link_state, CU_JIT_INPUT_LIBRARY,
-                                 filename.c_str(), 0, 0, 0);
+          result = cuLinkAddFile(_link_state, jit_input_type, filename.c_str(),
+                                 0, 0, 0);
         }
-#if JITIFY_PRINT_LOG
+#if JITIFY_PRINT_LINKER_LOG
         if (result == CUDA_ERROR_FILE_NOT_FOUND) {
-          std::cout << "Error: Device library not found: " << link_file
+          std::cerr << "Linker error: Device library not found: " << link_file
                     << std::endl;
+        } else if (result != CUDA_SUCCESS) {
+          std::cerr << "Linker error: Failed to add file: " << link_file
+                    << std::endl;
+          std::cerr << _error_log << std::endl;
         }
 #endif
         cuda_safe_call(result);
       }
       size_t cubin_size;
       void* cubin;
-      cuda_safe_call(cuLinkComplete(_link_state, &cubin, &cubin_size));
-      cuda_safe_call(cuModuleLoadData(&_module, cubin));
+      result = cuLinkComplete(_link_state, &cubin, &cubin_size);
+      if (result == CUDA_SUCCESS) {
+        result = cuModuleLoadData(&_module, cubin);
+      }
     }
-    cuda_safe_call(cuModuleGetFunction(&_kernel, _module, _func_name.c_str()));
+#ifdef JITIFY_PRINT_LINKER_LOG
+    std::cout << "---------------------------------------" << std::endl;
+    std::cout << "--- Linker for "
+              << reflection::detail::demangle(_func_name.c_str()) << " ---"
+              << std::endl;
+    std::cout << "---------------------------------------" << std::endl;
+    std::cout << _info_log << std::endl;
+    std::cout << std::endl;
+    std::cout << _error_log << std::endl;
+    std::cout << "---------------------------------------" << std::endl;
+#endif
+    cuda_safe_call(result);
+    // Allow _func_name to be empty to support cases where we want to generate
+    // PTX containing extern symbol definitions but no kernels.
+    if (!_func_name.empty()) {
+      cuda_safe_call(
+          cuModuleGetFunction(&_kernel, _module, _func_name.c_str()));
+    }
   }
   inline void destroy_module() {
     if (_link_state) {
@@ -942,44 +1175,69 @@ class CUDAKernel {
     _module = 0;
   }
 
-  // create a map of constants in the ptx file mapping demangled to mangled name
-  inline void create_constant() {
+  // create a map of __constant__ and __device__ variables in the ptx file
+  // mapping demangled to mangled name
+  inline void create_global_variable_map() {
     size_t pos = 0;
     while (pos < _ptx.size()) {
-      pos = _ptx.find(".const .align", pos);
+      pos = std::min(_ptx.find(".const .align", pos),
+                     _ptx.find(".global .align", pos));
       if (pos == std::string::npos) break;
-      size_t end = _ptx.find(";", pos);
-      std::string line = _ptx.substr(pos,end-pos);
-      size_t constant_start = line.find_last_of(" ") + 1;
-      size_t constant_end = line.find_last_of("[");
-      std::string entry = line.substr(constant_start,constant_end-constant_start);
-
-      std::string key = reflection::detail::demangle(entry.c_str());
-
-      // C++ demangled names include the filename so remove manually
-      size_t filename_end = key.find_first_of("::");
-      if (filename_end != std::string::npos) key = key.substr( filename_end + 2);
-
-      _constant[key] = entry;
+      size_t end = _ptx.find_first_of(";=", pos);
+      if (_ptx[end] == '=') --end;
+      std::string line = _ptx.substr(pos, end - pos);
       pos = end;
+      size_t symbol_start = line.find_last_of(" ") + 1;
+      size_t symbol_end = line.find_last_of("[");
+      std::string entry = line.substr(symbol_start, symbol_end - symbol_start);
+      std::string key = detail::demangle_ptx_variable_name(entry.c_str());
+      // Skip unsupported mangled names. E.g., a static variable defined inside
+      // a function (such variables are not directly addressable from outside
+      // the function, so skipping them is the correct behavior).
+      if (key == "") continue;
+      _global_map[key] = entry;
     }
+  }
+
+  inline void set_linker_log() {
+#ifdef JITIFY_PRINT_LINKER_LOG
+    _opts.push_back(CU_JIT_INFO_LOG_BUFFER);
+    _optvals.push_back((void*)_info_log);
+    _opts.push_back(CU_JIT_INFO_LOG_BUFFER_SIZE_BYTES);
+    _optvals.push_back((void*)(long)_log_size);
+    _opts.push_back(CU_JIT_ERROR_LOG_BUFFER);
+    _optvals.push_back((void*)_error_log);
+    _opts.push_back(CU_JIT_ERROR_LOG_BUFFER_SIZE_BYTES);
+    _optvals.push_back((void*)(long)_log_size);
+    _opts.push_back(CU_JIT_LOG_VERBOSE);
+    _optvals.push_back((void*)1);
+#endif
   }
 
  public:
   inline CUDAKernel() : _link_state(0), _module(0), _kernel(0) {}
   inline CUDAKernel(const CUDAKernel& other) = delete;
   inline CUDAKernel& operator=(const CUDAKernel& other) = delete;
-  inline CUDAKernel(CUDAKernel&& other) = default;
+  inline CUDAKernel(CUDAKernel&& other) = delete;
+  inline CUDAKernel& operator=(CUDAKernel&& other) = delete;
   inline CUDAKernel(const char* func_name, const char* ptx,
                     std::vector<std::string> link_files,
                     std::vector<std::string> link_paths, unsigned int nopts = 0,
-                    CUjit_option* opts = 0, void** optvals = 0) {
-    _func_name = func_name;
-    _ptx = ptx;
-    _opts.assign(opts, opts + nopts);
-    this->create_module(link_files, link_paths, optvals);
-    this->create_constant();
+                    CUjit_option* opts = 0, void** optvals = 0)
+      : _link_files(link_files),
+        _link_paths(link_paths),
+        _link_state(0),
+        _module(0),
+        _kernel(0),
+        _func_name(func_name),
+        _ptx(ptx),
+        _opts(opts, opts + nopts),
+        _optvals(optvals, optvals + nopts) {
+    this->set_linker_log();
+    this->create_module(link_files, link_paths);
+    this->create_global_variable_map();
   }
+
   inline CUDAKernel& set(const char* func_name, const char* ptx,
                          std::vector<std::string> link_files,
                          std::vector<std::string> link_paths,
@@ -988,39 +1246,79 @@ class CUDAKernel {
     this->destroy_module();
     _func_name = func_name;
     _ptx = ptx;
+    _link_files = link_files;
+    _link_paths = link_paths;
     _opts.assign(opts, opts + nopts);
-    this->create_module(link_files, link_paths, optvals);
-    this->create_constant();
+    _optvals.assign(optvals, optvals + nopts);
+    this->set_linker_log();
+    this->create_module(link_files, link_paths);
+    this->create_global_variable_map();
     return *this;
   }
   inline ~CUDAKernel() { this->destroy_module(); }
   inline operator CUfunction() const { return _kernel; }
 
   inline CUresult launch(dim3 grid, dim3 block, unsigned int smem,
-                         CUstream stream, std::vector<void*> arg_ptrs) {
+                         CUstream stream, std::vector<void*> arg_ptrs) const {
     return cuLaunchKernel(_kernel, grid.x, grid.y, grid.z, block.x, block.y,
                           block.z, smem, stream, arg_ptrs.data(), NULL);
   }
 
-  inline CUdeviceptr get_constant_ptr(const char *name) const {
-    CUdeviceptr const_ptr = 0;
-    auto constant = _constant.find(name);
-    if (constant != _constant.end()) {
-      cuda_safe_call(cuModuleGetGlobal(&const_ptr, 0, _module, constant->second.c_str()));
+  inline CUdeviceptr get_global_ptr(const char* name,
+                                    size_t* size = nullptr) const {
+    CUdeviceptr global_ptr = 0;
+    auto global = _global_map.find(name);
+    if (global != _global_map.end()) {
+      cuda_safe_call(cuModuleGetGlobal(&global_ptr, size, _module,
+                                       global->second.c_str()));
     } else {
-      throw std::runtime_error(std::string("failed to look up constant ") + name);
+      throw std::runtime_error(std::string("failed to look up global ") + name);
     }
-    return const_ptr;
+    return global_ptr;
   }
 
+  template <typename T>
+  inline CUresult get_global_data(const char* name, T* data, size_t count,
+                                  CUstream stream = 0) const {
+    size_t size_bytes;
+    CUdeviceptr ptr = get_global_ptr(name, &size_bytes);
+    size_t given_size_bytes = count * sizeof(T);
+    if (given_size_bytes != size_bytes) {
+      throw std::runtime_error(
+          std::string("Value for global variable ") + name +
+          " has wrong size: got " + std::to_string(given_size_bytes) +
+          " bytes, expected " + std::to_string(size_bytes));
+    }
+    return cuMemcpyDtoH(data, ptr, size_bytes);
+  }
+
+  template <typename T>
+  inline CUresult set_global_data(const char* name, const T* data, size_t count,
+                                  CUstream stream = 0) const {
+    size_t size_bytes;
+    CUdeviceptr ptr = get_global_ptr(name, &size_bytes);
+    size_t given_size_bytes = count * sizeof(T);
+    if (given_size_bytes != size_bytes) {
+      throw std::runtime_error(
+          std::string("Value for global variable ") + name +
+          " has wrong size: got " + std::to_string(given_size_bytes) +
+          " bytes, expected " + std::to_string(size_bytes));
+    }
+    return cuMemcpyHtoD(ptr, data, size_bytes);
+  }
+
+  const std::string& function_name() const { return _func_name; }
+  const std::string& ptx() const { return _ptx; }
+  const std::vector<std::string>& link_files() const { return _link_files; }
+  const std::vector<std::string>& link_paths() const { return _link_paths; }
 };
 
 static const char* jitsafe_header_preinclude_h = R"(
-// WAR for Thrust (which appears to have forgotten to include this in result_of_adaptable_function.h
-#include <type_traits>
+//// WAR for Thrust (which appears to have forgotten to include this in result_of_adaptable_function.h
+//#include <type_traits>
 
-// WAR for Thrust (which appear to have forgotten to include this in error_code.h)
-#include <string>
+//// WAR for Thrust (which appear to have forgotten to include this in error_code.h)
+//#include <string>
 
 // WAR for Thrust (which only supports gnuc, clang or msvc)
 #define __GNUC__ 4
@@ -1159,14 +1457,20 @@ static const char* jitsafe_header_limits =
     "#pragma once\n"
     "#include <climits>\n"
     "\n"
-    "namespace __jitify_limits_ns {\n"
+    "namespace std {\n"
     "// TODO: Floating-point limits\n"
     "namespace __jitify_detail {\n"
     "template<class T, T Min, T Max, int Digits=-1>\n"
     "struct IntegerLimits {\n"
     "	static inline __host__ __device__ T min() { return Min; }\n"
     "	static inline __host__ __device__ T max() { return Max; }\n"
+    "#if __cplusplus >= 201103L\n"
+    "	static constexpr inline __host__ __device__ T lowest() noexcept {\n"
+    "		return Min;\n"
+    "	}\n"
+    "#endif  // __cplusplus >= 201103L\n"
     "	enum {\n"
+    "       is_specialized = true,\n"
     "		digits     = (Digits == -1) ? (int)(sizeof(T)*8 - (Min != 0)) "
     ": Digits,\n"
     "		digits10   = (digits * 30103) / 100000,\n"
@@ -1179,7 +1483,9 @@ static const char* jitsafe_header_limits =
     "	};\n"
     "};\n"
     "} // namespace detail\n"
-    "template<typename T> struct numeric_limits {};\n"
+    "template<typename T> struct numeric_limits {\n"
+    "    enum { is_specialized = false };\n"
+    "};\n"
     "template<> struct numeric_limits<bool>               : public "
     "__jitify_detail::IntegerLimits<bool,              false,    true,1> {};\n"
     "template<> struct numeric_limits<char>               : public "
@@ -1218,9 +1524,7 @@ static const char* jitsafe_header_limits =
     "{};\n"
     "//template<typename T> struct numeric_limits { static const bool "
     "is_signed = ((T)(-1)<0); };\n"
-    "} // namespace __jitify_limits_ns\n"
-    "namespace std { using namespace __jitify_limits_ns; }\n"
-    "using namespace __jitify_limits_ns;\n";
+    "} // namespace std\n";
 
 // TODO: This is highly incomplete
 static const char* jitsafe_header_type_traits = R"(
@@ -1290,9 +1594,6 @@ static const char* jitsafe_header_type_traits = R"(
     template<class> struct is_function : false_type { };
     template<class Ret, class... Args> struct is_function<Ret(Args...)> : true_type {}; //regular
     template<class Ret, class... Args> struct is_function<Ret(Args......)> : true_type {}; // variadic
-    #if __cplusplus >= 201402L
-    template< class T > inline constexpr bool is_function_v = is_function<T>::value;
-    #endif
 
     template<class> struct result_of;
     template<class F, typename... Args>
@@ -1424,11 +1725,32 @@ static const char* jitsafe_header_stddef_h =
     "#pragma once\n"
     "#include <climits>\n"
     "namespace __jitify_stddef_ns {\n"
-    //"enum { NULL = 0 };\n"
-    "typedef unsigned long size_t;\n"
-    "typedef   signed long ptrdiff_t;\n"
+    "#if __cplusplus >= 201103L\n"
+    "typedef decltype(nullptr) nullptr_t;\n"
+    "#if defined(_MSC_VER)\n"
+    "  typedef double max_align_t;\n"
+    "#elif defined(__APPLE__)\n"
+    "  typedef long double max_align_t;\n"
+    "#else\n"
+    "  // Define max_align_t to match the GCC definition.\n"
+    "  typedef struct {\n"
+    "    long long __jitify_max_align_nonce1\n"
+    "        __attribute__((__aligned__(__alignof__(long long))));\n"
+    "    long double __jitify_max_align_nonce2\n"
+    "        __attribute__((__aligned__(__alignof__(long double))));\n"
+    "  } max_align_t;\n"
+    "#endif\n"
+    "#endif  // __cplusplus >= 201103L\n"
+    "#if __cplusplus >= 201703L\n"
+    "enum class byte : unsigned char {};\n"
+    "#endif  // __cplusplus >= 201703L\n"
     "} // namespace __jitify_stddef_ns\n"
-    "namespace std { using namespace __jitify_stddef_ns; }\n"
+    "namespace std {\n"
+    "  // NVRTC provides built-in definitions of ::size_t and ::ptrdiff_t.\n"
+    "  using ::size_t;\n"
+    "  using ::ptrdiff_t;\n"
+    "  using namespace __jitify_stddef_ns;\n"
+    "} // namespace std\n"
     "using namespace __jitify_stddef_ns;\n";
 
 static const char* jitsafe_header_stdlib_h =
@@ -1479,8 +1801,10 @@ static const char* jitsafe_header_ostream =
     "basic_ostream<CharT, Traits>& os );\n"
     "template< class CharT, class Traits > basic_ostream<CharT, Traits>& "
     "operator<<( basic_ostream<CharT,Traits>& os, const char* c );\n"
+    "#if __cplusplus >= 201103L\n"
     "template< class CharT, class Traits, class T > basic_ostream<CharT, "
     "Traits>& operator<<( basic_ostream<CharT,Traits>&& os, const T& value );\n"
+    "#endif  // __cplusplus >= 201103L\n"
     "} // namespace __jitify_ostream_ns\n"
     "namespace std { using namespace __jitify_ostream_ns; }\n"
     "using namespace __jitify_ostream_ns;\n";
@@ -1688,6 +2012,11 @@ static const char* jitsafe_header_math =
     // Note: Global namespace already includes CUDA math funcs
     "//using namespace __jitify_math_ns;\n";
 
+static const char* jitsafe_header_memory_h = R"(
+    #pragma once
+    #include <string.h>
+ )";
+
 // TODO: incomplete
 static const char* jitsafe_header_mutex = R"(
     #pragma once
@@ -1709,85 +2038,122 @@ static const char* jitsafe_header_algorithm = R"(
     #pragma once
     #if __cplusplus >= 201103L
     namespace __jitify_algorithm_ns {
+
     #if __cplusplus == 201103L
-    template<class T> const T& max(const T& a, const T& b)
-    {
-      return (b > a) ? b : a;
-    }
-    template<class T> const T& min(const T& a, const T& b)
-    {
-      return (b < a) ? b : a;
-    }
+    #define JITIFY_CXX14_CONSTEXPR
     #else
-    template<class T> constexpr const T& max(const T& a, const T& b)
+    #define JITIFY_CXX14_CONSTEXPR constexpr
+    #endif
+
+    template<class T> JITIFY_CXX14_CONSTEXPR const T& max(const T& a, const T& b)
     {
       return (b > a) ? b : a;
     }
-    template<class T> constexpr const T& min(const T& a, const T& b)
+    template<class T> JITIFY_CXX14_CONSTEXPR const T& min(const T& a, const T& b)
     {
       return (b < a) ? b : a;
     }
-    #endif
+
     } // namespace __jitify_algorithm_ns
     namespace std { using namespace __jitify_algorithm_ns; }
     using namespace __jitify_algorithm_ns;
     #endif
  )";
 
-static const char* jitsafe_headers[] = {
-    jitsafe_header_preinclude_h, jitsafe_header_float_h,
-    jitsafe_header_float_h,      jitsafe_header_limits_h,
-    jitsafe_header_limits_h,     jitsafe_header_stdint_h,
-    jitsafe_header_stdint_h,     jitsafe_header_stddef_h,
-    jitsafe_header_stddef_h,     jitsafe_header_stdlib_h,
-    jitsafe_header_stdlib_h,     jitsafe_header_stdio_h,
-    jitsafe_header_stdio_h,      jitsafe_header_string_h,
-    jitsafe_header_cstring,      jitsafe_header_iterator,
-    jitsafe_header_limits,       jitsafe_header_type_traits,
-    jitsafe_header_utility,      jitsafe_header_math,
-    jitsafe_header_math,         jitsafe_header_complex,
-    jitsafe_header_iostream,     jitsafe_header_ostream,
-    jitsafe_header_istream,      jitsafe_header_sstream,
-    jitsafe_header_vector,       jitsafe_header_string,
-    jitsafe_header_stdexcept,    jitsafe_header_mutex,
-    jitsafe_header_algorithm};
-static const char* jitsafe_header_names[] = {"jitify_preinclude.h",
-                                             "float.h",
-                                             "cfloat",
-                                             "limits.h",
-                                             "climits",
-                                             "stdint.h",
-                                             "cstdint",
-                                             "stddef.h",
-                                             "cstddef",
-                                             "stdlib.h",
-                                             "cstdlib",
-                                             "stdio.h",
-                                             "cstdio",
-                                             "string.h",
-                                             "cstring",
-                                             "iterator",
-                                             "limits",
-                                             "type_traits",
-                                             "utility",
-                                             "math",
-                                             "cmath",
-                                             "complex",
-                                             "iostream",
-                                             "ostream",
-                                             "istream",
-                                             "sstream",
-                                             "vector",
-                                             "string",
-                                             "stdexcept",
-                                             "mutex",
-                                             "algorithm"};
+static const char* jitsafe_header_time_h = R"(
+    #pragma once
+    #define NULL 0
+    #define CLOCKS_PER_SEC 1000000
+    namespace __jitify_time_ns {
+    typedef long time_t;
+    struct tm {
+      int tm_sec;
+      int tm_min;
+      int tm_hour;
+      int tm_mday;
+      int tm_mon;
+      int tm_year;
+      int tm_wday;
+      int tm_yday;
+      int tm_isdst;
+    };
+    #if __cplusplus >= 201703L
+    struct timespec {
+      time_t tv_sec;
+      long tv_nsec;
+    };
+    #endif
+    }  // namespace __jitify_time_ns
+    namespace std {
+      // NVRTC provides built-in definitions of ::size_t and ::clock_t.
+      using ::size_t;
+      using ::clock_t;
+      using namespace __jitify_time_ns;
+    }
+    using namespace __jitify_time_ns;
+ )";
 
-template <class T, size_t N>
-size_t array_size(T (&)[N]) {
+// WAR: These need to be pre-included as a workaround for NVRTC implicitly using
+// /usr/include as an include path. The other built-in headers will be included
+// lazily as needed.
+static const char* preinclude_jitsafe_header_names[] = {
+    "jitify_preinclude.h",
+    "limits.h",
+    "math.h",
+    "memory.h",
+    "stdint.h",
+    "stdlib.h",
+    "stdio.h",
+    "string.h",
+    "time.h",
+};
+
+template <class T, int N>
+int array_size(T (&)[N]) {
   return N;
 }
-const int jitsafe_headers_count = array_size(jitsafe_headers);
+const int preinclude_jitsafe_headers_count =
+    array_size(preinclude_jitsafe_header_names);
+
+static const std::map<std::string, std::string>& get_jitsafe_headers_map() {
+  static const std::map<std::string, std::string> jitsafe_headers_map = {
+      {"jitify_preinclude.h", jitsafe_header_preinclude_h},
+      {"float.h", jitsafe_header_float_h},
+      {"cfloat", jitsafe_header_float_h},
+      {"limits.h", jitsafe_header_limits_h},
+      {"climits", jitsafe_header_limits_h},
+      {"stdint.h", jitsafe_header_stdint_h},
+      {"cstdint", jitsafe_header_stdint_h},
+      {"stddef.h", jitsafe_header_stddef_h},
+      {"cstddef", jitsafe_header_stddef_h},
+      {"stdlib.h", jitsafe_header_stdlib_h},
+      {"cstdlib", jitsafe_header_stdlib_h},
+      {"stdio.h", jitsafe_header_stdio_h},
+      {"cstdio", jitsafe_header_stdio_h},
+      {"string.h", jitsafe_header_string_h},
+      {"cstring", jitsafe_header_cstring},
+      {"iterator", jitsafe_header_iterator},
+      {"limits", jitsafe_header_limits},
+      {"type_traits", jitsafe_header_type_traits},
+      {"utility", jitsafe_header_utility},
+      {"math.h", jitsafe_header_math},
+      {"cmath", jitsafe_header_math},
+      {"memory.h", jitsafe_header_memory_h},
+      {"complex", jitsafe_header_complex},
+      {"iostream", jitsafe_header_iostream},
+      {"ostream", jitsafe_header_ostream},
+      {"istream", jitsafe_header_istream},
+      {"sstream", jitsafe_header_sstream},
+      {"vector", jitsafe_header_vector},
+      {"string", jitsafe_header_string},
+      {"stdexcept", jitsafe_header_stdexcept},
+      {"mutex", jitsafe_header_mutex},
+      {"algorithm", jitsafe_header_algorithm},
+      {"time.h", jitsafe_header_time_h},
+      {"ctime", jitsafe_header_time_h},
+  };
+  return jitsafe_headers_map;
+}
 
 inline void add_options_from_env(std::vector<std::string>& options) {
   // Add options from environment variable
@@ -1812,11 +2178,12 @@ inline void add_options_from_env(std::vector<std::string>& options) {
   }
 #undef JITIFY_TOSTRING
 #undef JITIFY_TOSTRING_IMPL
-#endif
+#endif  // JITIFY_OPTIONS
 }
 
 inline void detect_and_add_cuda_arch(std::vector<std::string>& options) {
   for (int i = 0; i < (int)options.size(); ++i) {
+    // Note that this will also match the middle of "--gpu-architecture".
     if (options[i].find("-arch") != std::string::npos) {
       // Arch already specified in options
       return;
@@ -1824,8 +2191,15 @@ inline void detect_and_add_cuda_arch(std::vector<std::string>& options) {
   }
   // Use the compute capability of the current device
   // TODO: Check these API calls for errors
+  cudaError_t status;
   int device;
-  cudaGetDevice(&device);
+  status = cudaGetDevice(&device);
+  if (status != cudaSuccess) {
+    throw std::runtime_error(
+        std::string(
+            "Failed to detect GPU architecture: cudaGetDevice failed: ") +
+        cudaGetErrorString(status));
+  }
   int cc_major;
   cudaDeviceGetAttribute(&cc_major, cudaDevAttrComputeCapabilityMajor, device);
   int cc_minor;
@@ -1835,17 +2209,49 @@ inline void detect_and_add_cuda_arch(std::vector<std::string>& options) {
   //         version of NVRTC, otherwise newer hardware will cause errors
   //         on older versions of CUDA.
   // TODO: It would be better to detect this somehow, rather than hard-coding it
-#if CUDA_VERSION / 10 > 900
-#elif CUDA_VERSION / 10 == 900
-  cc = std::min(cc, 70);
-#elif CUDA_VERSION / 10 == 800
-  cc = std::min(cc, 61);
-#else
-  cc = std::min(cc, 53);
-#endif
+
+  // Tegra chips do not have forwards compatibility so we need to special case
+  // them.
+  bool is_tegra = ((cc_major == 3 && cc_minor == 2) ||  // Logan
+                   (cc_major == 5 && cc_minor == 3) ||  // Erista
+                   (cc_major == 6 && cc_minor == 2) ||  // Parker
+                   (cc_major == 7 && cc_minor == 2));   // Xavier
+  if (!is_tegra) {
+    // ensure that future CUDA versions just work (even if suboptimal)
+    const int cuda_major = std::min(10, CUDA_VERSION / 1000);
+    // clang-format off
+    switch (cuda_major) {
+      case 10: cc = std::min(cc, 75); break; // Turing
+      case  9: cc = std::min(cc, 70); break; // Volta
+      case  8: cc = std::min(cc, 61); break; // Pascal
+      case  7: cc = std::min(cc, 52); break; // Maxwell
+      default:
+        throw std::runtime_error("Unexpected CUDA major version " +
+                                 std::to_string(cuda_major));
+    }
+    // clang-format on
+  }
+
   std::stringstream ss;
   ss << cc;
   options.push_back("-arch=compute_" + ss.str());
+}
+
+inline void detect_and_add_cxx11_flag(std::vector<std::string>& options) {
+  // Reverse loop so we can erase on the fly.
+  for (int i = (int)options.size() - 1; i >= 0; --i) {
+    if (options[i].find("-std=c++98") != std::string::npos) {
+      // NVRTC doesn't support specifying c++98 explicitly, so we remove it.
+      options.erase(options.begin() + i);
+      return;
+    } else if (options[i].find("-std") != std::string::npos) {
+      // Some other standard was explicitly specified, don't change anything.
+      return;
+    }
+  }
+  // Jitify must be compiled with C++11 support, so we default to enabling it
+  // for the JIT-compiled code too.
+  options.push_back("-std=c++11");
 }
 
 inline void split_compiler_and_linker_options(
@@ -1867,6 +2273,90 @@ inline void split_compiler_and_linker_options(
   }
 }
 
+inline bool pop_remove_unused_globals_flag(std::vector<std::string>* options) {
+  auto it = std::remove_if(
+      options->begin(), options->end(), [](const std::string& opt) {
+        return opt.find("-remove-unused-globals") != std::string::npos;
+      });
+  if (it != options->end()) {
+    options->resize(it - options->begin());
+    return true;
+  }
+  return false;
+}
+
+inline std::string ptx_parse_decl_name(const std::string& line) {
+  size_t name_end = line.find_first_of("[;");
+  if (name_end == std::string::npos) {
+    throw std::runtime_error(
+        "Failed to parse .global/.const declaration in PTX: expected a "
+        "semicolon");
+  }
+  size_t name_start_minus1 = line.find_last_of(" \t", name_end);
+  if (name_start_minus1 == std::string::npos) {
+    throw std::runtime_error(
+        "Failed to parse .global/.const declaration in PTX: expected "
+        "whitespace");
+  }
+  size_t name_start = name_start_minus1 + 1;
+  std::string name = line.substr(name_start, name_end - name_start);
+  return name;
+}
+
+inline void ptx_remove_unused_globals(std::string* ptx) {
+  std::istringstream iss(*ptx);
+  std::vector<std::string> lines;
+  std::unordered_map<size_t, std::string> line_num_to_global_name;
+  std::unordered_set<std::string> name_set;
+  for (std::string line; std::getline(iss, line);) {
+    size_t line_num = lines.size();
+    lines.push_back(line);
+    auto terms = split_string(line);
+    if (terms.size() <= 1) continue;  // Ignore lines with no arguments
+    if (terms[0].substr(0, 2) == "//") continue;  // Ignore comment lines
+    if (terms[0].substr(0, 7) == ".global" ||
+        terms[0].substr(0, 6) == ".const") {
+      line_num_to_global_name.emplace(line_num, ptx_parse_decl_name(line));
+      continue;
+    }
+    if (terms[0][0] == '.') continue;  // Ignore .version, .reg, .param etc.
+    // Note: The first term will always be an instruction name; starting at 1
+    // also allows unchecked inspection of the previous term.
+    for (int i = 1; i < (int)terms.size(); ++i) {
+      if (terms[i].substr(0, 2) == "//") break;  // Ignore comments
+      // Note: The characters '.' and '%' are not treated as delimiters.
+      const char* token_delims = " \t()[]{},;+-*/~&|^?:=!<>\"'\\";
+      for (auto token : split_string(terms[i], -1, token_delims)) {
+        if (  // Ignore non-names
+            !(std::isalpha(token[0]) || token[0] == '_' || token[0] == '$') ||
+            token.find('.') != std::string::npos ||
+            // Ignore variable/parameter declarations
+            terms[i - 1][0] == '.' ||
+            // Ignore branch instructions
+            (token == "bra" && terms[i - 1][0] == '@') ||
+            // Ignore branch labels
+            (token.substr(0, 2) == "BB" &&
+             terms[i - 1].substr(0, 3) == "bra")) {
+          continue;
+        }
+        name_set.insert(token);
+      }
+    }
+  }
+  std::ostringstream oss;
+  for (size_t line_num = 0; line_num < lines.size(); ++line_num) {
+    auto it = line_num_to_global_name.find(line_num);
+    if (it != line_num_to_global_name.end()) {
+      const std::string& name = it->second;
+      if (!name_set.count(name)) {
+        continue;  // Remove unused .global declaration.
+      }
+    }
+    oss << lines[line_num] << '\n';
+  }
+  *ptx = oss.str();
+}
+
 inline nvrtcResult compile_kernel(std::string program_name,
                                   std::map<std::string, std::string> sources,
                                   std::vector<std::string> options,
@@ -1877,7 +2367,7 @@ inline nvrtcResult compile_kernel(std::string program_name,
   // Build arrays of header names and sources
   std::vector<const char*> header_names_c;
   std::vector<const char*> header_sources_c;
-  int num_headers = sources.size() - 1;
+  int num_headers = (int)(sources.size() - 1);
   header_names_c.reserve(num_headers);
   header_sources_c.reserve(num_headers);
   typedef std::map<std::string, std::string> source_map;
@@ -1891,6 +2381,10 @@ inline nvrtcResult compile_kernel(std::string program_name,
     header_names_c.push_back(name.c_str());
     header_sources_c.push_back(code.c_str());
   }
+
+  // TODO: This WAR is expected to be unnecessary as of CUDA > 10.2.
+  bool should_remove_unused_globals =
+      detail::pop_remove_unused_globals_flag(&options);
 
   std::vector<const char*> options_c(options.size() + 2);
   options_c[0] = "--device-as-default-execution-space";
@@ -1929,17 +2423,17 @@ inline nvrtcResult compile_kernel(std::string program_name,
   }
 #endif
 
-  nvrtcResult ret =
-      nvrtcCompileProgram(nvrtc_program, options_c.size(), options_c.data());
+  nvrtcResult ret = nvrtcCompileProgram(nvrtc_program, (int)options_c.size(),
+                                        options_c.data());
   if (log) {
     size_t logsize;
     CHECK_NVRTC(nvrtcGetProgramLogSize(nvrtc_program, &logsize));
     std::vector<char> vlog(logsize, 0);
     CHECK_NVRTC(nvrtcGetProgramLog(nvrtc_program, vlog.data()));
     log->assign(vlog.data(), logsize);
-    if (ret != NVRTC_SUCCESS) {
-      return ret;
-    }
+  }
+  if (ret != NVRTC_SUCCESS) {
+    return ret;
   }
 
   if (ptx) {
@@ -1948,6 +2442,9 @@ inline nvrtcResult compile_kernel(std::string program_name,
     std::vector<char> vptx(ptxsize);
     CHECK_NVRTC(nvrtcGetPTX(nvrtc_program, vptx.data()));
     ptx->assign(vptx.data(), ptxsize);
+    if (should_remove_unused_globals) {
+      detail::ptx_remove_unused_globals(ptx);
+    }
   }
 
   if (!instantiation.empty() && mangled_instantiation) {
@@ -1970,6 +2467,205 @@ inline nvrtcResult compile_kernel(std::string program_name,
   CHECK_NVRTC(nvrtcDestroyProgram(&nvrtc_program));
 #undef CHECK_NVRTC
   return NVRTC_SUCCESS;
+}
+
+inline void load_program(std::string const& cuda_source,
+                         std::vector<std::string> const& headers,
+                         file_callback_type file_callback,
+                         std::vector<std::string>* include_paths,
+                         std::map<std::string, std::string>* program_sources,
+                         std::vector<std::string>* program_options,
+                         std::string* program_name) {
+  // Extract include paths from compile options
+  std::vector<std::string>::iterator iter = program_options->begin();
+  while (iter != program_options->end()) {
+    std::string const& opt = *iter;
+    if (opt.substr(0, 2) == "-I") {
+      include_paths->push_back(opt.substr(2));
+      iter = program_options->erase(iter);
+    } else {
+      ++iter;
+    }
+  }
+
+  // Load program source
+  if (!detail::load_source(cuda_source, *program_sources, "", *include_paths,
+                           file_callback)) {
+    throw std::runtime_error("Source not found: " + cuda_source);
+  }
+  *program_name = program_sources->begin()->first;
+
+  // Maps header include names to their full file paths.
+  std::map<std::string, std::string> header_fullpaths;
+
+  // Load header sources
+  for (std::string const& header : headers) {
+    if (!detail::load_source(header, *program_sources, "", *include_paths,
+                             file_callback, &header_fullpaths)) {
+      // **TODO: Deal with source not found
+      throw std::runtime_error("Source not found: " + header);
+    }
+  }
+
+#if JITIFY_PRINT_SOURCE
+  std::string& program_source = (*program_sources)[*program_name];
+  std::cout << "---------------------------------------" << std::endl;
+  std::cout << "--- Source of " << *program_name << " ---" << std::endl;
+  std::cout << "---------------------------------------" << std::endl;
+  detail::print_with_line_numbers(program_source);
+  std::cout << "---------------------------------------" << std::endl;
+#endif
+
+  std::vector<std::string> compiler_options, linker_files, linker_paths;
+  detail::split_compiler_and_linker_options(*program_options, &compiler_options,
+                                            &linker_files, &linker_paths);
+
+  // If no arch is specified at this point we use whatever the current
+  // context is. This ensures we pick up the correct internal headers
+  // for arch-dependent compilation, e.g., some intrinsics are only
+  // present for specific architectures.
+  detail::detect_and_add_cuda_arch(compiler_options);
+  detail::detect_and_add_cxx11_flag(compiler_options);
+
+  // Iteratively try to compile the sources, and use the resulting errors to
+  // identify missing headers.
+  std::string log;
+  nvrtcResult ret;
+  while ((ret = detail::compile_kernel(*program_name, *program_sources,
+                                       compiler_options, "", &log)) ==
+         NVRTC_ERROR_COMPILATION) {
+    std::string include_name;
+    std::string include_parent;
+    int line_num = 0;
+    if (!detail::extract_include_info_from_compile_error(
+            log, include_name, include_parent, line_num)) {
+#if JITIFY_PRINT_LOG
+      detail::print_compile_log(*program_name, log);
+#endif
+      // There was a non include-related compilation error
+      // TODO: How to handle error?
+      throw std::runtime_error("Runtime compilation failed");
+    }
+
+    bool is_included_with_quotes = false;
+    if (program_sources->count(include_parent)) {
+      const std::string& parent_source = (*program_sources)[include_parent];
+      is_included_with_quotes =
+          is_include_directive_with_quotes(parent_source, line_num);
+    }
+
+    // Try to load the new header
+    // Note: This fullpath lookup is needed because the compiler error
+    // messages have the include name of the header instead of its full path.
+    std::string include_parent_fullpath = header_fullpaths[include_parent];
+    std::string include_path = detail::path_base(include_parent_fullpath);
+    if (detail::load_source(include_name, *program_sources, include_path,
+                            *include_paths, file_callback, &header_fullpaths,
+                            is_included_with_quotes)) {
+#if JITIFY_PRINT_HEADER_PATHS
+      std::cout << "Found #include " << include_name << " from "
+                << include_parent << ":" << line_num << " ["
+                << include_parent_fullpath << "]"
+                << " at:\n  " << header_fullpaths[include_name] << std::endl;
+#endif
+    } else {  // Failed to find header file.
+      // Comment-out the include line and print a warning
+      if (!program_sources->count(include_parent)) {
+        // ***TODO: Unless there's another mechanism (e.g., potentially
+        //            the parent path vs. filename problem), getting
+        //            here means include_parent was found automatically
+        //            in a system include path.
+        //            We need a WAR to zap it from *its parent*.
+
+        typedef std::map<std::string, std::string> source_map;
+        for (source_map::const_iterator it = program_sources->begin();
+             it != program_sources->end(); ++it) {
+          std::cout << "  " << it->first << std::endl;
+        }
+        throw std::out_of_range(include_parent +
+                                " not in loaded sources!"
+                                " This may be due to a header being loaded by"
+                                " NVRTC without Jitify's knowledge.");
+      }
+      std::string& parent_source = (*program_sources)[include_parent];
+      parent_source = detail::comment_out_code_line(line_num, parent_source);
+#if JITIFY_PRINT_LOG
+      std::cout << include_parent << "(" << line_num
+                << "): warning: " << include_name << ": [jitify] File not found"
+                << std::endl;
+#endif
+    }
+  }
+  if (ret != NVRTC_SUCCESS) {
+#if JITIFY_PRINT_LOG
+    if (ret == NVRTC_ERROR_INVALID_OPTION) {
+      std::cout << "Compiler options: ";
+      for (int i = 0; i < (int)compiler_options.size(); ++i) {
+        std::cout << compiler_options[i] << " ";
+      }
+      std::cout << std::endl;
+    }
+#endif
+    throw std::runtime_error(std::string("NVRTC error: ") +
+                             nvrtcGetErrorString(ret));
+  }
+}
+
+inline void instantiate_kernel(
+    std::string const& program_name,
+    std::map<std::string, std::string> const& program_sources,
+    std::string const& instantiation, std::vector<std::string> const& options,
+    std::string* log, std::string* ptx, std::string* mangled_instantiation,
+    std::vector<std::string>* linker_files,
+    std::vector<std::string>* linker_paths) {
+  std::vector<std::string> compiler_options;
+  detail::split_compiler_and_linker_options(options, &compiler_options,
+                                            linker_files, linker_paths);
+
+  nvrtcResult ret =
+      detail::compile_kernel(program_name, program_sources, compiler_options,
+                             instantiation, log, ptx, mangled_instantiation);
+#if JITIFY_PRINT_LOG
+  if (log->size() > 1) {
+    detail::print_compile_log(program_name, *log);
+  }
+#endif
+  if (ret != NVRTC_SUCCESS) {
+    throw std::runtime_error(std::string("NVRTC error: ") +
+                             nvrtcGetErrorString(ret));
+  }
+
+#if JITIFY_PRINT_PTX
+  std::cout << "---------------------------------------" << std::endl;
+  std::cout << *mangled_instantiation << std::endl;
+  std::cout << "---------------------------------------" << std::endl;
+  std::cout << "--- PTX for " << mangled_instantiation << " in " << program_name
+            << " ---" << std::endl;
+  std::cout << "---------------------------------------" << std::endl;
+  std::cout << *ptx << std::endl;
+  std::cout << "---------------------------------------" << std::endl;
+#endif
+}
+
+inline void get_1d_max_occupancy(CUfunction func,
+                                 CUoccupancyB2DSize smem_callback,
+                                 unsigned int* smem, int max_block_size,
+                                 unsigned int flags, int* grid, int* block) {
+  if (!func) {
+    throw std::runtime_error(
+        "Kernel pointer is NULL; you may need to define JITIFY_THREAD_SAFE "
+        "1");
+  }
+  CUresult res = cuOccupancyMaxPotentialBlockSizeWithFlags(
+      grid, block, func, smem_callback, *smem, max_block_size, flags);
+  if (res != CUDA_SUCCESS) {
+    const char* msg;
+    cuGetErrorName(res, &msg);
+    throw std::runtime_error(msg);
+  }
+  if (smem_callback) {
+    *smem = (unsigned int)smem_callback(*block);
+  }
 }
 
 }  // namespace detail
@@ -2031,10 +2727,8 @@ class Program_impl {
                       jitify::detail::vector<std::string> headers = 0,
                       jitify::detail::vector<std::string> options = 0,
                       file_callback_type file_callback = 0);
-#if __cplusplus >= 201103L
   inline Program_impl(Program_impl const&) = default;
   inline Program_impl(Program_impl&&) = default;
-#endif
   inline std::vector<std::string> const& options() const {
     return _config->options;
   }
@@ -2058,10 +2752,8 @@ class Kernel_impl {
  public:
   inline Kernel_impl(Program_impl const& program, std::string name,
                      jitify::detail::vector<std::string> options = 0);
-#if __cplusplus >= 201103L
   inline Kernel_impl(Kernel_impl const&) = default;
   inline Kernel_impl(Kernel_impl&&) = default;
-#endif
 };
 
 class KernelInstantiation_impl {
@@ -2077,10 +2769,8 @@ class KernelInstantiation_impl {
  public:
   inline KernelInstantiation_impl(
       Kernel_impl const& kernel, std::vector<std::string> const& template_args);
-#if __cplusplus >= 201103L
   inline KernelInstantiation_impl(KernelInstantiation_impl const&) = default;
   inline KernelInstantiation_impl(KernelInstantiation_impl&&) = default;
-#endif
   detail::CUDAKernel const& cuda_kernel() const { return *_cuda_kernel; }
 };
 
@@ -2088,22 +2778,20 @@ class KernelLauncher_impl {
   KernelInstantiation_impl _kernel_inst;
   dim3 _grid;
   dim3 _block;
-  size_t _smem;
+  unsigned int _smem;
   cudaStream_t _stream;
 
  public:
   inline KernelLauncher_impl(KernelInstantiation_impl const& kernel_inst,
-                             dim3 grid, dim3 block, size_t smem = 0,
+                             dim3 grid, dim3 block, unsigned int smem = 0,
                              cudaStream_t stream = 0)
       : _kernel_inst(kernel_inst),
         _grid(grid),
         _block(block),
         _smem(smem),
         _stream(stream) {}
-#if __cplusplus >= 201103L
   inline KernelLauncher_impl(KernelLauncher_impl const&) = default;
   inline KernelLauncher_impl(KernelLauncher_impl&&) = default;
-#endif
   inline CUresult launch(
       jitify::detail::vector<void*> arg_ptrs,
       jitify::detail::vector<std::string> arg_types = 0) const;
@@ -2113,12 +2801,13 @@ class KernelLauncher_impl {
  *    for launching.
  */
 class KernelLauncher {
-  JITIFY_UNIQUE_PTR<KernelLauncher_impl const> _impl;
+  std::unique_ptr<KernelLauncher_impl const> _impl;
 
  public:
   inline KernelLauncher(KernelInstantiation const& kernel_inst, dim3 grid,
-                        dim3 block, size_t smem = 0, cudaStream_t stream = 0);
-  JITIFY_DEFINE_AUTO_PTR_COPY_WAR(KernelLauncher)
+                        dim3 block, unsigned int smem = 0,
+                        cudaStream_t stream = 0);
+
   // Note: It's important that there is no implicit conversion required
   //         for arg_ptrs, because otherwise the parameter pack version
   //         below gets called instead (probably resulting in a segfault).
@@ -2135,7 +2824,6 @@ class KernelLauncher {
       jitify::detail::vector<std::string> arg_types = 0) const {
     return _impl->launch(arg_ptrs, arg_types);
   }
-#if __cplusplus >= 201103L
   // Regular function call syntax
   /*! Launch the kernel.
    *
@@ -2154,7 +2842,6 @@ class KernelLauncher {
     return this->launch(std::vector<void*>({(void*)&args...}),
                         {reflection::reflect<ArgTypes>()...});
   }
-#endif
 };
 
 /*! An object representing a kernel instantiation made up of a Kernel and
@@ -2162,17 +2849,24 @@ class KernelLauncher {
  */
 class KernelInstantiation {
   friend class KernelLauncher;
-  JITIFY_UNIQUE_PTR<KernelInstantiation_impl const> _impl;
+  std::unique_ptr<KernelInstantiation_impl const> _impl;
 
  public:
   inline KernelInstantiation(Kernel const& kernel,
                              std::vector<std::string> const& template_args);
-  JITIFY_DEFINE_AUTO_PTR_COPY_WAR(KernelInstantiation)
+
+  /*! Implicit conversion to the underlying CUfunction object.
+   *
+   * \note This allows use of CUDA APIs like
+   *   cuOccupancyMaxActiveBlocksPerMultiprocessor.
+   */
+  inline operator CUfunction() const { return _impl->cuda_kernel(); }
+
   /*! Configure the kernel launch.
    *
    *  \see configure
    */
-  inline KernelLauncher operator()(dim3 grid, dim3 block, size_t smem = 0,
+  inline KernelLauncher operator()(dim3 grid, dim3 block, unsigned int smem = 0,
                                    cudaStream_t stream = 0) const {
     return this->configure(grid, block, smem, stream);
   }
@@ -2181,9 +2875,10 @@ class KernelInstantiation {
    *  \param grid   The thread grid dimensions for the launch.
    *  \param block  The thread block dimensions for the launch.
    *  \param smem   The amount of shared memory to dynamically allocate, in
-   * bytes. \param stream The CUDA stream to launch the kernel in.
+   * bytes.
+   *  \param stream The CUDA stream to launch the kernel in.
    */
-  inline KernelLauncher configure(dim3 grid, dim3 block, size_t smem = 0,
+  inline KernelLauncher configure(dim3 grid, dim3 block, unsigned int smem = 0,
                                   cudaStream_t stream = 0) const {
     return KernelLauncher(*this, grid, block, smem, stream);
   }
@@ -2191,50 +2886,107 @@ class KernelInstantiation {
    *  automatically to maximise occupancy.
    *
    * \param max_block_size  The upper limit on the block size, or 0 for no
-   * limit. \param smem            The amount of shared memory to dynamically
-   * allocate, in bytes. \param smem_callback   A function returning smem for a
-   * given block size (overrides \p smem). \param stream          The CUDA
-   * stream to launch the kernel in. \param flags           The flags to pass to
-   * cuOccupancyMaxPotentialBlockSizeWithFlags.
+   * limit.
+   * \param smem  The amount of shared memory to dynamically allocate, in bytes.
+   * \param smem_callback  A function returning smem for a given block size (overrides \p smem).
+   * \param stream The CUDA stream to launch the kernel in.
+   * \param flags The flags to pass to cuOccupancyMaxPotentialBlockSizeWithFlags.
    */
   inline KernelLauncher configure_1d_max_occupancy(
-      int max_block_size = 0, size_t smem = 0,
+      int max_block_size = 0, unsigned int smem = 0,
       CUoccupancyB2DSize smem_callback = 0, cudaStream_t stream = 0,
       unsigned int flags = 0) const {
     int grid;
     int block;
     CUfunction func = _impl->cuda_kernel();
-    if (!func) {
-      throw std::runtime_error(
-          "Kernel pointer is NULL; you may need to define JITIFY_THREAD_SAFE "
-          "1");
-    }
-    CUresult res = cuOccupancyMaxPotentialBlockSizeWithFlags(
-        &grid, &block, func, smem_callback, smem, max_block_size, flags);
-    if (res != CUDA_SUCCESS) {
-      const char* msg;
-      cuGetErrorName(res, &msg);
-      throw std::runtime_error(msg);
-    }
-    if (smem_callback) {
-      smem = smem_callback(block);
-    }
+    detail::get_1d_max_occupancy(func, smem_callback, &smem, max_block_size,
+                                 flags, &grid, &block);
     return this->configure(grid, block, smem, stream);
   }
 
-  inline CUdeviceptr get_constant_ptr(const char *name) const { return _impl->cuda_kernel().get_constant_ptr(name); }
+  /*
+   * \deprecated Use \p get_global_ptr instead.
+   */
+  inline CUdeviceptr get_constant_ptr(const char* name,
+                                      size_t* size = nullptr) const {
+    return get_global_ptr(name, size);
+  }
+
+  /*
+   * Get a device pointer to a global __constant__ or __device__ variable using
+   * its un-mangled name. If provided, *size is set to the size of the variable
+   * in bytes.
+   */
+  inline CUdeviceptr get_global_ptr(const char* name,
+                                    size_t* size = nullptr) const {
+    return _impl->cuda_kernel().get_global_ptr(name, size);
+  }
+
+  /*
+   * Copy data from a global __constant__ or __device__ array to the host using
+   * its un-mangled name.
+   */
+  template <typename T>
+  inline CUresult get_global_array(const char* name, T* data, size_t count,
+                                   CUstream stream = 0) const {
+    return _impl->cuda_kernel().get_global_data(name, data, count, stream);
+  }
+
+  /*
+   * Copy a value from a global __constant__ or __device__ variable to the host
+   * using its un-mangled name.
+   */
+  template <typename T>
+  inline CUresult get_global_value(const char* name, T* value,
+                                   CUstream stream = 0) const {
+    return get_global_array(name, value, 1, stream);
+  }
+
+  /*
+   * Copy data from the host to a global __constant__ or __device__ array using
+   * its un-mangled name.
+   */
+  template <typename T>
+  inline CUresult set_global_array(const char* name, const T* data,
+                                   size_t count, CUstream stream = 0) const {
+    return _impl->cuda_kernel().set_global_data(name, data, count, stream);
+  }
+
+  /*
+   * Copy a value from the host to a global __constant__ or __device__ variable
+   * using its un-mangled name.
+   */
+  template <typename T>
+  inline CUresult set_global_value(const char* name, const T& value,
+                                   CUstream stream = 0) const {
+    return set_global_array(name, &value, 1, stream);
+  }
+
+  const std::string& mangled_name() const {
+    return _impl->cuda_kernel().function_name();
+  }
+
+  const std::string& ptx() const { return _impl->cuda_kernel().ptx(); }
+
+  const std::vector<std::string>& link_files() const {
+    return _impl->cuda_kernel().link_files();
+  }
+
+  const std::vector<std::string>& link_paths() const {
+    return _impl->cuda_kernel().link_paths();
+  }
 };
 
 /*! An object representing a kernel made up of a Program, a name and options.
  */
 class Kernel {
   friend class KernelInstantiation;
-  JITIFY_UNIQUE_PTR<Kernel_impl const> _impl;
+  std::unique_ptr<Kernel_impl const> _impl;
 
  public:
   Kernel(Program const& program, std::string name,
          jitify::detail::vector<std::string> options = 0);
-  JITIFY_DEFINE_AUTO_PTR_COPY_WAR(Kernel)
+
   /*! Instantiate the kernel.
    *
    *  \param template_args A vector of template arguments represented as
@@ -2252,7 +3004,7 @@ class Kernel {
           std::vector<std::string>()) const {
     return KernelInstantiation(*this, template_args);
   }
-#if __cplusplus >= 201103L
+
   // Regular template instantiation syntax (note limited flexibility)
   /*! Instantiate the kernel.
    *
@@ -2286,7 +3038,6 @@ class Kernel {
     return this->instantiate(
         std::vector<std::string>({reflection::reflect(targs)...}));
   }
-#endif
 };
 
 /*! An object representing a program made up of source code, headers
@@ -2294,20 +3045,20 @@ class Kernel {
  */
 class Program {
   friend class Kernel;
-  JITIFY_UNIQUE_PTR<Program_impl const> _impl;
+  std::unique_ptr<Program_impl const> _impl;
 
  public:
   Program(JitCache& cache, std::string source,
           jitify::detail::vector<std::string> headers = 0,
           jitify::detail::vector<std::string> options = 0,
           file_callback_type file_callback = 0);
-  JITIFY_DEFINE_AUTO_PTR_COPY_WAR(Program)
+
   /*! Select a kernel.
    *
-   *  \param name The name of the kernel (unmangled and without template
-   *    arguments).
-   *  \param options A vector of options to be passed to the
-   *    NVRTC compiler when compiling this kernel.
+   * \param name The name of the kernel (unmangled and without
+   * template arguments).
+   * \param options A vector of options to be passed to the NVRTC
+   * compiler when compiling this kernel.
    */
   inline Kernel kernel(std::string name,
                        jitify::detail::vector<std::string> options = 0) const {
@@ -2328,7 +3079,7 @@ class Program {
  */
 class JitCache {
   friend class Program;
-  JITIFY_UNIQUE_PTR<JitCache_impl> _impl;
+  std::unique_ptr<JitCache_impl> _impl;
 
  public:
   /*! JitCache constructor.
@@ -2362,7 +3113,8 @@ class JitCache {
    *  looked-up using the following mechanisms (in this order):
    *  \note 1) By calling file_callback.
    *  \note 2) By looking for the file embedded in the executable via the GCC
-   * linker. \note 3) By looking for the file in the filesystem.
+   * linker.
+   *  \note 3) By looking for the file in the filesystem.
    *
    *  \note Jitify recursively scans all source files for \p #include
    *  directives and automatically adds them to the set of headers needed
@@ -2383,9 +3135,6 @@ class JitCache {
   }
 };
 
-#undef JITIFY_UNIQUE_PTR
-#undef JITIFY_DEFINE_AUTO_PTR_COPY_WAR
-
 inline Program::Program(JitCache& cache, std::string source,
                         jitify::detail::vector<std::string> headers,
                         jitify::detail::vector<std::string> options,
@@ -2402,7 +3151,7 @@ inline KernelInstantiation::KernelInstantiation(
     : _impl(new KernelInstantiation_impl(*kernel._impl, template_args)) {}
 
 inline KernelLauncher::KernelLauncher(KernelInstantiation const& kernel_inst,
-                                      dim3 grid, dim3 block, size_t smem,
+                                      dim3 grid, dim3 block, unsigned int smem,
                                       cudaStream_t stream)
     : _impl(new KernelLauncher_impl(*kernel_inst._impl, grid, block, smem,
                                     stream)) {}
@@ -2478,37 +3227,11 @@ inline void KernelInstantiation_impl::build_kernel() {
 
   std::string instantiation = _kernel._name + _template_inst;
 
-  std::vector<std::string> compiler_options;
-  std::vector<std::string> linker_files;
-  std::vector<std::string> linker_paths;
-  detail::split_compiler_and_linker_options(_options, &compiler_options,
-                                            &linker_files, &linker_paths);
-
-  std::string log;
-  std::string ptx;
-  std::string mangled_instantiation;
-  nvrtcResult ret = detail::compile_kernel(program.name(), program.sources(),
-                                           compiler_options, instantiation,
-                                           &log, &ptx, &mangled_instantiation);
-#if JITIFY_PRINT_LOG
-  if (log.size() > 1) {
-    detail::print_compile_log(program.name(), log);
-  }
-#endif
-  if (ret != NVRTC_SUCCESS) {
-    throw std::runtime_error(std::string("NVRTC error: ") +
-                             nvrtcGetErrorString(ret));
-  }
-
-#if JITIFY_PRINT_PTX
-  std::cout << "---------------------------------------" << std::endl;
-  std::cout << mangled_instantiation << std::endl;
-  std::cout << "---------------------------------------" << std::endl;
-  std::cout << "--- PTX for " << program.name() << " ---" << std::endl;
-  std::cout << "---------------------------------------" << std::endl;
-  std::cout << ptx << std::endl;
-  std::cout << "---------------------------------------" << std::endl;
-#endif
+  std::string log, ptx, mangled_instantiation;
+  std::vector<std::string> linker_files, linker_paths;
+  detail::instantiate_kernel(program.name(), program.sources(), instantiation,
+                             _options, &log, &ptx, &mangled_instantiation,
+                             &linker_files, &linker_paths);
 
   _cuda_kernel->set(mangled_instantiation.c_str(), ptx.c_str(), linker_files,
                     linker_paths);
@@ -2521,6 +3244,7 @@ Kernel_impl::Kernel_impl(Program_impl const& program, std::string name,
   _options.insert(_options.end(), _program.options().begin(),
                   _program.options().end());
   detail::detect_and_add_cuda_arch(_options);
+  detail::detect_and_add_cxx11_flag(_options);
   std::string options_string = reflection::reflect_list(_options);
   using detail::hash_combine;
   using detail::hash_larson64;
@@ -2544,10 +3268,11 @@ Program_impl::Program_impl(JitCache_impl& cache, std::string source,
     _hash = hash_combine(_hash, hash_larson64(headers[i].c_str()));
   }
   _hash = hash_combine(_hash, (uint64_t)file_callback);
-  // Add built-in JIT-safe headers
-  for (int i = 0; i < detail::jitsafe_headers_count; ++i) {
-    const char* hdr_name = detail::jitsafe_header_names[i];
-    const char* hdr_source = detail::jitsafe_headers[i];
+  // Add pre-include built-in JIT-safe headers
+  for (int i = 0; i < detail::preinclude_jitsafe_headers_count; ++i) {
+    const char* hdr_name = detail::preinclude_jitsafe_header_names[i];
+    const std::string& hdr_source =
+        detail::get_jitsafe_headers_map().at(hdr_name);
     headers.push_back(std::string(hdr_name) + "\n" + hdr_source);
   }
   // Merge options from parent
@@ -2568,117 +3293,10 @@ inline void Program_impl::load_sources(std::string source,
                                        std::vector<std::string> headers,
                                        std::vector<std::string> options,
                                        file_callback_type file_callback) {
-  std::vector<std::string>& include_paths = _config->include_paths;
-  std::string& name = _config->name;
-  ProgramConfig::source_map& sources = _config->sources;
-
-  // Extract include paths from compile options
-  std::vector<std::string>::iterator iter = options.begin();
-  while (iter != options.end()) {
-    std::string const& opt = *iter;
-    if (opt.substr(0, 2) == "-I") {
-      include_paths.push_back(opt.substr(2));
-      options.erase(iter);
-    } else {
-      ++iter;
-    }
-  }
   _config->options = options;
-
-  // Load program source
-  if (!detail::load_source(source, sources, "", include_paths, file_callback)) {
-    throw std::runtime_error("Source not found: " + source);
-  }
-  name = sources.begin()->first;
-
-  // Load header sources
-  for (int i = 0; i < (int)headers.size(); ++i) {
-    if (!detail::load_source(headers[i], sources, "", include_paths,
-                             file_callback)) {
-      // **TODO: Deal with source not found
-      throw std::runtime_error("Source not found: " + headers[i]);
-    }
-  }
-
-#if JITIFY_PRINT_SOURCE
-  std::string& program_source = sources[name];
-  std::cout << "---------------------------------------" << std::endl;
-  std::cout << "--- Source of " << name << " ---" << std::endl;
-  std::cout << "---------------------------------------" << std::endl;
-  detail::print_with_line_numbers(program_source);
-  std::cout << "---------------------------------------" << std::endl;
-#endif
-
-  std::vector<std::string> compiler_options;
-  std::vector<std::string> linker_files;
-  std::vector<std::string> linker_paths;
-  detail::split_compiler_and_linker_options(options, &compiler_options,
-                                            &linker_files, &linker_paths);
-  detail::detect_and_add_cuda_arch(compiler_options);
-
-  std::string log;
-  nvrtcResult ret;
-  while ((ret = detail::compile_kernel(name, sources, compiler_options, "",
-                                       &log)) == NVRTC_ERROR_COMPILATION) {
-    std::string include_name;
-    std::string include_parent;
-    int line_num = 0;
-    if (!detail::extract_include_info_from_compile_error(
-            log, include_name, include_parent, line_num)) {
-      // There was a non include-related compilation error
-#if JITIFY_PRINT_LOG
-      detail::print_compile_log(name, log);
-#endif
-      // TODO: How to handle error?
-      throw std::runtime_error("Runtime compilation failed");
-    }
-
-    // Try to load the new header
-    std::string include_path = detail::path_base(include_parent);
-    if (!detail::load_source(include_name, sources, include_path, include_paths,
-                             file_callback)) {
-      // Comment-out the include line and print a warning
-      if (!sources.count(include_parent)) {
-        // ***TODO: Unless there's another mechanism (e.g., potentially
-        //            the parent path vs. filename problem), getting
-        //            here means include_parent was found automatically
-        //            in a system include path.
-        //            We need a WAR to zap it from *its parent*.
-
-        for (ProgramConfig::source_map::const_iterator it = sources.begin();
-             it != sources.end(); ++it) {
-          std::cout << "  " << it->first << std::endl;
-        }
-        throw std::out_of_range(include_parent +
-                                " not in loaded sources!"
-                                " This may be due to a header being loaded by"
-                                " NVRTC without Jitify's knowledge.");
-      }
-      std::string& parent_source = sources[include_parent];
-      parent_source = detail::comment_out_code_line(line_num, parent_source);
-#if JITIFY_PRINT_LOG
-      std::cout << include_parent << "(" << line_num
-                << "): warning: " << include_name << ": File not found"
-                << std::endl;
-#endif
-    }
-  }
-  if (ret != NVRTC_SUCCESS) {
-#if JITIFY_PRINT_LOG
-    if (ret == NVRTC_ERROR_INVALID_OPTION) {
-      std::cout << "Compiler options: ";
-      for (int i = 0; i < (int)compiler_options.size(); ++i) {
-        std::cout << compiler_options[i] << " ";
-      }
-      std::cout << std::endl;
-    }
-#endif
-    throw std::runtime_error(std::string("NVRTC error: ") +
-                             nvrtcGetErrorString(ret));
-  }
+  detail::load_program(source, headers, file_callback, &_config->include_paths,
+                       &_config->sources, &_config->options, &_config->name);
 }
-
-#if __cplusplus >= 201103L
 
 enum Location { HOST, DEVICE };
 
@@ -2688,8 +3306,9 @@ enum Location { HOST, DEVICE };
  *  \param options       Options to pass to the NVRTC compiler.
  *  \param file_callback See jitify::Program.
  *  \param block_size    The size of the CUDA thread block with which to
- * execute. \param cache_size    The number of kernels to store in the cache
- * before overwriting the    least-recently-used ones.
+ * execute.
+ *  \param cache_size    The number of kernels to store in the cache
+ * before overwriting the least-recently-used ones.
  */
 struct ExecutionPolicy {
   /*! Location (HOST or DEVICE) on which to execute.*/
@@ -2871,7 +3490,7 @@ CUresult parallel_for(ExecutionPolicy policy, IndexType begin, IndexType end,
 
   size_t n = end - begin;
   dim3 block(policy.block_size);
-  dim3 grid(std::min((n - 1) / block.x + 1, size_t(65535)));
+  dim3 grid((unsigned int)std::min((n - 1) / block.x + 1, size_t(65535)));
   cudaSetDevice(policy.device);
   return program.kernel("parallel_for_kernel")
       .instantiate<IndexType>()
@@ -2879,6 +3498,569 @@ CUresult parallel_for(ExecutionPolicy policy, IndexType begin, IndexType end,
       .launch(arg_ptrs);
 }
 
-#endif  // __cplusplus >= 201103L
+namespace experimental {
+
+using jitify::file_callback_type;
+
+namespace serialization {
+
+namespace detail {
+
+// This should be incremented whenever the serialization format changes in any
+// incompatible way.
+static constexpr const size_t kSerializationVersion = 1;
+
+inline void serialize(std::ostream& stream, size_t u) {
+  uint64_t u64 = u;
+  stream.write(reinterpret_cast<char*>(&u64), sizeof(u64));
+}
+
+inline bool deserialize(std::istream& stream, size_t* size) {
+  uint64_t u64;
+  stream.read(reinterpret_cast<char*>(&u64), sizeof(u64));
+  *size = u64;
+  return stream.good();
+}
+
+inline void serialize(std::ostream& stream, std::string const& s) {
+  serialize(stream, s.size());
+  stream.write(s.data(), s.size());
+}
+
+inline bool deserialize(std::istream& stream, std::string* s) {
+  size_t size;
+  if (!deserialize(stream, &size)) return false;
+  s->resize(size);
+  if (s->size()) {
+    stream.read(&(*s)[0], s->size());
+  }
+  return stream.good();
+}
+
+inline void serialize(std::ostream& stream, std::vector<std::string> const& v) {
+  serialize(stream, v.size());
+  for (auto const& s : v) {
+    serialize(stream, s);
+  }
+}
+
+inline bool deserialize(std::istream& stream, std::vector<std::string>* v) {
+  size_t size;
+  if (!deserialize(stream, &size)) return false;
+  v->resize(size);
+  for (auto& s : *v) {
+    if (!deserialize(stream, &s)) return false;
+  }
+  return true;
+}
+
+inline void serialize(std::ostream& stream,
+                      std::map<std::string, std::string> const& m) {
+  serialize(stream, m.size());
+  for (auto const& kv : m) {
+    serialize(stream, kv.first);
+    serialize(stream, kv.second);
+  }
+}
+
+inline bool deserialize(std::istream& stream,
+                        std::map<std::string, std::string>* m) {
+  size_t size;
+  if (!deserialize(stream, &size)) return false;
+  for (size_t i = 0; i < size; ++i) {
+    std::string key;
+    if (!deserialize(stream, &key)) return false;
+    if (!deserialize(stream, &(*m)[key])) return false;
+  }
+  return true;
+}
+
+template <typename T, typename... Rest>
+inline void serialize(std::ostream& stream, T const& value, Rest... rest) {
+  serialize(stream, value);
+  serialize(stream, rest...);
+}
+
+template <typename T, typename... Rest>
+inline bool deserialize(std::istream& stream, T* value, Rest... rest) {
+  if (!deserialize(stream, value)) return false;
+  return deserialize(stream, rest...);
+}
+
+inline void serialize_magic_number(std::ostream& stream) {
+  stream.write("JTFY", 4);
+  serialize(stream, kSerializationVersion);
+}
+
+inline bool deserialize_magic_number(std::istream& stream) {
+  char magic_number[4] = {0, 0, 0, 0};
+  stream.read(&magic_number[0], 4);
+  if (!(magic_number[0] == 'J' && magic_number[1] == 'T' &&
+        magic_number[2] == 'F' && magic_number[3] == 'Y')) {
+    return false;
+  }
+  size_t serialization_version;
+  if (!deserialize(stream, &serialization_version)) return false;
+  return serialization_version == kSerializationVersion;
+}
+
+}  // namespace detail
+
+template <typename... Values>
+inline std::string serialize(Values const&... values) {
+  std::ostringstream ss(std::stringstream::out | std::stringstream::binary);
+  detail::serialize_magic_number(ss);
+  detail::serialize(ss, values...);
+  return ss.str();
+}
+
+template <typename... Values>
+inline bool deserialize(std::string const& serialized, Values*... values) {
+  std::istringstream ss(serialized,
+                        std::stringstream::in | std::stringstream::binary);
+  if (!detail::deserialize_magic_number(ss)) return false;
+  return detail::deserialize(ss, values...);
+}
+
+}  // namespace serialization
+
+class Program;
+class Kernel;
+class KernelInstantiation;
+class KernelLauncher;
+
+/*! An object representing a program made up of source code, headers
+ *    and options.
+ */
+class Program {
+ private:
+  friend class KernelInstantiation;
+  std::string _name;
+  std::vector<std::string> _options;
+  std::map<std::string, std::string> _sources;
+
+  // Private constructor used by deserialize()
+  Program() {}
+
+ public:
+  /*! Create a program.
+   *
+   *  \param source A string containing either the source filename or
+   *    the source itself; in the latter case, the first line must be
+   *    the name of the program.
+   *  \param headers A vector of strings representing the source of
+   *    each header file required by the program. Each entry can be
+   *    either the header filename or the header source itself; in
+   *    the latter case, the first line must be the name of the header
+   *    (i.e., the name by which the header is #included).
+   *  \param options A vector of options to be passed to the
+   *    NVRTC compiler. Include paths specified with \p -I
+   *    are added to the search paths used by Jitify. The environment
+   *    variable JITIFY_OPTIONS can also be used to define additional
+   *    options.
+   *  \param file_callback A pointer to a callback function that is
+   *    invoked whenever a source file needs to be loaded. Inside this
+   *    function, the user can either load/specify the source themselves
+   *    or defer to Jitify's file-loading mechanisms.
+   *  \note Program or header source files referenced by filename are
+   *  looked-up using the following mechanisms (in this order):
+   *  \note 1) By calling file_callback.
+   *  \note 2) By looking for the file embedded in the executable via the GCC
+   * linker.
+   *  \note 3) By looking for the file in the filesystem.
+   *
+   *  \note Jitify recursively scans all source files for \p #include
+   *  directives and automatically adds them to the set of headers needed
+   *  by the program.
+   *  If a \p #include directive references a header that cannot be found,
+   *  the directive is automatically removed from the source code to prevent
+   *  immediate compilation failure. This may result in compilation errors
+   *  if the header was required by the program.
+   *
+   *  \note Jitify automatically includes NVRTC-safe versions of some
+   *  standard library headers.
+   */
+  Program(std::string const& cuda_source,
+          std::vector<std::string> const& given_headers = {},
+          std::vector<std::string> const& given_options = {},
+          file_callback_type file_callback = nullptr) {
+    // Add pre-include built-in JIT-safe headers
+    std::vector<std::string> headers = given_headers;
+    for (int i = 0; i < detail::preinclude_jitsafe_headers_count; ++i) {
+      const char* hdr_name = detail::preinclude_jitsafe_header_names[i];
+      const std::string& hdr_source =
+          detail::get_jitsafe_headers_map().at(hdr_name);
+      headers.push_back(std::string(hdr_name) + "\n" + hdr_source);
+    }
+
+    _options = given_options;
+    detail::add_options_from_env(_options);
+    std::vector<std::string> include_paths;
+    detail::load_program(cuda_source, headers, file_callback, &include_paths,
+                         &_sources, &_options, &_name);
+  }
+
+  /*! Restore a serialized program.
+   *
+   * \param serialized_program The serialized program to restore.
+   *
+   * \see serialize
+   */
+  static Program deserialize(std::string const& serialized_program) {
+    Program program;
+    if (!serialization::deserialize(serialized_program, &program._name,
+                                    &program._options, &program._sources)) {
+      throw std::runtime_error("Failed to deserialize program");
+    }
+    return program;
+  }
+
+  /*! Save the program.
+   *
+   * \see deserialize
+   */
+  std::string serialize() const {
+    // Note: Must update kSerializationVersion if this is changed.
+    return serialization::serialize(_name, _options, _sources);
+  };
+
+  /*! Select a kernel.
+   *
+   * \param name The name of the kernel (unmangled and without
+   * template arguments).
+   * \param options A vector of options to be passed to the NVRTC
+   * compiler when compiling this kernel.
+   */
+  Kernel kernel(std::string const& name,
+                std::vector<std::string> const& options = {}) const;
+};
+
+class Kernel {
+  friend class KernelInstantiation;
+  Program const* _program;
+  std::string _name;
+  std::vector<std::string> _options;
+
+ public:
+  Kernel(Program const* program, std::string const& name,
+         std::vector<std::string> const& options = {})
+      : _program(program), _name(name), _options(options) {}
+
+  /*! Instantiate the kernel.
+   *
+   *  \param template_args A vector of template arguments represented as
+   *    code-strings. These can be generated using
+   *    \code{.cpp}jitify::reflection::reflect<type>()\endcode or
+   *    \code{.cpp}jitify::reflection::reflect(value)\endcode
+   *
+   *  \note Template type deduction is not possible, so all types must be
+   *    explicitly specified.
+   */
+  KernelInstantiation instantiate(
+      std::vector<std::string> const& template_args =
+          std::vector<std::string>()) const;
+
+  // Regular template instantiation syntax (note limited flexibility)
+  /*! Instantiate the kernel.
+   *
+   *  \note The template arguments specified on this function are
+   *    used to instantiate the kernel. Non-type template arguments must
+   *    be wrapped with
+   *    \code{.cpp}jitify::reflection::NonType<type,value>\endcode
+   *
+   *  \note Template type deduction is not possible, so all types must be
+   *    explicitly specified.
+   */
+  template <typename... TemplateArgs>
+  KernelInstantiation instantiate() const;
+
+  // Template-like instantiation syntax
+  //   E.g., instantiate(myvar,Type<MyType>())(grid,block)
+  /*! Instantiate the kernel.
+   *
+   *  \param targs The template arguments for the kernel, represented as
+   *    values. Types must be wrapped with
+   *    \code{.cpp}jitify::reflection::Type<type>()\endcode or
+   *    \code{.cpp}jitify::reflection::type_of(value)\endcode
+   *
+   *  \note Template type deduction is not possible, so all types must be
+   *    explicitly specified.
+   */
+  template <typename... TemplateArgs>
+  KernelInstantiation instantiate(TemplateArgs... targs) const;
+};
+
+class KernelInstantiation {
+  friend class KernelLauncher;
+  std::unique_ptr<detail::CUDAKernel> _cuda_kernel;
+
+  // Private constructor used by deserialize()
+  KernelInstantiation(std::string const& func_name, std::string const& ptx,
+                      std::vector<std::string> const& link_files,
+                      std::vector<std::string> const& link_paths)
+      : _cuda_kernel(new detail::CUDAKernel(func_name.c_str(), ptx.c_str(),
+                                            link_files, link_paths)) {}
+
+ public:
+  KernelInstantiation(Kernel const& kernel,
+                      std::vector<std::string> const& template_args) {
+    Program const* program = kernel._program;
+
+    std::string template_inst =
+        (template_args.empty() ? ""
+                               : reflection::reflect_template(template_args));
+    std::string instantiation = kernel._name + template_inst;
+
+    std::vector<std::string> options;
+    options.insert(options.begin(), program->_options.begin(),
+                   program->_options.end());
+    options.insert(options.begin(), kernel._options.begin(),
+                   kernel._options.end());
+    detail::detect_and_add_cuda_arch(options);
+    detail::detect_and_add_cxx11_flag(options);
+
+    std::string log, ptx, mangled_instantiation;
+    std::vector<std::string> linker_files, linker_paths;
+    detail::instantiate_kernel(program->_name, program->_sources, instantiation,
+                               options, &log, &ptx, &mangled_instantiation,
+                               &linker_files, &linker_paths);
+
+    _cuda_kernel.reset(new detail::CUDAKernel(mangled_instantiation.c_str(),
+                                              ptx.c_str(), linker_files,
+                                              linker_paths));
+  }
+
+  /*! Implicit conversion to the underlying CUfunction object.
+   *
+   * \note This allows use of CUDA APIs like
+   *   cuOccupancyMaxActiveBlocksPerMultiprocessor.
+   */
+  operator CUfunction() const { return *_cuda_kernel; }
+
+  /*! Restore a serialized kernel instantiation.
+   *
+   * \param serialized_kernel_inst The serialized kernel instantiation to
+   * restore.
+   *
+   * \see serialize
+   */
+  static KernelInstantiation deserialize(
+      std::string const& serialized_kernel_inst) {
+    std::string func_name, ptx;
+    std::vector<std::string> link_files, link_paths;
+    if (!serialization::deserialize(serialized_kernel_inst, &func_name, &ptx,
+                                    &link_files, &link_paths)) {
+      throw std::runtime_error("Failed to deserialize kernel instantiation");
+    }
+    return KernelInstantiation(func_name, ptx, link_files, link_paths);
+  }
+
+  /*! Save the program.
+   *
+   * \see deserialize
+   */
+  std::string serialize() const {
+    // Note: Must update kSerializationVersion if this is changed.
+    return serialization::serialize(
+        _cuda_kernel->function_name(), _cuda_kernel->ptx(),
+        _cuda_kernel->link_files(), _cuda_kernel->link_paths());
+  }
+
+  /*! Configure the kernel launch.
+   *
+   *  \param grid   The thread grid dimensions for the launch.
+   *  \param block  The thread block dimensions for the launch.
+   *  \param smem   The amount of shared memory to dynamically allocate, in
+   * bytes.
+   *  \param stream The CUDA stream to launch the kernel in.
+   */
+  KernelLauncher configure(dim3 grid, dim3 block, unsigned int smem = 0,
+                           cudaStream_t stream = 0) const;
+
+  /*! Configure the kernel launch with a 1-dimensional block and grid chosen
+   *  automatically to maximise occupancy.
+   *
+   * \param max_block_size  The upper limit on the block size, or 0 for no
+   * limit.
+   * \param smem  The amount of shared memory to dynamically allocate, in bytes.
+   * \param smem_callback  A function returning smem for a given block size
+   * (overrides \p smem).
+   * \param stream The CUDA stream to launch the kernel in.
+   * \param flags The flags to pass to
+   * cuOccupancyMaxPotentialBlockSizeWithFlags.
+   */
+  KernelLauncher configure_1d_max_occupancy(
+      int max_block_size = 0, unsigned int smem = 0,
+      CUoccupancyB2DSize smem_callback = 0, cudaStream_t stream = 0,
+      unsigned int flags = 0) const;
+
+  /*
+   * \deprecated Use \p get_global_ptr instead.
+   */
+  CUdeviceptr get_constant_ptr(const char* name, size_t* size = nullptr) const {
+    return get_global_ptr(name, size);
+  }
+
+  /*
+   * Get a device pointer to a global __constant__ or __device__ variable using
+   * its un-mangled name. If provided, *size is set to the size of the variable
+   * in bytes.
+   */
+  CUdeviceptr get_global_ptr(const char* name, size_t* size = nullptr) const {
+    return _cuda_kernel->get_global_ptr(name, size);
+  }
+
+  /*
+   * Copy data from a global __constant__ or __device__ array to the host using
+   * its un-mangled name.
+   */
+  template <typename T>
+  CUresult get_global_array(const char* name, T* data, size_t count,
+                            CUstream stream = 0) const {
+    return _cuda_kernel->get_global_data(name, data, count, stream);
+  }
+
+  /*
+   * Copy a value from a global __constant__ or __device__ variable to the host
+   * using its un-mangled name.
+   */
+  template <typename T>
+  CUresult get_global_value(const char* name, T* value,
+                            CUstream stream = 0) const {
+    return get_global_array(name, value, 1, stream);
+  }
+
+  /*
+   * Copy data from the host to a global __constant__ or __device__ array using
+   * its un-mangled name.
+   */
+  template <typename T>
+  CUresult set_global_array(const char* name, const T* data, size_t count,
+                            CUstream stream = 0) const {
+    return _cuda_kernel->set_global_data(name, data, count, stream);
+  }
+
+  /*
+   * Copy a value from the host to a global __constant__ or __device__ variable
+   * using its un-mangled name.
+   */
+  template <typename T>
+  CUresult set_global_value(const char* name, const T& value,
+                            CUstream stream = 0) const {
+    return set_global_array(name, &value, 1, stream);
+  }
+
+  const std::string& mangled_name() const {
+    return _cuda_kernel->function_name();
+  }
+
+  const std::string& ptx() const { return _cuda_kernel->ptx(); }
+
+  const std::vector<std::string>& link_files() const {
+    return _cuda_kernel->link_files();
+  }
+
+  const std::vector<std::string>& link_paths() const {
+    return _cuda_kernel->link_paths();
+  }
+};
+
+class KernelLauncher {
+  KernelInstantiation const* _kernel_inst;
+  dim3 _grid;
+  dim3 _block;
+  unsigned int _smem;
+  cudaStream_t _stream;
+
+ public:
+  KernelLauncher(KernelInstantiation const* kernel_inst, dim3 grid, dim3 block,
+                 unsigned int smem = 0, cudaStream_t stream = 0)
+      : _kernel_inst(kernel_inst),
+        _grid(grid),
+        _block(block),
+        _smem(smem),
+        _stream(stream) {}
+
+  // Note: It's important that there is no implicit conversion required
+  //         for arg_ptrs, because otherwise the parameter pack version
+  //         below gets called instead (probably resulting in a segfault).
+  /*! Launch the kernel.
+   *
+   *  \param arg_ptrs  A vector of pointers to each function argument for the
+   *    kernel.
+   *  \param arg_types A vector of function argument types represented
+   *    as code-strings. This parameter is optional and is only used to print
+   *    out the function signature.
+   */
+  CUresult launch(std::vector<void*> arg_ptrs = {},
+                  std::vector<std::string> arg_types = {}) const {
+#if JITIFY_PRINT_LAUNCH
+    std::string arg_types_string =
+        (arg_types.empty() ? "..." : reflection::reflect_list(arg_types));
+    std::cout << "Launching " << _kernel_inst->_cuda_kernel->function_name()
+              << "<<<" << _grid << "," << _block << "," << _smem << ","
+              << _stream << ">>>"
+              << "(" << arg_types_string << ")" << std::endl;
+#endif
+    return _kernel_inst->_cuda_kernel->launch(_grid, _block, _smem, _stream,
+                                              arg_ptrs);
+  }
+
+  /*! Launch the kernel.
+   *
+   *  \param args Function arguments for the kernel.
+   */
+  template <typename... ArgTypes>
+  CUresult launch(ArgTypes... args) const {
+    return this->launch(std::vector<void*>({(void*)&args...}),
+                        {reflection::reflect<ArgTypes>()...});
+  }
+};
+
+inline Kernel Program::kernel(std::string const& name,
+                              std::vector<std::string> const& options) const {
+  return Kernel(this, name, options);
+}
+
+inline KernelInstantiation Kernel::instantiate(
+    std::vector<std::string> const& template_args) const {
+  return KernelInstantiation(*this, template_args);
+}
+
+template <typename... TemplateArgs>
+inline KernelInstantiation Kernel::instantiate() const {
+  return this->instantiate(
+      std::vector<std::string>({reflection::reflect<TemplateArgs>()...}));
+}
+
+template <typename... TemplateArgs>
+inline KernelInstantiation Kernel::instantiate(TemplateArgs... targs) const {
+  return this->instantiate(
+      std::vector<std::string>({reflection::reflect(targs)...}));
+}
+
+inline KernelLauncher KernelInstantiation::configure(
+    dim3 grid, dim3 block, unsigned int smem, cudaStream_t stream) const {
+  return KernelLauncher(this, grid, block, smem, stream);
+}
+
+inline KernelLauncher KernelInstantiation::configure_1d_max_occupancy(
+    int max_block_size, unsigned int smem, CUoccupancyB2DSize smem_callback,
+    cudaStream_t stream, unsigned int flags) const {
+  int grid;
+  int block;
+  CUfunction func = *_cuda_kernel;
+  detail::get_1d_max_occupancy(func, smem_callback, &smem, max_block_size,
+                               flags, &grid, &block);
+  return this->configure(grid, block, smem, stream);
+}
+
+}  // namespace experimental
 
 }  // namespace jitify
+
+#if defined(_WIN32) || defined(_WIN64)
+#pragma pop_macro("max")
+#pragma pop_macro("min")
+#pragma pop_macro("strtok_r")
+#endif

--- a/include/gauge_field_order.h
+++ b/include/gauge_field_order.h
@@ -443,21 +443,20 @@ namespace quda {
 #endif
       }
 
-      template<typename helper, typename reducer>
-        __host__ double transform_reduce(QudaFieldLocation location, int dim, helper h, double init, reducer r) const
+      template <typename helper, typename reducer>
+      __host__ double transform_reduce(QudaFieldLocation location, int dim, helper h, double init, reducer r) const
       {
-	if (dim >= geometry) errorQuda("Request dimension %d exceeds dimensionality of the field %d", dim, geometry);
+        if (dim >= geometry) errorQuda("Request dimension %d exceeds dimensionality of the field %d", dim, geometry);
         int lower = (dim == -1) ? 0 : dim;
         int ndim = (dim == -1 ? geometry : 1);
         std::vector<double> result(ndim);
-        std::vector<complex<storeFloat>*> v(ndim);
+        std::vector<complex<storeFloat> *> v(ndim);
         for (int d = 0; d < ndim; d++) v[d] = u[d + lower];
         ::quda::transform_reduce(location, result, v, 2 * volumeCB * nColor * nColor, h, init, r);
         double total = init;
         for (auto &res : result) total = r(total, res);
         return total;
       }
-
     };
 
     template<typename Float, int nColor, bool native_ghost, typename storeFloat, bool use_tex>
@@ -583,18 +582,17 @@ namespace quda {
 #endif
       }
 
-      template<typename helper, typename reducer>
-        __host__ double transform_reduce(QudaFieldLocation location, int dim, helper h, double init, reducer r) const
+      template <typename helper, typename reducer>
+      __host__ double transform_reduce(QudaFieldLocation location, int dim, helper h, double init, reducer r) const
       {
-	if (dim >= geometry) errorQuda("Request dimension %d exceeds dimensionality of the field %d", dim, geometry);
+        if (dim >= geometry) errorQuda("Request dimension %d exceeds dimensionality of the field %d", dim, geometry);
         int start = dim == -1 ? 0 : dim;
-        int count = (dim == -1 ? geometry : 1 ) * volumeCB * nColor * nColor;
+        int count = (dim == -1 ? geometry : 1) * volumeCB * nColor * nColor;
         std::vector<double> result = {init, init};
         std::vector<decltype(u)> v = {u + (0 * geometry + start) * count, u + (1 * geometry + start) * count};
         ::quda::transform_reduce(location, result, v, count, h, init, r);
         return r(result[0], result[1]);
       }
-
     };
 
     template<typename Float, int nColor, bool native_ghost, typename storeFloat, bool use_tex>
@@ -767,10 +765,10 @@ namespace quda {
 #endif
       }
 
-      template<typename helper, typename reducer>
-        __host__ double transform_reduce(QudaFieldLocation location, int dim, helper h, double init, reducer r) const
+      template <typename helper, typename reducer>
+      __host__ double transform_reduce(QudaFieldLocation location, int dim, helper h, double init, reducer r) const
       {
-	if (dim >= geometry) errorQuda("Requested dimension %d exceeds dimensionality of the field %d", dim, geometry);
+        if (dim >= geometry) errorQuda("Requested dimension %d exceeds dimensionality of the field %d", dim, geometry);
         int start = (dim == -1) ? 0 : dim;
         int count = (dim == -1 ? geometry : 1) * stride * nColor * nColor;
         std::vector<double> result = {init, init};
@@ -778,7 +776,6 @@ namespace quda {
         ::quda::transform_reduce(location, result, v, count, h, init, r);
         return r(result[0], result[1]);
       }
-
     };
 
     template<typename Float, int nColor, bool native_ghost, typename storeFloat, bool use_tex>
@@ -1035,9 +1032,9 @@ namespace quda {
 	 * @return L1 norm
 	 */
 	__host__ double norm1(int dim=-1, bool global=true) const {
-	  double nrm1 = accessor.transform_reduce(location, dim, abs_<double,storeFloat>(accessor.scale_inv),
-                                                  0.0, plus<double>());
-	  if (global) comm_allreduce(&nrm1);
+          double nrm1 = accessor.transform_reduce(location, dim, abs_<double, storeFloat>(accessor.scale_inv), 0.0,
+                                                  plus<double>());
+          if (global) comm_allreduce(&nrm1);
 	  return nrm1;
 	}
 
@@ -1047,9 +1044,9 @@ namespace quda {
 	 * @return L2 norm squared
 	 */
 	__host__ double norm2(int dim=-1, bool global=true) const {
-	  double nrm2 = accessor.transform_reduce(location, dim, square_<double,storeFloat>(accessor.scale_inv),
-                                                  0.0, plus<double>());
-	  if (global) comm_allreduce(&nrm2);
+          double nrm2 = accessor.transform_reduce(location, dim, square_<double, storeFloat>(accessor.scale_inv), 0.0,
+                                                  plus<double>());
+          if (global) comm_allreduce(&nrm2);
 	  return nrm2;
 	}
 
@@ -1059,9 +1056,9 @@ namespace quda {
 	 * @return Linfinity norm
 	 */
 	__host__ double abs_max(int dim=-1, bool global=true) const {
-	  double absmax = accessor.transform_reduce(location, dim, abs_<Float,storeFloat>(accessor.scale_inv),
-                                                    0.0, maximum<Float>());
-	  if (global) comm_allreduce_max(&absmax);
+          double absmax = accessor.transform_reduce(location, dim, abs_<Float, storeFloat>(accessor.scale_inv), 0.0,
+                                                    maximum<Float>());
+          if (global) comm_allreduce_max(&absmax);
 	  return absmax;
 	}
 
@@ -1071,9 +1068,9 @@ namespace quda {
 	 * @return Minimum norm
 	 */
 	__host__ double abs_min(int dim=-1, bool global=true) const {
-	  double absmin = accessor.transform_reduce(location, dim, abs_<Float,storeFloat>(accessor.scale_inv),
+          double absmin = accessor.transform_reduce(location, dim, abs_<Float, storeFloat>(accessor.scale_inv),
                                                     std::numeric_limits<double>::max(), minimum<Float>());
-	  if (global) comm_allreduce_min(&absmin);
+          if (global) comm_allreduce_min(&absmin);
 	  return absmin;
 	}
 

--- a/include/gauge_field_order.h
+++ b/include/gauge_field_order.h
@@ -587,9 +587,10 @@ namespace quda {
       {
         if (dim >= geometry) errorQuda("Request dimension %d exceeds dimensionality of the field %d", dim, geometry);
         int start = dim == -1 ? 0 : dim;
-        int count = (dim == -1 ? geometry : 1) * volumeCB * nColor * nColor;
+        int count = (dim == -1 ? geometry : 1) * volumeCB * nColor * nColor; // items per parity
         std::vector<double> result = {init, init};
-        std::vector<decltype(u)> v = {u + (0 * geometry + start) * count, u + (1 * geometry + start) * count};
+        std::vector<decltype(u)> v = {u + (0 * geometry + start) * volumeCB * nColor * nColor,
+                                      u + (1 * geometry + start) * volumeCB * nColor * nColor};
         ::quda::transform_reduce(location, result, v, count, h, init, r);
         return r(result[0], result[1]);
       }

--- a/include/gauge_field_order.h
+++ b/include/gauge_field_order.h
@@ -22,11 +22,11 @@
 #include <type_traits>
 #include <limits>
 #include <atomic.cuh>
-#include <thrust_helper.cuh>
 #include <gauge_field.h>
 #include <index_helper.cuh>
 #include <trove_helper.cuh>
 #include <texture_helper.cuh>
+#include <transform_reduce.h>
 
 namespace quda {
 
@@ -444,23 +444,18 @@ namespace quda {
       }
 
       template<typename helper, typename reducer>
-        __host__ double transform_reduce(QudaFieldLocation location, int dim, helper h, reducer r, double init) const {
+        __host__ double transform_reduce(QudaFieldLocation location, int dim, helper h, double init, reducer r) const
+      {
 	if (dim >= geometry) errorQuda("Request dimension %d exceeds dimensionality of the field %d", dim, geometry);
         int lower = (dim == -1) ? 0 : dim;
-        int upper = (dim == -1) ? geometry : dim+1;
-        double result = init;
-        if (location == QUDA_CUDA_FIELD_LOCATION) {
-          thrust_allocator alloc;
-          for (int d=lower; d<upper; d++) {
-            thrust::device_ptr<complex<storeFloat> > ptr(u[d]);
-            result = thrust::transform_reduce(thrust::cuda::par(alloc), ptr, ptr+2*volumeCB*nColor*nColor, h, result, r);
-          }
-        } else {
-          for (int d=lower; d<upper; d++) {
-            result = thrust::transform_reduce(thrust::seq, u[d], u[d]+2*volumeCB*nColor*nColor, h, result, r);
-          }
-        }
-        return result;
+        int ndim = (dim == -1 ? geometry : 1);
+        std::vector<double> result(ndim);
+        std::vector<complex<storeFloat>*> v(ndim);
+        for (int d = 0; d < ndim; d++) v[d] = u[d + lower];
+        ::quda::transform_reduce(location, result, v, 2 * volumeCB * nColor * nColor, h, init, r);
+        double total = init;
+        for (auto &res : result) total = r(total, res);
+        return total;
       }
 
     };
@@ -589,29 +584,15 @@ namespace quda {
       }
 
       template<typename helper, typename reducer>
-      __host__ double transform_reduce(QudaFieldLocation location, int dim, helper h, reducer r, double init) const {
+        __host__ double transform_reduce(QudaFieldLocation location, int dim, helper h, double init, reducer r) const
+      {
 	if (dim >= geometry) errorQuda("Request dimension %d exceeds dimensionality of the field %d", dim, geometry);
-        int lower = (dim == -1) ? 0 : dim;
-        int upper = (dim == -1) ? geometry : dim+1;
-        double result = init;
-        if (location == QUDA_CUDA_FIELD_LOCATION) {
-          thrust_allocator alloc;
-          thrust::device_ptr<complex<storeFloat> > ptr(u);
-          result = thrust::transform_reduce(thrust::cuda::par(alloc),
-                                            ptr+(0*geometry+lower)*volumeCB*nColor*nColor,
-                                            ptr+(0*geometry+upper)*volumeCB*nColor*nColor, h, result, r);
-          result = thrust::transform_reduce(thrust::cuda::par(alloc),
-                                            ptr+(1*geometry+lower)*volumeCB*nColor*nColor,
-                                            ptr+(1*geometry+upper)*volumeCB*nColor*nColor, h, result, r);
-        } else {
-          result = thrust::transform_reduce(thrust::seq,
-                                            u+(0*geometry+lower)*volumeCB*nColor*nColor,
-                                            u+(0*geometry+upper)*volumeCB*nColor*nColor, h, result, r);
-          result  = thrust::transform_reduce(thrust::seq,
-                                             u+(1*geometry+lower)*volumeCB*nColor*nColor,
-                                             u+(1*geometry+upper)*volumeCB*nColor*nColor, h, result, r);
-        }
-        return result;
+        int start = dim == -1 ? 0 : dim;
+        int count = (dim == -1 ? geometry : 1 ) * volumeCB * nColor * nColor;
+        std::vector<double> result = {init, init};
+        std::vector<decltype(u)> v = {u + (0 * geometry + start) * count, u + (1 * geometry + start) * count};
+        ::quda::transform_reduce(location, result, v, count, h, init, r);
+        return r(result[0], result[1]);
       }
 
     };
@@ -787,29 +768,15 @@ namespace quda {
       }
 
       template<typename helper, typename reducer>
-        __host__ double transform_reduce(QudaFieldLocation location, int dim, helper h, reducer r, double init) const {
-	if (dim >= geometry) errorQuda("Request dimension %d exceeds dimensionality of the field %d", dim, geometry);
-        int lower = (dim == -1) ? 0 : dim;
-        int upper = (dim == -1) ? geometry : dim+1;
-        double result = init;
-        if (location == QUDA_CUDA_FIELD_LOCATION) {
-          thrust_allocator alloc;
-          thrust::device_ptr<complex<storeFloat> > ptr(u);
-          result = thrust::transform_reduce(thrust::cuda::par(alloc),
-                                            ptr+0*offset_cb+lower*stride*nColor*nColor,
-                                            ptr+0*offset_cb+upper*stride*nColor*nColor, h, result, r);
-          result = thrust::transform_reduce(thrust::cuda::par(alloc),
-                                            ptr+1*offset_cb+lower*stride*nColor*nColor,
-                                            ptr+1*offset_cb+upper*stride*nColor*nColor, h, result, r);
-        } else {
-          result = thrust::transform_reduce(thrust::seq,
-                                            u+0*offset_cb+lower*stride*nColor*nColor,
-                                            u+0*offset_cb+upper*stride*nColor*nColor, h, result, r);
-          result = thrust::transform_reduce(thrust::seq,
-                                            u+1*offset_cb+lower*stride*nColor*nColor,
-                                            u+1*offset_cb+upper*stride*nColor*nColor, h, result, r);
-        }
-        return result;
+        __host__ double transform_reduce(QudaFieldLocation location, int dim, helper h, double init, reducer r) const
+      {
+	if (dim >= geometry) errorQuda("Requested dimension %d exceeds dimensionality of the field %d", dim, geometry);
+        int start = (dim == -1) ? 0 : dim;
+        int count = (dim == -1 ? geometry : 1) * stride * nColor * nColor;
+        std::vector<double> result = {init, init};
+        std::vector<decltype(u)> v = {u + 0 * offset_cb + start * count, u + 1 * offset_cb + start * count};
+        ::quda::transform_reduce(location, result, v, count, h, init, r);
+        return r(result[0], result[1]);
       }
 
     };
@@ -1069,7 +1036,7 @@ namespace quda {
 	 */
 	__host__ double norm1(int dim=-1, bool global=true) const {
 	  double nrm1 = accessor.transform_reduce(location, dim, abs_<double,storeFloat>(accessor.scale_inv),
-                                                  thrust::plus<double>(), 0.0);
+                                                  0.0, plus<double>());
 	  if (global) comm_allreduce(&nrm1);
 	  return nrm1;
 	}
@@ -1081,7 +1048,7 @@ namespace quda {
 	 */
 	__host__ double norm2(int dim=-1, bool global=true) const {
 	  double nrm2 = accessor.transform_reduce(location, dim, square_<double,storeFloat>(accessor.scale_inv),
-                                                  thrust::plus<double>(), 0.0);
+                                                  0.0, plus<double>());
 	  if (global) comm_allreduce(&nrm2);
 	  return nrm2;
 	}
@@ -1093,7 +1060,7 @@ namespace quda {
 	 */
 	__host__ double abs_max(int dim=-1, bool global=true) const {
 	  double absmax = accessor.transform_reduce(location, dim, abs_<Float,storeFloat>(accessor.scale_inv),
-                                                    thrust::maximum<Float>(), 0.0);
+                                                    0.0, maximum<Float>());
 	  if (global) comm_allreduce_max(&absmax);
 	  return absmax;
 	}
@@ -1105,7 +1072,7 @@ namespace quda {
 	 */
 	__host__ double abs_min(int dim=-1, bool global=true) const {
 	  double absmin = accessor.transform_reduce(location, dim, abs_<Float,storeFloat>(accessor.scale_inv),
-                                                    thrust::minimum<Float>(), std::numeric_limits<double>::max());
+                                                    std::numeric_limits<double>::max(), minimum<Float>());
 	  if (global) comm_allreduce_min(&absmin);
 	  return absmin;
 	}

--- a/include/index_helper.cuh
+++ b/include/index_helper.cuh
@@ -827,7 +827,7 @@ namespace quda {
   /**
      @brief Swizzler for reordering the (x) thread block indices - use on
      conjunction with swizzle-factor autotuning to find the optimum
-     swizzle factor.  Specfically, the thread block id is remapped by
+     swizzle factor.  Specifically, the thread block id is remapped by
      transposing its coordinates: if the original order can be
      parametrized by
 

--- a/include/jitify_helper.cuh
+++ b/include/jitify_helper.cuh
@@ -24,7 +24,11 @@
 // hide debugging info
 #define JITIFY_PRINT_INSTANTIATION 0
 #define JITIFY_PRINT_SOURCE        0
+#ifdef DEVEL
+#define JITIFY_PRINT_LOG           1
+#else
 #define JITIFY_PRINT_LOG           0
+#endif
 #define JITIFY_PRINT_PTX           0
 #define JITIFY_PRINT_LAUNCH        0
 

--- a/include/jitify_helper.cuh
+++ b/include/jitify_helper.cuh
@@ -17,7 +17,9 @@
 #define JITIFY_PRINT_SOURCE        1
 #define JITIFY_PRINT_LOG           1
 #define JITIFY_PRINT_PTX           1
+#define JITIFY_PRINT_LINKER_LOG    1
 #define JITIFY_PRINT_LAUNCH        1
+#define JITIFY_PRINT_HEADER_PATHS  1
 
 #else // !HOST_DEBUG
 
@@ -30,7 +32,9 @@
 #define JITIFY_PRINT_LOG           0
 #endif
 #define JITIFY_PRINT_PTX           0
+#define JITIFY_PRINT_LINKER_LOG    0
 #define JITIFY_PRINT_LAUNCH        0
+#define JITIFY_PRINT_HEADER_PATHS  0
 
 #endif // !HOST_DEBUG
 

--- a/include/jitify_options.hpp.in
+++ b/include/jitify_options.hpp.in
@@ -1,10 +1,3 @@
 #define JITIFY_OPTIONS -I${CMAKE_BINARY_DIR}/lib \
 -I${CMAKE_BINARY_DIR}/include \
--I${CMAKE_BINARY_DIR}/include/externals \
--I${CMAKE_BINARY_DIR}/include/externals/cub \
--I${CMAKE_BINARY_DIR}/include/externals/cub/block \
--I${CMAKE_BINARY_DIR}/include/externals/cub/warp \
--I${CMAKE_BINARY_DIR}/include/externals/cub/block/specializations \
--I${CMAKE_BINARY_DIR}/include/externals/cub/device/dispatch \
--I${CMAKE_BINARY_DIR}/include/externals/cub/device
-
+-I${CMAKE_BINARY_DIR}/include/externals

--- a/include/kernels/block_orthogonalize.cuh
+++ b/include/kernels/block_orthogonalize.cuh
@@ -108,6 +108,22 @@ namespace quda {
 #pragma omp parallel for
     for (int x_coarse=0; x_coarse<arg.coarseVolume; x_coarse++) {
 
+      // first copy over raw components into the container
+      for (int j = 0; j < nVec; j++) {
+        for (int parity = 0; parity < arg.nParity; parity++) {
+          parity = (arg.nParity == 2) ? parity : arg.parity;
+          for (int b = 0; b < arg.geoBlockSizeCB; b++) {
+            int x = arg.coarse_to_fine[(x_coarse * 2 + parity) * arg.geoBlockSizeCB + b];
+            int x_cb = x - parity * arg.fineVolumeCB;
+            for (int s = 0; s < nSpin; s++) {
+              for (int c = 0; c < nColor; c++) {
+                arg.V(parity, x_cb, s, c, j) = arg.B[j](parity, x_cb, s, c);
+              }
+            }
+          }
+        }
+      }
+
       // loop over number of block orthos
       for (int n = 0; n < arg.nBlockOrtho; n++) {
         for (int j = 0; j < nVec; j++) {
@@ -127,14 +143,8 @@ namespace quda {
                 int x_cb = x - parity * arg.fineVolumeCB;
 
                 complex<Float> v[nSpin][nColor];
-
-                if (n == 0) { // load from B on first Gram-Schmidt, otherwise V.
-                  for (int s = 0; s < nSpin; s++)
-                    for (int c = 0; c < nColor; c++) v[s][c] = arg.B[j](parity, x_cb, s, c);
-                } else {
-                  for (int s = 0; s < nSpin; s++)
-                    for (int c = 0; c < nColor; c++) v[s][c] = arg.V(parity, x_cb, s, c, j);
-                }
+                for (int s = 0; s < nSpin; s++)
+                  for (int c = 0; c < nColor; c++) v[s][c] = arg.V(parity, x_cb, s, c, j);
 
                 for (int s = 0; s < nSpin; s++) {
                   complex<Float> vis[nColor];
@@ -154,12 +164,8 @@ namespace quda {
                 int x_cb = x - parity * arg.fineVolumeCB;
 
                 complex<Float> v[nSpin][nColor];
-                if (n == 0)
-                  for (int s = 0; s < nSpin; s++)
-                    for (int c = 0; c < nColor; c++) v[s][c] = arg.B[j](parity, x_cb, s, c);
-                else
-                  for (int s = 0; s < nSpin; s++)
-                    for (int c = 0; c < nColor; c++) v[s][c] = arg.V(parity, x_cb, s, c, j);
+                for (int s = 0; s < nSpin; s++)
+                  for (int c = 0; c < nColor; c++) v[s][c] = arg.V(parity, x_cb, s, c, j);
 
                 for (int s = 0; s < nSpin; s++) {
                   complex<Float> vis[nColor];
@@ -184,12 +190,8 @@ namespace quda {
               int x_cb = x - parity * arg.fineVolumeCB;
 
               complex<Float> v[nSpin][nColor];
-              if (n == 0)
-                for (int s = 0; s < nSpin; s++)
-                  for (int c = 0; c < nColor; c++) v[s][c] = arg.B[j](parity, x_cb, s, c);
-              else
-                for (int s = 0; s < nSpin; s++)
-                  for (int c = 0; c < nColor; c++) v[s][c] = arg.V(parity, x_cb, s, c, j);
+              for (int s = 0; s < nSpin; s++)
+                for (int c = 0; c < nColor; c++) v[s][c] = arg.V(parity, x_cb, s, c, j);
               for (int s = 0; s < nSpin; s++) { colorNorm<nColor>(nrm[arg.spin_map(s, parity)], v[s]); }
             }
           }
@@ -205,12 +207,8 @@ namespace quda {
               int x_cb = x - parity * arg.fineVolumeCB;
 
               complex<Float> v[nSpin][nColor];
-              if (n == 0)
-                for (int s = 0; s < nSpin; s++)
-                  for (int c = 0; c < nColor; c++) v[s][c] = arg.B[j](parity, x_cb, s, c);
-              else
-                for (int s = 0; s < nSpin; s++)
-                  for (int c = 0; c < nColor; c++) v[s][c] = arg.V(parity, x_cb, s, c, j);
+              for (int s = 0; s < nSpin; s++)
+                for (int c = 0; c < nColor; c++) v[s][c] = arg.V(parity, x_cb, s, c, j);
 
               for (int s = 0; s < nSpin; s++) { colorScale<Float, nColor>(v[s], nrm[arg.spin_map(s, parity)]); }
 

--- a/include/kernels/block_orthogonalize.cuh
+++ b/include/kernels/block_orthogonalize.cuh
@@ -13,7 +13,7 @@
 namespace quda {
 
 #define MAX_MATRIX_SIZE 4096
-  static __constant__ signed char B_array_d[MAX_MATRIX_SIZE];
+  __constant__ signed char B_array_d[MAX_MATRIX_SIZE];
 
   // to avoid overflowing the parameter space we put the B array into a separate constant memory buffer
   static signed char B_array_h[MAX_MATRIX_SIZE];
@@ -261,8 +261,7 @@ namespace quda {
     sumFloat *nrm_ = (sumFloat *)&dot_storage;
 
     // cast the constant memory buffer to a Vector array
-    typedef typename std::remove_reference<decltype(*arg.B)>::type Vector;
-    const Vector *B = reinterpret_cast<const Vector *>(B_array_d);
+    const auto *B = reinterpret_cast<decltype(arg.B)>(B_array_d);
 
     // loop over number of block orthos
     for (int n = 0; n < arg.nBlockOrtho; n++) {

--- a/include/kernels/coarse_op_kernel.cuh
+++ b/include/kernels/coarse_op_kernel.cuh
@@ -643,9 +643,9 @@ namespace quda {
 	    //Off-diagonal Spin (forward link / negative projector applied)
             auto gammaAV = make_tile_A<complex, false>(tile);
 
-            for (int i=0; i<tile.K; i++) for (int j=0; j<tile.M; j++) { gammaAV(j,i) = -gamma.apply(s, AV(i,j)); }
+            for (int i=0; i<tile.K; i++) for (int j=0; j<tile.M; j++) { gammaAV(j,i) = -gamma.apply(s, conj(AV(i,j))); }
             UV.loadCS(arg.UV, 0, 0, parity, x_cb, s_col, k, j0);
-            vuv[s_c_row*coarseSpin+s_c_row].mma_nn(gammaAV, UV);
+            vuv[s_c_row*coarseSpin+s_c_col].mma_nn(gammaAV, UV);
 	  }
 	} //Fine color
       }

--- a/include/matrix_tile.cuh
+++ b/include/matrix_tile.cuh
@@ -1,0 +1,173 @@
+#pragma once
+
+#include <quda_matrix.h>
+#include <complex_quda.h>
+
+namespace quda {
+
+  /**
+     @brief MatrixTile is a fragment of a matrix held in registers.
+   */
+  template <typename T, int m, int n, bool ghost>
+  struct MatrixTile {
+    using real = typename RealType<T>::type;
+    T tile[m*n];
+    inline __device__ __host__ MatrixTile()
+    {
+#pragma unroll
+      for (int i=0; i<m; i++) {
+#pragma unroll
+        for (int j=0; j<n; j++) {
+          tile[i*n+j] = 0.0;
+        }
+      }
+    }
+
+    inline __device__ __host__ const T& operator()(int i, int j) const
+    {
+      return tile[i*n+j];
+    }
+
+    inline __device__ __host__ T& operator()(int i, int j)
+    {
+      return tile[i*n+j];
+    }
+
+    template <int k, bool ghost_a, bool ghost_b>
+    inline __device__ __host__ void mma_nn(const MatrixTile<T, m, k, ghost_a> &a, const MatrixTile<T, k, n, ghost_b> &b)
+    {
+#pragma unroll
+      for (int i = 0; i < m; i++) {
+#pragma unroll
+        for (int j = 0; j < n; j++) {
+#pragma unroll
+          for (int l = 0; l < k; l++) {
+            tile[i*n+j] = cmac(a.tile[i*k+l], b.tile[l*n+j], tile[i*n+j]);
+          }
+        }
+      }
+    }
+
+    template <int k, bool ghost_a, bool ghost_b>
+    inline __device__ __host__ void mma_nt(const MatrixTile<T, m, k, ghost_a> &a, const MatrixTile<T, n, k, ghost_b> &b)
+    {
+#pragma unroll
+      for (int i = 0; i < m; i++) {
+#pragma unroll
+        for (int j = 0; j < n; j++) {
+#pragma unroll
+          for (int l = 0; l < k; l++) {
+            tile[i*n+j] = cmac(a.tile[i*k+l], conj(b.tile[j*k+l]), tile[i*n+j]);
+          }
+        }
+      }
+    }
+
+    template <typename Accessor> inline __device__ __host__ void load(const Accessor &a, int d, int parity, int x_cb, int i0, int j0)
+    {
+#pragma unroll
+      for (int i=0; i<m; i++) {
+#pragma unroll
+        for (int j=0; j<n; j++) {
+          if (ghost)
+            tile[i*n+j] = a.Ghost(d, parity, x_cb, i0 + i, j0 + j);
+          else
+            tile[i*n+j] = a(d, parity, x_cb, i0 + i, j0 + j);
+        }
+      }
+    }
+
+    template <typename Accessor> inline __device__ __host__ void load(const Accessor &a, int d, int parity, int x_cb, int si, int sj, int i0, int j0)
+    {
+#pragma unroll
+      for (int i=0; i<m; i++) {
+#pragma unroll
+        for (int j=0; j<n; j++) {
+          if (ghost)
+            tile[i*n+j] = a.Ghost(d, parity, x_cb, si, sj, i0 + i, j0 + j);
+          else
+            tile[i*n+j] = a(d, parity, x_cb, si, sj, i0 + i, j0 + j);
+        }
+      }
+    }
+
+    template <typename Accessor> inline __device__ __host__ void save(Accessor &a, int d, int parity, int x_cb, int i0, int j0)
+    {
+#pragma unroll
+      for (int i = 0; i < m; i++) {
+#pragma unroll
+        for (int j = 0; j < n; j++) {
+          if (ghost)
+            a.Ghost(d, parity, x_cb, i0 + i, j0 + j) = tile[i*n+j];
+          else
+            a(d, parity, x_cb, i0 + i, j0 + j) = tile[i*n+j];
+        }
+      }
+    }
+
+    template <typename Accessor> inline __device__ __host__ void save(Accessor &a, int d, int parity, int x_cb, int si, int sj, int i0, int j0)
+    {
+#pragma unroll
+      for (int i = 0; i < m; i++) {
+#pragma unroll
+        for (int j = 0; j < n; j++) {
+          if (ghost)
+            a.Ghost(d, parity, x_cb, si, sj, i0 + i, j0 + j) = tile[i*n+j];
+          else
+            a(d, parity, x_cb, si, sj, i0 + i, j0 + j) = tile[i*n+j];
+        }
+      }
+    }
+
+    template <typename Accessor> inline __device__ __host__ void loadCS(const Accessor &a, int d, int dir, int parity, int x_cb, int s, int i0, int j0)
+    {
+#pragma unroll
+      for (int i=0; i<m; i++) {
+#pragma unroll
+        for (int j=0; j<n; j++) {
+          if (ghost)
+            tile[i*n+j] = a.Ghost(d, dir, parity, x_cb, s, i0 + i, j0 + j);
+          else
+            tile[i*n+j] = a(parity, x_cb, s, i0 + i, j0 + j);
+        }
+      }
+    }
+
+    template <typename Accessor> inline __device__ __host__ void saveCS(Accessor &a, int d, int dir, int parity, int x_cb, int s, int i0, int j0)
+    {
+#pragma unroll
+      for (int i=0; i<m; i++) {
+#pragma unroll
+        for (int j=0; j<n; j++) {
+          if (ghost)
+            a.Ghost(d, dir, parity, x_cb, s, i0 + i, j0 + j) = tile[i*n+j];
+          else
+            a(parity, x_cb, s, i0 + i, j0 + j) = tile[i*n+j];
+        }
+      }
+    }
+
+    inline __device__ __host__ real abs_max()
+    {
+      real maxTile[m*n];
+#pragma unroll
+      for (int i = 0; i < m; i++) {
+#pragma unroll
+        for (int j = 0; j < n; j++) {
+          maxTile[i*n+j] = fmax(fabs(tile[i*n+j].real()), fabs(tile[i*n+j].imag()));
+        }
+      }
+        
+      real max = 0.0;
+#pragma unroll
+      for (int i = 0; i < m; i++) {
+#pragma unroll
+        for (int j = 0; j < n; j++) {
+          max = fmax(max, maxTile[i*n+j]);
+        }
+      }
+      return max;
+    }
+  };
+
+}

--- a/include/matrix_tile.cuh
+++ b/include/matrix_tile.cuh
@@ -225,4 +225,40 @@ namespace quda {
     return out;
   }
 
+  /** @brief Helper for creating an A tile (MxK) */
+  template <typename T, bool ghost, typename Tile> __device__ __host__  inline auto make_tile_A(const Tile tile)
+  {
+    return MatrixTile<T, tile.M, tile.K, ghost>();
+  }
+
+  /** @brief Helper for creating an A transpose tile (KxM) */
+  template <typename T, bool ghost, typename Tile> __device__ __host__  inline auto make_tile_At(const Tile tile)
+  {
+    return MatrixTile<T, tile.K, tile.M, ghost>();
+  }
+
+  /** @brief Helper for creating a B tile (KxN) */
+  template <typename T, bool ghost, typename Tile> __device__ __host__  inline auto make_tile_B(const Tile tile)
+  {
+    return MatrixTile<T, tile.K, tile.N, ghost>();
+  }
+
+  /** @brief Helper for creating a B transpose tile (NxK) */
+  template <typename T, bool ghost, typename Tile> __device__ __host__  inline auto make_tile_Bt(const Tile tile)
+  {
+    return MatrixTile<T, tile.N, tile.K, ghost>();
+  }
+
+  /** @brief Helper for creating a C tile (MxN) */
+  template <typename T, bool ghost, typename Tile> __device__ __host__  inline auto make_tile_C(const Tile tile)
+  {
+    return MatrixTile<T, tile.M, tile.N, ghost>();
+  }
+
+  /** @brief Helper for creating a C transpose tile (NxM) */
+  template <typename T, bool ghost, typename Tile> __device__ __host__  inline auto make_tile_Ct(const Tile tile)
+  {
+    return MatrixTile<T, tile.N, tile.M, ghost>();
+  }
+
 }

--- a/include/multi_blas_helper.cuh
+++ b/include/multi_blas_helper.cuh
@@ -13,9 +13,9 @@ namespace quda
     // storage for matrix coefficients
 #define MAX_MATRIX_SIZE 8192
 #define MAX_ARG_SIZE 4096
-    static __constant__ signed char Amatrix_d[MAX_MATRIX_SIZE];
-    static __constant__ signed char Bmatrix_d[MAX_MATRIX_SIZE];
-    static __constant__ signed char Cmatrix_d[MAX_MATRIX_SIZE];
+    __constant__ signed char Amatrix_d[MAX_MATRIX_SIZE];
+    __constant__ signed char Bmatrix_d[MAX_MATRIX_SIZE];
+    __constant__ signed char Cmatrix_d[MAX_MATRIX_SIZE];
 
     static signed char *Amatrix_h;
     static signed char *Bmatrix_h;

--- a/include/transform_reduce.h
+++ b/include/transform_reduce.h
@@ -1,0 +1,231 @@
+#pragma once
+
+#include <cub_helper.cuh>
+#include <uint_to_char.h>
+#include <tune_quda.h>
+
+/**
+   @file transform_reandom.h
+
+   @brief QUDA reimplementation of thrust::transform_reduce as well as
+   wrappers also implementing thrust::reduce.
+ */
+
+namespace quda {
+
+  template <typename T> struct plus {
+    __device__ __host__ T operator()(T a, T b) { return a + b; }
+  };
+
+  template <typename T> struct maximum {
+    __device__ __host__ T operator()(T a, T b) { return a > b ? a : b; }
+  };
+
+  template <typename T> struct minimum {
+    __device__ __host__ T operator()(T a, T b) { return a < b ? a : b; }
+  };
+
+  template <typename T> struct identity {
+    __device__ __host__ T operator()(T a) { return a; }
+  };
+
+  template <typename reduce_t, typename T, typename count_t, typename transformer, typename reducer>
+  struct TransformReduceArg : public ReduceArg<reduce_t> {
+    static constexpr int block_size = 512;
+    static constexpr int n_batch_max = 4;
+    const T* v[n_batch_max];
+    count_t n_items;
+    int n_batch;
+    reduce_t init;
+    reduce_t result[n_batch_max];
+    transformer h;
+    reducer r;
+    TransformReduceArg(const std::vector<T*> &v, count_t n_items, transformer h, reduce_t init, reducer r) :
+      n_items(n_items),
+      n_batch(v.size()),
+      init(init),
+      h(h),
+      r(r)
+    {
+      if (n_batch > n_batch_max) errorQuda("Requested batch %d greater than max supported %d", n_batch, n_batch_max);
+      for (size_t j = 0; j < v.size(); j++) this->v[j] = v[j];
+    }
+
+  };
+
+  template <typename Arg> void transform_reduce(Arg &arg)
+  {
+    using count_t = decltype(arg.n_items);
+    using reduce_t = decltype(arg.init);
+
+    for (int j = 0; j < arg.n_batch; j++) {
+      auto v = arg.v[j];
+      reduce_t r_ = arg.init;
+      for (count_t i = 0; i < arg.n_items; i++) {
+        auto v_ = arg.h(v[i]);
+        r_ = arg.r(r_, v_);
+      }
+      arg.result[j] = r_;
+    }
+  }
+
+  template <typename Arg> __launch_bounds__(Arg::block_size) __global__ void transform_reduce_kernel(Arg arg)
+  {
+    using count_t = decltype(arg.n_items);
+    using reduce_t = decltype(arg.init);
+
+    count_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    int j = blockIdx.y;
+    auto v = arg.v[j];
+    reduce_t r_ = arg.init;
+
+    while (i < arg.n_items) {
+      auto v_ = arg.h(v[i]);
+      r_ = arg.r(r_, v_);
+      i += blockDim.x * gridDim.x;
+    }
+
+    reduce<Arg::block_size, reduce_t, false, decltype(arg.r)>(arg, r_, j);
+  }
+
+  template <typename Arg>
+  class TransformReduce : Tunable {
+    Arg &arg;
+    QudaFieldLocation location;
+
+    bool tuneSharedBytes() const { return false; }
+    unsigned int sharedBytesPerThread() const { return 0; }
+    unsigned int sharedBytesPerBlock(const TuneParam &param) const { return 0; }
+    int blockMin() const { return Arg::block_size; }
+    unsigned int maxBlockSize(const TuneParam &param) const { return Arg::block_size; }
+
+    bool advanceTuneParam(TuneParam &param) const {
+      // only do autotuning if we have device fields
+      if (location == QUDA_CUDA_FIELD_LOCATION) return Tunable::advanceTuneParam(param);
+      else return false;
+    }
+
+    void initTuneParam(TuneParam &param) const
+    {
+      Tunable::initTuneParam(param);
+      param.grid.y = arg.n_batch;
+    }
+
+  public:
+    TransformReduce(Arg &arg, QudaFieldLocation location) :
+      arg(arg),
+      location(location)
+      {
+        strcpy(aux, "batch_size=");
+        u32toa(aux+11, arg.n_batch);
+        if (location == QUDA_CPU_FIELD_LOCATION) strcat(aux, ",cpu");
+      }
+
+    void apply(const cudaStream_t &stream) {
+      TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
+
+      if (location == QUDA_CUDA_FIELD_LOCATION) {
+        transform_reduce_kernel<<<tp.grid, tp.block>>>(arg);
+        qudaDeviceSynchronize();
+        for (decltype(arg.n_batch) j = 0; j < arg.n_batch; j++) arg.result[j] = arg.result_h[j];
+      } else {        
+        transform_reduce(arg);
+      }
+    }
+
+    TuneKey tuneKey() const {
+      char count[16];
+      u32toa(count, arg.n_items);
+      return TuneKey(count, typeid(*this).name(), aux);
+    }
+
+    long long flops() const { return 0; } // just care about bandwidth
+    long long bytes() const { return arg.n_batch * arg.n_items * sizeof(*arg.v); } 
+  };
+
+  /**
+     @brief QUDA implementation providing thrust::transform_reduce like
+     functionality.  Improves upon thrust's implementation since a
+     single kernel is used which writes the result directly to host
+     memory, and is a batched implementation.
+     @param[in] location Location where the reduction will take place
+     @param[out] result Vector of results
+     @param[in] v Vector of inputs
+     @param[in] n_items Number of elements to be reduced in each input
+     @param[in] transformer Functor that applies transform to each element
+     @param[in] init The results are initialized to this value
+     @param[in] reducer Functor that applies the reduction to each transformed element
+   */
+  template <typename reduce_t, typename T, typename I, typename transformer, typename reducer>
+  void transform_reduce(QudaFieldLocation location, std::vector<reduce_t> &result, const std::vector<T *> &v, I n_items,
+                        transformer h, reduce_t init, reducer r)
+  {
+    if (result.size() != v.size()) errorQuda("result %lu and input %lu set sizes do not match", result.size(), v.size());
+    TransformReduceArg<reduce_t, T, I, transformer, reducer> arg(v, n_items, h, init, r);
+    TransformReduce<decltype(arg)> reduce(arg, location);
+    reduce.apply(0);
+    for (size_t j=0; j<result.size(); j++) result[j] = arg.result[j];
+  }
+
+  /**
+     @brief QUDA implementation providing thrust::transform_reduce like
+     functionality.  Improves upon thrust's implementation since a
+     single kernel is used which writes the result directly to host
+     memory.
+     @param[in] location Location where the reduction will take place
+     @param[out] result Result
+     @param[in] v Input vector
+     @param[in] n_items Number of elements to be reduced
+     @param[in] transformer Functor that applies transform to each element
+     @param[in] init Results is initialized to this value
+     @param[in] reducer Functor that applies the reduction to each transformed element
+   */
+  template <typename reduce_t, typename T, typename I, typename transformer, typename reducer>
+  reduce_t transform_reduce(QudaFieldLocation location, const T *v, I n_items, transformer h, reduce_t init, reducer r)
+  {
+    std::vector<reduce_t> result = { 0.0 };
+    std::vector<const T*> v_ = { v };
+    transform_reduce(location, result, v_, n_items, h, init, r);
+    return result[0];
+  }  
+
+  /**
+     @brief QUDA implementation providing thrust::reduce like
+     functionality.  Improves upon thrust's implementation since a
+     single kernel is used which writes the result directly to host
+     memory, and is a batched implementation.
+     @param[in] location Location where the reduction will take place
+     @param[out] result Result
+     @param[in] v Input vector
+     @param[in] n_items Number of elements to be reduced
+     @param[in] init The results are initialized to this value
+     @param[in] reducer Functor that applies the reduction to each transformed element
+   */
+  template <typename reduce_t, typename T, typename I, typename transformer, typename reducer>
+  void reduce(QudaFieldLocation location, std::vector<reduce_t> &result, const std::vector<T *> &v, I n_items,
+              reduce_t init, reducer r)
+  {
+    transform_reduce(location, result, v, n_items, identity<T>(), init, r);
+  }
+
+  /**
+     @brief QUDA implementation providing thrust::reduce like
+     functionality.  Improves upon thrust's implementation since a
+     single kernel is used which writes the result directly to host
+     memory.
+     @param[in] location Location where the reduction will take place
+     @param[out] result Result
+     @param[in] v Input vector
+     @param[in] n_items Number of elements to be reduced
+     @param[in] init Result is initialized to this value
+     @param[in] reducer Functor that applies the reduction to each transformed element
+   */
+  template <typename reduce_t, typename T, typename I, typename reducer>
+  reduce_t reduce(QudaFieldLocation location, const T *v, I n_items, reduce_t init, reducer r)
+  {
+    std::vector<reduce_t> result = { 0.0 };
+    std::vector<const T*> v_ = { v };
+    transform_reduce(location, result, v_, n_items, identity<T>(), init, r);
+    return result[0];
+  }  
+}

--- a/include/tune_quda.h
+++ b/include/tune_quda.h
@@ -8,9 +8,16 @@
 #include <cfloat>
 #include <stdarg.h>
 #include <map>
+#include <algorithm>
 
 #include <tune_key.h>
 #include <quda_internal.h>
+
+// this file has some workarounds to allow compilation using nvrtc of kernels that include this file
+#ifdef __CUDACC_RTC__
+#define CUresult bool
+#define CUDA_SUCCESS true
+#endif
 
 namespace quda {
 
@@ -46,6 +53,7 @@ namespace quda {
       return *this;
     }
 
+#ifndef __CUDACC_RTC__
     friend std::ostream& operator<<(std::ostream& output, const TuneParam& param) {
       output << "block=(" << param.block.x << "," << param.block.y << "," << param.block.z << "), ";
       output << "grid=(" << param.grid.x << "," << param.grid.y << "," << param.grid.z << "), ";
@@ -53,13 +61,16 @@ namespace quda {
       output << ", aux=(" << param.aux.x << "," << param.aux.y << "," << param.aux.z << "," << param.aux.w << ")";
       return output;
     }
+#endif
   };
 
+#ifndef __CUDACC_RTC__
   /**
    * @brief Returns a reference to the tunecache map
    * @return tunecache reference
    */
   const std::map<TuneKey, TuneParam> &getTuneCache();
+#endif
 
   class Tunable {
 
@@ -269,10 +280,13 @@ namespace quda {
     char aux[TuneKey::aux_n];
 
     int writeAuxString(const char *format, ...) {
+      int n = 0;
+#ifndef __CUDACC_RTC__
       va_list arguments;
       va_start(arguments, format);
-      int n = vsnprintf(aux, TuneKey::aux_n, format, arguments);
-      if (n < 0 || n >=TuneKey::aux_n) errorQuda("Error writing auxiliary string");
+      n = vsnprintf(aux, TuneKey::aux_n, format, arguments);
+      if (n < 0 || n >= TuneKey::aux_n) errorQuda("Error writing auxiliary string");
+#endif
       return n;
     }
 
@@ -285,6 +299,7 @@ namespace quda {
     */
     bool tuned()
     {
+#ifndef __CUDACC_RTC__
       // not tuning is equivalent to already tuned
       if (!getTuning()) return true;
 
@@ -292,6 +307,9 @@ namespace quda {
       if (use_managed_memory()) strcat(key.aux, ",managed");
       // if key is present in cache then already tuned
       return getTuneCache().find(key) != getTuneCache().end();
+#else
+      return true;
+#endif
     }
 
   public:
@@ -303,22 +321,24 @@ namespace quda {
     virtual void postTune() { }
     virtual int tuningIter() const { return 1; }
 
+#ifndef __CUDACC_RTC__
     virtual std::string paramString(const TuneParam &param) const
-      {
-	std::stringstream ps;
-	ps << param;
-	return ps.str();
-      }
+    {
+      std::stringstream ps;
+      ps << param;
+      return ps.str();
+    }
 
     virtual std::string perfString(float time) const
-      {
-	float gflops = flops() / (1e9 * time);
-	float gbytes = bytes() / (1e9 * time);
-	std::stringstream ss;
-	ss << std::setiosflags(std::ios::fixed) << std::setprecision(2) << gflops << " Gflop/s, ";
-	ss << gbytes << " GB/s";
-	return ss.str();
-      }
+    {
+      float gflops = flops() / (1e9 * time);
+      float gbytes = bytes() / (1e9 * time);
+      std::stringstream ss;
+      ss << std::setiosflags(std::ios::fixed) << std::setprecision(2) << gflops << " Gflop/s, ";
+      ss << gbytes << " GB/s";
+      return ss.str();
+    }
+#endif
 
     virtual void initTuneParam(TuneParam &param) const
     {
@@ -600,6 +620,12 @@ namespace quda {
   void setPolicyTuning(bool);
 
 } // namespace quda
+
+// undo jit-safe modifications
+#ifdef __CUDACC_RTC__
+#undef CUresult
+#undef CUDA_SUCCESS
+#endif
 
 #define postTrace() quda::postTrace_(__func__, quda::file_name(__FILE__), __LINE__)
 

--- a/include/tune_quda.h
+++ b/include/tune_quda.h
@@ -348,7 +348,7 @@ namespace quda {
     virtual void defaultTuneParam(TuneParam &param) const
     {
       initTuneParam(param);
-      if (tuneGridDim()) param.grid = dim3(maxGridSize(), 1, 1);
+      if (tuneGridDim()) param.grid.x = maxGridSize(); // don't set y and z in case derived initTuneParam has
     }
 
     virtual bool advanceTuneParam(TuneParam &param) const

--- a/lib/block_orthogonalize.cu
+++ b/lib/block_orthogonalize.cu
@@ -49,7 +49,7 @@ namespace quda {
 
         if (V.Location() == QUDA_CUDA_FIELD_LOCATION) {
 #ifdef JITIFY
-        create_jitify_program("kernels/block_orthogonalize.cuh");
+          create_jitify_program("kernels/block_orthogonalize.cuh");
 #endif
         }
       strcat(aux, compile_type_str(V));

--- a/lib/coarse_op.cuh
+++ b/lib/coarse_op.cuh
@@ -1,7 +1,7 @@
 #include <tune_quda.h>
-
 #include <jitify_helper.cuh>
 #include <kernels/coarse_op_kernel.cuh>
+#include <uint_to_char.h>
 
 namespace quda {
 
@@ -36,15 +36,15 @@ namespace quda {
     {
       if (type == COMPUTE_UV) {
         if (arg.dir == QUDA_BACKWARDS) {
-          if      (arg.dim==0) ComputeUVCPU<from_coarse,Float,0,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor>(arg);
-          else if (arg.dim==1) ComputeUVCPU<from_coarse,Float,1,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor>(arg);
-          else if (arg.dim==2) ComputeUVCPU<from_coarse,Float,2,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor>(arg);
-          else if (arg.dim==3) ComputeUVCPU<from_coarse,Float,3,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor>(arg);
+          if      (arg.dim==0) ComputeUVCPU<from_coarse,Float,0,QUDA_BACKWARDS,fineSpin,coarseSpin>(arg);
+          else if (arg.dim==1) ComputeUVCPU<from_coarse,Float,1,QUDA_BACKWARDS,fineSpin,coarseSpin>(arg);
+          else if (arg.dim==2) ComputeUVCPU<from_coarse,Float,2,QUDA_BACKWARDS,fineSpin,coarseSpin>(arg);
+          else if (arg.dim==3) ComputeUVCPU<from_coarse,Float,3,QUDA_BACKWARDS,fineSpin,coarseSpin>(arg);
         } else if (arg.dir == QUDA_FORWARDS) {
-          if      (arg.dim==0) ComputeUVCPU<from_coarse,Float,0,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor>(arg);
-          else if (arg.dim==1) ComputeUVCPU<from_coarse,Float,1,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor>(arg);
-          else if (arg.dim==2) ComputeUVCPU<from_coarse,Float,2,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor>(arg);
-          else if (arg.dim==3) ComputeUVCPU<from_coarse,Float,3,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor>(arg);
+          if      (arg.dim==0) ComputeUVCPU<from_coarse,Float,0,QUDA_FORWARDS,fineSpin,coarseSpin>(arg);
+          else if (arg.dim==1) ComputeUVCPU<from_coarse,Float,1,QUDA_FORWARDS,fineSpin,coarseSpin>(arg);
+          else if (arg.dim==2) ComputeUVCPU<from_coarse,Float,2,QUDA_FORWARDS,fineSpin,coarseSpin>(arg);
+          else if (arg.dim==3) ComputeUVCPU<from_coarse,Float,3,QUDA_FORWARDS,fineSpin,coarseSpin>(arg);
         } else {
           errorQuda("Undefined direction %d", arg.dir);
         }
@@ -144,15 +144,15 @@ namespace quda {
           .configure(tp.grid,tp.block,tp.shared_bytes,stream).launch(arg);
 #else
         if (arg.dir == QUDA_BACKWARDS) {
-          if      (arg.dim==0) ComputeUVGPU<from_coarse,Float,0,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
-          else if (arg.dim==1) ComputeUVGPU<from_coarse,Float,1,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
-          else if (arg.dim==2) ComputeUVGPU<from_coarse,Float,2,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
-          else if (arg.dim==3) ComputeUVGPU<from_coarse,Float,3,QUDA_BACKWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+          if      (arg.dim==0) ComputeUVGPU<from_coarse,Float,0,QUDA_BACKWARDS,fineSpin,coarseSpin><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+          else if (arg.dim==1) ComputeUVGPU<from_coarse,Float,1,QUDA_BACKWARDS,fineSpin,coarseSpin><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+          else if (arg.dim==2) ComputeUVGPU<from_coarse,Float,2,QUDA_BACKWARDS,fineSpin,coarseSpin><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+          else if (arg.dim==3) ComputeUVGPU<from_coarse,Float,3,QUDA_BACKWARDS,fineSpin,coarseSpin><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
         } else if (arg.dir == QUDA_FORWARDS) {
-          if      (arg.dim==0) ComputeUVGPU<from_coarse,Float,0,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
-          else if (arg.dim==1) ComputeUVGPU<from_coarse,Float,1,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
-          else if (arg.dim==2) ComputeUVGPU<from_coarse,Float,2,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
-          else if (arg.dim==3) ComputeUVGPU<from_coarse,Float,3,QUDA_FORWARDS,fineSpin,fineColor,coarseSpin,coarseColor><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+          if      (arg.dim==0) ComputeUVGPU<from_coarse,Float,0,QUDA_FORWARDS,fineSpin,coarseSpin><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+          else if (arg.dim==1) ComputeUVGPU<from_coarse,Float,1,QUDA_FORWARDS,fineSpin,coarseSpin><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+          else if (arg.dim==2) ComputeUVGPU<from_coarse,Float,2,QUDA_FORWARDS,fineSpin,coarseSpin><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
+          else if (arg.dim==3) ComputeUVGPU<from_coarse,Float,3,QUDA_FORWARDS,fineSpin,coarseSpin><<<tp.grid,tp.block,tp.shared_bytes>>>(arg);
         }
 #endif
 
@@ -610,7 +610,7 @@ namespace quda {
       case COMPUTE_RESCALE:
 	resizeVector(2*coarseColor,coarseColor);
         break;
-      case COMPUTE_UV:
+      case COMPUTE_UV: resizeVector(2 * arg.uvTile.M_tiles, arg.uvTile.N_tiles); break;
       case COMPUTE_TMAV: resizeVector(2, coarseColor); break;
       case COMPUTE_AV:
       case COMPUTE_TMCAV: resizeVector(4, coarseColor); break; // y dimension is chirality and parity
@@ -737,6 +737,15 @@ namespace quda {
           type == COMPUTE_TMCAV || type == COMPUTE_TWISTED_CLOVER_INV_MAX)
         strcat(Aux, ",Dynamic");
 #endif
+      if (type == COMPUTE_UV) {
+        strcat(Aux, ",tile_size=");
+        char uvTile[16];
+        u32toa(uvTile, arg.uvTile.M);
+        strcat(Aux, uvTile);
+        strcat(Aux,"x");
+        u32toa(uvTile, arg.uvTile.N);
+        strcat(Aux, uvTile);
+      }
 
       if (type == COMPUTE_UV || type == COMPUTE_VUV) {
         if      (dim == 0) strcat(Aux, ",dim=0");

--- a/lib/coarse_op.cuh
+++ b/lib/coarse_op.cuh
@@ -140,7 +140,7 @@ namespace quda {
         if (arg.dir != QUDA_BACKWARDS && arg.dir != QUDA_FORWARDS) errorQuda("Undefined direction %d", arg.dir);
 #ifdef JITIFY
         error = program->kernel("quda::ComputeUVGPU")
-          .instantiate(from_coarse,Type<Float>(),arg.dim,arg.dir,fineSpin,fineColor,coarseSpin,coarseColor,Type<Arg>())
+          .instantiate(from_coarse,Type<Float>(),arg.dim,arg.dir,fineSpin,coarseSpin,Type<Arg>())
           .configure(tp.grid,tp.block,tp.shared_bytes,stream).launch(arg);
 #else
         if (arg.dir == QUDA_BACKWARDS) {

--- a/lib/gauge_plaq.cu
+++ b/lib/gauge_plaq.cu
@@ -11,9 +11,9 @@ namespace quda {
 
     Arg &arg;
     const GaugeField &meta;
-
-  private:
     bool tuneGridDim() const { return true; }
+    unsigned int minGridSize() const { return maxGridSize() / 8; }
+    int gridStep() const { return minGridSize(); }
 
   public:
     GaugePlaq(Arg &arg, const GaugeField &meta) :

--- a/lib/multi_reduce_quda.cu
+++ b/lib/multi_reduce_quda.cu
@@ -483,7 +483,7 @@ namespace quda {
       checkPrecision(*x[0], *z[0]);
       checkPrecision(*y[0], *w[0]);
 
-      assert(siteUnroll == true);
+      static_assert(siteUnroll == true, "site unrolling must be enabled for mixed precision");
       int reduce_length = siteUnroll ? x[0]->RealLength() : x[0]->Length();
 
       if (y[0]->Precision() == QUDA_DOUBLE_PRECISION && x[0]->Precision() == QUDA_SINGLE_PRECISION) {


### PR DESCRIPTION
This pull request is an initial, and yet significant, rework of the multigrid setup kernels to better express locality in the form of explicit register-level tiling. 
* Introduced `MatrixTile` infrastructure for optimized deployment of matrix-matrix type computations, as performed in the multigrid setup kernels
* `computeUV`, `computeVUV` and `computeYhat` kernels all rewritten to use this new framework
* Verified against both staggered and Wilson multigrid setups
* As part of this pull, I have updated to the latest official jitify snapshot (and also verified the multigrid setup runs through fine with a jitify-enabled build)
* Improved jitify verbosity setting: when doing a `DEVEL` build of QUDA we can now see the build logs at runtime
* Reduced tuning time for plaquette (narrow grid search space which was unnecessarily large previously)

The end result of this work is that the multigrid-setup kernels are now significantly faster, while also autotuning much faster.  For some pathological multigrid setups, we see an 8x reduction in tuning time and 10x boost in performance.

For an example of this performance boost, we consider the following invocation
```bash
multigrid_invert_test --dim 16 16 16 16 --mg-levels 3 --mg-nvec 0 24 --mg-nvec 1 32 --prec-precondition half --prec-null half --nsrc 0
```
This will run 3-level MG and only run the setup.  Kernel performance is as follows (perf in GFLOPS):

  | old | new
-- | -- | --
UV level 0 | 1630 | 1660
VUV level 0 | 1890 | 2950
Yhat level 0 | 3110 | 5900
Yhat level 0 max | 3170 | 6730
UV level 1 | 340 | 4100
VUV level 1 | 3000 | 3400
Yhat level 1 | 830 | 2660
Yhat level 1 max | 810 | 4830

Noting that the `MatrixTile` framework is far from complete and is a stepping stone towards tensor-core deployment more broadly in QUDA.