### PR TITLE
Add support for optionally running some benchmarks from ctest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,6 +242,7 @@ set(QUDA_RECONSTRUCT
 
 # Set CTest options
 option(QUDA_CTEST_SEP_DSLASH_POLICIES "Test Dslash policies separately in ctest instead of only autotuning them." OFF)
+option(QUDA_CTEST_DISABLE_BENCHMARKS "Disable benchmark test" ON)
 
 option(QUDA_FAST_COMPILE_REDUCE "enable fast compilation in blas and reduction kernels (single warp per reduction)" OFF)
 option(QUDA_FAST_COMPILE_DSLASH "enable fast compilation in dslash kernels (~20% perf impact)" OFF)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -593,6 +593,7 @@ foreach(pol IN LISTS DSLASH_POLICIES)
             --dslash-type ${DIRAC_NAME}
             --test 0
             --dim 20 20 20 20
+            --Lsdim 12
             --gtest_output=json:dslash_${DIRAC_NAME}_benchmark_pol${pol2}.json
             --gtest_filter=*benchmark/*n0)
     set_tests_properties(benchmark_dslash_${DIRAC_NAME}-policy${pol2} PROPERTIES DISABLED ${QUDA_CTEST_DISABLE_BENCHMARKS})
@@ -616,6 +617,7 @@ foreach(pol IN LISTS DSLASH_POLICIES)
             --dslash-type ${DIRAC_NAME}
             --test 0
             --dim 20 20 20 20
+            --Lsdim 12
             --gtest_output=json:dslash_${DIRAC_NAME}_benchmark_pol${pol2}.json
             --gtest_filter=*benchmark/*n0)
     set_tests_properties(benchmark_dslash_${DIRAC_NAME}-policy${pol2} PROPERTIES DISABLED ${QUDA_CTEST_DISABLE_BENCHMARKS})
@@ -638,6 +640,7 @@ foreach(pol IN LISTS DSLASH_POLICIES)
             --dslash-type ${DIRAC_NAME}
             --test 0
             --dim 20 20 20 20
+            --Lsdim 12
             --gtest_output=json:dslash_${DIRAC_NAME}_benchmark_pol${pol2}.json
             --gtest_filter=*benchmark/*n0)
     set_tests_properties(benchmark_dslash_${DIRAC_NAME}-policy${pol2} PROPERTIES DISABLED ${QUDA_CTEST_DISABLE_BENCHMARKS})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -359,6 +359,7 @@ foreach(pol IN LISTS DSLASH_POLICIES)
   endif()
 
   if(QUDA_DIRAC_WILSON)
+    set(DIRAC_NAME wilson)
     add_test(NAME dslash_wilson-policy${pol2}
              COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:dslash_ctest> ${MPIEXEC_POSTFLAGS}
                      --dslash-type wilson
@@ -368,10 +369,23 @@ foreach(pol IN LISTS DSLASH_POLICIES)
     if(polenv)
       set_tests_properties(dslash_wilson-policy${pol2} PROPERTIES ENVIRONMENT QUDA_ENABLE_DSLASH_POLICY=${pol})
     endif()
+
+    add_test(NAME benchmark_dslash_${DIRAC_NAME}-policy${pol2}
+             COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:dslash_ctest> ${MPIEXEC_POSTFLAGS}
+                     --dslash-type ${DIRAC_NAME}
+                     --test 0
+                     --dim 20 20 20 20
+                     --gtest_output=json:dslash_${DIRAC_NAME}_benchmark_pol${pol2}.json
+                     --gtest_filter=*benchmark/*n0)
+    set_tests_properties(benchmark_dslash_${DIRAC_NAME}-policy${pol2} PROPERTIES DISABLED ${QUDA_CTEST_DISABLE_BENCHMARKS})
+    if(polenv)
+      set_tests_properties(benchmark_dslash_${DIRAC_NAME}-policy${pol2} PROPERTIES ENVIRONMENT QUDA_ENABLE_DSLASH_POLICY=${pol})
+    endif()
   endif()
 
   if(QUDA_DIRAC_CLOVER)
     # symmetric preconditioning
+    set(DIRAC_NAME clover)
     add_test(NAME dslash_clover-sym-policy${pol2}
              COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:dslash_ctest> ${MPIEXEC_POSTFLAGS}
                      --dslash-type clover
@@ -394,9 +408,23 @@ foreach(pol IN LISTS DSLASH_POLICIES)
     if(polenv)
       set_tests_properties(dslash_clover-asym-policy${pol2} PROPERTIES ENVIRONMENT QUDA_ENABLE_DSLASH_POLICY=${pol})
     endif()
+
+    add_test(NAME benchmark_dslash_${DIRAC_NAME}-policy${pol2}
+    COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:dslash_ctest> ${MPIEXEC_POSTFLAGS}
+            --dslash-type ${DIRAC_NAME}
+            --test 0
+            --dim 20 20 20 20
+            --gtest_output=json:dslash_${DIRAC_NAME}_benchmark_pol${pol2}.json
+            --gtest_filter=*benchmark/*n0)
+    set_tests_properties(benchmark_dslash_${DIRAC_NAME}-policy${pol2} PROPERTIES DISABLED ${QUDA_CTEST_DISABLE_BENCHMARKS})
+    if(polenv)
+      set_tests_properties(benchmark_dslash_${DIRAC_NAME}-policy${pol2} PROPERTIES ENVIRONMENT QUDA_ENABLE_DSLASH_POLICY=${pol})
+    endif()
+
   endif()
 
   if(QUDA_DIRAC_CLOVER_HASENBUSCH_TWIST)
+    set(DIRAC_NAME clover-hasenbusch-twist)
     # symmetric preconditioning
     add_test(NAME dslash_clover_hasenbusch_twist-sym-policy${pol2}
              COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:dslash_ctest> ${MPIEXEC_POSTFLAGS}
@@ -420,9 +448,22 @@ foreach(pol IN LISTS DSLASH_POLICIES)
     if(polenv)
       set_tests_properties(dslash_clover_hasenbusch_twist-asym-policy${pol2} PROPERTIES ENVIRONMENT QUDA_ENABLE_DSLASH_POLICY=${pol})
     endif()
+
+    add_test(NAME benchmark_dslash_${DIRAC_NAME}-policy${pol2}
+    COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:dslash_ctest> ${MPIEXEC_POSTFLAGS}
+            --dslash-type ${DIRAC_NAME}
+            --test 0
+            --dim 20 20 20 20
+            --gtest_output=json:dslash_${DIRAC_NAME}_benchmark_pol${pol2}.json
+            --gtest_filter=*benchmark/*n0)
+    set_tests_properties(benchmark_dslash_${DIRAC_NAME}-policy${pol2} PROPERTIES DISABLED ${QUDA_CTEST_DISABLE_BENCHMARKS})
+    if(polenv)
+      set_tests_properties(benchmark_dslash_${DIRAC_NAME}-policy${pol2} PROPERTIES ENVIRONMENT QUDA_ENABLE_DSLASH_POLICY=${pol})
+    endif()
   endif()
 
   if(QUDA_DIRAC_TWISTED_MASS)
+    set(DIRAC_NAME twisted-mass)
     add_test(NAME dslash_twisted-mass-sym-policy${pol2}
              COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:dslash_ctest> ${MPIEXEC_POSTFLAGS}
                      --dslash-type twisted-mass
@@ -477,9 +518,22 @@ foreach(pol IN LISTS DSLASH_POLICIES)
       set_tests_properties(dslash_ndeg-twisted-mass-asym-policy${pol2}
                            PROPERTIES ENVIRONMENT QUDA_ENABLE_DSLASH_POLICY=${pol})
     endif()
+
+    add_test(NAME benchmark_dslash_${DIRAC_NAME}-policy${pol2}
+    COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:dslash_ctest> ${MPIEXEC_POSTFLAGS}
+            --dslash-type ${DIRAC_NAME}
+            --test 0
+            --dim 20 20 20 20
+            --gtest_output=json:dslash_${DIRAC_NAME}_benchmark_pol${pol2}.json
+            --gtest_filter=*benchmark/*n0)
+    set_tests_properties(benchmark_dslash_${DIRAC_NAME}-policy${pol2} PROPERTIES DISABLED ${QUDA_CTEST_DISABLE_BENCHMARKS})
+    if(polenv)
+      set_tests_properties(benchmark_dslash_${DIRAC_NAME}-policy${pol2} PROPERTIES ENVIRONMENT QUDA_ENABLE_DSLASH_POLICY=${pol})
+    endif()
   endif()
 
   if(QUDA_DIRAC_TWISTED_CLOVER)
+    set(DIRAC_NAME twisted-clover)
     # symmetric preconditioning
     add_test(NAME dslash_twisted-clover-sym-policy${pol2}
              COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:dslash_ctest> ${MPIEXEC_POSTFLAGS}
@@ -505,9 +559,23 @@ foreach(pol IN LISTS DSLASH_POLICIES)
       set_tests_properties(dslash_twisted-clover-asym-policy${pol2}
                            PROPERTIES ENVIRONMENT QUDA_ENABLE_DSLASH_POLICY=${pol})
     endif()
+    
+    add_test(NAME benchmark_dslash_${DIRAC_NAME}-policy${pol2}
+    COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:dslash_ctest> ${MPIEXEC_POSTFLAGS}
+            --dslash-type ${DIRAC_NAME}
+            --test 0
+            --dim 20 20 20 20
+            --gtest_output=json:dslash_${DIRAC_NAME}_benchmark_pol${pol2}.json
+            --gtest_filter=*benchmark/*n0)
+    set_tests_properties(benchmark_dslash_${DIRAC_NAME}-policy${pol2} PROPERTIES DISABLED ${QUDA_CTEST_DISABLE_BENCHMARKS})  
+    if(polenv)
+      set_tests_properties(benchmark_dslash_${DIRAC_NAME}-policy${pol2} PROPERTIES ENVIRONMENT QUDA_ENABLE_DSLASH_POLICY=${pol})
+    endif()
+
   endif()
 
   if(QUDA_DIRAC_DOMAIN_WALL)
+    set(DIRAC_NAME domain-wall)
     add_test(NAME dslash_domain-wall-sym-policy${pol2}
              COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:dslash_ctest> ${MPIEXEC_POSTFLAGS}
                      --dslash-type domain-wall
@@ -520,7 +588,20 @@ foreach(pol IN LISTS DSLASH_POLICIES)
       set_tests_properties(dslash_domain-wall-sym-policy${pol2} PROPERTIES ENVIRONMENT QUDA_ENABLE_DSLASH_POLICY=${pol})
     endif()
 
+    add_test(NAME benchmark_dslash_${DIRAC_NAME}-policy${pol2}
+    COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:dslash_ctest> ${MPIEXEC_POSTFLAGS}
+            --dslash-type ${DIRAC_NAME}
+            --test 0
+            --dim 20 20 20 20
+            --gtest_output=json:dslash_${DIRAC_NAME}_benchmark_pol${pol2}.json
+            --gtest_filter=*benchmark/*n0)
+    set_tests_properties(benchmark_dslash_${DIRAC_NAME}-policy${pol2} PROPERTIES DISABLED ${QUDA_CTEST_DISABLE_BENCHMARKS})
+    if(polenv)
+      set_tests_properties(benchmark_dslash_${DIRAC_NAME}-policy${pol2} PROPERTIES ENVIRONMENT QUDA_ENABLE_DSLASH_POLICY=${pol})
+    endif()
+
     # symmetric 4-d preconditioning
+    set(DIRAC_NAME domain-wall-4d)
     add_test(NAME dslash_domain-wall-4d-sym-policy${pol2}
              COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:dslash_ctest> ${MPIEXEC_POSTFLAGS}
                      --dslash-type domain-wall-4d
@@ -529,6 +610,20 @@ foreach(pol IN LISTS DSLASH_POLICIES)
                      --dim 2 4 6 8
                      --Lsdim 4
         --gtest_output=xml:dslash_domain-wall-4d_test_pol${pol2}.xml)
+
+    add_test(NAME benchmark_dslash_${DIRAC_NAME}-policy${pol2}
+    COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:dslash_ctest> ${MPIEXEC_POSTFLAGS}
+            --dslash-type ${DIRAC_NAME}
+            --test 0
+            --dim 20 20 20 20
+            --gtest_output=json:dslash_${DIRAC_NAME}_benchmark_pol${pol2}.json
+            --gtest_filter=*benchmark/*n0)
+    set_tests_properties(benchmark_dslash_${DIRAC_NAME}-policy${pol2} PROPERTIES DISABLED ${QUDA_CTEST_DISABLE_BENCHMARKS})
+    if(polenv)
+      set_tests_properties(benchmark_dslash_${DIRAC_NAME}-policy${pol2} PROPERTIES ENVIRONMENT QUDA_ENABLE_DSLASH_POLICY=${pol})
+    endif()
+
+    set(DIRAC_NAME mobius)
     add_test(NAME dslash_mobius-sym-policy${pol2}
              COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:dslash_ctest> ${MPIEXEC_POSTFLAGS}
                      --dslash-type mobius
@@ -537,6 +632,19 @@ foreach(pol IN LISTS DSLASH_POLICIES)
                      --dim 2 4 6 8
                      --Lsdim 4
                      --gtest_output=xml:dslash_mobius_test_pol${pol2}.xml)
+    
+    add_test(NAME benchmark_dslash_${DIRAC_NAME}-policy${pol2}
+    COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:dslash_ctest> ${MPIEXEC_POSTFLAGS}
+            --dslash-type ${DIRAC_NAME}
+            --test 0
+            --dim 20 20 20 20
+            --gtest_output=json:dslash_${DIRAC_NAME}_benchmark_pol${pol2}.json
+            --gtest_filter=*benchmark/*n0)
+    set_tests_properties(benchmark_dslash_${DIRAC_NAME}-policy${pol2} PROPERTIES DISABLED ${QUDA_CTEST_DISABLE_BENCHMARKS})
+    if(polenv)
+      set_tests_properties(benchmark_dslash_${DIRAC_NAME}-policy${pol2} PROPERTIES ENVIRONMENT QUDA_ENABLE_DSLASH_POLICY=${pol})
+    endif()
+
     add_test(NAME dslash_mobius_eofa-sym-policy${pol2}
              COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:dslash_ctest> ${MPIEXEC_POSTFLAGS}
                      --dslash-type mobius-eofa
@@ -596,12 +704,28 @@ foreach(pol IN LISTS DSLASH_POLICIES)
   endif()
 
   if(QUDA_DIRAC_STAGGERED)
+    set(DIRAC_NAME asqtad)
     add_test(NAME dslash_improved_staggered-policy${pol2}
              COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:staggered_dslash_ctest> ${MPIEXEC_POSTFLAGS}
                      --dslash-type asqtad
                      --test MatPC
                      --dim 6 8 10 12
                      --gtest_output=xml:dslash_improved_staggered_test_pol${pol2}.xml)
+
+    add_test(NAME benchmark_dslash_${DIRAC_NAME}-policy${pol2}
+    COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:staggered_dslash_ctest> ${MPIEXEC_POSTFLAGS}
+            --dslash-type ${DIRAC_NAME}
+            --test 0
+            --dim 20 20 20 20
+            --gtest_output=json:dslash_${DIRAC_NAME}_benchmark_pol${pol2}.json
+            --gtest_filter=*benchmark/*n0)
+    set_tests_properties(benchmark_dslash_${DIRAC_NAME}-policy${pol2} PROPERTIES DISABLED ${QUDA_CTEST_DISABLE_BENCHMARKS})
+    if(polenv)
+      set_tests_properties(benchmark_dslash_${DIRAC_NAME}-policy${pol2} PROPERTIES ENVIRONMENT QUDA_ENABLE_DSLASH_POLICY=${pol})
+    endif()                 
+
+
+    set(DIRAC_NAME staggered)
     add_test(NAME dslash_naive_staggered-policy${pol2}
              COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:staggered_dslash_ctest> ${MPIEXEC_POSTFLAGS}
                      --dslash-type staggered
@@ -614,6 +738,18 @@ foreach(pol IN LISTS DSLASH_POLICIES)
       set_tests_properties(dslash_naive_staggered-policy${pol2}
                            PROPERTIES ENVIRONMENT QUDA_ENABLE_DSLASH_POLICY=${pol2})
     endif()
+
+    add_test(NAME benchmark_dslash_${DIRAC_NAME}-policy${pol2}
+    COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:staggered_dslash_ctest> ${MPIEXEC_POSTFLAGS}
+            --dslash-type ${DIRAC_NAME}
+            --test 0
+            --dim 20 20 20 20
+            --gtest_output=json:dslash_${DIRAC_NAME}_benchmark_pol${pol2}.json
+            --gtest_filter=*benchmark/*n0)
+    set_tests_properties(benchmark_dslash_${DIRAC_NAME}-policy${pol2} PROPERTIES DISABLED ${QUDA_CTEST_DISABLE_BENCHMARKS})
+    if(polenv)
+      set_tests_properties(benchmark_dslash_${DIRAC_NAME}-policy${pol2} PROPERTIES ENVIRONMENT QUDA_ENABLE_DSLASH_POLICY=${pol})
+    endif() 
 
     add_test(NAME dslash_improved_staggered_build-policy${pol2}
              COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:staggered_dslash_ctest> ${MPIEXEC_POSTFLAGS}


### PR DESCRIPTION
This add some basic dslash_test benchmarks to ctest so we can easily do some perf sweeps. 
This is controlled by the `QUDA_CTEST_DISABLE_BENCHMARKS` variable and by default benchmarks are disabled.

To selectively only run the benchmarks something like
```
ctest  -R "benchmark*" -V
```
can be used.

Output is store in a `.json` file.