### PR TITLE
Fix performance of heterogeneous atomic reductions

### DIFF
--- a/include/reduce_helper.h
+++ b/include/reduce_helper.h
@@ -130,7 +130,7 @@ namespace quda
       if (consumed) errorQuda("Cannot call complete more than once for each construction");
 
       for (int i = 0; i < n_reduce * n_item; i++) {
-        result_h[i].wait(init_value<system_atomic_t>(), cuda::std::memory_order_relaxed);
+        while (result_h[i].load(cuda::std::memory_order_relaxed) == init_value<system_atomic_t>()) {}
       }
 #else
       auto event = reducer::get_event();


### PR DESCRIPTION
 Fix the performance of heterogeneous atomic reductions:
 * use a busy-wait loop instead of `std::atomic::wait`, since the latter uses nanosleep which adds latency bubbles
 