### PR TITLE
Feature/milc mom

### DIFF
--- a/host_reference/gauge_force_reference.cpp
+++ b/host_reference/gauge_force_reference.cpp
@@ -5,6 +5,7 @@
 #include <type_traits>
 
 #include "quda.h"
+#include "gauge_field.h"
 #include "host_utils.h"
 #include "misc.h"
 #include "gauge_force_reference.h"
@@ -377,11 +378,22 @@ void gauge_force_reference_dir(void *refMom, int dir, double eb3, void **sitelin
   free(staple);
 }
 
-void gauge_force_reference(void *refMom, double eb3, void **sitelink, void **sitelink_ex_2d, QudaPrecision prec,
+void gauge_force_reference(void *refMom, double eb3, void **sitelink, QudaPrecision prec,
                            int ***path_dir, int *length, void *loop_coeff, int num_paths)
 {
+  // created extended field
+  int R[] = {2, 2, 2, 2};
+  QudaGaugeParam param = newQudaGaugeParam();
+  setGaugeParam(param);
+  param.gauge_order = QUDA_QDP_GAUGE_ORDER;
+  param.t_boundary = QUDA_PERIODIC_T;
+  
+  auto qdp_ex = quda::createExtendedGauge((void**)sitelink, param, R);
+
   for (int dir = 0; dir < 4; dir++) {
-    gauge_force_reference_dir(refMom, dir, eb3, sitelink, sitelink_ex_2d, prec, path_dir[dir], length, loop_coeff,
-                              num_paths);
+    gauge_force_reference_dir(refMom, dir, eb3, sitelink, (void**)qdp_ex->Gauge_p(), prec, path_dir[dir],
+                              length, loop_coeff, num_paths);
   }
+
+  delete qdp_ex;
 }

--- a/host_reference/gauge_force_reference.cpp
+++ b/host_reference/gauge_force_reference.cpp
@@ -378,8 +378,8 @@ void gauge_force_reference_dir(void *refMom, int dir, double eb3, void **sitelin
   free(staple);
 }
 
-void gauge_force_reference(void *refMom, double eb3, void **sitelink, QudaPrecision prec,
-                           int ***path_dir, int *length, void *loop_coeff, int num_paths)
+void gauge_force_reference(void *refMom, double eb3, void **sitelink, QudaPrecision prec, int ***path_dir, int *length,
+                           void *loop_coeff, int num_paths)
 {
   // created extended field
   int R[] = {2, 2, 2, 2};
@@ -387,12 +387,12 @@ void gauge_force_reference(void *refMom, double eb3, void **sitelink, QudaPrecis
   setGaugeParam(param);
   param.gauge_order = QUDA_QDP_GAUGE_ORDER;
   param.t_boundary = QUDA_PERIODIC_T;
-  
-  auto qdp_ex = quda::createExtendedGauge((void**)sitelink, param, R);
+
+  auto qdp_ex = quda::createExtendedGauge((void **)sitelink, param, R);
 
   for (int dir = 0; dir < 4; dir++) {
-    gauge_force_reference_dir(refMom, dir, eb3, sitelink, (void**)qdp_ex->Gauge_p(), prec, path_dir[dir],
-                              length, loop_coeff, num_paths);
+    gauge_force_reference_dir(refMom, dir, eb3, sitelink, (void **)qdp_ex->Gauge_p(), prec, path_dir[dir], length,
+                              loop_coeff, num_paths);
   }
 
   delete qdp_ex;

--- a/host_reference/gauge_force_reference.h
+++ b/host_reference/gauge_force_reference.h
@@ -1,4 +1,4 @@
 #pragma once
 
-void gauge_force_reference(void* refMom, double eb3, void** sitelink, QudaPrecision prec,
-                           int ***path_dir, int* length, void* loop_coeff, int num_paths);
+void gauge_force_reference(void *refMom, double eb3, void **sitelink, QudaPrecision prec, int ***path_dir, int *length,
+                           void *loop_coeff, int num_paths);

--- a/host_reference/gauge_force_reference.h
+++ b/host_reference/gauge_force_reference.h
@@ -1,15 +1,4 @@
-#ifndef __GAUGE_FORCE_REFERENCE__
-#define __GAUGE_FORCE_REFERENCE__
-#ifdef __cplusplus
-extern "C"{
-#endif
-  
-  void gauge_force_reference(void* refMom, double eb3, void** sitelink, void** sitelink_2d, QudaPrecision prec, 
-			     int ***path_dir, int* length, void* loop_coeff, int num_paths);
-  
-#ifdef __cplusplus
-}
-#endif
+#pragma once
 
-#endif
-
+void gauge_force_reference(void* refMom, double eb3, void** sitelink, QudaPrecision prec,
+                           int ***path_dir, int* length, void* loop_coeff, int num_paths);

--- a/include/quda.h
+++ b/include/quda.h
@@ -1075,7 +1075,6 @@ extern "C" {
   void computeKSLinkQuda(void* fatlink, void* longlink, void* ulink, void* inlink,
                          double *path_coeff, QudaGaugeParam *param);
 
-
   /**
    * Either downloads and sets the resident momentum field, or uploads
    * and returns the resident momentum field
@@ -1083,7 +1082,7 @@ extern "C" {
    * @param[in,out] mom The external momentum field
    * @param[in] param The parameters of the external field
    */
-  void momResidentQuda(void* mom, QudaGaugeParam* param);
+  void momResidentQuda(void *mom, QudaGaugeParam *param);
 
   /**
    * Compute the gauge force and update the mometum field

--- a/include/quda.h
+++ b/include/quda.h
@@ -1076,6 +1076,14 @@ extern "C" {
                          double *path_coeff, QudaGaugeParam *param);
 
 
+  /**
+   * Either downloads and sets the resident momentum field, or uploads
+   * and returns the resident momentum field
+   *
+   * @param[in,out] mom The external momentum field
+   * @param[in] param The parameters of the external field
+   */
+  void momResidentQuda(void* mom, QudaGaugeParam* param);
 
   /**
    * Compute the gauge force and update the mometum field

--- a/include/quda_milc_interface.h
+++ b/include/quda_milc_interface.h
@@ -658,17 +658,37 @@ extern "C" {
 		   QudaMILCSiteArg_t *arg);
 
   /**
-   * Evaluate the momentum contribution to the Hybrid Monte Carlo
-   * action.  The momentum field is assumed to be in MILC order.  MILC
-   * convention is applied, subtracting 4.0 from each momentum matrix
-   * to increased stability.
+   * Download the momentum from MILC and place into QUDA's resident
+   * momentum field.  The source momentum field can either be as part
+   * of a MILC site struct (QUDA_MILC_SITE_GAUGE_ORDER) or as a
+   * separate field (QUDA_MILC_GAUGE_ORDER).
    *
    * @param precision Precision of the field (2 - double, 1 - single)
-   * @param momentum The momentum field
+   * @param arg Metadata for MILC's internal site struct array
+   */
+  void qudaMomLoad(int precision, QudaMILCSiteArg_t *arg);
+
+  /**
+   * Upload the momentum to MILC from QUDA's resident momentum field.
+   * The destination momentum field can either be as part of a MILC site
+   * struct (QUDA_MILC_SITE_GAUGE_ORDER) or as a separate field
+   * (QUDA_MILC_GAUGE_ORDER).
+   *
+   * @param precision Precision of the field (2 - double, 1 - single)
+   * @param arg Metadata for MILC's internal site struct array
+   */
+  void qudaMomSave(int precision, QudaMILCSiteArg_t *arg);
+
+  /**
+   * Evaluate the momentum contribution to the Hybrid Monte Carlo
+   * action.  MILC convention is applied, subtracting 4.0 from each
+   * momentum matrix to increase stability.
+   *
+   * @param precision Precision of the field (2 - double, 1 - single)
+   * @param arg Metadata for MILC's internal site struct array
    * @return momentum action
    */
-  double qudaMomAction(int precision,
-		       void *momentum);
+  double qudaMomAction(int precision, QudaMILCSiteArg_t *arg);
 
   /**
    * Apply the staggered phase factors to the gauge field.  If the

--- a/lib/check_params.h
+++ b/lib/check_params.h
@@ -125,6 +125,9 @@ void printQudaGaugeParam(QudaGaugeParam *param) {
   P(make_resident_mom, INVALID_INT);
   P(return_result_gauge, INVALID_INT);
   P(return_result_mom, INVALID_INT);
+  P(gauge_offset, (size_t)INVALID_INT);
+  P(mom_offset, (size_t)INVALID_INT);
+  P(site_size, (size_t)INVALID_INT);
 #endif
 
 #ifdef INIT_PARAM

--- a/lib/copy_gauge.cu
+++ b/lib/copy_gauge.cu
@@ -29,6 +29,9 @@ namespace quda {
     } else if (u.Order() == QUDA_MILC_GAUGE_ORDER) {
       if (u.Reconstruct() != QUDA_RECONSTRUCT_10)
 	errorQuda("Unsuported order %d and reconstruct %d combination", u.Order(), u.Reconstruct());
+    } else if (u.Order() == QUDA_QDP_GAUGE_ORDER) {
+      if (u.Reconstruct() != QUDA_RECONSTRUCT_10)
+	errorQuda("Unsuported order %d and reconstruct %d combination", u.Order(), u.Reconstruct());
     } else if (u.Order() == QUDA_MILC_SITE_GAUGE_ORDER) {
       if (u.Reconstruct() != QUDA_RECONSTRUCT_10)
 	errorQuda("Unsuported order %d and reconstruct %d combination", u.Order(), u.Reconstruct());

--- a/lib/copy_gauge_inc.cu
+++ b/lib/copy_gauge_inc.cu
@@ -315,6 +315,15 @@ namespace quda {
 	    typedef FloatNOrder<FloatIn,10,2,10> momIn;
 	    CopyGaugeArg<momOut,momIn> arg(momOut(out, Out, 0, override), momIn(in, In, 0, override), in);
 	    copyMom<FloatOut,FloatIn,10,momOut,momIn>(arg,out,in,location);
+	  } else if (in.Order() == QUDA_QDP_GAUGE_ORDER) {
+#ifdef BUILD_QDP_INTERFACE
+	    typedef FloatNOrder<FloatOut,10,2,10> momOut;
+	    typedef QDPOrder<FloatIn,10> momIn;
+	    CopyGaugeArg<momOut,momIn> arg(momOut(out, Out, 0, override), momIn(in, In), in);
+	    copyMom<FloatOut,FloatIn,10,momOut,momIn>(arg,out,in,location);
+#else
+	    errorQuda("QDP interface has not been built\n");
+#endif
 	  } else if (in.Order() == QUDA_MILC_GAUGE_ORDER) {
 #ifdef BUILD_MILC_INTERFACE
 	    typedef FloatNOrder<FloatOut,10,2,10> momOut;
@@ -354,6 +363,23 @@ namespace quda {
 	  } else {
 	    errorQuda("Gauge field orders %d not supported", in.Order());
 	  }
+	} else if (out.Order() == QUDA_QDP_GAUGE_ORDER) {
+	  typedef QDPOrder<FloatOut,10> momOut;
+#ifdef BUILD_QDP_INTERFACE
+	  if (in.Order() == QUDA_FLOAT2_GAUGE_ORDER) {
+	    typedef FloatNOrder<FloatIn,10,2,10> momIn;
+	    CopyGaugeArg<momOut,momIn> arg(momOut(out, Out), momIn(in, In, 0, override), in);
+	    copyMom<FloatOut,FloatIn,10,momOut,momIn>(arg,out,in,location);
+	  } else if (in.Order() == QUDA_MILC_GAUGE_ORDER) {
+	    typedef MILCOrder<FloatIn,10> momIn;
+	    CopyGaugeArg<momOut,momIn> arg(momOut(out, Out), momIn(in, In), in);
+	    copyMom<FloatOut,FloatIn,10,momOut,momIn>(arg,out,in,location);
+	  } else {
+	    errorQuda("Gauge field orders %d not supported", in.Order());
+	  }
+#else
+	  errorQuda("QDP interface has not been built\n");
+#endif
 	} else if (out.Order() == QUDA_MILC_GAUGE_ORDER) {
 	  typedef MILCOrder<FloatOut,10> momOut;
 #ifdef BUILD_MILC_INTERFACE
@@ -363,6 +389,10 @@ namespace quda {
 	    copyMom<FloatOut,FloatIn,10,momOut,momIn>(arg,out,in,location);
 	  } else if (in.Order() == QUDA_MILC_GAUGE_ORDER) {
 	    typedef MILCOrder<FloatIn,10> momIn;
+	    CopyGaugeArg<momOut,momIn> arg(momOut(out, Out), momIn(in, In), in);
+	    copyMom<FloatOut,FloatIn,10,momOut,momIn>(arg,out,in,location);
+          } else if (in.Order() == QUDA_QDP_GAUGE_ORDER) {
+	    typedef QDPOrder<FloatIn,10> momIn;
 	    CopyGaugeArg<momOut,momIn> arg(momOut(out, Out), momIn(in, In), in);
 	    copyMom<FloatOut,FloatIn,10,momOut,momIn>(arg,out,in,location);
 	  } else {

--- a/lib/cpu_gauge_field.cpp
+++ b/lib/cpu_gauge_field.cpp
@@ -21,8 +21,8 @@ namespace quda {
     if (reconstruct != QUDA_RECONSTRUCT_NO && reconstruct != QUDA_RECONSTRUCT_10) {
       errorQuda("Reconstruction type %d not supported", reconstruct);
     }
-    if (reconstruct == QUDA_RECONSTRUCT_10 && order != QUDA_MILC_GAUGE_ORDER && order != QUDA_MILC_SITE_GAUGE_ORDER) {
-      errorQuda("10-reconstruction only supported with MILC gauge order");
+    if (reconstruct == QUDA_RECONSTRUCT_10 && link_type != QUDA_ASQTAD_MOM_LINKS) {
+      errorQuda("10-reconstruction only supported with momentum links");
     }
 
     int siteDim=0;

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -4125,6 +4125,11 @@ void momResidentQuda(void* mom, QudaGaugeParam* param)
     profileGaugeForce.TPSTART(QUDA_PROFILE_D2H);
     momResident->saveCPUField(cpuMom);
     profileGaugeForce.TPSTOP(QUDA_PROFILE_D2H);
+
+    profileGaugeForce.TPSTART(QUDA_PROFILE_FREE);
+    delete momResident;
+    momResident = nullptr;
+    profileGaugeForce.TPSTOP(QUDA_PROFILE_FREE);
   }
 
   profileGaugeForce.TPSTOP(QUDA_PROFILE_TOTAL);

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -3993,10 +3993,10 @@ int computeGaugeForceQuda(void* mom, void* siteLink,  int*** input_path_buf, int
   }
 
   GaugeFieldParam gParamMom(mom, *qudaGaugeParam, QUDA_ASQTAD_MOM_LINKS);
-  // FIXME - test program always uses MILC for mom but can use QDP for gauge
-  if (gParamMom.order == QUDA_QDP_GAUGE_ORDER) gParamMom.order = QUDA_MILC_GAUGE_ORDER;
-  if (gParamMom.order == QUDA_TIFR_GAUGE_ORDER || gParamMom.order == QUDA_TIFR_PADDED_GAUGE_ORDER) gParamMom.reconstruct = QUDA_RECONSTRUCT_NO;
-  else gParamMom.reconstruct = QUDA_RECONSTRUCT_10;
+  if (gParamMom.order == QUDA_TIFR_GAUGE_ORDER || gParamMom.order == QUDA_TIFR_PADDED_GAUGE_ORDER)
+    gParamMom.reconstruct = QUDA_RECONSTRUCT_NO;
+  else
+    gParamMom.reconstruct = QUDA_RECONSTRUCT_10;
 
   gParamMom.site_offset = qudaGaugeParam->mom_offset;
   gParamMom.site_size = qudaGaugeParam->site_size;

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -4081,7 +4081,7 @@ int computeGaugeForceQuda(void* mom, void* siteLink,  int*** input_path_buf, int
   return 0;
 }
 
-void momResidentQuda(void* mom, QudaGaugeParam* param)
+void momResidentQuda(void *mom, QudaGaugeParam *param)
 {
   profileGaugeForce.TPSTART(QUDA_PROFILE_TOTAL);
   profileGaugeForce.TPSTART(QUDA_PROFILE_INIT);
@@ -4091,7 +4091,8 @@ void momResidentQuda(void* mom, QudaGaugeParam* param)
   GaugeFieldParam gParamMom(mom, *param, QUDA_ASQTAD_MOM_LINKS);
   if (gParamMom.order == QUDA_TIFR_GAUGE_ORDER || gParamMom.order == QUDA_TIFR_PADDED_GAUGE_ORDER)
     gParamMom.reconstruct = QUDA_RECONSTRUCT_NO;
-  else gParamMom.reconstruct = QUDA_RECONSTRUCT_10;
+  else
+    gParamMom.reconstruct = QUDA_RECONSTRUCT_10;
   gParamMom.site_offset = param->mom_offset;
   gParamMom.site_size = param->site_size;
 
@@ -4109,8 +4110,8 @@ void momResidentQuda(void* mom, QudaGaugeParam* param)
   } else if (param->return_result_mom && !param->make_resident_mom) {
     if (!momResident) errorQuda("No resident momentum to return");
   } else {
-    errorQuda("Unexpected combination make_resident_mom = %d return_result_mom = %d",
-              param->make_resident_mom, param->return_result_mom);
+    errorQuda("Unexpected combination make_resident_mom = %d return_result_mom = %d", param->make_resident_mom,
+              param->return_result_mom);
   }
 
   profileGaugeForce.TPSTOP(QUDA_PROFILE_INIT);

--- a/lib/milc_interface.cpp
+++ b/lib/milc_interface.cpp
@@ -384,9 +384,8 @@ void qudaMomLoad(int prec, QudaMILCSiteArg_t *arg)
 {
   qudamilc_called<true>(__func__);
 
-  QudaGaugeParam param = newMILCGaugeParam(localDim,
-      (prec==1) ? QUDA_SINGLE_PRECISION : QUDA_DOUBLE_PRECISION,
-      QUDA_GENERAL_LINKS);
+  QudaGaugeParam param
+    = newMILCGaugeParam(localDim, (prec == 1) ? QUDA_SINGLE_PRECISION : QUDA_DOUBLE_PRECISION, QUDA_GENERAL_LINKS);
 
   void *mom = arg->site ? arg->site : arg->mom;
   param.mom_offset = arg->mom_offset;
@@ -406,9 +405,8 @@ void qudaMomSave(int prec, QudaMILCSiteArg_t *arg)
 {
   qudamilc_called<true>(__func__);
 
-  QudaGaugeParam param = newMILCGaugeParam(localDim,
-      (prec==1) ? QUDA_SINGLE_PRECISION : QUDA_DOUBLE_PRECISION,
-      QUDA_GENERAL_LINKS);
+  QudaGaugeParam param
+    = newMILCGaugeParam(localDim, (prec == 1) ? QUDA_SINGLE_PRECISION : QUDA_DOUBLE_PRECISION, QUDA_GENERAL_LINKS);
 
   void *mom = arg->site ? arg->site : arg->mom;
   param.mom_offset = arg->mom_offset;
@@ -427,9 +425,8 @@ double qudaMomAction(int prec, QudaMILCSiteArg_t *arg)
 {
   qudamilc_called<true>(__func__);
 
-  QudaGaugeParam param = newMILCGaugeParam(localDim,
-      (prec==1) ? QUDA_SINGLE_PRECISION : QUDA_DOUBLE_PRECISION,
-      QUDA_GENERAL_LINKS);
+  QudaGaugeParam param
+    = newMILCGaugeParam(localDim, (prec == 1) ? QUDA_SINGLE_PRECISION : QUDA_DOUBLE_PRECISION, QUDA_GENERAL_LINKS);
 
   void *mom = arg->site ? arg->site : arg->mom;
   param.mom_offset = arg->mom_offset;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -581,6 +581,13 @@ foreach(pol IN LISTS DSLASH_POLICIES)
              COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:covdev_test> ${MPIEXEEC_POSTFLAGS}
                      --dim 6 8 10 12
                      --gtest_output=xml:covdev_test_pol${pol2}.xml)
-   endif()
+  endif()
 
 endforeach(pol)
+
+if(QUDA_FORCE_GAUGE)
+  add_test(NAME gauge_force
+           COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:gauge_force_test> ${MPIEXEEC_POSTFLAGS}
+                   --dim 2 4 6 8
+                   --gtest_output=xml:gauge_force_test.xml)
+endif()

--- a/tests/gauge_force_test.cpp
+++ b/tests/gauge_force_test.cpp
@@ -265,11 +265,12 @@ void gauge_force_test(void)
   int num_paths = sizeof(path_dir_x)/sizeof(path_dir_x[0]);
 
   int** input_path_buf[4];
-  for (int dir =0; dir < 4; dir++) {
+  for (int dir = 0; dir < 4; dir++) {
     input_path_buf[dir] = (int **)safe_malloc(num_paths * sizeof(int *));
-    for (int i=0;i < num_paths;i++) {
+    for (int i = 0; i < num_paths; i++) {
       input_path_buf[dir][i] = (int*)safe_malloc(length[i]*sizeof(int));
-      if (dir == 0) memcpy(input_path_buf[dir][i], path_dir_x[i], length[i]*sizeof(int));
+      if (dir == 0)
+        memcpy(input_path_buf[dir][i], path_dir_x[i], length[i] * sizeof(int));
       else if(dir ==1) memcpy(input_path_buf[dir][i], path_dir_y[i], length[i]*sizeof(int));
       else if(dir ==2) memcpy(input_path_buf[dir][i], path_dir_z[i], length[i]*sizeof(int));
       else if(dir ==3) memcpy(input_path_buf[dir][i], path_dir_t[i], length[i]*sizeof(int));
@@ -284,7 +285,7 @@ void gauge_force_test(void)
 
   printfQuda("%d\n", __LINE__);
   // fills the gauge field with random numbers
-  createSiteLinkCPU((void**)U_qdp->Gauge_p(), gauge_param.cpu_prec, 0);
+  createSiteLinkCPU((void **)U_qdp->Gauge_p(), gauge_param.cpu_prec, 0);
 
   param.order = QUDA_MILC_GAUGE_ORDER;
   auto U_milc = new quda::cpuGaugeField(param);
@@ -299,7 +300,7 @@ void gauge_force_test(void)
   param.order = QUDA_QDP_GAUGE_ORDER;
   auto Mom_qdp = new quda::cpuGaugeField(param);
 
-  //initialize some data in cpuMom
+  // initialize some data in cpuMom
   createMomCPU(Mom_ref_milc->Gauge_p(), gauge_param.cpu_prec);
   printfQuda("%d\n", __LINE__);
   Mom_milc->copy(*Mom_ref_milc);
@@ -320,9 +321,7 @@ void gauge_force_test(void)
 
   if (getTuning() == QUDA_TUNE_YES) {
     printfQuda("Tuning...\n");
-    computeGaugeForceQuda(mom, sitelink,  input_path_buf, length,
-    			  loop_coeff_d, num_paths, max_length, eb3,
-    			  &gauge_param);
+    computeGaugeForceQuda(mom, sitelink, input_path_buf, length, loop_coeff_d, num_paths, max_length, eb3, &gauge_param);
     printfQuda("...done\n");
   }
 
@@ -334,9 +333,7 @@ void gauge_force_test(void)
   for (int i = 0; i < niter; i++) {
     Mom_->copy(*Mom_ref_milc); // restore initial momentum for correctness
     gettimeofday(&t0, NULL);
-    computeGaugeForceQuda(mom, sitelink,  input_path_buf, length,
-    			  loop_coeff_d, num_paths, max_length, eb3,
-    			  &gauge_param);
+    computeGaugeForceQuda(mom, sitelink, input_path_buf, length, loop_coeff_d, num_paths, max_length, eb3, &gauge_param);
     gettimeofday(&t1, NULL);
     total_time += t1.tv_sec - t0.tv_sec + 0.000001*(t1.tv_usec - t0.tv_usec);
   }
@@ -347,19 +344,19 @@ void gauge_force_test(void)
 
   void *refmom = Mom_ref_milc->Gauge_p();
   if (verify_results) {
-    gauge_force_reference(refmom, eb3, (void**)U_qdp->Gauge_p(), gauge_param.cpu_prec,
-    			  input_path_buf, length, loop_coeff, num_paths);
+    gauge_force_reference(refmom, eb3, (void **)U_qdp->Gauge_p(), gauge_param.cpu_prec, input_path_buf, length,
+                          loop_coeff, num_paths);
 
     int res = compare_floats(Mom_milc->Gauge_p(), refmom, 4 * V * mom_site_size, 1e-3, gauge_param.cpu_prec);
 
-    strong_check_mom(Mom_milc->Gauge_p(), refmom, 4*V, gauge_param.cpu_prec);
+    strong_check_mom(Mom_milc->Gauge_p(), refmom, 4 * V, gauge_param.cpu_prec);
 
     printfQuda("Test %s\n", (1 == res) ? "PASSED" : "FAILED");
   }
 
   printfQuda("Computing momentum action\n");
   auto action_quda = momActionQuda(mom, &gauge_param);
-  auto action_ref = mom_action(refmom, gauge_param.cpu_prec, 4*V);
+  auto action_ref = mom_action(refmom, gauge_param.cpu_prec, 4 * V);
   printfQuda("QUDA action = %e, reference = %e\n", action_quda, action_ref);
 
   double perf = 1.0*niter*flops*V/(total_time*1e+9);
@@ -376,7 +373,7 @@ void gauge_force_test(void)
   delete Mom_qdp;
   delete Mom_milc;
   delete Mom_ref_milc;
-  
+
   endQuda();
 }
 

--- a/utils/host_utils.cpp
+++ b/utils/host_utils.cpp
@@ -1568,6 +1568,35 @@ int strong_check_mom(void *momA, void *momB, int len, QudaPrecision prec)
   return ret;
 }
 
+// compute the magnitude squared anti-Hermitian matrix, including the
+// MILC convention of subtracting 4 from each site norm to improve
+// stability
+template <typename real> double mom_action(real *mom_, int len)
+{
+  double action = 0.0;
+  for (int i=0; i<len; i++) {
+    real *mom = mom_ + i * mom_site_size;
+    double local = 0.0;
+    for (int j = 0; j < 6; j++) local += mom[j] * mom[j];
+    for (int j = 6; j < 9; j++) local += 0.5 * mom[j] * mom[j];
+    local -= 4.0;
+    action += local;
+  }
+
+  return action;
+}
+
+double mom_action(void *mom, QudaPrecision prec, int len)
+{
+  double action = 0.0;
+  if (prec == QUDA_DOUBLE_PRECISION) {
+    return mom_action<double>((double*)mom, len);
+  } else if (prec == QUDA_SINGLE_PRECISION) {
+    return mom_action<float>((float*)mom, len);
+  }
+  return action;
+}
+
 static struct timeval startTime;
 
 void stopwatchStart() { gettimeofday(&startTime, NULL); }

--- a/utils/host_utils.cpp
+++ b/utils/host_utils.cpp
@@ -1574,7 +1574,7 @@ int strong_check_mom(void *momA, void *momB, int len, QudaPrecision prec)
 template <typename real> double mom_action(real *mom_, int len)
 {
   double action = 0.0;
-  for (int i=0; i<len; i++) {
+  for (int i = 0; i < len; i++) {
     real *mom = mom_ + i * mom_site_size;
     double local = 0.0;
     for (int j = 0; j < 6; j++) local += mom[j] * mom[j];
@@ -1590,9 +1590,9 @@ double mom_action(void *mom, QudaPrecision prec, int len)
 {
   double action = 0.0;
   if (prec == QUDA_DOUBLE_PRECISION) {
-    return mom_action<double>((double*)mom, len);
+    return mom_action<double>((double *)mom, len);
   } else if (prec == QUDA_SINGLE_PRECISION) {
-    return mom_action<float>((float*)mom, len);
+    return mom_action<float>((float *)mom, len);
   }
   return action;
 }

--- a/utils/host_utils.cpp
+++ b/utils/host_utils.cpp
@@ -1590,10 +1590,11 @@ double mom_action(void *mom, QudaPrecision prec, int len)
 {
   double action = 0.0;
   if (prec == QUDA_DOUBLE_PRECISION) {
-    return mom_action<double>((double *)mom, len);
+    action = mom_action<double>((double *)mom, len);
   } else if (prec == QUDA_SINGLE_PRECISION) {
-    return mom_action<float>((float *)mom, len);
+    action = mom_action<float>((float *)mom, len);
   }
+  comm_allreduce(&action);
   return action;
 }
 

--- a/utils/host_utils.h
+++ b/utils/host_utils.h
@@ -160,6 +160,12 @@ void check_gauge(void **, void **, double epsilon, QudaPrecision precision);
 int strong_check_link(void **linkA, const char *msgA, void **linkB, const char *msgB, int len, QudaPrecision prec);
 int strong_check_mom(void *momA, void *momB, int len, QudaPrecision prec);
 
+/**
+   @brief Host reference implementation of the momentum action
+   contribution.
+ */
+double mom_action(void *mom, QudaPrecision prec, int len);
+
 void createMomCPU(void *mom, QudaPrecision precision);
 void createHwCPU(void *hw, QudaPrecision precision);
 


### PR DESCRIPTION
This pull request is aimed at improving the performance of MILC RHMC:
* Adds new QUDA interface function `momResidentQuda` for setting or returning the resident momentum field in QUDA
* Adds new MILC-QUDA interface functions `qudaMomLoad` and `qudaMomSave` which downloads and sets the resident momentum field, or uploads and returns the resident momentum field, respectively.  Prior behaviour is preserved with this PR, so older versions of MILC are not broken.  A new version of MILC will be required to enable the momentum residency.
* When `qudaMomLoad` is called, the gauge force, fermion force, action evaluation and momentum exponentiation will all utilize the resident momentum field.  Calling `qudaMomSave` will invalidate the resident field.
* Some cleanup and fixes to the the momentum action evaluation to make the code cleaner.
* Added host unit test variant of the momentum action and utilize this in `gauge_force_test`.
* Cleaned up `computeGaugeForceQuda` to now support QDP-ordered momentum fields removing the prior hacks.
* Clean up of `gauge_force_test` to make the code cleaner and remove unnecessarily reimplementations of data reordering and field extension.