### PR TITLE
Fix a potential race condition in multi-GPU heatbath evolution

### DIFF
--- a/lib/pgauge_exchange.cu
+++ b/lib/pgauge_exchange.cu
@@ -192,6 +192,7 @@ namespace quda {
 
       GaugeFixUnPackArg<Float, recon> arg(data);
 
+      qudaDeviceSynchronize();
       for (int d = 0; d < 4; d++) {
         if ( !commDimPartitioned(d)) continue;
         comm_start(mh_recv_back[d]);


### PR DESCRIPTION
This PR fixes a race condition in the custom gauge exchange code leveraged by the heatbath routines. This fix already exists in `feature/generic_kernel`, so we're just pulling it back into the current develop.

I triggered hints of the race condition by running a 24^3x48 _global_ volume on one and two GPUs, comparing the plaquettes, and noting a discrepancy on some (but weirdly not all) iterations. For reference, the commands were:

```
./heatbath_test --dim 24 24 24 48 --gridsize 1 1 1 1 --heatbath-beta 7.0 --heatbath-warmup-steps 10 --heatbath-num-steps 20 --load-gauge l24t48b7p0
./heatbath_test --dim 24 24 24 24 --gridsize 1 1 1 2 --heatbath-beta 7.0 --heatbath-warmup-steps 10 --heatbath-num-steps 20 --load-gauge l24t48b7p0
```

Where `l24t48b7p0` was a previously generated fixed gauge field. The plaquette and topology on the two configurations were equivalent right after the gauge field was loaded but before beginning the heatbath evolution, confirming the issue wasn't with the measurements themselves.