### PR TITLE
Added ColorSpinor templates and independent reductions

### DIFF
--- a/include/blas_quda.h
+++ b/include/blas_quda.h
@@ -14,6 +14,9 @@ namespace quda {
     void init();
     void end(void);
 
+    /** returns the reduce buffer size allocated */
+    size_t reduceBufferSize();
+
     void* getDeviceReduceBuffer();
     void* getMappedHostReduceBuffer();
     void* getHostReduceBuffer();

--- a/include/color_spinor.h
+++ b/include/color_spinor.h
@@ -920,6 +920,28 @@ namespace quda {
   }
 
   /**
+     @brief Compute the color contraction over color at spin s
+     dot = \sum_s,c a(s,c) * b(s,c)
+     @param a Left-hand side ColorSpinor
+     @param b Right-hand side ColorSpinor
+     @return The color contraction
+  */
+  template <typename Float, int Nc, int Ns>
+  __device__ __host__ inline complex<Float> colorContract(const ColorSpinor<Float, Nc, Ns> &a,
+							  const ColorSpinor<Float, Nc, Ns> &b, int sa, int sb)
+  {
+    complex<Float> dot = 0;
+    for (int c = 0; c < Nc; c++) {
+      dot.x += a(sa, c).real() * b(sb, c).real();
+      dot.x -= a(sa, c).imag() * b(sb, c).imag();
+      dot.y += a(sa, c).real() * b(sb, c).imag();
+      dot.y += a(sa, c).imag() * b(sb, c).real();
+    }
+    
+    return dot;
+  }
+
+  /**
      Compute the inner product over color at spin s between two ColorSpinor fields
      dot = \sum_c conj(a(s,c)) * b(s,c)
      @param a Left-hand side ColorSpinor
@@ -981,6 +1003,28 @@ namespace quda {
     return dot;
   }
 
+  /**
+     Compute the cross product of two color vectors at spin sa and sb
+     cProd = \sum_{j,k} \epsilon_{i,j,k} a(s1,j) b(s2,k)     
+     @param a j ColorSpinor
+     @param b k ColorSpinor
+     @param sa j spin index
+     @param sb k spin index
+     @return The cross product
+  */
+  template <typename Float, int Nc, int Ns>
+    __device__ __host__ inline ColorSpinor<Float, Nc, 1> crossProduct(const ColorSpinor<Float, Nc, Ns> &a,
+								      const ColorSpinor<Float, Nc, Ns> &b, int sa, int sb)
+    {
+      ColorSpinor<Float, Nc, 1> res;
+      res(0,0) = a(sa,1) * b(sb,2) - a(sa,2) * b(sb,1);
+      res(0,1) = a(sa,2) * b(sb,0) - a(sa,0) * b(sb,2);
+      res(0,2) = a(sa,0) * b(sb,1) - a(sa,1) * b(sb,0);
+      
+      return res;
+    }
+  
+  
   /**
      Compute the outer product over color and take the spin trace
      out(j,i) = \sum_s a(s,j) * conj (b(s,i))

--- a/include/color_spinor.h
+++ b/include/color_spinor.h
@@ -1014,7 +1014,7 @@ namespace quda {
      @return The cross product
   */
   template <typename Float, 3, int Ns>
-    __device__ __host__ inline ColorSpinor<Float, Nc, 1> crossProduct(const ColorSpinor<Float, 3, Ns> &a,
+    __device__ __host__ inline ColorSpinor<Float, 3, 1> crossProduct(const ColorSpinor<Float, 3, Ns> &a,
 								      const ColorSpinor<Float, 3, Ns> &b, int sa, int sb)
     {
       ColorSpinor<Float, 3, 1> res;

--- a/include/color_spinor.h
+++ b/include/color_spinor.h
@@ -931,13 +931,13 @@ namespace quda {
 							  const ColorSpinor<Float, Nc, Ns> &b, int sa, int sb)
   {
     complex<Float> dot = 0;
-    for (int c = 0; c < Nc; c++) {      
+    for (int c = 0; c < Nc; c++) {
       dot.real(dot.real() + a(sa, c).real() * b(sb, c).real());
       dot.real(dot.real() - a(sa, c).imag() * b(sb, c).imag());
       dot.imag(dot.imag() + a(sa, c).real() * b(sb, c).imag());
       dot.imag(dot.imag() + a(sa, c).imag() * b(sb, c).real());
     }
-    
+
     return dot;
   }
 
@@ -975,7 +975,7 @@ namespace quda {
       dot.real(dot.real() + a(sa, c).real() * b(sb, c).real());
       dot.real(dot.real() + a(sa, c).imag() * b(sb, c).imag());
       dot.imag(dot.imag() + a(sa, c).real() * b(sb, c).imag());
-      dot.imag(dot.imag() - a(sa, c).imag() * b(sb, c).real());      
+      dot.imag(dot.imag() - a(sa, c).imag() * b(sb, c).real());
     }
     return dot;
   }
@@ -1014,14 +1014,14 @@ namespace quda {
      @return The cross product
   */
   template <typename Float, int Ns>
-    __device__ __host__ inline ColorSpinor<Float, 3, 1> crossProduct(const ColorSpinor<Float, 3, Ns> &a,
-								      const ColorSpinor<Float, 3, Ns> &b, int sa, int sb)
-    {
-      ColorSpinor<Float, 3, 1> res;
-      res(0,0) = a(sa,1) * b(sb,2) - a(sa,2) * b(sb,1);
-      res(0,1) = a(sa,2) * b(sb,0) - a(sa,0) * b(sb,2);
-      res(0,2) = a(sa,0) * b(sb,1) - a(sa,1) * b(sb,0);      
-      return res;
+  __device__ __host__ inline ColorSpinor<Float, 3, 1> crossProduct(const ColorSpinor<Float, 3, Ns> &a,
+                                                                   const ColorSpinor<Float, 3, Ns> &b, int sa, int sb)
+  {
+    ColorSpinor<Float, 3, 1> res;
+    res(0, 0) = a(sa, 1) * b(sb, 2) - a(sa, 2) * b(sb, 1);
+    res(0, 1) = a(sa, 2) * b(sb, 0) - a(sa, 0) * b(sb, 2);
+    res(0, 2) = a(sa, 0) * b(sb, 1) - a(sa, 1) * b(sb, 0);
+    return res;
     }
   
   

--- a/include/color_spinor.h
+++ b/include/color_spinor.h
@@ -1005,22 +1005,22 @@ namespace quda {
 
   /**
      Compute the cross product of two color vectors at spin sa and sb
-     cProd = \sum_{j,k} \epsilon_{i,j,k} a(s1,j) b(s2,k)     
+     cProd = \sum_{j,k} \epsilon_{i,j,k} a(s1,j) b(s2,k)
+     NB: Implemented for Nc=3 only
      @param a j ColorSpinor
      @param b k ColorSpinor
      @param sa j spin index
      @param sb k spin index
      @return The cross product
   */
-  template <typename Float, int Nc, int Ns>
-    __device__ __host__ inline ColorSpinor<Float, Nc, 1> crossProduct(const ColorSpinor<Float, Nc, Ns> &a,
-								      const ColorSpinor<Float, Nc, Ns> &b, int sa, int sb)
+  template <typename Float, 3, int Ns>
+    __device__ __host__ inline ColorSpinor<Float, Nc, 1> crossProduct(const ColorSpinor<Float, 3, Ns> &a,
+								      const ColorSpinor<Float, 3, Ns> &b, int sa, int sb)
     {
-      ColorSpinor<Float, Nc, 1> res;
+      ColorSpinor<Float, 3, 1> res;
       res(0,0) = a(sa,1) * b(sb,2) - a(sa,2) * b(sb,1);
       res(0,1) = a(sa,2) * b(sb,0) - a(sa,0) * b(sb,2);
-      res(0,2) = a(sa,0) * b(sb,1) - a(sa,1) * b(sb,0);
-      
+      res(0,2) = a(sa,0) * b(sb,1) - a(sa,1) * b(sb,0);      
       return res;
     }
   

--- a/include/color_spinor.h
+++ b/include/color_spinor.h
@@ -931,11 +931,11 @@ namespace quda {
 							  const ColorSpinor<Float, Nc, Ns> &b, int sa, int sb)
   {
     complex<Float> dot = 0;
-    for (int c = 0; c < Nc; c++) {
-      dot.x += a(sa, c).real() * b(sb, c).real();
-      dot.x -= a(sa, c).imag() * b(sb, c).imag();
-      dot.y += a(sa, c).real() * b(sb, c).imag();
-      dot.y += a(sa, c).imag() * b(sb, c).real();
+    for (int c = 0; c < Nc; c++) {      
+      dot.real(dot.real() + a(sa, c).real() * b(sb, c).real());
+      dot.real(dot.real() - a(sa, c).imag() * b(sb, c).imag());
+      dot.imag(dot.imag() + a(sa, c).real() * b(sb, c).imag());
+      dot.imag(dot.imag() + a(sa, c).imag() * b(sb, c).real());
     }
     
     return dot;
@@ -972,10 +972,10 @@ namespace quda {
     complex<Float> dot = 0;
 #pragma unroll
     for (int c = 0; c < Nc; c++) {
-      dot.x += a(sa, c).real() * b(sb, c).real();
-      dot.x += a(sa, c).imag() * b(sb, c).imag();
-      dot.y += a(sa, c).real() * b(sb, c).imag();
-      dot.y -= a(sa, c).imag() * b(sb, c).real();
+      dot.real(dot.real() + a(sa, c).real() * b(sb, c).real());
+      dot.real(dot.real() + a(sa, c).imag() * b(sb, c).imag());
+      dot.imag(dot.imag() + a(sa, c).real() * b(sb, c).imag());
+      dot.imag(dot.imag() - a(sa, c).imag() * b(sb, c).real());      
     }
     return dot;
   }
@@ -995,10 +995,10 @@ namespace quda {
     complex<Float> dot = 0;
 #pragma unroll
     for (int c = 0; c < Nc; c++) {
-      dot.x += a(sa, c).real() * b(sb, c).real();
-      dot.x += a(sa, c).imag() * b(sb, c).imag();
-      dot.y += a(sa, c).real() * b(sb, c).imag();
-      dot.y -= a(sa, c).imag() * b(sb, c).real();
+      dot.real(dot.real() + a(sa, c).real() * b(sb, c).real());
+      dot.real(dot.real() + a(sa, c).imag() * b(sb, c).imag());
+      dot.imag(dot.imag() + a(sa, c).real() * b(sb, c).imag());
+      dot.imag(dot.imag() - a(sa, c).imag() * b(sb, c).real());
     }
     return dot;
   }

--- a/include/color_spinor.h
+++ b/include/color_spinor.h
@@ -1013,7 +1013,7 @@ namespace quda {
      @param sb k spin index
      @return The cross product
   */
-  template <typename Float, 3, int Ns>
+  template <typename Float, int Ns>
     __device__ __host__ inline ColorSpinor<Float, 3, 1> crossProduct(const ColorSpinor<Float, 3, Ns> &a,
 								      const ColorSpinor<Float, 3, Ns> &b, int sa, int sb)
     {

--- a/lib/reduce_quda.cu
+++ b/lib/reduce_quda.cu
@@ -59,7 +59,7 @@ namespace quda {
       }
     }
 
-    void initReduce()
+    size_t reduceBufferSize()
     {
       /* we have these different reductions to cater for:
 
@@ -74,15 +74,19 @@ namespace quda {
            maximum number of blocks = 2 x SM count
       */
 
-      const int reduce_size = 4 * sizeof(device_reduce_t);
-      const int max_reduce_blocks = 2*deviceProp.multiProcessorCount;
-
-      const int max_reduce = 2 * max_reduce_blocks * reduce_size;
-      const int max_multi_reduce = 2 * QUDA_MAX_MULTI_REDUCE * max_reduce_blocks * reduce_size;
+      int reduce_size = 4 * sizeof(device_reduce_t);
+      int max_reduce = 2 * reduce_size;
+      int max_multi_reduce = 2 * QUDA_MAX_MULTI_REDUCE * reduce_size;
+      int max_reduce_blocks = 2 * deviceProp.multiProcessorCount;
 
       // reduction buffer size
-      size_t bytes = max_reduce > max_multi_reduce ? max_reduce : max_multi_reduce;
+      size_t bytes = max_reduce_blocks * std::max(max_reduce, max_multi_reduce);
+      return bytes;
+    }
 
+    void initReduce()
+    {
+      auto bytes = reduceBufferSize();
       if (!d_reduce) d_reduce = (device_reduce_t *) device_malloc(bytes);
 
       // these arrays are actually oversized currently (only needs to be device_reduce_t x 3)


### PR DESCRIPTION
This cherry-pick (and a commit) adds some tweaks needed for our the stochastic laph-NN code:

1. From @maddyscientist: Add an optional argument to ReduceArg where the argument is the number of independent reductions requested in the kernel and if this argument is non zero, there is a run-time check to ensure that the number of reductions is not greater than the maximum number possible.
2. Two minor additions to the ColorSpinor struct. One allows the user to call color contractions of spinors of different spin (eg, a spin 1 laplacian eigenvector and a spin 4 Wilson like vector) to give an open spin index contraction. The second is the addition of a color cross product `\epsilon_{ijk} A_{j} B_{k} = C_{i}` which is hardcoded to use 3 colors only.