### PR TITLE
Feature/abstraction2

### DIFF
--- a/include/blas_helper.cuh
+++ b/include/blas_helper.cuh
@@ -310,6 +310,10 @@ namespace quda
     template <> constexpr int n_vector<int8_t, false, 4, true>() { return 24; }
     template <> constexpr int n_vector<int8_t, false, 1, true>() { return 6; }
 
+#if defined(__CUDA_ARCH__) && __CUDACC_VER_MAJOR__ <= 9
+#define constexpr
+#endif
+
     template <template <typename...> class Functor,
               template <template <typename...> class, typename store_t, typename y_store_t, int, typename> class Blas,
               typename T, typename store_t, typename y_store_t, typename V, typename... Args>
@@ -330,6 +334,11 @@ namespace quda
 #endif
       }
     }
+
+#if defined(__CUDA_ARCH__) && __CUDACC_VER_MAJOR__ <= 9
+#undef constexpr
+#define constexpr constexpr
+#endif
 
     // The instantiate helpers are used to instantiate the precision
     // and spin for the blas and reduce kernels

--- a/include/clover_field_order.h
+++ b/include/clover_field_order.h
@@ -693,27 +693,25 @@ namespace quda {
 	void save() {
 	  if (backup_h) errorQuda("Already allocated host backup");
 	  backup_h = safe_malloc(bytes);
-	  cudaMemcpy(backup_h, clover, bytes, cudaMemcpyDeviceToHost);
+	  qudaMemcpy(backup_h, clover, bytes, cudaMemcpyDeviceToHost);
 	  if (norm_bytes) {
 	    backup_norm_h = safe_malloc(norm_bytes);
-	    cudaMemcpy(backup_norm_h, norm, norm_bytes, cudaMemcpyDeviceToHost);
+	    qudaMemcpy(backup_norm_h, norm, norm_bytes, cudaMemcpyDeviceToHost);
 	  }
-	  checkCudaError();
 	}
 
 	/**
 	   @brief Restore the field from the host after tuning
 	*/
 	void load() {
-	  cudaMemcpy(clover, backup_h, bytes, cudaMemcpyHostToDevice);
+	  qudaMemcpy(clover, backup_h, bytes, cudaMemcpyHostToDevice);
 	  host_free(backup_h);
 	  backup_h = nullptr;
 	  if (norm_bytes) {
-	    cudaMemcpy(norm, backup_norm_h, norm_bytes, cudaMemcpyHostToDevice);
+	    qudaMemcpy(norm, backup_norm_h, norm_bytes, cudaMemcpyHostToDevice);
 	    host_free(backup_norm_h);
 	    backup_norm_h = nullptr;
 	  }
-	  checkCudaError();
 	}
 
 	size_t Bytes() const {

--- a/include/color_spinor_field_order.h
+++ b/include/color_spinor_field_order.h
@@ -1213,18 +1213,16 @@ namespace quda {
   void save() {
     if (backup_h) errorQuda("Already allocated host backup");
     backup_h = safe_malloc(bytes);
-    cudaMemcpy(backup_h, field, bytes, cudaMemcpyDeviceToHost);
-    checkCudaError();
+    qudaMemcpy(backup_h, field, bytes, cudaMemcpyDeviceToHost);
   }
 
   /**
      @brief Restore the field from the host after tuning
   */
   void load() {
-    cudaMemcpy(field, backup_h, bytes, cudaMemcpyHostToDevice);
+    qudaMemcpy(field, backup_h, bytes, cudaMemcpyHostToDevice);
     host_free(backup_h);
     backup_h = nullptr;
-    checkCudaError();
   }
 
   size_t Bytes() const

--- a/include/device.h
+++ b/include/device.h
@@ -21,6 +21,12 @@ namespace quda
      */
     void destroy();
 
+    /**
+     * @brief Returns the maximum dynamic shared memory per block.
+     * @return The maximum dynamic shared memory to each block of threads
+     */
+    size_t max_dynamic_shared_memory();
+
     namespace profile
     {
 

--- a/include/gauge_field_order.h
+++ b/include/gauge_field_order.h
@@ -2111,18 +2111,16 @@ namespace quda {
       void save() {
 	if (backup_h) errorQuda("Already allocated host backup");
 	backup_h = safe_malloc(bytes);
-	cudaMemcpy(backup_h, gauge, bytes, cudaMemcpyDeviceToHost);
-	checkCudaError();
+	qudaMemcpy(backup_h, gauge, bytes, cudaMemcpyDeviceToHost);
       }
 
       /**
 	 @brief Restore the field from the host after tuning
       */
       void load() {
-	cudaMemcpy(gauge, backup_h, bytes, cudaMemcpyHostToDevice);
+	qudaMemcpy(gauge, backup_h, bytes, cudaMemcpyHostToDevice);
 	host_free(backup_h);
 	backup_h = nullptr;
-	checkCudaError();
       }
 
       size_t Bytes() const { return reconLen * sizeof(Float); }

--- a/include/instantiate.h
+++ b/include/instantiate.h
@@ -150,6 +150,10 @@ namespace quda
     }
   }
 
+#if defined(__CUDA_ARCH__) && __CUDACC_VER_MAJOR__ <= 9
+#define constexpr
+#endif
+
   /**
      @brief This instantiate function is used to instantiate the clover precision
      @param[in] c CloverField we wish to instantiate
@@ -186,10 +190,6 @@ namespace quda
       errorQuda("Unsupported precision %d\n", c.Precision());
     }
   }
-
-#if defined(__CUDA_ARCH__) && __CUDACC_VER_MAJOR__ <= 9
-#define constexpr
-#endif
 
   /**
      @brief This instantiate function is used to instantiate the colors

--- a/include/quda_api.h
+++ b/include/quda_api.h
@@ -76,9 +76,22 @@ namespace quda
      @param[in] width Width in bytes
      @param[in] height Number of rows
      @param[in] kind Type of memory copy
+  */
+  void qudaMemcpy2D_(void *dst, size_t dpitch, const void *src, size_t spitch, size_t width, size_t height,
+                     cudaMemcpyKind kind, const char *func, const char *file, const char *line);
+
+  /**
+     @brief Wrapper around cudaMemcpy2DAsync or driver API equivalent
+     @param[out] dst Destination pointer
+     @param[in] dpitch Destination pitch in bytes
+     @param[in] src Source pointer
+     @param[in] spitch Source pitch in bytes
+     @param[in] width Width in bytes
+     @param[in] height Number of rows
+     @param[in] kind Type of memory copy
      @param[in] stream Stream to issue copy
   */
-  void qudaMemcpy2DAsync_(void *dst, size_t dpitch, const void *src, size_t spitch, size_t width, size_t hieght,
+  void qudaMemcpy2DAsync_(void *dst, size_t dpitch, const void *src, size_t spitch, size_t width, size_t height,
                           cudaMemcpyKind kind, const qudaStream_t &stream, const char *func, const char *file,
                           const char *line);
 
@@ -193,6 +206,10 @@ namespace quda
 
 #define qudaMemcpyAsync(dst, src, count, kind, stream)                                                                 \
   ::quda::qudaMemcpyAsync_(dst, src, count, kind, stream, __func__, quda::file_name(__FILE__), __STRINGIFY__(__LINE__))
+
+#define qudaMemcpy2D(dst, dpitch, src, spitch, width, height, kind)     \
+  ::quda::qudaMemcpy2D_(dst, dpitch, src, spitch, width, height, kind, __func__, \
+                        quda::file_name(__FILE__), __STRINGIFY__(__LINE__))
 
 #define qudaMemcpy2DAsync(dst, dpitch, src, spitch, width, height, kind, stream)                                       \
   ::quda::qudaMemcpy2DAsync_(dst, dpitch, src, spitch, width, height, kind, stream, __func__,                          \

--- a/include/quda_api.h
+++ b/include/quda_api.h
@@ -70,9 +70,9 @@ namespace quda
   /**
      @brief Wrapper around cudaMemcpy2DAsync or driver API equivalent
      @param[out] dst Destination pointer
-     @param[in] dpitch Destination pitch
+     @param[in] dpitch Destination pitch in bytes
      @param[in] src Source pointer
-     @param[in] spitch Source pitch
+     @param[in] spitch Source pitch in bytes
      @param[in] width Width in bytes
      @param[in] height Number of rows
      @param[in] kind Type of memory copy
@@ -91,14 +91,37 @@ namespace quda
   void qudaMemset_(void *ptr, int value, size_t count, const char *func, const char *file, const char *line);
 
   /**
+     @brief Wrapper around cudaMemset2D or driver API equivalent
+     @param[out] ptr Starting address pointer
+     @param[in] Pitch in bytes
+     @param[in] value Value to set for each byte of specified memory
+     @param[in] width Width in bytes
+     @param[in] height Height in bytes
+   */
+  void qudaMemset2D_(void *ptr, size_t pitch, int value, size_t width, size_t height,
+                     const char *func, const char *file, const char *line);
+
+  /**
      @brief Wrapper around cudaMemsetAsync or driver API equivalent
      @param[out] ptr Starting address pointer
      @param[in] value Value to set for each byte of specified memory
      @param[in] count Size in bytes to set
-     @param[in] stream  Stream to issue memset
+     @param[in] stream Stream to issue memset
    */
   void qudaMemsetAsync_(void *ptr, int value, size_t count, const qudaStream_t &stream, const char *func,
                         const char *file, const char *line);
+
+  /**
+     @brief Wrapper around cudaMemsetAsync or driver API equivalent
+     @param[out] ptr Starting address pointer
+     @param[in] Pitch in bytes
+     @param[in] value Value to set for each byte of specified memory
+     @param[in] width Width in bytes
+     @param[in] height Height in bytes
+     @param[in] stream Stream to issue memset
+   */
+  void qudaMemset2DAsync_(void *ptr, size_t pitch, int value, size_t width, size_t height,
+                          const qudaStream_t &stream, const char *func, const char *file, const char *line);
 
   /**
      @brief Wrapper around cudaMemPrefetchAsync or driver API equivalent
@@ -195,8 +218,14 @@ namespace quda
 #define qudaMemset(ptr, value, count)                                                                                  \
   ::quda::qudaMemset_(ptr, value, count, __func__, quda::file_name(__FILE__), __STRINGIFY__(__LINE__))
 
+#define qudaMemset2D(ptr, pitch, value, width, height)             \
+  ::quda::qudaMemset2D_(ptr, pitch, value, width, height, __func__, quda::file_name(__FILE__), __STRINGIFY__(__LINE__))
+
 #define qudaMemsetAsync(ptr, value, count, stream)                                                                     \
   ::quda::qudaMemsetAsync_(ptr, value, count, stream, __func__, quda::file_name(__FILE__), __STRINGIFY__(__LINE__))
+
+#define qudaMemset2DAsync(ptr, pitch, value, width, height, stream)            \
+  ::quda::qudaMemset2DAsync_(ptr, pitch, value, width, height, stream, __func__, quda::file_name(__FILE__), __STRINGIFY__(__LINE__))
 
 #define qudaMemPrefetchAsync(ptr, count, mem_space, stream)                                                            \
   ::quda::qudaMemPrefetchAsync_(ptr, count, mem_space, stream, __func__, quda::file_name(__FILE__),                    \

--- a/include/quda_api.h
+++ b/include/quda_api.h
@@ -179,23 +179,6 @@ namespace quda
   void qudaDeviceSynchronize_(const char *func, const char *file, const char *line);
 
   /**
-     @brief Wrapper around cudaFuncSetAttribute with built-in error checking
-     @param[in] kernel Kernel function for which we are setting the attribute
-     @param[in] attr Attribute to set
-     @param[in] value Value to set
-  */
-  void qudaFuncSetAttribute_(const void *kernel, cudaFuncAttribute attr, int value, const char *func, const char *file,
-                             const char *line);
-
-  /**
-     @brief Wrapper around cudaFuncGetAttributes with built-in error checking
-     @param[in] attr the cudaFuncGetAttributes object to store the output
-     @param[in] kernel Kernel function for which we are setting the attribute
-  */
-  void qudaFuncGetAttributes_(cudaFuncAttributes &attr, const void *kernel, const char *func, const char *file,
-                              const char *line);
-
-  /**
      @brief Print out the timer profile for CUDA API calls
    */
   void printAPIProfile();
@@ -248,9 +231,3 @@ namespace quda
 
 #define qudaDeviceSynchronize()                                                                                        \
   ::quda::qudaDeviceSynchronize_(__func__, quda::file_name(__FILE__), __STRINGIFY__(__LINE__))
-
-#define qudaFuncSetAttribute(kernel, attr, value)                                                                      \
-  ::quda::qudaFuncSetAttribute_(kernel, attr, value, __func__, quda::file_name(__FILE__), __STRINGIFY__(__LINE__))
-
-#define qudaFuncGetAttributes(attr, kernel)                                                                            \
-  ::quda::qudaFuncGetAttributes_(attr, kernel, __func__, quda::file_name(__FILE__), __STRINGIFY__(__LINE__))

--- a/lib/blas_quda.cu
+++ b/lib/blas_quda.cu
@@ -80,7 +80,6 @@ namespace quda {
 #endif
 
         apply(*blasStream);
-        checkCudaError();
 
         blas::bytes += bytes();
         blas::flops += flops();

--- a/lib/block_orthogonalize.cu
+++ b/lib/block_orthogonalize.cu
@@ -218,7 +218,6 @@ namespace quda {
     BlockOrtho<double, vFloat, bFloat, nSpin, spinBlockSize, nColor, coarseSpin, nVec> ortho(
       V, B, fine_to_coarse, coarse_to_fine, geo_bs, n_block_ortho);
     ortho.apply(0);
-    checkCudaError();
   }
 
   template <typename vFloat, typename bFloat>

--- a/lib/clover_field.cpp
+++ b/lib/clover_field.cpp
@@ -152,8 +152,6 @@ namespace quda {
       if (cloverInv) pool_device_free(cloverInv);
       if (invNorm) pool_device_free(invNorm);
     }
-    
-    checkCudaError();
   }
 
   void cudaCloverField::copy(const CloverField &src, bool inverse) {
@@ -212,7 +210,6 @@ namespace quda {
     }
 
     qudaDeviceSynchronize();
-    checkCudaError();
   }
 
   void cudaCloverField::loadCPUField(const cpuCloverField &cpu) { copy(cpu); }
@@ -248,7 +245,6 @@ namespace quda {
     pool_pinned_free(packClover);
 
     qudaDeviceSynchronize();
-    checkCudaError();
   }
 
   void cudaCloverField::prefetch(QudaFieldLocation mem_space, qudaStream_t stream) const

--- a/lib/clover_invert.cu
+++ b/lib/clover_invert.cu
@@ -33,7 +33,6 @@ namespace quda {
         arg.complete(*clover.TrLog());
         comm_allreduce_array(clover.TrLog(), 2);
       }
-      checkCudaError();
     }
 
     void apply(const qudaStream_t &stream) {

--- a/lib/clover_outer_product.cu
+++ b/lib/clover_outer_product.cu
@@ -314,9 +314,6 @@ namespace quda {
    errorQuda("Clover Dirac operator has not been built!");
 #endif
 
-   checkCudaError();
   } // computeCloverForce
-
-
 
 } // namespace quda

--- a/lib/clover_quda.cu
+++ b/lib/clover_quda.cu
@@ -158,7 +158,6 @@ namespace quda {
       writeAuxString("threads=%d,stride=%d,prec=%lu",arg.threads,arg.clover.stride,sizeof(store_t));
 
       apply(0);
-      checkCudaError();
       qudaDeviceSynchronize();
     }
 

--- a/lib/clover_sigma_outer_product.cu
+++ b/lib/clover_sigma_outer_product.cu
@@ -125,7 +125,6 @@ namespace quda {
     errorQuda("Clover Dirac operator has not been built!");
 #endif
 
-    checkCudaError();
   } // computeCloverForce
 
 } // namespace quda

--- a/lib/coarse_op_mma_launch.h
+++ b/lib/coarse_op_mma_launch.h
@@ -341,7 +341,7 @@ namespace quda
       tp.grid = dim3(min_threads * t_m * t_n, 2, 1);
 
       auto kernel = ComputeVUVMMA<from_coarse, dim, dir, bM, bN, bK, block_y, block_z, Arg>;
-      setMaxDynamicSharedBytesPerBlock(kernel);
+      tp.set_max_shared_bytes = true;
       qudaLaunchKernel(kernel, tp, stream, arg);
     }
 

--- a/lib/coarse_op_mma_launch.h
+++ b/lib/coarse_op_mma_launch.h
@@ -22,14 +22,6 @@ namespace quda
 
 #if (CUDA_VERSION >= 10010 && __COMPUTE_CAPABILITY__ >= 700)
 
-    template <typename F> inline void setMaxDynamicSharedBytesPerBlock(F *func)
-    {
-      qudaFuncSetAttribute((const void *)func, cudaFuncAttributePreferredSharedMemoryCarveout,
-                           (int)cudaSharedmemCarveoutMaxShared);
-      qudaFuncSetAttribute((const void *)func, cudaFuncAttributeMaxDynamicSharedMemorySize,
-                           deviceProp.sharedMemPerBlockOptin);
-    }
-
     template <bool from_coarse, int dim, QudaDirection dir, int bM, int bN, int bK, int block_y, int block_z, class Arg>
     typename std::enable_if<!Arg::is_mma_compatible, void>::type
     launch_compute_uv_kernel(TuneParam &tp, const Arg &arg, int min_threads, const cudaStream_t &stream)
@@ -54,7 +46,7 @@ namespace quda
       tp.grid = dim3(min_threads * t_m * t_n, 2, 1);
 
       auto kernel = ComputeUVMMA<from_coarse, dim, dir, bM, bN, bK, block_y, block_z, Arg>;
-      setMaxDynamicSharedBytesPerBlock(kernel);
+      tp.set_max_shared_bytes = true;
       qudaLaunchKernel(kernel, tp, stream, arg);
     }
 

--- a/lib/coarse_op_preconditioned.cu
+++ b/lib/coarse_op_preconditioned.cu
@@ -225,7 +225,7 @@ namespace quda
     } else if (X.Location() == QUDA_CPU_FIELD_LOCATION && X.Order() == QUDA_QDP_GAUGE_ORDER) {
       const cpuGaugeField *X_h = static_cast<const cpuGaugeField*>(&X);
       cpuGaugeField *Xinv_h = static_cast<cpuGaugeField*>(&Xinv);
-      blas::flops += invert((void*)Xinv_h->Gauge_p(), (void*)X_h->Gauge_p(), n, X_h->Volume(), X.Precision(), X.Location());
+      blas::flops += invert(*(void**)Xinv_h->Gauge_p(), *(void**)X_h->Gauge_p(), n, X_h->Volume(), X.Precision(), X.Location());
     } else {
       errorQuda("Unsupported location=%d and order=%d", X.Location(), X.Order());
     }

--- a/lib/color_spinor_util.cu
+++ b/lib/color_spinor_util.cu
@@ -456,13 +456,13 @@ else if (a.Ncolor() == 96 && a.Nspin() == 2) {
     float scale = 1.0;
 
     if (isFixed<StoreType>::value) {
-      cudaMemcpy(&scale, &norm_ptr[i], sizeof(float), cudaMemcpyDeviceToHost);
+      qudaMemcpy(&scale, &norm_ptr[i], sizeof(float), cudaMemcpyDeviceToHost);
       scale *= fixedInvMaxValue<StoreType>::value;
     }
 
     for (int s = 0; s < Ns; s++) {
       for (int c = 0; c < Nc; c++) {
-        cudaMemcpy(indiv_num, &field_ptr[A.index(i % 2, i / 2, s, c, 0)], 2 * sizeof(StoreType), cudaMemcpyDeviceToHost);
+        qudaMemcpy(indiv_num, &field_ptr[A.index(i % 2, i / 2, s, c, 0)], 2 * sizeof(StoreType), cudaMemcpyDeviceToHost);
         data_cpu[2 * (c + Nc * s)] = scale * static_cast<Float>(indiv_num[0]);
         data_cpu[2 * (c + Nc * s) + 1] = scale * static_cast<Float>(indiv_num[1]);
       }

--- a/lib/comm_common.cpp
+++ b/lib/comm_common.cpp
@@ -535,11 +535,7 @@ MsgHandle *comm_declare_receive_relative_(const char *func, const char *file, in
     }
   } else {
     // test this memory allocation is ok by doing a memset
-    cudaError_t err = cudaMemset(buffer, 0, nbytes);
-    if (err != cudaSuccess) {
-      printfQuda("ERROR: buffer failed (%s:%d in %s(), dim=%d, dir=%d, nbytes=%zu)\n", file, line, func, dim, dir, nbytes);
-      errorQuda("aborting with error %s", cudaGetErrorString(err));
-    }
+    qudaMemset(buffer, 0, nbytes);
   }
 #endif
 
@@ -611,12 +607,7 @@ MsgHandle *comm_declare_strided_receive_relative_(const char *func, const char *
     }
   } else {
     // test this memory allocation is ok by doing a memset
-    cudaError_t err = cudaMemset2D(buffer, stride, 0, blksize, nblocks);
-    if (err != cudaSuccess) {
-      printfQuda("ERROR: buffer failed (%s:%d in %s(), dim=%d, dir=%d, blksize=%zu nblocks=%d stride=%zu)\n",
-		 file, line, func, dim, dir, blksize, nblocks, stride);
-      errorQuda("aborting with error %s", cudaGetErrorString(err));
-    }
+    qudaMemset2D(buffer, stride, 0, blksize, nblocks);
   }
 #endif
 

--- a/lib/comm_common.cpp
+++ b/lib/comm_common.cpp
@@ -235,7 +235,7 @@ void comm_peer2peer_init(const char* hostname_recv_buf)
     const int gpuid = comm_gpuid();
     cudaDeviceProp prop;
     cudaGetDeviceProperties(&prop, gpuid);
-    if(!prop.unifiedAddressing) return;
+    if (!prop.unifiedAddressing) return;
 
     comm_set_neighbor_ranks();
 
@@ -298,7 +298,6 @@ void comm_peer2peer_init(const char* hostname_recv_buf)
   peer2peer_present = comm_peer2peer_enabled_global();
 
   checkCudaErrorNoSync();
-  return;
 }
 
 bool comm_peer2peer_present() { return peer2peer_present; }
@@ -414,15 +413,12 @@ static int neighbor_rank[2][4] = { {-1,-1,-1,-1},
 
 static bool neighbors_cached = false;
 
-void comm_set_neighbor_ranks(Topology *topo){
-
+void comm_set_neighbor_ranks(Topology *topo)
+{
   if(neighbors_cached) return;
 
   Topology *topology = topo ? topo : default_topo; // use default topology if topo is NULL
-  if(!topology){
-    errorQuda("Topology not specified");
-    return;
-  }
+  if (!topology) errorQuda("Topology not specified");
      
   for(int d=0; d<4; ++d){
     int pos_displacement[QUDA_MAX_DIM] = { };
@@ -433,7 +429,6 @@ void comm_set_neighbor_ranks(Topology *topo){
     neighbor_rank[1][d] = comm_rank_displaced(topology, pos_displacement);
   }
   neighbors_cached = true;
-  return;
 }
 
 int comm_neighbor_rank(int dir, int dim){

--- a/lib/comm_common.cpp
+++ b/lib/comm_common.cpp
@@ -501,11 +501,7 @@ MsgHandle *comm_declare_send_relative_(const char *func, const char *file, int l
   } else {
     // test this memory allocation is ok by doing a memcpy from it
     void *tmp = device_malloc(nbytes);
-    cudaError_t err = cudaMemcpy(tmp, buffer, nbytes, cudaMemcpyDeviceToDevice);
-    if (err != cudaSuccess) {
-      printfQuda("ERROR: buffer failed (%s:%d in %s(), dim=%d, dir=%d, nbytes=%zu)\n", file, line, func, dim, dir, nbytes);
-      errorQuda("aborting with error %s", cudaGetErrorString(err));
-    }
+    qudaMemcpy(tmp, buffer, nbytes, cudaMemcpyDeviceToDevice);
     device_free(tmp);
   }
 #endif

--- a/lib/comm_common.cpp
+++ b/lib/comm_common.cpp
@@ -565,12 +565,7 @@ MsgHandle *comm_declare_strided_send_relative_(const char *func, const char *fil
   } else {
     // test this memory allocation is ok by doing a memcpy from it
     void *tmp = device_malloc(blksize*nblocks);
-    cudaError_t err = cudaMemcpy2D(tmp, blksize, buffer, stride, blksize, nblocks, cudaMemcpyDeviceToDevice);
-    if (err != cudaSuccess) {
-      printfQuda("ERROR: buffer failed (%s:%d in %s(), dim=%d, dir=%d, blksize=%zu nblocks=%d stride=%zu)\n",
-		 file, line, func, dim, dir, blksize, nblocks, stride);
-      errorQuda("aborting with error %s", cudaGetErrorString(err));
-    }
+    qudaMemcpy2D(tmp, blksize, buffer, stride, blksize, nblocks, cudaMemcpyDeviceToDevice);
     device_free(tmp);
   }
 #endif

--- a/lib/copy_gauge_extended.cu
+++ b/lib/copy_gauge_extended.cu
@@ -162,7 +162,6 @@ namespace quda {
       arg(outOrder, inOrder, E, X, faceVolumeCB, meta.Ndim(), meta.Geometry());
     CopyGaugeEx<FloatOut, FloatIn, length, OutOrder, InOrder> copier(arg, meta, location);
     copier.apply(0);
-    if (location == QUDA_CUDA_FIELD_LOCATION) checkCudaError();
   }
 
   template <typename FloatOut, typename FloatIn, int length, typename InOrder>

--- a/lib/covDev.cu
+++ b/lib/covDev.cu
@@ -145,8 +145,6 @@ namespace quda
         covDev, const_cast<cudaColorSpinorField *>(static_cast<const cudaColorSpinorField *>(&in)), in.VolumeCB(),
         in.GhostFaceCB(), profile);
       policy.apply(0);
-
-      checkCudaError();
     }
   };
 

--- a/lib/cpu_gauge_field.cpp
+++ b/lib/cpu_gauge_field.cpp
@@ -327,8 +327,6 @@ namespace quda {
 	src.GhostExchange() != QUDA_GHOST_EXCHANGE_PAD) {
       exchangeGhost(geometry == QUDA_VECTOR_GEOMETRY ? QUDA_LINK_BACKWARDS : QUDA_LINK_BIDIRECTIONAL);
     }
-
-    checkCudaError();
   }
 
   void cpuGaugeField::setGauge(void **gauge_)

--- a/lib/cuda_color_spinor_field.cpp
+++ b/lib/cuda_color_spinor_field.cpp
@@ -379,8 +379,6 @@ namespace quda {
                         subset_bytes - (size_t)stride * sizeof(float), 0);
       }
     }
-
-    checkCudaError();
   }
 
   void cudaColorSpinorField::copy(const cudaColorSpinorField &src)
@@ -445,7 +443,6 @@ namespace quda {
     }
 
     qudaDeviceSynchronize(); // include sync here for accurate host-device profiling
-    checkCudaError();
   }
 
 
@@ -495,7 +492,6 @@ namespace quda {
     }
 
     qudaDeviceSynchronize(); // need to sync before data can be used on CPU
-    checkCudaError();
   }
 
   void cudaColorSpinorField::allocateGhostBuffer(int nFace, bool spin_project) const

--- a/lib/cuda_color_spinor_field.cpp
+++ b/lib/cuda_color_spinor_field.cpp
@@ -351,7 +351,7 @@ namespace quda {
       char   *dst  = (char*)v + ((!composite_descr.is_composite || composite_descr.is_component) ? volumeCB : composite_descr.volumeCB)*fieldOrder*precision;
       if (pad_bytes)
         for (int subset=0; subset<siteSubset; subset++) {
-          cudaMemset2DAsync(dst + subset*bytes/siteSubset, pitch, 0, pad_bytes, Npad);
+          qudaMemset2DAsync(dst + subset*bytes/siteSubset, pitch, 0, pad_bytes, Npad, 0);
         }
     }
 

--- a/lib/cuda_color_spinor_field.cpp
+++ b/lib/cuda_color_spinor_field.cpp
@@ -296,25 +296,23 @@ namespace quda {
   void cudaColorSpinorField::backup() const {
     if (backed_up) errorQuda("ColorSpinorField already backed up");
     backup_h = new char[bytes];
-    cudaMemcpy(backup_h, v, bytes, cudaMemcpyDefault);
+    qudaMemcpy(backup_h, v, bytes, cudaMemcpyDefault);
     if (norm_bytes) {
       backup_norm_h = new char[norm_bytes];
-      cudaMemcpy(backup_norm_h, norm, norm_bytes, cudaMemcpyDefault);
+      qudaMemcpy(backup_norm_h, norm, norm_bytes, cudaMemcpyDefault);
     }
-    checkCudaError();
     backed_up = true;
   }
 
   void cudaColorSpinorField::restore() const
   {
     if (!backed_up) errorQuda("Cannot restore since not backed up");
-    cudaMemcpy(v, backup_h, bytes, cudaMemcpyDefault);
+    qudaMemcpy(v, backup_h, bytes, cudaMemcpyDefault);
     delete []backup_h;
     if (norm_bytes) {
-      cudaMemcpy(norm, backup_norm_h, norm_bytes, cudaMemcpyDefault);
+      qudaMemcpy(norm, backup_norm_h, norm_bytes, cudaMemcpyDefault);
       delete []backup_norm_h;
     }
-    checkCudaError();
     backed_up = false;
   }
 

--- a/lib/cuda_color_spinor_field.cpp
+++ b/lib/cuda_color_spinor_field.cpp
@@ -1099,17 +1099,17 @@ namespace quda {
 	  if (comm_dim_partitioned(i)) {
 	    if (pack_destination[2*i+0] == Device && !comm_peer2peer_enabled(0,i) && // fuse forwards and backwards if possible
 		pack_destination[2*i+1] == Device && !comm_peer2peer_enabled(1,i)) {
-	      cudaMemcpyAsync(my_face_dim_dir_h[bufferIndex][i][0], my_face_dim_dir_d[bufferIndex][i][0], 2*ghost_face_bytes_aligned[i], cudaMemcpyDeviceToHost, 0);
+	      qudaMemcpyAsync(my_face_dim_dir_h[bufferIndex][i][0], my_face_dim_dir_d[bufferIndex][i][0], 2*ghost_face_bytes_aligned[i], cudaMemcpyDeviceToHost, 0);
 	    } else {
 	      if (pack_destination[2*i+0] == Device && !comm_peer2peer_enabled(0,i))
-		cudaMemcpyAsync(my_face_dim_dir_h[bufferIndex][i][0], my_face_dim_dir_d[bufferIndex][i][0], ghost_face_bytes[i], cudaMemcpyDeviceToHost, 0);
+		qudaMemcpyAsync(my_face_dim_dir_h[bufferIndex][i][0], my_face_dim_dir_d[bufferIndex][i][0], ghost_face_bytes[i], cudaMemcpyDeviceToHost, 0);
 	      if (pack_destination[2*i+1] == Device && !comm_peer2peer_enabled(1,i))
-		cudaMemcpyAsync(my_face_dim_dir_h[bufferIndex][i][1], my_face_dim_dir_d[bufferIndex][i][1], ghost_face_bytes[i], cudaMemcpyDeviceToHost, 0);
+		qudaMemcpyAsync(my_face_dim_dir_h[bufferIndex][i][1], my_face_dim_dir_d[bufferIndex][i][1], ghost_face_bytes[i], cudaMemcpyDeviceToHost, 0);
 	    }
 	  }
 	}
       } else if (total_bytes && !pack_host) {
-	cudaMemcpyAsync(my_face_h[bufferIndex], ghost_send_buffer_d[bufferIndex], total_bytes, cudaMemcpyDeviceToHost, 0);
+	qudaMemcpyAsync(my_face_h[bufferIndex], ghost_send_buffer_d[bufferIndex], total_bytes, cudaMemcpyDeviceToHost, 0);
       }
     }
 
@@ -1153,17 +1153,17 @@ namespace quda {
 	  if (comm_dim_partitioned(i)) {
 	    if (halo_location[2*i+0] == Device && !comm_peer2peer_enabled(0,i) && // fuse forwards and backwards if possible
 		halo_location[2*i+1] == Device && !comm_peer2peer_enabled(1,i)) {
-	      cudaMemcpyAsync(from_face_dim_dir_d[bufferIndex][i][0], from_face_dim_dir_h[bufferIndex][i][0], 2*ghost_face_bytes_aligned[i], cudaMemcpyHostToDevice, 0);
+	      qudaMemcpyAsync(from_face_dim_dir_d[bufferIndex][i][0], from_face_dim_dir_h[bufferIndex][i][0], 2*ghost_face_bytes_aligned[i], cudaMemcpyHostToDevice, 0);
 	    } else {
 	      if (halo_location[2*i+0] == Device && !comm_peer2peer_enabled(0,i))
-		cudaMemcpyAsync(from_face_dim_dir_d[bufferIndex][i][0], from_face_dim_dir_h[bufferIndex][i][0], ghost_face_bytes[i], cudaMemcpyHostToDevice, 0);
+		qudaMemcpyAsync(from_face_dim_dir_d[bufferIndex][i][0], from_face_dim_dir_h[bufferIndex][i][0], ghost_face_bytes[i], cudaMemcpyHostToDevice, 0);
 	      if (halo_location[2*i+1] == Device && !comm_peer2peer_enabled(1,i))
-		cudaMemcpyAsync(from_face_dim_dir_d[bufferIndex][i][1], from_face_dim_dir_h[bufferIndex][i][1], ghost_face_bytes[i], cudaMemcpyHostToDevice, 0);
+		qudaMemcpyAsync(from_face_dim_dir_d[bufferIndex][i][1], from_face_dim_dir_h[bufferIndex][i][1], ghost_face_bytes[i], cudaMemcpyHostToDevice, 0);
 	    }
 	  }
 	}
       } else if (total_bytes && !halo_host) {
-	cudaMemcpyAsync(ghost_recv_buffer_d[bufferIndex], from_face_h[bufferIndex], total_bytes, cudaMemcpyHostToDevice, 0);
+	qudaMemcpyAsync(ghost_recv_buffer_d[bufferIndex], from_face_h[bufferIndex], total_bytes, cudaMemcpyHostToDevice, 0);
       }
     }
 

--- a/lib/cuda_gauge_field.cpp
+++ b/lib/cuda_gauge_field.cpp
@@ -147,7 +147,7 @@ namespace quda {
 	if (!comm_dim_partitioned(dim)) continue;
 	recvStart(dim, dir); // prepost the receive
 	if (!comm_peer2peer_enabled(dir,dim) && !comm_gdr_enabled()) {
-	  cudaMemcpyAsync(my_face_dim_dir_h[bufferIndex][dim][dir], my_face_dim_dir_d[bufferIndex][dim][dir],
+	  qudaMemcpyAsync(my_face_dim_dir_h[bufferIndex][dim][dir], my_face_dim_dir_d[bufferIndex][dim][dir],
 			  ghost_face_bytes[dim], cudaMemcpyDeviceToHost, streams[2*dim+dir]);
 	}
       }
@@ -167,7 +167,7 @@ namespace quda {
 	if (!comm_dim_partitioned(dim)) continue;
 	commsComplete(dim, dir);
 	if (!comm_peer2peer_enabled(1-dir,dim) && !comm_gdr_enabled()) {
-	  cudaMemcpyAsync(from_face_dim_dir_d[bufferIndex][dim][1-dir], from_face_dim_dir_h[bufferIndex][dim][1-dir],
+	  qudaMemcpyAsync(from_face_dim_dir_d[bufferIndex][dim][1-dir], from_face_dim_dir_h[bufferIndex][dim][1-dir],
 			  ghost_face_bytes[dim], cudaMemcpyHostToDevice, streams[2*dim+dir]);
 	}
       }
@@ -236,7 +236,7 @@ namespace quda {
 	if (!comm_dim_partitioned(dim)) continue;
 	recvStart(dim, dir); // prepost the receive
 	if (!comm_peer2peer_enabled(dir,dim) && !comm_gdr_enabled()) {
-	  cudaMemcpyAsync(my_face_dim_dir_h[bufferIndex][dim][dir], my_face_dim_dir_d[bufferIndex][dim][dir],
+	  qudaMemcpyAsync(my_face_dim_dir_h[bufferIndex][dim][dir], my_face_dim_dir_d[bufferIndex][dim][dir],
 			  ghost_face_bytes[dim], cudaMemcpyDeviceToHost, streams[2*dim+dir]);
 	}
       }
@@ -256,7 +256,7 @@ namespace quda {
 	if (!comm_dim_partitioned(dim)) continue;
 	commsComplete(dim, dir);
 	if (!comm_peer2peer_enabled(1-dir,dim) && !comm_gdr_enabled()) {
-	  cudaMemcpyAsync(from_face_dim_dir_d[bufferIndex][dim][1-dir], from_face_dim_dir_h[bufferIndex][dim][1-dir],
+	  qudaMemcpyAsync(from_face_dim_dir_d[bufferIndex][dim][1-dir], from_face_dim_dir_h[bufferIndex][dim][1-dir],
 			  ghost_face_bytes[dim], cudaMemcpyHostToDevice, streams[2*dim+dir]);
 	}
       }
@@ -437,7 +437,7 @@ namespace quda {
 	for (int dir=0; dir<2; dir++) {
 	  // issue host-to-device copies if needed
 	  if (!comm_peer2peer_enabled(dir,dim) && !comm_gdr_enabled()) {
-	    cudaMemcpyAsync(my_face_dim_dir_h[bufferIndex][dim][dir], my_face_dim_dir_d[bufferIndex][dim][dir],
+	    qudaMemcpyAsync(my_face_dim_dir_h[bufferIndex][dim][dir], my_face_dim_dir_d[bufferIndex][dim][dir],
 			    ghost_face_bytes[dim], cudaMemcpyDeviceToHost, streams[dir]);
 	  }
 	}
@@ -452,7 +452,7 @@ namespace quda {
 	for (int dir=0; dir<2; dir++) {
 	  // issue host-to-device copies if needed
 	  if (!comm_peer2peer_enabled(dir,dim) && !comm_gdr_enabled()) {
-	    cudaMemcpyAsync(from_face_dim_dir_d[bufferIndex][dim][dir], from_face_dim_dir_h[bufferIndex][dim][dir],
+	    qudaMemcpyAsync(from_face_dim_dir_d[bufferIndex][dim][dir], from_face_dim_dir_h[bufferIndex][dim][dir],
 			    ghost_face_bytes[dim], cudaMemcpyHostToDevice, streams[dir]);
 	  }
 	}

--- a/lib/cuda_gauge_field.cpp
+++ b/lib/cuda_gauge_field.cpp
@@ -627,13 +627,11 @@ namespace quda {
     staggeredPhaseType = src.StaggeredPhase();
 
     qudaDeviceSynchronize(); // include sync here for accurate host-device profiling
-    checkCudaError();
   }
 
   void cudaGaugeField::loadCPUField(const cpuGaugeField &cpu) {
     copy(cpu);
     qudaDeviceSynchronize();
-    checkCudaError();
   }
 
   void cudaGaugeField::loadCPUField(const cpuGaugeField &cpu, TimeProfile &profile) {
@@ -709,7 +707,6 @@ namespace quda {
     cpu.staggeredPhaseType = staggeredPhaseType;
 
     qudaDeviceSynchronize();
-    checkCudaError();
   }
 
   void cudaGaugeField::saveCPUField(cpuGaugeField &cpu, TimeProfile &profile) const {

--- a/lib/cuda_gauge_field.cpp
+++ b/lib/cuda_gauge_field.cpp
@@ -51,7 +51,7 @@ namespace quda {
       default:
 	errorQuda("Unsupported memory type %d", mem_type);
       }
-      if (create == QUDA_ZERO_FIELD_CREATE) cudaMemset(gauge, 0, bytes);
+      if (create == QUDA_ZERO_FIELD_CREATE) qudaMemset(gauge, 0, bytes);
     } else {
       gauge = param.gauge;
     }
@@ -79,8 +79,8 @@ namespace quda {
 
     size_t pitch = stride*order*precision;
     if (pad_bytes) {
-      cudaMemset2D(static_cast<char*>(even) + volumeCB*order*precision, pitch, 0, pad_bytes, Npad);
-      cudaMemset2D(static_cast<char*>(odd) + volumeCB*order*precision, pitch, 0, pad_bytes, Npad);
+      qudaMemset2D(static_cast<char*>(even) + volumeCB*order*precision, pitch, 0, pad_bytes, Npad);
+      qudaMemset2D(static_cast<char*>(odd) + volumeCB*order*precision, pitch, 0, pad_bytes, Npad);
     }
   }
 

--- a/lib/cuda_gauge_field.cpp
+++ b/lib/cuda_gauge_field.cpp
@@ -721,17 +721,15 @@ namespace quda {
   void cudaGaugeField::backup() const {
     if (backed_up) errorQuda("Gauge field already backed up");
     backup_h = new char[bytes];
-    cudaMemcpy(backup_h, gauge, bytes, cudaMemcpyDefault);
-    checkCudaError();
+    qudaMemcpy(backup_h, gauge, bytes, cudaMemcpyDefault);
     backed_up = true;
   }
 
   void cudaGaugeField::restore() const
   {
     if (!backed_up) errorQuda("Cannot restore since not backed up");
-    cudaMemcpy(gauge, backup_h, bytes, cudaMemcpyDefault);
+    qudaMemcpy(gauge, backup_h, bytes, cudaMemcpyDefault);
     delete []backup_h;
-    checkCudaError();
     backed_up = false;
   }
 

--- a/lib/dslash5_domain_wall.cu
+++ b/lib/dslash5_domain_wall.cu
@@ -108,11 +108,11 @@ public:
       apply(streams[Nstream - 1]);
     }
 
-    template <typename T, typename Arg> inline void launch(T *f, const TuneParam &tp, Arg &arg, const qudaStream_t &stream)
+    template <typename T, typename Arg> inline void launch(T *f, TuneParam &tp, Arg &arg, const qudaStream_t &stream)
     {
       if (shared && (arg.type == M5_INV_DWF || arg.type == M5_INV_MOBIUS || arg.type == M5_INV_ZMOBIUS)) {
         // if inverse kernel uses shared memory then maximize total shared memory pool
-        setMaxDynamicSharedBytesPerBlock(f);
+        tp.set_max_shared_bytes = true;
       }
       qudaLaunchKernel(f, tp, stream, arg);
     }

--- a/lib/dslash5_mobius_eofa.cu
+++ b/lib/dslash5_mobius_eofa.cu
@@ -96,11 +96,11 @@ namespace quda
         apply(streams[Nstream - 1]);
       }
 
-      template <typename T, typename Arg> inline void launch(T *f, const TuneParam &tp, Arg &arg, const qudaStream_t &stream)
+      template <typename T, typename Arg> inline void launch(T *f, TuneParam &tp, Arg &arg, const qudaStream_t &stream)
       {
         if (shared && (arg.type == M5_EOFA || arg.type == M5INV_EOFA)) {
           // if inverse kernel uses shared memory then maximize total shared memory
-          setMaxDynamicSharedBytesPerBlock(f);
+          tp.set_max_shared_bytes = true;
         }
         qudaLaunchKernel(f, tp, stream, arg);
       }

--- a/lib/dslash_coarse.hpp
+++ b/lib/dslash_coarse.hpp
@@ -314,12 +314,12 @@ namespace quda {
 
     void preTune() {
       saveOut = new char[out.Bytes()];
-      cudaMemcpy(saveOut, out.V(), out.Bytes(), cudaMemcpyDeviceToHost);
+      qudaMemcpy(saveOut, out.V(), out.Bytes(), cudaMemcpyDeviceToHost);
     }
 
     void postTune()
     {
-      cudaMemcpy(out.V(), saveOut, out.Bytes(), cudaMemcpyHostToDevice);
+      qudaMemcpy(out.V(), saveOut, out.Bytes(), cudaMemcpyHostToDevice);
       delete[] saveOut;
     }
 

--- a/lib/dslash_domain_wall_4d.cu
+++ b/lib/dslash_domain_wall_4d.cu
@@ -62,8 +62,6 @@ namespace quda
         dwf, const_cast<cudaColorSpinorField *>(static_cast<const cudaColorSpinorField *>(&in)),
         in.getDslashConstant().volume_4d_cb, in.getDslashConstant().ghostFaceCB, profile);
       policy.apply(0);
-
-      checkCudaError();
     }
   };
 

--- a/lib/dslash_domain_wall_5d.cu
+++ b/lib/dslash_domain_wall_5d.cu
@@ -74,8 +74,6 @@ namespace quda
         dwf, const_cast<cudaColorSpinorField *>(static_cast<const cudaColorSpinorField *>(&in)),
         in.getDslashConstant().volume_4d_cb, in.getDslashConstant().ghostFaceCB, profile);
       policy.apply(0);
-
-      checkCudaError();
     }
   };
 

--- a/lib/dslash_improved_staggered.cu
+++ b/lib/dslash_improved_staggered.cu
@@ -158,8 +158,6 @@ namespace quda
         staggered, const_cast<cudaColorSpinorField *>(static_cast<const cudaColorSpinorField *>(&in)), in.VolumeCB(),
         in.GhostFaceCB(), profile);
       policy.apply(0);
-
-      checkCudaError();
     }
   };
 

--- a/lib/dslash_ndeg_twisted_mass.cu
+++ b/lib/dslash_ndeg_twisted_mass.cu
@@ -64,8 +64,6 @@ namespace quda
         twisted, const_cast<cudaColorSpinorField *>(static_cast<const cudaColorSpinorField *>(&in)),
         in.getDslashConstant().volume_4d_cb, in.getDslashConstant().ghostFaceCB, profile);
       policy.apply(0);
-
-      checkCudaError();
     }
   };
 

--- a/lib/dslash_ndeg_twisted_mass_preconditioned.cu
+++ b/lib/dslash_ndeg_twisted_mass_preconditioned.cu
@@ -115,8 +115,6 @@ namespace quda
           in.getDslashConstant().volume_4d_cb, in.getDslashConstant().ghostFaceCB, profile);
         policy.apply(0);
       }
-
-      checkCudaError();
     }
   };
 

--- a/lib/dslash_pack2.cu
+++ b/lib/dslash_pack2.cu
@@ -196,16 +196,14 @@ public:
     template <typename T, typename Arg>
     inline void launch(T *f, const TuneParam &tp, Arg &arg, const qudaStream_t &stream)
     {
-      if (deviceProp.major >= 7) { // enable max shared memory mode on GPUs that support it
-        this->setMaxDynamicSharedBytesPerBlock(f);
-      }
-
       qudaLaunchKernel(f, tp, stream, arg);
     }
 
     void apply(const qudaStream_t &stream)
     {
       TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
+      // enable max shared memory mode on GPUs that support it
+      if (deviceProp.major >= 7) tp.set_max_shared_bytes = true;
 
       if (in.Nspin() == 4) {
         using Arg = PackArg<Float, nColor, 4, spin_project>;

--- a/lib/dslash_quda.cu
+++ b/lib/dslash_quda.cu
@@ -15,7 +15,7 @@ namespace quda {
 
   // these should not be namespaced!!
   // determines whether the temporal ghost zones are packed with a gather kernel,
-  // as opposed to multiple calls to cudaMemcpy()
+  // as opposed to multiple memcpys
   static bool kernelPackT = false;
 
   void setKernelPackT(bool packT) { kernelPackT = packT; }

--- a/lib/dslash_staggered.cu
+++ b/lib/dslash_staggered.cu
@@ -86,8 +86,6 @@ namespace quda
       } else {
         errorQuda("Unsupported staggered phase type %d", U.StaggeredPhase());
       }
-
-      checkCudaError();
     }
   };
 

--- a/lib/dslash_twisted_clover.cu
+++ b/lib/dslash_twisted_clover.cu
@@ -74,8 +74,6 @@ namespace quda
         twisted, const_cast<cudaColorSpinorField *>(static_cast<const cudaColorSpinorField *>(&in)), in.VolumeCB(),
         in.GhostFaceCB(), profile);
       policy.apply(0);
-
-      checkCudaError();
     }
   };
 

--- a/lib/dslash_twisted_clover_preconditioned.cu
+++ b/lib/dslash_twisted_clover_preconditioned.cu
@@ -120,7 +120,6 @@ namespace quda
           const_cast<cudaColorSpinorField *>(static_cast<const cudaColorSpinorField *>(&in)), in.VolumeCB(),
           in.GhostFaceCB(), profile);
       policy.apply(0);
-      checkCudaError();
     }
   };
 

--- a/lib/dslash_twisted_mass.cu
+++ b/lib/dslash_twisted_mass.cu
@@ -60,8 +60,6 @@ namespace quda
         twisted, const_cast<cudaColorSpinorField *>(static_cast<const cudaColorSpinorField *>(&in)), in.VolumeCB(),
         in.GhostFaceCB(), profile);
       policy.apply(0);
-
-      checkCudaError();
     }
   };
 

--- a/lib/dslash_twisted_mass_preconditioned.cu
+++ b/lib/dslash_twisted_mass_preconditioned.cu
@@ -91,8 +91,6 @@ namespace quda
           in.GhostFaceCB(), profile);
         policy.apply(0);
       }
-
-      checkCudaError();
     }
   };
 

--- a/lib/dslash_wilson.cu
+++ b/lib/dslash_wilson.cu
@@ -43,8 +43,6 @@ namespace quda
         wilson, const_cast<cudaColorSpinorField *>(static_cast<const cudaColorSpinorField *>(&in)), in.VolumeCB(),
         in.GhostFaceCB(), profile);
       policy.apply(0);
-
-      checkCudaError();
     }
   };
 

--- a/lib/dslash_wilson_clover.cu
+++ b/lib/dslash_wilson_clover.cu
@@ -74,8 +74,6 @@ namespace quda
           const_cast<cudaColorSpinorField *>(static_cast<const cudaColorSpinorField *>(&in)), in.VolumeCB(),
           in.GhostFaceCB(), profile);
       policy.apply(0);
-
-      checkCudaError();
     }
   };
 
@@ -93,8 +91,6 @@ namespace quda
         wilson, const_cast<cudaColorSpinorField *>(static_cast<const cudaColorSpinorField *>(&in)), in.VolumeCB(),
         in.GhostFaceCB(), profile);
       policy.apply(0);
-
-      checkCudaError();
     }
   };
 

--- a/lib/dslash_wilson_clover_hasenbusch_twist.cu
+++ b/lib/dslash_wilson_clover_hasenbusch_twist.cu
@@ -83,8 +83,6 @@ namespace quda
         wilson, const_cast<cudaColorSpinorField *>(static_cast<const cudaColorSpinorField *>(&in)), in.VolumeCB(),
         in.GhostFaceCB(), profile);
       policy.apply(0);
-
-      checkCudaError();
     }
   };
 

--- a/lib/dslash_wilson_clover_hasenbusch_twist_preconditioned.cu
+++ b/lib/dslash_wilson_clover_hasenbusch_twist_preconditioned.cu
@@ -129,8 +129,6 @@ namespace quda
         wilson, const_cast<cudaColorSpinorField *>(static_cast<const cudaColorSpinorField *>(&in)), in.VolumeCB(),
         in.GhostFaceCB(), profile);
       policy.apply(0);
-
-      checkCudaError();
     }
   };
 
@@ -283,10 +281,6 @@ namespace quda
         wilson, const_cast<cudaColorSpinorField *>(static_cast<const cudaColorSpinorField *>(&in)), in.VolumeCB(),
         in.GhostFaceCB(), profile);
       policy.apply(0);
-
-      checkCudaError();
-
-      checkCudaError();
     }
   };
 

--- a/lib/dslash_wilson_clover_preconditioned.cu
+++ b/lib/dslash_wilson_clover_preconditioned.cu
@@ -119,8 +119,6 @@ namespace quda
           const_cast<cudaColorSpinorField *>(static_cast<const cudaColorSpinorField *>(&in)), in.VolumeCB(),
           in.GhostFaceCB(), profile);
       policy.apply(0);
-
-      checkCudaError();
     }
   };
 

--- a/lib/extended_color_spinor_utilities.cu
+++ b/lib/extended_color_spinor_utilities.cu
@@ -266,7 +266,6 @@ namespace quda {
         CopySpinorEx<FloatOut, FloatIn, Ns, Nc, OutOrder, InOrder, Basis, false> copier(arg, meta, location);
         copier.apply(0);
       }
-      if(location == QUDA_CUDA_FIELD_LOCATION) checkCudaError();
     }
 
   template<typename FloatOut, typename FloatIn, int Ns, int Nc, typename OutOrder, typename InOrder>

--- a/lib/extract_gauge_ghost_extended.cu
+++ b/lib/extract_gauge_ghost_extended.cu
@@ -319,8 +319,6 @@ namespace quda {
     } else {
       errorQuda("Invalid dim=%d", dim);
     }
-
-    checkCudaError();
   }
 
   /** This is the template driver for extractGhost */

--- a/lib/gauge_field_strength_tensor.cu
+++ b/lib/gauge_field_strength_tensor.cu
@@ -30,7 +30,6 @@ public:
       }
       apply(0);
       qudaDeviceSynchronize();
-      checkCudaError();
     }
 
     void apply(const qudaStream_t &stream)

--- a/lib/gauge_fix_fft.cu
+++ b/lib/gauge_fix_fft.cu
@@ -298,9 +298,7 @@ namespace quda {
     GaugeFixINVPSP(GaugeFixArg<Float> &arg, const GaugeField &meta) :
       arg(arg),
       meta(meta)
-    {
-      cudaFuncSetCacheConfig(kernel_gauge_mult_norm_2D<Float>, cudaFuncCachePreferL1);
-    }
+    { }
 
     void apply(const qudaStream_t &stream) {
       TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
@@ -447,7 +445,6 @@ namespace quda {
       meta(meta)
     {
       half_alpha = alpha * 0.5;
-      cudaFuncSetCacheConfig(kernel_gauge_fix_U_EO_NEW<Float, Gauge>, cudaFuncCachePreferL1);
     }
 
     void setAlpha(Float alpha){ half_alpha = alpha * 0.5; }
@@ -523,7 +520,6 @@ namespace quda {
       meta(meta)
     {
       half_alpha = alpha * 0.5;
-      cudaFuncSetCacheConfig( kernel_gauge_GX<Elems, Float>,   cudaFuncCachePreferL1);
     }
 
     void setAlpha(Float alpha) { half_alpha = alpha * 0.5; }
@@ -610,9 +606,7 @@ namespace quda {
       dataOr(dataOr),
       arg(arg),
       meta(meta)
-    {
-      cudaFuncSetCacheConfig(kernel_gauge_fix_U_EO<Elems, Float, Gauge>, cudaFuncCachePreferL1);
-    }
+    { }
 
     void apply(const qudaStream_t &stream) {
       TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());

--- a/lib/gauge_fix_fft.cu
+++ b/lib/gauge_fix_fft.cu
@@ -790,7 +790,6 @@ namespace quda {
     arg.free();
     CUFFT_SAFE_CALL(cufftDestroy(plan_zt));
     CUFFT_SAFE_CALL(cufftDestroy(plan_xy));
-    checkCudaError();
     qudaDeviceSynchronize();
     profileInternalGaugeFixFFT.TPSTOP(QUDA_PROFILE_COMPUTE);
 

--- a/lib/gauge_fix_ovr.cu
+++ b/lib/gauge_fix_ovr.cu
@@ -1089,7 +1089,7 @@ public:
                                svd_rel_error, svd_abs_error);
     int num_failures = 0;
     int* num_failures_dev = static_cast<int*>(pool_device_malloc(sizeof(int)));
-    cudaMemset(num_failures_dev, 0, sizeof(int));
+    qudaMemset(num_failures_dev, 0, sizeof(int));
 
     GaugeFixQualityArg<Gauge> argQ(dataOr, data);
     GaugeFixQuality<Float,Gauge, gauge_dir> GaugeFixQuality(argQ, data);
@@ -1191,7 +1191,7 @@ public:
       errorQuda("Error in the unitarization\n");
       exit(1);
     }
-    cudaMemset(num_failures_dev, 0, sizeof(int));
+    qudaMemset(num_failures_dev, 0, sizeof(int));
 
     int iter = 0;
     for ( iter = 0; iter < Nsteps; iter++ ) {
@@ -1303,7 +1303,7 @@ public:
         unitarizeLinks(data, data, num_failures_dev);
         qudaMemcpy(&num_failures, num_failures_dev, sizeof(int), cudaMemcpyDeviceToHost);
         if ( num_failures > 0 ) errorQuda("Error in the unitarization\n");
-        cudaMemset(num_failures_dev, 0, sizeof(int));
+        qudaMemset(num_failures_dev, 0, sizeof(int));
         flop += 4588.0 * data.X()[0]*data.X()[1]*data.X()[2]*data.X()[3];
         byte += 8.0 * data.X()[0]*data.X()[1]*data.X()[2]*data.X()[3] * dataOr.Bytes();
       }
@@ -1326,7 +1326,7 @@ public:
       unitarizeLinks(data, data, num_failures_dev);
       qudaMemcpy(&num_failures, num_failures_dev, sizeof(int), cudaMemcpyDeviceToHost);
       if ( num_failures > 0 ) errorQuda("Error in the unitarization\n");
-      cudaMemset(num_failures_dev, 0, sizeof(int));
+      qudaMemset(num_failures_dev, 0, sizeof(int));
       flop += 4588.0 * data.X()[0]*data.X()[1]*data.X()[2]*data.X()[3];
       byte += 8.0 * data.X()[0]*data.X()[1]*data.X()[2]*data.X()[3] * dataOr.Bytes();
     }

--- a/lib/gauge_fix_ovr.cu
+++ b/lib/gauge_fix_ovr.cu
@@ -1243,11 +1243,11 @@ public:
         #else
           for ( int d = 0; d < 4; d++ ) {
             if ( !commDimPartitioned(d)) continue;
-            cudaMemcpyAsync(send[d], send_d[d], bytes[d], cudaMemcpyDeviceToHost, GFStream[d]);
+            qudaMemcpyAsync(send[d], send_d[d], bytes[d], cudaMemcpyDeviceToHost, GFStream[d]);
           }
           for ( int d = 0; d < 4; d++ ) {
             if ( !commDimPartitioned(d)) continue;
-            cudaMemcpyAsync(sendg[d], sendg_d[d], bytes[d], cudaMemcpyDeviceToHost, GFStream[4 + d]);
+            qudaMemcpyAsync(sendg[d], sendg_d[d], bytes[d], cudaMemcpyDeviceToHost, GFStream[4 + d]);
           }
         #endif
           //compute interior points
@@ -1264,12 +1264,12 @@ public:
           for ( int d = 0; d < 4; d++ ) {
             if ( !commDimPartitioned(d)) continue;
             comm_wait(mh_recv_back[d]);
-            cudaMemcpyAsync(recv_d[d], recv[d], bytes[d], cudaMemcpyHostToDevice, GFStream[d]);
+            qudaMemcpyAsync(recv_d[d], recv[d], bytes[d], cudaMemcpyHostToDevice, GFStream[d]);
           }
           for ( int d = 0; d < 4; d++ ) {
             if ( !commDimPartitioned(d)) continue;
             comm_wait(mh_recv_fwd[d]);
-            cudaMemcpyAsync(recvg_d[d], recvg[d], bytes[d], cudaMemcpyHostToDevice, GFStream[4 + d]);
+            qudaMemcpyAsync(recvg_d[d], recvg[d], bytes[d], cudaMemcpyHostToDevice, GFStream[4 + d]);
           }
         #endif
           for ( int d = 0; d < 4; d++ ) {

--- a/lib/gauge_fix_ovr.cu
+++ b/lib/gauge_fix_ovr.cu
@@ -1362,7 +1362,6 @@ public:
       cudaStreamDestroy(GFStream[8]);
     }
   #endif
-    checkCudaError();
     qudaDeviceSynchronize();
     profileInternalGaugeFixOVR.TPSTOP(QUDA_PROFILE_COMPUTE);
     if (getVerbosity() > QUDA_SUMMARIZE){

--- a/lib/gauge_force.cu
+++ b/lib/gauge_force.cu
@@ -206,7 +206,6 @@ namespace quda {
     {
       apply(0);
       qudaDeviceSynchronize();
-      checkCudaError();
     }
 
     void apply(const qudaStream_t &stream) {

--- a/lib/gauge_phase.cu
+++ b/lib/gauge_phase.cu
@@ -162,7 +162,6 @@ namespace quda {
       } else {
         errorQuda("Undefined phase type");
       }
-      checkCudaError();
     }
   };
 

--- a/lib/gauge_update_quda.cu
+++ b/lib/gauge_update_quda.cu
@@ -135,7 +135,6 @@ namespace quda {
           updateGauge.apply(0);
         }
       }
-      checkCudaError();
     }
   };
 

--- a/lib/hisq_paths_force_quda.cu
+++ b/lib/hisq_paths_force_quda.cu
@@ -844,8 +844,7 @@ namespace quda {
       QudaPrecision precision = checkPrecision(oprod, link, newOprod);
       instantiate<HisqStaplesForce, ReconstructNone>(Pmu, P3, P5, Pnumu, Qmu, Qnumu, newOprod, oprod, link, path_coeff_array);
 
-      cudaDeviceSynchronize();
-      checkCudaError();
+      qudaDeviceSynchronize();
     }
 
     template <typename real, int nColor, QudaReconstructType reconstruct=QUDA_RECONSTRUCT_NO>
@@ -1052,8 +1051,7 @@ namespace quda {
         LongLinkArg<real, nColor, recon> arg(newOprod, link, oldOprod, coeff);
         HisqForce<decltype(arg)> longLink(arg, link, 0, 0, FORCE_LONG_LINK);
         longLink.apply(0);
-        cudaDeviceSynchronize();
-        checkCudaError();
+        qudaDeviceSynchronize();
       }
     };
 
@@ -1074,8 +1072,7 @@ namespace quda {
         CompleteForceArg<real, nColor, recon> arg(force, link);
         HisqForce<decltype(arg)> completeForce(arg, link, 0, 0, FORCE_COMPLETE);
         completeForce.apply(0);
-        cudaDeviceSynchronize();
-        checkCudaError();
+        qudaDeviceSynchronize();
       }
     };
 

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -1045,7 +1045,6 @@ void loadCloverQuda(void *h_clover, void *h_clovinv, QudaInvertParam *inv_param)
     profileClover.TPSTOP(QUDA_PROFILE_D2H);
 
     delete hack;
-    checkCudaError();
   }
 
   profileClover.TPSTART(QUDA_PROFILE_FREE);
@@ -4172,7 +4171,6 @@ int computeGaugeForceQuda(void* mom, void* siteLink,  int*** input_path_buf, int
 
   profileGaugeForce.TPSTOP(QUDA_PROFILE_TOTAL);
 
-  checkCudaError();
 #else
   errorQuda("Gauge force has not been built");
 #endif // GPU_GAUGE_FORCE
@@ -4232,8 +4230,6 @@ void momResidentQuda(void *mom, QudaGaugeParam *param)
   }
 
   profileGaugeForce.TPSTOP(QUDA_PROFILE_TOTAL);
-
-  checkCudaError();
 }
 
 void createCloverQuda(QudaInvertParam* invertParam)
@@ -4465,8 +4461,6 @@ void computeStaggeredForceQuda(void* h_mom, double dt, double delta, void *h_for
 
   profileStaggeredForce.TPSTOP(QUDA_PROFILE_FREE);
   profileStaggeredForce.TPSTOP(QUDA_PROFILE_TOTAL);
-
-  checkCudaError();
 }
 
 void computeHISQForceQuda(void* const milc_momentum,
@@ -4899,7 +4893,6 @@ void computeCloverForceQuda(void *h_mom, double dt, void **h_x, void **h_p,
   delete dirac;
   profileCloverForce.TPSTOP(QUDA_PROFILE_FREE);
 
-  checkCudaError();
   profileCloverForce.TPSTOP(QUDA_PROFILE_TOTAL);
 }
 
@@ -5000,10 +4993,8 @@ void updateGaugeFieldQuda(void* gauge,
   delete cudaInGauge;
   if (cpuMom) delete cpuMom;
   if (cpuGauge) delete cpuGauge;
+
   profileGaugeUpdate.TPSTOP(QUDA_PROFILE_FREE);
-
-  checkCudaError();
-
   profileGaugeUpdate.TPSTOP(QUDA_PROFILE_TOTAL);
 }
 
@@ -5174,10 +5165,8 @@ double momActionQuda(void* momentum, QudaGaugeParam* param)
   }
 
   profileMomAction.TPSTOP(QUDA_PROFILE_FREE);
-
-  checkCudaError();
-
   profileMomAction.TPSTOP(QUDA_PROFILE_TOTAL);
+
   return action;
 }
 
@@ -5760,8 +5749,6 @@ int computeGaugeFixingOVRQuda(void *gauge, const unsigned int gauge_dir, const u
 
   GaugeFixOVRQuda.TPSTOP(QUDA_PROFILE_H2D);
 
-  checkCudaError();
-
   if (comm_size() == 1) {
     // perform the update
     GaugeFixOVRQuda.TPSTART(QUDA_PROFILE_COMPUTE);
@@ -5781,7 +5768,6 @@ int computeGaugeFixingOVRQuda(void *gauge, const unsigned int gauge_dir, const u
     copyExtendedGauge(*cudaInGauge, *cudaInGaugeEx, QUDA_CUDA_FIELD_LOCATION);
   }
 
-  checkCudaError();
   // copy the gauge field back to the host
   GaugeFixOVRQuda.TPSTART(QUDA_PROFILE_D2H);
   cudaInGauge->saveCPUField(*cpuGauge);
@@ -5802,7 +5788,6 @@ int computeGaugeFixingOVRQuda(void *gauge, const unsigned int gauge_dir, const u
     timeinfo[2] = GaugeFixOVRQuda.Last(QUDA_PROFILE_D2H);
   }
 
-  checkCudaError();
   return 0;
 }
 
@@ -5843,19 +5828,15 @@ int computeGaugeFixingFFTQuda(void* gauge, const unsigned int gauge_dir,  const 
 
   // perform the update
   GaugeFixFFTQuda.TPSTART(QUDA_PROFILE_COMPUTE);
-  checkCudaError();
 
   gaugeFixingFFT(*cudaInGauge, gauge_dir, Nsteps, verbose_interval, alpha, autotune, tolerance, stopWtheta);
 
   GaugeFixFFTQuda.TPSTOP(QUDA_PROFILE_COMPUTE);
 
-  checkCudaError();
   // copy the gauge field back to the host
   GaugeFixFFTQuda.TPSTART(QUDA_PROFILE_D2H);
-  checkCudaError();
   cudaInGauge->saveCPUField(*cpuGauge);
   GaugeFixFFTQuda.TPSTOP(QUDA_PROFILE_D2H);
-  checkCudaError();
 
   GaugeFixFFTQuda.TPSTOP(QUDA_PROFILE_TOTAL);
 
@@ -5872,7 +5853,6 @@ int computeGaugeFixingFFTQuda(void* gauge, const unsigned int gauge_dir,  const 
     timeinfo[2] = GaugeFixFFTQuda.Last(QUDA_PROFILE_D2H);
   }
 
-  checkCudaError();
   return 0;
 }
 

--- a/lib/inv_gmresdr_quda.cpp
+++ b/lib/inv_gmresdr_quda.cpp
@@ -374,8 +374,6 @@ namespace quda {
       }
     }
 
-    checkCudaError();
-
     for (int j = 0; j < args.k; j++) {
       Complex alpha = cDotProduct(Vm->Component(j), Vm->Component(args.k));
       caxpy(-alpha, Vm->Component(j), Vm->Component(args.k));

--- a/lib/laplace.cu
+++ b/lib/laplace.cu
@@ -183,8 +183,6 @@ namespace quda
       } else {
         errorQuda("Unsupported nSpin= %d", in.Nspin());
       }
-
-      checkCudaError();
     }
   };
 

--- a/lib/lattice_field.cpp
+++ b/lib/lattice_field.cpp
@@ -405,7 +405,6 @@ namespace quda {
       comm_barrier();
 
       initComms = false;
-      checkCudaError();
     }
 
   }
@@ -557,7 +556,6 @@ namespace quda {
   void LatticeField::destroyIPCComms() {
 
     if (!initIPCComms) return;
-    checkCudaError();
 
     // ensure that all processes bring down their communicators
     // synchronously so that we don't end up in an undefined state

--- a/lib/llfat_quda.cu
+++ b/lib/llfat_quda.cu
@@ -484,7 +484,6 @@ namespace quda {
     }
 
     qudaDeviceSynchronize();
-    checkCudaError();
 
     delete staple;
     delete staple1;

--- a/lib/mdw_fused_dslash.cu
+++ b/lib/mdw_fused_dslash.cu
@@ -6,8 +6,6 @@
 #include <mdw_dslash5_tensor_core.cuh>
 #endif
 
-#include <unordered_set>
-
 namespace quda
 {
   namespace mobius_tensor_core
@@ -578,12 +576,7 @@ namespace quda
 
       template <typename T> inline void launch(T *f, const TuneParam &tp, Arg &arg, const qudaStream_t &stream)
       {
-        static std::unordered_set<T *> cache;
-        auto search = cache.find(f);
-        if (search == cache.end()) {
-          cache.insert(f);
-          const_cast<TuneParam &>(tp).set_max_shared_bytes = true;
-        }
+        const_cast<TuneParam &>(tp).set_max_shared_bytes = true;
         qudaLaunchKernel(f, tp, stream, arg);
       }
 

--- a/lib/mdw_fused_dslash.cu
+++ b/lib/mdw_fused_dslash.cu
@@ -582,7 +582,7 @@ namespace quda
         auto search = cache.find(f);
         if (search == cache.end()) {
           cache.insert(f);
-          setMaxDynamicSharedBytesPerBlock(f);
+          const_cast<TuneParam &>(tp).set_max_shared_bytes = true;
         }
         qudaLaunchKernel(f, tp, stream, arg);
       }

--- a/lib/momentum.cu
+++ b/lib/momentum.cu
@@ -276,7 +276,6 @@ namespace quda {
 
     checkPrecision(mom, force);
     instantiate<UpdateMom, ReconstructMom>(force, mom, coeff, fname);
-    checkCudaError();
 #else
     errorQuda("%s not built", __func__);
 #endif // GPU_GAUGE_TOOLS
@@ -353,7 +352,6 @@ namespace quda {
     if (!force.isNative()) errorQuda("Unsupported output ordering: %d\n", force.Order());
     checkPrecision(force, U);
     instantiate<ApplyU, ReconstructNo12>(U, force);
-    checkCudaError();
 #else
     errorQuda("%s not built", __func__);
 #endif // GPU_GAUGE_TOOLS

--- a/lib/multi_blas_quda.cu
+++ b/lib/multi_blas_quda.cu
@@ -87,7 +87,6 @@ namespace quda {
 #endif
 
         apply(*getStream());
-        checkCudaError();
 
         blas::bytes += bytes();
         blas::flops += flops();

--- a/lib/multi_reduce_quda.cu
+++ b/lib/multi_reduce_quda.cu
@@ -147,7 +147,6 @@ namespace quda {
 #endif
 
         apply(*blas::getStream());
-        checkCudaError();
 
         blas::bytes += bytes();
         blas::flops += flops();

--- a/lib/pgauge_exchange.cu
+++ b/lib/pgauge_exchange.cu
@@ -216,8 +216,8 @@ namespace quda {
         arg.borderid = data.R()[d];
         qudaLaunchKernel(Kernel_UnPack<recon, Float, true, decltype(arg)>, tp, GFStream[1], arg);
 
-        cudaMemcpyAsync(send[d], send_d[d], bytes[d], cudaMemcpyDeviceToHost, GFStream[0]);
-        cudaMemcpyAsync(sendg[d], sendg_d[d], bytes[d], cudaMemcpyDeviceToHost, GFStream[1]);
+        qudaMemcpyAsync(send[d], send_d[d], bytes[d], cudaMemcpyDeviceToHost, GFStream[0]);
+        qudaMemcpyAsync(sendg[d], sendg_d[d], bytes[d], cudaMemcpyDeviceToHost, GFStream[1]);
 
         qudaStreamSynchronize(GFStream[0]);
         comm_start(mh_send_fwd[d]);
@@ -226,14 +226,14 @@ namespace quda {
         comm_start(mh_send_back[d]);
 
         comm_wait(mh_recv_back[d]);
-        cudaMemcpyAsync(recv_d[d], recv[d], bytes[d], cudaMemcpyHostToDevice, GFStream[0]);
+        qudaMemcpyAsync(recv_d[d], recv[d], bytes[d], cudaMemcpyHostToDevice, GFStream[0]);
 
         arg.array = reinterpret_cast<complex<Float>*>(recv_d[d]);
         arg.borderid = data.R()[d] - 1;
         qudaLaunchKernel(Kernel_UnPack<recon, Float, false, decltype(arg)>, tp, GFStream[0], arg);
 
         comm_wait(mh_recv_fwd[d]);
-        cudaMemcpyAsync(recvg_d[d], recvg[d], bytes[d], cudaMemcpyHostToDevice, GFStream[1]);
+        qudaMemcpyAsync(recvg_d[d], recvg[d], bytes[d], cudaMemcpyHostToDevice, GFStream[1]);
 
         arg.array = reinterpret_cast<complex<Float>*>(recvg_d[d]);
         arg.borderid = X[d] - data.R()[d];

--- a/lib/pgauge_exchange.cu
+++ b/lib/pgauge_exchange.cu
@@ -244,7 +244,6 @@ namespace quda {
         qudaStreamSynchronize(GFStream[0]);
         qudaStreamSynchronize(GFStream[1]);
       }
-      checkCudaError();
       qudaDeviceSynchronize();
     }
   };

--- a/lib/pgauge_init.cu
+++ b/lib/pgauge_init.cu
@@ -65,7 +65,6 @@ namespace quda {
       meta(data)
     {
       apply(0);
-      checkCudaError();
     }
 
     void apply(const qudaStream_t &stream)
@@ -271,7 +270,6 @@ namespace quda {
       meta(data)
     {
       apply(0);
-      checkCudaError();
       qudaDeviceSynchronize();
       data.exchangeExtendedGhost(data.R(),false);
     }

--- a/lib/prolongator.cu
+++ b/lib/prolongator.cu
@@ -209,10 +209,7 @@ namespace quda {
     } else {
       errorQuda("Unsupported V precision %d", v.Precision());
     }
-
-    if (checkLocation(out, in, v) == QUDA_CUDA_FIELD_LOCATION) checkCudaError();
   }
-
 
   template <typename Float, int fineSpin>
   void Prolongate(ColorSpinorField &out, const ColorSpinorField &in, const ColorSpinorField &v,
@@ -343,8 +340,6 @@ namespace quda {
     } else {
       errorQuda("Unsupported precision %d", out.Precision());
     }
-
-    if (checkLocation(out, in, v) == QUDA_CUDA_FIELD_LOCATION) checkCudaError();
 #else
     errorQuda("Multigrid has not been built");
 #endif

--- a/lib/random.cu
+++ b/lib/random.cu
@@ -143,24 +143,18 @@ namespace quda {
     }
   }
 
-  /*! @brief Restore CURAND array states initialization */
-  void RNG::restore() {
-    cudaError_t err = cudaMemcpy(state, backup_state, size * sizeof(cuRNGState), cudaMemcpyHostToDevice);
-    if (err != cudaSuccess) {
-      host_free(backup_state);
-      errorQuda("Failed to restore curand rng states array\n");
-    }
-    host_free(backup_state);
+  /*! @brief Backup CURAND array states initialization */
+  void RNG::backup()
+  {
+    backup_state = (cuRNGState *)safe_malloc(size * sizeof(cuRNGState));
+    qudaMemcpy(backup_state, state, size * sizeof(cuRNGState), cudaMemcpyDeviceToHost);
   }
 
-  /*! @brief Backup CURAND array states initialization */
-  void RNG::backup() {
-    backup_state = (cuRNGState *)safe_malloc(size * sizeof(cuRNGState));
-    cudaError_t err = cudaMemcpy(backup_state, state, size * sizeof(cuRNGState), cudaMemcpyDeviceToHost);
-    if (err != cudaSuccess) {
-      host_free(backup_state);
-      errorQuda("Failed to backup curand rng states array\n");
-    }
+  /*! @brief Restore CURAND array states initialization */
+  void RNG::restore()
+  {
+    qudaMemcpy(state, backup_state, size * sizeof(cuRNGState), cudaMemcpyHostToDevice);
+    host_free(backup_state);
   }
 
 } // namespace quda

--- a/lib/reduce_quda.cu
+++ b/lib/reduce_quda.cu
@@ -126,7 +126,6 @@ namespace quda {
 #endif
 
         apply(*(blas::getStream()));
-        checkCudaError();
 
         blas::bytes += bytes();
         blas::flops += flops();

--- a/lib/restrictor.cu
+++ b/lib/restrictor.cu
@@ -175,8 +175,6 @@ namespace quda {
     } else {
       errorQuda("Unsupported V precision %d", v.Precision());
     }
-
-    if (checkLocation(out, in, v) == QUDA_CUDA_FIELD_LOCATION) checkCudaError();
   }
 
   template <typename Float>

--- a/lib/staggered_oprod.cu
+++ b/lib/staggered_oprod.cu
@@ -222,7 +222,6 @@ namespace quda {
       }
     } // i=3,..,0
 
-    checkCudaError();
   } // computeStaggeredOprod
 
   void computeStaggeredOprod(GaugeField &U, GaugeField &L, ColorSpinorField &inEven, ColorSpinorField &inOdd,

--- a/lib/staggered_prolong_restrict.cu
+++ b/lib/staggered_prolong_restrict.cu
@@ -226,8 +226,6 @@ namespace quda {
     StaggeredProlongRestrictLaunch<Float, fineSpin, fineColor, coarseSpin, coarseColor, transferType>
     staggered_prolong_restrict(out, in, fine_to_coarse, parity);
     staggered_prolong_restrict.apply(0);
-    
-    if (checkLocation(out, in) == QUDA_CUDA_FIELD_LOCATION) checkCudaError();
   }
 
   template <int fineSpin, int fineColor, int coarseSpin, int coarseColor, StaggeredTransferType transferType>

--- a/lib/targets/cuda/device.cpp
+++ b/lib/targets/cuda/device.cpp
@@ -147,6 +147,13 @@ namespace quda
       }
     }
 
+    size_t max_dynamic_shared_memory()
+    {
+      static int max_shared_bytes = 0;
+      if (!max_shared_bytes) cudaDeviceGetAttribute(&max_shared_bytes, cudaDevAttrMaxSharedMemoryPerBlockOptin, comm_gpuid());
+      return max_shared_bytes;
+    }
+
     namespace profile {
 
       void start()

--- a/lib/targets/cuda/malloc.cpp
+++ b/lib/targets/cuda/malloc.cpp
@@ -225,7 +225,7 @@ namespace quda
     }
     track_malloc(DEVICE, a, ptr);
 #ifdef HOST_DEBUG
-    cudaMemset(ptr, 0xff, size);
+    qudaMemset(ptr, 0xff, size);
 #endif
     return ptr;
 #else
@@ -256,7 +256,7 @@ namespace quda
     }
     track_malloc(DEVICE_PINNED, a, ptr);
 #ifdef HOST_DEBUG
-    cudaMemset(ptr, 0xff, size);
+    qudaMemset(ptr, 0xff, size);
 #endif
     return ptr;
   }
@@ -355,7 +355,7 @@ namespace quda
     }
     track_malloc(MANAGED, a, ptr);
 #ifdef HOST_DEBUG
-    cudaMemset(ptr, 0xff, size);
+    qudaMemset(ptr, 0xff, size);
 #endif
     return ptr;
   }

--- a/lib/targets/cuda/quda_api.cpp
+++ b/lib/targets/cuda/quda_api.cpp
@@ -258,7 +258,7 @@ namespace quda {
     QudaMem set(ptr, value, count, false, func, file, line);
     set.apply(0);
     cudaError_t error = cudaGetLastError();
-    if (error != cudaSuccess) errorQuda("(CUDA) %s\n (%s:%s in %s())\n", cudaGetErrorString(error), file, line, func);
+    if (error != cudaSuccess && !activeTuning())) errorQuda("(CUDA) %s\n (%s:%s in %s())\n", cudaGetErrorString(error), file, line, func);
   }
 
   void qudaMemsetAsync_(void *ptr, int value, size_t count, const qudaStream_t &stream, const char *func,

--- a/lib/targets/cuda/quda_api.cpp
+++ b/lib/targets/cuda/quda_api.cpp
@@ -271,6 +271,20 @@ namespace quda {
     if (error != cudaSuccess) errorQuda("(CUDA) %s\n (%s:%s in %s())\n", cudaGetErrorString(error), file, line, func);
   }
 
+  void qudaMemset2D_(void *ptr, size_t pitch, int value, size_t width, size_t height,
+                     const char *func, const char *file, const char *line)
+  {
+    cudaError_t error = cudaMemset2D(ptr, pitch, value, width, height);
+    if (error != cudaSuccess) errorQuda("(CUDA) %s\n (%s:%s in %s())\n", cudaGetErrorString(error), file, line, func);
+  }
+
+  void qudaMemset2DAsync_(void *ptr, size_t pitch, int value, size_t width, size_t height,
+                          const qudaStream_t &stream, const char *func, const char *file, const char *line)
+  {
+    cudaError_t error = cudaMemset2DAsync(ptr, pitch, value, width, height, stream);
+    if (error != cudaSuccess) errorQuda("(CUDA) %s\n (%s:%s in %s())\n", cudaGetErrorString(error), file, line, func);
+  }
+
   void qudaMemPrefetchAsync_(void *ptr, size_t count, QudaFieldLocation mem_space, const qudaStream_t &stream,
                              const char *func, const char *file, const char *line)
   {

--- a/lib/targets/cuda/quda_api.cpp
+++ b/lib/targets/cuda/quda_api.cpp
@@ -268,6 +268,36 @@ namespace quda {
     }
   }
 
+  void qudaMemcpy2D_(void *dst, size_t dpitch, const void *src, size_t spitch, size_t width, size_t height,
+                     cudaMemcpyKind kind, const char *func, const char *file, const char *line)
+  {
+#ifdef USE_DRIVER_API
+    CUDA_MEMCPY2D param;
+    param.srcPitch = spitch;
+    param.srcY = 0;
+    param.srcXInBytes = 0;
+    param.dstPitch = dpitch;
+    param.dstY = 0;
+    param.dstXInBytes = 0;
+    param.WidthInBytes = width;
+    param.Height = height;
+
+    switch (kind) {
+    case cudaMemcpyDeviceToHost:
+      param.srcDevice = (CUdeviceptr)src;
+      param.srcMemoryType = CU_MEMORYTYPE_DEVICE;
+      param.dstHost = dst;
+      param.dstMemoryType = CU_MEMORYTYPE_HOST;
+      break;
+    default:
+      errorQuda("Unsupported cuMemcpyType2DAsync %d", kind);
+    }
+    PROFILE(cuMemcpy2D(&param), QUDA_PROFILE_MEMCPY2D_D2H_ASYNC);
+#else
+    PROFILE(cudaMemcpy2D(dst, dpitch, src, spitch, width, height, kind), QUDA_PROFILE_MEMCPY2D_D2H_ASYNC);
+#endif
+  }
+
   void qudaMemcpy2DAsync_(void *dst, size_t dpitch, const void *src, size_t spitch, size_t width, size_t height,
                           cudaMemcpyKind kind, const qudaStream_t &stream, const char *func, const char *file,
                           const char *line)

--- a/lib/targets/cuda/tune.cpp
+++ b/lib/targets/cuda/tune.cpp
@@ -839,7 +839,9 @@ namespace quda
         cudaEventDestroy(end);
 
         if (verbosity >= QUDA_DEBUG_VERBOSE) printfQuda("PostTune %s\n", key.name);
+        tuning = true;
         tunable.postTune();
+        tuning = false;
         param = best_param;
         tunecache[key] = best_param;
       }

--- a/lib/transfer.cpp
+++ b/lib/transfer.cpp
@@ -306,7 +306,6 @@ namespace quda {
     if (enable_gpu) {
       qudaMemcpy(fine_to_coarse_d, fine_to_coarse_h, B[0]->Volume()*sizeof(int), cudaMemcpyHostToDevice);
       qudaMemcpy(coarse_to_fine_d, coarse_to_fine_h, B[0]->Volume()*sizeof(int), cudaMemcpyHostToDevice);
-      checkCudaError();
     }
 
   }

--- a/lib/unitarize_force_quda.cu
+++ b/lib/unitarize_force_quda.cu
@@ -403,7 +403,7 @@ namespace quda {
       }
 
       void preTune() { ; }
-      void postTune() { cudaMemset(arg.fails, 0, sizeof(int)); } // reset fails counter
+      void postTune() { qudaMemset(arg.fails, 0, sizeof(int)); } // reset fails counter
 
       long long flops() const { return 4ll*4528*meta.Volume(); }
       long long bytes() const { return 4ll * meta.Volume() * (arg.force.Bytes() + arg.force_old.Bytes() + arg.u.Bytes()); }

--- a/lib/unitarize_force_quda.cu
+++ b/lib/unitarize_force_quda.cu
@@ -394,7 +394,6 @@ namespace quda {
       {
         apply(0);
         qudaDeviceSynchronize(); // need to synchronize to ensure failure write has completed
-        checkCudaError();
       }
 
       void apply(const qudaStream_t &stream) {

--- a/lib/unitarize_links_quda.cu
+++ b/lib/unitarize_links_quda.cu
@@ -347,7 +347,6 @@ namespace {
     {
       apply(0);
       qudaDeviceSynchronize(); // need to synchronize to ensure failure write has completed
-      checkCudaError();
     }
 
     void apply(const qudaStream_t &stream) {
@@ -437,7 +436,6 @@ namespace {
     {
       apply(0);
       qudaDeviceSynchronize();
-      checkCudaError();
     }
 
     void apply(const qudaStream_t &stream) {

--- a/lib/unitarize_links_quda.cu
+++ b/lib/unitarize_links_quda.cu
@@ -358,7 +358,7 @@ namespace {
     void preTune() { if (arg.in.gauge == arg.out.gauge) arg.out.save(); }
     void postTune() {
       if (arg.in.gauge == arg.out.gauge) arg.out.load();
-      cudaMemset(arg.fails, 0, sizeof(int)); // reset fails counter
+      qudaMemset(arg.fails, 0, sizeof(int)); // reset fails counter
     }
 
     long long flops() const {
@@ -448,7 +448,7 @@ namespace {
     void preTune() { arg.u.save(); }
     void postTune() {
       arg.u.load();
-      cudaMemset(arg.fails, 0, sizeof(int)); // reset fails counter
+      qudaMemset(arg.fails, 0, sizeof(int)); // reset fails counter
     }
 
     long long flops() const { return 0; } // depends on number of iterations

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -250,9 +250,6 @@ if(QUDA_MPI OR QUDA_QMP)
     set(QUDA_CTEST_LAUNCH ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG}
                           ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS})
   endif()
-else()
-  # if single-GPU compilation then only use a single process
-  set(QUDA_CTEST_LAUNCH ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 1 ${MPIEXEC_PREFLAGS})
 endif()
 
 # BLAS test

--- a/tests/blas_test.cpp
+++ b/tests/blas_test.cpp
@@ -1029,7 +1029,7 @@ int main(int argc, char** argv)
   setSpinorSiteSize(24);
   initComms(argc, argv, gridsize_from_cmdline);
   display_test_info();
-  initQuda(device);
+  initQuda(device_ordinal);
 
   setVerbosity(verbosity);
 

--- a/tests/blas_test.cpp
+++ b/tests/blas_test.cpp
@@ -267,8 +267,6 @@ void initFields(prec_pair_t prec_pair)
   QudaPrecision prec = prec_pair.first;
   QudaPrecision prec_other = prec_pair.second;
 
-  checkCudaError();
-
   param.setPrecision(prec, prec, true);
   vD = new cudaColorSpinorField(param);
   wD = new cudaColorSpinorField(param);
@@ -306,9 +304,6 @@ void initFields(prec_pair_t prec_pair)
 
   param.composite_dim = Nsrc;
   zmoD = new cudaColorSpinorField(param);
-
-  // check for successful allocation
-  checkCudaError();
 
   // only do copy if not doing half precision with mg
   bool flag = !(param.nSpin == 2 && (prec < QUDA_SINGLE_PRECISION || prec_other < QUDA_HALF_PRECISION));

--- a/tests/contract_test.cpp
+++ b/tests/contract_test.cpp
@@ -70,7 +70,7 @@ int main(int argc, char **argv)
   display_test_info();
 
   // initialize the QUDA library
-  initQuda(device);
+  initQuda(device_ordinal);
   int X[4] = {xdim, ydim, zdim, tdim};
   setDims(X);
   setSpinorSiteSize(24);

--- a/tests/covdev_test.cpp
+++ b/tests/covdev_test.cpp
@@ -45,7 +45,7 @@ const int nColor = 3;
 
 void init(int argc, char **argv)
 {
-  initQuda(device);
+  initQuda(device_ordinal);
 
   setVerbosity(QUDA_VERBOSE);
 

--- a/tests/deflated_invert_test.cpp
+++ b/tests/deflated_invert_test.cpp
@@ -75,7 +75,7 @@ int main(int argc, char **argv)
   display_test_info();
 
   // initialize the QUDA library
-  initQuda(device);
+  initQuda(device_ordinal);
 
   // *** QUDA parameters begin here.
 

--- a/tests/dslash_ctest.cpp
+++ b/tests/dslash_ctest.cpp
@@ -1059,7 +1059,7 @@ public:
   }
 
   static void SetUpTestCase() {
-    initQuda(device);
+    initQuda(device_ordinal);
   }
 
   // Per-test-case tear-down.

--- a/tests/dslash_test.cpp
+++ b/tests/dslash_test.cpp
@@ -53,7 +53,7 @@ CLI::TransformPairs<dslash_test_type> dtest_type_map {{"Dslash", dslash_test_typ
 
 void init(int argc, char **argv)
 {
-  initQuda(device);
+  initQuda(device_ordinal);
 
   gauge_param = newQudaGaugeParam();
   inv_param = newQudaInvertParam();

--- a/tests/eigensolve_test.cpp
+++ b/tests/eigensolve_test.cpp
@@ -105,7 +105,7 @@ int main(int argc, char **argv)
   setEigParam(eig_param);
 
   // Initialize the QUDA library
-  initQuda(device);
+  initQuda(device_ordinal);
   display_test_info();
 
   // Set some dimension parameters

--- a/tests/gauge_alg_test.cpp
+++ b/tests/gauge_alg_test.cpp
@@ -266,7 +266,7 @@ int main(int argc, char **argv)
   ::testing::TestEventListeners &listeners = ::testing::UnitTest::GetInstance()->listeners();
   if (comm_rank() != 0) { delete listeners.Release(listeners.default_result_printer()); }
 
-  initQuda(device);
+  initQuda(device_ordinal);
   test_rc = RUN_ALL_TESTS();
   endQuda();
 

--- a/tests/gauge_force_test.cpp
+++ b/tests/gauge_force_test.cpp
@@ -241,7 +241,7 @@ void gauge_force_test(void)
 {
   int max_length = 6;
 
-  initQuda(device);
+  initQuda(device_ordinal);
   setVerbosityQuda(QUDA_VERBOSE,"",stdout);
 
   QudaGaugeParam gauge_param = newQudaGaugeParam();

--- a/tests/heatbath_test.cpp
+++ b/tests/heatbath_test.cpp
@@ -74,7 +74,7 @@ int main(int argc, char **argv)
   display_test_info();
 
   // initialize the QUDA library
-  initQuda(device);
+  initQuda(device_ordinal);
 
   // *** QUDA parameters begin here.
 

--- a/tests/hisq_paths_force_test.cpp
+++ b/tests/hisq_paths_force_test.cpp
@@ -374,8 +374,6 @@ static int hisq_force_test(void)
   qudaDeviceSynchronize();
   gettimeofday(&t3, NULL);
 
-  checkCudaError();
-
   cudaMom->saveCPUField(*cpuMom);
 
   int accuracy_level = 3;

--- a/tests/hisq_paths_force_test.cpp
+++ b/tests/hisq_paths_force_test.cpp
@@ -165,7 +165,7 @@ static int R[4] = {0, 0, 0, 0};
 // set the layout, etc.
 static void hisq_force_init()
 {
-  initQuda(device);
+  initQuda(device_ordinal);
 
   qudaGaugeParam.X[0] = xdim;
   qudaGaugeParam.X[1] = ydim;

--- a/tests/hisq_stencil_test.cpp
+++ b/tests/hisq_stencil_test.cpp
@@ -51,7 +51,7 @@ static void hisq_test()
 
   QudaGaugeParam qudaGaugeParam;
 
-  initQuda(device);
+  initQuda(device_ordinal);
 
   if (prec == QUDA_HALF_PRECISION || prec == QUDA_QUARTER_PRECISION) {
     errorQuda("Precision %d is unsupported in some link fattening routines\n",prec);

--- a/tests/hisq_unitarize_force_test.cpp
+++ b/tests/hisq_unitarize_force_test.cpp
@@ -58,7 +58,7 @@ void createNoisyLinkCPU(void** field, QudaPrecision prec, int seed)
 // set the layout, etc.
 static void hisq_force_init()
 {
-  initQuda(device);
+  initQuda(device_ordinal);
 
   gaugeParam.X[0] = xdim;
   gaugeParam.X[1] = ydim;

--- a/tests/invert_test.cpp
+++ b/tests/invert_test.cpp
@@ -195,7 +195,7 @@ int main(int argc, char **argv)
   display_test_info();
 
   // Initialize the QUDA library
-  initQuda(device);
+  initQuda(device_ordinal);
 
   // set parameters for the reference Dslash, and prepare fields to be loaded
   if (dslash_type == QUDA_DOMAIN_WALL_DSLASH || dslash_type == QUDA_DOMAIN_WALL_4D_DSLASH

--- a/tests/invertmsrc_test.cpp
+++ b/tests/invertmsrc_test.cpp
@@ -76,7 +76,7 @@ int main(int argc, char **argv)
   for (int i=0; i<inv_param.num_offset; i++) inv_param.offset[i] = offset[i];
 
   // initialize the QUDA library
-  initQuda(device);
+  initQuda(device_ordinal);
 
   // Set some dimension parameters for the host routines
   if (dslash_type == QUDA_DOMAIN_WALL_DSLASH ||

--- a/tests/llfat_test.cpp
+++ b/tests/llfat_test.cpp
@@ -27,7 +27,7 @@ static void llfat_test()
   void* ghost_sitelink_diag[16];
 #endif
 
-  initQuda(device);
+  initQuda(device_ordinal);
 
   cpu_prec = prec;
   host_gauge_data_type_size = cpu_prec;

--- a/tests/multigrid_benchmark_test.cpp
+++ b/tests/multigrid_benchmark_test.cpp
@@ -84,9 +84,6 @@ void initFields(QudaPrecision prec)
   xD = new cudaColorSpinorField(param);
   yD = new cudaColorSpinorField(param);
 
-  // check for successful allocation
-  checkCudaError();
-
   //*xD = *xH;
   //*yD = *yH;
 

--- a/tests/multigrid_benchmark_test.cpp
+++ b/tests/multigrid_benchmark_test.cpp
@@ -229,7 +229,7 @@ int main(int argc, char** argv)
 
   initComms(argc, argv, gridsize_from_cmdline);
   display_test_info();
-  initQuda(device);
+  initQuda(device_ordinal);
 
   setVerbosity(verbosity);
 

--- a/tests/multigrid_evolve_test.cpp
+++ b/tests/multigrid_evolve_test.cpp
@@ -175,7 +175,7 @@ int main(int argc, char **argv)
   display_test_info();
 
   // initialize the QUDA library
-  initQuda(device);
+  initQuda(device_ordinal);
 
   // *** Everything between here and the timer is application specific
   setDims(gauge_param.X);

--- a/tests/pack_test.cpp
+++ b/tests/pack_test.cpp
@@ -73,7 +73,7 @@ void init() {
 
   spinor->Source(QUDA_RANDOM_SOURCE);
 
-  initQuda(device);
+  initQuda(device_ordinal);
 
   setVerbosityQuda(QUDA_VERBOSE, "", stdout);
 

--- a/tests/plaq_test.cpp
+++ b/tests/plaq_test.cpp
@@ -30,7 +30,7 @@ int main(int argc, char **argv)
   setWilsonGaugeParam(gauge_param);
   setDims(gauge_param.X);
 
-  initQuda(device);
+  initQuda(device_ordinal);
 
   setVerbosity(verbosity);
 

--- a/tests/staggered_dslash_ctest.cpp
+++ b/tests/staggered_dslash_ctest.cpp
@@ -5,21 +5,14 @@
 #include <algorithm>
 
 #include <quda.h>
-#include <quda_internal.h>
+#include <gauge_field.h>
 #include <dirac_quda.h>
-#include <dslash_quda.h>
-#include <invert_quda.h>
-#include <util_quda.h>
-#include <blas_quda.h>
-
 #include <misc.h>
 #include <host_utils.h>
 #include <command_line_params.h>
 #include <dslash_reference.h>
 #include <staggered_dslash_reference.h>
 #include <staggered_gauge_utils.h>
-#include <gauge_field.h>
-#include <unitarization_links.h>
 
 #include "dslash_test_helpers.h"
 #include <assert.h>
@@ -477,7 +470,7 @@ public:
     end();
   }
 
-  static void SetUpTestCase() { initQuda(device); }
+  static void SetUpTestCase() { initQuda(device_ordinal); }
 
   // Per-test-case tear-down.
   // Called after the last test in this test case.

--- a/tests/staggered_dslash_test.cpp
+++ b/tests/staggered_dslash_test.cpp
@@ -67,7 +67,7 @@ CLI::TransformPairs<dslash_test_type> dtest_type_map {{"Dslash", dslash_test_typ
 
 void init()
 {
-  initQuda(device);
+  initQuda(device_ordinal);
 
   gauge_param = newQudaGaugeParam();
   inv_param = newQudaInvertParam();

--- a/tests/staggered_eigensolve_test.cpp
+++ b/tests/staggered_eigensolve_test.cpp
@@ -5,14 +5,6 @@
 
 // QUDA headers
 #include <quda.h>
-#include <quda_internal.h>
-#include <dirac_quda.h>
-#include <dslash_quda.h>
-#include <invert_quda.h>
-#include <util_quda.h>
-#include <blas_quda.h>
-#include <unitarization_links.h>
-#include <gauge_field.h>
 
 // External headers
 #include <misc.h>
@@ -64,8 +56,6 @@ void display_test_info()
   printfQuda("Grid partition info:     X  Y  Z  T\n");
   printfQuda("                         %d  %d  %d  %d\n", dimPartitioned(0), dimPartitioned(1), dimPartitioned(2),
              dimPartitioned(3));
-
-  return;
 }
 
 int main(int argc, char **argv)
@@ -121,9 +111,7 @@ int main(int argc, char **argv)
     errorQuda("ARPACK check only available in double precision");
   }
 
-  // This must be before the FaceBuffer is created
-  // (this is because it allocates pinned memory - FIXME)
-  initQuda(device);
+  initQuda(device_ordinal);
 
   setDims(gauge_param.X);
   dw_setDims(gauge_param.X, 1); // so we can use 5-d indexing from dwf

--- a/tests/staggered_invert_test.cpp
+++ b/tests/staggered_invert_test.cpp
@@ -200,7 +200,7 @@ int main(int argc, char **argv)
   }
 
   // This must be before the FaceBuffer is created (this is because it allocates pinned memory - FIXME)
-  initQuda(device);
+  initQuda(device_ordinal);
 
   setDims(gauge_param.X);
   // Hack: use the domain wall dimensions so we may use the 5th dim for multi indexing

--- a/tests/staggered_invertmsrc_test.cpp
+++ b/tests/staggered_invertmsrc_test.cpp
@@ -166,7 +166,7 @@ invert_test(void)
       0.8);
 
   // this must be before the FaceBuffer is created (this is because it allocates pinned memory - FIXME)
-  initQuda(device);
+  initQuda(device_ordinal);
 
   setDims(gaugeParam.X);
   dw_setDims(gaugeParam.X,1); // so we can use 5-d indexing from dwf

--- a/tests/su3_test.cpp
+++ b/tests/su3_test.cpp
@@ -130,7 +130,7 @@ int main(int argc, char **argv)
     new_gauge[dir] = malloc(V * gauge_site_size * host_gauge_data_type_size);
   }
 
-  initQuda(device);
+  initQuda(device_ordinal);
 
   setVerbosity(verbosity);
 

--- a/tests/unitarize_link_test.cpp
+++ b/tests/unitarize_link_test.cpp
@@ -58,7 +58,7 @@ static int unitarize_link_test(int &test_rc)
 {
   QudaGaugeParam qudaGaugeParam = newQudaGaugeParam();
 
-  initQuda(device);
+  initQuda(device_ordinal);
 
   qudaGaugeParam.anisotropy = 1.0;
 

--- a/utils/command_line_params.cpp
+++ b/utils/command_line_params.cpp
@@ -4,9 +4,9 @@
 // parameters parsed from the command line
 
 #ifdef MULTI_GPU
-int device = -1;
+int device_ordinal = -1;
 #else
-int device = 0;
+int device_ordinal = 0;
 #endif
 
 int rank_order;
@@ -383,7 +383,7 @@ std::shared_ptr<QUDAApp> make_app(std::string app_description, std::string app_n
     ->transform(CLI::QUDACheckedTransformer(contract_type_map));
   ;
   quda_app->add_flag("--dagger", dagger, "Set the dagger to 1 (default 0)");
-  quda_app->add_option("--device", device, "Set the CUDA device to use (default 0, single GPU only)")
+  quda_app->add_option("--device", device_ordinal, "Set the CUDA device to use (default 0, single GPU only)")
     ->check(CLI::Range(0, 16));
 
   quda_app->add_option("--dslash-type", dslash_type, "Set the dslash type")

--- a/utils/command_line_params.h
+++ b/utils/command_line_params.h
@@ -147,7 +147,7 @@ template <typename T> std::string inline get_string(CLI::TransformPairs<T> &map,
 // }
 // parameters
 
-extern int device;
+extern int device_ordinal;
 extern int rank_order;
 extern bool native_blas_lapack;
 extern std::array<int, 4> gridsize_from_cmdline;

--- a/utils/face_gauge.cpp
+++ b/utils/face_gauge.cpp
@@ -1018,7 +1018,6 @@ void exchange_llfat_cleanup(void)
     }
 
   }
-  checkCudaError();
 }
 
 #undef gauge_site_size


### PR DESCRIPTION
This is the next round of abstractions, and isn't very controversial.  This PR should fix most of the outstanding issues with H*P conversion.

* It is now safe to call `qudaMemcpy` in `preTune` and `postTune` methods allowing us to convert 90% of the `cudaMemcpy*` calls into `qudaMemcpy*` calls.  (The only remaining ones are those that involving peer-to-peer copies that will be dealt with in the next PR.)
* Replaced all `cudaMemset*` calls with `qudaMemset*` equivalents.  Added a couple of new APIs `qudaMemset2D` and `qudaMemset2DAsync` to achieve this.
* Shared memory opt in is now dealt with entirely in the CUDA target backend; this is requested now with `TuneParam::set_max_shared_bytes`.   As a result, I've removed `qudaFuncSetAttribute` and `qudaFuncGetAttributes` abstractions from `quda_api.h` since these are no longer needed.
* Removed legacy and unnecessary calls to `cudaFuncSetCacheConfig`
* Removed all unnecessary calls to `checkCudaError` now that error checking is handled in the target backend.  Those remaining will be removed in the next abstraction PR, e.g., those concerning events, streams and P2P setup.

@hummingtree can you check that the max-shared bytes cleanup I've done is all kosher?