### PR TITLE
gauge_force_test and Communicator topology memory

### DIFF
--- a/include/communicator_quda.h
+++ b/include/communicator_quda.h
@@ -98,8 +98,8 @@ Topology *comm_create_topology(int ndim, const int *dims, QudaCommsMap rank_from
 
 inline void comm_destroy_topology(Topology *topo)
 {
-  delete topo->ranks;
-  delete topo->coords;
+  delete [] topo->ranks;
+  delete [] topo->coords;
   delete topo;
 }
 

--- a/include/communicator_quda.h
+++ b/include/communicator_quda.h
@@ -98,9 +98,9 @@ Topology *comm_create_topology(int ndim, const int *dims, QudaCommsMap rank_from
 
 inline void comm_destroy_topology(Topology *topo)
 {
-  host_free(topo->ranks);
-  host_free(topo->coords);
-  host_free(topo);
+  delete topo->ranks;
+  delete topo->coords;
+  delete topo;
 }
 
 inline int comm_ndim(const Topology *topo) { return topo->ndim; }

--- a/lib/comm_common.cpp
+++ b/lib/comm_common.cpp
@@ -174,7 +174,7 @@ Topology *comm_create_topology(int ndim, const int *dims, QudaCommsMap rank_from
 {
   if (ndim > QUDA_MAX_DIM) { errorQuda("ndim exceeds QUDA_MAX_DIM"); }
 
-  Topology *topo = (Topology *)safe_malloc(sizeof(Topology));
+  Topology *topo = new Topology;
 
   topo->ndim = ndim;
 
@@ -184,8 +184,8 @@ Topology *comm_create_topology(int ndim, const int *dims, QudaCommsMap rank_from
     nodes *= dims[i];
   }
 
-  topo->ranks = (int *)safe_malloc(nodes * sizeof(int));
-  topo->coords = (int(*)[QUDA_MAX_DIM])safe_malloc(nodes * sizeof(int[QUDA_MAX_DIM]));
+  topo->ranks = new int[nodes];
+  topo->coords = (int(*)[QUDA_MAX_DIM])new int[QUDA_MAX_DIM * nodes];
 
   int x[QUDA_MAX_DIM];
   for (int i = 0; i < QUDA_MAX_DIM; i++) x[i] = 0;

--- a/tests/gauge_force_test.cpp
+++ b/tests/gauge_force_test.cpp
@@ -241,7 +241,6 @@ void gauge_force_test(void)
 {
   int max_length = 6;
 
-  initQuda(device_ordinal);
   setVerbosityQuda(QUDA_VERBOSE,"",stdout);
 
   QudaGaugeParam gauge_param = newQudaGaugeParam();
@@ -368,8 +367,6 @@ void gauge_force_test(void)
   delete Mom_qdp;
   delete Mom_milc;
   delete Mom_ref_milc;
-
-  endQuda();
 }
 
 TEST(force, verify) { ASSERT_EQ(force_check, 1) << "CPU and QUDA implementations do not agree"; }
@@ -408,6 +405,8 @@ int main(int argc, char **argv)
 
   initComms(argc, argv, gridsize_from_cmdline);
 
+  initQuda(device_ordinal);
+
   display_test_info();
 
   gauge_force_test();
@@ -421,6 +420,7 @@ int main(int argc, char **argv)
     if (test_rc != 0) warningQuda("Tests failed");
   }
 
+  endQuda();
   finalizeComms();
   return test_rc;
 }


### PR DESCRIPTION
Two hot fixes:
- Move `endQuda()` to the very end of `tests/gauge_force_test.cpp`.
- Make the `topology` memory allocation/deallocation independent of QUDA's memory pool. This is needed since when the program exits, e.g. when `exit(x)` is called before `endQuda()` is called, the static variables, includes QUDA's memory pool notebook and the Communicator stack are cleaned up by `cpp`, with no specific order. Having the Communicator stack depend on the notebook leads to segmentation faults.