### PR TITLE
Fix bug with multi-reduce (leaf transformation applied when not at leaf)

### DIFF
--- a/lib/multi_reduce_quda.cu
+++ b/lib/multi_reduce_quda.cu
@@ -387,7 +387,7 @@ namespace quda {
         }
 
         // we are at the leaf of the binary tree (e.g., we ran the kernel): perform the row-to-column-major transpose here.
-        if (x.size() <= tile_size.x && is_valid_NXZ(x.size(), true)) {
+        if (x.size() <= tile_size.x && is_valid_NXZ(x.size(), true) && x.size() * y.size() <= max_n_reduce()) {
           const unsigned int xlen = x.size();
           const unsigned int ylen = y.size();
           for (unsigned int j = 0; j < xlen; j++)


### PR DESCRIPTION
Fixes a bug in the mult-reduce recursion when msrc * nsrc > max_n_reduce (1024 currently) but the partitioned tile size is valid.   The leaf reordering was being applied erroneously.  For example, without this patch, the following test would fail 
```
tests/blas_test --dim 2 2 2 2 --msrc 8 --nsrc 129 --prec single --niter 1
```
with error
```
[ RUN      ] QUDA/BlasTest.verify/reDotProduct_block_single_single
/home/kate/github/quda-1.1/tests/blas_test.cpp:1105: Failure
Expected: (deviation) <= (tol), actual: 0.0658992 vs 1e-06
CPU and CUDA implementations do not agree
[  FAILED  ] QUDA/BlasTest.verify/reDotProduct_block_single_single, where GetParam() = (7, 34) (137 ms)
[ RUN      ] QUDA/BlasTest.verify/cDotProductNorm_block_single_single
[       OK ] QUDA/BlasTest.verify/cDotProductNorm_block_single_single (1190 ms)
[ RUN      ] QUDA/BlasTest.verify/cDotProduct_block_single_single
/home/kate/github/quda-1.1/tests/blas_test.cpp:1105: Failure
Expected: (deviation) <= (tol), actual: 1 vs 1e-06
CPU and CUDA implementations do not agree
[  FAILED  ] QUDA/BlasTest.verify/cDotProduct_block_single_single, where GetParam() = (7, 36) (134 ms)
```