### PR TITLE
Compute gauge path

### DIFF
--- a/include/gauge_force_quda.h
+++ b/include/gauge_force_quda.h
@@ -16,6 +16,20 @@ namespace quda {
    */
   void gaugeForce(GaugeField& mom, const GaugeField& u, double coeff, int ***input_path,
 		  int *length, double *path_coeff, int num_paths, int max_length);
+
+  /**
+     @brief Compute the product of gauge-links along the given path
+     @param[out] out Gauge field which the result is added to
+     @param[in] u Gauge field (extended when running no multiple GPUs)
+     @param[in] coeff Global coefficient for the result
+     @param[in] input_path Host-array holding all path contributions
+     @param[in] length Host array holding the length of all paths
+     @param[in] path_coeff Coefficient of each path
+     @param[in] num_paths Numer of paths
+     @param[in] max_length Maximum length of each path
+   */
+  void gaugePath(GaugeField& out, const GaugeField& u, double coeff, int ***input_path,
+		  int *length, double *path_coeff, int num_paths, int max_length);
 } // namespace quda
 
 

--- a/include/kernels/gauge_force.cuh
+++ b/include/kernels/gauge_force.cuh
@@ -51,10 +51,11 @@ namespace quda {
     }
   };
 
-  template <typename Float_, int nColor_, QudaReconstructType recon_u, QudaReconstructType recon_m>
+  template <typename Float_, int nColor_, QudaReconstructType recon_u, QudaReconstructType recon_m, bool force_>
   struct GaugeForceArg {
     using Float = Float_;
     static constexpr int nColor = nColor_;
+    static constexpr bool force = force_;
     static_assert(nColor == 3, "Only nColor=3 enabled at this time");
     typedef typename gauge_mapper<Float,recon_u>::type Gauge;
     typedef typename gauge_mapper<Float,recon_m>::type Mom;
@@ -153,8 +154,13 @@ namespace quda {
 
     // update mom(x)
     Link mom = arg.mom(dir, idx, parity);
-    mom = mom - arg.epsilon * linkA;
-    makeAntiHerm(mom);
+    if(arg.force) {
+      mom = mom - arg.epsilon * linkA;
+      makeAntiHerm(mom);
+    }
+    else {
+      mom = mom + arg.epsilon * linkA;
+    }
     arg.mom(dir, idx, parity) = mom;
   }
 

--- a/include/kernels/gauge_force.cuh
+++ b/include/kernels/gauge_force.cuh
@@ -16,7 +16,7 @@ namespace quda {
     const double *path_coeff;
     int count;
 
-    paths(void *buffer, size_t bytes, int ***input_path, int *length_h, double *path_coeff_h, int num_paths, int max_length) :
+    paths(void *buffer, size_t bytes, int pad, int ***input_path, int *length_h, double *path_coeff_h, int num_paths, int max_length) :
       num_paths(num_paths),
       max_length(max_length),
       count(0)
@@ -39,7 +39,7 @@ namespace quda {
       memcpy((char*)path_h + 4 * num_paths * max_length * sizeof(int), length_h, num_paths*sizeof(int));
 
       // path_coeff array
-      memcpy((char*)path_h + 4 * num_paths * max_length * sizeof(int) + num_paths*sizeof(int), path_coeff_h, num_paths*sizeof(double));
+      memcpy((char*)path_h + 4 * num_paths * max_length * sizeof(int) + num_paths*sizeof(int) + pad, path_coeff_h, num_paths*sizeof(double));
 
       qudaMemcpy(buffer, path_h, bytes, qudaMemcpyHostToDevice);
       host_free(path_h);
@@ -47,7 +47,7 @@ namespace quda {
       // finally set the pointers to the correct offsets in the buffer
       for (int d=0; d < 4; d++) this->input_path[d] = (int*)((char*)buffer + d*num_paths*max_length*sizeof(int));
       length = (int*)((char*)buffer + 4*num_paths*max_length*sizeof(int));
-      path_coeff = (double*)((char*)buffer + 4 * num_paths * max_length * sizeof(int) + num_paths*sizeof(int));
+      path_coeff = (double*)((char*)buffer + 4 * num_paths * max_length * sizeof(int) + num_paths*sizeof(int) + pad);
     }
   };
 

--- a/include/kernels/gauge_force.cuh
+++ b/include/kernels/gauge_force.cuh
@@ -64,7 +64,7 @@ namespace quda {
   struct GaugeForceArg {
     using Float = Float_;
     static constexpr int nColor = nColor_;
-    static constexpr bool force = force_;
+    static constexpr bool compute_force = force_;
     static_assert(nColor == 3, "Only nColor=3 enabled at this time");
     typedef typename gauge_mapper<Float,recon_u>::type Gauge;
     typedef typename gauge_mapper<Float,recon_m>::type Mom;
@@ -163,7 +163,7 @@ namespace quda {
 
     // update mom(x)
     Link mom = arg.mom(dir, idx, parity);
-    if(arg.force) {
+    if(arg.compute_force) {
       mom = mom - arg.epsilon * linkA;
       makeAntiHerm(mom);
     }

--- a/include/quda.h
+++ b/include/quda.h
@@ -77,7 +77,8 @@ extern "C" {
 
     int overlap; /**< Width of overlapping domains */
 
-    int overwrite_mom; /**< When computing momentum, should we overwrite it or accumulate to to */
+    int overwrite_gauge; /**< When computing gauge, should we overwrite it or accumulate to it */
+    int overwrite_mom; /**< When computing momentum, should we overwrite it or accumulate to it */
 
     int use_resident_gauge;  /**< Use the resident gauge field as input */
     int use_resident_mom;    /**< Use the resident momentum field as input*/
@@ -1253,6 +1254,23 @@ extern "C" {
    * @param param The parameters of the external fields and the computation settings
    */
   int computeGaugeForceQuda(void* mom, void* sitelink,  int*** input_path_buf, int* path_length,
+			    double* loop_coeff, int num_paths, int max_length, double dt,
+			    QudaGaugeParam* qudaGaugeParam);
+
+  /**
+   * Compute the product of gauge along a path and add to/overwrite the output field
+   *
+   * @param out The output field to be updated
+   * @param sitelink The gauge field from which we compute the force
+   * @param input_path_buf[dim][num_paths][path_length]
+   * @param path_length One less that the number of links in a loop (e.g., 3 for a staple)
+   * @param loop_coeff Coefficients of the different loops in the Symanzik action
+   * @param num_paths How many contributions from path_length different "staples"
+   * @param max_length The maximum number of non-zero of links in any path in the action
+   * @param dt The integration step size (for MILC this is dt*beta/3)
+   * @param param The parameters of the external fields and the computation settings
+   */
+  int computeGaugePathQuda(void* out, void* sitelink,  int*** input_path_buf, int* path_length,
 			    double* loop_coeff, int num_paths, int max_length, double dt,
 			    QudaGaugeParam* qudaGaugeParam);
 

--- a/lib/gauge_force.cu
+++ b/lib/gauge_force.cu
@@ -4,7 +4,7 @@
 
 namespace quda {
 
-  template <typename Float, int nColor, QudaReconstructType recon_u, bool force=true> class ForceGauge : public TunableKernel3D
+  template <typename Float, int nColor, QudaReconstructType recon_u, bool compute_force=true> class ForceGauge : public TunableKernel3D
   {
     const GaugeField &u;
     GaugeField &mom;
@@ -29,7 +29,7 @@ namespace quda {
     void apply(const qudaStream_t &stream)
     {
       TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
-      launch<GaugeForce>(tp, stream, GaugeForceArg<Float, nColor, recon_u, force ? QUDA_RECONSTRUCT_10 : recon_u, force>(mom, u, epsilon, p));
+      launch<GaugeForce>(tp, stream, GaugeForceArg<Float, nColor, recon_u, compute_force ? QUDA_RECONSTRUCT_10 : recon_u, compute_force>(mom, u, epsilon, p));
     }
 
     void preTune() { mom.backup(); }

--- a/lib/gauge_force.cu
+++ b/lib/gauge_force.cu
@@ -51,16 +51,11 @@ namespace quda {
     checkLocation(mom, u);
     if (mom.Reconstruct() != QUDA_RECONSTRUCT_10) errorQuda("Reconstruction type %d not supported", mom.Reconstruct());
 
-    // create path struct in a single allocation
-    size_t bytes = 4 * num_paths * path_max_length * sizeof(int) + num_paths*sizeof(int);
-    int pad = (sizeof(double) - bytes % sizeof(double)) % sizeof(double);
-    bytes += pad + num_paths*sizeof(double);
-    void *buffer = pool_device_malloc(bytes);
-    paths p(buffer, bytes, pad, input_path, length_h, path_coeff_h, num_paths, path_max_length);
+    paths p(input_path, length_h, path_coeff_h, num_paths, path_max_length);
 
     // gauge field must be passed as first argument so we peel off its reconstruct type
     instantiate<GaugeForce_,ReconstructNo12>(u, mom, epsilon, p);
-    pool_device_free(buffer);
+    p.free();
   }
   
   void gaugePath(GaugeField& out, const GaugeField& u, double coeff, int ***input_path,
@@ -70,16 +65,11 @@ namespace quda {
     checkLocation(out, u);
     checkReconstruct(out, u);
 
-    // create path struct in a single allocation
-    size_t bytes = 4 * num_paths * path_max_length * sizeof(int) + num_paths*sizeof(int);
-    int pad = (sizeof(double) - bytes % sizeof(double)) % sizeof(double);
-    bytes += pad + num_paths*sizeof(double);
-    void *buffer = pool_device_malloc(bytes);
-    paths p(buffer, bytes, pad, input_path, length_h, path_coeff_h, num_paths, path_max_length);
+    paths p(input_path, length_h, path_coeff_h, num_paths, path_max_length);
 
     // gauge field must be passed as first argument so we peel off its reconstruct type
     instantiate<GaugePath>(u, out, coeff, p);
-    pool_device_free(buffer);
+    p.free();
   }
 #else
   void gaugeForce(GaugeField&, const GaugeField&, double, int ***, int *, double *, int, int)

--- a/lib/gauge_force.cu
+++ b/lib/gauge_force.cu
@@ -4,7 +4,7 @@
 
 namespace quda {
 
-  template <typename Float, int nColor, QudaReconstructType recon_u> class ForceGauge : public TunableKernel3D
+  template <typename Float, int nColor, QudaReconstructType recon_u, bool force=true> class ForceGauge : public TunableKernel3D
   {
     const GaugeField &u;
     GaugeField &mom;
@@ -29,7 +29,7 @@ namespace quda {
     void apply(const qudaStream_t &stream)
     {
       TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
-      launch<GaugeForce>(tp, stream, GaugeForceArg<Float, nColor, recon_u, QUDA_RECONSTRUCT_10>(mom, u, epsilon, p));
+      launch<GaugeForce>(tp, stream, GaugeForceArg<Float, nColor, recon_u, force ? QUDA_RECONSTRUCT_10 : recon_u, force>(mom, u, epsilon, p));
     }
 
     void preTune() { mom.backup(); }
@@ -38,6 +38,10 @@ namespace quda {
     long long flops() const { return (p.count - p.num_paths + 1) * 198ll * mom.Volume() * 4; }
     long long bytes() const { return (p.count + 1ll) * u.Bytes() + 2 * mom.Bytes(); }
   };
+
+  template<typename Float, int nColor, QudaReconstructType recon_u> using GaugeForce_ = ForceGauge<Float,nColor,recon_u,true>;
+
+  template<typename Float, int nColor, QudaReconstructType recon_u> using GaugePath = ForceGauge<Float,nColor,recon_u,false>;
 
 #ifdef GPU_GAUGE_FORCE
   void gaugeForce(GaugeField& mom, const GaugeField& u, double epsilon, int ***input_path,
@@ -55,11 +59,34 @@ namespace quda {
     paths p(buffer, bytes, pad, input_path, length_h, path_coeff_h, num_paths, path_max_length);
 
     // gauge field must be passed as first argument so we peel off its reconstruct type
-    instantiate<ForceGauge,ReconstructNo12>(u, mom, epsilon, p);
+    instantiate<GaugeForce_,ReconstructNo12>(u, mom, epsilon, p);
+    pool_device_free(buffer);
+  }
+  
+  void gaugePath(GaugeField& out, const GaugeField& u, double coeff, int ***input_path,
+		 int *length_h, double *path_coeff_h, int num_paths, int path_max_length)
+  {
+    checkPrecision(out, u);
+    checkLocation(out, u);
+    checkReconstruct(out, u);
+
+    // create path struct in a single allocation
+    size_t bytes = 4 * num_paths * path_max_length * sizeof(int) + num_paths*sizeof(int);
+    int pad = (sizeof(double) - bytes % sizeof(double)) % sizeof(double);
+    bytes += pad + num_paths*sizeof(double);
+    void *buffer = pool_device_malloc(bytes);
+    paths p(buffer, bytes, pad, input_path, length_h, path_coeff_h, num_paths, path_max_length);
+
+    // gauge field must be passed as first argument so we peel off its reconstruct type
+    instantiate<GaugePath>(u, out, coeff, p);
     pool_device_free(buffer);
   }
 #else
   void gaugeForce(GaugeField&, const GaugeField&, double, int ***, int *, double *, int, int)
+  {
+    errorQuda("Gauge force has not been built");
+  }
+  void gaugePath(GaugeField&, const GaugeField&, double, int ***, int *, double *, int, int)
   {
     errorQuda("Gauge force has not been built");
   }

--- a/lib/gauge_force.cu
+++ b/lib/gauge_force.cu
@@ -48,9 +48,11 @@ namespace quda {
     if (mom.Reconstruct() != QUDA_RECONSTRUCT_10) errorQuda("Reconstruction type %d not supported", mom.Reconstruct());
 
     // create path struct in a single allocation
-    size_t bytes = 4 * num_paths * path_max_length * sizeof(int) + num_paths*sizeof(int) + num_paths*sizeof(double);
+    size_t bytes = 4 * num_paths * path_max_length * sizeof(int) + num_paths*sizeof(int);
+    int pad = (sizeof(double) - bytes % sizeof(double)) % sizeof(double);
+    bytes += pad + num_paths*sizeof(double);
     void *buffer = pool_device_malloc(bytes);
-    paths p(buffer, bytes, input_path, length_h, path_coeff_h, num_paths, path_max_length);
+    paths p(buffer, bytes, pad, input_path, length_h, path_coeff_h, num_paths, path_max_length);
 
     // gauge field must be passed as first argument so we peel off its reconstruct type
     instantiate<ForceGauge,ReconstructNo12>(u, mom, epsilon, p);

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -4336,8 +4336,8 @@ int computeGaugePathQuda(void* out, void* siteLink,  int*** input_path_buf, int*
 
 void momResidentQuda(void *mom, QudaGaugeParam *param)
 {
-  profileGaugePath.TPSTART(QUDA_PROFILE_TOTAL);
-  profileGaugePath.TPSTART(QUDA_PROFILE_INIT);
+  profileGaugeForce.TPSTART(QUDA_PROFILE_TOTAL);
+  profileGaugeForce.TPSTART(QUDA_PROFILE_INIT);
 
   checkGaugeParam(param);
 
@@ -4367,26 +4367,26 @@ void momResidentQuda(void *mom, QudaGaugeParam *param)
               param->return_result_mom);
   }
 
-  profileGaugePath.TPSTOP(QUDA_PROFILE_INIT);
+  profileGaugeForce.TPSTOP(QUDA_PROFILE_INIT);
 
   if (param->make_resident_mom) {
     // we are downloading the momentum from the host
-    profileGaugePath.TPSTART(QUDA_PROFILE_H2D);
+    profileGaugeForce.TPSTART(QUDA_PROFILE_H2D);
     momResident->loadCPUField(cpuMom);
-    profileGaugePath.TPSTOP(QUDA_PROFILE_H2D);
+    profileGaugeForce.TPSTOP(QUDA_PROFILE_H2D);
   } else if (param->return_result_mom) {
     // we are uploading the momentum to the host
-    profileGaugePath.TPSTART(QUDA_PROFILE_D2H);
+    profileGaugeForce.TPSTART(QUDA_PROFILE_D2H);
     momResident->saveCPUField(cpuMom);
-    profileGaugePath.TPSTOP(QUDA_PROFILE_D2H);
+    profileGaugeForce.TPSTOP(QUDA_PROFILE_D2H);
 
-    profileGaugePath.TPSTART(QUDA_PROFILE_FREE);
+    profileGaugeForce.TPSTART(QUDA_PROFILE_FREE);
     delete momResident;
     momResident = nullptr;
-    profileGaugePath.TPSTOP(QUDA_PROFILE_FREE);
+    profileGaugeForce.TPSTOP(QUDA_PROFILE_FREE);
   }
 
-  profileGaugePath.TPSTOP(QUDA_PROFILE_TOTAL);
+  profileGaugeForce.TPSTOP(QUDA_PROFILE_TOTAL);
 }
 
 void createCloverQuda(QudaInvertParam* invertParam)

--- a/tests/gauge_force_test.cpp
+++ b/tests/gauge_force_test.cpp
@@ -236,7 +236,7 @@ int path_dir_t[][5] = {
 static double force_check;
 static double deviation;
 
-void gauge_force_test(void)
+void gauge_force_test(bool force)
 {
   int max_length = 6;
 
@@ -291,9 +291,11 @@ void gauge_force_test(void)
   param.order = QUDA_MILC_GAUGE_ORDER;
   auto U_milc = new quda::cpuGaugeField(param);
   if (gauge_order == QUDA_MILC_GAUGE_ORDER) U_milc->copy(*U_qdp);
-  param.reconstruct = QUDA_RECONSTRUCT_10;
+  if (force) {
+    param.reconstruct = QUDA_RECONSTRUCT_10;
+    param.link_type = QUDA_ASQTAD_MOM_LINKS;
+  }
   param.create = QUDA_ZERO_FIELD_CREATE;
-  param.link_type = QUDA_ASQTAD_MOM_LINKS;
   auto Mom_milc = new quda::cpuGaugeField(param);
   auto Mom_ref_milc = new quda::cpuGaugeField(param);
 
@@ -301,9 +303,11 @@ void gauge_force_test(void)
   auto Mom_qdp = new quda::cpuGaugeField(param);
 
   // initialize some data in cpuMom
-  createMomCPU(Mom_ref_milc->Gauge_p(), gauge_param.cpu_prec);
-  if (gauge_order == QUDA_MILC_GAUGE_ORDER) Mom_milc->copy(*Mom_ref_milc);
-  if (gauge_order == QUDA_QDP_GAUGE_ORDER) Mom_qdp->copy(*Mom_ref_milc);
+  if(force) {
+    createMomCPU(Mom_ref_milc->Gauge_p(), gauge_param.cpu_prec);
+    if (gauge_order == QUDA_MILC_GAUGE_ORDER) Mom_milc->copy(*Mom_ref_milc);
+    if (gauge_order == QUDA_QDP_GAUGE_ORDER) Mom_qdp->copy(*Mom_ref_milc);
+  }
   void *mom = nullptr;
   void *sitelink = nullptr;
 
@@ -317,9 +321,13 @@ void gauge_force_test(void)
     errorQuda("Unsupported gauge order %d", gauge_order);
   }
 
-  if (getTuning() == QUDA_TUNE_YES)
-    computeGaugeForceQuda(mom, sitelink, input_path_buf, length, loop_coeff_d, num_paths, max_length, eb3, &gauge_param);
-
+  if (getTuning() == QUDA_TUNE_YES) {
+    if(force)
+      computeGaugeForceQuda(mom, sitelink, input_path_buf, length, loop_coeff_d, num_paths, max_length, eb3, &gauge_param);
+    else
+      computeGaugePathQuda(mom, sitelink, input_path_buf, length, loop_coeff_d, num_paths, max_length, eb3, &gauge_param);
+  }
+    
   struct timeval t0, t1;
   double total_time = 0.0;
   // Multiple execution to exclude warmup time in the first run
@@ -328,7 +336,10 @@ void gauge_force_test(void)
   for (int i = 0; i < niter; i++) {
     Mom_->copy(*Mom_ref_milc); // restore initial momentum for correctness
     gettimeofday(&t0, NULL);
-    computeGaugeForceQuda(mom, sitelink, input_path_buf, length, loop_coeff_d, num_paths, max_length, eb3, &gauge_param);
+    if(force)
+      computeGaugeForceQuda(mom, sitelink, input_path_buf, length, loop_coeff_d, num_paths, max_length, eb3, &gauge_param);
+    else
+      computeGaugePathQuda(mom, sitelink, input_path_buf, length, loop_coeff_d, num_paths, max_length, eb3, &gauge_param);      
     gettimeofday(&t1, NULL);
     total_time += t1.tv_sec - t0.tv_sec + 0.000001*(t1.tv_usec - t0.tv_usec);
   }
@@ -340,18 +351,21 @@ void gauge_force_test(void)
   void *refmom = Mom_ref_milc->Gauge_p();
   if (verify_results) {
     gauge_force_reference(refmom, eb3, (void **)U_qdp->Gauge_p(), gauge_param.cpu_prec, input_path_buf, length,
-                          loop_coeff, num_paths);
+                          loop_coeff, num_paths, force);
     force_check = compare_floats(Mom_milc->Gauge_p(), refmom, 4 * V * mom_site_size, getTolerance(cuda_prec),
                                  gauge_param.cpu_prec);
-    strong_check_mom(Mom_milc->Gauge_p(), refmom, 4 * V, gauge_param.cpu_prec);
+    if(force)
+      strong_check_mom(Mom_milc->Gauge_p(), refmom, 4 * V, gauge_param.cpu_prec);
   }
 
-  printfQuda("\nComputing momentum action\n");
-  auto action_quda = momActionQuda(mom, &gauge_param);
-  auto action_ref = mom_action(refmom, gauge_param.cpu_prec, 4 * V);
-  deviation = std::abs(action_quda - action_ref) / std::abs(action_ref);
-  printfQuda("QUDA action = %e, reference = %e relative deviation = %e\n", action_quda, action_ref, deviation);
-
+  if(force) {
+    printfQuda("\nComputing momentum action\n");
+    auto action_quda = momActionQuda(mom, &gauge_param);
+    auto action_ref = mom_action(refmom, gauge_param.cpu_prec, 4 * V);
+    deviation = std::abs(action_quda - action_ref) / std::abs(action_ref);
+    printfQuda("QUDA action = %e, reference = %e relative deviation = %e\n", action_quda, action_ref, deviation);
+  }
+  
   double perf = 1.0*niter*flops*V/(total_time*1e+9);
   printfQuda("total time = %.2f ms\n", total_time * 1e+3);
   printfQuda("overall performance : %.2f GFLOPS\n",perf);
@@ -408,7 +422,10 @@ int main(int argc, char **argv)
 
   display_test_info();
 
-  gauge_force_test();
+  gauge_force_test(true);
+
+  // The same test is also used for gauge path (force=false)
+  gauge_force_test(false);
 
   if (verify_results) {
     // Ensure gtest prints only from rank 0

--- a/tests/host_reference/gauge_force_reference.cpp
+++ b/tests/host_reference/gauge_force_reference.cpp
@@ -229,6 +229,16 @@ template <typename su3_matrix> static void mult_su3_na(su3_matrix *a, su3_matrix
   }
 }
 
+template <typename su3_matrix, typename Float> static void add_su3(su3_matrix *a, su3_matrix *b, Float eb3)
+{
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      b->e[i][j].real += eb3*a->e[i][j].real;
+      b->e[i][j].imag += eb3*a->e[i][j].imag;
+    }
+  }
+}
+
 template <typename su3_matrix> void print_su3_matrix(su3_matrix *a)
 {
   for (int i = 0; i < 3; i++) {
@@ -339,11 +349,27 @@ static void update_mom(anti_hermitmat *momentum, int dir, su3_matrix **sitelink,
   }
 }
 
+template <typename su3_matrix, typename Float>
+static void update_gauge(su3_matrix *gauge, int dir, su3_matrix **sitelink, su3_matrix *staple, Float eb3, const lattice_t &lat)
+{
+  for (size_t i = 0; i < lat.volume; i++) {
+    su3_matrix tmat;
+
+    su3_matrix *lnk = sitelink[dir] + i;
+    su3_matrix *stp = staple + i;
+    su3_matrix *out = gauge + 4 * i + dir;
+
+    mult_su3_na(lnk, stp, &tmat);
+
+    add_su3(&tmat, out, eb3);
+  }
+}
+
 /* This function only computes one direction @dir
  *
  */
 void gauge_force_reference_dir(void *refMom, int dir, double eb3, void **sitelink, void **sitelink_ex,
-                               QudaPrecision prec, int **path_dir, int *length, void *loop_coeff, int num_paths, const lattice_t &lat)
+                               QudaPrecision prec, int **path_dir, int *length, void *loop_coeff, int num_paths, const lattice_t &lat, bool force)
 {
   size_t size = V * 2 * lat.n_color * lat.n_color * prec;
   void *staple = safe_malloc(size);
@@ -359,17 +385,24 @@ void gauge_force_reference_dir(void *refMom, int dir, double eb3, void **sitelin
     }
   }
 
-  if (prec == QUDA_DOUBLE_PRECISION) {
-    update_mom((danti_hermitmat *)refMom, dir, (dsu3_matrix **)sitelink, (dsu3_matrix *)staple, (double)eb3, lat);
+  if (force) {
+    if (prec == QUDA_DOUBLE_PRECISION) {
+      update_mom((danti_hermitmat *)refMom, dir, (dsu3_matrix **)sitelink, (dsu3_matrix *)staple, (double)eb3, lat);
+    } else {
+      update_mom((fanti_hermitmat *)refMom, dir, (fsu3_matrix **)sitelink, (fsu3_matrix *)staple, (float)eb3, lat);
+    }
   } else {
-    update_mom((fanti_hermitmat *)refMom, dir, (fsu3_matrix **)sitelink, (fsu3_matrix *)staple, (float)eb3, lat);
+    if (prec == QUDA_DOUBLE_PRECISION) {
+      update_gauge((dsu3_matrix *)refMom, dir, (dsu3_matrix **)sitelink, (dsu3_matrix *)staple, (double)eb3, lat);
+    } else {
+      update_gauge((fsu3_matrix *)refMom, dir, (fsu3_matrix **)sitelink, (fsu3_matrix *)staple, (float)eb3, lat);
+    }    
   }
-
   host_free(staple);
 }
 
 void gauge_force_reference(void *refMom, double eb3, void **sitelink, QudaPrecision prec, int ***path_dir, int *length,
-                           void *loop_coeff, int num_paths)
+                           void *loop_coeff, int num_paths, bool force)
 {
   // created extended field
   int R[4];
@@ -383,7 +416,7 @@ void gauge_force_reference(void *refMom, double eb3, void **sitelink, QudaPrecis
   lattice_t lat(*qdp_ex);
 
   for (int dir = 0; dir < 4; dir++) {
-    gauge_force_reference_dir(refMom, dir, eb3, sitelink, (void **)qdp_ex->Gauge_p(), prec, path_dir[dir], length, loop_coeff, num_paths, lat);
+    gauge_force_reference_dir(refMom, dir, eb3, sitelink, (void **)qdp_ex->Gauge_p(), prec, path_dir[dir], length, loop_coeff, num_paths, lat, force);
   }
 
   delete qdp_ex;

--- a/tests/host_reference/gauge_force_reference.cpp
+++ b/tests/host_reference/gauge_force_reference.cpp
@@ -369,7 +369,7 @@ static void update_gauge(su3_matrix *gauge, int dir, su3_matrix **sitelink, su3_
  *
  */
 void gauge_force_reference_dir(void *refMom, int dir, double eb3, void **sitelink, void **sitelink_ex,
-                               QudaPrecision prec, int **path_dir, int *length, void *loop_coeff, int num_paths, const lattice_t &lat, bool force)
+                               QudaPrecision prec, int **path_dir, int *length, void *loop_coeff, int num_paths, const lattice_t &lat, bool compute_force)
 {
   size_t size = V * 2 * lat.n_color * lat.n_color * prec;
   void *staple = safe_malloc(size);
@@ -385,7 +385,7 @@ void gauge_force_reference_dir(void *refMom, int dir, double eb3, void **sitelin
     }
   }
 
-  if (force) {
+  if (compute_force) {
     if (prec == QUDA_DOUBLE_PRECISION) {
       update_mom((danti_hermitmat *)refMom, dir, (dsu3_matrix **)sitelink, (dsu3_matrix *)staple, (double)eb3, lat);
     } else {
@@ -402,7 +402,7 @@ void gauge_force_reference_dir(void *refMom, int dir, double eb3, void **sitelin
 }
 
 void gauge_force_reference(void *refMom, double eb3, void **sitelink, QudaPrecision prec, int ***path_dir, int *length,
-                           void *loop_coeff, int num_paths, bool force)
+                           void *loop_coeff, int num_paths, bool compute_force)
 {
   // created extended field
   int R[4];
@@ -416,7 +416,7 @@ void gauge_force_reference(void *refMom, double eb3, void **sitelink, QudaPrecis
   lattice_t lat(*qdp_ex);
 
   for (int dir = 0; dir < 4; dir++) {
-    gauge_force_reference_dir(refMom, dir, eb3, sitelink, (void **)qdp_ex->Gauge_p(), prec, path_dir[dir], length, loop_coeff, num_paths, lat, force);
+    gauge_force_reference_dir(refMom, dir, eb3, sitelink, (void **)qdp_ex->Gauge_p(), prec, path_dir[dir], length, loop_coeff, num_paths, lat, compute_force);
   }
 
   delete qdp_ex;

--- a/tests/host_reference/gauge_force_reference.h
+++ b/tests/host_reference/gauge_force_reference.h
@@ -1,4 +1,4 @@
 #pragma once
 
 void gauge_force_reference(void *refMom, double eb3, void **sitelink, QudaPrecision prec, int ***path_dir, int *length,
-                           void *loop_coeff, int num_paths, bool force);
+                           void *loop_coeff, int num_paths, bool compute_force);

--- a/tests/host_reference/gauge_force_reference.h
+++ b/tests/host_reference/gauge_force_reference.h
@@ -1,4 +1,4 @@
 #pragma once
 
 void gauge_force_reference(void *refMom, double eb3, void **sitelink, QudaPrecision prec, int ***path_dir, int *length,
-                           void *loop_coeff, int num_paths);
+                           void *loop_coeff, int num_paths, bool force);


### PR DESCRIPTION
This PR extends the gauge force kernel to compute the product of gauge links along a given path.
It is useful for computing Gauge actions.

**NOTE:** commit 08110b2 fixes a bug in the current implementation: if `path_coeff` is not aligned as `double`, CUDA would raise a `misaligned address` error. For this reason I added a padding.

For its usage in lyncs  I'm happy with the current implementation (https://github.com/Lyncs-API/lyncs.quda/blob/bae5bf21769f2c1bc3724137bba8ce8d796c2e32/lyncs_quda/gauge_field.py#L317).

But I suppose you would like more features like tests and function in interface_quda?