### PR TITLE
Hotfix/shmem cleanup

### DIFF
--- a/include/dslash_helper.cuh
+++ b/include/dslash_helper.cuh
@@ -585,8 +585,7 @@ namespace quda
       __syncthreads();
       // do exterior
     }
-    arg.kernel_type = EXTERIOR_KERNEL_ALL;
-    arg.threads = arg.exterior_threads;
+
     int local_tid = threadIdx.x + blockDim.x * (myblockidx % (blocks_per_dir)); // index within the block
     int tid = local_tid + threadl + dir * threads_my_dir; // global index corresponfing to local_tid
 

--- a/include/kernels/dslash_domain_wall_5d.cuh
+++ b/include/kernels/dslash_domain_wall_5d.cuh
@@ -92,7 +92,7 @@ namespace quda
     template <KernelType mykernel_type = kernel_type>
     __host__ __device__ __forceinline__ void operator()(int idx, int s, int parity)
     {
-      int x5_cb = s * arg.threads + idx; // 5-d checkerboard index
+      int x5_cb = s * (mykernel_type == EXTERIOR_KERNEL_ALL ? arg.exterior_threads : arg.threads) + idx; // 5-d checkerboard index
       apply<mykernel_type>(x5_cb, parity);
     }
   };

--- a/include/kernels/dslash_pack.cuh
+++ b/include/kernels/dslash_pack.cuh
@@ -363,7 +363,7 @@ namespace quda
     }
     // if we are not in the uber kernel
     if (!intranode && !arg.packkernel && (!(arg.shmem & 2))) {
-      if (threadIdx.x == 0 && threadIdx.y == 0 && threadIdx.z == 0) {
+      if (threadIdx.x == 0 && threadIdx.y == 0 && threadIdx.z == 0 && blockIdx.x % arg.blocks_per_dir == 0) {
         if (!(getNeighborRank(2 * dim + dir, arg) < 0))
           nvshmemx_uint64_signal(arg.sync_arr + 2 * dim + (1 - dir), arg.counter, getNeighborRank(2 * dim + dir, arg));
       }


### PR DESCRIPTION
Some small shmem related cleanups:
* only signal from 1 block when using the uber kernel + separate packing kernel
* do not modify dslash arg unnecessarily in the kernel