### PR TITLE
Fix bug in multi-reductions

### DIFF
--- a/include/kernels/multi_blas_core.cuh
+++ b/include/kernels/multi_blas_core.cuh
@@ -20,17 +20,17 @@ namespace quda
     /**
        @brief Parameter struct for generic multi-blas kernel.
        @tparam NXZ is dimension of input vectors: X,Z
-       @tparam NYW is dimension of in-output vectors: Y,W
-       @tparam SpinorX Type of input spinor for x argument
-       @tparam SpinorY Type of input spinor for y argument
-       @tparam SpinorZ Type of input spinor for z argument
-       @tparam SpinorW Type of input spinor for w argument
+       @tparam store_t Default store type for the fields
+       @tparam N Default field vector i/o length
+       @tparam y_store_t Store type for the y fields
+       @tparam N Y-field vector i/o length
        @tparam Functor Functor used to operate on data
     */
-    template <int NXZ, typename store_t, int N, typename y_store_t, int Ny, typename Functor>
+    template <int NXZ_, typename store_t, int N, typename y_store_t, int Ny, typename Functor>
     struct MultiBlasArg :
-      SpinorXZ<NXZ, store_t, N, Functor::use_z>,
-      SpinorYW<max_YW_size<NXZ, store_t, y_store_t, Functor>(), store_t, N, y_store_t, Ny, Functor::use_w> {
+      SpinorXZ<NXZ_, store_t, N, Functor::use_z>,
+      SpinorYW<max_YW_size<NXZ_, store_t, y_store_t, Functor>(), store_t, N, y_store_t, Ny, Functor::use_w> {
+      static constexpr int NXZ = NXZ_;
       static constexpr int NYW_max = max_YW_size<NXZ, store_t, y_store_t, Functor>();
       const int NYW;
       Functor f;
@@ -55,6 +55,13 @@ namespace quda
         }
       }
     };
+
+    // strictly required pre-C++17 and can cause link errors otherwise
+    template <int NXZ_, typename store_t, int N, typename y_store_t, int Ny, typename Functor>
+    constexpr int MultiBlasArg<NXZ_, store_t, N, y_store_t, Ny, Functor>::NXZ;
+
+    template <int NXZ_, typename store_t, int N, typename y_store_t, int Ny, typename Functor>
+    constexpr int MultiBlasArg<NXZ_, store_t, N, y_store_t, Ny, Functor>::NYW_max;
 
     template <int warp_split, typename T> __device__ __host__ void warp_combine(T &x)
     {

--- a/include/multi_blas_helper.cuh
+++ b/include/multi_blas_helper.cuh
@@ -169,9 +169,9 @@ namespace quda
       if (f.NYW > NYW_max) errorQuda("NYW exceeds max size (%d > %d)", f.NYW, NYW_max);
       if (NXZ * f.NYW * scalar_width > MAX_MATRIX_SIZE)
         errorQuda("Coefficient matrix exceeds max size (%d > %d)", NXZ * f.NYW * scalar_width, MAX_MATRIX_SIZE);
-      if (f.reducer && NXZ * f.NYW > QUDA_MAX_MULTI_REDUCE)
+      if (f.reducer && NXZ * f.NYW > max_n_reduce())
         errorQuda("NXZ * NYW = %d exceeds maximum number of reductions %d * %d > %d",
-                  NXZ * f.NYW, NXZ, f.NYW, QUDA_MAX_MULTI_REDUCE);
+                  NXZ * f.NYW, NXZ, f.NYW, max_n_reduce());
       if (Functor::multi_1d && std::min(NXZ, f.NYW) != 1)
         errorQuda("Expected 1-d multi-blas but appears 2-d (NXZ = %d, NYW = %d)", NXZ, f.NYW);
       if (Functor::multi_1d && std::max(NXZ, f.NYW) > max_N_multi_1d())

--- a/include/reduce_helper.h
+++ b/include/reduce_helper.h
@@ -30,6 +30,8 @@ namespace quda
     cudaEvent_t &get_event();
   } // namespace reducer
 
+  constexpr int max_n_reduce() { return QUDA_MAX_MULTI_REDUCE; }
+
   /**
      @brief The initialization value we used to check for completion
    */

--- a/lib/multi_reduce_quda.cu
+++ b/lib/multi_reduce_quda.cu
@@ -25,13 +25,14 @@ namespace quda {
     template <int block_size, typename real, int len, int NXZ, typename Arg>
     typename std::enable_if<block_size==32, qudaError_t>::type launch(Arg &arg, const TuneParam &tp, const qudaStream_t &stream)
     {
+      if (block_size != tp.block.x) errorQuda("Unexpected block size %d\n", tp.block.x);
       return qudaLaunchKernel(multiReduceKernel<block_size, real, len, NXZ, Arg>, tp, stream, arg);
     }
 
 #ifdef QUDA_FAST_COMPILE_REDUCE
-    constexpr unsigned int max_block_size() { return 32; }
+    constexpr static unsigned int max_block_size() { return 32; }
 #else
-    constexpr unsigned int max_block_size() { return 128; }
+    constexpr static unsigned int max_block_size() { return 128; }
 #endif
 
     template <typename real, int len, int NXZ, typename Arg, typename T>

--- a/lib/multi_reduce_quda.cu
+++ b/lib/multi_reduce_quda.cu
@@ -348,7 +348,7 @@ namespace quda {
 
         coeff_array<T> a, b, c;
 
-        if (x.size() <= tile_size.x && is_valid_NXZ(x.size(), true)) {
+        if (x.size() <= tile_size.x && is_valid_NXZ(x.size(), true) && x.size() * y.size() <= max_n_reduce()) {
           // problem will fit, so do the computation
           multiReduce<ReducerDiagonal, ReducerOffDiagonal>(tmp_dot, a, b, c, x, y, z, w, i_idx, j_idx);
         } else {

--- a/lib/reduce_helper.cu
+++ b/lib/reduce_helper.cu
@@ -23,7 +23,6 @@ namespace quda
     void *get_host_buffer() { return h_reduce; }
     count_t *get_count() { return reduce_count; }
     cudaEvent_t &get_event() { return reduceEnd; }
-    constexpr int max_n_reduce() { return QUDA_MAX_MULTI_REDUCE; }
 
     size_t buffer_size()
     {

--- a/lib/reduce_quda.cu
+++ b/lib/reduce_quda.cu
@@ -22,13 +22,14 @@ namespace quda {
     template <int block_size, typename real, int len, typename Arg>
     typename std::enable_if<block_size==32, qudaError_t>::type launch(Arg &arg, const TuneParam &tp, const qudaStream_t &stream)
     {
+      if (block_size != tp.block.x) errorQuda("Unexpected block size %d\n", tp.block.x);
       return qudaLaunchKernel(reduceKernel<block_size, real, len, Arg>, tp, stream, arg);
     }
 
 #ifdef QUDA_FAST_COMPILE_REDUCE
-    constexpr unsigned int max_block_size() { return 32; }
+    constexpr static unsigned int max_block_size() { return 32; }
 #else
-    constexpr unsigned int max_block_size() { return 1024; }
+    constexpr static unsigned int max_block_size() { return 1024; }
 #endif
 
    /**


### PR DESCRIPTION
This is a bug fix PR:
* `max_block_size` should be declared static in `reduce_quda.cu` and `multi_reduce_quda.cu`, else debug builds (which do not inline functions) can fail due to incorrect function resolution at runtime resulting in flaky autotuning (closes #1058)
* The maximum number of reductions `max_n_reduce()` should be taken into account when doing tile recursing to avoid choosing an invalid tile size (fixes issue pointed out by @cpviolator in #1058)

