### PR TITLE
Staggered cleanup and bugfixes

### DIFF
--- a/lib/coarse_op.cuh
+++ b/lib/coarse_op.cuh
@@ -885,6 +885,7 @@ namespace quda {
 
 	if (dir == QUDA_BACKWARDS) strcat(Aux,",dir=back");
 	else if (dir == QUDA_FORWARDS) strcat(Aux,",dir=fwd");
+        else if (dir == QUDA_IN_PLACE) strcat(Aux,",dir=clover");
 
         if (arg.bidirectional && type == COMPUTE_VUV) strcat(Aux,",bidirectional");
       }

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -1888,7 +1888,6 @@ namespace quda {
       return;
     }
 
-    if (for_multishift) {
     // multiply the source to compensate for normalization of the Dirac operator, if necessary
     // you are responsible for restoring what's in param.offset
     switch (param.solution_type) {
@@ -1896,37 +1895,36 @@ namespace quda {
         if (param.mass_normalization == QUDA_MASS_NORMALIZATION ||
             param.mass_normalization == QUDA_ASYMMETRIC_MASS_NORMALIZATION) {
 	  blas::ax(2.0*kappa, b);
-	  for(int i=0; i<param.num_offset; i++)  param.offset[i] *= 2.0*kappa;
+	  if (for_multishift) for(int i=0; i<param.num_offset; i++)  param.offset[i] *= 2.0*kappa;
         }
         break;
       case QUDA_MATDAG_MAT_SOLUTION:
         if (param.mass_normalization == QUDA_MASS_NORMALIZATION ||
             param.mass_normalization == QUDA_ASYMMETRIC_MASS_NORMALIZATION) {
 	  blas::ax(4.0*kappa*kappa, b);
-	  for(int i=0; i<param.num_offset; i++)  param.offset[i] *= 4.0*kappa*kappa;
+	  if (for_multishift) for(int i=0; i<param.num_offset; i++)  param.offset[i] *= 4.0*kappa*kappa;
         }
         break;
       case QUDA_MATPC_SOLUTION:
         if (param.mass_normalization == QUDA_MASS_NORMALIZATION) {
 	  blas::ax(4.0*kappa*kappa, b);
-	  for(int i=0; i<param.num_offset; i++)  param.offset[i] *= 4.0*kappa*kappa;
+	  if (for_multishift) for(int i=0; i<param.num_offset; i++)  param.offset[i] *= 4.0*kappa*kappa;
         } else if (param.mass_normalization == QUDA_ASYMMETRIC_MASS_NORMALIZATION) {
 	  blas::ax(2.0*kappa, b);
-	  for(int i=0; i<param.num_offset; i++)  param.offset[i] *= 2.0*kappa;
+	  if (for_multishift) for(int i=0; i<param.num_offset; i++)  param.offset[i] *= 2.0*kappa;
         }
         break;
       case QUDA_MATPCDAG_MATPC_SOLUTION:
         if (param.mass_normalization == QUDA_MASS_NORMALIZATION) {
 	  blas::ax(16.0*std::pow(kappa,4), b);
-	  for(int i=0; i<param.num_offset; i++)  param.offset[i] *= 16.0*std::pow(kappa,4);
+	  if (for_multishift) for(int i=0; i<param.num_offset; i++)  param.offset[i] *= 16.0*std::pow(kappa,4);
         } else if (param.mass_normalization == QUDA_ASYMMETRIC_MASS_NORMALIZATION) {
 	  blas::ax(4.0*kappa*kappa, b);
-	  for(int i=0; i<param.num_offset; i++)  param.offset[i] *= 4.0*kappa*kappa;
+	  if (for_multishift) for(int i=0; i<param.num_offset; i++)  param.offset[i] *= 4.0*kappa*kappa;
         }
         break;
       default:
         errorQuda("Solution type %d not supported", param.solution_type);
-    }
     }
 
     if (getVerbosity() >= QUDA_DEBUG_VERBOSE) printfQuda("Mass rescale done\n");

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -1856,7 +1856,8 @@ namespace quda {
     dEig = Dirac::create(diracEigParam);
   }
 
-  void massRescale(cudaColorSpinorField &b, QudaInvertParam &param, bool for_multishift) {
+  void massRescale(cudaColorSpinorField &b, QudaInvertParam &param, bool for_multishift)
+  {
 
     double kappa5 = (0.5/(5.0 + param.m5));
     double kappa = (param.dslash_type == QUDA_DOMAIN_WALL_DSLASH || param.dslash_type == QUDA_DOMAIN_WALL_4D_DSLASH
@@ -1895,32 +1896,38 @@ namespace quda {
         if (param.mass_normalization == QUDA_MASS_NORMALIZATION ||
             param.mass_normalization == QUDA_ASYMMETRIC_MASS_NORMALIZATION) {
 	  blas::ax(2.0*kappa, b);
-	  if (for_multishift) for(int i=0; i<param.num_offset; i++)  param.offset[i] *= 2.0*kappa;
+          if (for_multishift)
+            for (int i = 0; i < param.num_offset; i++) param.offset[i] *= 2.0 * kappa;
         }
         break;
       case QUDA_MATDAG_MAT_SOLUTION:
         if (param.mass_normalization == QUDA_MASS_NORMALIZATION ||
             param.mass_normalization == QUDA_ASYMMETRIC_MASS_NORMALIZATION) {
 	  blas::ax(4.0*kappa*kappa, b);
-	  if (for_multishift) for(int i=0; i<param.num_offset; i++)  param.offset[i] *= 4.0*kappa*kappa;
+          if (for_multishift)
+            for (int i = 0; i < param.num_offset; i++) param.offset[i] *= 4.0 * kappa * kappa;
         }
         break;
       case QUDA_MATPC_SOLUTION:
         if (param.mass_normalization == QUDA_MASS_NORMALIZATION) {
 	  blas::ax(4.0*kappa*kappa, b);
-	  if (for_multishift) for(int i=0; i<param.num_offset; i++)  param.offset[i] *= 4.0*kappa*kappa;
+          if (for_multishift)
+            for (int i = 0; i < param.num_offset; i++) param.offset[i] *= 4.0 * kappa * kappa;
         } else if (param.mass_normalization == QUDA_ASYMMETRIC_MASS_NORMALIZATION) {
 	  blas::ax(2.0*kappa, b);
-	  if (for_multishift) for(int i=0; i<param.num_offset; i++)  param.offset[i] *= 2.0*kappa;
+          if (for_multishift)
+            for (int i = 0; i < param.num_offset; i++) param.offset[i] *= 2.0 * kappa;
         }
         break;
       case QUDA_MATPCDAG_MATPC_SOLUTION:
         if (param.mass_normalization == QUDA_MASS_NORMALIZATION) {
 	  blas::ax(16.0*std::pow(kappa,4), b);
-	  if (for_multishift) for(int i=0; i<param.num_offset; i++)  param.offset[i] *= 16.0*std::pow(kappa,4);
+          if (for_multishift)
+            for (int i = 0; i < param.num_offset; i++) param.offset[i] *= 16.0 * std::pow(kappa, 4);
         } else if (param.mass_normalization == QUDA_ASYMMETRIC_MASS_NORMALIZATION) {
 	  blas::ax(4.0*kappa*kappa, b);
-	  if (for_multishift) for(int i=0; i<param.num_offset; i++)  param.offset[i] *= 4.0*kappa*kappa;
+          if (for_multishift)
+            for (int i = 0; i < param.num_offset; i++) param.offset[i] *= 4.0 * kappa * kappa;
         }
         break;
       default:
@@ -1934,7 +1941,6 @@ namespace quda {
       double nin = blas::norm2(b);
       printfQuda("Mass rescale: norm of source out = %g\n", nin);
     }
-
   }
 }
 
@@ -2964,7 +2970,7 @@ void invertQuda(void *hp_x, void *hp_b, QudaInvertParam *param)
     blas::ax(1.0/sqrt(nb), *x);
   }
 
-  massRescale(*static_cast<cudaColorSpinorField*>(b), *param, false);
+  massRescale(*static_cast<cudaColorSpinorField *>(b), *param, false);
 
   dirac.prepare(in, out, *x, *b, param->solution_type);
 
@@ -3424,7 +3430,7 @@ void invertMultiSrcQuda(void **_hp_x, void **_hp_b, QudaInvertParam *param)
   }
 
   for(int i=0; i < param->num_src; i++) {
-    massRescale(dynamic_cast<cudaColorSpinorField&>( b->Component(i) ), *param, false);
+    massRescale(dynamic_cast<cudaColorSpinorField &>(b->Component(i)), *param, false);
   }
 
   // MW: need to check what dirac.prepare does
@@ -3777,9 +3783,7 @@ void invertMultiShiftQuda(void **_hp_x, void *_hp_b, QudaInvertParam *param)
 
   // backup shifts
   double unscaled_shifts[QUDA_MAX_MULTI_SHIFT];
-  for (int i = 0; i < param->num_offset; i++) {
-    unscaled_shifts[i] = param->offset[i];
-  }
+  for (int i = 0; i < param->num_offset; i++) { unscaled_shifts[i] = param->offset[i]; }
 
   // rescale
   massRescale(*b, *param, true);

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -1889,44 +1889,44 @@ namespace quda {
     }
 
     if (for_multishift) {
-      // multiply the source to compensate for normalization of the Dirac operator, if necessary
-      // you are responsible for restoring what's in param.offset
-      switch (param.solution_type) {
-        case QUDA_MAT_SOLUTION:
-          if (param.mass_normalization == QUDA_MASS_NORMALIZATION ||
-              param.mass_normalization == QUDA_ASYMMETRIC_MASS_NORMALIZATION) {
-  	  blas::ax(2.0*kappa, b);
-  	  for(int i=0; i<param.num_offset; i++)  param.offset[i] *= 2.0*kappa;
-          }
-          break;
-        case QUDA_MATDAG_MAT_SOLUTION:
-          if (param.mass_normalization == QUDA_MASS_NORMALIZATION ||
-              param.mass_normalization == QUDA_ASYMMETRIC_MASS_NORMALIZATION) {
-  	  blas::ax(4.0*kappa*kappa, b);
-  	  for(int i=0; i<param.num_offset; i++)  param.offset[i] *= 4.0*kappa*kappa;
-          }
-          break;
-        case QUDA_MATPC_SOLUTION:
-          if (param.mass_normalization == QUDA_MASS_NORMALIZATION) {
-  	  blas::ax(4.0*kappa*kappa, b);
-  	  for(int i=0; i<param.num_offset; i++)  param.offset[i] *= 4.0*kappa*kappa;
-          } else if (param.mass_normalization == QUDA_ASYMMETRIC_MASS_NORMALIZATION) {
-  	  blas::ax(2.0*kappa, b);
-  	  for(int i=0; i<param.num_offset; i++)  param.offset[i] *= 2.0*kappa;
-          }
-          break;
-        case QUDA_MATPCDAG_MATPC_SOLUTION:
-          if (param.mass_normalization == QUDA_MASS_NORMALIZATION) {
-  	  blas::ax(16.0*std::pow(kappa,4), b);
-  	  for(int i=0; i<param.num_offset; i++)  param.offset[i] *= 16.0*std::pow(kappa,4);
-          } else if (param.mass_normalization == QUDA_ASYMMETRIC_MASS_NORMALIZATION) {
-  	  blas::ax(4.0*kappa*kappa, b);
-  	  for(int i=0; i<param.num_offset; i++)  param.offset[i] *= 4.0*kappa*kappa;
-          }
-          break;
-        default:
-          errorQuda("Solution type %d not supported", param.solution_type);
-      }
+    // multiply the source to compensate for normalization of the Dirac operator, if necessary
+    // you are responsible for restoring what's in param.offset
+    switch (param.solution_type) {
+      case QUDA_MAT_SOLUTION:
+        if (param.mass_normalization == QUDA_MASS_NORMALIZATION ||
+            param.mass_normalization == QUDA_ASYMMETRIC_MASS_NORMALIZATION) {
+	  blas::ax(2.0*kappa, b);
+	  for(int i=0; i<param.num_offset; i++)  param.offset[i] *= 2.0*kappa;
+        }
+        break;
+      case QUDA_MATDAG_MAT_SOLUTION:
+        if (param.mass_normalization == QUDA_MASS_NORMALIZATION ||
+            param.mass_normalization == QUDA_ASYMMETRIC_MASS_NORMALIZATION) {
+	  blas::ax(4.0*kappa*kappa, b);
+	  for(int i=0; i<param.num_offset; i++)  param.offset[i] *= 4.0*kappa*kappa;
+        }
+        break;
+      case QUDA_MATPC_SOLUTION:
+        if (param.mass_normalization == QUDA_MASS_NORMALIZATION) {
+	  blas::ax(4.0*kappa*kappa, b);
+	  for(int i=0; i<param.num_offset; i++)  param.offset[i] *= 4.0*kappa*kappa;
+        } else if (param.mass_normalization == QUDA_ASYMMETRIC_MASS_NORMALIZATION) {
+	  blas::ax(2.0*kappa, b);
+	  for(int i=0; i<param.num_offset; i++)  param.offset[i] *= 2.0*kappa;
+        }
+        break;
+      case QUDA_MATPCDAG_MATPC_SOLUTION:
+        if (param.mass_normalization == QUDA_MASS_NORMALIZATION) {
+	  blas::ax(16.0*std::pow(kappa,4), b);
+	  for(int i=0; i<param.num_offset; i++)  param.offset[i] *= 16.0*std::pow(kappa,4);
+        } else if (param.mass_normalization == QUDA_ASYMMETRIC_MASS_NORMALIZATION) {
+	  blas::ax(4.0*kappa*kappa, b);
+	  for(int i=0; i<param.num_offset; i++)  param.offset[i] *= 4.0*kappa*kappa;
+        }
+        break;
+      default:
+        errorQuda("Solution type %d not supported", param.solution_type);
+    }
     }
 
     if (getVerbosity() >= QUDA_DEBUG_VERBOSE) printfQuda("Mass rescale done\n");

--- a/tests/staggered_dslash_ctest.cpp
+++ b/tests/staggered_dslash_ctest.cpp
@@ -92,7 +92,11 @@ void init(int precision, QudaReconstructType link_recon, int partition)
   gauge_param.cuda_prec_refinement_sloppy = prec;
 
   setDims(gauge_param.X);
-  dw_setDims(gauge_param.X, Nsrc); // so we can use 5-d indexing from dwf
+  dw_setDims(gauge_param.X, 1);
+  if (Nsrc != 1) {
+    warningQuda("Ignoring Nsrc = %d, setting to 1.", Nsrc);
+    Nsrc = 1;
+  }
   setSpinorSiteSize(6);
 
   setStaggeredInvertParam(inv_param);
@@ -184,7 +188,7 @@ void init(int precision, QudaReconstructType link_recon, int partition)
   csParam.nSpin = 1;
   csParam.nDim = 5;
   for (int d = 0; d < 4; d++) { csParam.x[d] = gauge_param.X[d]; }
-  csParam.x[4] = Nsrc; // number of sources becomes the fifth dimension
+  csParam.x[4] = 1;
 
   csParam.setPrecision(inv_param.cpu_prec);
   inv_param.solution_type = QUDA_MAT_SOLUTION;

--- a/tests/staggered_dslash_test.cpp
+++ b/tests/staggered_dslash_test.cpp
@@ -77,7 +77,11 @@ void init()
   inv_param.dagger = dagger ? QUDA_DAG_YES : QUDA_DAG_NO;
 
   setDims(gauge_param.X);
-  dw_setDims(gauge_param.X, Nsrc); // so we can use 5-d indexing from dwf
+  dw_setDims(gauge_param.X, 1);
+  if (Nsrc != 1) {
+    warningQuda("Ignoring Nsrc = %d, setting to 1.", Nsrc);
+    Nsrc = 1;
+  }
   setSpinorSiteSize(staggeredSpinorSiteSize);
 
   // Allocate a lot of memory because I'm very confused
@@ -171,7 +175,7 @@ void init()
   csParam.nSpin = 1;
   csParam.nDim = 5;
   for (int d = 0; d < 4; d++) { csParam.x[d] = gauge_param.X[d]; }
-  csParam.x[4] = Nsrc; // number of sources becomes the fifth dimension
+  csParam.x[4] = 1;
 
   csParam.setPrecision(inv_param.cpu_prec);
   inv_param.solution_type = QUDA_MAT_SOLUTION;

--- a/tests/staggered_invert_test.cpp
+++ b/tests/staggered_invert_test.cpp
@@ -270,13 +270,15 @@ int main(int argc, char **argv)
 
   // Staggered vector construct START
   //-----------------------------------------------------------------------------------
-  quda::ColorSpinorField *in;
+  std::vector<quda::ColorSpinorField *> in;
   quda::ColorSpinorField *out;
   quda::ColorSpinorField *ref;
   quda::ColorSpinorField *tmp;
   quda::ColorSpinorParam cs_param;
   constructStaggeredTestSpinorParam(&cs_param, &inv_param, &gauge_param);
-  in = quda::ColorSpinorField::Create(cs_param);
+  for (int k = 0; k < Nsrc; k++) {
+    in.emplace_back(quda::ColorSpinorField::Create(cs_param));
+  }
   out = quda::ColorSpinorField::Create(cs_param);
   ref = quda::ColorSpinorField::Create(cs_param);
   tmp = quda::ColorSpinorField::Create(cs_param);
@@ -315,9 +317,9 @@ int main(int argc, char **argv)
     }
 
     for (int k = 0; k < Nsrc; k++) {
-      quda::spinorNoise(*in, *rng, QUDA_NOISE_UNIFORM);
+      quda::spinorNoise(*in[k], *rng, QUDA_NOISE_UNIFORM);
       if (inv_deflate) eig_param.preserve_deflation = k < Nsrc - 1 ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE;
-      invertQuda(out->V(), in->V(), &inv_param);
+      invertQuda(out->V(), in[k]->V(), &inv_param);
 
       time[k] = inv_param.secs;
       gflops[k] = inv_param.gflops / inv_param.secs;
@@ -325,7 +327,7 @@ int main(int argc, char **argv)
       printfQuda("Done: %i iter / %g secs = %g Gflops\n\n", inv_param.iter, inv_param.secs,
                  inv_param.gflops / inv_param.secs);
       if (verify_results)
-        verifyStaggeredInversion(tmp, ref, in, out, mass, qdp_fatlink, qdp_longlink, (void **)cpuFat->Ghost(),
+        verifyStaggeredInversion(tmp, ref, in[k], out, mass, qdp_fatlink, qdp_longlink, (void **)cpuFat->Ghost(),
                                  (void **)cpuLong->Ghost(), gauge_param, inv_param, 0);
     }
 
@@ -354,15 +356,15 @@ int main(int argc, char **argv)
       qudaOutArray[i] = ColorSpinorField::Create(cs_param);
       outArray[i] = qudaOutArray[i]->V();
     }
-    quda::spinorNoise(*in, *rng, QUDA_NOISE_UNIFORM);
-    invertMultiShiftQuda((void **)outArray, in->V(), &inv_param);
+    quda::spinorNoise(*in[0], *rng, QUDA_NOISE_UNIFORM);
+    invertMultiShiftQuda((void **)outArray, in[0]->V(), &inv_param);
 
     printfQuda("Done: %i iter / %g secs = %g Gflops\n\n", inv_param.iter, inv_param.secs,
                inv_param.gflops / inv_param.secs);
 
     for (int i = 0; i < multishift; i++) {
       printfQuda("%dth solution: mass=%f, ", i, masses[i]);
-      verifyStaggeredInversion(tmp, ref, in, qudaOutArray[i], masses[i], qdp_fatlink, qdp_longlink,
+      verifyStaggeredInversion(tmp, ref, in[0], qudaOutArray[i], masses[i], qdp_fatlink, qdp_longlink,
                                (void **)cpuFat->Ghost(), (void **)cpuLong->Ghost(), gauge_param, inv_param, i);
     }
 
@@ -401,7 +403,7 @@ int main(int argc, char **argv)
   if (cpuFat != nullptr) { delete cpuFat; cpuFat = nullptr; }
   if (cpuLong != nullptr) { delete cpuLong; cpuLong = nullptr; }
 
-  delete in;
+  for (auto in_vec : in) { delete in_vec; }
   delete out;
   delete ref;
   delete tmp;

--- a/tests/staggered_invert_test.cpp
+++ b/tests/staggered_invert_test.cpp
@@ -243,7 +243,9 @@ int main(int argc, char **argv)
   }
 
   // Create ghost gauge fields in case of multi GPU builds.
-  gauge_param.type = (dslash_type == QUDA_STAGGERED_DSLASH || dslash_type == QUDA_LAPLACE_DSLASH) ? QUDA_SU3_LINKS : QUDA_ASQTAD_FAT_LINKS;
+  gauge_param.type = (dslash_type == QUDA_STAGGERED_DSLASH || dslash_type == QUDA_LAPLACE_DSLASH) ?
+    QUDA_SU3_LINKS :
+    QUDA_ASQTAD_FAT_LINKS;
   gauge_param.reconstruct = QUDA_RECONSTRUCT_NO;
   gauge_param.location = QUDA_CPU_FIELD_LOCATION;
 
@@ -276,9 +278,7 @@ int main(int argc, char **argv)
   quda::ColorSpinorField *tmp;
   quda::ColorSpinorParam cs_param;
   constructStaggeredTestSpinorParam(&cs_param, &inv_param, &gauge_param);
-  for (int k = 0; k < Nsrc; k++) {
-    in.emplace_back(quda::ColorSpinorField::Create(cs_param));
-  }
+  for (int k = 0; k < Nsrc; k++) { in.emplace_back(quda::ColorSpinorField::Create(cs_param)); }
   out = quda::ColorSpinorField::Create(cs_param);
   ref = quda::ColorSpinorField::Create(cs_param);
   tmp = quda::ColorSpinorField::Create(cs_param);

--- a/tests/staggered_invert_test.cpp
+++ b/tests/staggered_invert_test.cpp
@@ -243,6 +243,7 @@ int main(int argc, char **argv)
   }
 
   // Create ghost gauge fields in case of multi GPU builds.
+  gauge_param.type = (dslash_type == QUDA_STAGGERED_DSLASH || dslash_type == QUDA_LAPLACE_DSLASH) ? QUDA_SU3_LINKS : QUDA_ASQTAD_FAT_LINKS;
   gauge_param.reconstruct = QUDA_RECONSTRUCT_NO;
   gauge_param.location = QUDA_CPU_FIELD_LOCATION;
 


### PR DESCRIPTION
* Fixed a tunekey goof from the coarse coarse clover PR---technically didn't lead to a tunekey degeneracy hazard, but better to fix it than not.
* Fixed issues with `Nsrc != 1` in `staggered_dslash_[c]test` by enforcing `Nsrc = 1`; can be reverted once multi-rhs is here.
* Bugfix: `staggered_invert_test` was giving garbage for the host residual if there were comms in any direction (incl those from `--partition != 0`). The issue was roughly that the CPU fat link halo depth wasn't being properly set; the fix was a one-liner setting `gauge_param.type`.
* Tweaked `staggered_invert_test` to allocate all `Nsrc` sources up front to simplify @hummingtree 's work
* Added support for performing `Nsrc > 1` multishift solves...
* ~...which uncovered some static variable linking issues within the multishift interface. Downstream effect: values that were being modified in place within the `QudaInvertParam` weren't being restored properly. Threw in a quick fix that removed the static variable.~
* Just kidding: there was a massive bug in staggered multishift solves that by sheer luck has never been an issue. The bug appears if you run more than one `invertMultiShiftQuda` with staggered-type fermions _without_ explicitly resetting the shifts each time (iirc MILC does reset the shifts each time, which is why this bug never manifested there). For Wilson-type fermions, shifts were "cached" to a static array, rescaled in place to match `kappa` conventions, and then restored after the solves. For staggered-type fermions no rescalings were necessary so no caching was done, but shifts were still "restored" from the uninitialized static array, giving garbage. This has now been fixed.

@hummingtree this PR should address all the issues you uncovered, some of which had been kicking around for a while! Let me know if you hit any other woes, or if there's anything I can clarify to help you with your split grid work.