### PR TITLE
MILC HISQ MG struct initialization hotfix

### DIFF
--- a/lib/milc_interface.cpp
+++ b/lib/milc_interface.cpp
@@ -1317,7 +1317,8 @@ struct mgInputStruct {
   double deflate_a_min; // ignored if no polynomial acceleration
   int deflate_poly_deg; // ignored if no polynomial acceleration
 
-  void setArrayDefaults() {
+  void setArrayDefaults()
+  {
     // set dummy values so all elements are initialized
     // some of these values get immediately overriden in the
     // constructor, in some cases with identical values:
@@ -1329,9 +1330,7 @@ struct mgInputStruct {
       setup_maxiter[i] = 500;
       mg_vec_infile[i][0] = 0;
       mg_vec_outfile[i][0] = 0;
-      for (int d = 0; d < 4; d++) {
-        geo_block_size[i][d] = 2;
-      }
+      for (int d = 0; d < 4; d++) { geo_block_size[i][d] = 2; }
 
       coarse_solve_type[i] = QUDA_DIRECT_PC_SOLVE;
       coarse_solver[i] = QUDA_GCR_INVERTER;

--- a/lib/milc_interface.cpp
+++ b/lib/milc_interface.cpp
@@ -1322,7 +1322,7 @@ struct mgInputStruct {
     // set dummy values so all elements are initialized
     // some of these values get immediately overriden in the
     // constructor, in some cases with identical values:
-    // this is to separate "initialzing" with "best practices"
+    // this is to separate "initializing" with "best practices"
     for (int i = 0; i < QUDA_MAX_MG_LEVEL; i++) {
       nvec[i] = 24;
       setup_inv[i] = QUDA_CGNR_INVERTER;

--- a/lib/milc_interface.cpp
+++ b/lib/milc_interface.cpp
@@ -1317,6 +1317,34 @@ struct mgInputStruct {
   double deflate_a_min; // ignored if no polynomial acceleration
   int deflate_poly_deg; // ignored if no polynomial acceleration
 
+  void setArrayDefaults() {
+    // set dummy values so all elements are initialized
+    // some of these values get immediately overriden in the
+    // constructor, in some cases with identical values:
+    // this is to separate "initialzing" with "best practices"
+    for (int i = 0; i < QUDA_MAX_MG_LEVEL; i++) {
+      nvec[i] = 24;
+      setup_inv[i] = QUDA_CGNR_INVERTER;
+      setup_tol[i] = 1e-5;
+      setup_maxiter[i] = 500;
+      mg_vec_infile[i][0] = 0;
+      mg_vec_outfile[i][0] = 0;
+      for (int d = 0; d < 4; d++) {
+        geo_block_size[i][d] = 2;
+      }
+
+      coarse_solve_type[i] = QUDA_DIRECT_PC_SOLVE;
+      coarse_solver[i] = QUDA_GCR_INVERTER;
+      coarse_solver_tol[i] = 0.25;
+      coarse_solver_maxiter[i] = 16;
+      smoother_type[i] = QUDA_CA_GCR_INVERTER;
+      nu_pre[i] = 0;
+      nu_post[i] = 2;
+
+      mg_verbosity[i] = QUDA_SUMMARIZE;
+    }
+  }
+
   // set defaults
   mgInputStruct() :
     mg_levels(4),
@@ -1330,6 +1358,10 @@ struct mgInputStruct {
     deflate_a_min(1e-2),
     deflate_poly_deg(50)
   {
+    /* initialize internal arrays */
+    setArrayDefaults();
+
+    /* required or best-practice values for typical solves */
     nvec[0] = 24;             // must be this
     geo_block_size[0][0] = 2; // must be this...
     geo_block_size[0][1] = 2; // "


### PR DESCRIPTION
I was a bit sloppy when I wrote the MILC HISQ MG interface and didn't initialize all values in the custom `struct`, which ended up biting me in gcc 9. This PR fixes this, adding some dummy initialization values to all of the array fields. A point of future work is (still) cleaning up this messy interface.