### PR TITLE
Feature/generic kernel hotfixes

### DIFF
--- a/lib/targets/cuda/device.cpp
+++ b/lib/targets/cuda/device.cpp
@@ -283,16 +283,26 @@ namespace quda
       switch (deviceProp.major) {
       case 2:
 	return 8;
+	break;
       case 3:
 	return 16;
+	break;
       case 5:
-      case 6: return 32;
+	 return 32;
+	 break;
+      case 6: 
+	 return 32;
+	 break;
       case 7:
-        switch (deviceProp.minor) {
-        case 0: return 32;
-        case 2: return 32;
-        case 5: return 16;
+	{
+          switch (deviceProp.minor) {
+            case 0: return 32; break;
+            case 2: return 32; break;
+            case 5: return 16; break;
+	    default: return 32; break;
+	  };
         }
+	break;
       default:
         warningQuda("Unknown SM architecture %d.%d - assuming limit of 32 blocks per SM\n",
                     deviceProp.major, deviceProp.minor);

--- a/tests/blas_test.cpp
+++ b/tests/blas_test.cpp
@@ -365,7 +365,7 @@ double benchmark(Kernel kernel, const int niter)
   cudaEvent_t start, end;
   cudaEventCreate(&start);
   cudaEventCreate(&end);
-  cudaEventRecord(start, 0);
+  cudaEventRecord(start, device::get_cuda_stream(device::get_default_stream()));
 
   {
     switch (kernel) {
@@ -529,7 +529,7 @@ double benchmark(Kernel kernel, const int niter)
     }
   }
 
-  cudaEventRecord(end, 0);
+  cudaEventRecord(end, device::get_cuda_stream(device::get_default_stream()));
   cudaEventSynchronize(end);
   float runTime;
   cudaEventElapsedTime(&runTime, start, end);

--- a/tests/covdev_test.cpp
+++ b/tests/covdev_test.cpp
@@ -163,13 +163,13 @@ double dslashCUDA(int niter, int mu)
 {
   cudaEvent_t start, end;
   cudaEventCreate(&start);
-  cudaEventRecord(start, 0);
+  cudaEventRecord(start, device::get_cuda_stream(device::get_default_stream()));
   cudaEventSynchronize(start);
 
   for (int i = 0; i < niter; i++) dirac->MCD(*cudaSpinorOut, *cudaSpinor, mu);
 
   cudaEventCreate(&end);
-  cudaEventRecord(end, 0);
+  cudaEventRecord(end, device::get_cuda_stream(device::get_default_stream()));
   cudaEventSynchronize(end);
   float runTime;
   cudaEventElapsedTime(&runTime, start, end);

--- a/tests/dslash_ctest.cpp
+++ b/tests/dslash_ctest.cpp
@@ -327,7 +327,7 @@ DslashTime dslashCUDA(int niter)
   cudaEventCreate(&end);
 
   comm_barrier();
-  cudaEventRecord(start, 0);
+  cudaEventRecord(start, device::get_cuda_stream(device::get_default_stream()));
 
   for (int i = 0; i < niter; i++) {
 
@@ -536,7 +536,7 @@ DslashTime dslashCUDA(int niter)
     }
   }
 
-  cudaEventRecord(end, 0);
+  cudaEventRecord(end, device::get_cuda_stream(device::get_default_stream()));
   cudaEventSynchronize(end);
   float runTime;
   cudaEventElapsedTime(&runTime, start, end);

--- a/tests/dslash_test.cpp
+++ b/tests/dslash_test.cpp
@@ -297,7 +297,7 @@ DslashTime dslashCUDA(int niter) {
   cudaEventCreate(&end);
 
   comm_barrier();
-  cudaEventRecord(start, 0);
+  cudaEventRecord(start, device::get_cuda_stream(device::get_default_stream()));
 
   for (int i = 0; i < niter; i++) {
 
@@ -506,7 +506,7 @@ DslashTime dslashCUDA(int niter) {
     }
   }
     
-  cudaEventRecord(end, 0);
+  cudaEventRecord(end, device::get_cuda_stream(device::get_default_stream()));
   cudaEventSynchronize(end);
   float runTime;
   cudaEventElapsedTime(&runTime, start, end);

--- a/tests/multigrid_benchmark_test.cpp
+++ b/tests/multigrid_benchmark_test.cpp
@@ -169,7 +169,7 @@ double benchmark(int test, const int niter) {
   cudaEvent_t start, end;
   cudaEventCreate(&start);
   cudaEventCreate(&end);
-  cudaEventRecord(start, 0);
+  cudaEventRecord(start, device::get_cuda_stream(device::get_default_stream()));
 
   switch(test) {
   case 0:
@@ -185,7 +185,7 @@ double benchmark(int test, const int niter) {
     errorQuda("Undefined test %d", test);
   }
 
-  cudaEventRecord(end, 0);
+  cudaEventRecord(end, device::get_cuda_stream(device::get_default_stream()));
   cudaEventSynchronize(end);
   float runTime;
   cudaEventElapsedTime(&runTime, start, end);

--- a/tests/staggered_dslash_ctest.cpp
+++ b/tests/staggered_dslash_ctest.cpp
@@ -300,11 +300,11 @@ DslashTime dslashCUDA(int niter) {
 
   cudaEvent_t start, end;
   cudaEventCreate(&start);
-  cudaEventRecord(start, 0);
+  cudaEventRecord(start, device::get_cuda_stream(device::get_default_stream()));
   cudaEventSynchronize(start);
 
   comm_barrier();
-  cudaEventRecord(start, 0);
+  cudaEventRecord(start, device::get_cuda_stream(device::get_default_stream()));
 
   for (int i = 0; i < niter; i++) {
 
@@ -331,7 +331,7 @@ DslashTime dslashCUDA(int niter) {
   }
 
   cudaEventCreate(&end);
-  cudaEventRecord(end, 0);
+  cudaEventRecord(end, device::get_cuda_stream(device::get_default_stream()));
   cudaEventSynchronize(end);
   float runTime;
   cudaEventElapsedTime(&runTime, start, end);

--- a/tests/staggered_dslash_test.cpp
+++ b/tests/staggered_dslash_test.cpp
@@ -277,11 +277,11 @@ DslashTime dslashCUDA(int niter) {
 
   cudaEvent_t start, end;
   cudaEventCreate(&start);
-  cudaEventRecord(start, 0);
+  cudaEventRecord(start, device::get_cuda_stream(device::get_default_stream()));
   cudaEventSynchronize(start);
 
   comm_barrier();
-  cudaEventRecord(start, 0);
+  cudaEventRecord(start, device::get_cuda_stream(device::get_default_stream()));
 
   for (int i = 0; i < niter; i++) {
 
@@ -308,7 +308,7 @@ DslashTime dslashCUDA(int niter) {
   }
 
   cudaEventCreate(&end);
-  cudaEventRecord(end, 0);
+  cudaEventRecord(end, device::get_cuda_stream(device::get_default_stream()));
   cudaEventSynchronize(end);
   float runTime;
   cudaEventElapsedTime(&runTime, start, end);


### PR DESCRIPTION
Fixes issue #1087  and also a compiler error I encountered with lib/targets/cuda/device.cpp where the code 

``` 
 switch (deviceProp.major) {
      case 2:
	return 8;
      case 3:
	return 16;
      case 5:
      case 6: return 32;
      case 7:
        switch (deviceProp.minor) {
        case 0: return 32;
        case 2: return 32;
        case 5: return 16;
        }
      default:
        warningQuda("Unknown SM architecture %d.%d - assuming limit of 32 blocks per SM\n",
                    deviceProp.major, deviceProp.minor);
        return 32;
      }
```
caused the compiler to complain that fallthrough is possible from the internal switch statement. This happens only on CUDA version < 11 (i.e. the 10.2 I was working with)