### PR TITLE
Feature/milc multishift double

### DIFF
--- a/lib/milc_interface.cpp
+++ b/lib/milc_interface.cpp
@@ -977,8 +977,8 @@ void qudaInvert(int external_precision, int quda_precision, double mass, QudaInv
 
   // override fine precision to double, switch to mixed as necessary
   if (!do_not_force_double && device_precision == QUDA_SINGLE_PRECISION) {
+    // force outer double
     device_precision = QUDA_DOUBLE_PRECISION;
-    // invalidateGaugeQuda();
   }
 
   QudaGaugeParam fat_param = newQudaGaugeParam();

--- a/lib/milc_interface.cpp
+++ b/lib/milc_interface.cpp
@@ -858,17 +858,19 @@ void qudaMultishiftInvert(int external_precision, int quda_precision, int num_of
   static bool force_double_queried = false;
   static bool do_not_force_double = false;
   if (!force_double_queried) {
-    char* donotusedouble_env = getenv("QUDA_MILC_OVERRIDE_DOUBLE_MULTISHIFT"); // disable forcing outer double precision
-    if (donotusedouble_env && (!(strcmp(donotusedouble_env, "0") == 0)))  {
-      do_not_force_double=true;
+    char *donotusedouble_env = getenv("QUDA_MILC_OVERRIDE_DOUBLE_MULTISHIFT"); // disable forcing outer double precision
+    if (donotusedouble_env && (!(strcmp(donotusedouble_env, "0") == 0))) {
+      do_not_force_double = true;
       printfQuda("Disabling always using double as fine precision for MILC multishift\n");
     }
     force_double_queried = true;
   }
 
   QudaPrecision device_precision = (quda_precision == 2) ? QUDA_DOUBLE_PRECISION : QUDA_SINGLE_PRECISION;
-  bool use_mixed_precision = (((quda_precision==2) && inv_args.mixed_precision) ||
-                          ((quda_precision==1) && (inv_args.mixed_precision==2)) ) ? true : false;
+  bool use_mixed_precision = (((quda_precision == 2) && inv_args.mixed_precision)
+                              || ((quda_precision == 1) && (inv_args.mixed_precision == 2))) ?
+    true :
+    false;
 
   QudaPrecision device_precision_sloppy;
   switch(inv_args.mixed_precision) {
@@ -956,9 +958,9 @@ void qudaInvert(int external_precision, int quda_precision, double mass, QudaInv
   static bool force_double_queried = false;
   static bool do_not_force_double = false;
   if (!force_double_queried) {
-    char* donotusedouble_env = getenv("QUDA_MILC_OVERRIDE_DOUBLE_MULTISHIFT"); // disable forcing outer double precision
-    if (donotusedouble_env && (!(strcmp(donotusedouble_env, "0") == 0)))  {
-      do_not_force_double=true;
+    char *donotusedouble_env = getenv("QUDA_MILC_OVERRIDE_DOUBLE_MULTISHIFT"); // disable forcing outer double precision
+    if (donotusedouble_env && (!(strcmp(donotusedouble_env, "0") == 0))) {
+      do_not_force_double = true;
       printfQuda("Disabling always using double as fine precision for MILC multishift\n");
     }
     force_double_queried = true;
@@ -976,7 +978,7 @@ void qudaInvert(int external_precision, int quda_precision, double mass, QudaInv
   // override fine precision to double, switch to mixed as necessary
   if (!do_not_force_double && device_precision == QUDA_SINGLE_PRECISION) {
     device_precision = QUDA_DOUBLE_PRECISION;
-    //invalidateGaugeQuda();
+    // invalidateGaugeQuda();
   }
 
   QudaGaugeParam fat_param = newQudaGaugeParam();

--- a/lib/milc_interface.cpp
+++ b/lib/milc_interface.cpp
@@ -854,14 +854,34 @@ void qudaMultishiftInvert(int external_precision, int quda_precision, int num_of
   if (target_residual[0] == 0) errorQuda("qudaMultishiftInvert: zeroth target residual cannot be zero\n");
 
   QudaPrecision host_precision = (external_precision == 2) ? QUDA_DOUBLE_PRECISION : QUDA_SINGLE_PRECISION;
+
+  static bool force_double_queried = false;
+  static bool do_not_force_double = false;
+  if (!force_double_queried) {
+    char* donotusedouble_env = getenv("QUDA_MILC_OVERRIDE_DOUBLE_MULTISHIFT"); // disable forcing outer double precision
+    if (donotusedouble_env && (!(strcmp(donotusedouble_env, "0") == 0)))  {
+      do_not_force_double=true;
+      printfQuda("Disabling always using double as fine precision for MILC multishift\n");
+    }
+    force_double_queried = true;
+  }
+
   QudaPrecision device_precision = (quda_precision == 2) ? QUDA_DOUBLE_PRECISION : QUDA_SINGLE_PRECISION;
-  const bool use_mixed_precision = (((quda_precision==2) && inv_args.mixed_precision) ||
-                                     ((quda_precision==1) && (inv_args.mixed_precision==2)) ) ? true : false;
+  bool use_mixed_precision = (((quda_precision==2) && inv_args.mixed_precision) ||
+                          ((quda_precision==1) && (inv_args.mixed_precision==2)) ) ? true : false;
+
   QudaPrecision device_precision_sloppy;
   switch(inv_args.mixed_precision) {
   case 2: device_precision_sloppy = QUDA_HALF_PRECISION; break;
   case 1: device_precision_sloppy = QUDA_SINGLE_PRECISION; break;
   default: device_precision_sloppy = device_precision;
+  }
+
+  // override fine precision to double, switch to mixed as necessary
+  if (!do_not_force_double && device_precision == QUDA_SINGLE_PRECISION) {
+    // force outer double
+    device_precision = QUDA_DOUBLE_PRECISION;
+    if (device_precision_sloppy == QUDA_SINGLE_PRECISION) use_mixed_precision = true;
   }
 
   QudaGaugeParam fat_param = newQudaGaugeParam();
@@ -889,7 +909,7 @@ void qudaMultishiftInvert(int external_precision, int quda_precision, int num_of
   setColorSpinorParams(localDim, host_precision, &csParam);
 
   // dirty hack to invalidate the cached gauge field without breaking interface compatability
-  if (*num_iters == -1) invalidateGaugeQuda();
+  if (*num_iters == -1 || !canReuseResidentGauge(&invertParam)) invalidateGaugeQuda();
 
   // set the solver
   if (invalidate_quda_gauge || !create_quda_gauge) {
@@ -931,15 +951,32 @@ void qudaInvert(int external_precision, int quda_precision, double mass, QudaInv
 
   if (target_fermilab_residual == 0 && target_residual == 0) errorQuda("qudaInvert: requesting zero residual\n");
 
-  // static const QudaVerbosity verbosity = getVerbosity();
   QudaPrecision host_precision = (external_precision == 2) ? QUDA_DOUBLE_PRECISION : QUDA_SINGLE_PRECISION;
-  QudaPrecision device_precision = (quda_precision == 2) ? QUDA_DOUBLE_PRECISION : QUDA_SINGLE_PRECISION;
-  QudaPrecision device_precision_sloppy;
 
+  static bool force_double_queried = false;
+  static bool do_not_force_double = false;
+  if (!force_double_queried) {
+    char* donotusedouble_env = getenv("QUDA_MILC_OVERRIDE_DOUBLE_MULTISHIFT"); // disable forcing outer double precision
+    if (donotusedouble_env && (!(strcmp(donotusedouble_env, "0") == 0)))  {
+      do_not_force_double=true;
+      printfQuda("Disabling always using double as fine precision for MILC multishift\n");
+    }
+    force_double_queried = true;
+  }
+
+  QudaPrecision device_precision = (quda_precision == 2) ? QUDA_DOUBLE_PRECISION : QUDA_SINGLE_PRECISION;
+
+  QudaPrecision device_precision_sloppy;
   switch(inv_args.mixed_precision) {
   case 2: device_precision_sloppy = QUDA_HALF_PRECISION; break;
   case 1: device_precision_sloppy = QUDA_SINGLE_PRECISION; break;
   default: device_precision_sloppy = device_precision;
+  }
+
+  // override fine precision to double, switch to mixed as necessary
+  if (!do_not_force_double && device_precision == QUDA_SINGLE_PRECISION) {
+    device_precision = QUDA_DOUBLE_PRECISION;
+    //invalidateGaugeQuda();
   }
 
   QudaGaugeParam fat_param = newQudaGaugeParam();


### PR DESCRIPTION
This PR changes the behavior of `qudaMultishiftInvert` and `qudaInvert` to always use `double` as the outer precision, independent of if `float` or `double` is passed in as the outer precision. The environment variable `QUDA_MILC_OVERRIDE_DOUBLE_MULTISHIFT` can be set to override this behavior and return to the original behavior. This PR is meant to avoid wasteful single precision refinement solves when the requested tolerance is below single precision tolerance, ~1e-6 to 1e-7. In practice this PR should have no effect on outer `double` solves, which has been verified as noted below.

This PR also addresses what seems to be a bug in `qudaMultishiftInvert` where `invalidateGaugeQuda()` isn't called when `canReuseResidentGauge()` returns false. This check was already present in `qudaInvert`. I'm not exactly sure why this wasn't a problem before; perhaps it's because this is the first time in practice the fine precision is changed within a production workflow, in any case it seems like we'd been running on borrowed time. Not including this fix led to `errorQuda` being called due to precision mismatches between resident fields (some in single, some in double).

This PR has been tested against MILC RHMC in the following incantations:

- NERSC small in all combinations of overall precisions (double and single) and mixed precision settings (0 = no mixed precision, 1 = single precision sloppy, 2 = half precision sloppy), where there is no regression in performance except for (single, no mixed precision). This later case is reasonable because pure single does not have a refinement step while the implicit change to `double-single` triggers a refinement step within the multishift solve, which is arguably a rare case.
- NERSC medium in pure double to verify no regression, comparing `develop` with this branch both with and without `QUDA_MILC_OVERRIDE_DOUBLE_MULTISHIFT` set, demonstrating no regression above noise and no deviations in output observables (until the 14th digit but, I mean, come on)
- MILC single precision ECP RHMD benchmark, where a 144^3x288 volume, 96 node run goes from taking ~5500 seconds to ~5200 seconds

In the later case, there are no deviations in observables until the fourth digit, and delta H remains "sane".

One negative side effect is the time spend downloading the gauge field goes up for single precision outer solves (for ex, going from 15 sec to 90 sec in the ECP RHMD benchmark). This is explained by extra downloads required by the precision changes. This is more than amortized by the sharp reduction in single-source refinement iterations. This overhead will also disappear in future gauge residency work in MILC RHMD.