### PR TITLE
Add the correct boundary condition to the Mobius preconditioner

### DIFF
--- a/host_reference/domain_wall_dslash_reference.cpp
+++ b/host_reference/domain_wall_dslash_reference.cpp
@@ -1331,7 +1331,11 @@ void mdw_mdagm_local(void *out, void **gauge, void *in, double _Complex *kappa_b
                      double _Complex *b5, double _Complex *c5)
 {
 
-  const int R[4] = {2, 2, 2, 2};
+  int R[4];
+
+  for (int d = 0; d < 4; d++) {
+    R[d] = comm_dim_partitioned(d) ? 2 : 0;
+  }
 
   cpuGaugeField *padded_gauge = createExtendedGauge(gauge, gauge_param, R);
 

--- a/include/mdw_dslash5_tensor_core.cuh
+++ b/include/mdw_dslash5_tensor_core.cuh
@@ -8,8 +8,7 @@
 #include <math_helper.cuh>
 #include <shared_memory_cache_helper.cuh>
 
-#define THRUST_IGNORE_CUB_VERSION_CHECK
-#include <cub/cub.cuh>
+#include <cub_helper.cuh>
 
 #if (__CUDACC_VER_MAJOR__ >= 9 && __COMPUTE_CAPABILITY__ >= 700)
 #include <mma.h>

--- a/include/quda_cuda_api.h
+++ b/include/quda_cuda_api.h
@@ -159,6 +159,13 @@ namespace quda {
      @param[in] value Value to set
   */
   cudaError_t qudaFuncSetAttribute(const void* func, cudaFuncAttribute attr, int value);
+
+  /**
+     @brief Wrapper around cudaFuncGetAttributes
+     @param[in] attr the cudaFuncGetAttributes object to store the output
+     @param[in] func Function for which we are setting the attribute
+  */
+  cudaError_t qudaFuncGetAttributes(cudaFuncAttributes &attr, const void* func);
 #endif
 
   /**

--- a/include/tune_quda.h
+++ b/include/tune_quda.h
@@ -204,10 +204,10 @@ namespace quda {
 #if CUDA_VERSION >= 9000
       qudaFuncSetAttribute(
           (const void *)func, cudaFuncAttributePreferredSharedMemoryCarveout, (int)cudaSharedmemCarveoutMaxShared);
-      cudaFuncAttributes attr;
-      cudaFuncGetAttributes(&attr, (const void *)func);
+      cudaFuncAttributes attributes;
+      qudaFuncGetAttributes(attributes, (const void *)func);
       qudaFuncSetAttribute((const void *)func, cudaFuncAttributeMaxDynamicSharedMemorySize,
-                           maxDynamicSharedBytesPerBlock() - attr.sharedSizeBytes);
+                           maxDynamicSharedBytesPerBlock() - attributes.sharedSizeBytes);
 #endif
     }
 

--- a/include/tune_quda.h
+++ b/include/tune_quda.h
@@ -204,8 +204,10 @@ namespace quda {
 #if CUDA_VERSION >= 9000
       qudaFuncSetAttribute(
           (const void *)func, cudaFuncAttributePreferredSharedMemoryCarveout, (int)cudaSharedmemCarveoutMaxShared);
-      qudaFuncSetAttribute(
-          (const void *)func, cudaFuncAttributeMaxDynamicSharedMemorySize, maxDynamicSharedBytesPerBlock());
+      cudaFuncAttributes attr;
+      cudaFuncGetAttributes(&attr, (const void *)func);
+      qudaFuncSetAttribute((const void *)func, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                           maxDynamicSharedBytesPerBlock() - attr.sharedSizeBytes);
 #endif
     }
 

--- a/lib/dirac_mobius.cpp
+++ b/lib/dirac_mobius.cpp
@@ -376,9 +376,17 @@ namespace quda {
   {
     if (zMobius) { errorQuda("DiracMobiusPC::MdagMLocal doesn't currently support zMobius.\n"); }
 
+    int shift0[4] = {0, 0, 0, 0};
+    int shift1[4];
+    int shift2[4];
+
+    for (int d = 0; d < 4; d++) {
+      shift1[d] = comm_dim_partitioned(d) ? 1 : 0;
+      shift2[d] = comm_dim_partitioned(d) ? 2 : 0;
+    }
+
     if (extended_gauge == nullptr) {
-      const int R[] = {2, 2, 2, 2};
-      extended_gauge = createExtendedGauge(*gauge, R, profile, true);
+      extended_gauge = createExtendedGauge(*gauge, shift2, profile, true);
     }
 
     checkDWF(in, out);
@@ -391,14 +399,10 @@ namespace quda {
     ColorSpinorField *unextended_tmp1 = ColorSpinorField::Create(csParam);
     ColorSpinorField *unextended_tmp2 = ColorSpinorField::Create(csParam);
 
-    csParam.x[0] += 2; // x direction is checkerboarded
-    for (int i = 1; i < 4; ++i) { csParam.x[i] += 4; }
+    csParam.x[0] += shift2[0]; // x direction is checkerboarded
+    for (int d = 1; d < 4; ++d) { csParam.x[d] += shift2[d] * 2; }
     ColorSpinorField *extended_tmp1 = ColorSpinorField::Create(csParam);
     ColorSpinorField *extended_tmp2 = ColorSpinorField::Create(csParam);
-
-    int shift0[4] = {0, 0, 0, 0};
-    int shift1[4] = {1, 1, 1, 1};
-    int shift2[4] = {2, 2, 2, 2};
 
     int odd_bit = (getMatPCType() == QUDA_MATPC_ODD_ODD) ? 1 : 0;
     QudaParity parity[2] = {static_cast<QudaParity>((1 + odd_bit) % 2), static_cast<QudaParity>((0 + odd_bit) % 2)};

--- a/lib/mdw_fused_dslash.cu
+++ b/lib/mdw_fused_dslash.cu
@@ -30,16 +30,6 @@ namespace quda
 
 #if (__CUDACC_VER_MAJOR__ >= 9 && __COMPUTE_CAPABILITY__ >= 700)
 
-    template <typename F> inline void setMaxDynamicSharedBytesPerBlock(F *func)
-    {
-      qudaFuncSetAttribute((const void *)func, cudaFuncAttributePreferredSharedMemoryCarveout,
-                           (int)cudaSharedmemCarveoutMaxShared);
-      cudaFuncAttributes attr;
-      cudaFuncGetAttributes(&attr, (const void *)func);
-      qudaFuncSetAttribute((const void *)func, cudaFuncAttributeMaxDynamicSharedMemorySize,
-                           deviceProp.sharedMemPerBlockOptin - attr.sharedSizeBytes);
-    }
-
     /**
       @brief Parameter structure for applying the Dslash
     */
@@ -638,7 +628,7 @@ namespace quda
 
       template <typename T> inline void launch(T *f, const TuneParam &tp, Arg &arg, const qudaStream_t &stream)
       {
-        quda::mobius_tensor_core::setMaxDynamicSharedBytesPerBlock(f);
+        setMaxDynamicSharedBytesPerBlock(f);
         void *args[] = {&arg};
         qudaLaunchKernel((const void *)f, tp.grid, tp.block, args, tp.shared_bytes, stream);
       }

--- a/lib/mdw_fused_dslash.cu
+++ b/lib/mdw_fused_dslash.cu
@@ -284,7 +284,7 @@ namespace quda
       coordinate[3] = aux[3];
 
       // Find the full coordinate in the shrinked volume.
-      coordinate[0] += (parity + coordinate[3] + coordinate[2] + coordinate[1]) & 1;
+      coordinate[0] += (shift[0] + shift[1] + shift[2] + shift[3] + parity + coordinate[3] + coordinate[2] + coordinate[1]) & 1;
 
 // Now go back to the extended volume.
 #pragma unroll
@@ -615,25 +615,30 @@ namespace quda
         char config[512];
         switch (arg.type) {
         case MdwfFusedDslashType::D4_D5INV_D5PRE:
-          sprintf(config, ",f0,shift%d,%d,%d,%d,halo%d,%d,%d,%d", arg.shift[0], arg.shift[1], arg.shift[2],
-                  arg.shift[3], arg.halo_shift[0], arg.halo_shift[1], arg.halo_shift[2], arg.halo_shift[3]);
+          sprintf(config, ",f0,shift%d,%d,%d,%d,halo%d,%d,%d,%d,comm%d,%d,%d,%d", arg.shift[0], arg.shift[1],
+                  arg.shift[2], arg.shift[3], arg.halo_shift[0], arg.halo_shift[1], arg.halo_shift[2],
+                  arg.halo_shift[3], arg.comm[0], arg.comm[1], arg.comm[2], arg.comm[3]);
           strcat(aux, config);
           break;
         case MdwfFusedDslashType::D4DAG_D5PREDAG_D5INVDAG:
-          sprintf(config, ",f2,shift%d,%d,%d,%d", arg.shift[0], arg.shift[1], arg.shift[2], arg.shift[3]);
+          sprintf(config, ",f2,shift%d,%d,%d,%d,halo2,2,2,2,comm%d,%d,%d,%d", arg.shift[0], arg.shift[1], arg.shift[2],
+                  arg.shift[3], arg.comm[0], arg.comm[1], arg.comm[2], arg.comm[3]);
           strcat(aux, config);
           break;
         case MdwfFusedDslashType::D4_D5INV_D5INVDAG:
-          sprintf(config, ",f1,shift%d,%d,%d,%d,halo%d,%d,%d,%d", arg.shift[0], arg.shift[1], arg.shift[2],
-                  arg.shift[3], arg.halo_shift[0], arg.halo_shift[1], arg.halo_shift[2], arg.halo_shift[3]);
+          sprintf(config, ",f1,shift%d,%d,%d,%d,halo%d,%d,%d,%d,comm%d,%d,%d,%d", arg.shift[0], arg.shift[1],
+                  arg.shift[2], arg.shift[3], arg.halo_shift[0], arg.halo_shift[1], arg.halo_shift[2],
+                  arg.halo_shift[3], arg.comm[0], arg.comm[1], arg.comm[2], arg.comm[3]);
           strcat(aux, config);
           break;
         case MdwfFusedDslashType::D4DAG_D5PREDAG:
-          sprintf(config, ",f3,shift%d,%d,%d,%d", arg.shift[0], arg.shift[1], arg.shift[2], arg.shift[3]);
+          sprintf(config, ",f3,shift%d,%d,%d,%d,halo2,2,2,2,comm%d,%d,%d,%d", arg.shift[0], arg.shift[1], arg.shift[2],
+                  arg.shift[3], arg.comm[0], arg.comm[1], arg.comm[2], arg.comm[3]);
           strcat(aux, config);
           break;
         case MdwfFusedDslashType::D5PRE:
-          sprintf(config, ",f4,shift%d,%d,%d,%d", arg.shift[0], arg.shift[1], arg.shift[2], arg.shift[3]);
+          sprintf(config, ",f4,shift%d,%d,%d,%d,halo2,2,2,2,comm%d,%d,%d,%d", arg.shift[0], arg.shift[1], arg.shift[2],
+                  arg.shift[3], arg.comm[0], arg.comm[1], arg.comm[2], arg.comm[3]);
           strcat(aux, config);
           break;
         default: errorQuda("Unknown MdwfFusedDslashType");

--- a/lib/mdw_fused_dslash.cu
+++ b/lib/mdw_fused_dslash.cu
@@ -3,6 +3,8 @@
 #include <dslash.h>
 #include <mdw_dslash5_tensor_core.cuh>
 
+#include <unordered_set>
+
 namespace quda
 {
   namespace mobius_tensor_core
@@ -628,7 +630,12 @@ namespace quda
 
       template <typename T> inline void launch(T *f, const TuneParam &tp, Arg &arg, const qudaStream_t &stream)
       {
-        setMaxDynamicSharedBytesPerBlock(f);
+        static std::unordered_set<T *> cache;
+        auto search = cache.find(f);
+        if (search == cache.end()) {
+          cache.insert(f);
+          setMaxDynamicSharedBytesPerBlock(f);
+        }
         void *args[] = {&arg};
         qudaLaunchKernel((const void *)f, tp.grid, tp.block, args, tp.shared_bytes, stream);
       }

--- a/lib/mdw_fused_dslash.cu
+++ b/lib/mdw_fused_dslash.cu
@@ -236,7 +236,6 @@ namespace quda
       for (int d = 0; d < 4; d++) // loop over dimension
       {
         int x[4] = {coordinate[0], coordinate[1], coordinate[2], coordinate[3]};
-        // coordinate[d]++;
         x[d] = (coordinate[d] == arg.dim[d] - 1 && !arg.comm[d]) ? 0 : coordinate[d] + 1;
         if (!halo || !is_halo_4d(x, arg.dim, arg.halo_shift)) {
           // Forward gather - compute fwd offset for vector fetch
@@ -252,7 +251,6 @@ namespace quda
           const Vector in = arg.in(fwd_idx, their_spinor_parity);
           out += (U * in.project(d, proj_dir)).reconstruct(d, proj_dir);
         }
-        // coordinate[d] -= 2;
         x[d] = (coordinate[d] == 0 && !arg.comm[d]) ? arg.dim[d] - 1 : coordinate[d] - 1;
         if (!halo || !is_halo_4d(x, arg.dim, arg.halo_shift)) {
           // Backward gather - compute back offset for spinor and gauge fetch
@@ -270,7 +268,6 @@ namespace quda
           const Vector in = arg.in(back_idx, their_spinor_parity);
           out += (conj(U) * in.project(d, proj_dir)).reconstruct(d, proj_dir);
         }
-        // coordinate[d]++;
       } // nDim
     }
 
@@ -623,38 +620,20 @@ namespace quda
       {
         strcpy(aux, meta.AuxString());
         if (arg.dagger) strcat(aux, ",Dagger");
-        //        if (arg.xpay) strcat(aux,",xpay");
         char config[512];
         switch (arg.type) {
-        case MdwfFusedDslashType::D4_D5INV_D5PRE:
-          sprintf(config, ",f0,shift%d,%d,%d,%d,halo%d,%d,%d,%d,comm%d,%d,%d,%d", arg.shift[0], arg.shift[1],
-                  arg.shift[2], arg.shift[3], arg.halo_shift[0], arg.halo_shift[1], arg.halo_shift[2],
-                  arg.halo_shift[3], arg.comm[0], arg.comm[1], arg.comm[2], arg.comm[3]);
-          strcat(aux, config);
-          break;
-        case MdwfFusedDslashType::D4DAG_D5PREDAG_D5INVDAG:
-          sprintf(config, ",f2,shift%d,%d,%d,%d,halo2,2,2,2,comm%d,%d,%d,%d", arg.shift[0], arg.shift[1], arg.shift[2],
-                  arg.shift[3], arg.comm[0], arg.comm[1], arg.comm[2], arg.comm[3]);
-          strcat(aux, config);
-          break;
-        case MdwfFusedDslashType::D4_D5INV_D5INVDAG:
-          sprintf(config, ",f1,shift%d,%d,%d,%d,halo%d,%d,%d,%d,comm%d,%d,%d,%d", arg.shift[0], arg.shift[1],
-                  arg.shift[2], arg.shift[3], arg.halo_shift[0], arg.halo_shift[1], arg.halo_shift[2],
-                  arg.halo_shift[3], arg.comm[0], arg.comm[1], arg.comm[2], arg.comm[3]);
-          strcat(aux, config);
-          break;
-        case MdwfFusedDslashType::D4DAG_D5PREDAG:
-          sprintf(config, ",f3,shift%d,%d,%d,%d,halo2,2,2,2,comm%d,%d,%d,%d", arg.shift[0], arg.shift[1], arg.shift[2],
-                  arg.shift[3], arg.comm[0], arg.comm[1], arg.comm[2], arg.comm[3]);
-          strcat(aux, config);
-          break;
-        case MdwfFusedDslashType::D5PRE:
-          sprintf(config, ",f4,shift%d,%d,%d,%d,halo2,2,2,2,comm%d,%d,%d,%d", arg.shift[0], arg.shift[1], arg.shift[2],
-                  arg.shift[3], arg.comm[0], arg.comm[1], arg.comm[2], arg.comm[3]);
-          strcat(aux, config);
-          break;
+        case MdwfFusedDslashType::D4_D5INV_D5PRE: sprintf(config, ",f0"); break;
+        case MdwfFusedDslashType::D4DAG_D5PREDAG_D5INVDAG: sprintf(config, ",f2"); break;
+        case MdwfFusedDslashType::D4_D5INV_D5INVDAG: sprintf(config, ",f1"); break;
+        case MdwfFusedDslashType::D4DAG_D5PREDAG: sprintf(config, ",f3"); break;
+        case MdwfFusedDslashType::D5PRE: sprintf(config, ",f4"); break;
         default: errorQuda("Unknown MdwfFusedDslashType");
         }
+        strcat(aux, config);
+        sprintf(config, "shift%d%d%d%d,halo%d%d%d%d,comm%d%d%d%d", arg.shift[0], arg.shift[1], arg.shift[2],
+                arg.shift[3], arg.halo_shift[0], arg.halo_shift[1], arg.halo_shift[2], arg.halo_shift[3], arg.comm[0],
+                arg.comm[1], arg.comm[2], arg.comm[3]);
+        strcat(aux, config);
       }
 
       template <typename T> inline void launch(T *f, const TuneParam &tp, Arg &arg, const qudaStream_t &stream)

--- a/lib/quda_cuda_api.cpp
+++ b/lib/quda_cuda_api.cpp
@@ -398,6 +398,13 @@ namespace quda {
     PROFILE(cudaError_t error = cudaFuncSetAttribute(func, attr, value), QUDA_PROFILE_FUNC_SET_ATTRIBUTE);
     return error;
   }
+
+  cudaError_t qudaFuncGetAttributes(cudaFuncAttributes &attr, const void* func)
+  {
+    // no driver API variant here since we have C++ functions
+    PROFILE(cudaError_t error = cudaFuncGetAttributes(&attr, func), QUDA_PROFILE_FUNC_SET_ATTRIBUTE);
+    return error;
+  }
 #endif
 
   void printAPIProfile() {


### PR DESCRIPTION
This PR adds the correct boundary condition to the `MdagMLocal` operator for Mobius domain wall fermion.

Previously no matter what the operator always have a zero Dirchlet boundary condition, for which each direction needs to be padded to catch the snake terms. Now with this PR, if a direction is not partitioned, i.e. `comm_dim_partitioned(d) == 0`, the direction `d` will not be padded and the stencils will simply extract data from the other side of that direction.

This PR also fixes a bug where the reduction in the overall scaling process (in order to fit the range of fp16 for the tensor cores) tries access illegal shared memory addresses. Now this reduction is done by CUB.

This way if the x direction is not partitioned, we no longer have the non-coalesced memory accesses previously experienced, which improves the performance of the preconditioner.

As an example on a Titan V, `Ls=16`, with a local volume of `12x12x12x16`, the timing of the preconditioner with different boundary conditions are,


comm | time [s]
:-: | :-:
comm0000 | 0.000598
comm0001 | 0.000629
comm0010 | 0.000658
comm0011 | 0.000695
comm0100 | 0.000708
comm0101 | 0.000734
comm0110 | 0.000799
comm0111 | 0.000821
comm1000 | 0.000723
comm1001 | 0.000749
comm1010 | 0.000818
comm1011 | 0.000837
comm1100 | 0.000844
comm1101 | 0.000863
comm1110 | 0.000880
comm1111 | 0.000971

![time_vs_comm_both](https://user-images.githubusercontent.com/12970356/86169926-62251d80-bae8-11ea-9255-8595caa27188.png)

