### PR TITLE
Move singularity of recon-8 to {{0,1,0},{1,0,0},{0,0,-1}}

### DIFF
--- a/host_reference/dslash_reference.cpp
+++ b/host_reference/dslash_reference.cpp
@@ -172,10 +172,10 @@ void verifyWilsonTypeInversion(void *spinorOut, void **spinorOutMulti, void *spi
       errorQuda("Mass normalization %s not implemented", get_mass_normalization_str(inv_param.mass_normalization));
     }
 
-    void *spinorTmp = malloc(V * spinor_site_size * host_spinor_data_type_size * inv_param.Ls);
+    void *spinorTmp = malloc(Vh * spinor_site_size * host_spinor_data_type_size * inv_param.Ls);
     printfQuda("Host residuum checks: \n");
     for (int i = 0; i < inv_param.num_offset; i++) {
-      ax(0, spinorCheck, V * spinor_site_size, inv_param.cpu_prec);
+      ax(0, spinorCheck, Vh * spinor_site_size, inv_param.cpu_prec);
 
       if (dslash_type == QUDA_TWISTED_MASS_DSLASH) {
         if (inv_param.twist_flavor != QUDA_TWIST_SINGLET) {

--- a/include/gauge_field_order.h
+++ b/include/gauge_field_order.h
@@ -1613,12 +1613,15 @@ namespace quda {
 
         __device__ __host__ inline void Pack(real out[8], const complex in[9], int idx) const
         {
-          out[0] = Trig<isFixed<Float>::value, real>::Atan2(in[3].imag(), in[3].real()); // a1 -> b1
+          out[0] = Trig<isFixed<Float>::value, real>::Atan2(in[3].imag(), in[3].real());   // a1 -> b1
           out[1] = Trig<isFixed<Float>::value, real>::Atan2(-in[6].imag(), -in[6].real()); // c1 -> -c1
 
-          out[2] = in[4].real(); out[3] = in[4].imag(); // a2 -> b2
-          out[4] = in[5].real(); out[5] = in[5].imag(); // a3 -> b3
-          out[6] = in[0].real(); out[7] = in[0].imag(); // b1 -> a1
+          out[2] = in[4].real();
+          out[3] = in[4].imag(); // a2 -> b2
+          out[4] = in[5].real();
+          out[5] = in[5].imag(); // a3 -> b3
+          out[6] = in[0].real();
+          out[7] = in[0].imag(); // b1 -> a1
         }
 
         template <typename I>
@@ -1696,10 +1699,11 @@ namespace quda {
           // to {{a1,a2,a3},{b1,b2,b3},{c1,c2,c3}}
 #pragma unroll
           for (int i = 0; i < 3; i++) {
-            const auto tmp = out[i]; out[i] = out[i+3]; out[i+3] = tmp;
-            out[i+6] = -out[i+6];
+            const auto tmp = out[i];
+            out[i] = out[i + 3];
+            out[i + 3] = tmp;
+            out[i + 6] = -out[i + 6];
           }
-          
         }
 
         template <typename I>

--- a/lib/solver.cpp
+++ b/lib/solver.cpp
@@ -329,19 +329,15 @@ namespace quda {
     if (param.residual_type & QUDA_HEAVY_QUARK_RESIDUAL) {
       if (std::isnan(hq2) || std::isinf(hq2))
         errorQuda("Solver appears to have diverged with heavy quark residual %e", hq2);
-      
-      if (hq2 > hq_tol)
-        return false;
+
+      if (hq2 > hq_tol) return false;
     }
 
     // check the L2 relative residual norm if necessary
-    if ((param.residual_type & QUDA_L2_RELATIVE_RESIDUAL) ||
-	  (param.residual_type & QUDA_L2_ABSOLUTE_RESIDUAL)) {
-      if (std::isnan(r2) || std::isinf(r2))
-        errorQuda("Solver appears to have diverged with residual %e", hq2);
+    if ((param.residual_type & QUDA_L2_RELATIVE_RESIDUAL) || (param.residual_type & QUDA_L2_ABSOLUTE_RESIDUAL)) {
+      if (std::isnan(r2) || std::isinf(r2)) errorQuda("Solver appears to have diverged with residual %e", hq2);
 
-      if (r2 > r2_tol)
-        return false;
+      if (r2 > r2_tol) return false;
     }
 
     return true;
@@ -353,9 +349,8 @@ namespace quda {
     if (param.residual_type & QUDA_HEAVY_QUARK_RESIDUAL) {
       if (std::isnan(hq2) || std::isinf(hq2))
         errorQuda("Solver appears to have diverged with heavy quark residual %e", hq2);
-      
-      if (hq2 > hq_tol) 
-        return false;
+
+      if (hq2 > hq_tol) return false;
     }
 
     return true;
@@ -364,13 +359,10 @@ namespace quda {
   bool Solver::convergenceL2(double r2, double hq2, double r2_tol, double hq_tol) {
 
     // check the L2 relative residual norm if necessary
-    if ((param.residual_type & QUDA_L2_RELATIVE_RESIDUAL) ||
-          (param.residual_type & QUDA_L2_ABSOLUTE_RESIDUAL)) {
-      if (std::isnan(r2) || std::isinf(r2))
-        errorQuda("Solver appears to have diverged with residual %e", hq2);
+    if ((param.residual_type & QUDA_L2_RELATIVE_RESIDUAL) || (param.residual_type & QUDA_L2_ABSOLUTE_RESIDUAL)) {
+      if (std::isnan(r2) || std::isinf(r2)) errorQuda("Solver appears to have diverged with residual %e", hq2);
 
-      if (r2 > r2_tol) 
-        return false;
+      if (r2 > r2_tol) return false;
     }
 
     return true;
@@ -418,15 +410,12 @@ namespace quda {
   bool MultiShiftSolver::convergence(const double *r2, const double *r2_tol, int n) const {
 
     // check the L2 relative residual norm if necessary
-    if ((param.residual_type & QUDA_L2_RELATIVE_RESIDUAL) ||
-            (param.residual_type & QUDA_L2_ABSOLUTE_RESIDUAL))
-    {
-      for (int i=0; i<n; i++)
-      {
-        if (std::isnan(r2[i]) || std::isinf(r2[i])) errorQuda("Multishift solver appears to have diverged on shift %d with residual %e", i, r2[i]);
+    if ((param.residual_type & QUDA_L2_RELATIVE_RESIDUAL) || (param.residual_type & QUDA_L2_ABSOLUTE_RESIDUAL)) {
+      for (int i = 0; i < n; i++) {
+        if (std::isnan(r2[i]) || std::isinf(r2[i]))
+          errorQuda("Multishift solver appears to have diverged on shift %d with residual %e", i, r2[i]);
 
-        if (r2[i] > r2_tol[i] && r2_tol[i] != 0.0)
-          return false;
+        if (r2[i] > r2_tol[i] && r2_tol[i] != 0.0) return false;
       }
     }
 

--- a/lib/solver.cpp
+++ b/lib/solver.cpp
@@ -326,13 +326,23 @@ namespace quda {
   bool Solver::convergence(double r2, double hq2, double r2_tol, double hq_tol) {
 
     // check the heavy quark residual norm if necessary
-    if ( (param.residual_type & QUDA_HEAVY_QUARK_RESIDUAL) && (hq2 > hq_tol) )
-      return false;
+    if (param.residual_type & QUDA_HEAVY_QUARK_RESIDUAL) {
+      if (std::isnan(hq2) || std::isinf(hq2))
+        errorQuda("Solver appears to have diverged with heavy quark residual %e", hq2);
+      
+      if (hq2 > hq_tol)
+        return false;
+    }
 
     // check the L2 relative residual norm if necessary
-    if ( ((param.residual_type & QUDA_L2_RELATIVE_RESIDUAL) ||
-	  (param.residual_type & QUDA_L2_ABSOLUTE_RESIDUAL)) && (r2 > r2_tol) )
-      return false;
+    if ((param.residual_type & QUDA_L2_RELATIVE_RESIDUAL) ||
+	  (param.residual_type & QUDA_L2_ABSOLUTE_RESIDUAL)) {
+      if (std::isnan(r2) || std::isinf(r2))
+        errorQuda("Solver appears to have diverged with residual %e", hq2);
+
+      if (r2 > r2_tol)
+        return false;
+    }
 
     return true;
   }
@@ -340,8 +350,13 @@ namespace quda {
   bool Solver::convergenceHQ(double r2, double hq2, double r2_tol, double hq_tol) {
 
     // check the heavy quark residual norm if necessary
-    if ( (param.residual_type & QUDA_HEAVY_QUARK_RESIDUAL) && (hq2 > hq_tol) )
-      return false;
+    if (param.residual_type & QUDA_HEAVY_QUARK_RESIDUAL) {
+      if (std::isnan(hq2) || std::isinf(hq2))
+        errorQuda("Solver appears to have diverged with heavy quark residual %e", hq2);
+      
+      if (hq2 > hq_tol) 
+        return false;
+    }
 
     return true;
   }
@@ -349,9 +364,14 @@ namespace quda {
   bool Solver::convergenceL2(double r2, double hq2, double r2_tol, double hq_tol) {
 
     // check the L2 relative residual norm if necessary
-    if ( ((param.residual_type & QUDA_L2_RELATIVE_RESIDUAL) ||
-    (param.residual_type & QUDA_L2_ABSOLUTE_RESIDUAL)) && (r2 > r2_tol) )
-      return false;
+    if ((param.residual_type & QUDA_L2_RELATIVE_RESIDUAL) ||
+          (param.residual_type & QUDA_L2_ABSOLUTE_RESIDUAL)) {
+      if (std::isnan(r2) || std::isinf(r2))
+        errorQuda("Solver appears to have diverged with residual %e", hq2);
+
+      if (r2 > r2_tol) 
+        return false;
+    }
 
     return true;
   }
@@ -367,7 +387,7 @@ namespace quda {
       }
     }
 
-    if (std::isnan(r2)) errorQuda("Solver appears to have diverged");
+    if (std::isnan(r2) || std::isinf(r2)) errorQuda("Solver appears to have diverged");
   }
 
   void Solver::PrintSummary(const char *name, int k, double r2, double b2,
@@ -397,11 +417,17 @@ namespace quda {
 
   bool MultiShiftSolver::convergence(const double *r2, const double *r2_tol, int n) const {
 
-    for (int i=0; i<n; i++) {
-      // check the L2 relative residual norm if necessary
-      if ( ((param.residual_type & QUDA_L2_RELATIVE_RESIDUAL) ||
-	    (param.residual_type & QUDA_L2_ABSOLUTE_RESIDUAL)) && (r2[i] > r2_tol[i]) && r2_tol[i] != 0.0)
-	return false;
+    // check the L2 relative residual norm if necessary
+    if ((param.residual_type & QUDA_L2_RELATIVE_RESIDUAL) ||
+            (param.residual_type & QUDA_L2_ABSOLUTE_RESIDUAL))
+    {
+      for (int i=0; i<n; i++)
+      {
+        if (std::isnan(r2[i]) || std::isinf(r2[i])) errorQuda("Multishift solver appears to have diverged on shift %d with residual %e", i, r2[i]);
+
+        if (r2[i] > r2_tol[i] && r2_tol[i] != 0.0)
+          return false;
+      }
     }
 
     return true;


### PR DESCRIPTION
This ~(draft)~ PR moves the singular point of recon-8 (and by extension -9) from the identity matrix to {{0,1,0},{1,0,0},{0,0,-1}}. In practice, this avoids issues with unit gauge fields that may come up in free-field experiments or during the first trajectory of (R)HMC from a cold start.

In its current state the PR is functionally correct and passes a performance "laugh test", but still needs a more exhaustive sweep of volumes, precisions, etc.

As part of this test I found that something has gone awry with generating a unit staggered field. Building the free HISQ fat/long links works just fine.

This PR will close #978 once it's fully tested.

Representative sanity check with Wilson:
```
for r in 18 12 8; do echo -n "recon $r , "; ./invert_test --verbosity verbose --prec double --prec-sloppy single --recon 18 --recon-sloppy $r --nsrc 20 --unit-gauge 1 2>&1 | grep "mean solve" | awk ' { print $11,$12,$13,$14; } '; done
```

Representative sanity check with HISQ:
```
for r in 18 13 9; do echo -n "recon $r , "; ./staggered_invert_test --verbosity verbose --dslash-type asqtad --compute-fat-long true --mass 0.3 --test 1 --prec double --prec-sloppy single --recon 18 --recon-sloppy $r --nsrc 20 --unit-gauge 1 2>&1 | grep "mean solve" | awk ' { print $11,$12,$13,$14; } '; done
```