### PR TITLE
Feature/device

### DIFF
--- a/include/device.h
+++ b/include/device.h
@@ -1,0 +1,39 @@
+namespace quda
+{
+
+  namespace device
+  {
+
+    /**
+       @brief Create the device context.  Called by initQuda when
+       initializing the library.
+     */
+    void init(int dev);
+
+    /**
+       @brief Create the streams associated with parallel execution.
+     */
+    void create_context();
+
+    /**
+       @brief Free any persistent context state.  Called by endQuda when
+       tearing down the library.
+     */
+    void destroy();
+
+    namespace profile
+    {
+
+      /**
+         @brief Start profiling
+       */
+      void start();
+
+      /**
+         @brief Stop profiling
+       */
+      void stop();
+    }
+
+  }
+}

--- a/include/malloc_quda.h
+++ b/include/malloc_quda.h
@@ -62,6 +62,11 @@ namespace quda {
 
   QudaFieldLocation get_pointer_location(const void *ptr);
 
+  /*
+    @brief Get device view of a host-mapped pointer
+   */
+  void *get_mapped_device_pointer_(const char *func, const char *file, int line, const void *ptr);
+
   /**
    * @return whether the pointer is aligned
    */
@@ -82,7 +87,7 @@ namespace quda {
 #define device_pinned_free(ptr) quda::device_pinned_free_(__func__, quda::file_name(__FILE__), __LINE__, ptr)
 #define managed_free(ptr) quda::managed_free_(__func__, quda::file_name(__FILE__), __LINE__, ptr)
 #define host_free(ptr) quda::host_free_(__func__, quda::file_name(__FILE__), __LINE__, ptr)
-
+#define get_mapped_device_pointer(ptr) quda::get_mapped_device_pointer_(__func__, quda::file_name(__FILE__), __LINE__, ptr)
 
 namespace quda {
 

--- a/lib/cuda_color_spinor_field.cpp
+++ b/lib/cuda_color_spinor_field.cpp
@@ -158,10 +158,10 @@ namespace quda {
 	break;
       case QUDA_MEMORY_MAPPED:
 	v_h = mapped_malloc(bytes);
-	cudaHostGetDevicePointer(&v, v_h, 0); // set the matching device pointer
+	v = get_mapped_device_pointer(v_h);
 	if (precision == QUDA_HALF_PRECISION || precision == QUDA_QUARTER_PRECISION) {
 	  norm_h = mapped_malloc(norm_bytes);
-	  cudaHostGetDevicePointer(&norm, norm_h, 0); // set the matching device pointer
+	  norm = get_mapped_device_pointer(norm_h); // set the matching device pointer
 	}
 	break;
       default:
@@ -429,9 +429,7 @@ namespace quda {
 
       if (src.FieldOrder() == QUDA_PADDED_SPACE_SPIN_COLOR_FIELD_ORDER) {
         // special case where we use mapped memory to read/write directly from application's array
-        void *src_d;
-        cudaError_t error = cudaHostGetDevicePointer(&src_d, const_cast<void*>(src.V()), 0);
-        if (error != cudaSuccess) errorQuda("Failed to get device pointer for ColorSpinorField field");
+        void *src_d = get_mapped_device_pointer(src.V());
         copyGenericColorSpinor(*this, src, QUDA_CUDA_FIELD_LOCATION, v, src_d);
       } else {
         void *Src=nullptr, *srcNorm=nullptr, *buffer=nullptr;
@@ -445,8 +443,7 @@ namespace quda {
           buffer = pool_pinned_malloc(src.Bytes()+src.NormBytes());
           memcpy(buffer, src.V(), src.Bytes());
           memcpy(static_cast<char*>(buffer)+src.Bytes(), src.Norm(), src.NormBytes());
-          cudaError_t error = cudaHostGetDevicePointer(&Src, buffer, 0);
-          if (error != cudaSuccess) errorQuda("Failed to get device pointer for ColorSpinorField field");
+          Src = get_mapped_device_pointer(buffer);
           srcNorm = static_cast<char*>(Src) + src.Bytes();
         }
 
@@ -478,9 +475,7 @@ namespace quda {
 
       if (dest.FieldOrder() == QUDA_PADDED_SPACE_SPIN_COLOR_FIELD_ORDER) {
 	// special case where we use zero-copy memory to read/write directly from application's array
-	void *dest_d;
-	cudaError_t error = cudaHostGetDevicePointer(&dest_d, const_cast<void*>(dest.V()), 0);
-        if (error != cudaSuccess) errorQuda("Failed to get device pointer for ColorSpinorField field");
+	void *dest_d = get_mapped_device_pointer(dest.V());
         copyGenericColorSpinor(dest, *this, QUDA_CUDA_FIELD_LOCATION, dest_d, v);
       } else {
         void *dst = nullptr, *dstNorm = nullptr, *buffer = nullptr;
@@ -490,8 +485,7 @@ namespace quda {
           dstNorm = static_cast<char*>(dst) + dest.Bytes();
         } else {
           buffer = pool_pinned_malloc(dest.Bytes()+dest.NormBytes());
-          cudaError_t error = cudaHostGetDevicePointer(&dst, buffer, 0);
-          if (error != cudaSuccess) errorQuda("Failed to get device pointer for ColorSpinorField");
+          dst = get_mapped_device_pointer(buffer);
           dstNorm = static_cast<char*>(dst)+dest.Bytes();
         }
 

--- a/lib/cuda_gauge_field.cpp
+++ b/lib/cuda_gauge_field.cpp
@@ -46,7 +46,7 @@ namespace quda {
 	break;
       case QUDA_MEMORY_MAPPED:
         gauge_h = mapped_malloc(bytes);
-	cudaHostGetDevicePointer(&gauge, gauge_h, 0); // set the matching device pointer
+	gauge = get_mapped_device_pointer(gauge_h); // set the matching device pointer
 	break;
       default:
 	errorQuda("Unsupported memory type %d", mem_type);
@@ -576,9 +576,7 @@ namespace quda {
             src.Order() == QUDA_BQCD_GAUGE_ORDER      ||
             src.Order() == QUDA_TIFR_PADDED_GAUGE_ORDER) {
 	  // special case where we use zero-copy memory to read/write directly from application's array
-	  void *src_d;
-	  cudaError_t error = cudaHostGetDevicePointer(&src_d, const_cast<void*>(src.Gauge_p()), 0);
-	  if (error != cudaSuccess) errorQuda("Failed to get device pointer for MILC site / BQCD array");
+	  void *src_d = get_mapped_device_pointer(src.Gauge_p());
 
 	  if (src.GhostExchange() == QUDA_GHOST_EXCHANGE_NO) {
 	    copyGenericGauge(*this, src, QUDA_CUDA_FIELD_LOCATION, gauge, src_d);
@@ -654,9 +652,7 @@ namespace quda {
           cpu.Order() == QUDA_BQCD_GAUGE_ORDER      ||
           cpu.Order() == QUDA_TIFR_PADDED_GAUGE_ORDER) {
 	// special case where we use zero-copy memory to read/write directly from application's array
-	void *cpu_d;
-	cudaError_t error = cudaHostGetDevicePointer(&cpu_d, const_cast<void*>(cpu.Gauge_p()), 0);
-	if (error != cudaSuccess) errorQuda("Failed to get device pointer for MILC site / BQCD array");
+	void *cpu_d = get_mapped_device_pointer(cpu.Gauge_p());
 	if (cpu.GhostExchange() == QUDA_GHOST_EXCHANGE_NO) {
 	  copyGenericGauge(cpu, *this, QUDA_CUDA_FIELD_LOCATION, cpu_d, gauge);
 	} else {

--- a/lib/dslash_quda.cu
+++ b/lib/dslash_quda.cu
@@ -85,11 +85,6 @@ namespace quda {
     // FIX this is a hack from hell
     // Auxiliary work that can be done while waiting on comms to finis
     Worker *aux_worker;
-
-#if CUDA_VERSION >= 8000
-    cuuint32_t *commsEnd_h;
-    CUdeviceptr commsEnd_d[Nstream];
-#endif
   }
 
   void createDslashEvents()
@@ -108,14 +103,6 @@ namespace quda {
     }
 
     aux_worker = NULL;
-
-#if CUDA_VERSION >= 8000
-    commsEnd_h = static_cast<cuuint32_t*>(mapped_malloc(Nstream*sizeof(int)));
-    for (int i=0; i<Nstream; i++) {
-      commsEnd_d[i] = (CUdeviceptr)get_mapped_device_pointer(commsEnd_h+i);
-      commsEnd_h[i] = 0;
-    }
-#endif
 
     checkCudaError();
 
@@ -144,11 +131,6 @@ namespace quda {
   void destroyDslashEvents()
   {
     using namespace dslash;
-
-#if CUDA_VERSION >= 8000
-    host_free(commsEnd_h);
-    commsEnd_h = 0;
-#endif
 
     for (int i=0; i<Nstream; i++) {
       cudaEventDestroy(gatherStart[i]);

--- a/lib/dslash_quda.cu
+++ b/lib/dslash_quda.cu
@@ -112,7 +112,7 @@ namespace quda {
 #if CUDA_VERSION >= 8000
     commsEnd_h = static_cast<cuuint32_t*>(mapped_malloc(Nstream*sizeof(int)));
     for (int i=0; i<Nstream; i++) {
-      cudaHostGetDevicePointer((void**)&commsEnd_d[i], commsEnd_h+i, 0);
+      commsEnd_d[i] = (CUdeviceptr)get_mapped_device_pointer(commsEnd_h+i);
       commsEnd_h[i] = 0;
     }
 #endif

--- a/lib/gauge_observable.cpp
+++ b/lib/gauge_observable.cpp
@@ -9,8 +9,7 @@ namespace quda
     profile.TPSTART(QUDA_PROFILE_COMPUTE);
     if (param.su_project) {
       int *num_failures_h = static_cast<int *>(pool_pinned_malloc(sizeof(int)));
-      int *num_failures_d;
-      cudaHostGetDevicePointer(&num_failures_d, num_failures_h, 0);
+      int *num_failures_d = static_cast<int *>(get_mapped_device_pointer(num_failures_h));
       *num_failures_h = 0;
       auto tol = u.Precision() == QUDA_DOUBLE_PRECISION ? 1e-14 : QUDA_SINGLE_PRECISION;
       projectSU3(u, tol, num_failures_d);

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -9,6 +9,7 @@
 #include <quda.h>
 #include <quda_fortran.h>
 #include <quda_internal.h>
+#include <device.h>
 #include <comm_quda.h>
 #include <tune_quda.h>
 #include <blas_quda.h>
@@ -29,19 +30,7 @@
 #include <mpi_comm_handle.h>
 
 #include <multigrid.h>
-
 #include <deflation.h>
-
-#ifdef NUMA_NVML
-#include <numa_affinity.h>
-#endif
-
-#ifdef QUDA_NVML
-#include <nvml.h>
-#endif
-
-#include <cuda.h>
-
 #include <ks_force_quda.h>
 
 #ifdef GPU_GAUGE_FORCE
@@ -51,8 +40,6 @@
 
 #define MAX(a,b) ((a)>(b)? (a):(b))
 #define TDIFF(a,b) (b.tv_sec - a.tv_sec + 0.000001*(b.tv_usec - a.tv_usec))
-
-#define MAX_GPU_NUM_PER_NODE 16
 
 // define newQudaGaugeParam() and newQudaInvertParam()
 #define INIT_PARAM
@@ -73,9 +60,6 @@
 #include <contract_quda.h>
 
 #include <momentum.h>
-
-
-#include <cuda_profiler_api.h>
 
 using namespace quda;
 
@@ -150,9 +134,6 @@ std::vector< std::vector<ColorSpinorField*> > chronoResident(QUDA_MAX_CHRONO);
 // Mapped memory buffer used to hold unitarization failures
 static int *num_failures_h = nullptr;
 static int *num_failures_d = nullptr;
-
-cudaDeviceProp deviceProp;
-qudaStream_t *streams;
 
 static bool initialized = false;
 
@@ -250,10 +231,8 @@ static TimeProfile profileInit2End("initQuda-endQuda",false);
 static bool enable_profiler = false;
 static bool do_not_profile_quda = false;
 
-static void profilerStart(const char *f) {
-
-
-
+static void profilerStart(const char *f)
+{
   static std::vector<int> target_list;
   static bool enable = false;
   static bool init = false;
@@ -277,7 +256,6 @@ static void profilerStart(const char *f) {
      }
    }
 
-
     char* donotprofile_env = getenv("QUDA_DO_NOT_PROFILE"); // disable profiling of QUDA parts
     if (donotprofile_env && (!(strcmp(donotprofile_env, "0") == 0)))  {
       do_not_profile_quda=true;
@@ -289,14 +267,14 @@ static void profilerStart(const char *f) {
   static int target_count = 0;
   static unsigned int i = 0;
   if (do_not_profile_quda){
-    cudaProfilerStop();
+    device::profile::stop();
     printfQuda("Stopping profiling in QUDA\n");
   } else {
     if (enable) {
       if (i < target_list.size() && target_count++ == target_list[i]) {
         enable_profiler = true;
         printfQuda("Starting profiling for %s\n", f);
-        cudaProfilerStart();
+        device::profile::start();
       i++; // advance to next target
     }
   }
@@ -304,13 +282,13 @@ static void profilerStart(const char *f) {
 }
 
 static void profilerStop(const char *f) {
-  if(do_not_profile_quda){
-    cudaProfilerStart();
+  if (do_not_profile_quda){
+    device::profile::start();
   } else {
 
     if (enable_profiler) {
       printfQuda("Stopping profiling for %s\n", f);
-      cudaProfilerStop();
+      device::profile::stop();
       enable_profiler = false;
     }
   }
@@ -481,8 +459,8 @@ extern char* gitversion;
 /*
  * Set the device that QUDA uses.
  */
-void initQudaDevice(int dev) {
-
+void initQudaDevice(int dev)
+{
   //static bool initialized = false;
   if (initialized) return;
   initialized = true;
@@ -499,123 +477,18 @@ void initQudaDevice(int dev) {
 #endif
   }
 
-  int driver_version;
-  cudaDriverGetVersion(&driver_version);
-  printfQuda("CUDA Driver version = %d\n", driver_version);
-
-  int runtime_version;
-  cudaRuntimeGetVersion(&runtime_version);
-  printfQuda("CUDA Runtime version = %d\n", runtime_version);
-
-#ifdef QUDA_NVML
-  nvmlReturn_t result = nvmlInit();
-  if (NVML_SUCCESS != result) errorQuda("NVML Init failed with error %d", result);
-  const int length = 80;
-  char graphics_version[length];
-  result = nvmlSystemGetDriverVersion(graphics_version, length);
-  if (NVML_SUCCESS != result) errorQuda("nvmlSystemGetDriverVersion failed with error %d", result);
-  printfQuda("Graphic driver version = %s\n", graphics_version);
-  result = nvmlShutdown();
-  if (NVML_SUCCESS != result) errorQuda("NVML Shutdown failed with error %d", result);
-#endif
-
-#if defined(MULTI_GPU) && (CUDA_VERSION == 4000)
-  //check if CUDA_NIC_INTEROP is set to 1 in the enviroment
-  // not needed for CUDA >= 4.1
-  char* cni_str = getenv("CUDA_NIC_INTEROP");
-  if(cni_str == nullptr){
-    errorQuda("Environment variable CUDA_NIC_INTEROP is not set");
-  }
-  int cni_int = atoi(cni_str);
-  if (cni_int != 1){
-    errorQuda("Environment variable CUDA_NIC_INTEROP is not set to 1");
-  }
-#endif
-
-  int deviceCount;
-  cudaGetDeviceCount(&deviceCount);
-  if (deviceCount == 0) {
-    errorQuda("No CUDA devices found");
-  }
-
-  for(int i=0; i<deviceCount; i++) {
-    cudaGetDeviceProperties(&deviceProp, i);
-    checkCudaErrorNoSync(); // "NoSync" for correctness in HOST_DEBUG mode
-    if (getVerbosity() >= QUDA_SUMMARIZE) {
-      printfQuda("Found device %d: %s\n", i, deviceProp.name);
-    }
-  }
-
 #ifdef MULTI_GPU
   if (dev < 0) {
     if (!comms_initialized) {
       errorQuda("initDeviceQuda() called with a negative device ordinal, but comms have not been initialized");
-    }
+        }
     dev = comm_gpuid();
   }
 #else
   if (dev < 0 || dev >= 16) errorQuda("Invalid device number %d", dev);
 #endif
 
-  cudaGetDeviceProperties(&deviceProp, dev);
-  checkCudaErrorNoSync(); // "NoSync" for correctness in HOST_DEBUG mode
-  if (deviceProp.major < 1) {
-    errorQuda("Device %d does not support CUDA", dev);
-  }
-
-
-// Check GPU and QUDA build compatibiliy
-// 4 cases:
-// a) QUDA and GPU match: great
-// b) QUDA built for higher compute capability: error
-// c) QUDA built for lower major compute capability: warn if QUDA_ALLOW_JIT, else error
-// d) QUDA built for same major compute capability but lower minor: warn
-
-  const int my_major = __COMPUTE_CAPABILITY__ / 100;
-  const int my_minor = (__COMPUTE_CAPABILITY__  - my_major * 100) / 10;
-// b) UDA was compiled for a higher compute capability
-  if (deviceProp.major * 100 + deviceProp.minor * 10 < __COMPUTE_CAPABILITY__)
-    errorQuda("** Running on a device with compute capability %i.%i but QUDA was compiled for %i.%i. ** \n --- Please set the correct QUDA_GPU_ARCH when running cmake.\n", deviceProp.major, deviceProp.minor, my_major, my_minor);
-
-
-// c) QUDA was compiled for a lower compute capability
-  if (deviceProp.major < my_major) {
-    char *allow_jit_env = getenv("QUDA_ALLOW_JIT");
-    if (allow_jit_env && strcmp(allow_jit_env, "1") == 0) {
-      if (getVerbosity() > QUDA_SILENT) warningQuda("** Running on a device with compute capability %i.%i but QUDA was compiled for %i.%i. **\n -- Jitting the PTX since QUDA_ALLOW_JIT=1 was set. Note that this will take some time.\n", deviceProp.major, deviceProp.minor, my_major, my_minor);
-    } else {
-      errorQuda("** Running on a device with compute capability %i.%i but QUDA was compiled for %i.%i. **\n --- Please set the correct QUDA_GPU_ARCH when running cmake.\n If you want the PTX to be jitted for your current GPU arch please set the enviroment variable QUDA_ALLOW_JIT=1.", deviceProp.major, deviceProp.minor, my_major, my_minor);
-    }
-  }
-// d) QUDA built for same major compute capability but lower minor
-  if (deviceProp.major == my_major and deviceProp.minor > my_minor) {
-    warningQuda("** Running on a device with compute capability %i.%i but QUDA was compiled for %i.%i. **\n -- This might result in a lower performance. Please consider adjusting QUDA_GPU_ARCH when running cmake.\n", deviceProp.major, deviceProp.minor, my_major, my_minor);
-  }
-
-  if (getVerbosity() >= QUDA_SUMMARIZE) {
-    printfQuda("Using device %d: %s\n", dev, deviceProp.name);
-  }
-#ifndef USE_QDPJIT
-  cudaSetDevice(dev);
-  checkCudaErrorNoSync(); // "NoSync" for correctness in HOST_DEBUG mode
-#endif
-
-
-#if ((CUDA_VERSION >= 6000) && defined NUMA_NVML)
-  char *enable_numa_env = getenv("QUDA_ENABLE_NUMA");
-  if (enable_numa_env && strcmp(enable_numa_env, "0") == 0) {
-    if (getVerbosity() > QUDA_SILENT) printfQuda("Disabling numa_affinity\n");
-  }
-  else{
-    setNumaAffinityNVML(dev);
-  }
-#endif
-
-
-
-  cudaDeviceSetCacheConfig(cudaFuncCachePreferL1);
-  //cudaDeviceSetSharedMemConfig(cudaSharedMemBankSizeEightByte);
-  // cudaGetDeviceProperties(&deviceProp, dev);
+  device::init(dev);
 
   { // determine if we will do CPU or GPU data reordering (default is GPU)
     char *reorder_str = getenv("QUDA_REORDER_LOCATION");
@@ -643,18 +516,9 @@ void initQudaMemory()
 
   if (!comms_initialized) init_default_comms();
 
-  streams = new qudaStream_t[Nstream];
-
-  int greatestPriority;
-  int leastPriority;
-  cudaDeviceGetStreamPriorityRange(&leastPriority, &greatestPriority);
-  for (int i=0; i<Nstream-1; i++) {
-    cudaStreamCreateWithPriority(&streams[i], cudaStreamDefault, greatestPriority);
-  }
-  cudaStreamCreateWithPriority(&streams[Nstream-1], cudaStreamDefault, leastPriority);
-
-  checkCudaError();
+  device::create_context();
   createDslashEvents();
+
   blas::init();
 
   // initalize the memory pool allocators
@@ -1465,11 +1329,6 @@ void endQuda(void)
   num_failures_h = nullptr;
   num_failures_d = nullptr;
 
-  if (streams) {
-    for (int i=0; i<Nstream; i++) cudaStreamDestroy(streams[i]);
-    delete []streams;
-    streams = nullptr;
-  }
   destroyDslashEvents();
 
   saveTuneCache();
@@ -1528,12 +1387,7 @@ void endQuda(void)
 
   assertAllMemFree();
 
-  char *device_reset_env = getenv("QUDA_DEVICE_RESET");
-  if (device_reset_env && strcmp(device_reset_env,"1") == 0) {
-    // end this CUDA context
-    cudaDeviceReset();
-  }
-
+  device::destroy();
 }
 
 

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -525,7 +525,7 @@ void initQudaMemory()
   pool::init();
 
   num_failures_h = static_cast<int*>(mapped_malloc(sizeof(int)));
-  cudaHostGetDevicePointer(&num_failures_d, num_failures_h, 0);
+  num_failures_d = static_cast<int*>(get_mapped_device_pointer(num_failures_h));
 
   loadTuneCache();
 

--- a/lib/lattice_field.cpp
+++ b/lib/lattice_field.cpp
@@ -250,13 +250,13 @@ namespace quda {
 	  ghost_pinned_send_buffer_h[b] = mapped_malloc(ghost_bytes);
 
 	  // set the matching device-mapped pointer
-	  cudaHostGetDevicePointer(&ghost_pinned_send_buffer_hd[b], ghost_pinned_send_buffer_h[b], 0);
+	  ghost_pinned_send_buffer_hd[b] = get_mapped_device_pointer(ghost_pinned_send_buffer_h[b]);
 
 	  // pinned buffer used for receiving
 	  ghost_pinned_recv_buffer_h[b] = mapped_malloc(ghost_bytes);
 
 	  // set the matching device-mapped pointer
-	  cudaHostGetDevicePointer(&ghost_pinned_recv_buffer_hd[b], ghost_pinned_recv_buffer_h[b], 0);
+	  ghost_pinned_recv_buffer_hd[b] = get_mapped_device_pointer(ghost_pinned_recv_buffer_h[b]);
         }
 
         initGhostFaceBuffer = true;

--- a/lib/reduce_quda.cu
+++ b/lib/reduce_quda.cu
@@ -97,7 +97,7 @@ namespace quda {
 #if (defined(_MSC_VER) && defined(_WIN64)) || defined(__LP64__)
 	if(deviceProp.canMapHostMemory) {
 	  h_reduce = (device_reduce_t *) mapped_malloc(bytes);
-	  cudaHostGetDevicePointer(&hd_reduce, h_reduce, 0); // set the matching device pointer
+	  hd_reduce = (device_reduce_t *)get_mapped_device_pointer(h_reduce); // set the matching device pointer
 	} else
 #endif
 	  {

--- a/lib/targets/cuda/CMakeLists.txt
+++ b/lib/targets/cuda/CMakeLists.txt
@@ -1,5 +1,5 @@
 # generate an object library for all target specific files 
-add_library(quda_cuda_target OBJECT malloc.cpp tune.cpp blas_lapack_cublas.cpp)
+add_library(quda_cuda_target OBJECT device.cpp malloc.cpp tune.cpp blas_lapack_cublas.cpp)
 if(QUDA_BUILD_SHAREDLIB)
   set_target_properties(quda_cuda_target PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
 endif()

--- a/lib/targets/cuda/device.cpp
+++ b/lib/targets/cuda/device.cpp
@@ -1,0 +1,165 @@
+#include <cuda_runtime.h>
+#include <cuda_profiler_api.h>
+#include <util_quda.h>
+#include <quda_internal.h>
+
+#ifdef QUDA_NVML
+#include <nvml.h>
+#endif
+
+#ifdef NUMA_NVML
+#include <numa_affinity.h>
+#endif
+
+cudaDeviceProp deviceProp;
+qudaStream_t *streams;
+
+namespace quda
+{
+
+  namespace device
+  {
+
+    static bool initialized = false;
+
+    void init(int dev)
+    {
+      if (initialized) return;
+      initialized = true;
+
+      int driver_version;
+      cudaDriverGetVersion(&driver_version);
+      printfQuda("CUDA Driver version = %d\n", driver_version);
+
+      int runtime_version;
+      cudaRuntimeGetVersion(&runtime_version);
+      printfQuda("CUDA Runtime version = %d\n", runtime_version);
+
+#ifdef QUDA_NVML
+      nvmlReturn_t result = nvmlInit();
+      if (NVML_SUCCESS != result) errorQuda("NVML Init failed with error %d", result);
+      const int length = 80;
+      char graphics_version[length];
+      result = nvmlSystemGetDriverVersion(graphics_version, length);
+      if (NVML_SUCCESS != result) errorQuda("nvmlSystemGetDriverVersion failed with error %d", result);
+      printfQuda("Graphic driver version = %s\n", graphics_version);
+      result = nvmlShutdown();
+      if (NVML_SUCCESS != result) errorQuda("NVML Shutdown failed with error %d", result);
+#endif
+
+      int deviceCount;
+      cudaGetDeviceCount(&deviceCount);
+      if (deviceCount == 0) {
+        errorQuda("No CUDA devices found");
+      }
+
+      for (int i = 0; i < deviceCount; i++) {
+        cudaGetDeviceProperties(&deviceProp, i);
+        checkCudaErrorNoSync(); // "NoSync" for correctness in HOST_DEBUG mode
+        if (getVerbosity() >= QUDA_SUMMARIZE) {
+          printfQuda("Found device %d: %s\n", i, deviceProp.name);
+        }
+      }
+
+      cudaGetDeviceProperties(&deviceProp, dev);
+      checkCudaErrorNoSync(); // "NoSync" for correctness in HOST_DEBUG mode
+      if (deviceProp.major < 1) {
+        errorQuda("Device %d does not support CUDA", dev);
+      }
+
+      // Check GPU and QUDA build compatibiliy
+      // 4 cases:
+      // a) QUDA and GPU match: great
+      // b) QUDA built for higher compute capability: error
+      // c) QUDA built for lower major compute capability: warn if QUDA_ALLOW_JIT, else error
+      // d) QUDA built for same major compute capability but lower minor: warn
+
+      const int my_major = __COMPUTE_CAPABILITY__ / 100;
+      const int my_minor = (__COMPUTE_CAPABILITY__  - my_major * 100) / 10;
+      // b) UDA was compiled for a higher compute capability
+      if (deviceProp.major * 100 + deviceProp.minor * 10 < __COMPUTE_CAPABILITY__)
+        errorQuda("** Running on a device with compute capability %i.%i but QUDA was compiled for %i.%i. ** \n --- Please set the correct QUDA_GPU_ARCH when running cmake.\n", deviceProp.major, deviceProp.minor, my_major, my_minor);
+
+      // c) QUDA was compiled for a lower compute capability
+      if (deviceProp.major < my_major) {
+        char *allow_jit_env = getenv("QUDA_ALLOW_JIT");
+        if (allow_jit_env && strcmp(allow_jit_env, "1") == 0) {
+          if (getVerbosity() > QUDA_SILENT) warningQuda("** Running on a device with compute capability %i.%i but QUDA was compiled for %i.%i. **\n -- Jitting the PTX since QUDA_ALLOW_JIT=1 was set. Note that this will take some time.\n", deviceProp.major, deviceProp.minor, my_major, my_minor);
+        } else {
+          errorQuda("** Running on a device with compute capability %i.%i but QUDA was compiled for %i.%i. **\n --- Please set the correct QUDA_GPU_ARCH when running cmake.\n If you want the PTX to be jitted for your current GPU arch please set the enviroment variable QUDA_ALLOW_JIT=1.", deviceProp.major, deviceProp.minor, my_major, my_minor);
+        }
+      }
+      // d) QUDA built for same major compute capability but lower minor
+      if (deviceProp.major == my_major and deviceProp.minor > my_minor) {
+        warningQuda("** Running on a device with compute capability %i.%i but QUDA was compiled for %i.%i. **\n -- This might result in a lower performance. Please consider adjusting QUDA_GPU_ARCH when running cmake.\n", deviceProp.major, deviceProp.minor, my_major, my_minor);
+      }
+
+      if (getVerbosity() >= QUDA_SUMMARIZE) {
+        printfQuda("Using device %d: %s\n", dev, deviceProp.name);
+      }
+#ifndef USE_QDPJIT
+      cudaSetDevice(dev);
+      checkCudaErrorNoSync(); // "NoSync" for correctness in HOST_DEBUG mode
+#endif
+
+#ifdef NUMA_NVML
+      char *enable_numa_env = getenv("QUDA_ENABLE_NUMA");
+      if (enable_numa_env && strcmp(enable_numa_env, "0") == 0) {
+        if (getVerbosity() > QUDA_SILENT) printfQuda("Disabling numa_affinity\n");
+      } else{
+        setNumaAffinityNVML(dev);
+      }
+#endif
+
+      cudaDeviceSetCacheConfig(cudaFuncCachePreferL1);
+      //cudaDeviceSetSharedMemConfig(cudaSharedMemBankSizeEightByte);
+      // cudaGetDeviceProperties(&deviceProp, dev);
+    }
+
+    void create_context()
+    {
+      streams = new qudaStream_t[Nstream];
+
+      int greatestPriority;
+      int leastPriority;
+      cudaDeviceGetStreamPriorityRange(&leastPriority, &greatestPriority);
+      for (int i=0; i<Nstream-1; i++) {
+        cudaStreamCreateWithPriority(&streams[i], cudaStreamDefault, greatestPriority);
+      }
+      cudaStreamCreateWithPriority(&streams[Nstream-1], cudaStreamDefault, leastPriority);
+
+      checkCudaError();
+
+    }
+
+    void destroy()
+    {
+      if (streams) {
+        for (int i=0; i<Nstream; i++) cudaStreamDestroy(streams[i]);
+        delete []streams;
+        streams = nullptr;
+      }
+
+      char *device_reset_env = getenv("QUDA_DEVICE_RESET");
+      if (device_reset_env && strcmp(device_reset_env,"1") == 0) {
+        // end this CUDA context
+        cudaDeviceReset();
+      }
+    }
+
+    namespace profile {
+
+      void start()
+      {
+        cudaProfilerStart();
+      }
+
+      void stop()
+      {
+        cudaProfilerStop();
+      }
+
+    }
+
+  }
+}

--- a/lib/targets/cuda/malloc.cpp
+++ b/lib/targets/cuda/malloc.cpp
@@ -506,6 +506,18 @@ namespace quda
     }
   }
 
+  void *get_mapped_device_pointer_(const char *func, const char *file, int line, const void *host)
+  {
+    void *device;
+    auto error = cudaHostGetDevicePointer(&device, const_cast<void *>(host), 0);
+    if (error != cudaSuccess) {
+      errorQuda("cudaHostGetDevicePointer failed with error %s (%s:%d in %s()",
+                cudaGetErrorString(error), file, line, func);
+    }
+    return device;
+  }
+
+
   namespace pool
   {
 

--- a/tests/unitarize_link_test.cpp
+++ b/tests/unitarize_link_test.cpp
@@ -176,10 +176,8 @@ static int unitarize_link_test(int &test_rc)
 			     svd_rel_error,
 			     svd_abs_error);
 
-  int *num_failures_h = (int*)mapped_malloc(sizeof(int));
-  int *num_failures_d = nullptr;
-  cudaError_t error = cudaHostGetDevicePointer(&num_failures_d, num_failures_h, 0);
-  if (error != cudaSuccess) errorQuda("cudaHostGetDevicePointer failed with error: %s", cudaGetErrorString(error));
+  int *num_failures_h = static_cast<int *>(mapped_malloc(sizeof(int)));
+  int *num_failures_d = static_cast<int *>(get_mapped_device_pointer(num_failures_h));
   *num_failures_h = 0;
 
   struct timeval t0, t1;


### PR DESCRIPTION
The PR continues the abstraction effort and cleanup some old experiments:
* Move CUDA specific initialization and destruction from `initQuda` and `endQuda`, moving to new target-specific file lib/targets/cuda/device.cpp
* Abstracted `cudaHostGetDevicePointer` to new function, `get_mapped_device_pointer` in malloc.cpp
* In preparation of merging NVSHMEM, remove old asynchronous dslash policy experiments

Notably this PR removes all CUDA specifics from interface_quda.cpp