### PR TITLE
Potential fix for MPI CXX link issue

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -364,7 +364,7 @@ if(QUDA_MPI OR QUDA_QMP)
 endif()
 
 if(QUDA_MPI)
-  target_link_libraries(quda PUBLIC MPI::MPI_C)
+  target_link_libraries(quda PUBLIC MPI::MPI_CXX)
   target_compile_definitions(quda PUBLIC MPI_COMMS)
 endif()
 
@@ -378,7 +378,7 @@ if(QUDA_QMP)
   target_include_directories(quda SYSTEM PUBLIC $<BUILD_INTERFACE:${QUDA_QMPHOME}/include>)
   target_compile_definitions(quda PUBLIC QMP_COMMS)
   target_link_libraries(quda INTERFACE ${QUDA_QMP_LDFLAGS} ${QUDA_QMP_LIBS})
-  target_link_libraries(quda PUBLIC MPI::MPI_C)
+  target_link_libraries(quda PUBLIC MPI::MPI_CXX)
 endif()
 
 if(QUDA_QIO)
@@ -406,7 +406,7 @@ if(QUDA_QDPJIT)
               ${LIME_LIB}
               ${QUDA_QMP_LDFLAGS}
               ${QMP_LIB}
-              MPI::MPI_C)
+              MPI::MPI_CXX)
 endif()
 
 if(QUDA_ARPACK)


### PR DESCRIPTION
Use `MPI:CXX` instead of `MPI::C` in cmake.
This seems to link fine for MPI built without C++ bindings.

@weinbe2 @hummingtree  can you check this fixes your issues (#1010) ?