### PR TITLE
Correct logic for gauge deletion in staggered gauges, add/fix comments

### DIFF
--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -1153,7 +1153,7 @@ void freeSloppyGaugeQuda()
   // Long gauges
   //---------------------------------------------------------------------------
   // Delete gaugeLongRefinement if it does not alias gaugeLongSloppy.
-  if ( gaugeLongRefinement != gaugeLongSloppy && gaugeLongRefinement) delete gaugeLongRefinement;
+  if (gaugeLongRefinement != gaugeLongSloppy && gaugeLongRefinement) delete gaugeLongRefinement;
 
   // Delete gaugeLongPrecondition if it does not alias gaugeLongPrecise, gaugeLongSloppy, or gaugeLongEigensolver.
   if (gaugeLongPrecondition != gaugeLongSloppy && gaugeLongPrecondition != gaugeLongPrecise
@@ -1166,7 +1166,7 @@ void freeSloppyGaugeQuda()
 
   // Delete gaugeLongSloppy if it does not alias gaugeLongPrecise.
   if (gaugeLongSloppy != gaugeLongPrecise && gaugeLongSloppy) delete gaugeLongSloppy;
-  
+
   gaugeLongEigensolver = nullptr;
   gaugeLongRefinement = nullptr;
   gaugeLongPrecondition = nullptr;
@@ -1254,8 +1254,7 @@ void loadSloppyGaugeQuda(const QudaPrecision *prec, const QudaReconstructType *r
 
     if (gaugePrecondition) errorQuda("gaugePrecondition already exists");
 
-    if (gauge_param.Precision() == gaugePrecise->Precision()
-	&& gauge_param.reconstruct == gaugePrecise->Reconstruct()) {
+    if (gauge_param.Precision() == gaugePrecise->Precision() && gauge_param.reconstruct == gaugePrecise->Reconstruct()) {
       gaugePrecondition = gaugePrecise;
     } else if (gauge_param.Precision() == gaugeSloppy->Precision()
                && gauge_param.reconstruct == gaugeSloppy->Reconstruct()) {
@@ -1271,8 +1270,7 @@ void loadSloppyGaugeQuda(const QudaPrecision *prec, const QudaReconstructType *r
 
     if (gaugeRefinement) errorQuda("gaugeRefinement already exists");
 
-    if (gauge_param.Precision() == gaugeSloppy->Precision()
-	&& gauge_param.reconstruct == gaugeSloppy->Reconstruct()) {
+    if (gauge_param.Precision() == gaugeSloppy->Precision() && gauge_param.reconstruct == gaugeSloppy->Reconstruct()) {
       gaugeRefinement = gaugeSloppy;
     } else {
       gaugeRefinement = new cudaGaugeField(gauge_param);
@@ -1285,8 +1283,7 @@ void loadSloppyGaugeQuda(const QudaPrecision *prec, const QudaReconstructType *r
 
     if (gaugeEigensolver) errorQuda("gaugeEigensolver already exists");
 
-    if (gauge_param.Precision() == gaugePrecise->Precision()
-	&& gauge_param.reconstruct == gaugePrecise->Reconstruct()) {
+    if (gauge_param.Precision() == gaugePrecise->Precision() && gauge_param.reconstruct == gaugePrecise->Reconstruct()) {
       gaugeEigensolver = gaugePrecise;
     } else if (gauge_param.Precision() == gaugeSloppy->Precision()
                && gauge_param.reconstruct == gaugeSloppy->Reconstruct()) {
@@ -1304,7 +1301,7 @@ void loadSloppyGaugeQuda(const QudaPrecision *prec, const QudaReconstructType *r
   if (gaugeFatPrecise) {
     GaugeFieldParam gauge_param(*gaugeFatPrecise);
     // switch the parameters for creating the mirror sloppy cuda gauge field
-    
+
     gauge_param.setPrecision(prec[0], true);
 
     if (gaugeFatSloppy) errorQuda("gaugeFatSloppy already exists");
@@ -1370,7 +1367,7 @@ void loadSloppyGaugeQuda(const QudaPrecision *prec, const QudaReconstructType *r
   if (gaugeLongPrecise) {
     GaugeFieldParam gauge_param(*gaugeLongPrecise);
     // switch the parameters for creating the mirror sloppy cuda gauge field
-    
+
     gauge_param.reconstruct = recon[0];
     gauge_param.setPrecision(prec[0], true);
 

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -1128,6 +1128,9 @@ void freeSloppyGaugeQuda()
 {
   if (!initialized) errorQuda("QUDA not initialized");
 
+  // Wilson gauges
+  //---------------------------------------------------------------------------
+  // Delete gaugeRefinement if it does not alias gaugeSloppy.
   if (gaugeRefinement != gaugeSloppy && gaugeRefinement) delete gaugeRefinement;
 
   // Delete gaugePrecondition if it does not alias gaugePrecise, gaugeSloppy, or gaugeEigensolver.
@@ -1145,33 +1148,47 @@ void freeSloppyGaugeQuda()
   gaugeRefinement = nullptr;
   gaugePrecondition = nullptr;
   gaugeSloppy = nullptr;
+  //---------------------------------------------------------------------------
 
-  if (gaugeLongSloppy != gaugeLongRefinement && gaugeLongRefinement) delete gaugeLongRefinement;
+  // Long gauges
+  //---------------------------------------------------------------------------
+  // Delete gaugeLongRefinement if it does not alias gaugeLongSloppy.
+  if ( gaugeLongRefinement != gaugeLongSloppy && gaugeLongRefinement) delete gaugeLongRefinement;
 
+  // Delete gaugeLongPrecondition if it does not alias gaugeLongPrecise, gaugeLongSloppy, or gaugeLongEigensolver.
   if (gaugeLongPrecondition != gaugeLongSloppy && gaugeLongPrecondition != gaugeLongPrecise
       && gaugeLongPrecondition != gaugeLongEigensolver && gaugeLongPrecondition)
     delete gaugeLongPrecondition;
 
+  // Delete gaugeLongEigensolver if it does not alias gaugeLongPrecise or gaugeLongSloppy.
   if (gaugeLongEigensolver != gaugeLongSloppy && gaugeLongEigensolver != gaugeLongPrecise && gaugeLongEigensolver)
     delete gaugeLongEigensolver;
 
-  if (gaugeLongSloppy != gaugeLongPrecise && gaugeLongSloppy != gaugeLongEigensolver) delete gaugeLongSloppy;
-
+  // Delete gaugeLongSloppy if it does not alias gaugeLongPrecise.
+  if (gaugeLongSloppy != gaugeLongPrecise && gaugeLongSloppy) delete gaugeLongSloppy;
+  
   gaugeLongEigensolver = nullptr;
   gaugeLongRefinement = nullptr;
   gaugeLongPrecondition = nullptr;
   gaugeLongSloppy = nullptr;
+  //---------------------------------------------------------------------------
 
-  if (gaugeFatSloppy != gaugeFatRefinement && gaugeFatRefinement) delete gaugeFatRefinement;
+  // Fat gauges
+  //---------------------------------------------------------------------------
+  // Delete gaugeFatRefinement if it does not alias gaugeFatSloppy.
+  if (gaugeFatRefinement != gaugeFatSloppy && gaugeFatRefinement) delete gaugeFatRefinement;
 
+  // Delete gaugeFatPrecondition if it does not alias gaugeFatPrecise, gaugeFatSloppy, or gaugeFatEigensolver.
   if (gaugeFatPrecondition != gaugeFatSloppy && gaugeFatPrecondition != gaugeFatPrecise
       && gaugeFatPrecondition != gaugeFatEigensolver && gaugeFatPrecondition)
     delete gaugeFatPrecondition;
 
+  // Delete gaugeFatEigensolver if it does not alias gaugeFatPrecise or gaugeFatSloppy.
   if (gaugeFatEigensolver != gaugeFatSloppy && gaugeFatEigensolver != gaugeFatPrecise && gaugeFatEigensolver)
     delete gaugeFatEigensolver;
 
-  if (gaugeFatSloppy != gaugeFatPrecise && gaugeFatSloppy != gaugeFatEigensolver) delete gaugeFatSloppy;
+  // Delete gaugeFatSloppy if it does not alias gaugeFatPrecise.
+  if (gaugeFatSloppy != gaugeFatPrecise && gaugeFatSloppy) delete gaugeFatSloppy;
 
   gaugeFatEigensolver = nullptr;
   gaugeFatRefinement = nullptr;
@@ -1237,7 +1254,8 @@ void loadSloppyGaugeQuda(const QudaPrecision *prec, const QudaReconstructType *r
 
     if (gaugePrecondition) errorQuda("gaugePrecondition already exists");
 
-    if (gauge_param.Precision() == gaugePrecise->Precision() && gauge_param.reconstruct == gaugePrecise->Reconstruct()) {
+    if (gauge_param.Precision() == gaugePrecise->Precision()
+	&& gauge_param.reconstruct == gaugePrecise->Reconstruct()) {
       gaugePrecondition = gaugePrecise;
     } else if (gauge_param.Precision() == gaugeSloppy->Precision()
                && gauge_param.reconstruct == gaugeSloppy->Reconstruct()) {
@@ -1253,7 +1271,8 @@ void loadSloppyGaugeQuda(const QudaPrecision *prec, const QudaReconstructType *r
 
     if (gaugeRefinement) errorQuda("gaugeRefinement already exists");
 
-    if (gauge_param.Precision() == gaugeSloppy->Precision() && gauge_param.reconstruct == gaugeSloppy->Reconstruct()) {
+    if (gauge_param.Precision() == gaugeSloppy->Precision()
+	&& gauge_param.reconstruct == gaugeSloppy->Reconstruct()) {
       gaugeRefinement = gaugeSloppy;
     } else {
       gaugeRefinement = new cudaGaugeField(gauge_param);
@@ -1266,7 +1285,8 @@ void loadSloppyGaugeQuda(const QudaPrecision *prec, const QudaReconstructType *r
 
     if (gaugeEigensolver) errorQuda("gaugeEigensolver already exists");
 
-    if (gauge_param.Precision() == gaugePrecise->Precision() && gauge_param.reconstruct == gaugePrecise->Reconstruct()) {
+    if (gauge_param.Precision() == gaugePrecise->Precision()
+	&& gauge_param.reconstruct == gaugePrecise->Reconstruct()) {
       gaugeEigensolver = gaugePrecise;
     } else if (gauge_param.Precision() == gaugeSloppy->Precision()
                && gauge_param.reconstruct == gaugeSloppy->Reconstruct()) {
@@ -1283,7 +1303,8 @@ void loadSloppyGaugeQuda(const QudaPrecision *prec, const QudaReconstructType *r
   // fat links (if they exist)
   if (gaugeFatPrecise) {
     GaugeFieldParam gauge_param(*gaugeFatPrecise);
-
+    // switch the parameters for creating the mirror sloppy cuda gauge field
+    
     gauge_param.setPrecision(prec[0], true);
 
     if (gaugeFatSloppy) errorQuda("gaugeFatSloppy already exists");
@@ -1326,10 +1347,9 @@ void loadSloppyGaugeQuda(const QudaPrecision *prec, const QudaReconstructType *r
     }
 
     // switch the parameters for creating the mirror eigensolver cuda gauge field
-    gauge_param.reconstruct = recon[3];
     gauge_param.setPrecision(prec[3], true);
 
-    if (gaugeFatEigensolver) errorQuda("gaugePrecondition already exists");
+    if (gaugeFatEigensolver) errorQuda("gaugeFatEigensolver already exists");
 
     if (gauge_param.Precision() == gaugeFatPrecise->Precision()
         && gauge_param.reconstruct == gaugeFatPrecise->Reconstruct()) {
@@ -1349,7 +1369,8 @@ void loadSloppyGaugeQuda(const QudaPrecision *prec, const QudaReconstructType *r
   // long links (if they exist)
   if (gaugeLongPrecise) {
     GaugeFieldParam gauge_param(*gaugeLongPrecise);
-
+    // switch the parameters for creating the mirror sloppy cuda gauge field
+    
     gauge_param.reconstruct = recon[0];
     gauge_param.setPrecision(prec[0], true);
 


### PR DESCRIPTION
This fixes a memory leak introduced by #1031 in which the longSloppy gauge field was not deleted.