### PR TITLE
fixing a error in the construction of the MatDagger for Mobius fermions

### DIFF
--- a/host_reference/domain_wall_dslash_reference.cpp
+++ b/host_reference/domain_wall_dslash_reference.cpp
@@ -808,18 +808,30 @@ void mdw_mat(void *out, void **gauge, void *in, double _Complex *kappa_b, double
   void *outEven = out;
   void *outOdd = (char *)out + V5h * spinor_site_size * precision;
 
-  mdw_dslash_4_pre(tmp, gauge, inEven, 0, dagger, precision, gauge_param, mferm, b5, c5, true);
-  dslash_4_4d(outOdd, gauge, tmp, 1, dagger, precision, gauge_param, mferm);
-  mdw_dslash_5(tmp, gauge, inOdd, 1, dagger, precision, gauge_param, mferm, kappa5, true);
+  if (!dagger) {
+    mdw_dslash_4_pre(tmp, gauge, inEven, 0, dagger, precision, gauge_param, mferm, b5, c5, true);
+    dslash_4_4d(outOdd, gauge, tmp, 1, dagger, precision, gauge_param, mferm);
+    mdw_dslash_5(tmp, gauge, inOdd, 1, dagger, precision, gauge_param, mferm, kappa5, true);
+  } else {
+    dslash_4_4d(tmp, gauge, inEven, 1, dagger, precision, gauge_param, mferm);
+    mdw_dslash_4_pre(outOdd, gauge, tmp, 0, dagger, precision, gauge_param, mferm, b5, c5, true);
+    mdw_dslash_5(tmp, gauge, inOdd, 1, dagger, precision, gauge_param, mferm, kappa5, true);
+  }
 
   for(int xs = 0 ; xs < Ls ; xs++) {
     cxpay((char *)tmp + precision * Vh * spinor_site_size * xs, -kappa_b[xs],
           (char *)outOdd + precision * Vh * spinor_site_size * xs, Vh * spinor_site_size, precision);
   }
 
-  mdw_dslash_4_pre(tmp, gauge, inOdd, 1, dagger, precision, gauge_param, mferm, b5, c5, true);
-  dslash_4_4d(outEven, gauge, tmp, 0, dagger, precision, gauge_param, mferm);
-  mdw_dslash_5(tmp, gauge, inEven, 0, dagger, precision, gauge_param, mferm, kappa5, true);
+  if (!dagger) {
+    mdw_dslash_4_pre(tmp, gauge, inOdd, 1, dagger, precision, gauge_param, mferm, b5, c5, true);
+    dslash_4_4d(outEven, gauge, tmp, 0, dagger, precision, gauge_param, mferm);
+    mdw_dslash_5(tmp, gauge, inEven, 0, dagger, precision, gauge_param, mferm, kappa5, true);
+  } else {
+    dslash_4_4d(tmp, gauge, inOdd, 0, dagger, precision, gauge_param, mferm);
+    mdw_dslash_4_pre(outEven, gauge, tmp, 1, dagger, precision, gauge_param, mferm, b5, c5, true);
+    mdw_dslash_5(tmp, gauge, inEven, 0, dagger, precision, gauge_param, mferm, kappa5, true);
+  }
 
   for(int xs = 0 ; xs < Ls ; xs++) {
     cxpay((char *)tmp + precision * Vh * spinor_site_size * xs, -kappa_b[xs],

--- a/lib/dirac_mobius.cpp
+++ b/lib/dirac_mobius.cpp
@@ -143,16 +143,15 @@ namespace quda {
     if (tmp2 && tmp2->SiteSubset() == QUDA_FULL_SITE_SUBSET) tmp = tmp2;
     bool reset = newTmp(&tmp, in);
 
-    if ( dagger == QUDA_DAG_NO ) {
-        ApplyDslash5(out, in, in, mass, m5, b_5, c_5, 0.0, dagger, DSLASH5_MOBIUS_PRE);
-        ApplyDomainWall4D(*tmp, out, *gauge, 0.0, m5, b_5, c_5, in, QUDA_INVALID_PARITY, dagger, commDim, profile);
-        ApplyDslash5(out, in, in, mass, m5, b_5, c_5, 0.0, dagger, DSLASH5_MOBIUS);
-    }
-    else {
-        // the third term is added, not multiplied, so we only need to swap the first two in the dagger
-        ApplyDomainWall4D(out, in, *gauge, 0.0, m5, b_5, c_5, in, QUDA_INVALID_PARITY, dagger, commDim, profile);
-        ApplyDslash5(*tmp, out, in, mass, m5, b_5, c_5, 0.0, dagger, DSLASH5_MOBIUS_PRE);
-        ApplyDslash5(out, in, in, mass, m5, b_5, c_5, 0.0, dagger, DSLASH5_MOBIUS);
+    if (dagger == QUDA_DAG_NO) {
+      ApplyDslash5(out, in, in, mass, m5, b_5, c_5, 0.0, dagger, DSLASH5_MOBIUS_PRE);
+      ApplyDomainWall4D(*tmp, out, *gauge, 0.0, m5, b_5, c_5, in, QUDA_INVALID_PARITY, dagger, commDim, profile);
+      ApplyDslash5(out, in, in, mass, m5, b_5, c_5, 0.0, dagger, DSLASH5_MOBIUS);
+    } else {
+      // the third term is added, not multiplied, so we only need to swap the first two in the dagger
+      ApplyDomainWall4D(out, in, *gauge, 0.0, m5, b_5, c_5, in, QUDA_INVALID_PARITY, dagger, commDim, profile);
+      ApplyDslash5(*tmp, out, in, mass, m5, b_5, c_5, 0.0, dagger, DSLASH5_MOBIUS_PRE);
+      ApplyDslash5(out, in, in, mass, m5, b_5, c_5, 0.0, dagger, DSLASH5_MOBIUS);
     }
     blas::axpy(-kappa_b, *tmp, out);
 

--- a/lib/dirac_mobius.cpp
+++ b/lib/dirac_mobius.cpp
@@ -143,9 +143,17 @@ namespace quda {
     if (tmp2 && tmp2->SiteSubset() == QUDA_FULL_SITE_SUBSET) tmp = tmp2;
     bool reset = newTmp(&tmp, in);
 
-    ApplyDslash5(out, in, in, mass, m5, b_5, c_5, 0.0, dagger, DSLASH5_MOBIUS_PRE);
-    ApplyDomainWall4D(*tmp, out, *gauge, 0.0, m5, b_5, c_5, in, QUDA_INVALID_PARITY, dagger, commDim, profile);
-    ApplyDslash5(out, in, in, mass, m5, b_5, c_5, 0.0, dagger, DSLASH5_MOBIUS);
+    if ( dagger == QUDA_DAG_NO ) {
+        ApplyDslash5(out, in, in, mass, m5, b_5, c_5, 0.0, dagger, DSLASH5_MOBIUS_PRE);
+        ApplyDomainWall4D(*tmp, out, *gauge, 0.0, m5, b_5, c_5, in, QUDA_INVALID_PARITY, dagger, commDim, profile);
+        ApplyDslash5(out, in, in, mass, m5, b_5, c_5, 0.0, dagger, DSLASH5_MOBIUS);
+    }
+    else {
+        // the third term is added, not multiplied, so we only need to swap the first two in the dagger
+        ApplyDomainWall4D(out, in, *gauge, 0.0, m5, b_5, c_5, in, QUDA_INVALID_PARITY, dagger, commDim, profile);
+        ApplyDslash5(*tmp, out, in, mass, m5, b_5, c_5, 0.0, dagger, DSLASH5_MOBIUS_PRE);
+        ApplyDslash5(out, in, in, mass, m5, b_5, c_5, 0.0, dagger, DSLASH5_MOBIUS);
+    }
     blas::axpy(-kappa_b, *tmp, out);
 
     long long Ls = in.X(4);


### PR DESCRIPTION
Balint found an error in the construction of the Dagger operator in `DiracMobius::M` when building full MAT operators (not preconditioned) - we added a switch to properly construct the dagger operator.  We verified the fixed operator agrees with that from Chroma in the application of the full (both checkerboard parities) Möbius Matrix.