### PR TITLE
Hotfix/multiblas

### DIFF
--- a/include/kernels/multi_blas_core.cuh
+++ b/include/kernels/multi_blas_core.cuh
@@ -28,9 +28,9 @@ namespace quda
        @tparam Functor Functor used to operate on data
     */
     template <int NXZ, typename store_t, int N, typename y_store_t, int Ny, typename Functor>
-    struct MultiBlasArg
-      : SpinorXZ<NXZ, store_t, N, Functor::use_z>,
-      SpinorYW<max_YW_size<NXZ, store_t, y_store_t, Functor>(), y_store_t, Ny, Functor::use_w> {
+    struct MultiBlasArg :
+      SpinorXZ<NXZ, store_t, N, Functor::use_z>,
+      SpinorYW<max_YW_size<NXZ, store_t, y_store_t, Functor>(), store_t, N, y_store_t, Ny, Functor::use_w> {
       static constexpr int NYW_max = max_YW_size<NXZ, store_t, y_store_t, Functor>();
       const int NYW;
       Functor f;
@@ -249,7 +249,7 @@ namespace quda
     };
 
     /**
-       Functor performing the operations: y[i] = a*x[i] + y[i]; x[i] = b*z[i] + c*x[i]
+       Functor performing the operations: y[i] = a*w[i] + y[i]; w[i] = b*x[i] + c*w[i]
     */
     template <typename real>
     struct multi_axpyBzpcx_ : public MultiBlasFunctor<real, true> {

--- a/include/kernels/multi_reduce_core.cuh
+++ b/include/kernels/multi_reduce_core.cuh
@@ -5,8 +5,6 @@
 #include <multi_blas_helper.cuh>
 #include <cub_helper.cuh>
 
-//#define WARP_MULTI_REDUCE
-
 namespace quda
 {
 
@@ -28,7 +26,7 @@ namespace quda
     struct MultiReduceArg :
       public ReduceArg<vector_type<typename Reducer_::reduce_t, NXZ>>,
       SpinorXZ<NXZ, store_t, N, Reducer_::use_z>,
-      SpinorYW<max_YW_size<NXZ, store_t, y_store_t, Reducer_>(), y_store_t, Ny, Reducer_::use_w>
+      SpinorYW<max_YW_size<NXZ, store_t, y_store_t, Reducer_>(), store_t, N, y_store_t, Ny, Reducer_::use_w>
     {
       using Reducer = Reducer_;
       static constexpr int NYW_max = max_YW_size<NXZ, store_t, y_store_t, Reducer>();

--- a/include/multi_blas_helper.cuh
+++ b/include/multi_blas_helper.cuh
@@ -42,7 +42,13 @@ namespace quda
        @tparam fixed Whether we are using fixed point
        @return Max power of two
      */
+#if QUDA_PRECISION <= 3
+    // if we only have a fixed-point build then we need this WAR to avoid some invalid template instantiations
+    // this is temporary - can be removed once the norm and v pointers are fused
+    template <bool reducer, bool fixed> constexpr int max_NXZ_power2() { return reducer ? 16 : 64; }
+#else
     template <bool reducer, bool fixed> constexpr int max_NXZ_power2() { return reducer ? 16 : (fixed ? 64 : 128); }
+#endif
 
     /**
        @brief Return the maximum power of two enabled by default for

--- a/include/multi_blas_helper.cuh
+++ b/include/multi_blas_helper.cuh
@@ -92,7 +92,7 @@ namespace quda
       using SpinorX = Spinor<xType, 4>;
       using SpinorY = Spinor<yType, 4>;
       using SpinorZ = SpinorX;
-      using SpinorW = Spinor<xType, 4>;
+      using SpinorW = SpinorX;
 
       // compute the size remaining for the Y and W accessors
       constexpr int arg_size = (MAX_ARG_SIZE - sizeof(int)                                    // NYW parameter

--- a/include/multi_blas_helper.cuh
+++ b/include/multi_blas_helper.cuh
@@ -80,9 +80,14 @@ namespace quda
        the maximum size of YW is and allocate this amount of space.  This
        allows for a much larger NXZ (NYW) when NYW (NXZ) is small.
     */
-    template <int NXZ, typename SpinorX, typename SpinorY, typename SpinorZ, typename SpinorW, typename Functor>
+    template <int NXZ, typename xType, typename yType, typename Functor>
     inline constexpr int max_YW_size()
     {
+      using SpinorX = Spinor<xType, 4>;
+      using SpinorY = Spinor<yType, 4>;
+      using SpinorZ = SpinorX;
+      using SpinorW = Spinor<xType, 4>;
+
       // compute the size remaining for the Y and W accessors
       constexpr int arg_size = (MAX_ARG_SIZE - sizeof(int)                                    // NYW parameter
                                 - sizeof(SpinorX[NXZ])                                        // SpinorX array
@@ -98,23 +103,6 @@ namespace quda
       constexpr int coeff_size = Functor::coeff_mul ? MAX_MATRIX_SIZE / (NXZ * sizeof(typename Functor::coeff_t)) : arg_size;
 
       return std::min(arg_size, coeff_size);
-    }
-
-    /**
-       @brief Helper function to compute the maximum YW size for the
-       multi-blas runctions.  Since the SpinorX and SpinorZ arrays are
-       statically allocated with length NXZ, we can statically compute how
-       the maximum size of YW is and allocate this amount of space.  This
-       allows for a much larger NXZ (NYW) when NYW (NXZ) is small.
-    */
-    template <int NXZ, typename xType, typename yType, typename Functor>
-    inline constexpr int max_YW_size()
-    {
-      using SpinorX = Spinor<xType, 4>;
-      using SpinorY = Spinor<yType, 4>;
-      using SpinorZ = SpinorX;
-      using SpinorW = Spinor<xType, 4>;
-      return max_YW_size<NXZ, SpinorX, SpinorY, SpinorZ, SpinorW, Functor>();
     }
 
     /**
@@ -195,15 +183,16 @@ namespace quda
       Spinor<store_t, N> Z[NXZ];
     };
 
-    template <int NYW, typename store_t, int N, bool> struct SpinorYW {
-      Spinor<store_t, N> Y[NYW];
-      Spinor<store_t, N> *W;
+    template <int NYW, typename x_store_t, int Nx, typename y_store_t, int Ny, bool> struct SpinorYW {
+      Spinor<y_store_t, Ny> Y[NYW];
+      Spinor<y_store_t, Ny> *W;
       SpinorYW() : W(Y) {}
     };
 
-    template <int NYW, typename store_t, int N> struct SpinorYW<NYW, store_t, N, true> {
-      Spinor<store_t, N> Y[NYW];
-      Spinor<store_t, N> W[NYW];
+    template <int NYW, typename x_store_t, int Nx, typename y_store_t, int Ny>
+    struct SpinorYW<NYW, x_store_t, Nx, y_store_t, Ny, true> {
+      Spinor<y_store_t, Ny> Y[NYW];
+      Spinor<x_store_t, Nx> W[NYW];
     };
 
     template <typename T> struct coeff_array {

--- a/lib/blas_quda.cu
+++ b/lib/blas_quda.cu
@@ -59,10 +59,12 @@ namespace quda {
         auto y_prec = checkPrecision(y, v);
         auto x_order = checkOrder(x, z, w);
         auto y_order = checkOrder(y, v);
+        if (sizeof(store_t) != x_prec) errorQuda("Expected precision %lu but received %d", sizeof(store_t), x_prec);
+        if (sizeof(y_store_t) != y_prec) errorQuda("Expected precision %lu but received %d", sizeof(y_store_t), y_prec);
         if (x_prec == y_prec && x_order != y_order) errorQuda("Orders %d %d do not match", x_order, y_order);
 
         strcpy(aux, x.AuxString());
-        if (x.Precision() != y.Precision()) {
+        if (x_prec != y_prec) {
           strcat(aux, ",");
           strcat(aux, y.AuxString());
         }

--- a/lib/blas_quda.cu
+++ b/lib/blas_quda.cu
@@ -83,18 +83,20 @@ namespace quda {
 
       void apply(const qudaStream_t &stream)
       {
-        constexpr bool site_unroll = !std::is_same<store_t, y_store_t>::value || isFixed<store_t>::value;
-        if (site_unroll && (x.Ncolor() != 3 || x.Nspin() == 2))
+        constexpr bool site_unroll_check = !std::is_same<store_t, y_store_t>::value || isFixed<store_t>::value;
+        if (site_unroll_check && (x.Ncolor() != 3 || x.Nspin() == 2))
           errorQuda("site unroll not supported for nSpin = %d nColor = %d", x.Nspin(), x.Ncolor());
 
         TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
         if (location == QUDA_CUDA_FIELD_LOCATION) {
-          if (site_unroll) checkNative(x, y, z, w, v); // require native order when using site_unroll
+          if (site_unroll_check) checkNative(x, y, z, w, v); // require native order when using site_unroll
           using device_store_t = typename device_type_mapper<store_t>::type;
           using device_y_store_t = typename device_type_mapper<y_store_t>::type;
           using device_real_t = typename mapper<device_y_store_t>::type;
           Functor<device_real_t> f_(a, b, c);
 
+          // redefine site_unroll with device_store types to ensure we have correct N/Ny/M values 
+          constexpr bool site_unroll = !std::is_same<device_store_t, device_y_store_t>::value || isFixed<device_store_t>::value;
           constexpr int N = n_vector<device_store_t, true, nSpin, site_unroll>();
           constexpr int Ny = n_vector<device_y_store_t, true, nSpin, site_unroll>();
           constexpr int M = site_unroll ? (nSpin == 4 ? 24 : 6) : N; // real numbers per thread
@@ -119,10 +121,11 @@ namespace quda {
           using host_real_t = typename mapper<host_y_store_t>::type;
           Functor<host_real_t> f_(a, b, c);
 
-          // if site unrolling then we need full AoS ordering
+          // redefine site_unroll with host_store types to ensure we have correct N/Ny/M values 
+          constexpr bool site_unroll = !std::is_same<host_store_t, host_y_store_t>::value || isFixed<host_store_t>::value;
           constexpr int N = n_vector<host_store_t, false, nSpin, site_unroll>();
           constexpr int Ny = n_vector<host_y_store_t, false, nSpin, site_unroll>();
-          constexpr int M = N;
+          constexpr int M = N; // if site unrolling then M=N will be 24/6, e.g., full AoS
           const int length = x.Length() / (nParity * M);
 
           BlasArg<host_store_t, N, host_y_store_t, Ny, decltype(f_)> arg(x, y, z, w, v, f_, length, nParity);

--- a/lib/multi_blas_quda.cu
+++ b/lib/multi_blas_quda.cu
@@ -58,6 +58,8 @@ namespace quda {
         auto y_prec = y[0]->Precision();
         auto x_order = checkOrder(*x[0], *z[0], *w[0]);
         auto y_order = y[0]->FieldOrder();
+        if (sizeof(store_t) != x_prec) errorQuda("Expected precision %lu but received %d", sizeof(store_t), x_prec);
+        if (sizeof(y_store_t) != y_prec) errorQuda("Expected precision %lu but received %d", sizeof(y_store_t), y_prec);
         if (x_prec == y_prec && x_order != y_order) errorQuda("Orders %d %d do not match", x_order, y_order);
 
         // heuristic for enabling if we need the warp-splitting optimization
@@ -75,7 +77,7 @@ namespace quda {
         Cmatrix_h = reinterpret_cast<signed char *>(const_cast<typename T::type *>(c.data));
 
         strcpy(aux, x[0]->AuxString());
-        if (x[0]->Precision() != y[0]->Precision()) {
+        if (x_prec != y_prec) {
           strcat(aux, ",");
           strcat(aux, y[0]->AuxString());
         }

--- a/lib/multi_reduce_quda.cu
+++ b/lib/multi_reduce_quda.cu
@@ -297,7 +297,9 @@ namespace quda {
       void preTune()
       {
         for (int i = 0; i < NYW; ++i) {
+          if (r.write.X) x[i]->backup();
           if (r.write.Y) y[i]->backup();
+          if (r.write.Z) z[i]->backup();
           if (r.write.W) w[i]->backup();
         }
       }
@@ -305,7 +307,9 @@ namespace quda {
       void postTune()
       {
         for (int i = 0; i < NYW; ++i) {
+          if (r.write.X) x[i]->restore();
           if (r.write.Y) y[i]->restore();
+          if (r.write.Z) z[i]->restore();
           if (r.write.W) w[i]->restore();
         }
       }

--- a/lib/multi_reduce_quda.cu
+++ b/lib/multi_reduce_quda.cu
@@ -184,19 +184,21 @@ namespace quda {
       {
         staticCheck<NXZ, store_t, y_store_t, decltype(r)>(r, x, y);
 
-        constexpr bool site_unroll = !std::is_same<store_t, y_store_t>::value || isFixed<store_t>::value;
-        if (site_unroll && (x[0]->Ncolor() != 3 || x[0]->Nspin() == 2))
+        constexpr bool site_unroll_check = !std::is_same<store_t, y_store_t>::value || isFixed<store_t>::value;
+        if (site_unroll_check && (x[0]->Ncolor() != 3 || x[0]->Nspin() == 2))
           errorQuda("site unroll not supported for nSpin = %d nColor = %d", x[0]->Nspin(), x[0]->Ncolor());
 
         TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
 
         if (location == QUDA_CUDA_FIELD_LOCATION) {
-          if (site_unroll) checkNative(*x[0], *y[0], *z[0], *w[0]); // require native order when using site_unroll
+          if (site_unroll_check) checkNative(*x[0], *y[0], *z[0], *w[0]); // require native order when using site_unroll
           using device_store_t = typename device_type_mapper<store_t>::type;
           using device_y_store_t = typename device_type_mapper<y_store_t>::type;
           using device_real_t = typename mapper<device_y_store_t>::type;
           Reducer<device_reduce_t, device_real_t> r_(NXZ, NYW);
 
+          // redefine site_unroll with device_store types to ensure we have correct N/Ny/M values
+          constexpr bool site_unroll = !std::is_same<device_store_t, device_y_store_t>::value || isFixed<device_store_t>::value;
           constexpr int N = n_vector<device_store_t, true, nSpin, site_unroll>();
           constexpr int Ny = n_vector<device_y_store_t, true, nSpin, site_unroll>();
           constexpr int M = site_unroll ? (nSpin == 4 ? 24 : 6) : N; // real numbers per thread

--- a/lib/reduce_quda.cu
+++ b/lib/reduce_quda.cu
@@ -222,12 +222,14 @@ namespace quda {
         auto y_prec = checkPrecision(y, v);
         auto x_order = checkOrder(x, z, w);
         auto y_order = checkOrder(y, v);
+        if (sizeof(store_t) != x_prec) errorQuda("Expected precision %lu but received %d", sizeof(store_t), x_prec);
+        if (sizeof(y_store_t) != y_prec) errorQuda("Expected precision %lu but received %d", sizeof(y_store_t), y_prec);
         if (x_prec == y_prec && x_order != y_order) errorQuda("Orders %d %d do not match", x_order, y_order);
 
         strcpy(aux, x.AuxString());
-        if (x.Precision() != z.Precision()) {
+        if (x_prec != y_prec) {
           strcat(aux, ",");
-          strcat(aux, z.AuxString());
+          strcat(aux, y.AuxString());
         }
         if (location == QUDA_CPU_FIELD_LOCATION) strcat(aux, ",CPU");
         else if (getFastReduce()) strcat(aux, ",fast_reduce");
@@ -418,7 +420,7 @@ namespace quda {
 
     Complex axpyCGNorm(double a, ColorSpinorField &x, ColorSpinorField &y)
     {
-      double2 cg_norm = instantiateReduce<axpyCGNorm2, true>(a, 0.0, 0.0, x, y, x, x, x);
+      double2 cg_norm = instantiateReduce<axpyCGNorm2, true>(a, 0.0, 0.0, x, y, x, x, y);
       return Complex(cg_norm.x, cg_norm.y);
     }
 

--- a/lib/reduce_quda.cu
+++ b/lib/reduce_quda.cu
@@ -250,18 +250,20 @@ namespace quda {
 
       void apply(const qudaStream_t &stream)
       {
-        constexpr bool site_unroll = !std::is_same<store_t, y_store_t>::value || isFixed<store_t>::value || decltype(r)::site_unroll;
-        if (site_unroll && (x.Ncolor() != 3 || x.Nspin() == 2))
+        constexpr bool site_unroll_check = !std::is_same<store_t, y_store_t>::value || isFixed<store_t>::value || decltype(r)::site_unroll;
+        if (site_unroll_check && (x.Ncolor() != 3 || x.Nspin() == 2))
           errorQuda("site unroll not supported for nSpin = %d nColor = %d", x.Nspin(), x.Ncolor());
 
         TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
         if (location == QUDA_CUDA_FIELD_LOCATION) {
-          if (site_unroll) checkNative(x, y, z, w, v); // require native order when using site_unroll
+          if (site_unroll_check) checkNative(x, y, z, w, v); // require native order when using site_unroll
           using device_store_t = typename device_type_mapper<store_t>::type;
           using device_y_store_t = typename device_type_mapper<y_store_t>::type;
           using device_real_t = typename mapper<device_y_store_t>::type;
           Reducer<device_reduce_t, device_real_t> r_(a, b);
 
+          // redefine site_unroll with device_store types to ensure we have correct N/Ny/M values
+          constexpr bool site_unroll = !std::is_same<device_store_t, device_y_store_t>::value || isFixed<device_store_t>::value || decltype(r)::site_unroll;
           constexpr int N = n_vector<device_store_t, true, nSpin, site_unroll>();
           constexpr int Ny = n_vector<device_y_store_t, true, nSpin, site_unroll>();
           constexpr int M = site_unroll ? (nSpin == 4 ? 24 : 6) : N; // real numbers per thread
@@ -280,10 +282,11 @@ namespace quda {
           using host_real_t = typename mapper<host_y_store_t>::type;
           Reducer<double, host_real_t> r_(a, b);
 
-          // if site unrolling then we need full AoS ordering
+          // redefine site_unroll with host_store types to ensure we have correct N/Ny/M values
+          constexpr bool site_unroll = !std::is_same<host_store_t, host_y_store_t>::value || isFixed<host_store_t>::value || decltype(r)::site_unroll;
           constexpr int N = n_vector<host_store_t, false, nSpin, site_unroll>();
           constexpr int Ny = n_vector<host_y_store_t, false, nSpin, site_unroll>();
-          constexpr int M = N;
+          constexpr int M = N; // if site unrolling then M=N will be 24/6, e.g., full AoS
           const int length = x.Length() / (nParity * M);
 
           ReductionArg<host_store_t, N, host_y_store_t, Ny, decltype(r_)> arg(x, y, z, w, v, r_, length, nParity);

--- a/tests/blas_test.cpp
+++ b/tests/blas_test.cpp
@@ -67,74 +67,107 @@ void display_test_info()
 
 using prec_pair_t = std::pair<QudaPrecision, QudaPrecision>;
 
-const std::map<QudaPrecision, std::string> prec_map = { {QUDA_QUARTER_PRECISION, "quarter" },
-                                                        {QUDA_HALF_PRECISION, "half" },
-                                                        {QUDA_SINGLE_PRECISION, "single" },
-                                                        {QUDA_DOUBLE_PRECISION, "double" } };
+const std::map<QudaPrecision, std::string> prec_map = {{QUDA_QUARTER_PRECISION, "quarter"},
+                                                       {QUDA_HALF_PRECISION, "half"},
+                                                       {QUDA_SINGLE_PRECISION, "single"},
+                                                       {QUDA_DOUBLE_PRECISION, "double"}};
 
 const int Nprec = prec_map.size();
 
-enum class Kernel {copyHS, copyLS, axpbyz, ax, caxpy, caxpby, cxpaypbz, axpyBzpcx,
-                   axpyZpbx, caxpbypzYmbw, cabxpyAx, caxpyXmaz, norm2, reDotProduct, axpbyzNorm,
-                   axpyCGNorm, caxpyNorm, caxpyXmazNormX, cabxpyzAxNorm, cDotProduct, caxpyDotzy,
-                   cDotProductNormA, caxpbypzYmbwcDotProductUYNormY, HeavyQuarkResidualNorm,
-                   xpyHeavyQuarkResidualNorm, tripleCGReduction, tripleCGUpdate, axpyReDot,
-                   caxpyBxpz, caxpyBzpx, axpy_block, caxpy_block, axpyBzpcx_block, reDotProductNorm_block,
-                   reDotProduct_block, cDotProductNorm_block, cDotProduct_block};
+enum class Kernel {
+  copyHS,
+  copyLS,
+  axpbyz,
+  ax,
+  caxpy,
+  caxpby,
+  cxpaypbz,
+  axpyBzpcx,
+  axpyZpbx,
+  caxpbypzYmbw,
+  cabxpyAx,
+  caxpyXmaz,
+  norm2,
+  reDotProduct,
+  axpbyzNorm,
+  axpyCGNorm,
+  caxpyNorm,
+  caxpyXmazNormX,
+  cabxpyzAxNorm,
+  cDotProduct,
+  caxpyDotzy,
+  cDotProductNormA,
+  caxpbypzYmbwcDotProductUYNormY,
+  HeavyQuarkResidualNorm,
+  xpyHeavyQuarkResidualNorm,
+  tripleCGReduction,
+  tripleCGUpdate,
+  axpyReDot,
+  caxpyBxpz,
+  caxpyBzpx,
+  axpy_block,
+  caxpy_block,
+  axpyBzpcx_block,
+  reDotProductNorm_block,
+  reDotProduct_block,
+  cDotProductNorm_block,
+  cDotProduct_block
+};
 
 // For googletest names must be non-empty, unique, and may only contain ASCII
 // alphanumeric characters or underscore
-const std::map<Kernel, std::string> kernel_map = { {Kernel::copyHS, "copyHS"},
-                                                   {Kernel::copyLS, "copyLS"},
-                                                   {Kernel::axpbyz, "axpbyz"},
-                                                   {Kernel::ax, "ax"},
-                                                   {Kernel::caxpy, "caxpy"},
-                                                   {Kernel::caxpby, "caxpby"},
-                                                   {Kernel::cxpaypbz, "cxpaypbz"},
-                                                   {Kernel::axpyBzpcx, "axpyBzpcx"},
-                                                   {Kernel::axpyZpbx, "axpyZpbx"},
-                                                   {Kernel::caxpbypzYmbw, "caxpbypzYmbw"},
-                                                   {Kernel::cabxpyAx, "cabxpyAx"},
-                                                   {Kernel::caxpyXmaz, "caxpyXmaz"},
-                                                   {Kernel::norm2, "norm2"},
-                                                   {Kernel::reDotProduct, "reDotProduct"},
-                                                   {Kernel::axpbyzNorm, "axpbyzNorm"},
-                                                   {Kernel::axpyCGNorm, "axpyCGNorm"},
-                                                   {Kernel::caxpyNorm, "caxpyNorm"},
-                                                   {Kernel::caxpyXmazNormX, "caxpyXmazNormX"},
-                                                   {Kernel::cabxpyzAxNorm, "cabxpyzAxNorm"},
-                                                   {Kernel::cDotProduct, "cDotProduct"},
-                                                   {Kernel::caxpyDotzy, "caxpyDotzy"},
-                                                   {Kernel::cDotProductNormA, "cDotProductNormA"},
-                                                   {Kernel::caxpbypzYmbwcDotProductUYNormY, "caxpbypzYmbwcDotProductUYNormY"},
-                                                   {Kernel::HeavyQuarkResidualNorm, "HeavyQuarkResidualNorm"},
-                                                   {Kernel::xpyHeavyQuarkResidualNorm, "xpyHeavyQuarkResidualNorm"},
-                                                   {Kernel::tripleCGReduction, "tripleCGReduction"},
-                                                   {Kernel::tripleCGUpdate, "tripleCGUpdate"},
-                                                   {Kernel::axpyReDot, "axpyReDot"},
-                                                   {Kernel::caxpyBxpz, "caxpyBxpz"},
-                                                   {Kernel::caxpyBzpx, "caxpyBzpx"},
-                                                   {Kernel::axpy_block, "axpy_block"},
-                                                   {Kernel::caxpy_block, "caxpy_block"},
-                                                   {Kernel::axpyBzpcx_block, "axpyBzpcx_block"},
-                                                   {Kernel::reDotProductNorm_block, "reDotProductNorm_block"},
-                                                   {Kernel::reDotProduct_block, "reDotProduct_block"},
-                                                   {Kernel::cDotProductNorm_block, "cDotProductNorm_block"},
-                                                   {Kernel::cDotProduct_block, "cDotProduct_block"} };
+const std::map<Kernel, std::string> kernel_map
+  = {{Kernel::copyHS, "copyHS"},
+     {Kernel::copyLS, "copyLS"},
+     {Kernel::axpbyz, "axpbyz"},
+     {Kernel::ax, "ax"},
+     {Kernel::caxpy, "caxpy"},
+     {Kernel::caxpby, "caxpby"},
+     {Kernel::cxpaypbz, "cxpaypbz"},
+     {Kernel::axpyBzpcx, "axpyBzpcx"},
+     {Kernel::axpyZpbx, "axpyZpbx"},
+     {Kernel::caxpbypzYmbw, "caxpbypzYmbw"},
+     {Kernel::cabxpyAx, "cabxpyAx"},
+     {Kernel::caxpyXmaz, "caxpyXmaz"},
+     {Kernel::norm2, "norm2"},
+     {Kernel::reDotProduct, "reDotProduct"},
+     {Kernel::axpbyzNorm, "axpbyzNorm"},
+     {Kernel::axpyCGNorm, "axpyCGNorm"},
+     {Kernel::caxpyNorm, "caxpyNorm"},
+     {Kernel::caxpyXmazNormX, "caxpyXmazNormX"},
+     {Kernel::cabxpyzAxNorm, "cabxpyzAxNorm"},
+     {Kernel::cDotProduct, "cDotProduct"},
+     {Kernel::caxpyDotzy, "caxpyDotzy"},
+     {Kernel::cDotProductNormA, "cDotProductNormA"},
+     {Kernel::caxpbypzYmbwcDotProductUYNormY, "caxpbypzYmbwcDotProductUYNormY"},
+     {Kernel::HeavyQuarkResidualNorm, "HeavyQuarkResidualNorm"},
+     {Kernel::xpyHeavyQuarkResidualNorm, "xpyHeavyQuarkResidualNorm"},
+     {Kernel::tripleCGReduction, "tripleCGReduction"},
+     {Kernel::tripleCGUpdate, "tripleCGUpdate"},
+     {Kernel::axpyReDot, "axpyReDot"},
+     {Kernel::caxpyBxpz, "caxpyBxpz"},
+     {Kernel::caxpyBzpx, "caxpyBzpx"},
+     {Kernel::axpy_block, "axpy_block"},
+     {Kernel::caxpy_block, "caxpy_block"},
+     {Kernel::axpyBzpcx_block, "axpyBzpcx_block"},
+     {Kernel::reDotProductNorm_block, "reDotProductNorm_block"},
+     {Kernel::reDotProduct_block, "reDotProduct_block"},
+     {Kernel::cDotProductNorm_block, "cDotProductNorm_block"},
+     {Kernel::cDotProduct_block, "cDotProduct_block"}};
 
 const int Nkernels = kernel_map.size();
 
 // kernels that utilize multi-blas
-bool is_multi(Kernel kernel) {
+bool is_multi(Kernel kernel)
+{
   return std::string(kernel_map.at(kernel)).find("_block") != std::string::npos ? true : false;
 }
 
-bool is_copy(Kernel kernel) {
-  return (kernel == Kernel::copyHS || kernel == Kernel::copyLS);
-}
+bool is_copy(Kernel kernel) { return (kernel == Kernel::copyHS || kernel == Kernel::copyLS); }
 
 // kernels that require site unrolling
-bool is_site_unroll(Kernel kernel) {
+bool is_site_unroll(Kernel kernel)
+{
   return (kernel == Kernel::HeavyQuarkResidualNorm || kernel == Kernel::xpyHeavyQuarkResidualNorm);
 }
 
@@ -155,7 +188,7 @@ bool skip_kernel(prec_pair_t pair, Kernel kernel)
   // if we've selected a given precision then make sure we only run that
   if (prec_sloppy != QUDA_INVALID_PRECISION && other_prec != prec_sloppy) return true;
 
-  if ( Nspin == 2 && this_prec < QUDA_SINGLE_PRECISION ) {
+  if (Nspin == 2 && this_prec < QUDA_SINGLE_PRECISION) {
     // avoid quarter, half precision tests if doing coarse fields
     return true;
   } else if (Ncolor != 3 && is_site_unroll(kernel)) {
@@ -322,7 +355,6 @@ void freeFields()
   zmH.clear();
 }
 
-
 double benchmark(Kernel kernel, const int niter)
 {
   double a = 1.0, b = 2.0, c = 3.0;
@@ -342,15 +374,15 @@ double benchmark(Kernel kernel, const int niter)
     switch (kernel) {
 
     case Kernel::copyHS:
-      for (int i=0; i < niter; ++i) blas::copy(*yD, *xoD);
+      for (int i = 0; i < niter; ++i) blas::copy(*yD, *xoD);
       break;
 
     case Kernel::copyLS:
-      for (int i=0; i < niter; ++i) blas::copy(*yoD, *xD);
+      for (int i = 0; i < niter; ++i) blas::copy(*yoD, *xD);
       break;
 
     case Kernel::axpbyz:
-      for (int i=0; i < niter; ++i) blas::axpbyz(a, *xD, b, *yoD, *zoD);
+      for (int i = 0; i < niter; ++i) blas::axpbyz(a, *xD, b, *yoD, *zoD);
       break;
 
     case Kernel::ax:
@@ -358,7 +390,7 @@ double benchmark(Kernel kernel, const int niter)
       break;
 
     case Kernel::caxpy:
-      for (int i=0; i < niter; ++i) blas::caxpy(a2, *xD, *yoD);
+      for (int i = 0; i < niter; ++i) blas::caxpy(a2, *xD, *yoD);
       break;
 
     case Kernel::caxpby:
@@ -370,11 +402,11 @@ double benchmark(Kernel kernel, const int niter)
       break;
 
     case Kernel::axpyBzpcx:
-      for (int i=0; i < niter; ++i) blas::axpyBzpcx(a, *xD, *yoD, b, *zD, c);
+      for (int i = 0; i < niter; ++i) blas::axpyBzpcx(a, *xD, *yoD, b, *zD, c);
       break;
 
     case Kernel::axpyZpbx:
-      for (int i=0; i < niter; ++i) blas::axpyZpbx(a, *xD, *yoD, *zD, b);
+      for (int i = 0; i < niter; ++i) blas::axpyZpbx(a, *xD, *yoD, *zD, b);
       break;
 
     case Kernel::caxpbypzYmbw:
@@ -398,11 +430,11 @@ double benchmark(Kernel kernel, const int niter)
       break;
 
     case Kernel::axpbyzNorm:
-      for (int i=0; i < niter; ++i) blas::axpbyzNorm(a, *xD, b, *yD, *zD);
+      for (int i = 0; i < niter; ++i) blas::axpbyzNorm(a, *xD, b, *yD, *zD);
       break;
 
     case Kernel::axpyCGNorm:
-      for (int i=0; i < niter; ++i) blas::axpyCGNorm(a, *xD, *yoD);
+      for (int i = 0; i < niter; ++i) blas::axpyCGNorm(a, *xD, *yoD);
       break;
 
     case Kernel::caxpyNorm:
@@ -430,7 +462,7 @@ double benchmark(Kernel kernel, const int niter)
       break;
 
     case Kernel::caxpbypzYmbwcDotProductUYNormY:
-      for (int i=0; i < niter; ++i) blas::caxpbypzYmbwcDotProductUYNormY(a2, *xD, b2, *yD, *zoD, *wD, *voD);
+      for (int i = 0; i < niter; ++i) blas::caxpbypzYmbwcDotProductUYNormY(a2, *xD, b2, *yD, *zoD, *wD, *voD);
       break;
 
     case Kernel::HeavyQuarkResidualNorm:
@@ -454,11 +486,11 @@ double benchmark(Kernel kernel, const int niter)
       break;
 
     case Kernel::caxpyBxpz:
-      for (int i=0; i < niter; ++i) blas::caxpyBxpz(a2, *xD, *yD, b2, *zD);
+      for (int i = 0; i < niter; ++i) blas::caxpyBxpz(a2, *xD, *yD, b2, *zD);
       break;
 
     case Kernel::caxpyBzpx:
-      for (int i=0; i < niter; ++i) blas::caxpyBzpx(a2, *xD, *yD, b2, *zD);
+      for (int i = 0; i < niter; ++i) blas::caxpyBzpx(a2, *xD, *yD, b2, *zD);
       break;
 
     case Kernel::axpy_block:
@@ -466,31 +498,31 @@ double benchmark(Kernel kernel, const int niter)
       break;
 
     case Kernel::caxpy_block:
-      for (int i=0; i < niter; ++i) blas::caxpy(A, *xmD,* ymoD);
+      for (int i = 0; i < niter; ++i) blas::caxpy(A, *xmD, *ymoD);
       break;
 
     case Kernel::axpyBzpcx_block:
-      for (int i=0; i < niter; ++i) blas::axpyBzpcx((double*)A, xmD->Components(), zmoD->Components(), (double*)B, *yD, (double*)C);
+      for (int i = 0; i < niter; ++i)
+        blas::axpyBzpcx((double *)A, xmD->Components(), zmoD->Components(), (double *)B, *yD, (double *)C);
       break;
 
     case Kernel::reDotProductNorm_block:
-      for (int i=0; i < niter; ++i) blas::reDotProduct((double*)A2, xmD->Components(), xmD->Components());
+      for (int i = 0; i < niter; ++i) blas::reDotProduct((double *)A2, xmD->Components(), xmD->Components());
       break;
 
     case Kernel::reDotProduct_block:
-      for (int i=0; i < niter; ++i) blas::reDotProduct((double*)A, xmD->Components(), ymoD->Components());
+      for (int i = 0; i < niter; ++i) blas::reDotProduct((double *)A, xmD->Components(), ymoD->Components());
       break;
 
     case Kernel::cDotProductNorm_block:
-      for (int i=0; i < niter; ++i) blas::cDotProduct(A2, xmD->Components(), xmD->Components());
+      for (int i = 0; i < niter; ++i) blas::cDotProduct(A2, xmD->Components(), xmD->Components());
       break;
 
     case Kernel::cDotProduct_block:
-      for (int i=0; i < niter; ++i) blas::cDotProduct(A, xmD->Components(), ymoD->Components());
+      for (int i = 0; i < niter; ++i) blas::cDotProduct(A, xmD->Components(), ymoD->Components());
       break;
 
-    default:
-      errorQuda("Undefined blas kernel %s\n", kernel_map.at(kernel).c_str());
+    default: errorQuda("Undefined blas kernel %s\n", kernel_map.at(kernel).c_str());
     }
   }
 
@@ -654,17 +686,21 @@ double test(Kernel kernel)
   case Kernel::axpbyzNorm:
     *xD = *xH;
     *yD = *yH;
-    {double d = blas::axpbyzNorm(a, *xD, b, *yD, *zD);
+    {
+      double d = blas::axpbyzNorm(a, *xD, b, *yD, *zD);
       double h = blas::axpbyzNorm(a, *xH, b, *yH, *zH);
-    error = ERROR(z) + fabs(d-h)/fabs(h);}
+      error = ERROR(z) + fabs(d - h) / fabs(h);
+    }
     break;
 
   case Kernel::axpyCGNorm:
     *xD = *xH;
     *yoD = *yH;
-    {quda::Complex d = blas::axpyCGNorm(a, *xD, *yoD);
-    quda::Complex h = blas::axpyCGNorm(a, *xH, *yH);
-    error = ERROR(yo) + fabs(d.real()-h.real())/fabs(h.real()) + fabs(d.imag()-h.imag())/fabs(h.imag());}
+    {
+      quda::Complex d = blas::axpyCGNorm(a, *xD, *yoD);
+      quda::Complex h = blas::axpyCGNorm(a, *xH, *yH);
+      error = ERROR(yo) + fabs(d.real() - h.real()) / fabs(h.real()) + fabs(d.imag() - h.imag()) / fabs(h.imag());
+    }
     break;
 
   case Kernel::caxpyNorm:
@@ -780,18 +816,22 @@ double test(Kernel kernel)
     *xD = *xH;
     *yD = *yH;
     *zD = *zH;
-    {blas::caxpyBxpz(a, *xD, *yD, b2, *zD);
-     blas::caxpyBxpz(a, *xH, *yH, b2, *zH);
-     error = ERROR(x) + ERROR(z);}
+    {
+      blas::caxpyBxpz(a, *xD, *yD, b2, *zD);
+      blas::caxpyBxpz(a, *xH, *yH, b2, *zH);
+      error = ERROR(x) + ERROR(z);
+    }
     break;
 
   case Kernel::caxpyBzpx:
     *xD = *xH;
     *yD = *yH;
     *zD = *zH;
-    {blas::caxpyBzpx(a, *xD, *yD, b2, *zD);
-     blas::caxpyBzpx(a, *xH, *yH, b2, *zH);
-     error = ERROR(x) + ERROR(z);}
+    {
+      blas::caxpyBzpx(a, *xD, *yD, b2, *zD);
+      blas::caxpyBzpx(a, *xH, *yH, b2, *zH);
+      error = ERROR(x) + ERROR(z);
+    }
     break;
 
   case Kernel::axpy_block:
@@ -812,7 +852,7 @@ double test(Kernel kernel)
 
   case Kernel::caxpy_block:
     for (int i=0; i < Nsrc; i++) xmD->Component(i) = *(xmH[i]);
-    for (int i=0; i < Msrc; i++) ymoD->Component(i) = *(ymH[i]);
+    for (int i = 0; i < Msrc; i++) ymoD->Component(i) = *(ymH[i]);
 
     blas::caxpy(A, *xmD, *ymoD);
     for (int i=0; i < Nsrc; i++){
@@ -822,7 +862,7 @@ double test(Kernel kernel)
     }
     error = 0;
     for (int i=0; i < Msrc; i++){
-      error+= fabs(blas::norm2((ymoD->Component(i))) - blas::norm2(*(ymH[i]))) / blas::norm2(*(ymH[i]));
+      error += fabs(blas::norm2((ymoD->Component(i))) - blas::norm2(*(ymH[i]))) / blas::norm2(*(ymH[i]));
     }
     error/= Msrc;
     break;
@@ -834,7 +874,7 @@ double test(Kernel kernel)
     }
     *yD = *yH;
 
-    blas::axpyBzpcx((double*)A, xmD->Components(), zmoD->Components(), (double*)B, *yD, (const double*)C);
+    blas::axpyBzpcx((double *)A, xmD->Components(), zmoD->Components(), (double *)B, *yD, (const double *)C);
 
     for (int i=0; i<Nsrc; i++) {
       blas::axpyBzpcx(((double*)A)[i], *xmH[i], *zmH[i], ((double*)B)[i], *yH, ((double*)C)[i]);
@@ -843,19 +883,20 @@ double test(Kernel kernel)
     error = 0;
     for (int i=0; i < Nsrc; i++){
       error+= fabs(blas::norm2((xmD->Component(i))) - blas::norm2(*(xmH[i]))) / blas::norm2(*(xmH[i]));
-      error+= fabs(blas::norm2((zmoD->Component(i))) - blas::norm2(*(zmH[i]))) / blas::norm2(*(zmH[i]));
+      error += fabs(blas::norm2((zmoD->Component(i))) - blas::norm2(*(zmH[i]))) / blas::norm2(*(zmH[i]));
     }
     error/= Nsrc;
     break;
 
   case Kernel::reDotProductNorm_block:
     for (int i=0; i < Nsrc; i++) xmD->Component(i) = *(xmH[i]);
-    blas::reDotProduct((double*)A2, xmD->Components(), xmD->Components());
+    blas::reDotProduct((double *)A2, xmD->Components(), xmD->Components());
     error = 0.0;
     for (int i = 0; i < Nsrc; i++) {
       for (int j = 0; j < Nsrc; j++) {
-        ((double*)B2)[i*Nsrc+j] = blas::reDotProduct(xmD->Component(i), xmD->Component(j));
-        error += std::abs(((double*)A2)[i*Nsrc+j] - ((double*)B2)[i*Nsrc+j])/std::abs(((double*)B2)[i*Nsrc+j]);
+        ((double *)B2)[i * Nsrc + j] = blas::reDotProduct(xmD->Component(i), xmD->Component(j));
+        error += std::abs(((double *)A2)[i * Nsrc + j] - ((double *)B2)[i * Nsrc + j])
+          / std::abs(((double *)B2)[i * Nsrc + j]);
       }
     }
     error /= Nsrc*Nsrc;
@@ -863,14 +904,15 @@ double test(Kernel kernel)
 
   case Kernel::reDotProduct_block:
     for (int i=0; i < Nsrc; i++) xmD->Component(i) = *(xmH[i]);
-    for (int i=0; i < Msrc; i++) ymoD->Component(i) = *(ymH[i]);
+    for (int i = 0; i < Msrc; i++) ymoD->Component(i) = *(ymH[i]);
     for (int i=0; i < Msrc; i++) ymD->Component(i) = *(ymH[i]);
-    blas::reDotProduct((double*)A, xmD->Components(), ymoD->Components());
+    blas::reDotProduct((double *)A, xmD->Components(), ymoD->Components());
     error = 0.0;
     for (int i = 0; i < Nsrc; i++) {
       for (int j = 0; j < Msrc; j++) {
-        ((double*)B)[i*Msrc+j] = blas::reDotProduct(xmD->Component(i), ymD->Component(j));
-        error += std::abs(((double*)A)[i*Msrc+j] - ((double*)B)[i*Msrc+j])/std::abs(((double*)B)[i*Msrc+j]);
+        ((double *)B)[i * Msrc + j] = blas::reDotProduct(xmD->Component(i), ymD->Component(j));
+        error
+          += std::abs(((double *)A)[i * Msrc + j] - ((double *)B)[i * Msrc + j]) / std::abs(((double *)B)[i * Msrc + j]);
       }
     }
     error /= Nsrc*Msrc;
@@ -882,8 +924,8 @@ double test(Kernel kernel)
     error = 0.0;
     for (int i = 0; i < Nsrc; i++) {
       for (int j = 0; j < Nsrc; j++) {
-	B2[i*Nsrc+j] = blas::cDotProduct(xmD->Component(i), xmD->Component(j));
-	error += std::abs(A2[i*Nsrc+j] - B2[i*Nsrc+j])/std::abs(B2[i*Nsrc+j]);
+        B2[i * Nsrc + j] = blas::cDotProduct(xmD->Component(i), xmD->Component(j));
+        error += std::abs(A2[i * Nsrc + j] - B2[i * Nsrc + j]) / std::abs(B2[i * Nsrc + j]);
       }
     }
     error /= Nsrc*Nsrc;
@@ -891,21 +933,20 @@ double test(Kernel kernel)
 
   case Kernel::cDotProduct_block:
     for (int i=0; i < Nsrc; i++) xmD->Component(i) = *(xmH[i]);
-    for (int i=0; i < Msrc; i++) ymoD->Component(i) = *(ymH[i]);
+    for (int i = 0; i < Msrc; i++) ymoD->Component(i) = *(ymH[i]);
     for (int i=0; i < Msrc; i++) ymD->Component(i) = *(ymH[i]);
     blas::cDotProduct(A, xmD->Components(), ymoD->Components());
     error = 0.0;
     for (int i = 0; i < Nsrc; i++) {
       for (int j = 0; j < Msrc; j++) {
-	B[i*Msrc+j] = blas::cDotProduct(xmD->Component(i), ymD->Component(j));
-	error += std::abs(A[i*Msrc+j] - B[i*Msrc+j])/std::abs(B[i*Msrc+j]);
+        B[i * Msrc + j] = blas::cDotProduct(xmD->Component(i), ymD->Component(j));
+        error += std::abs(A[i * Msrc + j] - B[i * Msrc + j]) / std::abs(B[i * Msrc + j]);
       }
     }
     error /= Nsrc*Msrc;
     break;
 
-  default:
-    errorQuda("Undefined blas kernel %s\n", kernel_map.at(kernel).c_str());
+  default: errorQuda("Undefined blas kernel %s\n", kernel_map.at(kernel).c_str());
   }
   delete[] A;
   delete[] B;
@@ -980,7 +1021,8 @@ using ::testing::Range;
 using ::testing::Combine;
 
 // map the 1-d precision test index into 2-d mixed prec
-prec_pair_t prec_idx_map(int idx) {
+prec_pair_t prec_idx_map(int idx)
+{
   switch (idx) {
   case 0: return std::make_pair(QUDA_QUARTER_PRECISION, QUDA_QUARTER_PRECISION);
   case 1: return std::make_pair(QUDA_QUARTER_PRECISION, QUDA_HALF_PRECISION);
@@ -1004,11 +1046,8 @@ protected:
   const prec_pair_t prec_pair;
   const int &kernel;
 
- public:
-  BlasTest() :
-    param(GetParam()),
-    prec_pair(prec_idx_map(::testing::get<0>(param))),
-    kernel(::testing::get<1>(param)) { }
+public:
+  BlasTest() : param(GetParam()), prec_pair(prec_idx_map(::testing::get<0>(param))), kernel(::testing::get<1>(param)) {}
   virtual void SetUp() {
     if (!skip_kernel(prec_pair, (Kernel)kernel)) initFields(prec_pair);
   }
@@ -1027,8 +1066,14 @@ TEST_P(BlasTest, verify) {
   // failed without running
   double deviation = test(kernel);
   // printfQuda("%-35s error = %e\n", names[kernel], deviation);
-  double tol_x = (prec_pair.first == QUDA_DOUBLE_PRECISION ? 1e-12 : (prec_pair.first == QUDA_SINGLE_PRECISION ? 1e-6 : (prec_pair.first == QUDA_HALF_PRECISION ? 1e-4 : 1e-2)));
-  double tol_y = (prec_pair.second == QUDA_DOUBLE_PRECISION ? 1e-12 : (prec_pair.second == QUDA_SINGLE_PRECISION ? 1e-6 : (prec_pair.second == QUDA_HALF_PRECISION ? 1e-4 : 1e-2)));
+  double tol_x
+    = (prec_pair.first == QUDA_DOUBLE_PRECISION ?
+         1e-12 :
+         (prec_pair.first == QUDA_SINGLE_PRECISION ? 1e-6 : (prec_pair.first == QUDA_HALF_PRECISION ? 1e-4 : 1e-2)));
+  double tol_y
+    = (prec_pair.second == QUDA_DOUBLE_PRECISION ?
+         1e-12 :
+         (prec_pair.second == QUDA_SINGLE_PRECISION ? 1e-6 : (prec_pair.second == QUDA_HALF_PRECISION ? 1e-4 : 1e-2)));
   double tol = std::max(tol_x, tol_y);
   tol = is_copy(kernel) ? 5e-2 : tol; // use different tolerance for copy
   EXPECT_LE(deviation, tol) << "CPU and CUDA implementations do not agree";
@@ -1066,4 +1111,4 @@ std::string getblasname(testing::TestParamInfo<::testing::tuple<int, int>> param
 }
 
 // instantiate all test cases
-INSTANTIATE_TEST_SUITE_P(QUDA, BlasTest, Combine(Range(0, (Nprec*(Nprec+1))/2), Range(0, Nkernels)), getblasname);
+INSTANTIATE_TEST_SUITE_P(QUDA, BlasTest, Combine(Range(0, (Nprec * (Nprec + 1)) / 2), Range(0, Nkernels)), getblasname);

--- a/tests/blas_test.cpp
+++ b/tests/blas_test.cpp
@@ -14,8 +14,6 @@
 // google test
 #include <gtest/gtest.h>
 
-constexpr int Nkernels = 43;
-
 using namespace quda;
 
 ColorSpinorField *xH, *yH, *zH, *wH, *vH, *hH, *mH, *lH;
@@ -43,66 +41,78 @@ void display_test_info()
 
 int Nprec = 4;
 
-const char *prec_str[] = {"quarter", "half", "single", "double"};
+const std::string prec_str[] = {"quarter", "half", "single", "double"};
+
+enum class Kernel {copyHS, copyMS, copyLS, axpbyz, ax, caxpy, caxpby, cxpaypbz, axpyBzpcx,
+                   axpyZpbx, caxpbypzYmbw, cabxpyAx, caxpyXmaz, norm2, reDotProduct, axpbyzNorm,
+                   caxpyNorm, caxpyXmazNormX, cabxpyzAxNorm, cDotProduct, caxpyDotzy,
+                   cDotProductNormA, caxpbypzYmbwcDotProductUYNormY, HeavyQuarkResidualNorm,
+                   xpyHeavyQuarkResidualNorm, tripleCGReduction, tripleCGUpdate, axpyReDot,
+                   caxpyBxpz, caxpyBzpx, axpy_block, caxpy_block, axpyBzpcx_block, reDotProductNorm_block,
+                   reDotProduct_block, cDotProductNorm_block, cDotProduct_block};
 
 // For googletest names must be non-empty, unique, and may only contain ASCII
 // alphanumeric characters or underscore
-const std::vector<std::string> names = {"copyHS",
-                                        "copyMS",
-                                        "copyLS",
-                                        "axpby",
-                                        "xpy",
-                                        "axpy",
-                                        "xpay",
-                                        "mxpy",
-                                        "ax",
-                                        "caxpy",
-                                        "caxpby",
-                                        "cxpaypbz",
-                                        "axpyBzpcx",
-                                        "axpyZpbx",
-                                        "caxpbypzYmbw",
-                                        "cabxpyAx",
-                                        "caxpyXmaz",
-                                        "norm",
-                                        "reDotProduct",
-                                        "axpyNorm",
-                                        "xmyNorm",
-                                        "caxpyNorm",
-                                        "caxpyXmazNormX",
-                                        "cabxpyzAxNorm",
-                                        "cDotProduct",
-                                        "caxpyDotzy",
-                                        "cDotProductNormA",
-                                        "cDotProductNormB",
-                                        "caxpbypzYmbwcDotProductUYNormY",
-                                        "HeavyQuarkResidualNorm",
-                                        "xpyHeavyQuarkResidualNorm",
-                                        "tripleCGReduction",
-                                        "tripleCGUpdate",
-                                        "axpyReDot",
-                                        "caxpy_block",
-                                        "axpyBzpcx_block",
-                                        "caxpyBxpz",
-                                        "caxpyBzpx",
-                                        "cDotProductNorm_block",
-                                        "cDotProduct_block",
-                                        "reDotProductNorm_block",
-                                        "reDotProduct_block",
-                                        "axpy_block"};
+const std::map<Kernel, std::string> kernel_map = { {Kernel::copyHS, "copyHS"},
+                                                   {Kernel::copyMS, "copyMS"},
+                                                   {Kernel::copyLS, "copyLS"},
+                                                   {Kernel::axpbyz, "axpbyz"},
+                                                   {Kernel::ax, "ax"},
+                                                   {Kernel::caxpy, "caxpy"},
+                                                   {Kernel::caxpby, "caxpby"},
+                                                   {Kernel::cxpaypbz, "cxpaypbz"},
+                                                   {Kernel::axpyBzpcx, "axpyBzpcx"},
+                                                   {Kernel::axpyZpbx, "axpyZpbx"},
+                                                   {Kernel::caxpbypzYmbw, "caxpbypzYmbw"},
+                                                   {Kernel::cabxpyAx, "cabxpyAx"},
+                                                   {Kernel::caxpyXmaz, "caxpyXmaz"},
+                                                   {Kernel::norm2, "norm2"},
+                                                   {Kernel::reDotProduct, "reDotProduct"},
+                                                   {Kernel::axpbyzNorm, "axpyNorm"},
+                                                   {Kernel::caxpyNorm, "caxpyNorm"},
+                                                   {Kernel::caxpyXmazNormX, "caxpyXmazNormX"},
+                                                   {Kernel::cabxpyzAxNorm, "cabxpyzAxNorm"},
+                                                   {Kernel::cDotProduct, "cDotProduct"},
+                                                   {Kernel::caxpyDotzy, "caxpyDotzy"},
+                                                   {Kernel::cDotProductNormA, "cDotProductNormA"},
+                                                   {Kernel::caxpbypzYmbwcDotProductUYNormY, "caxpbypzYmbwcDotProductUYNormY"},
+                                                   {Kernel::HeavyQuarkResidualNorm, "HeavyQuarkResidualNorm"},
+                                                   {Kernel::xpyHeavyQuarkResidualNorm, "xpyHeavyQuarkResidualNorm"},
+                                                   {Kernel::tripleCGReduction, "tripleCGReduction"},
+                                                   {Kernel::tripleCGUpdate, "tripleCGUpdate"},
+                                                   {Kernel::axpyReDot, "axpyReDot"},
+                                                   {Kernel::caxpyBxpz, "caxpyBxpz"},
+                                                   {Kernel::caxpyBzpx, "caxpyBzpx"},
+                                                   {Kernel::axpy_block, "axpy_block"},
+                                                   {Kernel::caxpy_block, "caxpy_block"},
+                                                   {Kernel::axpyBzpcx_block, "axpyBzpcx_block"},
+                                                   {Kernel::reDotProductNorm_block, "reDotProductNorm_block"},
+                                                   {Kernel::reDotProduct_block, "reDotProduct_block"},
+                                                   {Kernel::cDotProductNorm_block, "cDotProductNorm_block"},
+                                                   {Kernel::cDotProduct_block, "cDotProduct_block"} };
+
+const int Nkernels = kernel_map.size();
 
 // kernels that utilize multi-blas
-bool is_multi(int kernel) { return std::string(names[kernel]).find("_block") != std::string::npos ? true : false; }
+bool is_multi(Kernel kernel) {
+  return std::string(kernel_map.at(kernel)).find("_block") != std::string::npos ? true : false;
+}
+
+bool is_copy(Kernel kernel) {
+  return (kernel == Kernel::copyHS || kernel == Kernel::copyMS || kernel == Kernel::copyLS);
+}
 
 // kernels that require site unrolling
-bool is_site_unroll(int kernel) { return std::string(names[kernel]).find("HeavyQuark") != std::string::npos ? true : false; }
+bool is_site_unroll(Kernel kernel) {
+  return (kernel == Kernel::HeavyQuarkResidualNorm || kernel == Kernel::xpyHeavyQuarkResidualNorm);
+}
 
-bool skip_kernel(int precision, int kernel)
+bool skip_kernel(int precision, Kernel kernel)
 {
   if ((QUDA_PRECISION & getPrecision(precision)) == 0) return true;
 
   // if we've selected a given kernel then make sure we only run that
-  if (test_type != -1 && kernel != test_type) return true;
+  if (test_type != -1 && (int)kernel != test_type) return true;
 
   // if we've selected a given precision then make sure we only run that
   auto this_prec = getPrecision(precision);
@@ -111,13 +121,13 @@ bool skip_kernel(int precision, int kernel)
   if ( Nspin == 2 && ( precision == 0 || precision ==1 ) ) {
     // avoid quarter, half precision tests if doing coarse fields
     return true;
-  } else if (Nspin == 2 && (kernel == 1 || kernel == 2)) {
+  } else if (Nspin == 2 && (kernel == Kernel::copyMS || kernel == Kernel::copyLS)) {
     // avoid low-precision copy if doing coarse fields
     return true;
   } else if (Ncolor != 3 && is_site_unroll(kernel)) {
     // only benchmark heavy-quark norm if doing 3 colors
     return true;
-  } else if ((Nprec < 4) && (kernel == 0)) {
+  } else if ((Nprec < 4) && (kernel == Kernel::copyHS)) {
     // only benchmark high-precision copy() if double is supported
     return true;
   }
@@ -331,7 +341,7 @@ void freeFields()
 }
 
 
-double benchmark(int kernel, const int niter) {
+double benchmark(Kernel kernel, const int niter) {
 
   double a = 1.0, b = 2.0, c = 3.0;
   quda::Complex a2, b2;
@@ -349,183 +359,156 @@ double benchmark(int kernel, const int niter) {
   {
     switch (kernel) {
 
-    case 0:
+    case Kernel::copyHS:
       for (int i=0; i < niter; ++i) blas::copy(*yD, *hD);
       break;
 
-    case 1:
+    case Kernel::copyMS:
       for (int i=0; i < niter; ++i) blas::copy(*yD, *mD);
       break;
 
-    case 2:
+    case Kernel::copyLS:
       for (int i=0; i < niter; ++i) blas::copy(*yD, *lD);
       break;
 
-    case 3:
-      for (int i=0; i < niter; ++i) blas::axpby(a, *xD, b, *yD);
+    case Kernel::axpbyz:
+      for (int i=0; i < niter; ++i) blas::axpbyz(a, *xD, b, *yD, *zD);
       break;
 
-    case 4:
-      for (int i=0; i < niter; ++i) blas::xpy(*xD, *yD);
-      break;
-
-    case 5:
-      for (int i=0; i < niter; ++i) blas::axpy(a, *xD, *yD);
-      break;
-
-    case 6:
-      for (int i=0; i < niter; ++i) blas::xpay(*xD, a, *yD);
-      break;
-
-    case 7:
-      for (int i=0; i < niter; ++i) blas::mxpy(*xD, *yD);
-      break;
-
-    case 8:
+    case Kernel::ax:
       for (int i=0; i < niter; ++i) blas::ax(a, *xD);
       break;
 
-    case 9:
+    case Kernel::caxpy:
       for (int i=0; i < niter; ++i) blas::caxpy(a2, *xD, *yD);
       break;
 
-    case 10:
+    case Kernel::caxpby:
       for (int i=0; i < niter; ++i) blas::caxpby(a2, *xD, b2, *yD);
       break;
 
-    case 11:
+    case Kernel::cxpaypbz:
       for (int i=0; i < niter; ++i) blas::cxpaypbz(*xD, a2, *yD, b2, *zD);
       break;
 
-    case 12:
+    case Kernel::axpyBzpcx:
       for (int i=0; i < niter; ++i) blas::axpyBzpcx(a, *xD, *yD, b, *zD, c);
       break;
 
-    case 13:
+    case Kernel::axpyZpbx:
       for (int i=0; i < niter; ++i) blas::axpyZpbx(a, *xD, *yD, *zD, b);
       break;
 
-    case 14:
+    case Kernel::caxpbypzYmbw:
       for (int i=0; i < niter; ++i) blas::caxpbypzYmbw(a2, *xD, b2, *yD, *zD, *wD);
       break;
 
-    case 15:
+    case Kernel::cabxpyAx:
       for (int i=0; i < niter; ++i) blas::cabxpyAx(a, b2, *xD, *yD);
       break;
 
-    case 16:
+    case Kernel::caxpyXmaz:
       for (int i=0; i < niter; ++i) blas::caxpyXmaz(a2, *xD, *yD, *zD);
       break;
 
-      // double
-    case 17:
+    case Kernel::norm2:
       for (int i=0; i < niter; ++i) blas::norm2(*xD);
       break;
 
-    case 18:
+    case Kernel::reDotProduct:
       for (int i=0; i < niter; ++i) blas::reDotProduct(*xD, *yD);
       break;
 
-    case 19:
-      for (int i=0; i < niter; ++i) blas::axpyNorm(a, *xD, *yD);
+    case Kernel::axpbyzNorm:
+      for (int i=0; i < niter; ++i) blas::axpbyzNorm(a, *xD, b, *yD, *zD);
       break;
 
-    case 20:
-      for (int i=0; i < niter; ++i) blas::xmyNorm(*xD, *yD);
-      break;
-
-    case 21:
+    case Kernel::caxpyNorm:
       for (int i=0; i < niter; ++i) blas::caxpyNorm(a2, *xD, *yD);
       break;
 
-    case 22:
+    case Kernel::caxpyXmazNormX:
       for (int i=0; i < niter; ++i) blas::caxpyXmazNormX(a2, *xD, *yD, *zD);
       break;
 
-    case 23:
+    case Kernel::cabxpyzAxNorm:
       for (int i=0; i < niter; ++i) blas::cabxpyzAxNorm(a, b2, *xD, *yD, *yD);
       break;
 
-    // double2
-    case 24:
+    case Kernel::cDotProduct:
       for (int i=0; i < niter; ++i) blas::cDotProduct(*xD, *yD);
       break;
 
-    case 25:
+    case Kernel::caxpyDotzy:
       for (int i=0; i < niter; ++i) blas::caxpyDotzy(a2, *xD, *yD, *zD);
       break;
 
-    // double3
-    case 26:
+    case Kernel::cDotProductNormA:
       for (int i=0; i < niter; ++i) blas::cDotProductNormA(*xD, *yD);
       break;
 
-    case 27:
-      for (int i=0; i < niter; ++i) blas::cDotProductNormB(*xD, *yD);
-      break;
-
-    case 28:
+    case Kernel::caxpbypzYmbwcDotProductUYNormY:
       for (int i=0; i < niter; ++i) blas::caxpbypzYmbwcDotProductUYNormY(a2, *xD, b2, *yD, *zD, *wD, *vD);
       break;
 
-    case 29:
+    case Kernel::HeavyQuarkResidualNorm:
       for (int i=0; i < niter; ++i) blas::HeavyQuarkResidualNorm(*xD, *yD);
       break;
 
-    case 30:
+    case Kernel::xpyHeavyQuarkResidualNorm:
       for (int i=0; i < niter; ++i) blas::xpyHeavyQuarkResidualNorm(*xD, *yD, *zD);
       break;
 
-    case 31:
+    case Kernel::tripleCGReduction:
       for (int i=0; i < niter; ++i) blas::tripleCGReduction(*xD, *yD, *zD);
       break;
 
-    case 32:
+    case Kernel::tripleCGUpdate:
       for (int i=0; i < niter; ++i) blas::tripleCGUpdate(a, b, *xD, *yD, *zD, *wD);
       break;
 
-    case 33:
+    case Kernel::axpyReDot:
       for (int i=0; i < niter; ++i) blas::axpyReDot(a, *xD, *yD);
       break;
 
-    case 34:
+    case Kernel::caxpy_block:
       for (int i=0; i < niter; ++i) blas::caxpy(A, *xmD,* ymD);
       break;
 
-    case 35:
+    case Kernel::axpyBzpcx_block:
       for (int i=0; i < niter; ++i) blas::axpyBzpcx((double*)A, xmD->Components(), zmD->Components(), (double*)B, *yD, (double*)C);
       break;
 
-    case 36:
+    case Kernel::caxpyBxpz:
       for (int i=0; i < niter; ++i) blas::caxpyBxpz(a2, *xD, *yD, b2, *zD);
       break;
 
-    case 37:
+    case Kernel::caxpyBzpx:
       for (int i=0; i < niter; ++i) blas::caxpyBzpx(a2, *xD, *yD, b2, *zD);
       break;
 
-    case 38:
+    case Kernel::cDotProductNorm_block:
       for (int i=0; i < niter; ++i) blas::cDotProduct(A2, xmD->Components(), xmD->Components());
       break;
 
-    case 39:
+    case Kernel::cDotProduct_block:
       for (int i=0; i < niter; ++i) blas::cDotProduct(A, xmD->Components(), ymD->Components());
       break;
 
-    case 40:
+    case Kernel::reDotProductNorm_block:
       for (int i=0; i < niter; ++i) blas::reDotProduct((double*)A2, xmD->Components(), xmD->Components());
       break;
 
-    case 41:
+    case Kernel::reDotProduct_block:
       for (int i=0; i < niter; ++i) blas::reDotProduct((double*)A, xmD->Components(), ymD->Components());
       break;
 
-    case 42:
+    case Kernel::axpy_block:
       for (int i = 0; i < niter; ++i) blas::axpy(Ar, xmD->Components(), ymD->Components());
       break;
 
     default:
-      errorQuda("Undefined blas kernel %d\n", kernel);
+      errorQuda("Undefined blas kernel %s\n", kernel_map.at(kernel).c_str());
     }
   }
 
@@ -546,7 +529,7 @@ double benchmark(int kernel, const int niter) {
 
 #define ERROR(a) fabs(blas::norm2(*a##D) - blas::norm2(*a##H)) / blas::norm2(*a##H)
 
-double test(int kernel) {
+double test(Kernel kernel) {
 
   double a = M_PI, b = M_PI*exp(1.0), c = sqrt(M_PI);
   quda::Complex a2(a, b), b2(b, -c), c2(a+b, c*a);
@@ -575,76 +558,43 @@ double test(int kernel) {
 
   switch (kernel) {
 
-  case 0:
+  case Kernel::copyHS:
     *hD = *hH;
     blas::copy(*yD, *hD);
     blas::copy(*yH, *hH);
     error = ERROR(y);
     break;
 
-  case 1:
+  case Kernel::copyMS:  
     *mD = *mH;
     blas::copy(*yD, *mD);
     blas::copy(*yH, *mH);
     error = ERROR(y);
     break;
 
-  case 2:
+  case Kernel::copyLS:
     *lD = *lH;
     blas::copy(*yD, *lD);
     blas::copy(*yH, *lH);
     error = ERROR(y);
     break;
 
-  case 3:
+  case Kernel::axpbyz:
     *xD = *xH;
     *yD = *yH;
-    blas::axpby(a, *xD, b, *yD);
-    blas::axpby(a, *xH, b, *yH);
-    error = ERROR(y);
+    blas::axpbyz(a, *xD, b, *yD, *zD);
+    blas::axpbyz(a, *xH, b, *yH, *zH);
+    error = ERROR(z);
     break;
 
-  case 4:
-    *xD = *xH;
-    *yD = *yH;
-    blas::xpy(*xD, *yD);
-    blas::xpy(*xH, *yH);
-    error = ERROR(y);
-    break;
-
-  case 5:
-    *xD = *xH;
-    *yD = *yH;
-    blas::axpy(a, *xD, *yD);
-    blas::axpy(a, *xH, *yH);
-    *zH = *yD;
-    error = ERROR(y);
-    break;
-
-  case 6:
-    *xD = *xH;
-    *yD = *yH;
-    blas::xpay(*xD, a, *yD);
-    blas::xpay(*xH, a, *yH);
-    error = ERROR(y);
-    break;
-
-  case 7:
-    *xD = *xH;
-    *yD = *yH;
-    blas::mxpy(*xD, *yD);
-    blas::mxpy(*xH, *yH);
-    error = ERROR(y);
-    break;
-
-  case 8:
+  case Kernel::ax:
     *xD = *xH;
     blas::ax(a, *xD);
     blas::ax(a, *xH);
     error = ERROR(x);
     break;
 
-  case 9:
+  case Kernel::caxpy:
     *xD = *xH;
     *yD = *yH;
     blas::caxpy(a2, *xD, *yD);
@@ -652,7 +602,7 @@ double test(int kernel) {
     error = ERROR(y);
     break;
 
-  case 10:
+  case Kernel::caxpby:
     *xD = *xH;
     *yD = *yH;
     blas::caxpby(a2, *xD, b2, *yD);
@@ -660,7 +610,7 @@ double test(int kernel) {
     error = ERROR(y);
     break;
 
-  case 11:
+  case Kernel::cxpaypbz:
     *xD = *xH;
     *yD = *yH;
     *zD = *zH;
@@ -669,7 +619,7 @@ double test(int kernel) {
     error = ERROR(z);
     break;
 
-  case 12:
+  case Kernel::axpyBzpcx:
     *xD = *xH;
     *yD = *yH;
     *zD = *zH;
@@ -678,7 +628,7 @@ double test(int kernel) {
     error = ERROR(x) + ERROR(y);
     break;
 
-  case 13:
+  case Kernel::axpyZpbx:
     *xD = *xH;
     *yD = *yH;
     *zD = *zH;
@@ -687,7 +637,7 @@ double test(int kernel) {
     error = ERROR(x) + ERROR(y);
     break;
 
-  case 14:
+  case Kernel::caxpbypzYmbw:
     *xD = *xH;
     *yD = *yH;
     *zD = *zH;
@@ -697,7 +647,7 @@ double test(int kernel) {
     error = ERROR(z) + ERROR(y);
     break;
 
-  case 15:
+  case Kernel::cabxpyAx:
     *xD = *xH;
     *yD = *yH;
     blas::cabxpyAx(a, b2, *xD, *yD);
@@ -705,7 +655,7 @@ double test(int kernel) {
     error = ERROR(y) + ERROR(x);
     break;
 
-  case 16:
+  case Kernel::caxpyXmaz:
     *xD = *xH;
     *yD = *yH;
     *zD = *zH;
@@ -714,35 +664,27 @@ double test(int kernel) {
      error = ERROR(y) + ERROR(x);}
     break;
 
-  case 17:
+  case Kernel::norm2:
     *xD = *xH;
     *yH = *xD;
     error = fabs(blas::norm2(*xD) - blas::norm2(*xH)) / blas::norm2(*xH);
     break;
 
-  case 18:
+  case Kernel::reDotProduct:
     *xD = *xH;
     *yD = *yH;
     error = fabs(blas::reDotProduct(*xD, *yD) - blas::reDotProduct(*xH, *yH)) / fabs(blas::reDotProduct(*xH, *yH));
     break;
 
-  case 19:
+  case Kernel::axpbyzNorm:
     *xD = *xH;
     *yD = *yH;
-    {double d = blas::axpyNorm(a, *xD, *yD);
-    double h = blas::axpyNorm(a, *xH, *yH);
-    error = ERROR(y) + fabs(d-h)/fabs(h);}
+    {double d = blas::axpbyzNorm(a, *xD, b, *yD, *zD);
+      double h = blas::axpbyzNorm(a, *xH, b, *yH, *zH);
+    error = ERROR(z) + fabs(d-h)/fabs(h);}
     break;
 
-  case 20:
-    *xD = *xH;
-    *yD = *yH;
-    {double d = blas::xmyNorm(*xD, *yD);
-    double h = blas::xmyNorm(*xH, *yH);
-    error = ERROR(y) + fabs(d-h)/fabs(h);}
-    break;
-
-  case 21:
+  case Kernel::caxpyNorm:
     *xD = *xH;
     *yD = *yH;
     {double d = blas::caxpyNorm(a, *xD, *yD);
@@ -750,7 +692,7 @@ double test(int kernel) {
     error = ERROR(y) + fabs(d-h)/fabs(h);}
     break;
 
-  case 22:
+  case Kernel::caxpyXmazNormX:
     *xD = *xH;
     *yD = *yH;
     *zD = *zH;
@@ -759,7 +701,7 @@ double test(int kernel) {
       error = ERROR(y) + ERROR(x) + fabs(d-h)/fabs(h);}
     break;
 
-  case 23:
+  case Kernel::cabxpyzAxNorm:
     *xD = *xH;
     *yD = *yH;
     {double d = blas::cabxpyzAxNorm(a, b2, *xD, *yD, *yD);
@@ -767,13 +709,13 @@ double test(int kernel) {
       error = ERROR(x) + ERROR(y) + fabs(d-h)/fabs(h);}
     break;
 
-  case 24:
+  case Kernel::cDotProduct:
     *xD = *xH;
     *yD = *yH;
     error = abs(blas::cDotProduct(*xD, *yD) - blas::cDotProduct(*xH, *yH)) / abs(blas::cDotProduct(*xH, *yH));
     break;
 
-  case 25:
+  case Kernel::caxpyDotzy:
     *xD = *xH;
     *yD = *yH;
     *zD = *zH;
@@ -782,7 +724,7 @@ double test(int kernel) {
     error = ERROR(y) + abs(d-h)/abs(h);}
     break;
 
-  case 26:
+  case Kernel::cDotProductNormA:
     *xD = *xH;
     *yD = *yH;
     { double3 d = blas::cDotProductNormA(*xD, *yD);
@@ -791,16 +733,7 @@ double test(int kernel) {
     }
     break;
 
-  case 27:
-    *xD = *xH;
-    *yD = *yH;
-    { double3 d = blas::cDotProductNormB(*xD, *yD);
-      double3 h = blas::cDotProductNormB(*xH, *yH);
-      error = abs(Complex(d.x - h.x, d.y - h.y)) / abs(Complex(h.x, h.y)) + fabs(d.z - h.z) / fabs(h.z);
-    }
-    break;
-
-  case 28:
+  case Kernel::caxpbypzYmbwcDotProductUYNormY:
     *xD = *xH;
     *yD = *yH;
     *zD = *zH;
@@ -813,7 +746,7 @@ double test(int kernel) {
     }
     break;
 
-  case 29:
+  case Kernel::HeavyQuarkResidualNorm:
     *xD = *xH;
     *yD = *yH;
     { double3 d = blas::HeavyQuarkResidualNorm(*xD, *yD);
@@ -822,7 +755,7 @@ double test(int kernel) {
 	fabs(d.y - h.y) / fabs(h.y) + fabs(d.z - h.z) / fabs(h.z); }
     break;
 
-  case 30:
+  case Kernel::xpyHeavyQuarkResidualNorm:
     *xD = *xH;
     *yD = *yH;
     *zD = *zH;
@@ -832,7 +765,7 @@ double test(int kernel) {
 	fabs(d.y - h.y) / fabs(h.y) + fabs(d.z - h.z) / fabs(h.z); }
     break;
 
-  case 31:
+  case Kernel::tripleCGReduction:
     *xD = *xH;
     *yD = *yH;
     *zD = *zH;
@@ -842,7 +775,7 @@ double test(int kernel) {
 	fabs(d.y - h.y) / fabs(h.y) + fabs(d.z - h.z) / fabs(h.z); }
     break;
 
-  case 32:
+  case Kernel::tripleCGUpdate:
     *xD = *xH;
     *yD = *yH;
     *zD = *zH;
@@ -852,7 +785,7 @@ double test(int kernel) {
       error = ERROR(y) + ERROR(z) + ERROR(w); }
     break;
 
-  case 33:
+  case Kernel::axpyReDot:
     *xD = *xH;
     *yD = *yH;
     { double d = blas::axpyReDot(a, *xD, *yD);
@@ -860,7 +793,7 @@ double test(int kernel) {
       error = ERROR(y) + fabs(d-h)/fabs(h); }
     break;
 
-  case 34:
+  case Kernel::caxpy_block:
     for (int i=0; i < Nsrc; i++) xmD->Component(i) = *(xmH[i]);
     for (int i=0; i < Msrc; i++) ymD->Component(i) = *(ymH[i]);
 
@@ -877,7 +810,7 @@ double test(int kernel) {
     error/= Msrc;
     break;
 
-  case 35:
+  case Kernel::axpyBzpcx_block:
     for (int i=0; i < Nsrc; i++) {
       xmD->Component(i) = *(xmH[i]);
       zmD->Component(i) = *(zmH[i]);
@@ -898,7 +831,7 @@ double test(int kernel) {
     error/= Nsrc;
     break;
 
-  case 36:
+  case Kernel::caxpyBxpz:
     *xD = *xH;
     *yD = *yH;
     *zD = *zH;
@@ -907,7 +840,7 @@ double test(int kernel) {
      error = ERROR(x) + ERROR(z);}
     break;
 
-  case 37:
+  case Kernel::caxpyBzpx:
     *xD = *xH;
     *yD = *yH;
     *zD = *zH;
@@ -916,7 +849,7 @@ double test(int kernel) {
      error = ERROR(x) + ERROR(z);}
     break;
 
-  case 38:
+  case Kernel::cDotProductNorm_block:
     for (int i=0; i < Nsrc; i++) xmD->Component(i) = *(xmH[i]);
     blas::cDotProduct(A2, xmD->Components(), xmD->Components());
     error = 0.0;
@@ -929,7 +862,7 @@ double test(int kernel) {
     error /= Nsrc*Nsrc;
     break;
 
-  case 39:
+  case Kernel::cDotProduct_block:
     for (int i=0; i < Nsrc; i++) xmD->Component(i) = *(xmH[i]);
     for (int i=0; i < Msrc; i++) ymD->Component(i) = *(ymH[i]);
     blas::cDotProduct(A, xmD->Components(), ymD->Components());
@@ -943,7 +876,7 @@ double test(int kernel) {
     error /= Nsrc*Msrc;
     break;
 
-  case 40:
+  case Kernel::reDotProductNorm_block:
     for (int i=0; i < Nsrc; i++) xmD->Component(i) = *(xmH[i]);
     blas::reDotProduct((double*)A2, xmD->Components(), xmD->Components());
     error = 0.0;
@@ -956,7 +889,7 @@ double test(int kernel) {
     error /= Nsrc*Nsrc;
     break;
 
-  case 41:
+  case Kernel::reDotProduct_block:
     for (int i=0; i < Nsrc; i++) xmD->Component(i) = *(xmH[i]);
     for (int i=0; i < Msrc; i++) ymD->Component(i) = *(ymH[i]);
     blas::reDotProduct((double*)A, xmD->Components(), ymD->Components());
@@ -970,7 +903,7 @@ double test(int kernel) {
     error /= Nsrc*Msrc;
     break;
 
-  case 42:
+  case Kernel::axpy_block:
     for (int i = 0; i < Nsrc; i++) xmD->Component(i) = *(xmH[i]);
     for (int i = 0; i < Msrc; i++) ymD->Component(i) = *(ymH[i]);
 
@@ -987,7 +920,7 @@ double test(int kernel) {
     break;
 
   default:
-    errorQuda("Undefined blas kernel %d\n", kernel);
+    errorQuda("Undefined blas kernel %s\n", kernel_map.at(kernel).c_str());
   }
   delete[] A;
   delete[] B;
@@ -1070,17 +1003,17 @@ protected:
 public:
   BlasTest() : param(GetParam()), prec(::testing::get<0>(param)), kernel(::testing::get<1>(param)) {}
   virtual void SetUp() {
-    if (!skip_kernel(prec, kernel)) initFields(prec);
+    if (!skip_kernel(prec, (Kernel)kernel)) initFields(prec);
   }
   virtual void TearDown()
   {
-    if (!skip_kernel(prec, kernel)) { freeFields(); }
+    if (!skip_kernel(prec, (Kernel)kernel)) { freeFields(); }
   }
 };
 
 TEST_P(BlasTest, verify) {
   int prec = ::testing::get<0>(GetParam());
-  int kernel = ::testing::get<1>(GetParam());
+  Kernel kernel = (Kernel)::testing::get<1>(GetParam());
   if (skip_kernel(prec, kernel)) GTEST_SKIP();
 
   // certain tests will fail to run for coarse grids so mark these as
@@ -1088,13 +1021,13 @@ TEST_P(BlasTest, verify) {
   double deviation = test(kernel);
   // printfQuda("%-35s error = %e\n", names[kernel], deviation);
   double tol = (prec == 3 ? 1e-12 : (prec == 2 ? 1e-6 : (prec == 1 ? 1e-4 : 1e-2)));
-  tol = (kernel < 4) ? 5e-2 : tol; // use different tolerance for copy
+  tol = is_copy(kernel) ? 5e-2 : tol; // use different tolerance for copy
   EXPECT_LE(deviation, tol) << "CPU and CUDA implementations do not agree";
 }
 
 TEST_P(BlasTest, benchmark) {
   int prec = ::testing::get<0>(GetParam());
-  int kernel = ::testing::get<1>(GetParam());
+  Kernel kernel = (Kernel)::testing::get<1>(GetParam());
   if (skip_kernel(prec, kernel)) GTEST_SKIP();
 
   // do the initial tune
@@ -1110,15 +1043,15 @@ TEST_P(BlasTest, benchmark) {
   double gbytes = quda::blas::bytes/(secs*1e9);
   RecordProperty("Gflops", std::to_string(gflops));
   RecordProperty("GBs", std::to_string(gbytes));
-  printfQuda("%-31s: Gflop/s = %6.1f, GB/s = %6.1f\n", names[kernel].c_str(), gflops, gbytes);
+  printfQuda("%-31s: Gflop/s = %6.1f, GB/s = %6.1f\n", kernel_map.at(kernel).c_str(), gflops, gbytes);
 }
 
 std::string getblasname(testing::TestParamInfo<::testing::tuple<int, int>> param)
 {
   int prec = ::testing::get<0>(param.param);
   int kernel = ::testing::get<1>(param.param);
-  std::string str(names[kernel]);
-  str += std::string("_") + std::string(prec_str[prec]);
+  std::string str(kernel_map.at((Kernel)kernel));
+  str += std::string("_") + prec_str[prec];
   return str;
 }
 


### PR DESCRIPTION
This is a hotfix PR that fixes multiple issues with the blas kernels, some of which were introduced in #1021 and some were long since present.
* Add mixed-precision support to blas_test for better test coverage
* blas_test is now more robust: use enums map to set which kernels to do as opposed to relying on some set index order 
* Fix `tuneKey` for mixed-precision blas kernels
* Fix mixed-precision multi-1d multi-blas kernels
* Fix mixed-precision multi-reduce kernels (cannot use transpose tuner for these cases)
* Fix multi-blas compilation for pure fixed-point compilation
* Fix broken mixed-precision `axpyCGNorm`
* Reduced some template bloat in multi-blas
