### PR TITLE
Expose additional MG params plus C interface compilation test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -356,22 +356,22 @@ set(CMAKE_C_FLAGS_DEVEL
     "-Wall -g -O3"
     CACHE STRING "Flags used by the C compiler during regular development builds.")
 set(CMAKE_C_FLAGS_STRICT
-    "-Wall -O3 -Werror -Wno-error=unused-private-field"
+    "-Wall -O3 -Werror"
     CACHE STRING "Flags used by the C compiler during strict jenkins builds.")
 set(CMAKE_C_FLAGS_RELEASE
-    "-Wall -O3 -w"
+    "-Wall -O3"
     CACHE STRING "Flags used by the C compiler during release builds.")
 set(CMAKE_C_FLAGS_HOSTDEBUG
     "-Wall -Wno-unknown-pragmas -g -fno-inline"
     CACHE STRING "Flags used by the C compiler during host-debug builds.")
 set(CMAKE_C_FLAGS_DEVICEDEBUG
-    "-Wall"
+    "-Wall -Wno-unknown-pragmas"
     CACHE STRING "Flags used by the C compiler during device-debug builds.")
 set(CMAKE_C_FLAGS_DEBUG
-    "-Wall -g -fno-inline"
+    "-Wall -Wno-unknown-pragmas -g -fno-inline"
     CACHE STRING "Flags used by the C compiler during full (host+device) debug builds.")
 set(CMAKE_C_FLAGS_SANITIZE
-    "-Wall -g -fno-inline -fsanitize=address,undefined"
+    "-Wall -Wno-unknown-pragmas -g -fno-inline -fsanitize=address,undefined"
     CACHE STRING "Flags used by the C compiler during sanitizer debug builds.")
 
 enable_language(C)

--- a/include/quda.h
+++ b/include/quda.h
@@ -1448,7 +1448,7 @@ extern "C" {
    * @param[in] native boolean to use either the native or generic version
    * @param[in] param The data defining the problem execution.
    */
-  void blasGEMMQuda(void *arrayA, void *arrayB, void *arrayC, bool native, QudaBLASParam *param);
+  void blasGEMMQuda(void *arrayA, void *arrayB, void *arrayC, QudaBoolean native, QudaBLASParam *param);
 
   /**
    * @brief Flush the chronological history for the given index

--- a/lib/interface/blas_interface.cpp
+++ b/lib/interface/blas_interface.cpp
@@ -9,7 +9,7 @@ using namespace quda;
 TimeProfile &getProfileBLAS();
 void checkBLASParam(QudaBLASParam &param);
 
-void blasGEMMQuda(void *arrayA, void *arrayB, void *arrayC, bool use_native, QudaBLASParam *blas_param)
+void blasGEMMQuda(void *arrayA, void *arrayB, void *arrayC, QudaBoolean use_native, QudaBLASParam *blas_param)
 {
   getProfileBLAS().TPSTART(QUDA_PROFILE_TOTAL);
   checkBLASParam(*blas_param);
@@ -45,7 +45,7 @@ void blasGEMMQuda(void *arrayA, void *arrayB, void *arrayC, bool use_native, Qud
   // BatchGEMM function, and before function exit all pointers and values are
   // restored to the values they had on entry.
 
-  if (!use_native) {
+  if (use_native == QUDA_BOOLEAN_FALSE) {
     getProfileBLAS().TPSTART(QUDA_PROFILE_COMPUTE);
     blas_lapack::generic::stridedBatchGEMM(arrayA, arrayB, arrayC, *blas_param, QUDA_CPU_FIELD_LOCATION);
     getProfileBLAS().TPSTOP(QUDA_PROFILE_COMPUTE);

--- a/lib/milc_interface.cpp
+++ b/lib/milc_interface.cpp
@@ -1970,15 +1970,6 @@ void milcSetMultigridParam(milcMultigridPack *mg_pack, QudaPrecision host_precis
       } else {
         errorQuda("unexpected solve type = %d\n", input_struct.coarse_solve_type[i]);
       }
-
-      // solve
-      // if (coarse_solve_type[i] == QUDA_DIRECT_SOLVE) {
-      //  mg_param.coarse_grid_solution_type[i] = QUDA_MAT_SOLUTION;
-      //} else if (coarse_solve_type[i] == QUDA_DIRECT_PC_SOLVE) {
-      //  mg_param.coarse_grid_solution_type[i] = QUDA_MATPC_SOLUTION;
-      //} else {
-      //  errorQuda("Unexpected solve_type = %d\n", coarse_solve_type[i]);
-      //}
     }
 
     mg_param.omega[i] = 0.85; // ignored // omega; // over/under relaxation factor

--- a/lib/milc_interface.cpp
+++ b/lib/milc_interface.cpp
@@ -1549,8 +1549,7 @@ struct mgInputStruct {
         coarse_solve_type[atoi(input_line[1].c_str())] = getQudaSolveType(input_line[2].c_str());
       }
 
-    } else
-      if (strcmp(input_line[0].c_str(), "coarse_solver") == 0) {
+    } else if (strcmp(input_line[0].c_str(), "coarse_solver") == 0) {
       if (input_line.size() < 3) {
         error_code = 1;
       } else {
@@ -1851,8 +1850,9 @@ void milcSetMultigridParam(milcMultigridPack *mg_pack, QudaPrecision host_precis
     mg_param.setup_maxiter_refresh[i] = 0; // setup_maxiter_refresh[i];
     mg_param.n_vec[i] = (i == 0) ? 24 : input_struct.nvec[i];
     mg_param.n_block_ortho[i] = 2; // n_block_ortho[i];                          // number of times to Gram-Schmidt
-    mg_param.precision_null[i] = input_struct.preconditioner_precision;          // precision to store the null-space basis
-    mg_param.smoother_halo_precision[i] = input_struct.preconditioner_precision; // precision of the halo exchange in the smoother
+    mg_param.precision_null[i] = input_struct.preconditioner_precision; // precision to store the null-space basis
+    mg_param.smoother_halo_precision[i]
+      = input_struct.preconditioner_precision; // precision of the halo exchange in the smoother
     mg_param.nu_pre[i] = input_struct.nu_pre[i];
     mg_param.nu_post[i] = input_struct.nu_post[i];
     mg_param.mu_factor[i] = 1.; // mu_factor[i];
@@ -1887,9 +1887,9 @@ void milcSetMultigridParam(milcMultigridPack *mg_pack, QudaPrecision host_precis
     // set to QUDA_DIRECT_PC_SOLVE for to enable even/odd preconditioning on the smoother
     // from test routines: // smoother_solve_type[i];
     switch (i) {
-      case 0: mg_param.smoother_solve_type[0] = QUDA_DIRECT_SOLVE; break;
-      case 1: mg_param.smoother_solve_type[1] = QUDA_DIRECT_PC_SOLVE; break;
-      default: mg_param.smoother_solve_type[i] = input_struct.coarse_solve_type[i]; break;
+    case 0: mg_param.smoother_solve_type[0] = QUDA_DIRECT_SOLVE; break;
+    case 1: mg_param.smoother_solve_type[1] = QUDA_DIRECT_PC_SOLVE; break;
+    default: mg_param.smoother_solve_type[i] = input_struct.coarse_solve_type[i]; break;
     }
 
     // set to QUDA_ADDITIVE_SCHWARZ for Additive Schwarz precondioned smoother (presently only impelemented for MR)
@@ -1980,7 +1980,6 @@ void milcSetMultigridParam(milcMultigridPack *mg_pack, QudaPrecision host_precis
       //  errorQuda("Unexpected solve_type = %d\n", coarse_solve_type[i]);
       //}
     }
-
 
     mg_param.omega[i] = 0.85; // ignored // omega; // over/under relaxation factor
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ target_include_directories(quda_test SYSTEM PUBLIC  googletest/include googletes
 target_include_directories(quda_test SYSTEM PUBLIC ${CUDAToolkit_INCLUDE_DIRS})
 target_include_directories(quda_test SYSTEM PUBLIC ${EIGEN_INCLUDE_DIRS})
 target_link_libraries(quda_test PUBLIC quda)
+target_compile_options(quda_test PUBLIC -fPIC)
 add_subdirectory(utils)
 add_subdirectory(host_reference)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -59,10 +59,10 @@ endif()
 
 # define tests
 add_executable(c_interface_test c_interface_test.c)
-  target_link_libraries(c_interface_test ${TEST_LIBS})
-  quda_checkbuildtest(c_interface_test QUDA_BUILD_ALL_TESTS)
+target_link_libraries(c_interface_test ${TEST_LIBS})
+quda_checkbuildtest(c_interface_test QUDA_BUILD_ALL_TESTS)
 
-  # if we build with QDP JIT the tests cannot run anyway
+# if we build with QDP JIT the tests cannot run anyway
 if(QUDA_QDPJIT)
   set(QUDA_BUILD_ALL_TESTS OFF)
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -57,8 +57,11 @@ if(QUDA_ARPACK)
 endif()
 
 # define tests
+add_executable(c_interface_test c_interface_test.c)
+  target_link_libraries(c_interface_test ${TEST_LIBS})
+  quda_checkbuildtest(c_interface_test QUDA_BUILD_ALL_TESTS)
 
-# if we build with QDP JIT the tests cannot run anyway
+  # if we build with QDP JIT the tests cannot run anyway
 if(QUDA_QDPJIT)
   set(QUDA_BUILD_ALL_TESTS OFF)
 endif()

--- a/tests/blas_interface_test.cpp
+++ b/tests/blas_interface_test.cpp
@@ -270,7 +270,7 @@ double test(int data_type)
   }
 
   // Perform device GEMM Blas operation
-  blasGEMMQuda(arrayA, arrayB, arrayC, native_blas_lapack, &blas_param);
+  blasGEMMQuda(arrayA, arrayB, arrayC, native_blas_lapack ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE, &blas_param);
 
   double deviation = 0.0;
   if (verify_results) {

--- a/tests/c_interface_test.c
+++ b/tests/c_interface_test.c
@@ -1,6 +1,7 @@
 #include <quda.h>
 
-int main(){
+int main()
+{
   initQuda(0);
   endQuda();
 }

--- a/tests/c_interface_test.c
+++ b/tests/c_interface_test.c
@@ -1,0 +1,6 @@
+#include <quda.h>
+
+int main(){
+  initQuda(0);
+  endQuda();
+}


### PR DESCRIPTION
This PR:
* Exposes two additional parameters to the MILC HISQ MG interface: (1) coarse link/near-null precision (half or single instead of hard-coded half), and (2) coarsening the full or preconditioned operator on intermediate and coarsest levels (instead of hard-coded preconditioned)
* Adds @mathiaswagner 's C interface compile test
* Fixes an issue in the C interface introduced by having a `bool` in the signature of the BLAS interface.

Closes #1079 and #926 