### PR TITLE
Hotfix/ldg

### DIFF
--- a/include/color_spinor_field_order.h
+++ b/include/color_spinor_field_order.h
@@ -676,11 +676,13 @@ namespace quda {
        */
       __device__ __host__ inline const complex<Float> operator()(int parity, int x_cb, int s, int c, int n=0) const
       {
-#ifdef __CUDA_ARCH__
+#if (__CUDA_ARCH__ >= 320 && __CUDA_ARCH__ < 520)
         if (!fixed) {
-          return complex<Float>(__ldg(v + accessor.index(parity, x_cb, s, c, n)));
+          auto v_ = __ldg(v + accessor.index(parity, x_cb, s, c, n));
+          return complex<Float>(v_.x, v_.y);
         } else {
-          complex<storeFloat> tmp = __ldg(v + accessor.index(parity, x_cb, s, c, n));
+          auto v_ = __ldg(v + accessor.index(parity, x_cb, s, c, n));
+          complex<storeFloat> tmp(v_.x, v_.y);
           Float norm_ = block_float ? __ldg(norm + parity * norm_offset + x_cb) : scale_inv;
           return norm_*complex<Float>(static_cast<Float>(tmp.x), static_cast<Float>(tmp.y));
         }
@@ -719,14 +721,16 @@ namespace quda {
        */
       __device__ __host__ inline const complex<Float> Ghost(int dim, int dir, int parity, int x_cb, int s, int c, int n=0) const
       {
-#ifdef __CUDA_ARCH__
+#if (__CUDA_ARCH__ >= 320 && __CUDA_ARCH__ < 520)
         if (!ghost_fixed) {
-          return complex<Float>(__ldg(ghost[2 * dim + dir] + ghostAccessor.index(dim, dir, parity, x_cb, s, c, n)));
+          auto v_ = __ldg(ghost[2 * dim + dir] + ghostAccessor.index(dim, dir, parity, x_cb, s, c, n));
+          return complex<Float>(v_.x, v_.y);
         } else {
           Float scale = ghost_scale_inv;
           if (block_float_ghost)
             scale *= __ldg(ghost_norm[2 * dim + dir] + parity * ghostAccessor.faceVolumeCB[dim] + x_cb);
-          complex<ghostFloat> tmp = __ldg(ghost[2 * dim + dir] + ghostAccessor.index(dim, dir, parity, x_cb, s, c, n));
+          auto v_ = __ldg(ghost[2 * dim + dir] + ghostAccessor.index(dim, dir, parity, x_cb, s, c, n));
+          complex<ghostFloat> tmp(v_.x, v_.y);
           return scale*complex<Float>(static_cast<Float>(tmp.x), static_cast<Float>(tmp.y));
         }
 #else

--- a/include/register_traits.h
+++ b/include/register_traits.h
@@ -482,16 +482,16 @@ namespace quda {
   template <> struct TexVectorType<char, 4>{typedef char4 type; };
 
   template <typename VectorType>
-    __device__ __host__ inline VectorType vector_load(void *ptr, int idx) {
-#define USE_LDG
-#if defined(__CUDA_ARCH__) && defined(USE_LDG)
+    __device__ __host__ inline VectorType vector_load(const void * __restrict__ ptr, int idx)
+  {
+#if (__CUDA_ARCH__ >= 320 && __CUDA_ARCH__ < 520)
     return __ldg(reinterpret_cast< VectorType* >(ptr) + idx);
 #else
-    return reinterpret_cast< VectorType* >(ptr)[idx];
+    return reinterpret_cast< const VectorType __restrict__ * >(ptr)[idx];
 #endif
   }
 
-  template <> __device__ __host__ inline short8 vector_load(void *ptr, int idx)
+  template <> __device__ __host__ inline short8 vector_load(const void * __restrict__ ptr, int idx)
   {
     float4 tmp = vector_load<float4>(ptr, idx);
     short8 recast;
@@ -499,7 +499,7 @@ namespace quda {
     return recast;
   }
 
-  template <> __device__ __host__ inline char8 vector_load(void *ptr, int idx)
+  template <> __device__ __host__ inline char8 vector_load(const void * __restrict__ ptr, int idx)
   {
     float2 tmp = vector_load<float2>(ptr, idx);
     char8 recast;

--- a/include/register_traits.h
+++ b/include/register_traits.h
@@ -482,16 +482,16 @@ namespace quda {
   template <> struct TexVectorType<char, 4>{typedef char4 type; };
 
   template <typename VectorType>
-    __device__ __host__ inline VectorType vector_load(const void * __restrict__ ptr, int idx)
+    __device__ __host__ inline VectorType vector_load(const void *ptr, int idx)
   {
 #if (__CUDA_ARCH__ >= 320 && __CUDA_ARCH__ < 520)
     return __ldg(reinterpret_cast< VectorType* >(ptr) + idx);
 #else
-    return reinterpret_cast< const VectorType __restrict__ * >(ptr)[idx];
+    return reinterpret_cast< const VectorType * >(ptr)[idx];
 #endif
   }
 
-  template <> __device__ __host__ inline short8 vector_load(const void * __restrict__ ptr, int idx)
+  template <> __device__ __host__ inline short8 vector_load(const void *ptr, int idx)
   {
     float4 tmp = vector_load<float4>(ptr, idx);
     short8 recast;
@@ -499,7 +499,7 @@ namespace quda {
     return recast;
   }
 
-  template <> __device__ __host__ inline char8 vector_load(const void * __restrict__ ptr, int idx)
+  template <> __device__ __host__ inline char8 vector_load(const void *ptr, int idx)
   {
     float2 tmp = vector_load<float2>(ptr, idx);
     char8 recast;

--- a/lib/gauge_force.cu
+++ b/lib/gauge_force.cu
@@ -1,7 +1,6 @@
 #include <gauge_field_order.h>
 #include <quda_matrix.h>
 #include <index_helper.cuh>
-#include <generics/ldg.h>
 #include <tune_quda.h>
 #include <instantiate.h>
 

--- a/tests/staggered_invert_test.cpp
+++ b/tests/staggered_invert_test.cpp
@@ -248,8 +248,6 @@ int main(int argc, char **argv)
   }
 
   // Create ghost gauge fields in case of multi GPU builds.
-#ifdef MULTI_GPU
-
   gauge_param.reconstruct = QUDA_RECONSTRUCT_NO;
   gauge_param.location = QUDA_CPU_FIELD_LOCATION;
 
@@ -261,8 +259,6 @@ int main(int argc, char **argv)
   GaugeFieldParam cpuLongParam(milc_longlink, gauge_param);
   cpuLongParam.ghostExchange = QUDA_GHOST_EXCHANGE_PAD;
   cpuLong = GaugeField::Create(cpuLongParam);
-  // constructStaggeredHostGhostGaugeField(cpuFat, cpuLong, milc_fatlink, milc_longlink, gauge_param);
-#endif
 
   loadFatLongGaugeQuda(milc_fatlink, milc_longlink, gauge_param);
 
@@ -408,10 +404,8 @@ int main(int argc, char **argv)
   if (milc_fatlink != nullptr) { free(milc_fatlink); milc_fatlink = nullptr; }
   if (milc_longlink != nullptr) { free(milc_longlink); milc_longlink = nullptr; }
 
-#ifdef MULTI_GPU
   if (cpuFat != nullptr) { delete cpuFat; cpuFat = nullptr; }
   if (cpuLong != nullptr) { delete cpuLong; cpuLong = nullptr; }
-#endif
 
   delete in;
   delete out;


### PR DESCRIPTION
Only use `__ldg` on Kepler to Maxwell 1 architectures, else use generic loads.  On Maxwell 2 on upwards this will lead to cached loads, giving equivalent performance and behaviour to `__ldg`.