### PR TITLE
Feature/oprod

### DIFF
--- a/include/color_spinor.h
+++ b/include/color_spinor.h
@@ -992,7 +992,6 @@ namespace quda {
   __device__ __host__ inline Matrix<complex<Float>, Nc> outerProdSpinTrace(const ColorSpinor<Float, Nc, Ns> &a,
                                                                            const ColorSpinor<Float, Nc, Ns> &b)
   {
-
     Matrix<complex<Float>, Nc> out;
 
     // outer product over color
@@ -1015,6 +1014,35 @@ namespace quda {
 	  out(j,i).imag( out(j,i).imag() - a(s,j).real() * b(s,i).imag() );
 	  // out(j,i) += a(s,j) * conj(b(s,i));
 	}
+      }
+    }
+    return out;
+  }
+
+  /**
+     Compute the outer product over color and take the spin trace
+     out(j,i) = \sum_s a(s,j) * conj (b(s,i))
+     @param a Left-hand side ColorSpinor
+     @param b Right-hand side ColorSpinor
+     @return The spin traced matrix
+  */
+  template <typename Float, int Nc>
+  __device__ __host__ inline Matrix<complex<Float>, Nc> outerProduct(const ColorSpinor<Float, Nc, 1> &a,
+                                                                     const ColorSpinor<Float, Nc, 1> &b)
+  {
+    Matrix<complex<Float>, Nc> out;
+
+    // outer product over color
+#pragma unroll
+    for (int i = 0; i < Nc; i++) {
+#pragma unroll
+      for (int j = 0; j < Nc; j++) {
+        // trace over spin (manual unroll for perf)
+        out(j, i).real(a(0, j).real() * b(0, i).real());
+        out(j, i).real(out(j, i).real() + a(0, j).imag() * b(0, i).imag());
+        out(j, i).imag(a(0, j).imag() * b(0, i).real());
+        out(j, i).imag(out(j, i).imag() - a(0, j).real() * b(0, i).imag());
+        // out(j,i) = a(0,j) * conj(b(0,i));
       }
     }
     return out;

--- a/include/quda_matrix.h
+++ b/include/quda_matrix.h
@@ -660,7 +660,6 @@ namespace quda {
           (*m)(i,j) = (*m)(j,i) = 0;
         }
       }
-      return;
     }
 
 
@@ -676,7 +675,6 @@ namespace quda {
           (*m)(i,j) = (*m)(j,i) = make_float2(0.,0.);
         }
       }
-      return;
     }
 
 
@@ -692,7 +690,6 @@ namespace quda {
           (*m)(i,j) = (*m)(j,i) = make_double2(0.,0.);
         }
       }
-      return;
     }
 
 
@@ -708,7 +705,6 @@ namespace quda {
           (*m)(i,j) = 0;
         }
       }
-      return;
     }
 
 
@@ -723,7 +719,6 @@ namespace quda {
           (*m)(i,j) = make_float2(0.,0.);
         }
       }
-      return;
     }
 
 
@@ -738,7 +733,6 @@ namespace quda {
           (*m)(i,j) = make_double2(0.,0.);
         }
       }
-      return;
     }
 
 
@@ -811,35 +805,6 @@ namespace quda {
       for (int i=0; i<N; ++i){
         (*a)[i] = m(i,c); // c is the column index
       }
-      return;
-    }
-
-
-  template<class T, int N>
-    __device__ __host__ inline
-    void outerProd(const Array<T,N>& a, const Array<T,N> & b, Matrix<T,N>* m){
-#pragma unroll
-      for (int i=0; i<N; ++i){
-        const T conjb_i = conj(b[i]);
-        for (int j=0; j<N; ++j){
-          (*m)(j,i) = a[j]*conjb_i; // we reverse the ordering of indices because it cuts down on the number of function calls
-        }
-      }
-      return;
-    }
-
-  template<class T, int N>
-    __device__ __host__ inline
-    void outerProd(const T (&a)[N], const T (&b)[N], Matrix<T,N>* m){
-#pragma unroll
-      for (int i=0; i<N; ++i){
-        const T conjb_i = conj(b[i]);
-#pragma unroll
-        for (int j=0; j<N; ++j){
-          (*m)(j,i) = a[j]*conjb_i; // we reverse the ordering of indices because it cuts down on the number of function calls
-        }
-      }
-      return;
     }
 
 
@@ -866,178 +831,10 @@ namespace quda {
       return os;
     }
 
-
-  template<class T, class U>
-    __device__ inline
-    void loadLinkVariableFromArray(const T* const array, const int dir, const int idx, const int stride, Matrix<U,3> *link)
-    {
-#pragma unroll
-      for (int i=0; i<9; ++i){
-        link->data[i] = array[idx + (dir*9 + i)*stride];
-      }
-      return;
-    }
-
-
-  template<class T, class U, int N>
-    __device__ inline
-    void loadMatrixFromArray(const T* const array, const int idx, const int stride, Matrix<U,N> *mat)
-    {
-#pragma unroll
-      for (int i=0; i<(N*N); ++i){
-        mat->data[i] = array[idx + i*stride];
-      }
-    }
-
-
-  __device__ inline
-    void loadLinkVariableFromArray(const float2* const array, const int dir, const int idx, const int stride, Matrix<complex<double>,3> *link)
-    {
-      float2 single_temp;
-#pragma unroll
-      for (int i=0; i<9; ++i){
-        single_temp = array[idx + (dir*9 + i)*stride];
-        link->data[i].x = single_temp.x;
-        link->data[i].y = single_temp.y;
-      }
-      return;
-    }
-
-
-
-  template<class T, int N, class U>
-    __device__ inline
-    void writeMatrixToArray(const Matrix<T,N>& mat, const int idx, const int stride, U* const array)
-    {
-#pragma unroll
-      for (int i=0; i<(N*N); ++i){
-        array[idx + i*stride] = mat.data[i];
-      }
-    }
-
-  __device__ inline
-    void appendMatrixToArray(const Matrix<complex<double>,3>& mat, const int idx, const int stride, double2* const array)
-    {
-#pragma unroll
-      for (int i=0; i<9; ++i){
-        array[idx + i*stride].x += mat.data[i].x;
-        array[idx + i*stride].y += mat.data[i].y;
-      }
-    }
-
-  __device__ inline
-    void appendMatrixToArray(const Matrix<complex<float>,3>& mat, const int idx, const int stride, float2* const array)
-    {
-#pragma unroll
-      for (int i=0; i<9; ++i){
-        array[idx + i*stride].x += mat.data[i].x;
-        array[idx + i*stride].y += mat.data[i].y;
-      }
-    }
-
-
-  template<class T, class U>
-    __device__ inline
-    void writeLinkVariableToArray(const Matrix<T,3> & link, const int dir, const int idx, const int stride, U* const array)
-    {
-#pragma unroll
-      for (int i=0; i<9; ++i){
-        array[idx + (dir*9 + i)*stride] = link.data[i];
-      }
-      return;
-    }
-
-
-
-
-  __device__ inline
-    void writeLinkVariableToArray(const Matrix<complex<double>,3> & link, const int dir, const int idx, const int stride, float2* const array)
-    {
-      float2 single_temp;
-
-#pragma unroll
-      for (int i=0; i<9; ++i){
-        single_temp.x = link.data[i].x;
-        single_temp.y = link.data[i].y;
-        array[idx + (dir*9 + i)*stride] = single_temp;
-      }
-      return;
-    }
-
-
-  template<class T>
-    __device__ inline
-    void loadMomentumFromArray(const T* const array, const int dir, const int idx, const int stride, Matrix<T,3> *mom)
-    {
-      T temp2[5];
-      temp2[0] = array[idx + dir*stride*5];
-      temp2[1] = array[idx + dir*stride*5 + stride];
-      temp2[2] = array[idx + dir*stride*5 + 2*stride];
-      temp2[3] = array[idx + dir*stride*5 + 3*stride];
-      temp2[4] = array[idx + dir*stride*5 + 4*stride];
-
-      mom->data[0].x = 0.;
-      mom->data[0].y = temp2[3].x;
-      mom->data[1] = temp2[0];
-      mom->data[2] = temp2[1];
-
-      mom->data[3].x = -mom->data[1].x;
-      mom->data[3].y =  mom->data[1].y;
-      mom->data[4].x = 0.;
-      mom->data[4].y = temp2[3].y;
-      mom->data[5]   = temp2[2];
-
-      mom->data[6].x = -mom->data[2].x;
-      mom->data[6].y =  mom->data[2].y;
-
-      mom->data[7].x = -mom->data[5].x;
-      mom->data[7].y =  mom->data[5].y;
-
-      mom->data[8].x = 0.;
-      mom->data[8].y = temp2[4].x;
-
-      return;
-    }
-
-
-
-  template<class T, class U>
-    __device__  inline
-    void writeMomentumToArray(const Matrix<T,3> & mom, const int dir, const int idx, const U coeff, const int stride, T* const array)
-    {
-      typedef typename T::value_type real;
-      T temp2;
-      temp2.x = (mom.data[1].x - mom.data[3].x)*0.5*coeff;
-      temp2.y = (mom.data[1].y + mom.data[3].y)*0.5*coeff;
-      array[idx + dir*stride*5] = temp2;
-
-      temp2.x = (mom.data[2].x - mom.data[6].x)*0.5*coeff;
-      temp2.y = (mom.data[2].y + mom.data[6].y)*0.5*coeff;
-      array[idx + dir*stride*5 + stride] = temp2;
-
-      temp2.x = (mom.data[5].x - mom.data[7].x)*0.5*coeff;
-      temp2.y = (mom.data[5].y + mom.data[7].y)*0.5*coeff;
-      array[idx + dir*stride*5 + stride*2] = temp2;
-
-      const real temp = (mom.data[0].y + mom.data[4].y + mom.data[8].y)*0.3333333333333333333333333;
-      temp2.x =  (mom.data[0].y-temp)*coeff;
-      temp2.y =  (mom.data[4].y-temp)*coeff;
-      array[idx + dir*stride*5 + stride*3] = temp2;
-
-      temp2.x = (mom.data[8].y - temp)*coeff;
-      temp2.y = 0.0;
-      array[idx + dir*stride*5 + stride*4] = temp2;
-
-      return;
-    }
-
-
-
   template<class Cmplx>
     __device__  __host__ inline
     void computeLinkInverse(Matrix<Cmplx,3>* uinv, const Matrix<Cmplx,3>& u)
     {
-
       const Cmplx & det = getDeterminant(u);
       const Cmplx & det_inv = static_cast<typename Cmplx::value_type>(1.0)/det;
 
@@ -1069,8 +866,6 @@ namespace quda {
 
       temp = u(0,0)*u(1,1) - u(0,1)*u(1,0);
       (*uinv)(2,2) = (temp*det_inv);
-
-      return;
     }
   // template this!
   inline void copyArrayToLink(Matrix<float2,3>* link, float* array){
@@ -1082,7 +877,6 @@ namespace quda {
         (*link)(i,j).y = array[(i*3+j)*2 + 1];
       }
     }
-    return;
   }
 
   template<class Cmplx, class Real>
@@ -1095,7 +889,6 @@ namespace quda {
           (*link)(i,j).y = array[(i*3+j)*2 + 1];
         }
       }
-      return;
     }
 
 
@@ -1109,7 +902,6 @@ namespace quda {
         array[(i*3+j)*2 + 1] = link(i,j).y;
       }
     }
-    return;
   }
 
   // and this!
@@ -1123,7 +915,6 @@ namespace quda {
           array[(i*3+j)*2 + 1] = link(i,j).y;
         }
       }
-      return;
     }
 
   template<class T>
@@ -1155,8 +946,6 @@ namespace quda {
     sum += (double)(a(2,2).x * b(2,2).x  + a(2,2).y * b(2,2).y);
     return sum;
   }
-
-
 
   // and this!
   template<class Cmplx>

--- a/lib/clover_outer_product.cu
+++ b/lib/clover_outer_product.cu
@@ -2,248 +2,82 @@
 #include <cstdlib>
 
 #include <tune_quda.h>
-#include <quda_internal.h>
 #include <gauge_field_order.h>
+#include <color_spinor_field_order.h>
 #include <quda_matrix.h>
 #include <color_spinor.h>
 #include <dslash_quda.h>
 
 namespace quda {
 
-#ifdef GPU_CLOVER_DIRAC
-
-  namespace { // anonymous
-#include <texture.h>
-  }
-
-  template<int N>
-  void createEventArray(cudaEvent_t (&event)[N], unsigned int flags=cudaEventDefault)
-  {
-    for(int i=0; i<N; ++i)
-      cudaEventCreate(&event[i],flags);
-    return;
-  }
-
-  template<int N>
-  void destroyEventArray(cudaEvent_t (&event)[N])
-  {
-    for(int i=0; i<N; ++i)
-      cudaEventDestroy(event[i]);
-  }
-
-
-  static cudaEvent_t packEnd;
-  static cudaEvent_t gatherEnd[4];
-  static cudaEvent_t scatterEnd[4];
-  static cudaEvent_t oprodStart;
-  static cudaEvent_t oprodEnd;
-
-
-  void createCloverForceEvents(){
-    cudaEventCreate(&packEnd, cudaEventDisableTiming);
-    createEventArray(gatherEnd, cudaEventDisableTiming);
-    createEventArray(scatterEnd, cudaEventDisableTiming);
-    cudaEventCreate(&oprodStart, cudaEventDisableTiming);
-    cudaEventCreate(&oprodEnd, cudaEventDisableTiming);
-    return;
-  }
-
-  void destroyCloverForceEvents(){
-    destroyEventArray(gatherEnd);
-    destroyEventArray(scatterEnd);
-    cudaEventDestroy(packEnd);
-    cudaEventDestroy(oprodStart);
-    cudaEventDestroy(oprodEnd);
-    return;
-  }
-
   enum OprodKernelType { OPROD_INTERIOR_KERNEL, OPROD_EXTERIOR_KERNEL };
 
-  template<typename Float, typename Output, typename Gauge, typename InputA, typename InputB, typename InputC, typename InputD>
-    struct CloverForceArg {
-      unsigned int length;
-      int X[4];
-      unsigned int parity;
-      unsigned int dir;
-      unsigned int ghostOffset[4];
-      unsigned int displacement;
-      OprodKernelType kernelType;
-      bool partitioned[4];
-      InputA inA;
-      InputB inB_shift;
-      InputC inC;
-      InputD inD_shift;
-      Gauge  gauge;
-      Output force;
-      Float coeff;
+  template<typename Float, int nColor_, QudaReconstructType recon>
+  struct CloverForceArg {
+    typedef typename mapper<Float>::type real;
+    static constexpr int nColor = nColor_;
+    static constexpr int nSpin = 4;
+    static constexpr int spin_project = true;
+    using F = typename colorspinor_mapper<Float, nSpin, nColor, spin_project>::type;
+    using Gauge = typename gauge_mapper<Float, recon, 18>::type;
+    using Force = typename gauge_mapper<Float, QUDA_RECONSTRUCT_NO, 18>::type;
 
-      CloverForceArg(const unsigned int parity, const unsigned int dir, const unsigned int *ghostOffset,
-          const unsigned int displacement, const OprodKernelType kernelType, const double coeff, InputA &inA,
-          InputB &inB_shift, InputC &inC, InputD &inD_shift, Gauge &gauge, Output &force, GaugeField &meta) :
-          length(meta.VolumeCB()),
-          parity(parity),
-          dir(5),
-          displacement(displacement),
-          kernelType(kernelType),
-          coeff(coeff),
-          inA(inA),
-          inB_shift(inB_shift),
-          inC(inC),
-          inD_shift(inD_shift),
-          gauge(gauge),
-          force(force)
-      {
-        for(int i=0; i<4; ++i) this->X[i] = meta.X()[i];
-        for(int i=0; i<4; ++i) this->ghostOffset[i] = ghostOffset[i];
-        for(int i=0; i<4; ++i) this->partitioned[i] = commDimPartitioned(i) ? true : false;
-      }
-  };
+    const F inA;
+    const F inB;
+    const F inC;
+    const F inD;
+    Gauge  gauge;
+    Force force;
+    unsigned int length;
+    int X[4];
+    unsigned int parity;
+    unsigned int dir;
+    unsigned int displacement;
+    OprodKernelType kernelType;
+    bool partitioned[4];
+    Float coeff;
 
-  enum IndexType {
-    EVEN_X = 0,
-    EVEN_Y = 1,
-    EVEN_Z = 2,
-    EVEN_T = 3
-  };
-
-  template <IndexType idxType>
-  __device__ inline void coordsFromIndex(
-      int &idx, int c[4], const unsigned int cb_idx, const unsigned int parity, const int X[4])
-  {
-    const int &LX = X[0];
-    const int &LY = X[1];
-    const int &LZ = X[2];
-    const int XYZ = X[2] * X[1] * X[0];
-    const int XY = X[1] * X[0];
-
-    idx = 2 * cb_idx;
-
-    int x, y, z, t;
-
-    if (idxType == EVEN_X /*!(LX & 1)*/) { // X even
-      //   t = idx / XYZ;
-      //   z = (idx / XY) % Z;
-      //   y = (idx / X) % Y;
-      //   idx += (parity + t + z + y) & 1;
-      //   x = idx % X;
-      // equivalent to the above, but with fewer divisions/mods:
-      int aux1 = idx / LX;
-      x = idx - aux1 * LX;
-      int aux2 = aux1 / LY;
-      y = aux1 - aux2 * LY;
-      t = aux2 / LZ;
-      z = aux2 - t * LZ;
-      aux1 = (parity + t + z + y) & 1;
-      x += aux1;
-      idx += aux1;
-    } else if (idxType == EVEN_Y /*!(LY & 1)*/) { // Y even
-      t = idx / XYZ;
-      z = (idx / XY) % LZ;
-      idx += (parity + t + z) & 1;
-      y = (idx / LX) % LY;
-      x = idx % LX;
-    } else if (idxType == EVEN_Z /*!(LZ & 1)*/) { // Z even
-      t = idx / XYZ;
-      idx += (parity + t) & 1;
-      z = (idx / XY) % LZ;
-      y = (idx / LX) % LY;
-      x = idx % LX;
-    } else {
-      idx += parity;
-      t = idx / XYZ;
-      z = (idx / XY) % LZ;
-      y = (idx / LX) % LY;
-      x = idx % LX;
-    }
-
-    c[0] = x;
-    c[1] = y;
-    c[2] = z;
-    c[3] = t;
-    }
-
-  // Get the  coordinates for the exterior kernels
-    __device__ inline void coordsFromIndexExterior(int x[4], const unsigned int cb_idx, const int X[4],
-        const unsigned int dir, const int displacement, const unsigned int parity)
+    CloverForceArg(GaugeField &force, const GaugeField &gauge, const ColorSpinorField &inA, const ColorSpinorField &inB,
+                   const ColorSpinorField &inC, const ColorSpinorField &inD, const unsigned int parity, const double coeff) :
+      inA(inA),
+      inB(inB),
+      inC(inC),
+      inD(inD),
+      gauge(gauge),
+      force(force),
+      length(gauge.VolumeCB()),
+      parity(parity),
+      dir(5),
+      displacement(1),
+      kernelType(OPROD_INTERIOR_KERNEL),
+      coeff(coeff)
     {
-      int Xh[2] = {X[0] / 2, X[1] / 2};
-      switch (dir) {
-      case 0:
-        x[2] = cb_idx / Xh[1] % X[2];
-        x[3] = cb_idx / (Xh[1] * X[2]) % X[3];
-        x[0] = cb_idx / (Xh[1] * X[2] * X[3]);
-        x[0] += (X[0] - displacement);
-        x[1] = 2 * (cb_idx % Xh[1]) + ((x[0] + x[2] + x[3] + parity) & 1);
-        break;
-
-      case 1:
-        x[2] = cb_idx / Xh[0] % X[2];
-        x[3] = cb_idx / (Xh[0] * X[2]) % X[3];
-        x[1] = cb_idx / (Xh[0] * X[2] * X[3]);
-        x[1] += (X[1] - displacement);
-        x[0] = 2 * (cb_idx % Xh[0]) + ((x[1] + x[2] + x[3] + parity) & 1);
-        break;
-
-      case 2:
-        x[1] = cb_idx / Xh[0] % X[1];
-        x[3] = cb_idx / (Xh[0] * X[1]) % X[3];
-        x[2] = cb_idx / (Xh[0] * X[1] * X[3]);
-        x[2] += (X[2] - displacement);
-        x[0] = 2 * (cb_idx % Xh[0]) + ((x[1] + x[2] + x[3] + parity) & 1);
-        break;
-
-      case 3:
-        x[1] = cb_idx / Xh[0] % X[1];
-        x[2] = cb_idx / (Xh[0] * X[1]) % X[2];
-        x[3] = cb_idx / (Xh[0] * X[1] * X[2]);
-        x[3] += (X[3] - displacement);
-        x[0] = 2 * (cb_idx % Xh[0]) + ((x[1] + x[2] + x[3] + parity) & 1);
-        break;
-      }
-      return;
-  }
-
-
-  __device__ __forceinline__
-  int neighborIndex(const unsigned int cb_idx, const int shift[4],  const bool partitioned[4], const unsigned int parity, const int X[4]){
-    int full_idx;
-    int x[4];
-    coordsFromIndex<EVEN_X>(full_idx, x, cb_idx, parity, X);
-
-    for(int dim = 0; dim<4; ++dim){
-      if(partitioned[dim])
-	if( (x[dim]+shift[dim])<0 || (x[dim]+shift[dim])>=X[dim]) return -1;
+      for (int i=0; i<4; ++i) this->X[i] = gauge.X()[i];
+      for (int i=0; i<4; ++i) this->partitioned[i] = commDimPartitioned(i) ? true : false;
     }
+  };
 
-    for(int dim=0; dim<4; ++dim){
-      x[dim] = shift[dim] ? (x[dim]+shift[dim] + X[dim]) % X[dim] : x[dim];
-    }
-    return  (((x[3]*X[2] + x[2])*X[1] + x[1])*X[0] + x[0]) >> 1;
-  }
-
-
-
-  template<typename real, typename Output, typename Gauge, typename InputA, typename InputB, typename InputC, typename InputD>
-  __global__ void interiorOprodKernel(CloverForceArg<real, Output, Gauge, InputA, InputB, InputC, InputD> arg) {
+  template<typename real, typename Arg> __global__ void interiorOprodKernel(Arg arg)
+  {
     typedef complex<real> Complex;
     int idx = blockIdx.x*blockDim.x + threadIdx.x;
 
-    ColorSpinor<real,3,4> A, B_shift, C, D_shift;
-    Matrix<Complex,3> U, result, temp;
+    ColorSpinor<real, Arg::nColor, 4> A, B_shift, C, D_shift;
+    Matrix<Complex, Arg::nColor> U, result, temp;
 
-    while (idx<arg.length){
-      arg.inA.load(static_cast<Complex*>(A.data), idx);
-      arg.inC.load(static_cast<Complex*>(C.data), idx);
+    while (idx<arg.length) {
+      A = arg.inA(idx, 0);
+      C = arg.inC(idx, 0);
 
 #pragma unroll
-      for(int dim=0; dim<4; ++dim){
+      for (int dim=0; dim<4; ++dim) {
 	int shift[4] = {0,0,0,0};
 	shift[dim] = 1;
 	const int nbr_idx = neighborIndex(idx, shift, arg.partitioned, arg.parity, arg.X);
 
-	if(nbr_idx >= 0){
-	  arg.inB_shift.load(static_cast<Complex*>(B_shift.data), nbr_idx);
-	  arg.inD_shift.load(static_cast<Complex*>(D_shift.data), nbr_idx);
+	if (nbr_idx >= 0) {
+	  B_shift = arg.inB(nbr_idx, 0);
+	  D_shift = arg.inD(nbr_idx, 0);
 
 	  B_shift = (B_shift.project(dim,1)).reconstruct(dim,1);
 	  result = outerProdSpinTrace(B_shift,A);
@@ -260,32 +94,29 @@ namespace quda {
 
       idx += gridDim.x*blockDim.x;
     }
-    return;
   } // interiorOprodKernel
 
-  template<int dim, typename real, typename Output, typename Gauge, typename InputA, typename InputB, typename InputC, typename InputD>
-  __global__ void exteriorOprodKernel(CloverForceArg<real, Output, Gauge, InputA, InputB, InputC, InputD> arg) {
+  template<int dim, typename real, typename Arg> __global__ void exteriorOprodKernel(Arg arg)
+  {
     typedef complex<real> Complex;
     int cb_idx = blockIdx.x*blockDim.x + threadIdx.x;
 
-    ColorSpinor<real,3,4> A, B_shift, C, D_shift;
-    ColorSpinor<real,3,2> projected_tmp;
-    Matrix<Complex,3> U, result, temp;
+    ColorSpinor<real, Arg::nColor, 4> A, B_shift, C, D_shift;
+    ColorSpinor<real, Arg::nColor, 2> projected_tmp;
+    Matrix<Complex, Arg::nColor> U, result, temp;
 
     int x[4];
-    while (cb_idx<arg.length){
+    while (cb_idx<arg.length) {
       coordsFromIndexExterior(x, cb_idx, arg.X, dim, arg.displacement, arg.parity);
       const unsigned int bulk_cb_idx = ((((x[3]*arg.X[2] + x[2])*arg.X[1] + x[1])*arg.X[0] + x[0]) >> 1);
-      arg.inA.load(static_cast<Complex*>(A.data), bulk_cb_idx);
-      arg.inC.load(static_cast<Complex*>(C.data), bulk_cb_idx);
+      A = arg.inA(bulk_cb_idx, 0);
+      C = arg.inC(bulk_cb_idx, 0);
 
-      const unsigned int ghost_idx = arg.ghostOffset[dim] + cb_idx;
-
-      arg.inB_shift.loadGhost(static_cast<Complex*>(projected_tmp.data), ghost_idx, dim);
+      projected_tmp = arg.inB.Ghost(dim, 1, cb_idx, 0);
       B_shift = projected_tmp.reconstruct(dim, 1);
       result = outerProdSpinTrace(B_shift,A);
 
-      arg.inD_shift.loadGhost(static_cast<Complex*>(projected_tmp.data), ghost_idx, dim);
+      projected_tmp = arg.inD.Ghost(dim, 1, cb_idx, 0);
       D_shift = projected_tmp.reconstruct(dim,-1);
       result += outerProdSpinTrace(D_shift,C);
 
@@ -296,16 +127,12 @@ namespace quda {
 
       cb_idx += gridDim.x*blockDim.x;
     }
-    return;
   } // exteriorOprodKernel
 
-  template<typename Float, typename Output, typename Gauge, typename InputA, typename InputB, typename InputC, typename InputD>
+  template<typename Float, typename Arg>
   class CloverForce : public Tunable {
-
-  private:
-    CloverForceArg<Float,Output,Gauge,InputA,InputB,InputC,InputD> &arg;
+    Arg &arg;
     const GaugeField &meta;
-    QudaFieldLocation location; // location of the lattice fields
 
     unsigned int sharedBytesPerThread() const { return 0; }
     unsigned int sharedBytesPerBlock(const TuneParam &) const { return 0; }
@@ -314,30 +141,27 @@ namespace quda {
     bool tuneGridDim() const { return false; }
 
   public:
-    CloverForce(CloverForceArg<Float,Output,Gauge,InputA,InputB,InputC,InputD> &arg,
-		const GaugeField &meta, QudaFieldLocation location)
-      : arg(arg), meta(meta), location(location) {
-      writeAuxString("prec=%lu,stride=%d", sizeof(Float), arg.inA.Stride());
+    CloverForce(Arg &arg, GaugeField &meta) :
+      arg(arg), meta(meta) {
+      writeAuxString(meta.AuxString());
       // this sets the communications pattern for the packing kernel
       int comms[QUDA_MAX_DIM] = { commDimPartitioned(0), commDimPartitioned(1), commDimPartitioned(2), commDimPartitioned(3) };
       setPackComms(comms);
     }
 
-    virtual ~CloverForce() {}
-
-    void apply(const qudaStream_t &stream){
-      if(location == QUDA_CUDA_FIELD_LOCATION){
+    void apply(const qudaStream_t &stream) {
+      if (meta.Location() == QUDA_CUDA_FIELD_LOCATION) {
 	// Disable tuning for the time being
 	TuneParam tp = tuneLaunch(*this,getTuning(),getVerbosity());
 
-	if(arg.kernelType == OPROD_INTERIOR_KERNEL){
-	  interiorOprodKernel<<<tp.grid,tp.block,tp.shared_bytes,stream>>>(arg);
+	if (arg.kernelType == OPROD_INTERIOR_KERNEL) {
+	  interiorOprodKernel<Float><<<tp.grid,tp.block,tp.shared_bytes,stream>>>(arg);
         } else if (arg.kernelType == OPROD_EXTERIOR_KERNEL) {
           if (arg.dir == 0)
-            exteriorOprodKernel<0><<<tp.grid, tp.block, tp.shared_bytes, stream>>>(arg);
-	  else if (arg.dir == 1) exteriorOprodKernel<1><<<tp.grid,tp.block,tp.shared_bytes, stream>>>(arg);
-	  else if (arg.dir == 2) exteriorOprodKernel<2><<<tp.grid,tp.block,tp.shared_bytes, stream>>>(arg);
-	  else if (arg.dir == 3) exteriorOprodKernel<3><<<tp.grid,tp.block,tp.shared_bytes, stream>>>(arg);
+            exteriorOprodKernel<0,Float><<<tp.grid, tp.block, tp.shared_bytes, stream>>>(arg);
+	  else if (arg.dir == 1) exteriorOprodKernel<1,Float><<<tp.grid,tp.block,tp.shared_bytes, stream>>>(arg);
+	  else if (arg.dir == 2) exteriorOprodKernel<2,Float><<<tp.grid,tp.block,tp.shared_bytes, stream>>>(arg);
+	  else if (arg.dir == 3) exteriorOprodKernel<3,Float><<<tp.grid,tp.block,tp.shared_bytes, stream>>>(arg);
         } else {
           errorQuda("Kernel type not supported\n");
         }
@@ -346,10 +170,10 @@ namespace quda {
       }
     } // apply
 
-    void preTune(){
+    void preTune() {
       this->arg.force.save();
     }
-    void postTune(){
+    void postTune() {
       this->arg.force.load();
     }
 
@@ -362,9 +186,9 @@ namespace quda {
     }
     long long bytes() const {
       if (arg.kernelType == OPROD_INTERIOR_KERNEL) {
-	return ((long long)arg.length)*(arg.inA.Bytes() + arg.inC.Bytes() + 4*(arg.inB_shift.Bytes() + arg.inD_shift.Bytes() + 2*arg.force.Bytes() + arg.gauge.Bytes()));
+	return arg.length*(arg.inA.Bytes() + arg.inC.Bytes() + 4*(arg.inB.Bytes() + arg.inD.Bytes() + 2*arg.force.Bytes() + arg.gauge.Bytes()));
       } else {
-	return ((long long)arg.length)*(arg.inA.Bytes() + arg.inB_shift.Bytes()/2 + arg.inC.Bytes() + arg.inD_shift.Bytes()/2 + 2*arg.force.Bytes() + arg.gauge.Bytes());
+	return arg.length*(arg.inA.Bytes() + arg.inB.Bytes()/2 + arg.inC.Bytes() + arg.inD.Bytes()/2 + 2*arg.force.Bytes() + arg.gauge.Bytes());
       }
     }
 
@@ -396,8 +220,8 @@ namespace quda {
 
     qudaDeviceSynchronize();
 
-    for(int i=3; i>=0; i--){
-      if(commDimPartitioned(i)){
+    for (int i=3; i>=0; i--) {
+      if (commDimPartitioned(i)) {
 	// Initialize the host transfer from the source spinor
 	a.gather(1, dag, 2*i);
       } // commDim(i)
@@ -406,13 +230,13 @@ namespace quda {
     qudaDeviceSynchronize(); comm_barrier();
 
     for (int i=3; i>=0; i--) {
-      if(commDimPartitioned(i)) {
+      if (commDimPartitioned(i)) {
 	a.commsStart(1, 2*i, dag);
       }
     }
 
     for (int i=3; i>=0; i--) {
-      if(commDimPartitioned(i)) {
+      if (commDimPartitioned(i)) {
 	a.commsWait(1, 2*i, dag);
 	a.scatter(1, dag, 2*i);
       }
@@ -425,55 +249,36 @@ namespace quda {
     comm_barrier();
   }
 
-  template<typename Float, typename Output, typename Gauge, typename InputA, typename InputB, typename InputC, typename InputD>
-  void computeCloverForceCuda(Output force, Gauge gauge, GaugeField& out,
-			      InputA& inA, InputB& inB, InputC &inC, InputD &inD,
-			      cudaColorSpinorField& src1, cudaColorSpinorField& src2,
-			      const unsigned int parity, const int faceVolumeCB[4], const double coeff)
+  template <typename Float, QudaReconstructType recon>
+  void computeCloverForce(GaugeField &force, const GaugeField &gauge, const ColorSpinorField& inA, const ColorSpinorField& inB,
+                          const ColorSpinorField& inC, const ColorSpinorField& inD, int parity, const double coeff)
   {
-      qudaEventRecord(oprodStart, streams[Nstream-1]);
+    // Create the arguments for the interior kernel
+    CloverForceArg<Float, 3, recon> arg(force, gauge, inA, inB, inC, inD, parity, coeff);
+    CloverForce<Float,decltype(arg)> oprod(arg, force);
 
-      unsigned int ghostOffset[4] = {0,0,0,0};
-      for (int dir=0; dir<4; ++dir) {
-	if (src1.GhostOffset(dir) != src2.GhostOffset(dir))
-	  errorQuda("Mismatched ghost offset[%d] %d != %d", dir, src1.GhostOffset(dir), src2.GhostOffset(dir));
-	ghostOffset[dir] = (src1.GhostOffset(dir,1))/src1.FieldOrder(); // offset we want is the forwards one
+    arg.kernelType = OPROD_INTERIOR_KERNEL;
+    arg.length = inA.VolumeCB();
+    oprod.apply(0);
+
+    for (int i=3; i>=0; i--) {
+      if (commDimPartitioned(i)) {
+        // update parameters for this exterior kernel
+        arg.kernelType = OPROD_EXTERIOR_KERNEL;
+        arg.dir = i;
+        arg.length = inA.GhostFaceCB()[i];
+        arg.displacement = 1; // forwards displacement
+        oprod.apply(0);
       }
+    } // i=3,..,0
+  } // computeCloverForce
 
-      // Create the arguments for the interior kernel
-      CloverForceArg<Float,Output,Gauge,InputA,InputB,InputC,InputD> arg(parity, 0, ghostOffset, 1, OPROD_INTERIOR_KERNEL, coeff, inA, inB, inC, inD, gauge, force, out);
-      CloverForce<Float,Output,Gauge,InputA,InputB,InputC,InputD> oprod(arg, out, QUDA_CUDA_FIELD_LOCATION);
-
-      arg.kernelType = OPROD_INTERIOR_KERNEL;
-      arg.length = src1.VolumeCB();
-      oprod.apply(0);
-
-      for (int i=3; i>=0; i--) {
-	if (commDimPartitioned(i)) {
-	  // update parameters for this exterior kernel
-	  arg.kernelType = OPROD_EXTERIOR_KERNEL;
-	  arg.dir = i;
-	  arg.length = faceVolumeCB[i];
-	  arg.displacement = 1; // forwards displacement
-	  oprod.apply(0);
-	}
-      } // i=3,..,0
-    } // computeCloverForceCuda
-
-#endif // GPU_CLOVER_DIRAC
-
-    void computeCloverForce(GaugeField &force, const GaugeField &U, std::vector<ColorSpinorField *> &x,
-        std::vector<ColorSpinorField *> &p, std::vector<double> &coeff)
-    {
-
+  void computeCloverForce(GaugeField &force, const GaugeField &U, std::vector<ColorSpinorField *> &x,
+                          std::vector<ColorSpinorField *> &p, std::vector<double> &coeff)
+  {
 #ifdef GPU_CLOVER_DIRAC
-    if(force.Order() != QUDA_FLOAT2_GAUGE_ORDER)
-      errorQuda("Unsupported output ordering: %d\n", force.Order());
-
-    if(x[0]->Precision() != force.Precision())
-      errorQuda("Mixed precision not supported: %d %d\n", x[0]->Precision(), force.Precision());
-
-    createCloverForceEvents(); // FIXME not actually used
+    if (force.Order() != QUDA_FLOAT2_GAUGE_ORDER) errorQuda("Unsupported output ordering: %d\n", force.Order());
+    checkPrecision(*x[0], *p[0], force, U);
 
     int dag = 1;
 
@@ -491,50 +296,26 @@ namespace quda {
 	ColorSpinorField& inD = (parity&1) ? p[i]->Even(): p[i]->Odd();
 
 	if (x[0]->Precision() == QUDA_DOUBLE_PRECISION) {
-          Spinor<double2, double2, 12, 0> spinorA(inA);
-
-          Spinor<double2, double2, 12, 0> spinorB(inB);
           exchangeGhost(static_cast<cudaColorSpinorField&>(inB), parity, dag);
-
-          Spinor<double2, double2, 12, 0> spinorC(inC);
-
-          Spinor<double2, double2, 12, 0> spinorD(inD);
           exchangeGhost(static_cast<cudaColorSpinorField&>(inD), parity, 1-dag);
 
 	  if (U.Reconstruct() == QUDA_RECONSTRUCT_NO) {
-	    computeCloverForceCuda<double>(gauge::FloatNOrder<double, 18, 2, 18>(force),
-					   gauge::FloatNOrder<double,18, 2, 18>(U),
-					   force, spinorA, spinorB, spinorC, spinorD,
-					   static_cast<cudaColorSpinorField&>(inB),
-					   static_cast<cudaColorSpinorField&>(inD),
-					   parity, inB.GhostFace(), coeff[i]);
+	    computeCloverForce<double, QUDA_RECONSTRUCT_NO>(force, U, inA, inB, inC, inD, parity, coeff[i]);
 	  } else if (U.Reconstruct() == QUDA_RECONSTRUCT_12) {
-	    computeCloverForceCuda<double>(gauge::FloatNOrder<double, 18, 2, 18>(force),
-					   gauge::FloatNOrder<double,18, 2, 12>(U),
-					   force, spinorA, spinorB, spinorC, spinorD,
-					   static_cast<cudaColorSpinorField&>(inB),
-					   static_cast<cudaColorSpinorField&>(inD),
-					   parity, inB.GhostFace(), coeff[i]);
+	    computeCloverForce<double, QUDA_RECONSTRUCT_12>(force, U, inA, inB, inC, inD, parity, coeff[i]);
 	  } else {
 	    errorQuda("Unsupported recontruction type");
 	  }
-#if 0 // FIXME - Spinor class expect float4 pointer not Complex pointer
-	} else if (x[0]->Precision() == QUDA_SINGLE_PRECISION) {
-#endif
 	} else {
 	  errorQuda("Unsupported precision: %d\n", x[0]->Precision());
 	}
       }
     }
-
-    destroyCloverForceEvents(); // not actually used
-
 #else // GPU_CLOVER_DIRAC not defined
    errorQuda("Clover Dirac operator has not been built!");
 #endif
 
    checkCudaError();
-   return;
   } // computeCloverForce
 
 

--- a/lib/clover_sigma_outer_product.cu
+++ b/lib/clover_sigma_outer_product.cu
@@ -15,8 +15,6 @@ namespace quda {
 
   template <typename Float, typename Arg> class CloverSigmaOprod : public TunableVectorYZ
   {
-
-private:
     Arg &arg;
     const GaugeField &meta;
 
@@ -29,7 +27,7 @@ private:
   public:
       CloverSigmaOprod(Arg &arg, const GaugeField &meta) : TunableVectorYZ(2, 6), arg(arg), meta(meta)
       {
-        writeAuxString("prec=%lu,stride=%d,nvector=%d", sizeof(Float), arg.inA[0].Stride(), arg.nvector);
+        writeAuxString("%s,nvector=%d", meta.AuxString(), arg.nvector);
         // this sets the communications pattern for the packing kernel
 #ifdef JITIFY
         create_jitify_program("kernels/clover_sigma_outer_product.cuh");
@@ -51,14 +49,7 @@ private:
 #else
           switch (arg.nvector) {
           case 1: sigmaOprodKernel<1, Float><<<tp.grid, tp.block, tp.shared_bytes, stream>>>(arg); break;
-          case 2: sigmaOprodKernel<2, Float><<<tp.grid, tp.block, tp.shared_bytes, stream>>>(arg); break;
-          case 3: sigmaOprodKernel<3, Float><<<tp.grid, tp.block, tp.shared_bytes, stream>>>(arg); break;
-          case 4: sigmaOprodKernel<4, Float><<<tp.grid, tp.block, tp.shared_bytes, stream>>>(arg); break;
-          case 5: sigmaOprodKernel<5, Float><<<tp.grid, tp.block, tp.shared_bytes, stream>>>(arg); break;
-          case 6: sigmaOprodKernel<6, Float><<<tp.grid, tp.block, tp.shared_bytes, stream>>>(arg); break;
-          case 7: sigmaOprodKernel<7, Float><<<tp.grid, tp.block, tp.shared_bytes, stream>>>(arg); break;
-          case 8: sigmaOprodKernel<8, Float><<<tp.grid, tp.block, tp.shared_bytes, stream>>>(arg); break;
-          case 9: sigmaOprodKernel<9, Float><<<tp.grid, tp.block, tp.shared_bytes, stream>>>(arg); break;
+          default: errorQuda("Unsupported nvector = %d\n", arg.nvector);
           }
 #endif
         } else { // run the CPU code
@@ -83,13 +74,13 @@ private:
       TuneKey tuneKey() const { return TuneKey(meta.VolString(), "CloverSigmaOprod", aux); }
   }; // CloverSigmaOprod
 
-  template<typename Float, typename Output, typename InputA, typename InputB>
-  void computeCloverSigmaOprod(Output oprod, const GaugeField& out, InputA *inA, InputB *inB,
-			       std::vector<std::vector<double> > &coeff, int nvector) {
+  template<typename Float>
+  void computeCloverSigmaOprod(GaugeField& oprod, const std::vector<ColorSpinorField*> &x,
+			       const std::vector<ColorSpinorField*> &p, const std::vector<std::vector<double> > &coeff, int nvector)
+  {
     // Create the arguments
-    typedef CloverSigmaOprodArg<Float, Output, InputA, InputB> Arg;
-    Arg arg(oprod, inA, inB, coeff, out, nvector);
-    CloverSigmaOprod<Float, Arg> sigma_oprod(arg, out);
+    CloverSigmaOprodArg<Float, 3> arg(oprod, x, p, coeff, nvector);
+    CloverSigmaOprod<Float, decltype(arg)> sigma_oprod(arg, oprod);
     sigma_oprod.apply(0);
   } // computeCloverSigmaOprod
 
@@ -125,22 +116,8 @@ private:
 
     if (oprod.Order() != QUDA_FLOAT2_GAUGE_ORDER) errorQuda("Unsupported output ordering: %d\n", oprod.Order());
 
-    if(x[0]->Precision() != oprod.Precision())
-      errorQuda("Mixed precision not supported: %d %d\n", x[0]->Precision(), oprod.Precision());
-
-    if(oprod.Precision() == QUDA_DOUBLE_PRECISION){
-
-      Spinor<double2, double2, 12, 0> spinorA[MAX_NVECTOR];
-      Spinor<double2, double2, 12, 0> spinorB[MAX_NVECTOR];
-
-      for (unsigned int i=0; i<x.size(); i++) {
-	spinorA[i].set(*dynamic_cast<cudaColorSpinorField*>(x[i]));
-	spinorB[i].set(*dynamic_cast<cudaColorSpinorField*>(p[i]));
-      }
-
-      computeCloverSigmaOprod<double>(gauge::FloatNOrder<double, 18, 2, 18>(oprod),
-				      oprod, spinorA, spinorB, coeff, x.size());
-
+    if (checkPrecision(*x[0], *p[0], oprod) == QUDA_DOUBLE_PRECISION) {
+      computeCloverSigmaOprod<double>(oprod, x, p, coeff, x.size());
     } else {
       errorQuda("Unsupported precision: %d\n", oprod.Precision());
     }
@@ -149,7 +126,6 @@ private:
 #endif
 
     checkCudaError();
-    return;
   } // computeCloverForce
 
 } // namespace quda

--- a/lib/cpu_gauge_field.cpp
+++ b/lib/cpu_gauge_field.cpp
@@ -265,8 +265,7 @@ namespace quda {
 
     if (link_type == QUDA_ASQTAD_FAT_LINKS) {
       fat_link_max = src.LinkMax();
-      if ((precision == QUDA_HALF_PRECISION || precision == QUDA_QUARTER_PRECISION) && fat_link_max == 0.0)
-        errorQuda("fat_link_max has not been computed");
+      if (fat_link_max == 0.0 && precision < QUDA_SINGLE_PRECISION) fat_link_max = src.abs_max();
     } else {
       fat_link_max = 1.0;
     }

--- a/lib/cuda_color_spinor_field.cpp
+++ b/lib/cuda_color_spinor_field.cpp
@@ -1308,10 +1308,10 @@ namespace quda {
     if (!commDimPartitioned(dim)) return;
     unpackGhostExtended(from_face_dim_dir_h[bufferIndex][dim][dir], nFace, static_cast<QudaParity>(parity), dim, dir == 0 ? QUDA_BACKWARDS : QUDA_FORWARDS, dagger, &stream[2*dim/*+0*/], zero_copy);
   }
- 
-  void cudaColorSpinorField::exchangeGhost(QudaParity parity, int nFace, int dagger, const MemoryLocation *pack_destination_,
-					   const MemoryLocation *halo_location_, bool gdr_send, bool gdr_recv,
-					   QudaPrecision ghost_precision_) const
+
+  void cudaColorSpinorField::exchangeGhost(QudaParity parity, int nFace, int dagger,
+                                           const MemoryLocation *pack_destination_, const MemoryLocation *halo_location_,
+                                           bool gdr_send, bool gdr_recv, QudaPrecision ghost_precision_) const
   {
 
     // we are overriding the ghost precision, and it doesn't match what has already been allocated
@@ -1453,10 +1453,10 @@ namespace quda {
     }
 
     // ensure that the p2p sending is completed before returning
-    for (int dim=0; dim<nDimComms; dim++) {
+    for (int dim = 0; dim < nDimComms; dim++) {
       if (!comm_dim_partitioned(dim)) continue;
-      for (int dir=0; dir<2; dir++) {
-	if (comm_peer2peer_enabled(dir,dim)) qudaStreamWaitEvent(0, ipcCopyEvent[bufferIndex][dir][dim], 0);
+      for (int dir = 0; dir < 2; dir++) {
+        if (comm_peer2peer_enabled(dir, dim)) qudaStreamWaitEvent(0, ipcCopyEvent[bufferIndex][dir][dim], 0);
       }
     }
 

--- a/lib/cuda_gauge_field.cpp
+++ b/lib/cuda_gauge_field.cpp
@@ -84,7 +84,6 @@ namespace quda {
       createTexObject(oddPhaseTex, (char*)odd + phase_offset, false, isPhase);
     }
 #endif
-
   }
 
   void cudaGaugeField::zeroPad() {
@@ -634,8 +633,7 @@ namespace quda {
 
     if (link_type == QUDA_ASQTAD_FAT_LINKS) {
       fat_link_max = src.LinkMax();
-      if ((precision == QUDA_HALF_PRECISION  || precision == QUDA_QUARTER_PRECISION) && fat_link_max == 0.0) 
-        errorQuda("fat_link_max has not been computed");
+      if (fat_link_max == 0.0 && precision < QUDA_SINGLE_PRECISION) fat_link_max = src.abs_max();
     } else {
       fat_link_max = 1.0;
     }

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -707,12 +707,6 @@ void loadGaugeQuda(void *h_gauge, QudaGaugeParam *param)
   // Set the specific input parameters and create the cpu gauge field
   GaugeFieldParam gauge_param(h_gauge, *param);
 
-  // if we are using half precision then we need to compute the fat
-  // link maximum while still on the cpu
-  // FIXME get a kernel for this
-  if (param->type == QUDA_ASQTAD_FAT_LINKS)
-    gauge_param.compute_fat_link_max = true;
-
   if (gauge_param.order <= 4) gauge_param.ghostExchange = QUDA_GHOST_EXCHANGE_NO;
   GaugeField *in = (param->location == QUDA_CPU_FIELD_LOCATION) ?
     static_cast<GaugeField*>(new cpuGaugeField(gauge_param)) :

--- a/lib/milc_interface.cpp
+++ b/lib/milc_interface.cpp
@@ -267,7 +267,6 @@ void qudaLoadUnitarizedLink(int prec, QudaFatLinkArgs_t fatlink_args,
 					   QUDA_GENERAL_LINKS);
 
   computeKSLinkQuda(fatlink, nullptr, ulink, inlink, const_cast<double*>(act_path_coeff), &param);
-  qudamilc_called<false>(__func__);
 
   // requires loadGaugeQuda to be called in subequent solver
   invalidateGaugeQuda();

--- a/lib/staggered_oprod.cu
+++ b/lib/staggered_oprod.cu
@@ -3,301 +3,163 @@
 
 #include <staggered_oprod.h>
 #include <tune_quda.h>
-#include <quda_internal.h>
 #include <gauge_field_order.h>
+#include <color_spinor_field_order.h>
 #include <quda_matrix.h>
-#include <dslash_quda.h>
+#include <index_helper.cuh>
 
 namespace quda {
 
-#ifdef GPU_STAGGERED_DIRAC
-
-  namespace { // anonymous
-#include <texture.h>
-  }
-
   enum OprodKernelType { OPROD_INTERIOR_KERNEL, OPROD_EXTERIOR_KERNEL };
 
-  template <typename Float, typename Output, typename InputA, typename InputB> struct StaggeredOprodArg {
+  template <typename Float, int nColor_> struct StaggeredOprodArg {
+    typedef typename mapper<Float>::type real;
+    static constexpr int nColor = nColor_;
+    static constexpr int nSpin = 1;
+    using F = typename colorspinor_mapper<Float, nSpin, nColor>::type;
+    using GU = typename gauge_mapper<Float, QUDA_RECONSTRUCT_NO, 18>::type;
+    using GL = typename gauge_mapper<Float, QUDA_RECONSTRUCT_NO, 18>::type;
+
+    const F inA; /** input vector field */
+    const F inB; /** input vector field */
+    GU U;        /** output one-hop field */
+    GL L;        /** output three-hop field */
+
     unsigned int length;
     const int parity;
     int dir;
     int displacement;
     OprodKernelType kernelType;
     const int nFace;
-    const InputA inA;
-    const InputB inB;
-    Output outA;
-    Output outB;
     Float coeff[2];
     int X[4];
-    unsigned int ghostOffset[4];
     bool partitioned[4];
 
-    StaggeredOprodArg(int parity, int dir, const unsigned int *ghostOffset, int displacement,
-                      const OprodKernelType &kernelType, int nFace, const double coeff[2], InputA &inA, InputB &inB,
-                      Output &outA, Output &outB, GaugeField &meta) :
-      length(meta.VolumeCB()),
+    StaggeredOprodArg(GaugeField &U, GaugeField &L, const ColorSpinorField &inA, const ColorSpinorField &inB,
+                      int parity, int dir, int displacement, const OprodKernelType &kernelType, int nFace, const double coeff[2]) :
+      inA(inA),
+      inB(inB, nFace),
+      U(U),
+      L(L),
+      length(U.VolumeCB()),
       parity(parity),
       dir(dir),
       displacement(displacement),
       kernelType(kernelType),
-      nFace(nFace),
-      inA(inA),
-      inB(inB),
-      outA(outA),
-      outB(outB)
+      nFace(nFace)
     {
       this->coeff[0] = coeff[0];
       this->coeff[1] = coeff[1];
-      for (int i = 0; i < 4; ++i) this->X[i] = meta.X()[i];
-      for (int i = 0; i < 4; ++i) this->ghostOffset[i] = ghostOffset[i];
+      for (int i = 0; i < 4; ++i) this->X[i] = U.X()[i];
       for (int i = 0; i < 4; ++i) this->partitioned[i] = commDimPartitioned(i) ? true : false;
     }
   };
 
-  enum IndexType {
-    EVEN_X = 0,
-    EVEN_Y = 1,
-    EVEN_Z = 2,
-    EVEN_T = 3
-  };
-
-  template <IndexType idxType>
-  __device__ inline void coordsFromIndex(int &idx, int c[4], unsigned int cb_idx, int parity, const int X[4])
+  template<typename real, typename Arg> __global__ void interiorOprodKernel(Arg arg)
   {
-      const int &LX = X[0];
-      const int &LY = X[1];
-      const int &LZ = X[2];
-      const int XYZ = X[2]*X[1]*X[0];
-      const int XY = X[1]*X[0];
+    using complex = complex<real>;
+    using matrix = Matrix<complex, Arg::nColor>;
+    using vector = ColorSpinor<real, Arg::nColor, 1>;
 
-      idx = 2*cb_idx;
+    unsigned int idx = blockIdx.x*blockDim.x + threadIdx.x;
+    const unsigned int gridSize = gridDim.x*blockDim.x;
 
-      int x, y, z, t;
+    matrix result;
 
-      if (idxType == EVEN_X /*!(LX & 1)*/) { // X even
-        //   t = idx / XYZ;
-        //   z = (idx / XY) % Z;
-        //   y = (idx / X) % Y;
-        //   idx += (parity + t + z + y) & 1;
-        //   x = idx % X;
-        // equivalent to the above, but with fewer divisions/mods:
-        int aux1 = idx / LX;
-        x = idx - aux1 * LX;
-        int aux2 = aux1 / LY;
-        y = aux1 - aux2 * LY;
-        t = aux2 / LZ;
-        z = aux2 - t * LZ;
-        aux1 = (parity + t + z + y) & 1;
-        x += aux1;
-        idx += aux1;
-      } else if (idxType == EVEN_Y /*!(LY & 1)*/) { // Y even
-        t = idx / XYZ;
-        z = (idx / XY) % LZ;
-        idx += (parity + t + z) & 1;
-        y = (idx / LX) % LY;
-        x = idx % LX;
-      } else if (idxType == EVEN_Z /*!(LZ & 1)*/) { // Z even
-        t = idx / XYZ;
-        idx += (parity + t) & 1;
-        z = (idx / XY) % LZ;
-        y = (idx / LX) % LY;
-        x = idx % LX;
-      } else {
-        idx += parity;
-        t = idx / XYZ;
-        z = (idx / XY) % LZ;
-        y = (idx / LX) % LY;
-        x = idx % LX;
-      }
-
-      c[0] = x;
-      c[1] = y;
-      c[2] = z;
-      c[3] = t;
-    }
-  
-
-  // Get the  coordinates for the exterior kernels
-    __device__ inline void coordsFromIndex(int x[4], unsigned int cb_idx, const int X[4], int dir, int displacement,
-                                           int parity)
-    {
-      int Xh[2] = {X[0] / 2, X[1] / 2};
-      switch (dir) {
-      case 0:
-        x[2] = cb_idx / Xh[1] % X[2];
-        x[3] = cb_idx / (Xh[1] * X[2]) % X[3];
-        x[0] = cb_idx / (Xh[1] * X[2] * X[3]);
-        x[0] += (X[0] - displacement);
-        x[1] = 2 * (cb_idx % Xh[1]) + ((x[0] + x[2] + x[3] + parity) & 1);
-        break;
-
-      case 1:
-        x[2] = cb_idx / Xh[0] % X[2];
-        x[3] = cb_idx / (Xh[0] * X[2]) % X[3];
-        x[1] = cb_idx / (Xh[0] * X[2] * X[3]);
-        x[1] += (X[1] - displacement);
-        x[0] = 2 * (cb_idx % Xh[0]) + ((x[1] + x[2] + x[3] + parity) & 1);
-        break;
-
-      case 2:
-        x[1] = cb_idx / Xh[0] % X[1];
-        x[3] = cb_idx / (Xh[0] * X[1]) % X[3];
-        x[2] = cb_idx / (Xh[0] * X[1] * X[3]);
-        x[2] += (X[2] - displacement);
-        x[0] = 2 * (cb_idx % Xh[0]) + ((x[1] + x[2] + x[3] + parity) & 1);
-        break;
-
-      case 3:
-        x[1] = cb_idx / Xh[0] % X[1];
-        x[2] = cb_idx / (Xh[0] * X[1]) % X[2];
-        x[3] = cb_idx / (Xh[0] * X[1] * X[2]);
-        x[3] += (X[3] - displacement);
-        x[0] = 2 * (cb_idx % Xh[0]) + ((x[1] + x[2] + x[3] + parity) & 1);
-        break;
-      }
-      return;
-  }
-
-  __device__ inline int neighborIndex(unsigned int cb_idx, const int shift[4], const bool partitioned[4], int parity,
-                                      const int X[4])
-  {
-    int full_idx;
-    int x[4]; 
-
-    coordsFromIndex<EVEN_X>(full_idx, x, cb_idx, parity, X);
-    
-    for(int dim = 0; dim<4; ++dim){
-      if( partitioned[dim] )
-	if( (x[dim]+shift[dim])<0 || (x[dim]+shift[dim])>=X[dim]) return -1;
-    }
-
-    for(int dim=0; dim<4; ++dim){
-      x[dim] = shift[dim] ? (x[dim]+shift[dim] + X[dim]) % X[dim] : x[dim];
-    }
-    return (((x[3]*X[2] + x[2])*X[1] + x[1])*X[0] + x[0]) >> 1;
-  }
-
-  template<typename real, typename Output, typename InputA, typename InputB>
-  __global__ void interiorOprodKernel(StaggeredOprodArg<real, Output, InputA, InputB> arg)
-    {
-      using complex = complex<real>;
-      using matrix = Matrix<complex,3>;
-
-      unsigned int idx = blockIdx.x*blockDim.x + threadIdx.x;
-      const unsigned int gridSize = gridDim.x*blockDim.x;
-
-      complex x[3], y[3], z[3];
-      matrix result;
-
-      while(idx<arg.length){
-        arg.inA.load(x, idx);
+    while (idx < arg.length) {
+      const vector x = arg.inA(idx, 0);
 
 #pragma unroll
-        for(int dim=0; dim<4; ++dim){
-          int shift[4] = {0,0,0,0};
-          shift[dim] = 1;
-          const int first_nbr_idx = neighborIndex(idx, shift, arg.partitioned, arg.parity, arg.X);
-          if(first_nbr_idx >= 0){
-            arg.inB.load(y, first_nbr_idx);
-            outerProd(y,x,&result);
-            matrix tempA = arg.outA(dim, idx, arg.parity);
-            result = tempA + result*arg.coeff[0];
-    
-	    arg.outA(dim, idx, arg.parity) = result;
+      for (int dim=0; dim<4; ++dim) {
+        int shift[4] = {0,0,0,0};
+        shift[dim] = 1;
+        const int first_nbr_idx = neighborIndex(idx, shift, arg.partitioned, arg.parity, arg.X);
+        if (first_nbr_idx >= 0) {
+          const vector y = arg.inB(first_nbr_idx, 0);
+          result = outerProduct(y, x);
+          matrix tempA = arg.U(dim, idx, arg.parity);
+          result = tempA + result*arg.coeff[0];
 
-	    if (arg.nFace == 3) {
-	      shift[dim] = 3;
-	      const int third_nbr_idx = neighborIndex(idx, shift, arg.partitioned, arg.parity, arg.X);
-	      if (third_nbr_idx >= 0) {
-		arg.inB.load(z, third_nbr_idx);
-		outerProd(z, x, &result);
-		matrix tempB = arg.outB(dim, idx, arg.parity);
-		result = tempB + result*arg.coeff[1];
-		arg.outB(dim, idx, arg.parity) = result;
-	      }
-	    }
+          arg.U(dim, idx, arg.parity) = result;
+
+          if (arg.nFace == 3) {
+            shift[dim] = 3;
+            const int third_nbr_idx = neighborIndex(idx, shift, arg.partitioned, arg.parity, arg.X);
+            if (third_nbr_idx >= 0) {
+              const vector z = arg.inB(third_nbr_idx, 0);
+              result = outerProduct(z, x);
+              matrix tempB = arg.L(dim, idx, arg.parity);
+              result = tempB + result*arg.coeff[1];
+              arg.L(dim, idx, arg.parity) = result;
+            }
           }
-        } // dim
+        }
+      } // dim
 
-        idx += gridSize;
-      }
-      return;
-    } // interiorOprodKernel
-
-
-  template<int dim, typename real, typename Output, typename InputA, typename InputB>
-  __global__ void exteriorOprodKernel(StaggeredOprodArg<real, Output, InputA, InputB> arg)
-    {
-      using complex = complex<real>;
-      using matrix = Matrix<complex,3>;
-
-      unsigned int cb_idx = blockIdx.x*blockDim.x + threadIdx.x;
-      const unsigned int gridSize = gridDim.x*blockDim.x;
-
-      complex a[3], b[3];
-      matrix result;
-
-      Output& out = (arg.displacement == 1) ? arg.outA : arg.outB;
-      real coeff = (arg.displacement == 1) ? arg.coeff[0] : arg.coeff[1];
-
-      int x[4];
-      while(cb_idx<arg.length){
-        coordsFromIndex(x, cb_idx, arg.X, arg.dir, arg.displacement, arg.parity);
-        const unsigned int bulk_cb_idx = ((((x[3]*arg.X[2] + x[2])*arg.X[1] + x[1])*arg.X[0] + x[0]) >> 1);
-
-        matrix inmatrix = out(arg.dir, bulk_cb_idx, arg.parity);
-        arg.inA.load(a, bulk_cb_idx);
-
-        const unsigned int ghost_idx = arg.ghostOffset[dim] + cb_idx;
-        arg.inB.loadGhost(b, ghost_idx, arg.dir);
-
-        outerProd(b, a, &result);
-        result = inmatrix + result*coeff;
-        out(arg.dir, bulk_cb_idx, arg.parity) = result;
-
-        cb_idx += gridSize;
-      }
-      return;
+      idx += gridSize;
     }
+  } // interiorOprodKernel
 
+  template<int dim, typename real, typename Arg> __global__ void exteriorOprodKernel(Arg arg)
+  {
+    using complex = complex<real>;
+    using matrix = Matrix<complex, Arg::nColor>;
+    using vector = ColorSpinor<real, Arg::nColor, 1>;
 
-  template<typename Float, typename Output, typename InputA, typename InputB>
+    unsigned int cb_idx = blockIdx.x*blockDim.x + threadIdx.x;
+    const unsigned int gridSize = gridDim.x*blockDim.x;
+
+    matrix result;
+
+    auto &out = (arg.displacement == 1) ? arg.U : arg.L;
+    real coeff = (arg.displacement == 1) ? arg.coeff[0] : arg.coeff[1];
+
+    int x[4];
+    while (cb_idx < arg.length) {
+      coordsFromIndexExterior(x, cb_idx, arg.X, arg.dir, arg.displacement, arg.parity);
+      const unsigned int bulk_cb_idx = ((((x[3]*arg.X[2] + x[2])*arg.X[1] + x[1])*arg.X[0] + x[0]) >> 1);
+
+      matrix inmatrix = out(arg.dir, bulk_cb_idx, arg.parity);
+      const vector a = arg.inA(bulk_cb_idx, 0);
+      const vector b = arg.inB.Ghost(arg.dir, 1, cb_idx, 0);
+
+      result = outerProduct(b, a);
+      result = inmatrix + result*coeff;
+      out(arg.dir, bulk_cb_idx, arg.parity) = result;
+
+      cb_idx += gridSize;
+    }
+  }
+
+  template<typename Float, typename Arg>
   class StaggeredOprodField : public Tunable {
 
-  private:
-    StaggeredOprodArg<Float,Output,InputA,InputB> &arg;
+    Arg &arg;
     const GaugeField &meta;
 
     unsigned int sharedBytesPerThread() const { return 0; }
     unsigned int sharedBytesPerBlock(const TuneParam &) const { return 0; }
 
-    unsigned int minThreads() const { return arg.outA.volumeCB; }
+    unsigned int minThreads() const { return arg.U.volumeCB; }
     bool tunedGridDim() const { return false; }
 
   public:
-    StaggeredOprodField(StaggeredOprodArg<Float,Output,InputA,InputB> &arg, const GaugeField &meta)
+    StaggeredOprodField(Arg &arg, const GaugeField &meta)
       : arg(arg), meta(meta) {
-      writeAuxString("threads=%d,prec=%lu,stride=%d",arg.length,sizeof(Complex)/2,arg.inA.Stride());
-      // this sets the communications pattern for the packing kernel
-      int comms[QUDA_MAX_DIM] = { commDimPartitioned(0), commDimPartitioned(1), commDimPartitioned(2), commDimPartitioned(3) };
-      setPackComms(comms);
+      writeAuxString(meta.AuxString());
     }
 
-    virtual ~StaggeredOprodField() {}
-
-    void apply(const qudaStream_t &stream){
+    void apply(const qudaStream_t &stream) {
       if (meta.Location() == QUDA_CUDA_FIELD_LOCATION) {
 	// Disable tuning for the time being
-	TuneParam tp = tuneLaunch(*this, QUDA_TUNE_NO, getVerbosity());
+	TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
 	if (arg.kernelType == OPROD_INTERIOR_KERNEL) {
-	  interiorOprodKernel<<<tp.grid,tp.block,tp.shared_bytes, stream>>>(arg);
+	  interiorOprodKernel<Float><<<tp.grid,tp.block,tp.shared_bytes, stream>>>(arg);
 	} else if (arg.kernelType == OPROD_EXTERIOR_KERNEL) {
-	       if (arg.dir == 0) exteriorOprodKernel<0><<<tp.grid,tp.block,tp.shared_bytes, stream>>>(arg);
-	  else if (arg.dir == 1) exteriorOprodKernel<1><<<tp.grid,tp.block,tp.shared_bytes, stream>>>(arg);
-	  else if (arg.dir == 2) exteriorOprodKernel<2><<<tp.grid,tp.block,tp.shared_bytes, stream>>>(arg);
-	  else if (arg.dir == 3) exteriorOprodKernel<3><<<tp.grid,tp.block,tp.shared_bytes, stream>>>(arg);
+          if (arg.dir == 0) exteriorOprodKernel<0,Float><<<tp.grid,tp.block,tp.shared_bytes, stream>>>(arg);
+	  else if (arg.dir == 1) exteriorOprodKernel<1,Float><<<tp.grid,tp.block,tp.shared_bytes, stream>>>(arg);
+	  else if (arg.dir == 2) exteriorOprodKernel<2,Float><<<tp.grid,tp.block,tp.shared_bytes, stream>>>(arg);
+	  else if (arg.dir == 3) exteriorOprodKernel<3,Float><<<tp.grid,tp.block,tp.shared_bytes, stream>>>(arg);
 	} else {
 	  errorQuda("Kernel type not supported\n");
 	}
@@ -306,73 +168,37 @@ namespace quda {
       }
     } // apply
 
-    void preTune(){ this->arg.outA.save(); this->arg.outB.save(); }
-    void postTune(){ this->arg.outA.load(); this->arg.outB.load(); }
-  
+    void preTune() { arg.U.save(); arg.L.save(); }
+    void postTune() { arg.U.load(); arg.L.load(); }
+
     long long flops() const { return 0; } // FIXME
     long long bytes() const { return 0; } // FIXME
-    TuneKey tuneKey() const { return TuneKey(meta.VolString(), typeid(*this).name(), aux);}
+    TuneKey tuneKey() const {
+      char aux[TuneKey::aux_n];
+      strcpy(aux, this->aux);
+      if (arg.kernelType == OPROD_EXTERIOR_KERNEL) {
+        strcat(aux, ",dir=");
+        char tmp[2];
+        u32toa(tmp, arg.dir);
+        strcat(aux, tmp);
+        strcat(aux, ",displacement=");
+        u32toa(tmp, arg.displacement);
+        strcat(aux, tmp);
+      }
+      return TuneKey(meta.VolString(), typeid(*this).name(), aux);
+    }
   }; // StaggeredOprodField
 
-
-  void exchangeGhost(int nFace, cudaColorSpinorField &a, int parity, int dag) {
-    // need to enable packing in temporal direction to get spin-projector correct
-    pushKernelPackT(true);
-
-    // first transfer src1
-    qudaDeviceSynchronize();
-
-    MemoryLocation location[2*QUDA_MAX_DIM] = {Device, Device, Device, Device, Device, Device, Device, Device};
-    a.pack(nFace, 1-parity, dag, Nstream-1, location, Device);
-
-    qudaDeviceSynchronize();
-
-    for(int i=3; i>=0; i--){
-      if(commDimPartitioned(i)){
-	// Initialize the host transfer from the source spinor
-	a.gather(nFace, dag, 2*i);
-      } // commDim(i)
-    } // i=3,..,0
-
-    qudaDeviceSynchronize(); comm_barrier();
-
-    for (int i=3; i>=0; i--) {
-      if(commDimPartitioned(i)) {
-	a.commsStart(nFace, 2*i, dag);
-      }
-    }
-
-    for (int i=3; i>=0; i--) {
-      if(commDimPartitioned(i)) {
-	a.commsWait(nFace, 2*i, dag);
-	a.scatter(nFace, dag, 2*i);
-      }
-    }
-
-    qudaDeviceSynchronize();
-    popKernelPackT(); // restore packing state
-
-    a.bufferIndex = (1 - a.bufferIndex);
-    comm_barrier();
-  }
-
-  template <typename Float, typename Output, typename InputA, typename InputB>
-  void computeStaggeredOprodCuda(Output outA, Output outB, GaugeField &outFieldA, GaugeField &outFieldB, InputA &inA,
-                                 InputB &inB, cudaColorSpinorField &src, int parity, const int faceVolumeCB[4],
-                                 const double coeff[2], int nFace)
+  template <typename Float>
+  void computeStaggeredOprod(GaugeField &U, GaugeField &L, ColorSpinorField &inA, ColorSpinorField &inB, int parity, const double coeff[2], int nFace)
   {
-    unsigned int ghostOffset[4] = {0, 0, 0, 0};
-    for (int dir = 0; dir < 4; ++dir)
-      ghostOffset[dir] = src.GhostOffset(dir, 1) / src.FieldOrder(); // offset we want is the forwards one
-
     // Create the arguments for the interior kernel
-    StaggeredOprodArg<Float, Output, InputA, InputB> arg(parity, 0, ghostOffset, 1, OPROD_INTERIOR_KERNEL, nFace, coeff,
-                                                         inA, inB, outA, outB, outFieldA);
-    StaggeredOprodField<Float, Output, InputA, InputB> oprod(arg, outFieldA);
+    StaggeredOprodArg<Float, 3> arg(U, L, inA, inB, parity, 0, 1, OPROD_INTERIOR_KERNEL, nFace, coeff);
+    StaggeredOprodField<Float, decltype(arg)> oprod(arg, U);
 
     arg.kernelType = OPROD_INTERIOR_KERNEL;
-    arg.length = src.VolumeCB();
-    oprod.apply(streams[Nstream - 1]);
+    arg.length = U.VolumeCB();
+    oprod.apply(0);
 
     for (int i = 3; i >= 0; i--) {
       if (commDimPartitioned(i)) {
@@ -383,69 +209,48 @@ namespace quda {
         // First, do the one hop term
         {
           arg.displacement = 1;
-          arg.length = faceVolumeCB[i];
-          oprod.apply(streams[Nstream - 1]);
+          arg.length = inB.GhostFaceCB()[i];
+          oprod.apply(0);
         }
 
         // Now do the 3 hop term
         if (nFace == 3) {
           arg.displacement = 3;
-          arg.length = arg.displacement * faceVolumeCB[i];
-          oprod.apply(streams[Nstream - 1]);
+          arg.length = arg.displacement * inB.GhostFaceCB()[i];
+          oprod.apply(0);
         }
       }
     } // i=3,..,0
 
     checkCudaError();
-    } // computeStaggeredOprodCuda
+  } // computeStaggeredOprod
 
-#endif // GPU_STAGGERED_DIRAC
+  void computeStaggeredOprod(GaugeField &U, GaugeField &L, ColorSpinorField &inEven, ColorSpinorField &inOdd,
+                             int parity, const double coeff[2], int nFace)
+  {
+    if (U.Order() != QUDA_FLOAT2_GAUGE_ORDER) errorQuda("Unsupported output ordering: %d\n", U.Order());
+    if (L.Order() != QUDA_FLOAT2_GAUGE_ORDER) errorQuda("Unsupported output ordering: %d\n", L.Order());
 
-    void computeStaggeredOprod(GaugeField &outA, GaugeField &outB, ColorSpinorField &inEven, ColorSpinorField &inOdd,
-                               int parity, const double coeff[2], int nFace)
-    {
-#ifdef GPU_STAGGERED_DIRAC
-    if(outA.Order() != QUDA_FLOAT2_GAUGE_ORDER)
-      errorQuda("Unsupported output ordering: %d\n", outA.Order());    
+    ColorSpinorField &inA = (parity & 1) ? inOdd : inEven;
+    ColorSpinorField &inB = (parity & 1) ? inEven : inOdd;
 
-    if(outB.Order() != QUDA_FLOAT2_GAUGE_ORDER)
-      errorQuda("Unsupported output ordering: %d\n", outB.Order());    
+    inB.exchangeGhost((QudaParity)(1-parity), nFace, 0);
 
-    if(inEven.Precision() != outA.Precision()) errorQuda("Mixed precision not supported: %d %d\n", inEven.Precision(), outA.Precision());
-
-    cudaColorSpinorField &inA = (parity&1) ? static_cast<cudaColorSpinorField&>(inOdd) : static_cast<cudaColorSpinorField&>(inEven);
-    cudaColorSpinorField &inB = (parity&1) ? static_cast<cudaColorSpinorField&>(inEven) : static_cast<cudaColorSpinorField&>(inOdd);
-
-    inA.allocateGhostBuffer(nFace);
-    inB.allocateGhostBuffer(nFace);
-
-    if (inEven.Precision() == QUDA_DOUBLE_PRECISION) {
-      Spinor<double2, double2, 3, 0> spinorA(inA, nFace);
-      Spinor<double2, double2, 3, 0> spinorB(inB, nFace);
-      exchangeGhost(nFace,static_cast<cudaColorSpinorField&>(inB), parity, 0);
-
-      computeStaggeredOprodCuda<double>(gauge::FloatNOrder<double, 18, 2, 18>(outA), gauge::FloatNOrder<double, 18, 2, 18>(outB),
-					outA, outB, spinorA, spinorB, inB, parity, inB.GhostFace(), coeff, nFace);
-    } else if (inEven.Precision() == QUDA_SINGLE_PRECISION) {
-      Spinor<float2, float2, 3, 0> spinorA(inA, nFace);
-      Spinor<float2, float2, 3, 0> spinorB(inB, nFace);
-      exchangeGhost(nFace,static_cast<cudaColorSpinorField&>(inB), parity, 0);
-
-      computeStaggeredOprodCuda<float>(gauge::FloatNOrder<float, 18, 2, 18>(outA), gauge::FloatNOrder<float, 18, 2, 18>(outB),
-				       outA, outB, spinorA, spinorB, inB, parity, inB.GhostFace(), coeff, nFace);
+    auto prec = checkPrecision(inEven, inOdd, U, L);
+    if (prec == QUDA_DOUBLE_PRECISION) {
+      computeStaggeredOprod<double>(U, L, inA, inB, parity, coeff, nFace);
+    } else if (prec == QUDA_SINGLE_PRECISION) {
+      computeStaggeredOprod<float>(U, L, inA, inB, parity, coeff, nFace);
     } else {
-      errorQuda("Unsupported precision: %d\n", inEven.Precision());
+      errorQuda("Unsupported precision: %d", prec);
     }
 
-#else // GPU_STAGGERED_DIRAC not defined
-    errorQuda("Staggered Outer Product has not been built!"); 
-#endif
-
-    return;
-  } // computeStaggeredOprod
+    inB.bufferIndex = (1 - inB.bufferIndex);
+  }
 
   void computeStaggeredOprod(GaugeField *out[], ColorSpinorField& in, const double coeff[], int nFace)
   {
+#ifdef GPU_STAGGERED_DIRAC
     if (nFace == 1) {
       computeStaggeredOprod(*out[0], *out[0], in.Even(), in.Odd(), 0, coeff, nFace);
       double coeff_[2] = {-coeff[0],0.0}; // need to multiply by -1 on odd sites
@@ -456,6 +261,9 @@ namespace quda {
     } else {
       errorQuda("Invalid nFace=%d", nFace);
     }
+#else // GPU_STAGGERED_DIRAC not defined
+    errorQuda("Staggered Outer Product has not been built!");
+#endif
   }
 
 } // namespace quda

--- a/lib/svd_quda.h
+++ b/lib/svd_quda.h
@@ -53,15 +53,13 @@ inline double getNorm(const Array<complex<double>,3>& a){
   return quadSum(temp1,temp3);
 }
 
-
-template <class T, class V>
-inline DEVICEHOST auto constructHHMat(const T & tau, const V & v)
+template <class T, class V> inline DEVICEHOST auto constructHHMat(const T &tau, const V &v)
 {
-  Matrix<T,3> hh, temp1, temp2;
+  Matrix<T, 3> hh, temp1, temp2;
 
   ColorSpinor<decltype(tau.real()), 3, 1> v_;
-  for (int i=0; i<3; i++) v_(0, i) = v[i];
-  temp1 = outerProduct(v_,v_);
+  for (int i = 0; i < 3; i++) v_(0, i) = v[i];
+  temp1 = outerProduct(v_, v_);
 
   temp2 = conj(tau)*temp1;
 
@@ -260,7 +258,7 @@ void getRealBidiagMatrix(const Matrix<complex<Float>,3> &mat, Matrix<complex<Flo
 {
   typedef complex<Float> Complex;
 
-  Matrix<Complex,3> p, temp;
+  Matrix<Complex, 3> p, temp;
   Array<Complex,3> vec;
 
   const Complex COMPLEX_UNITY(1.0,0.0);

--- a/lib/svd_quda.h
+++ b/lib/svd_quda.h
@@ -1,13 +1,11 @@
-#include <float.h>
+#pragma once
 
-#ifndef _SVD_QUDA_H_
-#define _SVD_QUDA_H_
+#include <float.h>
 
 #define DEVICEHOST __device__ __host__
 #define SVDPREC 1e-11
 #define LOG2 0.69314718055994530942
 #define INVALID_DOUBLE (-DBL_MAX)
-
 
 //namespace quda{
 
@@ -56,19 +54,21 @@ inline double getNorm(const Array<complex<double>,3>& a){
 }
 
 
-template<class T>
-inline DEVICEHOST 
-void constructHHMat(const T & tau, const Array<T,3> & v, Matrix<T,3> & hh)
+template <class T, class V>
+inline DEVICEHOST auto constructHHMat(const T & tau, const V & v)
 {
-  Matrix<T,3> temp1, temp2;
-  outerProd(v,v,&temp1);
+  Matrix<T,3> hh, temp1, temp2;
+
+  ColorSpinor<decltype(tau.real()), 3, 1> v_;
+  for (int i=0; i<3; i++) v_(0, i) = v[i];
+  temp1 = outerProduct(v_,v_);
 
   temp2 = conj(tau)*temp1;
 
   setIdentity(&temp1);
 
-  hh =  temp1 - temp2; 
-  return;
+  hh = temp1 - temp2;
+  return hh;
 }
 
 
@@ -87,7 +87,6 @@ void getLambdaMax(const Matrix<Real,3> & b, Real & lambda_max){
   }else{
     lambda_max = m22 + (m12*m12)/(norm1 - dm);
   }
-  return;
 }
 
 
@@ -261,10 +260,8 @@ void getRealBidiagMatrix(const Matrix<complex<Float>,3> &mat, Matrix<complex<Flo
 {
   typedef complex<Float> Complex;
 
-  Matrix<Complex,3> p;
+  Matrix<Complex,3> p, temp;
   Array<Complex,3> vec;
-  Matrix<Complex,3> temp;
-
 
   const Complex COMPLEX_UNITY(1.0,0.0);
   const Complex COMPLEX_ZERO = 0.0;
@@ -305,7 +302,7 @@ void getRealBidiagMatrix(const Matrix<complex<Float>,3> &mat, Matrix<complex<Flo
     tau.x =  (beta - mat(0,0).x)/beta;
     tau.y =  mat(0,0).y/beta;
     // construct the Householder matrix
-    constructHHMat(tau, vec, temp);
+    temp = constructHHMat(tau, vec);
     p = conj(temp)*mat;    
     u = temp;
   }
@@ -328,7 +325,7 @@ void getRealBidiagMatrix(const Matrix<complex<Float>,3> &mat, Matrix<complex<Flo
     tau.x = (beta - p(0,1).x)/beta; // work around for LLVM
     tau.y = (- p(0,1).y)/beta;
     // construct the Householder matrix
-    constructHHMat(tau, vec, temp);
+    temp = constructHHMat(tau, vec);
     p = p*temp;
     v = temp;
   }
@@ -356,7 +353,7 @@ void getRealBidiagMatrix(const Matrix<complex<Float>,3> &mat, Matrix<complex<Flo
     // so that we wouldn't need to call conj(temp) below.
     // I would have to be careful to make sure this change 
     // is consistent with the other parts of the code.
-    constructHHMat(tau, vec, temp);
+    temp = constructHHMat(tau, vec);
     p = conj(temp)*p;
     u = u*temp;
   }
@@ -639,5 +636,3 @@ DEVICEHOST void computeSVD(const Matrix<complex<Float>, 3> &m, Matrix<complex<Fl
 //} // end namespace quda
 
 #undef INVALID_DOUBLE
-
-#endif // _SVD_QUDA_H

--- a/lib/unitarize_force_quda.cu
+++ b/lib/unitarize_force_quda.cu
@@ -6,6 +6,7 @@
 #include <quda_matrix.h>
 #include <gauge_field_order.h>
 #include <instantiate.h>
+#include <color_spinor.h>
 
 namespace quda {
 

--- a/lib/unitarize_links_quda.cu
+++ b/lib/unitarize_links_quda.cu
@@ -9,7 +9,7 @@
 #include <su3_project.cuh>
 #include <index_helper.cuh>
 #include <instantiate.h>
-
+#include <color_spinor.h>
 
 namespace quda {
 


### PR DESCRIPTION
This pull request is mainly clean up pull, but also will give some small boosts in MILC performance. 
* Cleanup of the outer-product routines to use `colorspinor` accessors instead of the legacy textures accessors.  Still much optimization to be done for these routines, but this can wait until multi-RHS support is present in QUDA.
* Removal of legacy functions that are no longer used.
* Fix for latent race condition in `cudaColorSpinorField::exchangeGhost`: function does not return until any outstanding P2P sending is complete.
* Staggered outer product kernel now uses the regular `exchangeGhost` function for improved scaling.
* `GaugeField::fat_link_max` is now not computed until it is needed, as opposed to doing it whenever a fat-link host field is created.  This means we can do this evaluation on the device as opposed to the host, the end result is more than a halving in time spent in `loadGaugeQuda` when running using MILC.

This cleanup and optimization has been verified against MILC RHMC.