### PR TITLE
Feature/pcg deflation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -338,7 +338,7 @@ set(CMAKE_CXX_FLAGS_DEBUG
     "-Wall -Wno-unknown-pragmas -g -fno-inline"
     CACHE STRING "Flags used by the C++ compiler during full (host+device) debug builds.")
 set(CMAKE_CXX_FLAGS_SANITIZE
-    "$-Wall -Wno-unknown-pragmas -g -fno-inline -fsanitize=address,undefined"
+    "-Wall -Wno-unknown-pragmas -g -fno-inline -fsanitize=address,undefined"
     CACHE STRING "Flags used by the C++ compiler during santizer debug builds.")
 
 enable_language(CXX)

--- a/lib/cuda_color_spinor_field.cpp
+++ b/lib/cuda_color_spinor_field.cpp
@@ -567,7 +567,7 @@ namespace quda {
     cudaMemcpy(v, backup_h, bytes, cudaMemcpyHostToDevice);
     delete []backup_h;
     if (norm_bytes) {
-      cudaMemcpy(v, backup_norm_h, norm_bytes, cudaMemcpyHostToDevice);
+      cudaMemcpy(norm, backup_norm_h, norm_bytes, cudaMemcpyHostToDevice);
       delete []backup_norm_h;
     }
     checkCudaError();

--- a/lib/inv_cg_quda.cpp
+++ b/lib/inv_cg_quda.cpp
@@ -240,7 +240,6 @@ namespace quda {
 
     if (!param.is_preconditioner) profile.TPSTART(QUDA_PROFILE_INIT);
 
-    // Check to see that we're not trying to invert on a zero-field source
     double b2 = blas::norm2(b);
 
     // Check to see that we're not trying to invert on a zero-field source

--- a/lib/inv_pcg_quda.cpp
+++ b/lib/inv_pcg_quda.cpp
@@ -84,7 +84,7 @@ namespace quda
 
     if (K) delete K;
     destroyDeflationSpace();
-    
+
     profile.TPSTOP(QUDA_PROFILE_FREE);
   }
 
@@ -103,7 +103,7 @@ namespace quda
 
     int k = 0;
     int rUpdate = 0;
-    
+
     if (param.deflate) {
       // Construct the eigensolver and deflation space if requested.
       constructDeflationSpace(b, matPrecon);
@@ -119,7 +119,7 @@ namespace quda
         recompute_evals = false;
       }
     }
-    
+
     cudaColorSpinorField *minvrPre = NULL;
     cudaColorSpinorField *rPre = NULL;
     cudaColorSpinorField *minvr = NULL;
@@ -131,7 +131,7 @@ namespace quda
     if (K) minvr = new cudaColorSpinorField(b);
     csParam.create = QUDA_ZERO_FIELD_CREATE;
     cudaColorSpinorField y(b, csParam);
-    
+
     mat(r, x, y); // => r = A*x;
     double r2 = xmyNorm(b, r);
 
@@ -142,7 +142,6 @@ namespace quda
       r2 = blas::xmyNorm(b, r);
     }
 
-    
     csParam.setPrecision(param.precision_sloppy);
     cudaColorSpinorField tmpSloppy(x, csParam);
     cudaColorSpinorField Ap(x, csParam);
@@ -168,7 +167,7 @@ namespace quda
 
     cudaColorSpinorField &xSloppy = *x_sloppy;
     cudaColorSpinorField &rSloppy = *r_sloppy;
-    
+
     if (&x != &xSloppy) {
       copy(y, x); // copy x to y
       zero(xSloppy);
@@ -298,8 +297,7 @@ namespace quda
 
           maxr_deflate = sqrt(r2);
         }
-	
-	
+
         copy(rSloppy, r); // copy r to rSloppy
         zero(xSloppy);
 

--- a/lib/inv_pcg_quda.cpp
+++ b/lib/inv_pcg_quda.cpp
@@ -133,11 +133,31 @@ namespace quda
     csParam.create = QUDA_ZERO_FIELD_CREATE;
     cudaColorSpinorField y(b, csParam);
 
+    csParam.setPrecision(param.precision_sloppy);
+
+    // temporary fields
+    ColorSpinorField *tmpp = ColorSpinorField::Create(csParam);
+    ColorSpinorField *tmp2p = nullptr;
+    ColorSpinorField *tmp3p = nullptr;
+    if (!mat.isStaggered()) {
+      // tmp2 only needed for multi-gpu Wilson-like kernels
+      tmp2p = ColorSpinorField::Create(csParam);
+      // additional high-precision temporary if Wilson and mixed-precision
+      csParam.setPrecision(param.precision);
+      tmp3p = (param.precision != param.precision_sloppy) ? ColorSpinorField::Create(csParam) : tmpp;
+      csParam.setPrecision(param.precision_sloppy);
+    } else {
+      tmp3p = tmp2p = tmpp;
+    }
+    ColorSpinorField &tmp = *tmpp;
+    ColorSpinorField &tmp2 = *tmp2p;
+    ColorSpinorField &tmp3 = *tmp3p;
+
     // compute initial residual
     double r2 = 0.0;
     if (param.use_init_guess == QUDA_USE_INIT_GUESS_YES) {
       // Compute r = b - A * x
-      mat(r, x);
+      mat(r, x, y, tmp3);
       r2 = blas::xmyNorm(b, r);
       if (b2 == 0) b2 = r2;
       // y contains the original guess.
@@ -151,12 +171,10 @@ namespace quda
     if (param.deflate && param.maxiter > 1) {
       // Deflate and accumulate to solution vector
       eig_solve->deflate(y, r, evecs, evals, true);
-      mat(r, y);
+      mat(r, y, x, tmp3);
       r2 = blas::xmyNorm(b, r);
     }
 
-    csParam.setPrecision(param.precision_sloppy);
-    cudaColorSpinorField tmpSloppy(x, csParam);
     cudaColorSpinorField Ap(x, csParam);
 
     cudaColorSpinorField *r_sloppy;
@@ -178,8 +196,8 @@ namespace quda
       x_sloppy = new cudaColorSpinorField(x, csParam);
     }
 
-    cudaColorSpinorField &xSloppy = *x_sloppy;
-    cudaColorSpinorField &rSloppy = *r_sloppy;
+    ColorSpinorField &xSloppy = *x_sloppy;
+    ColorSpinorField &rSloppy = *r_sloppy;
 
     blas::zero(x);
     if (&x != &xSloppy) blas::zero(xSloppy);
@@ -243,7 +261,7 @@ namespace quda
 
     while (!convergence(r2, heavy_quark_res, stop, param.tol_hq) && k < param.maxiter) {
 
-      matSloppy(Ap, *p, tmpSloppy);
+      matSloppy(Ap, *p, tmp, tmp2);
 
       double sigma;
       pAp = reDotProduct(*p, Ap);
@@ -292,7 +310,7 @@ namespace quda
         axpy(alpha, *p, xSloppy); // xSloppy += alpha*p
         xpy(xSloppy, y);          // y += x
         // Now compute r
-        mat(r, y, x); // x is just a temporary here
+        mat(r, y, x, tmp3); // x is just a temporary here
         r2 = xmyNorm(b, r);
 
         if (param.deflate && sqrt(r2) < maxr_deflate * param.tol_restart) {
@@ -300,7 +318,7 @@ namespace quda
           eig_solve->deflate(y, r, evecs, evals, true);
 
           // Compute r_defl = RHS - A * LHS
-          mat(r, y, x);
+          mat(r, y, x, tmp3);
           r2 = blas::xmyNorm(b, r);
 
           maxr_deflate = sqrt(r2);
@@ -367,10 +385,10 @@ namespace quda
 
     if (k == param.maxiter) warningQuda("Exceeded maximum iterations %d", param.maxiter);
 
-    if (getVerbosity() >= QUDA_VERBOSE) printfQuda("CG: Reliable updates = %d\n", rUpdate);
+    if (getVerbosity() >= QUDA_VERBOSE) printfQuda("PCG: Reliable updates = %d\n", rUpdate);
 
     // compute the true residual
-    mat(r, x, y);
+    mat(r, x, y, tmp3);
     double true_res = xmyNorm(b, r);
     param.true_res = sqrt(true_res / b2);
 
@@ -382,6 +400,12 @@ namespace quda
 
     profile.TPSTOP(QUDA_PROFILE_EPILOGUE);
     profile.TPSTART(QUDA_PROFILE_FREE);
+
+    if (tmpp) delete tmpp;
+    if (!mat.isStaggered()) {
+      if (tmp2p && tmpp != tmp2p) delete tmp2p;
+      if (tmp3p && tmpp != tmp3p && param.precision != param.precision_sloppy) delete tmp3p;
+    }
 
     if (K) { // These are only needed if preconditioning is used
       delete minvrPre;


### PR DESCRIPTION
This PR adds the option to deflate a Preconditioned CG solve type. Using the following commands:

```
./invert_test --inv-type pcg --inv-deflate false --verbosity verbose --eig-use-poly-acc true --eig-spectrum SR --load-gauge /scratch/lattices/wl_16_64_5p5_x2p38_um0p4086_cfg_1000.lime --sdim 16 --tdim 64 --mass -0.42 --anisotropy 2.38 --niter 10000 --eig-nKr 256 --eig-nEv 128 --tol 1e-6
```
and
```
./invert_test --inv-type pcg --inv-deflate true --verbosity verbose --eig-use-poly-acc true --eig-spectrum SR --load-gauge /scratch/lattices/wl_16_64_5p5_x2p38_um0p4086_cfg_1000.lime --sdim 16 --tdim 64 --mass -0.42 --anisotropy 2.38 --niter 10000 --eig-nKr 256 --eig-nEv 128 --tol 1e-6
```
for no deflation and with deflation respectively, one can observe a 2x solver speed up.

TODO: the matVec routines in the `inv_pcg_quda.cpp` file pass no spare vectors to use as temps because I do not know which (if any) vectors are available for such.