### PR TITLE
Optimized coarse coarse clover workflow

### DIFF
--- a/include/clover_field_order.h
+++ b/include/clover_field_order.h
@@ -372,6 +372,9 @@ namespace quda {
     template <typename Float, int nColor, int nSpin, QudaCloverFieldOrder order>
       struct FieldOrder {
 
+      /** Does this field type support ghost zones? */
+      static constexpr bool supports_ghost_zone = false;
+
       protected:
 	/** An internal reference to the actual field we are accessing */
 	CloverField &A;

--- a/include/clover_field_order.h
+++ b/include/clover_field_order.h
@@ -375,19 +375,19 @@ namespace quda {
       /** Does this field type support ghost zones? */
       static constexpr bool supports_ghost_zone = false;
 
-      protected:
-	/** An internal reference to the actual field we are accessing */
-	CloverField &A;
-	const int volumeCB;
-	const Accessor<Float,nColor,nSpin,order> accessor;
-	bool inverse;
-	const QudaFieldLocation location;
+    protected:
+      /** An internal reference to the actual field we are accessing */
+      CloverField &A;
+      const int volumeCB;
+      const Accessor<Float, nColor, nSpin, order> accessor;
+      bool inverse;
+      const QudaFieldLocation location;
 
-      public:
-	/** 
-	 * Constructor for the FieldOrder class
-	 * @param field The field that we are accessing
-	 */
+    public:
+      /**
+       * Constructor for the FieldOrder class
+       * @param field The field that we are accessing
+       */
       FieldOrder(CloverField &A, bool inverse=false)
       : A(A), volumeCB(A.VolumeCB()), accessor(A,inverse), inverse(inverse), location(A.Location())
 	{ }

--- a/include/color_spinor_field_order.h
+++ b/include/color_spinor_field_order.h
@@ -577,6 +577,10 @@ namespace quda {
       {
         typedef float norm_type;
 
+      public:
+        /** Does this field type support ghost zones? */
+        static constexpr bool supports_ghost_zone = true;
+
       protected:
         complex<storeFloat> *v;
         const AccessorCB<storeFloat, nSpin, nColor, nVec, order> accessor;

--- a/include/enum_quda.h
+++ b/include/enum_quda.h
@@ -487,7 +487,7 @@ typedef enum QudaBLASDataOrder_s {
   QUDA_BLAS_DATAORDER_INVALID = QUDA_INVALID_ENUM
 } QudaBLASDataOrder;
 
-typedef enum QudaDirection_s { QUDA_BACKWARDS = -1, QUDA_FORWARDS = +1, QUDA_BOTH_DIRS = 2 } QudaDirection;
+typedef enum QudaDirection_s { QUDA_BACKWARDS = -1, QUDA_IN_PLACE=0, QUDA_FORWARDS = +1, QUDA_BOTH_DIRS = 2 } QudaDirection;
 
 typedef enum QudaLinkDirection_s { QUDA_LINK_BACKWARDS, QUDA_LINK_FORWARDS, QUDA_LINK_BIDIRECTIONAL } QudaLinkDirection;
 

--- a/include/enum_quda.h
+++ b/include/enum_quda.h
@@ -487,7 +487,12 @@ typedef enum QudaBLASDataOrder_s {
   QUDA_BLAS_DATAORDER_INVALID = QUDA_INVALID_ENUM
 } QudaBLASDataOrder;
 
-typedef enum QudaDirection_s { QUDA_BACKWARDS = -1, QUDA_IN_PLACE=0, QUDA_FORWARDS = +1, QUDA_BOTH_DIRS = 2 } QudaDirection;
+typedef enum QudaDirection_s {
+  QUDA_BACKWARDS = -1,
+  QUDA_IN_PLACE = 0,
+  QUDA_FORWARDS = +1,
+  QUDA_BOTH_DIRS = 2
+} QudaDirection;
 
 typedef enum QudaLinkDirection_s { QUDA_LINK_BACKWARDS, QUDA_LINK_FORWARDS, QUDA_LINK_BIDIRECTIONAL } QudaLinkDirection;
 

--- a/include/gauge_field_order.h
+++ b/include/gauge_field_order.h
@@ -932,6 +932,9 @@ namespace quda {
       accessor_type accessor;
       GhostAccessor<Float, nColor, order, native_ghost, storeFloat> ghostAccessor;
 
+      /** Does this field type support ghost zones? */
+      static constexpr bool supports_ghost_zone = true;
+
       /**
        * Constructor for the FieldOrder class
        * @param field The field that we are accessing

--- a/lib/coarse_op.cuh
+++ b/lib/coarse_op.cuh
@@ -56,7 +56,7 @@ namespace quda {
           else if (arg.dim==2) ComputeUVCPU<2,QUDA_FORWARDS>(arg);
           else if (arg.dim==3) ComputeUVCPU<3,QUDA_FORWARDS>(arg);
         } else if (arg.dir == QUDA_IN_PLACE) {
-          ComputeUVCPU<-1,QUDA_IN_PLACE>(arg);
+          ComputeUVCPU<0,QUDA_IN_PLACE>(arg);
         } else {
           errorQuda("Undefined direction %d", arg.dir);
         }
@@ -123,7 +123,7 @@ namespace quda {
           else if (arg.dim==2) ComputeVUVCPU<2,QUDA_FORWARDS>(arg);
           else if (arg.dim==3) ComputeVUVCPU<3,QUDA_FORWARDS>(arg);
         } else if (arg.dir == QUDA_IN_PLACE) {
-          ComputeVUVCPU<-1,QUDA_IN_PLACE>(arg);
+          ComputeVUVCPU<0,QUDA_IN_PLACE>(arg);
         } else {
           errorQuda("Undefined direction %d", arg.dir);
         }
@@ -192,7 +192,7 @@ namespace quda {
           else if (arg.dim==2) qudaLaunchKernel(ComputeUVGPU<2,QUDA_FORWARDS,Arg>, tp, stream, arg);
           else if (arg.dim==3) qudaLaunchKernel(ComputeUVGPU<3,QUDA_FORWARDS,Arg>, tp, stream, arg);
         } else if (arg.dir == QUDA_IN_PLACE) {
-          qudaLaunchKernel(ComputeUVGPU<-1,QUDA_IN_PLACE,Arg>, tp, stream, arg);
+          qudaLaunchKernel(ComputeUVGPU<0,QUDA_IN_PLACE,Arg>, tp, stream, arg);
         }
 #endif
         }
@@ -352,7 +352,7 @@ namespace quda {
             else if (arg.dim==2) qudaLaunchKernel(ComputeVUVGPU<true,parity_flip,2,QUDA_FORWARDS,Arg>, tp, stream, arg);
             else if (arg.dim==3) qudaLaunchKernel(ComputeVUVGPU<true,parity_flip,3,QUDA_FORWARDS,Arg>, tp, stream, arg);
           } else if (arg.dir == QUDA_IN_PLACE) {
-            qudaLaunchKernel(ComputeVUVGPU<true,parity_flip,-1,QUDA_IN_PLACE,Arg>, tp, stream, arg);
+            qudaLaunchKernel(ComputeVUVGPU<true,parity_flip,0,QUDA_IN_PLACE,Arg>, tp, stream, arg);
           } else {
             errorQuda("Undefined direction %d", arg.dir);
           }
@@ -371,7 +371,7 @@ namespace quda {
             else if (arg.dim==2) qudaLaunchKernel(ComputeVUVGPU<false,parity_flip,2,QUDA_FORWARDS,Arg>, tp, stream, arg);
             else if (arg.dim==3) qudaLaunchKernel(ComputeVUVGPU<false,parity_flip,3,QUDA_FORWARDS,Arg>, tp, stream, arg);
           } else if (arg.dir == QUDA_IN_PLACE) {
-            qudaLaunchKernel(ComputeVUVGPU<false,parity_flip,-1,QUDA_IN_PLACE,Arg>, tp, stream, arg);
+            qudaLaunchKernel(ComputeVUVGPU<false,parity_flip,0,QUDA_IN_PLACE,Arg>, tp, stream, arg);
           } else {
             errorQuda("Undefined direction %d", arg.dir);
           }
@@ -1317,7 +1317,8 @@ namespace quda {
       if (getVerbosity() >= QUDA_VERBOSE) printfQuda("Computing coarse CV and VCV via UV and VUV\n");
 
       if (uv.Precision() == QUDA_HALF_PRECISION) {
-        double U_max = 3.0*G_.abs_max(0); // use G as a proxy for the coarse clover
+        // use G as a proxy for the coarse clover because `C_` is a dummy object on the coarse level
+        double U_max = 3.0*G_.abs_max(0);
         double uv_max = U_max * v.Scale();
         uv.Scale(uv_max);
         arg.UV.resetScale(uv_max);

--- a/lib/coarse_op.cuh
+++ b/lib/coarse_op.cuh
@@ -55,6 +55,8 @@ namespace quda {
           else if (arg.dim==1) ComputeUVCPU<1,QUDA_FORWARDS>(arg);
           else if (arg.dim==2) ComputeUVCPU<2,QUDA_FORWARDS>(arg);
           else if (arg.dim==3) ComputeUVCPU<3,QUDA_FORWARDS>(arg);
+        } else if (arg.dir == QUDA_IN_PLACE) {
+          ComputeUVCPU<-1,QUDA_IN_PLACE>(arg);
         } else {
           errorQuda("Undefined direction %d", arg.dir);
         }
@@ -120,11 +122,17 @@ namespace quda {
           else if (arg.dim==1) ComputeVUVCPU<1,QUDA_FORWARDS>(arg);
           else if (arg.dim==2) ComputeVUVCPU<2,QUDA_FORWARDS>(arg);
           else if (arg.dim==3) ComputeVUVCPU<3,QUDA_FORWARDS>(arg);
+        } else if (arg.dir == QUDA_IN_PLACE) {
+          ComputeVUVCPU<-1,QUDA_IN_PLACE>(arg);
         } else {
           errorQuda("Undefined direction %d", arg.dir);
         }
       } else if (type == COMPUTE_COARSE_CLOVER) {
+#if defined(WILSONCOARSE)
         ComputeCoarseCloverCPU(arg);
+#else
+        errorQuda("ComputeCoarseClover not enabled for non-Wilson coarsenings");
+#endif
       } else if (type == COMPUTE_REVERSE_Y) {
         ComputeYReverseCPU(arg);
       } else if (type == COMPUTE_DIAGONAL) {
@@ -161,13 +169,13 @@ namespace quda {
       using namespace jitify::reflection;
 #endif
       if (type == COMPUTE_UV) {
-        if (use_mma) {
+        if (use_mma && arg.dir != QUDA_IN_PLACE) {
 
           mma::launch_compute_uv_kernel<from_coarse>(tp, arg, arg.fineVolumeCB, stream);
 
         } else {
 
-          if (arg.dir != QUDA_BACKWARDS && arg.dir != QUDA_FORWARDS) errorQuda("Undefined direction %d", arg.dir);
+          if (arg.dir != QUDA_BACKWARDS && arg.dir != QUDA_FORWARDS && arg.dir != QUDA_IN_PLACE) errorQuda("Undefined direction %d", arg.dir);
 #ifdef JITIFY
         error = program->kernel("quda::ComputeUVGPU")
           .instantiate(arg.dim,arg.dir,Type<Arg>())
@@ -183,6 +191,8 @@ namespace quda {
           else if (arg.dim==1) qudaLaunchKernel(ComputeUVGPU<1,QUDA_FORWARDS,Arg>, tp, stream, arg);
           else if (arg.dim==2) qudaLaunchKernel(ComputeUVGPU<2,QUDA_FORWARDS,Arg>, tp, stream, arg);
           else if (arg.dim==3) qudaLaunchKernel(ComputeUVGPU<3,QUDA_FORWARDS,Arg>, tp, stream, arg);
+        } else if (arg.dir == QUDA_IN_PLACE) {
+          qudaLaunchKernel(ComputeUVGPU<-1,QUDA_IN_PLACE,Arg>, tp, stream, arg);
         }
 #endif
         }
@@ -285,7 +295,7 @@ namespace quda {
 
       } else if (type == COMPUTE_VUV) {
 
-        if (use_mma) {
+        if (use_mma && arg.dir != QUDA_IN_PLACE) {
 
           mma::launch_compute_vuv_kernel<from_coarse>(tp, arg, arg.fineVolumeCB, stream);
 
@@ -321,6 +331,7 @@ namespace quda {
             tp.grid.z = 1;
           }
 
+          if (arg.dir != QUDA_BACKWARDS && arg.dir != QUDA_FORWARDS && arg.dir != QUDA_IN_PLACE) errorQuda("Undefined direction %d", arg.dir);
 #ifdef JITIFY
         error = program->kernel("quda::ComputeVUVGPU")
           .instantiate(arg.shared_atomic,arg.parity_flip,arg.dim,arg.dir,Type<Arg>())
@@ -340,6 +351,8 @@ namespace quda {
             else if (arg.dim==1) qudaLaunchKernel(ComputeVUVGPU<true,parity_flip,1,QUDA_FORWARDS,Arg>, tp, stream, arg);
             else if (arg.dim==2) qudaLaunchKernel(ComputeVUVGPU<true,parity_flip,2,QUDA_FORWARDS,Arg>, tp, stream, arg);
             else if (arg.dim==3) qudaLaunchKernel(ComputeVUVGPU<true,parity_flip,3,QUDA_FORWARDS,Arg>, tp, stream, arg);
+          } else if (arg.dir == QUDA_IN_PLACE) {
+            qudaLaunchKernel(ComputeVUVGPU<true,parity_flip,-1,QUDA_IN_PLACE,Arg>, tp, stream, arg);
           } else {
             errorQuda("Undefined direction %d", arg.dir);
           }
@@ -357,6 +370,8 @@ namespace quda {
             else if (arg.dim==1) qudaLaunchKernel(ComputeVUVGPU<false,parity_flip,1,QUDA_FORWARDS,Arg>, tp, stream, arg);
             else if (arg.dim==2) qudaLaunchKernel(ComputeVUVGPU<false,parity_flip,2,QUDA_FORWARDS,Arg>, tp, stream, arg);
             else if (arg.dim==3) qudaLaunchKernel(ComputeVUVGPU<false,parity_flip,3,QUDA_FORWARDS,Arg>, tp, stream, arg);
+          } else if (arg.dir == QUDA_IN_PLACE) {
+            qudaLaunchKernel(ComputeVUVGPU<false,parity_flip,-1,QUDA_IN_PLACE,Arg>, tp, stream, arg);
           } else {
             errorQuda("Undefined direction %d", arg.dir);
           }
@@ -384,7 +399,7 @@ namespace quda {
           .instantiate(Type<Arg>())
           .configure(tp.grid,tp.block,tp.shared_bytes,stream).launch(arg);
 #else
-#if !defined(STAGGEREDCOARSE)
+#if defined(WILSONCOARSE)
         qudaLaunchKernel(ComputeCoarseCloverGPU<Arg>, tp, stream, arg);
 #else
         errorQuda("ComputeCoarseClover not enabled for staggered coarsenings");
@@ -764,7 +779,7 @@ namespace quda {
 
     bool advanceTuneParam(TuneParam &param) const {
 
-      if (use_mma && (type == COMPUTE_UV || type == COMPUTE_VUV)) {
+      if (use_mma && (type == COMPUTE_UV || type == COMPUTE_VUV) && dir != QUDA_IN_PLACE) {
         constexpr bool query_max = true;
         int max;
         if (type == COMPUTE_UV) {
@@ -789,7 +804,7 @@ namespace quda {
     void initTuneParam(TuneParam &param) const
     {
       TunableVectorYZ::initTuneParam(param);
-      param.aux.x = ((type == COMPUTE_VUV || type == COMPUTE_UV) && use_mma) ? 0 : 1; // aggregates per block
+      param.aux.x = ((type == COMPUTE_VUV || type == COMPUTE_UV) && use_mma && dir != QUDA_IN_PLACE) ? 0 : 1; // aggregates per block
       param.aux.y = arg.shared_atomic;
       param.aux.z = arg.parity_flip; // not actually tuned over at present
 
@@ -804,7 +819,7 @@ namespace quda {
     void defaultTuneParam(TuneParam &param) const
     {
       TunableVectorYZ::defaultTuneParam(param);
-      param.aux.x = ((type == COMPUTE_VUV || type == COMPUTE_UV) && use_mma) ? 0 : 1; // aggregates per block
+      param.aux.x = ((type == COMPUTE_VUV || type == COMPUTE_UV) && use_mma && dir != QUDA_IN_PLACE) ? 0 : 1; // aggregates per block
       // param.aux.x = 1; // aggregates per block
       param.aux.y = arg.shared_atomic;
       param.aux.z = arg.parity_flip; // not actually tuned over at present
@@ -822,7 +837,7 @@ namespace quda {
 
       if (type == COMPUTE_UV) {
         strcat(Aux, ",computeUV");
-        if (use_mma) strcat(Aux, ",MMA");
+        if (use_mma && dir != QUDA_IN_PLACE) strcat(Aux, ",MMA");
       } else if (type == COMPUTE_AV)
         strcat(Aux, ",computeAV");
       else if (type == COMPUTE_TMAV)               strcat(Aux,",computeTmAV");
@@ -833,7 +848,7 @@ namespace quda {
         strcat(Aux, ",computeTwistedCloverInverseMax");
       else if (type == COMPUTE_VUV) {
         strcat(Aux, ",computeVUV");
-        if (use_mma) strcat(Aux, ",MMA");
+        if (use_mma && dir != QUDA_IN_PLACE) strcat(Aux, ",MMA");
       } else if (type == COMPUTE_COARSE_CLOVER)
         strcat(Aux, ",computeCoarseClover");
       else if (type == COMPUTE_REVERSE_Y)          strcat(Aux,",computeYreverse");
@@ -1288,11 +1303,38 @@ namespace quda {
       y.apply(0);
     }
 
-    // Check if we have a clover term that needs to be coarsened
-    if (dirac == QUDA_CLOVER_DIRAC || dirac == QUDA_COARSE_DIRAC || dirac == QUDA_TWISTED_CLOVER_DIRAC) {
+    // Check if we have a fine or coarse clover term that needs to be coarsened
+    if (dirac == QUDA_CLOVER_DIRAC || dirac == QUDA_TWISTED_CLOVER_DIRAC) {
       if (getVerbosity() >= QUDA_VERBOSE) printfQuda("Computing fine->coarse clover term\n");
       y.setComputeType(COMPUTE_COARSE_CLOVER);
       y.apply(0);
+    } else if (dirac == QUDA_COARSE_DIRAC) {
+
+      // We can write coarsening the coarse clover as a UV, VUV sequence where `U` is replaced with `C`
+      y.setDimension(-1);
+      y.setDirection(QUDA_IN_PLACE);
+
+      if (getVerbosity() >= QUDA_VERBOSE) printfQuda("Computing coarse CV and VCV via UV and VUV\n");
+
+      if (uv.Precision() == QUDA_HALF_PRECISION) {
+        double U_max = 3.0*G_.abs_max(0); // use G as a proxy for the coarse clover
+        double uv_max = U_max * v.Scale();
+        uv.Scale(uv_max);
+        arg.UV.resetScale(uv_max);
+
+        if (getVerbosity() >= QUDA_VERBOSE) printfQuda("C_max (U[0] as proxy) = %e v_max = %e cv_max = %e\n", U_max, v.Scale(), uv_max);
+      }
+
+      y.setComputeType(COMPUTE_UV);  // compute C*V product
+      y.apply(0);
+
+      if (getVerbosity() >= QUDA_VERBOSE) printfQuda("CV2 = %e\n", arg.UV.norm2());
+
+      y.setComputeType(COMPUTE_VUV); // compute X += VCV
+      y.apply(0);
+      if (getVerbosity() >= QUDA_VERBOSE)
+        printfQuda("X2 (atomic) = %e\n", X_atomic_.norm2(0, coarseGaugeAtomic::fixedPoint()));
+
     } else if (dirac == QUDA_STAGGERED_DIRAC || dirac == QUDA_STAGGEREDPC_DIRAC || dirac == QUDA_ASQTAD_DIRAC || dirac == QUDA_ASQTADPC_DIRAC) { 
       if (getVerbosity() >= QUDA_VERBOSE) printfQuda("Summing staggered mass contribution to coarse clover\n");
       y.setComputeType(COMPUTE_STAGGEREDMASS);


### PR DESCRIPTION
This PR reduces the compile time of a full Wilson+staggered MG build to about an hour.

...More substantively, this PR leverages `computeUV` and `computeVUV` to coarsen the coarse clover, as opposed to using the existing `computeCoarseClover` routine. The key observation is that `computeUV` as it stood applied the coarse links `Y` to the near-nulls `V` in the +/- `dir` direction. This can be simply reformulated to apply the coarse clover `X` to the near-nulls `V` at the same site instead. `computeVUV` is then broadly unchanged, since it already completes the inner-product in a site-local sense, not requiring any gather from a neighboring site.

With this modification, we can remove the code paths in `computeCoarseClover` relevant for coarsening the coarse operator. The routine still exists for coarsening the fine clover, which isn't a real compile time or performance limiter. 

These changes can be trivially (in a textual sense) ported to the MMA routines as well. That is intentionally being deferred to a later PR---I'll implement it, then (politely) ask @hummingtree to do performance verifications and tweaks as is necessary.

This PR is functionally complete, I'm just doing a full parameter sweep across fermion types, precisions, etc, to make sure everything's ship-shape. Once that's done I'll take it out of draft PR status.