### PR TITLE
Minor CG clean-up, marginally improved HQ residual stability, QIO tweaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -649,8 +649,8 @@ if(QUDA_QIO)
       GIT_SHALLOW YES
       PREFIX usqcd
       CONFIGURE_COMMAND CC=${MPI_C_COMPILER} CXX=${MPI_CXX_COMPILER} <SOURCE_DIR>/configure "INSTALL=${INSTALL_EXE} -C"
-                        "CFLAGS=-Wall -O3 -std=c99 -DHAVE_BGL " --with-qmp=${QUDA_QMPHOME} --prefix=<INSTALL_DIR>
-                        --enable-largefile --disable-qmp-route --enable-dml-output-buffering
+                        "CFLAGS=-Wall -O3 -std=c99 " --with-qmp=${QUDA_QMPHOME} --prefix=<INSTALL_DIR>
+                        --enable-largefile --disable-qmp-route --enable-dml-output-buffering --enable-dml-bufsize=33554432
       BUILD_COMMAND make
       INSTALL_COMMAND make install
       DEPENDS QMP

--- a/include/invert_quda.h
+++ b/include/invert_quda.h
@@ -564,19 +564,11 @@ namespace quda {
     void PrintSummary(const char *name, int k, double r2, double b2, double r2_tol, double hq_tol);
 
     /**
-       @brief Helper function which returns the epsilon tolerance for a given precision
+       @brief Returns the epsilon tolerance for a given precision, by default returns
+       the solver precision.
+       @param[in] prec Input precision, default value is solver precision
     */
-    const double solverPrecisionEpsilonHelper(QudaPrecision prec) const;
-
-    /**
-       @brief Returns the epsilon tolerance of the solver precision
-    */
-    const double solverPrecisionEpsilon() const;
-
-    /**
-       @brief Returns the epsilon tolerance of the solver sloppy precision
-    */
-    const double solverPrecisionSloppyEpsilon() const;
+    const double precisionEpsilon(QudaPrecision prec = QUDA_INVALID_PRECISION);
 
     /**
        @brief Constructs the deflation space and eigensolver

--- a/include/invert_quda.h
+++ b/include/invert_quda.h
@@ -564,6 +564,21 @@ namespace quda {
     void PrintSummary(const char *name, int k, double r2, double b2, double r2_tol, double hq_tol);
 
     /**
+       @brief Helper function which returns the epsilon tolerance for a given precision
+    */
+    const double solverPrecisionEpsilonHelper(QudaPrecision prec) const;
+
+    /**
+       @brief Returns the epsilon tolerance of the solver precision
+    */
+    const double solverPrecisionEpsilon() const;
+
+    /**
+       @brief Returns the epsilon tolerance of the solver sloppy precision
+    */
+    const double solverPrecisionSloppyEpsilon() const;
+
+    /**
        @brief Constructs the deflation space and eigensolver
        @param[in] meta A sample ColorSpinorField with which to instantiate
        the eigensolver

--- a/include/invert_quda.h
+++ b/include/invert_quda.h
@@ -568,7 +568,7 @@ namespace quda {
        the solver precision.
        @param[in] prec Input precision, default value is solver precision
     */
-    const double precisionEpsilon(QudaPrecision prec = QUDA_INVALID_PRECISION);
+    double precisionEpsilon(QudaPrecision prec = QUDA_INVALID_PRECISION) const;
 
     /**
        @brief Constructs the deflation space and eigensolver

--- a/lib/inv_cg_quda.cpp
+++ b/lib/inv_cg_quda.cpp
@@ -544,7 +544,9 @@ namespace quda {
 
       // For heavy-quark inversion force a reliable update if we continue after,
       // or if r2/b2 has fictitiously dropped too far below precision epsilon
-      if ( use_heavy_quark_res and L2breakdown and (convergenceHQ(r2, heavy_quark_res, stop, param.tol_hq) or (r2 / b2) < hq_res_stall_check ) and param.delta >= param.tol ) {
+      if (use_heavy_quark_res and L2breakdown
+          and (convergenceHQ(r2, heavy_quark_res, stop, param.tol_hq) or (r2 / b2) < hq_res_stall_check)
+          and param.delta >= param.tol) {
         updateX = 1;
       }
 

--- a/lib/inv_cg_quda.cpp
+++ b/lib/inv_cg_quda.cpp
@@ -330,8 +330,8 @@ namespace quda {
     // alternative reliable updates
     // alternative reliable updates - set precision - does not hurt performance here
 
-    const double u = solverPrecisionSloppyEpsilon();
-    const double uhigh = solverPrecisionEpsilon();
+    const double u = precisionEpsilon(param.precision_sloppy);
+    const double uhigh = precisionEpsilon(); // solver precision
 
     const double deps=sqrt(u);
     constexpr double dfac = 1.1;

--- a/lib/inv_cg_quda.cpp
+++ b/lib/inv_cg_quda.cpp
@@ -237,6 +237,9 @@ namespace quda {
     const int Np = (param.solution_accumulator_pipeline == 0 ? 1 : param.solution_accumulator_pipeline);
     if (Np < 0 || Np > 16) errorQuda("Invalid value %d for solution_accumulator_pipeline\n", Np);
 
+    // Detect whether this is a pure double solve or not; informs the necessity of some stability checks
+    bool is_pure_double = (param.precision == QUDA_DOUBLE_PRECISION && param.precision_sloppy == QUDA_DOUBLE_PRECISION);
+
     // whether to select alternative reliable updates
     bool alternative_reliable = param.use_alternative_reliable;
 
@@ -352,8 +355,9 @@ namespace quda {
     // for detecting HQ residual stalls
     // let |r2/b2| drop to epsilon tolerance * 1e-30, semi-arbitrarily, but
     // with the intent of letting the solve grind as long as possible before
-    // triggering a `NaN`
-    const double hq_res_stall_check = uhigh * uhigh * 1e-60;
+    // triggering a `NaN`. Ignored for pure double solves because if
+    // pure double has stability issues, bigger problems are at hand.
+    const double hq_res_stall_check = is_pure_double ? 0. : uhigh * uhigh * 1e-60;
 
     // compute initial residual
     double r2 = 0.0;

--- a/lib/inv_cg_quda.cpp
+++ b/lib/inv_cg_quda.cpp
@@ -350,8 +350,10 @@ namespace quda {
     }
 
     // for detecting HQ residual stalls
-    // let |r2/b2| drop to epsilon tolerance * 1e-10, semi-arbitrarily
-    const double hq_res_stall_check = uhigh * uhigh * 1e-20;
+    // let |r2/b2| drop to epsilon tolerance * 1e-30, semi-arbitrarily, but
+    // with the intent of letting the solve grind as long as possible before
+    // triggering a `NaN`
+    const double hq_res_stall_check = uhigh * uhigh * 1e-60;
 
     // compute initial residual
     double r2 = 0.0;

--- a/lib/solver.cpp
+++ b/lib/solver.cpp
@@ -407,7 +407,7 @@ namespace quda {
     }
   }
 
-  const double Solver::precisionEpsilon(QudaPrecision prec)
+  double Solver::precisionEpsilon(QudaPrecision prec) const
   {
     double eps = 0.;
     if (prec == QUDA_INVALID_PRECISION) { prec = param.precision; }

--- a/lib/solver.cpp
+++ b/lib/solver.cpp
@@ -407,9 +407,11 @@ namespace quda {
     }
   }
 
-  const double Solver::solverPrecisionEpsilonHelper(QudaPrecision prec) const
+  const double Solver::precisionEpsilon(QudaPrecision prec)
   {
     double eps = 0.;
+    if (prec == QUDA_INVALID_PRECISION) { prec = param.precision; }
+
     switch (prec) {
     case QUDA_DOUBLE_PRECISION: eps = std::numeric_limits<double>::epsilon() / 2.; break;
     case QUDA_SINGLE_PRECISION: eps = std::numeric_limits<float>::epsilon() / 2.; break;
@@ -418,13 +420,6 @@ namespace quda {
     default: errorQuda("Invalid precision %d", param.precision); break;
     }
     return eps;
-  }
-
-  const double Solver::solverPrecisionEpsilon() const { return solverPrecisionEpsilonHelper(param.precision); }
-
-  const double Solver::solverPrecisionSloppyEpsilon() const
-  {
-    return solverPrecisionEpsilonHelper(param.precision_sloppy);
   }
 
   bool MultiShiftSolver::convergence(const double *r2, const double *r2_tol, int n) const {

--- a/lib/solver.cpp
+++ b/lib/solver.cpp
@@ -407,7 +407,8 @@ namespace quda {
     }
   }
 
-  const double Solver::solverPrecisionEpsilonHelper(QudaPrecision prec) const {
+  const double Solver::solverPrecisionEpsilonHelper(QudaPrecision prec) const
+  {
     double eps = 0.;
     switch (prec) {
     case QUDA_DOUBLE_PRECISION: eps = std::numeric_limits<double>::epsilon() / 2.; break;
@@ -419,12 +420,10 @@ namespace quda {
     return eps;
   }
 
+  const double Solver::solverPrecisionEpsilon() const { return solverPrecisionEpsilonHelper(param.precision); }
 
-  const double Solver::solverPrecisionEpsilon() const {
-    return solverPrecisionEpsilonHelper(param.precision);
-  }
-
-  const double Solver::solverPrecisionSloppyEpsilon() const {
+  const double Solver::solverPrecisionSloppyEpsilon() const
+  {
     return solverPrecisionEpsilonHelper(param.precision_sloppy);
   }
 

--- a/lib/solver.cpp
+++ b/lib/solver.cpp
@@ -407,6 +407,27 @@ namespace quda {
     }
   }
 
+  const double Solver::solverPrecisionEpsilonHelper(QudaPrecision prec) const {
+    double eps = 0.;
+    switch (prec) {
+    case QUDA_DOUBLE_PRECISION: eps = std::numeric_limits<double>::epsilon() / 2.; break;
+    case QUDA_SINGLE_PRECISION: eps = std::numeric_limits<float>::epsilon() / 2.; break;
+    case QUDA_HALF_PRECISION: eps = pow(2., -13); break;
+    case QUDA_QUARTER_PRECISION: eps = pow(2., -6); break;
+    default: errorQuda("Invalid precision %d", param.precision); break;
+    }
+    return eps;
+  }
+
+
+  const double Solver::solverPrecisionEpsilon() const {
+    return solverPrecisionEpsilonHelper(param.precision);
+  }
+
+  const double Solver::solverPrecisionSloppyEpsilon() const {
+    return solverPrecisionEpsilonHelper(param.precision_sloppy);
+  }
+
   bool MultiShiftSolver::convergence(const double *r2, const double *r2_tol, int n) const {
 
     // check the L2 relative residual norm if necessary


### PR DESCRIPTION
While this PR was originally intended to be a stability hotfix, it has turned into a misc clean-up/small improvements PR.

This PR:
* Moves some `numerical_limits` epsilon heuristics from the CG solver into base `Solver` class routines
* Adds a stability "catch" for heavy quark residual solves where the solve hard restarts if `|r2|/|b2|` drops "unreasonably" low, in response to observations that `|r2|/|b2|` can go far below the numerically reasonable ~1e-16 after `L2breakdown` is set to `true`
* ...disables the above catch for pure `double` solves, since if pure `double` breaks down there's no hope. (Note: this _doesn't_ disable the solve automatically restarting if it hits the requested accumulated residual but the "true" residual isn't sufficiently small.)
* Slips in a change to the `configure` flags to QIO based on feedback from @jcosborn 