### PR TITLE
hotfix/eigensolver_gamma_basis

### DIFF
--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -2400,7 +2400,7 @@ void eigensolveQuda(void **host_evecs, double _Complex *host_evals, QudaEigParam
   cudaParam.location = QUDA_CUDA_FIELD_LOCATION;
   cudaParam.create = QUDA_ZERO_FIELD_CREATE;
   cudaParam.setPrecision(inv_param->cuda_prec_eigensolver, inv_param->cuda_prec_eigensolver, true);
-  // Ensure device vectors qre in UKQCD basis.
+  // Ensure device vectors are in UKQCD basis.
   cudaParam.gammaBasis = QUDA_UKQCD_GAMMA_BASIS;
 
   std::vector<Complex> evals(eig_param->n_conv, 0.0);

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -2388,7 +2388,7 @@ void eigensolveQuda(void **host_evecs, double _Complex *host_evals, QudaEigParam
   // compute function.
   const int *X = cudaGauge->X();
   ColorSpinorParam cpuParam(host_evecs[0], *inv_param, X, inv_param->solution_type, inv_param->input_location);
-
+  
   // create wrappers around application vector set
   std::vector<ColorSpinorField *> host_evecs_;
   for (int i = 0; i < eig_param->n_conv; i++) {
@@ -2400,7 +2400,9 @@ void eigensolveQuda(void **host_evecs, double _Complex *host_evals, QudaEigParam
   cudaParam.location = QUDA_CUDA_FIELD_LOCATION;
   cudaParam.create = QUDA_ZERO_FIELD_CREATE;
   cudaParam.setPrecision(inv_param->cuda_prec_eigensolver, inv_param->cuda_prec_eigensolver, true);
-
+  // Ensure device vectors qre in UKQCD basis.
+  cudaParam.gammaBasis = QUDA_UKQCD_GAMMA_BASIS;
+  
   std::vector<Complex> evals(eig_param->n_conv, 0.0);
   std::vector<ColorSpinorField *> kSpace;
   for (int i = 0; i < eig_param->n_conv; i++) { kSpace.push_back(ColorSpinorField::Create(cudaParam)); }
@@ -2459,7 +2461,9 @@ void eigensolveQuda(void **host_evecs, double _Complex *host_evals, QudaEigParam
   // Copy eigen values back
   for (int i = 0; i < eig_param->n_conv; i++) { memcpy(host_evals + i, &evals[i], sizeof(Complex)); }
 
-  // Transfer Eigenpairs back to host if using GPU eigensolver
+  // Transfer Eigenpairs back to host if using GPU eigensolver. The copy
+  // will automatically rotate from device UKQCD gamma basis to the 
+  // host side gamma basis. 
   if (!(eig_param->arpack_check)) {
     profileEigensolve.TPSTART(QUDA_PROFILE_D2H);
     for (int i = 0; i < eig_param->n_conv; i++) *host_evecs_[i] = *kSpace[i];

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -2388,7 +2388,7 @@ void eigensolveQuda(void **host_evecs, double _Complex *host_evals, QudaEigParam
   // compute function.
   const int *X = cudaGauge->X();
   ColorSpinorParam cpuParam(host_evecs[0], *inv_param, X, inv_param->solution_type, inv_param->input_location);
-  
+
   // create wrappers around application vector set
   std::vector<ColorSpinorField *> host_evecs_;
   for (int i = 0; i < eig_param->n_conv; i++) {
@@ -2402,7 +2402,7 @@ void eigensolveQuda(void **host_evecs, double _Complex *host_evals, QudaEigParam
   cudaParam.setPrecision(inv_param->cuda_prec_eigensolver, inv_param->cuda_prec_eigensolver, true);
   // Ensure device vectors qre in UKQCD basis.
   cudaParam.gammaBasis = QUDA_UKQCD_GAMMA_BASIS;
-  
+
   std::vector<Complex> evals(eig_param->n_conv, 0.0);
   std::vector<ColorSpinorField *> kSpace;
   for (int i = 0; i < eig_param->n_conv; i++) { kSpace.push_back(ColorSpinorField::Create(cudaParam)); }
@@ -2462,8 +2462,8 @@ void eigensolveQuda(void **host_evecs, double _Complex *host_evals, QudaEigParam
   for (int i = 0; i < eig_param->n_conv; i++) { memcpy(host_evals + i, &evals[i], sizeof(Complex)); }
 
   // Transfer Eigenpairs back to host if using GPU eigensolver. The copy
-  // will automatically rotate from device UKQCD gamma basis to the 
-  // host side gamma basis. 
+  // will automatically rotate from device UKQCD gamma basis to the
+  // host side gamma basis.
   if (!(eig_param->arpack_check)) {
     profileEigensolve.TPSTART(QUDA_PROFILE_D2H);
     for (int i = 0; i < eig_param->n_conv; i++) *host_evecs_[i] = *kSpace[i];

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -2400,8 +2400,8 @@ void eigensolveQuda(void **host_evecs, double _Complex *host_evals, QudaEigParam
   cudaParam.location = QUDA_CUDA_FIELD_LOCATION;
   cudaParam.create = QUDA_ZERO_FIELD_CREATE;
   cudaParam.setPrecision(inv_param->cuda_prec_eigensolver, inv_param->cuda_prec_eigensolver, true);
-  // Ensure device vectors qre in UKQCD basis.
-  cudaParam.gammaBasis = QUDA_UKQCD_GAMMA_BASIS;
+  // Ensure device vectors qre in UKQCD basis for Wilson type fermions
+  if(cudaParam.nSpin != 1) cudaParam.gammaBasis = QUDA_UKQCD_GAMMA_BASIS;
   
   std::vector<Complex> evals(eig_param->n_conv, 0.0);
   std::vector<ColorSpinorField *> kSpace;

--- a/tests/eigensolve_test.cpp
+++ b/tests/eigensolve_test.cpp
@@ -96,7 +96,11 @@ int main(int argc, char **argv)
   QudaInvertParam eig_inv_param = newQudaInvertParam();
   setInvertParam(eig_inv_param);
   // Specific changes to the invert param for the eigensolver
-  eig_inv_param.gamma_basis = QUDA_UKQCD_GAMMA_BASIS;
+  // QUDA's device routines require UKQCD gamma basis. QUDA will
+  // automatically rotate from this basis on the host, to UKQCD
+  // on the device, and back to this basis upon completion.
+  eig_inv_param.gamma_basis = QUDA_DEGRAND_ROSSI_GAMMA_BASIS;
+
   eig_inv_param.solve_type
     = (eig_inv_param.solution_type == QUDA_MAT_SOLUTION ? QUDA_DIRECT_SOLVE : QUDA_DIRECT_PC_SOLVE);
   QudaEigParam eig_param = newQudaEigParam();

--- a/utils/command_line_params.cpp
+++ b/utils/command_line_params.cpp
@@ -737,9 +737,9 @@ void add_multigrid_option_group(std::shared_ptr<QUDAApp> quda_app)
                          "Perform a maximun of n restarts in eigensolver (default 100)");
   quda_app->add_mgoption(opgroup, "--mg-eig-block-size", mg_eig_block_size, CLI::Validator(),
                          "The block size to use in the block variant eigensolver");
-  quda_app->add_mgoption(opgroup, "--mg-eig-n_ev", mg_eig_n_ev, CLI::Validator(),
+  quda_app->add_mgoption(opgroup, "--mg-eig-n-ev", mg_eig_n_ev, CLI::Validator(),
                          "The size of eigenvector search space in the eigensolver");
-  quda_app->add_mgoption(opgroup, "--mg-eig-n_kr", mg_eig_n_kr, CLI::Validator(),
+  quda_app->add_mgoption(opgroup, "--mg-eig-n-kr", mg_eig_n_kr, CLI::Validator(),
                          "The size of the Krylov subspace to use in the eigensolver");
   quda_app->add_mgoption(opgroup, "--mg-eig-n-ev-deflate", mg_eig_n_ev_deflate, CLI::Validator(),
                          "The number of converged eigenpairs that will be used in the deflation routines");


### PR DESCRIPTION
Ensure the eigensolver rotates the Krylov space from/to the host gamma basis.

Previous behaviour had the UKQCD gamma basis hardcoded in the `eigensolve_test` routine, so the CPU and GPU bases always matched. We now pass Degrand Rossi for the CPU basis, and ensure that a gamma basis rotation is applied during vector CPU->GPU and GPU->CPU transfer.