### PR TITLE
Hotfix/various

### DIFF
--- a/include/color_spinor_field.h
+++ b/include/color_spinor_field.h
@@ -225,7 +225,7 @@ namespace quda {
     // normally used to create cuda param from a cpu param
     ColorSpinorParam(ColorSpinorParam &cpuParam, QudaInvertParam &inv_param,
                      QudaFieldLocation location = QUDA_CUDA_FIELD_LOCATION) :
-      LatticeFieldParam(cpuParam.nDim, cpuParam.x, inv_param.sp_pad, inv_param.cuda_prec),
+      LatticeFieldParam(cpuParam.nDim, cpuParam.x, 0, inv_param.cuda_prec),
       location(location),
       nColor(cpuParam.nColor),
       nSpin(cpuParam.nSpin),

--- a/tests/invert_test.cpp
+++ b/tests/invert_test.cpp
@@ -589,7 +589,7 @@ int main(int argc, char **argv)
         }
       }
 
-    } else if(inv_param.solution_type == QUDA_MATPC_SOLUTION) {
+    } else if (inv_param.solution_type == QUDA_MATPC_SOLUTION) {
 
       if (dslash_type == QUDA_TWISTED_MASS_DSLASH) {
 	if (inv_param.twist_flavor != QUDA_TWIST_SINGLET) {
@@ -649,7 +649,6 @@ int main(int argc, char **argv)
     } else if (inv_param.solution_type == QUDA_MATPCDAG_MATPC_SOLUTION) {
 
       void *spinorTmp = malloc(V*spinorSiteSize*sSize*inv_param.Ls);
-
       ax(0, spinorCheck, V*spinorSiteSize, inv_param.cpu_prec);
       
       if (dslash_type == QUDA_TWISTED_MASS_DSLASH) {
@@ -716,6 +715,8 @@ int main(int argc, char **argv)
       }
 
       free(spinorTmp);
+    } else {
+      errorQuda("Solution type %d not implemented", inv_param.solution_type);
     }
 
 


### PR DESCRIPTION
Bugfix pull
* The `QudaInvertParam::sp_pad` parameter is now ignored, and all `ColorSpinorField` instances will use zero padding.  This closes #973, which wasn't really a bug, rather a statement that different pad values can lead to different tunings which will slightly change the convergence due to floating point rounding.
* Ensure that unsupported `solution_type` values are caught in `invert_test` and don't just silently fail.