### PR TITLE
Remove variable-size arrays from dslash test code

### DIFF
--- a/tests/blas_interface_test.cpp
+++ b/tests/blas_interface_test.cpp
@@ -366,7 +366,6 @@ int main(int argc, char **argv)
   initQuda(device_ordinal);
   int X[4] = {xdim, ydim, zdim, tdim};
   setDims(X);
-  setSpinorSiteSize(24);
   //-----------------------------------------------------------------------------
 
   int result = 0;

--- a/tests/blas_test.cpp
+++ b/tests/blas_test.cpp
@@ -1021,7 +1021,6 @@ int main(int argc, char** argv)
     Ncolor = 3;
   }
 
-  setSpinorSiteSize(24);
   initComms(argc, argv, gridsize_from_cmdline);
   display_test_info();
   initQuda(device_ordinal);

--- a/tests/contract_test.cpp
+++ b/tests/contract_test.cpp
@@ -76,7 +76,6 @@ int main(int argc, char **argv)
   initQuda(device_ordinal);
   int X[4] = {xdim, ydim, zdim, tdim};
   setDims(X);
-  setSpinorSiteSize(24);
   //-----------------------------------------------------------------------------
 
   prec = QUDA_INVALID_PRECISION;

--- a/tests/covdev_test.cpp
+++ b/tests/covdev_test.cpp
@@ -57,8 +57,6 @@ void init(int argc, char **argv)
 
   if (Nsrc != 1) warningQuda("The covariant derivative doesn't support 5-d indexing, only source 0 will be tested");
 
-  setSpinorSiteSize(24);
-
   inv_param = newQudaInvertParam();
   setInvertParam(inv_param);
   inv_param.dslash_type = QUDA_COVDEV_DSLASH; // ensure we use the correct dslash

--- a/tests/deflated_invert_test.cpp
+++ b/tests/deflated_invert_test.cpp
@@ -126,8 +126,6 @@ int main(int argc, char **argv)
     setDims(gauge_param.X);
   }
 
-  setSpinorSiteSize(24);
-
   // Allocate host side memory for the gauge field.
   //----------------------------------------------------------------------------
   void *gauge[4];

--- a/tests/dslash_test_utils.h
+++ b/tests/dslash_test_utils.h
@@ -140,8 +140,6 @@ struct DslashTestWrapper {
       Ls = 1;
     }
 
-    setSpinorSiteSize(24);
-
     inv_param.dagger = dagger ? QUDA_DAG_YES : QUDA_DAG_NO;
     not_dagger = dagger ? QUDA_DAG_NO : QUDA_DAG_YES;
 

--- a/tests/eigensolve_test.cpp
+++ b/tests/eigensolve_test.cpp
@@ -120,10 +120,6 @@ int main(int argc, char **argv)
     setDims(gauge_param.X);
   }
 
-  // Set spinor site size (wilson types only in this file)
-  int sss = 24;
-  setSpinorSiteSize(sss);
-
   // Allocate host side memory for the gauge field.
   void *gauge[4];
   for (int dir = 0; dir < 4; dir++) gauge[dir] = malloc(V * gauge_site_size * host_gauge_data_type_size);
@@ -146,7 +142,7 @@ int main(int argc, char **argv)
   // Host side arrays to store the eigenpairs computed by QUDA
   void **host_evecs = (void **)malloc(eig_n_conv * sizeof(void *));
   for (int i = 0; i < eig_n_conv; i++) {
-    host_evecs[i] = (void *)malloc(V * eig_inv_param.Ls * sss * eig_inv_param.cpu_prec);
+    host_evecs[i] = (void *)malloc(V * eig_inv_param.Ls * spinor_site_size * eig_inv_param.cpu_prec);
   }
   double _Complex *host_evals = (double _Complex *)malloc(eig_param.n_ev * sizeof(double _Complex));
 

--- a/tests/heatbath_test.cpp
+++ b/tests/heatbath_test.cpp
@@ -83,7 +83,6 @@ int main(int argc, char **argv)
 
   // *** Everything between here and the timer is  application specific.
   setDims(gauge_param.X);
-  setSpinorSiteSize(24);
 
   void *load_gauge[4];
   // Allocate space on the host (always best to allocate and free in the same scope)

--- a/tests/host_reference/covdev_reference.cpp
+++ b/tests/host_reference/covdev_reference.cpp
@@ -43,7 +43,7 @@ template <typename sFloat, typename gFloat>
 void covdevReference(sFloat *res, gFloat **link, sFloat *spinorField, 
 		     int oddBit, int daggerBit, int mu) 
 {
-  for (int i = 0; i < Vh * my_spinor_site_size; i++) res[i] = 0.0;
+  for (int i = 0; i < Vh * spinor_site_size; i++) res[i] = 0.0;
 
   gFloat *linkEven[4], *linkOdd[4];
   
@@ -53,9 +53,9 @@ void covdevReference(sFloat *res, gFloat **link, sFloat *spinorField,
   }
 
   for (int sid = 0; sid < Vh; sid++) {
-    int offset = my_spinor_site_size * sid;
+    int offset = spinor_site_size * sid;
 
-    sFloat gaugedSpinor[my_spinor_site_size];
+    sFloat gaugedSpinor[spinor_site_size];
 
     gFloat *lnk    = gaugeLink(sid, mu, oddBit, linkEven, linkOdd, 1);
     sFloat *spinor = spinorNeighbor(sid, mu, oddBit, spinorField, 1);
@@ -68,7 +68,7 @@ void covdevReference(sFloat *res, gFloat **link, sFloat *spinorField,
         su3Mul (&gaugedSpinor[s*6], lnk, &spinor[s*6]);
     }
 
-    sum(&res[offset], &res[offset], gaugedSpinor, my_spinor_site_size);
+    sum(&res[offset], &res[offset], gaugedSpinor, spinor_site_size);
   } // 4-d volume
 }
 
@@ -96,9 +96,9 @@ template <typename sFloat, typename gFloat>
 void Mat(sFloat *out, gFloat **link, sFloat *in, int daggerBit, int mu) 
 {
   sFloat *inEven = in;
-  sFloat *inOdd = in + Vh * my_spinor_site_size;
+  sFloat *inOdd = in + Vh * spinor_site_size;
   sFloat *outEven = out;
-  sFloat *outOdd = out + Vh * my_spinor_site_size;
+  sFloat *outOdd = out + Vh * spinor_site_size;
 
   // full dslash operator
   covdevReference(outOdd,  link, inEven, 1, daggerBit, mu);
@@ -181,7 +181,7 @@ template <typename sFloat, typename gFloat>
 void covdevReference_mg4dir(sFloat *res, gFloat **link, gFloat **ghostLink, sFloat *spinorField,
                             sFloat **fwd_nbr_spinor, sFloat **back_nbr_spinor, int oddBit, int daggerBit, int mu)
 {
-  for (int i = 0; i < Vh * my_spinor_site_size; i++) res[i] = 0.0;
+  for (int i = 0; i < Vh * spinor_site_size; i++) res[i] = 0.0;
 
   gFloat *linkEven[4], *linkOdd[4];
   gFloat *ghostLinkEven[4], *ghostLinkOdd[4];
@@ -195,12 +195,12 @@ void covdevReference_mg4dir(sFloat *res, gFloat **link, gFloat **ghostLink, sFlo
   }
 
   for (int sid = 0; sid < Vh; sid++) {
-    int offset = my_spinor_site_size * sid;
+    int offset = spinor_site_size * sid;
 
     gFloat *lnk    = gaugeLink_mg4dir(sid, mu, oddBit, linkEven, linkOdd, ghostLinkEven, ghostLinkOdd, 1, 1);
     sFloat *spinor = spinorNeighbor_mg4dir(sid, mu, oddBit, spinorField, fwd_nbr_spinor, back_nbr_spinor, 1, 1);
 
-    sFloat gaugedSpinor[my_spinor_site_size];
+    sFloat gaugedSpinor[spinor_site_size];
 
     if (daggerBit) {
       for (int s = 0; s < 4; s++)
@@ -209,7 +209,7 @@ void covdevReference_mg4dir(sFloat *res, gFloat **link, gFloat **ghostLink, sFlo
       for (int s = 0; s < 4; s++)
         su3Mul (&gaugedSpinor[s*6], lnk, &spinor[s*6]);
     }
-    sum(&res[offset], &res[offset], gaugedSpinor, my_spinor_site_size);
+    sum(&res[offset], &res[offset], gaugedSpinor, spinor_site_size);
   } // 4-d volume
 }
 

--- a/tests/host_reference/domain_wall_dslash_reference.cpp
+++ b/tests/host_reference/domain_wall_dslash_reference.cpp
@@ -327,9 +327,8 @@ void dslashReference_4d_sgpu(sFloat *res, gFloat **gaugeFull, sFloat *spinorFiel
 #ifdef MULTI_GPU
 template <QudaPCType type, typename sFloat, typename gFloat>
 void dslashReference_4d_mgpu(sFloat *res, gFloat **gaugeFull, gFloat **ghostGauge, sFloat *spinorField,
-    sFloat **fwdSpinor, sFloat **backSpinor, int oddBit, int daggerBit)
+                             sFloat **fwdSpinor, sFloat **backSpinor, int oddBit, int daggerBit)
 {
-  // int my_spinor_site_size = 24;
   for (int i = 0; i < V5h * spinor_site_size; i++) res[i] = 0.0;
 
   gFloat *gaugeEven[4], *gaugeOdd[4];

--- a/tests/host_reference/dslash_reference.cpp
+++ b/tests/host_reference/dslash_reference.cpp
@@ -423,9 +423,9 @@ void verifyStaggeredInversion(quda::ColorSpinorField *tmp, quda::ColorSpinorFiel
     len = Vh;
   }
 
-  mxpy(in->V(), ref->V(), len * my_spinor_site_size, inv_param.cpu_prec);
-  double nrm2 = norm_2(ref->V(), len * my_spinor_site_size, inv_param.cpu_prec);
-  double src2 = norm_2(in->V(), len * my_spinor_site_size, inv_param.cpu_prec);
+  mxpy(in->V(), ref->V(), len * stag_spinor_site_size, inv_param.cpu_prec);
+  double nrm2 = norm_2(ref->V(), len * stag_spinor_site_size, inv_param.cpu_prec);
+  double src2 = norm_2(in->V(), len * stag_spinor_site_size, inv_param.cpu_prec);
   double hqr = sqrt(quda::blas::HeavyQuarkResidualNorm(*out, *ref).z);
   double l2r = sqrt(nrm2 / src2);
 

--- a/tests/host_reference/dslash_reference.h
+++ b/tests/host_reference/dslash_reference.h
@@ -141,7 +141,8 @@ static inline Float *gaugeLink(int i, int dir, int oddBit, Float **gaugeEven, Fl
 }
 
 template <typename Float>
-static inline Float *spinorNeighbor(int i, int dir, int oddBit, Float *spinorField, int neighbor_distance) 
+static inline Float *spinorNeighbor(int i, int dir, int oddBit, Float *spinorField, int neighbor_distance,
+                                    int site_size = 24)
 {
   int j;
   int nb = neighbor_distance;
@@ -157,7 +158,7 @@ static inline Float *spinorNeighbor(int i, int dir, int oddBit, Float *spinorFie
   default: j = -1; break;
   }
 
-  return &spinorField[j * (my_spinor_site_size)];
+  return &spinorField[j * site_size];
 }
 
 
@@ -197,7 +198,7 @@ template <QudaPCType type> int neighborIndex_5d(int i, int oddBit, int dxs, int 
 }
 
 template <QudaPCType type, typename Float>
-Float *spinorNeighbor_5d(int i, int dir, int oddBit, Float *spinorField, int neighbor_distance = 1, int siteSize = 24)
+Float *spinorNeighbor_5d(int i, int dir, int oddBit, Float *spinorField, int neighbor_distance = 1, int site_size = 24)
 {
   int nb = neighbor_distance;
   int j;
@@ -214,7 +215,7 @@ Float *spinorNeighbor_5d(int i, int dir, int oddBit, Float *spinorField, int nei
   case 9: j = neighborIndex_5d<type>(i, oddBit, -nb, 0, 0, 0, 0); break;
   default: j = -1; break;
   }
-  return &spinorField[j*siteSize];
+  return &spinorField[j * site_size];
 }
 
 #ifdef MULTI_GPU
@@ -306,7 +307,7 @@ static inline Float *gaugeLink_mg4dir(int i, int dir, int oddBit, Float **gaugeE
 
 template <typename Float>
 static inline Float *spinorNeighbor_mg4dir(int i, int dir, int oddBit, Float *spinorField, Float** fwd_nbr_spinor, 
-					   Float** back_nbr_spinor, int neighbor_distance, int nFace)
+					   Float** back_nbr_spinor, int neighbor_distance, int nFace, int site_size = 24)
 {
   int j;
   int nb = neighbor_distance;
@@ -326,7 +327,7 @@ static inline Float *spinorNeighbor_mg4dir(int i, int dir, int oddBit, Float *sp
       int new_x1 = (x1 + nb)% X1;
       if(x1+nb >=X1 && comm_dim_partitioned(0) ){
         int offset = ( x1 + nb -X1)*X4*X3*X2/2+(x4*X3*X2 + x3*X2+x2)/2;
-        return fwd_nbr_spinor[0] + offset * my_spinor_site_size;
+        return fwd_nbr_spinor[0] + offset * site_size;
       }
       j = (x4*X3*X2*X1 + x3*X2*X1 + x2*X1 + new_x1) / 2;
       break;
@@ -336,7 +337,7 @@ static inline Float *spinorNeighbor_mg4dir(int i, int dir, int oddBit, Float *sp
       int new_x1 = (x1 - nb + X1)% X1;
       if(x1 - nb < 0 && comm_dim_partitioned(0)){
         int offset = ( x1+nFace- nb)*X4*X3*X2/2+(x4*X3*X2 + x3*X2+x2)/2;
-        return back_nbr_spinor[0] + offset * my_spinor_site_size;
+        return back_nbr_spinor[0] + offset * site_size;
       } 
       j = (x4*X3*X2*X1 + x3*X2*X1 + x2*X1 + new_x1) / 2;
       break;
@@ -346,7 +347,7 @@ static inline Float *spinorNeighbor_mg4dir(int i, int dir, int oddBit, Float *sp
       int new_x2 = (x2 + nb)% X2;
       if(x2+nb >=X2 && comm_dim_partitioned(1)){
         int offset = ( x2 + nb -X2)*X4*X3*X1/2+(x4*X3*X1 + x3*X1+x1)/2;
-        return fwd_nbr_spinor[1] + offset * my_spinor_site_size;
+        return fwd_nbr_spinor[1] + offset * site_size;
       } 
       j = (x4*X3*X2*X1 + x3*X2*X1 + new_x2*X1 + x1) / 2;
       break;
@@ -356,7 +357,7 @@ static inline Float *spinorNeighbor_mg4dir(int i, int dir, int oddBit, Float *sp
       int new_x2 = (x2 - nb + X2)% X2;
       if(x2 - nb < 0 && comm_dim_partitioned(1)){
         int offset = ( x2 + nFace -nb)*X4*X3*X1/2+(x4*X3*X1 + x3*X1+x1)/2;
-        return back_nbr_spinor[1] + offset * my_spinor_site_size;
+        return back_nbr_spinor[1] + offset * site_size;
       } 
       j = (x4*X3*X2*X1 + x3*X2*X1 + new_x2*X1 + x1) / 2;
       break;
@@ -366,7 +367,7 @@ static inline Float *spinorNeighbor_mg4dir(int i, int dir, int oddBit, Float *sp
       int new_x3 = (x3 + nb)% X3;
       if(x3+nb >=X3 && comm_dim_partitioned(2)){
         int offset = ( x3 + nb -X3)*X4*X2*X1/2+(x4*X2*X1 + x2*X1+x1)/2;
-        return fwd_nbr_spinor[2] + offset * my_spinor_site_size;
+        return fwd_nbr_spinor[2] + offset * site_size;
       } 
       j = (x4*X3*X2*X1 + new_x3*X2*X1 + x2*X1 + x1) / 2;
       break;
@@ -376,7 +377,7 @@ static inline Float *spinorNeighbor_mg4dir(int i, int dir, int oddBit, Float *sp
       int new_x3 = (x3 - nb + X3)% X3;
       if(x3 - nb < 0 && comm_dim_partitioned(2)){
         int offset = ( x3 + nFace -nb)*X4*X2*X1/2+(x4*X2*X1 + x2*X1+x1)/2;
-        return back_nbr_spinor[2] + offset * my_spinor_site_size;
+        return back_nbr_spinor[2] + offset * site_size;
       }
       j = (x4*X3*X2*X1 + new_x3*X2*X1 + x2*X1 + x1) / 2;
       break;
@@ -387,7 +388,7 @@ static inline Float *spinorNeighbor_mg4dir(int i, int dir, int oddBit, Float *sp
       int x4 = x4_mg(i, oddBit);
       if ( (x4 + nb) >= Z[3]  && comm_dim_partitioned(3)){
         int offset = (x4+nb - Z[3])*Vsh_t;
-        return &fwd_nbr_spinor[3][(offset + j) * my_spinor_site_size];
+        return &fwd_nbr_spinor[3][(offset + j) * site_size];
       }
       break;
     }
@@ -397,14 +398,14 @@ static inline Float *spinorNeighbor_mg4dir(int i, int dir, int oddBit, Float *sp
       int x4 = x4_mg(i, oddBit);
       if ( (x4 - nb) < 0 && comm_dim_partitioned(3)){
         int offset = ( x4 - nb +nFace)*Vsh_t;
-        return &back_nbr_spinor[3][(offset + j) * my_spinor_site_size];
+        return &back_nbr_spinor[3][(offset + j) * site_size];
       }
       break;
     }
   default: j = -1; printf("ERROR: wrong dir\n"); exit(1);
   }
 
-  return &spinorField[j * (my_spinor_site_size)];
+  return &spinorField[j * site_size];
 }
 
 template <QudaPCType type> int neighborIndex_5d_mgpu(int i, int oddBit, int dxs, int dx4, int dx3, int dx2, int dx1)
@@ -443,7 +444,7 @@ template <QudaPCType type> int x4_5d_mgpu(int i, int oddBit)
 
 template <QudaPCType type, typename Float>
 Float *spinorNeighbor_5d_mgpu(int i, int dir, int oddBit, Float *spinorField, Float **fwd_nbr_spinor,
-    Float **back_nbr_spinor, int neighbor_distance, int nFace, int spinorSize = 24)
+    Float **back_nbr_spinor, int neighbor_distance, int nFace, int site_size = 24)
 {
   int j;
   int nb = neighbor_distance;
@@ -465,7 +466,7 @@ Float *spinorNeighbor_5d_mgpu(int i, int dir, int oddBit, Float *spinorField, Fl
       int new_x1 = (x1 + nb)% X1;
       if(x1+nb >=X1 && comm_dim_partitioned(0)) {
         int offset = ((x1 + nb -X1)*Ls*X4*X3*X2+xs*X4*X3*X2+x4*X3*X2 + x3*X2+x2) >> 1;
-        return fwd_nbr_spinor[0] + offset*spinorSize;
+        return fwd_nbr_spinor[0] + offset * site_size;
       }
       j = (xs*X4*X3*X2*X1 + x4*X3*X2*X1 + x3*X2*X1 + x2*X1 + new_x1) >> 1;
       break;
@@ -475,7 +476,7 @@ Float *spinorNeighbor_5d_mgpu(int i, int dir, int oddBit, Float *spinorField, Fl
       int new_x1 = (x1 - nb + X1)% X1;
       if(x1 - nb < 0 && comm_dim_partitioned(0)) {
         int offset = (( x1+nFace- nb)*Ls*X4*X3*X2 + xs*X4*X3*X2 + x4*X3*X2 + x3*X2 + x2) >> 1;
-        return back_nbr_spinor[0] + offset*spinorSize;
+        return back_nbr_spinor[0] + offset * site_size;
       }
       j = (xs*X4*X3*X2*X1 + x4*X3*X2*X1 + x3*X2*X1 + x2*X1 + new_x1) >> 1;
       break;
@@ -485,7 +486,7 @@ Float *spinorNeighbor_5d_mgpu(int i, int dir, int oddBit, Float *spinorField, Fl
       int new_x2 = (x2 + nb)% X2;
       if(x2+nb >=X2 && comm_dim_partitioned(1)) {
         int offset = (( x2 + nb -X2)*Ls*X4*X3*X1+xs*X4*X3*X1+x4*X3*X1 + x3*X1+x1) >> 1;
-        return fwd_nbr_spinor[1] + offset*spinorSize;
+        return fwd_nbr_spinor[1] + offset * site_size;
       }
       j = (xs*X4*X3*X2*X1 + x4*X3*X2*X1 + x3*X2*X1 + new_x2*X1 + x1) >> 1;
       break;
@@ -495,7 +496,7 @@ Float *spinorNeighbor_5d_mgpu(int i, int dir, int oddBit, Float *spinorField, Fl
       int new_x2 = (x2 - nb + X2)% X2;
       if(x2 - nb < 0 && comm_dim_partitioned(1)) {
         int offset = (( x2 + nFace -nb)*Ls*X4*X3*X1+xs*X4*X3*X1+ x4*X3*X1 + x3*X1+x1) >> 1;
-        return back_nbr_spinor[1] + offset*spinorSize;
+        return back_nbr_spinor[1] + offset * site_size;
       }
       j = (xs*X4*X3*X2*X1 + x4*X3*X2*X1 + x3*X2*X1 + new_x2*X1 + x1) >> 1;
       break;
@@ -505,7 +506,7 @@ Float *spinorNeighbor_5d_mgpu(int i, int dir, int oddBit, Float *spinorField, Fl
       int new_x3 = (x3 + nb)% X3;
       if(x3+nb >=X3 && comm_dim_partitioned(2)) {
         int offset = (( x3 + nb -X3)*Ls*X4*X2*X1+xs*X4*X2*X1+x4*X2*X1 + x2*X1+x1) >> 1;
-        return fwd_nbr_spinor[2] + offset*spinorSize;
+        return fwd_nbr_spinor[2] + offset * site_size;
       }
       j = (xs*X4*X3*X2*X1 + x4*X3*X2*X1 + new_x3*X2*X1 + x2*X1 + x1) >> 1;
       break;
@@ -515,7 +516,7 @@ Float *spinorNeighbor_5d_mgpu(int i, int dir, int oddBit, Float *spinorField, Fl
       int new_x3 = (x3 - nb + X3)% X3;
       if(x3 - nb < 0 && comm_dim_partitioned(2)){
         int offset = (( x3 + nFace -nb)*Ls*X4*X2*X1+xs*X4*X2*X1+x4*X2*X1+x2*X1+x1) >> 1;
-        return back_nbr_spinor[2] + offset*spinorSize;
+        return back_nbr_spinor[2] + offset * site_size;
       }
       j = (xs*X4*X3*X2*X1 + x4*X3*X2*X1 + new_x3*X2*X1 + x2*X1 + x1) >> 1;
       break;
@@ -525,7 +526,7 @@ Float *spinorNeighbor_5d_mgpu(int i, int dir, int oddBit, Float *spinorField, Fl
       int x4 = x4_5d_mgpu<type>(i, oddBit);
       if ( (x4 + nb) >= Z[3] && comm_dim_partitioned(3)) {
         int offset = ((x4 + nb - Z[3])*Ls*X3*X2*X1+xs*X3*X2*X1+x3*X2*X1+x2*X1+x1) >> 1;
-        return fwd_nbr_spinor[3] + offset*spinorSize;
+        return fwd_nbr_spinor[3] + offset * site_size;
       }
       j = neighborIndex_5d_mgpu<type>(i, oddBit, 0, +nb, 0, 0, 0);
       break;
@@ -535,7 +536,7 @@ Float *spinorNeighbor_5d_mgpu(int i, int dir, int oddBit, Float *spinorField, Fl
       int x4 = x4_5d_mgpu<type>(i, oddBit);
       if ( (x4 - nb) < 0 && comm_dim_partitioned(3)) {
         int offset = (( x4 - nb +nFace)*Ls*X3*X2*X1+xs*X3*X2*X1+x3*X2*X1+x2*X1+x1) >> 1;
-        return back_nbr_spinor[3] + offset*spinorSize;
+        return back_nbr_spinor[3] + offset * site_size;
       }
       j = neighborIndex_5d_mgpu<type>(i, oddBit, 0, -nb, 0, 0, 0);
       break;
@@ -543,7 +544,7 @@ Float *spinorNeighbor_5d_mgpu(int i, int dir, int oddBit, Float *spinorField, Fl
   default: j = -1; printf("ERROR: wrong dir\n"); exit(1);
   }
 
-  return &spinorField[j*(spinorSize)];
+  return &spinorField[j * site_size];
 }
 
 

--- a/tests/host_reference/staggered_dslash_reference.cpp
+++ b/tests/host_reference/staggered_dslash_reference.cpp
@@ -39,7 +39,7 @@ void staggeredDslashReference(sFloat *res, gFloat **fatlink, gFloat **longlink, 
                               gFloat **ghostLonglink, sFloat *spinorField, sFloat **fwd_nbr_spinor,
                               sFloat **back_nbr_spinor, int oddBit, int daggerBit, int nSrc, QudaDslashType dslash_type)
 {
-  for (int i = 0; i < Vh * my_spinor_site_size * nSrc; i++) res[i] = 0.0;
+  for (int i = 0; i < Vh * stag_spinor_site_size * nSrc; i++) res[i] = 0.0;
 
   gFloat *fatlinkEven[4], *fatlinkOdd[4];
   gFloat *longlinkEven[4], *longlinkOdd[4];
@@ -67,7 +67,7 @@ void staggeredDslashReference(sFloat *res, gFloat **fatlink, gFloat **longlink, 
 
     for (int i = 0; i < Vh; i++) {
       int sid = i + xs * Vh;
-      int offset = my_spinor_site_size * sid;
+      int offset = stag_spinor_site_size * sid;
 
       for (int dir = 0; dir < 8; dir++) {
 #ifdef MULTI_GPU
@@ -78,47 +78,47 @@ void staggeredDslashReference(sFloat *res, gFloat **fatlink, gFloat **longlink, 
           gaugeLink_mg4dir(i, dir, oddBit, longlinkEven, longlinkOdd, ghostLonglinkEven, ghostLonglinkOdd, 3, 3) :
           nullptr;
         sFloat *first_neighbor_spinor = spinorNeighbor_5d_mgpu<QUDA_4D_PC>(
-          sid, dir, oddBit, spinorField, fwd_nbr_spinor, back_nbr_spinor, 1, nFace, my_spinor_site_size);
+          sid, dir, oddBit, spinorField, fwd_nbr_spinor, back_nbr_spinor, 1, nFace, stag_spinor_site_size);
         sFloat *third_neighbor_spinor = dslash_type == QUDA_ASQTAD_DSLASH ?
           spinorNeighbor_5d_mgpu<QUDA_4D_PC>(sid, dir, oddBit, spinorField, fwd_nbr_spinor, back_nbr_spinor, 3, nFace,
-                                             my_spinor_site_size) :
+                                             stag_spinor_site_size) :
           nullptr;
 #else
         gFloat *fatlnk = gaugeLink(i, dir, oddBit, fatlinkEven, fatlinkOdd, 1);
         gFloat *longlnk
           = dslash_type == QUDA_ASQTAD_DSLASH ? gaugeLink(i, dir, oddBit, longlinkEven, longlinkOdd, 3) : nullptr;
         sFloat *first_neighbor_spinor
-          = spinorNeighbor_5d<QUDA_4D_PC>(sid, dir, oddBit, spinorField, 1, my_spinor_site_size);
+          = spinorNeighbor_5d<QUDA_4D_PC>(sid, dir, oddBit, spinorField, 1, stag_spinor_site_size);
         sFloat *third_neighbor_spinor = dslash_type == QUDA_ASQTAD_DSLASH ?
-          spinorNeighbor_5d<QUDA_4D_PC>(sid, dir, oddBit, spinorField, 3, my_spinor_site_size) :
+          spinorNeighbor_5d<QUDA_4D_PC>(sid, dir, oddBit, spinorField, 3, stag_spinor_site_size) :
           nullptr;
 #endif
-        sFloat gaugedSpinor[my_spinor_site_size];
+        sFloat gaugedSpinor[stag_spinor_site_size];
 
         if (dir % 2 == 0) {
           su3Mul(gaugedSpinor, fatlnk, first_neighbor_spinor);
-          sum(&res[offset], &res[offset], gaugedSpinor, my_spinor_site_size);
+          sum(&res[offset], &res[offset], gaugedSpinor, stag_spinor_site_size);
 
           if (dslash_type == QUDA_ASQTAD_DSLASH) {
             su3Mul(gaugedSpinor, longlnk, third_neighbor_spinor);
-            sum(&res[offset], &res[offset], gaugedSpinor, my_spinor_site_size);
+            sum(&res[offset], &res[offset], gaugedSpinor, stag_spinor_site_size);
           }
         } else {
           su3Tmul(gaugedSpinor, fatlnk, first_neighbor_spinor);
           if (dslash_type == QUDA_LAPLACE_DSLASH) {
-            sum(&res[offset], &res[offset], gaugedSpinor, my_spinor_site_size);
+            sum(&res[offset], &res[offset], gaugedSpinor, stag_spinor_site_size);
           } else {
-            sub(&res[offset], &res[offset], gaugedSpinor, my_spinor_site_size);
+            sub(&res[offset], &res[offset], gaugedSpinor, stag_spinor_site_size);
           }
 
           if (dslash_type == QUDA_ASQTAD_DSLASH) {
             su3Tmul(gaugedSpinor, longlnk, third_neighbor_spinor);
-            sub(&res[offset], &res[offset], gaugedSpinor, my_spinor_site_size);
+            sub(&res[offset], &res[offset], gaugedSpinor, stag_spinor_site_size);
           }
         }
       }
 
-      if (daggerBit) negx(&res[offset], my_spinor_site_size);
+      if (daggerBit) negx(&res[offset], stag_spinor_site_size);
     } // 4-d volume
   }   // right-hand-side
 }
@@ -192,8 +192,8 @@ void staggeredMatDagMat(ColorSpinorField *out, void **fatlink, void **longlink, 
 
   double msq_x4 = mass * mass * 4;
   if (sPrecision == QUDA_DOUBLE_PRECISION) {
-    axmy((double *)in->V(), (double)msq_x4, (double *)out->V(), out->X(4) * Vh * my_spinor_site_size);
+    axmy((double *)in->V(), (double)msq_x4, (double *)out->V(), out->X(4) * Vh * stag_spinor_site_size);
   } else {
-    axmy((float *)in->V(), (float)msq_x4, (float *)out->V(), out->X(4) * Vh * my_spinor_site_size);
+    axmy((float *)in->V(), (float)msq_x4, (float *)out->V(), out->X(4) * Vh * stag_spinor_site_size);
   }
 }

--- a/tests/host_reference/wilson_dslash_reference.cpp
+++ b/tests/host_reference/wilson_dslash_reference.cpp
@@ -101,8 +101,9 @@ void multiplySpinorByDiracProjector(Float *res, int projIdx, Float *spinorIn) {
 #ifndef MULTI_GPU
 
 template <typename sFloat, typename gFloat>
-void dslashReference(sFloat *res, gFloat **gaugeFull, sFloat *spinorField, int oddBit, int daggerBit) {
-  for (int i = 0; i < Vh * my_spinor_site_size; i++) res[i] = 0.0;
+void dslashReference(sFloat *res, gFloat **gaugeFull, sFloat *spinorField, int oddBit, int daggerBit)
+{
+  for (int i = 0; i < Vh * spinor_site_size; i++) res[i] = 0.0;
 
   gFloat *gaugeEven[4], *gaugeOdd[4];
   for (int dir = 0; dir < 4; dir++) {  
@@ -115,7 +116,7 @@ void dslashReference(sFloat *res, gFloat **gaugeFull, sFloat *spinorField, int o
       gFloat *gauge = gaugeLink(i, dir, oddBit, gaugeEven, gaugeOdd, 1);
       sFloat *spinor = spinorNeighbor(i, dir, oddBit, spinorField, 1);
       
-      sFloat projectedSpinor[4*3*2], gaugedSpinor[4*3*2];
+      sFloat projectedSpinor[spinor_site_size], gaugedSpinor[spinor_site_size];
       int projIdx = 2*(dir/2)+(dir+daggerBit)%2;
       multiplySpinorByDiracProjector(projectedSpinor, projIdx, spinor);
       
@@ -124,7 +125,7 @@ void dslashReference(sFloat *res, gFloat **gaugeFull, sFloat *spinorField, int o
 	else su3Tmul(&gaugedSpinor[s*(3*2)], gauge, &projectedSpinor[s*(3*2)]);
       }
       
-      sum(&res[i*(4*3*2)], &res[i*(4*3*2)], gaugedSpinor, 4*3*2);
+      sum(&res[i * spinor_site_size], &res[i * spinor_site_size], gaugedSpinor, spinor_site_size);
     }
   }
 }
@@ -133,8 +134,9 @@ void dslashReference(sFloat *res, gFloat **gaugeFull, sFloat *spinorField, int o
 
 template <typename sFloat, typename gFloat>
 void dslashReference(sFloat *res, gFloat **gaugeFull,  gFloat **ghostGauge, sFloat *spinorField, 
-		     sFloat **fwdSpinor, sFloat **backSpinor, int oddBit, int daggerBit) {
-  for (int i = 0; i < Vh * my_spinor_site_size; i++) res[i] = 0.0;
+		     sFloat **fwdSpinor, sFloat **backSpinor, int oddBit, int daggerBit)
+{
+  for (int i = 0; i < Vh * spinor_site_size; i++) res[i] = 0.0;
 
   gFloat *gaugeEven[4], *gaugeOdd[4];
   gFloat *ghostGaugeEven[4], *ghostGaugeOdd[4];
@@ -152,7 +154,7 @@ void dslashReference(sFloat *res, gFloat **gaugeFull,  gFloat **ghostGauge, sFlo
       gFloat *gauge = gaugeLink_mg4dir(i, dir, oddBit, gaugeEven, gaugeOdd, ghostGaugeEven, ghostGaugeOdd, 1, 1);
       sFloat *spinor = spinorNeighbor_mg4dir(i, dir, oddBit, spinorField, fwdSpinor, backSpinor, 1, 1);
 
-      sFloat projectedSpinor[my_spinor_site_size], gaugedSpinor[my_spinor_site_size];
+      sFloat projectedSpinor[spinor_site_size], gaugedSpinor[spinor_site_size];
       int projIdx = 2*(dir/2)+(dir+daggerBit)%2;
       multiplySpinorByDiracProjector(projectedSpinor, projIdx, spinor);
       
@@ -161,7 +163,7 @@ void dslashReference(sFloat *res, gFloat **gaugeFull,  gFloat **ghostGauge, sFlo
 	else su3Tmul(&gaugedSpinor[s*(3*2)], gauge, &projectedSpinor[s*(3*2)]);
       }
       
-      sum(&res[i*(4*3*2)], &res[i*(4*3*2)], gaugedSpinor, 4*3*2);
+      sum(&res[i * spinor_site_size], &res[i * spinor_site_size], gaugedSpinor, spinor_site_size);
     }
 
   }

--- a/tests/invert_test.cpp
+++ b/tests/invert_test.cpp
@@ -214,7 +214,6 @@ int main(int argc, char **argv)
   } else {
     setDims(gauge_param.X);
   }
-  setSpinorSiteSize(24);
 
   // Allocate host side memory for the gauge field.
   //----------------------------------------------------------------------------

--- a/tests/invertmsrc_test.cpp
+++ b/tests/invertmsrc_test.cpp
@@ -87,8 +87,6 @@ int main(int argc, char **argv)
     setDims(gauge_param.X);
   }
 
-  setSpinorSiteSize(24);
-
   // Allocate host side memory for the gauge field.
   //----------------------------------------------------------------------------
   void *gauge[4];

--- a/tests/multigrid_evolve_test.cpp
+++ b/tests/multigrid_evolve_test.cpp
@@ -180,8 +180,6 @@ int main(int argc, char **argv)
   // *** Everything between here and the timer is application specific
   setDims(gauge_param.X);
 
-  setSpinorSiteSize(24);
-
   // Allocate host side memory for the gauge field.
   //----------------------------------------------------------------------------
   void *gauge[4];

--- a/tests/staggered_dslash_test_utils.h
+++ b/tests/staggered_dslash_test_utils.h
@@ -22,8 +22,6 @@
 
 using namespace quda;
 
-#define staggeredSpinorSiteSize 6
-
 dslash_test_type dtest_type = dslash_test_type::Dslash;
 CLI::TransformPairs<dslash_test_type> dtest_type_map {
   {"Dslash", dslash_test_type::Dslash}, {"MatPC", dslash_test_type::MatPC}, {"Mat", dslash_test_type::Mat}
@@ -232,7 +230,6 @@ struct StaggeredDslashTestWrapper {
       warningQuda("Ignoring Nsrc = %d, setting to 1.", Nsrc);
       Nsrc = 1;
     }
-    setSpinorSiteSize(staggeredSpinorSiteSize);
 
     // Allocate a lot of memory because I'm very confused
     void *milc_fatlink_cpu = malloc(4 * V * gauge_site_size * host_gauge_data_type_size);

--- a/tests/staggered_eigensolve_test.cpp
+++ b/tests/staggered_eigensolve_test.cpp
@@ -115,7 +115,6 @@ int main(int argc, char **argv)
 
   setDims(gauge_param.X);
   dw_setDims(gauge_param.X, 1); // so we can use 5-d indexing from dwf
-  setSpinorSiteSize(6);
 
   // Staggered Gauge construct START
   //-----------------------------------------------------------------------------------
@@ -158,7 +157,7 @@ int main(int argc, char **argv)
   // Host side arrays to store the eigenpairs computed by QUDA
   void **host_evecs = (void **)malloc(eig_n_conv * sizeof(void *));
   for (int i = 0; i < eig_n_conv; i++) {
-    host_evecs[i] = (void *)malloc(V * my_spinor_site_size * eig_inv_param.cpu_prec);
+    host_evecs[i] = (void *)malloc(V * stag_spinor_site_size * eig_inv_param.cpu_prec);
   }
   double _Complex *host_evals = (double _Complex *)malloc(eig_param.n_ev * sizeof(double _Complex));
 

--- a/tests/staggered_invert_test.cpp
+++ b/tests/staggered_invert_test.cpp
@@ -211,7 +211,6 @@ int main(int argc, char **argv)
   setDims(gauge_param.X);
   // Hack: use the domain wall dimensions so we may use the 5th dim for multi indexing
   dw_setDims(gauge_param.X, 1);
-  setSpinorSiteSize(6);
 
   // Staggered Gauge construct START
   //-----------------------------------------------------------------------------------

--- a/tests/staggered_invertmsrc_test.cpp
+++ b/tests/staggered_invertmsrc_test.cpp
@@ -170,7 +170,6 @@ invert_test(void)
 
   setDims(gaugeParam.X);
   dw_setDims(gaugeParam.X,1); // so we can use 5-d indexing from dwf
-  setSpinorSiteSize(6);
 
   for (int dir = 0; dir < 4; dir++) {
     qdp_fatlink[dir] = malloc(V * gauge_site_size * host_gauge_data_type_size);

--- a/tests/utils/host_utils.cpp
+++ b/tests/utils/host_utils.cpp
@@ -49,8 +49,6 @@ int V5;
 int V5h;
 double kappa5;
 
-int my_spinor_site_size;
-
 extern float fat_link_max;
 
 // Set some local QUDA precision variables
@@ -369,8 +367,6 @@ void dw_setDims(int *X, const int L5)
   Vs_t = Z[0]*Z[1]*Z[2]*Ls;//?
   Vsh_t = Vs_t/2;  //?
 }
-
-void setSpinorSiteSize(int n) { my_spinor_site_size = n; }
 
 int dimPartitioned(int dim) { return ((gridsize_from_cmdline[dim] > 1) || dim_partitioned[dim]); }
 

--- a/tests/utils/host_utils.h
+++ b/tests/utils/host_utils.h
@@ -27,7 +27,6 @@ extern int Ls;
 extern int V5;
 extern int V5h;
 
-extern int my_spinor_site_size;
 extern size_t host_gauge_data_type_size;
 extern size_t host_spinor_data_type_size;
 extern size_t host_clover_data_type_size;
@@ -130,7 +129,6 @@ int lex_rank_from_coords_x(const int *coords, void *fdata);
 void get_size_from_env(int *const dims, const char env[]);
 void setDims(int *X);
 void dw_setDims(int *X, const int L5);
-void setSpinorSiteSize(int n);
 int dimPartitioned(int dim);
 
 bool last_node_in_t();


### PR DESCRIPTION
This PR expunges the global variable `my_spinor_site_size` variable from the test code, and replaces the associated variable-size arrays, which are undefined behaviour in C++, with static arrays using `spinor_site_size` and `stag_spinor_site_size` for Wilson-type and staggered-type test codes, respectively.

Note this fixes the test codes when compiled using nvc++ as the host compiler.