### PR TITLE
Move über kernel into a separate kernel instantiation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,7 +277,7 @@ option(QUDA_DOWNLOAD_ARPACK "Download ARPACK-NG software as requested by QUDA_AR
 option(QUDA_DOWNLOAD_OPENBLAS "Download OpenBLAS software as requested by QUDA_OPENBLAS" OFF)
 option(QUDA_JITIFY "build QUDA using Jitify" OFF)
 option(QUDA_DOWNLOAD_NVSHMEM "Download NVSHMEM" OFF)
-set(QUDA_DOWNLOAD_NVSHMEM_TAR "" CACHE STRING "location of NVSHMEM tarball")
+set(QUDA_DOWNLOAD_NVSHMEM_TAR "https://developer.download.nvidia.com/compute/redist/nvshmem/2.1.2/source/nvshmem_src_2.1.2-0.txz" CACHE STRING "location of NVSHMEM tarball")
 set(QUDA_GDRCOPY_HOME "/usr/local/gdrcopy" CACHE STRING "path to gdrcopy used when QUDA_DOWNLOAD_NVSHMEM is enabled")
 
 
@@ -582,12 +582,19 @@ endif()
 
 if(QUDA_NVSHMEM)
   if(QUDA_DOWNLOAD_NVSHMEM)
+    get_filename_component(NVSHMEM_CUDA_HOME ${CUDAToolkit_INCLUDE_DIRS} DIRECTORY)
+    find_path(GDRCOPY_HOME NAME gdrapi.h PATHS "/usr/local/gdrcopy" ${QUDA_GDRCOPY_HOME} PATH_SUFFIXES "include")
+    mark_as_advanced(GDRCOPY_HOME)
+    if(NOT GDRCOPY_HOME)
+      message(SEND_ERROR "QUDA_DOWNLOAD_NVSHMEM requires gdrcopy to be installed. Please set QUDA_GDRCOPY_HOME to the location of your gdrcopy installation.")
+    endif()
+    get_filename_component(NVSHMEM_GDRCOPY_HOME ${GDRCOPY_HOME} DIRECTORY)
     ExternalProject_Add(NVSHMEM
                         URL ${QUDA_DOWNLOAD_NVSHMEM_TAR}
                         PREFIX nvshmem
                         CONFIGURE_COMMAND ""
                         BUILD_IN_SOURCE ON
-                        BUILD_COMMAND  make NVSHMEM_PREFIX=<INSTALL_DIR> NVSHMEM_MPI_SUPPORT=1 GDRCOPY_HOME=${QUDA_GDRCOPY_HOME} install
+                        BUILD_COMMAND  make -j8 CUDA_HOME=${NVSHMEM_CUDA_HOME} NVSHMEM_PREFIX=<INSTALL_DIR> NVSHMEM_MPI_SUPPORT=1 GDRCOPY_HOME=${NVSHMEM_GDRCOPY_HOME} install
                         INSTALL_COMMAND ""
                         LOG_INSTALL ON
                         LOG_BUILD ON

--- a/include/complex_quda.h
+++ b/include/complex_quda.h
@@ -459,8 +459,7 @@ template<>
 {
 public:
   typedef float value_type;
-  __host__ __device__
-    inline complex<float>(){};
+  __host__ __device__ inline complex<float>() : float2() {};
   __host__ __device__
     inline complex<float>(const float & re, const float& im = float())
     {
@@ -581,8 +580,7 @@ template<>
 {
 public:
   typedef double value_type;
-  __host__ __device__
-    inline complex<double>(){};
+  __host__ __device__ inline complex<double>() : double2() {};
   __host__ __device__
     inline complex<double>(const double & re, const double& im = double())
     {
@@ -710,7 +708,7 @@ template <> struct complex<int8_t> : public char2 {
 public:
   typedef int8_t value_type;
 
-  __host__ __device__ inline complex<int8_t>() {};
+  __host__ __device__ inline complex<int8_t>() : char2() {};
 
   __host__ __device__ inline complex<int8_t>(const int8_t &re, const int8_t &im = float())
   {
@@ -757,7 +755,7 @@ struct complex <short> : public short2
 public:
   typedef short value_type;
 
-  __host__ __device__ inline complex<short>(){};
+  __host__ __device__ inline complex<short>() : short2() {};
 
   __host__ __device__ inline complex<short>(const short & re, const short& im = float())
     {
@@ -803,7 +801,7 @@ struct complex <int> : public int2
 public:
   typedef int value_type;
 
-  __host__ __device__ inline complex<int>(){};
+  __host__ __device__ inline complex<int>() : int2() {};
 
   __host__ __device__ inline complex<int>(const int& re, const int& im = float())
     {

--- a/include/dslash.h
+++ b/include/dslash.h
@@ -126,7 +126,7 @@ namespace quda
           // so we set all ghost pointers else if doing exterior
           // kernel, then we only have to update the non-p2p ghosts,
           // since these may have been assigned to zero-copy memory
-          if (!comm_peer2peer_enabled(dir, dim) || arg.kernel_type == INTERIOR_KERNEL) {
+          if (!comm_peer2peer_enabled(dir, dim) || arg.kernel_type == INTERIOR_KERNEL || arg.kernel_type == UBER_KERNEL) {
             ghost[2 * dim + dir] = (typename Arg::Float *)((char *)in.Ghost2() + in.GhostOffset(dim, dir));
           }
         }
@@ -134,7 +134,7 @@ namespace quda
 
       arg.in.resetGhost(in, ghost);
 
-      if (arg.pack_threads && arg.kernel_type == INTERIOR_KERNEL) {
+      if (arg.pack_threads && (arg.kernel_type == INTERIOR_KERNEL || arg.kernel_type == UBER_KERNEL)) {
         arg.blocks_per_dir = tp.aux.x;
         arg.setPack(true, this->packBuffer); // need to recompute for updated block_per_dir
         arg.in_pack.resetGhost(in, this->packBuffer);
@@ -147,7 +147,7 @@ namespace quda
         // if we are doing tuning we should not wait on the sync_arr to be set.
         arg.counter = (activeTuning() && !policyTuning()) ? 2 : dslash::get_shmem_sync_counter();
       }
-      if (arg.shmem > 0 && arg.kernel_type == INTERIOR_KERNEL) {
+      if (arg.shmem > 0 && (arg.kernel_type == INTERIOR_KERNEL || arg.kernel_type == UBER_KERNEL)) {
         arg.counter = activeTuning() ?
           (uberTuning() && !policyTuning() ? dslash::inc_shmem_sync_counter() : dslash::get_shmem_sync_counter()) :
           dslash::get_shmem_sync_counter();
@@ -167,7 +167,7 @@ namespace quda
 
     virtual bool advanceAux(TuneParam &param) const
     {
-      if (arg.pack_threads && arg.kernel_type == INTERIOR_KERNEL) {
+      if (arg.pack_threads && (arg.kernel_type == INTERIOR_KERNEL || arg.kernel_type == UBER_KERNEL)) {
 
         int max_threads_per_dir = 0;
         for (int i = 0; i < 4; ++i) {
@@ -220,8 +220,8 @@ namespace quda
         step_z = vector_length_z;
       }
       TunableVectorYZ::initTuneParam(param);
-      if (arg.pack_threads && arg.kernel_type == INTERIOR_KERNEL) param.aux.x = 1;  // packing blocks per direction
-      if (arg.exterior_dims && arg.kernel_type == INTERIOR_KERNEL) param.aux.y = 1; // exterior blocks
+      if (arg.pack_threads && (arg.kernel_type == INTERIOR_KERNEL || arg.kernel_type == UBER_KERNEL)) param.aux.x = 1;  // packing blocks per direction
+      if (arg.exterior_dims && arg.kernel_type == UBER_KERNEL) param.aux.y = 1; // exterior blocks
     }
 
     virtual void defaultTuneParam(TuneParam &param) const
@@ -234,8 +234,8 @@ namespace quda
         step_z = vector_length_z;
       }
       TunableVectorYZ::defaultTuneParam(param);
-      if (arg.pack_threads && arg.kernel_type == INTERIOR_KERNEL) param.aux.x = 1;  // packing blocks per direction
-      if (arg.exterior_dims && arg.kernel_type == INTERIOR_KERNEL) param.aux.y = 1; // exterior blocks
+      if (arg.pack_threads && (arg.kernel_type == INTERIOR_KERNEL || arg.kernel_type == UBER_KERNEL)) param.aux.x = 1;  // packing blocks per direction
+      if (arg.exterior_dims && arg.kernel_type == UBER_KERNEL) param.aux.y = 1; // exterior blocks
     }
 
     /**
@@ -299,6 +299,7 @@ namespace quda
         switch (arg.kernel_type) {
         case INTERIOR_KERNEL: launch<P, nParity, dagger, xpay, INTERIOR_KERNEL>(tp, stream); break;
 #ifdef MULTI_GPU
+        case UBER_KERNEL: launch<P, nParity, dagger, xpay, UBER_KERNEL>(tp, stream); break;
         case EXTERIOR_KERNEL_X: launch<P, nParity, dagger, xpay, EXTERIOR_KERNEL_X>(tp, stream); break;
         case EXTERIOR_KERNEL_Y: launch<P, nParity, dagger, xpay, EXTERIOR_KERNEL_Y>(tp, stream); break;
         case EXTERIOR_KERNEL_Z: launch<P, nParity, dagger, xpay, EXTERIOR_KERNEL_Z>(tp, stream); break;
@@ -390,6 +391,7 @@ namespace quda
       fillAuxBase();
 #ifdef MULTI_GPU
       fillAux(INTERIOR_KERNEL, "policy_kernel=interior");
+      fillAux(UBER_KERNEL, "policy_kernel=uber");
       fillAux(EXTERIOR_KERNEL_ALL, "policy_kernel=exterior_all");
       fillAux(EXTERIOR_KERNEL_X, "policy_kernel=exterior_x");
       fillAux(EXTERIOR_KERNEL_Y, "policy_kernel=exterior_y");
@@ -485,7 +487,7 @@ namespace quda
 
     virtual TuneKey tuneKey() const
     {
-      auto aux_ = (arg.pack_blocks > 0 && arg.kernel_type == INTERIOR_KERNEL) ?
+      auto aux_ = (arg.pack_blocks > 0 && (arg.kernel_type == INTERIOR_KERNEL || arg.kernel_type == UBER_KERNEL)) ?
         aux_pack :
         ((arg.shmem > 0 && arg.kernel_type == EXTERIOR_KERNEL_ALL) ? aux_barrier : aux[arg.kernel_type]);
       return TuneKey(in.VolString(), typeid(*this).name(), aux_);
@@ -497,7 +499,7 @@ namespace quda
      */
     virtual void preTune()
     {
-      if (arg.kernel_type != INTERIOR_KERNEL && arg.kernel_type != KERNEL_POLICY) out.backup();
+      if (arg.kernel_type != INTERIOR_KERNEL && arg.kernel_type != UBER_KERNEL && arg.kernel_type != KERNEL_POLICY) out.backup();
     }
 
     /**
@@ -505,7 +507,7 @@ namespace quda
      */
     virtual void postTune()
     {
-      if (arg.kernel_type != INTERIOR_KERNEL && arg.kernel_type != KERNEL_POLICY) out.restore();
+      if (arg.kernel_type != INTERIOR_KERNEL && arg.kernel_type != UBER_KERNEL && arg.kernel_type != KERNEL_POLICY) out.restore();
     }
 
     /*
@@ -550,6 +552,7 @@ namespace quda
         flops_ = (ghost_flops + (arg.xpay ? xpay_flops : xpay_flops / 2)) * ghost_sites;
         break;
       }
+      case UBER_KERNEL:
       case INTERIOR_KERNEL:
         if (arg.pack_threads) { flops_ += pack_flops * arg.nParity * in.getDslashConstant().Ls * arg.pack_threads; }
       case KERNEL_POLICY: {
@@ -597,6 +600,7 @@ namespace quda
         break;
       }
       case INTERIOR_KERNEL:
+      case UBER_KERNEL:
         if (arg.pack_threads) { bytes_ += pack_bytes * arg.nParity * in.getDslashConstant().Ls * arg.pack_threads; }
       case KERNEL_POLICY: {
         long long sites = in.Volume();

--- a/include/dslash.h
+++ b/include/dslash.h
@@ -220,7 +220,8 @@ namespace quda
         step_z = vector_length_z;
       }
       TunableVectorYZ::initTuneParam(param);
-      if (arg.pack_threads && (arg.kernel_type == INTERIOR_KERNEL || arg.kernel_type == UBER_KERNEL)) param.aux.x = 1;  // packing blocks per direction
+      if (arg.pack_threads && (arg.kernel_type == INTERIOR_KERNEL || arg.kernel_type == UBER_KERNEL))
+        param.aux.x = 1;                                                        // packing blocks per direction
       if (arg.exterior_dims && arg.kernel_type == UBER_KERNEL) param.aux.y = 1; // exterior blocks
     }
 
@@ -234,7 +235,8 @@ namespace quda
         step_z = vector_length_z;
       }
       TunableVectorYZ::defaultTuneParam(param);
-      if (arg.pack_threads && (arg.kernel_type == INTERIOR_KERNEL || arg.kernel_type == UBER_KERNEL)) param.aux.x = 1;  // packing blocks per direction
+      if (arg.pack_threads && (arg.kernel_type == INTERIOR_KERNEL || arg.kernel_type == UBER_KERNEL))
+        param.aux.x = 1;                                                        // packing blocks per direction
       if (arg.exterior_dims && arg.kernel_type == UBER_KERNEL) param.aux.y = 1; // exterior blocks
     }
 
@@ -501,7 +503,8 @@ namespace quda
      */
     virtual void preTune()
     {
-      if (arg.kernel_type != INTERIOR_KERNEL && arg.kernel_type != UBER_KERNEL && arg.kernel_type != KERNEL_POLICY) out.backup();
+      if (arg.kernel_type != INTERIOR_KERNEL && arg.kernel_type != UBER_KERNEL && arg.kernel_type != KERNEL_POLICY)
+        out.backup();
     }
 
     /**
@@ -509,7 +512,8 @@ namespace quda
      */
     virtual void postTune()
     {
-      if (arg.kernel_type != INTERIOR_KERNEL && arg.kernel_type != UBER_KERNEL && arg.kernel_type != KERNEL_POLICY) out.restore();
+      if (arg.kernel_type != INTERIOR_KERNEL && arg.kernel_type != UBER_KERNEL && arg.kernel_type != KERNEL_POLICY)
+        out.restore();
     }
 
     /*

--- a/include/dslash.h
+++ b/include/dslash.h
@@ -299,7 +299,9 @@ namespace quda
         switch (arg.kernel_type) {
         case INTERIOR_KERNEL: launch<P, nParity, dagger, xpay, INTERIOR_KERNEL>(tp, stream); break;
 #ifdef MULTI_GPU
+#ifdef NVSHMEM_COMMS
         case UBER_KERNEL: launch<P, nParity, dagger, xpay, UBER_KERNEL>(tp, stream); break;
+#endif
         case EXTERIOR_KERNEL_X: launch<P, nParity, dagger, xpay, EXTERIOR_KERNEL_X>(tp, stream); break;
         case EXTERIOR_KERNEL_Y: launch<P, nParity, dagger, xpay, EXTERIOR_KERNEL_Y>(tp, stream); break;
         case EXTERIOR_KERNEL_Z: launch<P, nParity, dagger, xpay, EXTERIOR_KERNEL_Z>(tp, stream); break;
@@ -552,8 +554,8 @@ namespace quda
         flops_ = (ghost_flops + (arg.xpay ? xpay_flops : xpay_flops / 2)) * ghost_sites;
         break;
       }
-      case UBER_KERNEL:
       case INTERIOR_KERNEL:
+      case UBER_KERNEL:
         if (arg.pack_threads) { flops_ += pack_flops * arg.nParity * in.getDslashConstant().Ls * arg.pack_threads; }
       case KERNEL_POLICY: {
         long long sites = in.Volume();

--- a/include/dslash_helper.cuh
+++ b/include/dslash_helper.cuh
@@ -471,7 +471,7 @@ namespace quda
    */
   template <KernelType kernel_type, typename Arg> void __device__ inline shmem_signalinterior(const Arg &arg)
   {
-    if (kernel_type == UBER_KERNEL && (arg.shmem & 64)) {
+    if (kernel_type == UBER_KERNEL) {
       __syncthreads();
       if (threadIdx.x == 0 && threadIdx.y == 0 && threadIdx.z == 0) {
         int amlast = arg.interior_count.fetch_add(1, cuda::std::memory_order_acq_rel); // ensure that my block is done
@@ -484,124 +484,125 @@ namespace quda
     }
   }
 
-  template <class D, typename Arg, int nParity>
+  template <KernelType kernel_type, class D, typename Arg, int nParity>
   void __device__ __forceinline__ shmem_exterior(D &dslash, Arg &arg, int s)
   {
     // shmem exterior kernel with grid-strided loop
+    if (kernel_type == UBER_KERNEL || kernel_type == EXTERIOR_KERNEL_ALL) {
+      // figure out some details on blocks
+      const bool shmem_interiordone = (arg.shmem & 64);
+      const int myblockidx = arg.exterior_blocks > 0 ? blockIdx.x - (gridDim.x - arg.exterior_blocks) : blockIdx.x;
+      const int nComm = arg.commDim[0] + arg.commDim[1] + arg.commDim[2] + arg.commDim[3];
+      const int blocks_per_dim = (arg.exterior_blocks > 0 ? arg.exterior_blocks : gridDim.x) / (nComm);
+      const int blocks_per_dir = blocks_per_dim / 2;
 
-    // figure out some details on blocks
-    const bool shmem_interiordone = (arg.shmem & 64);
-    const int myblockidx = arg.exterior_blocks > 0 ? blockIdx.x - (gridDim.x - arg.exterior_blocks) : blockIdx.x;
-    const int nComm = arg.commDim[0] + arg.commDim[1] + arg.commDim[2] + arg.commDim[3];
-    const int blocks_per_dim = (arg.exterior_blocks > 0 ? arg.exterior_blocks : gridDim.x) / (nComm);
-    const int blocks_per_dir = blocks_per_dim / 2;
-
-    int dir = (myblockidx % blocks_per_dim) / (blocks_per_dir);
-    // this is the dimdir we are working on ...
-    int dim;
-    int threadl;
-    int threads_my_dir;
-    switch (myblockidx / blocks_per_dim) {
-    case 0: dim = arg.dim_map[0]; break;
-    case 1: dim = arg.dim_map[1]; break;
-    case 2: dim = arg.dim_map[2]; break;
-    case 3: dim = arg.dim_map[3]; break;
-    default: dim = -1;
-    }
-
-    switch (dim) {
-    case 0:
-      threads_my_dir = (arg.threadDimMapUpper[0] - arg.threadDimMapLower[0]) / 2;
-      threadl = arg.threadDimMapLower[0];
-      break;
-    case 1:
-      threads_my_dir = (arg.threadDimMapUpper[1] - arg.threadDimMapLower[1]) / 2;
-      threadl = arg.threadDimMapLower[1];
-      break;
-    case 2:
-      threads_my_dir = (arg.threadDimMapUpper[2] - arg.threadDimMapLower[2]) / 2;
-      threadl = arg.threadDimMapLower[2];
-      break;
-    case 3:
-      threads_my_dir = (arg.threadDimMapUpper[3] - arg.threadDimMapLower[3]) / 2;
-      threadl = arg.threadDimMapLower[3];
-      break;
-    default: threadl = 0; threads_my_dir = 0;
-    }
-    int dimdir = 2 * dim + dir;
-
-    constexpr bool shmembarrier = true; // always true for now (arg.shmem & 16);
-
-    if (shmembarrier) {
-
-      if (shmem_interiordone && threadIdx.x == blockDim.x - 1 && threadIdx.y == 0 && threadIdx.z == 0) {
-        auto tst_val = arg.interior_done.load(cuda::std::memory_order_relaxed);
-        while (tst_val < arg.counter - 1) {
-          arg.interior_done.compare_exchange_strong(tst_val, arg.counter - 1, cuda::std::memory_order_relaxed,
-                                                    cuda::std::memory_order_relaxed);
-        }
-        arg.interior_done.wait(arg.counter - 1, cuda::std::memory_order_acquire);
+      int dir = (myblockidx % blocks_per_dim) / (blocks_per_dir);
+      // this is the dimdir we are working on ...
+      int dim;
+      int threadl;
+      int threads_my_dir;
+      switch (myblockidx / blocks_per_dim) {
+      case 0: dim = arg.dim_map[0]; break;
+      case 1: dim = arg.dim_map[1]; break;
+      case 2: dim = arg.dim_map[2]; break;
+      case 3: dim = arg.dim_map[3]; break;
+      default: dim = -1;
       }
 
-      if (threadIdx.x < 8 && threadIdx.y == 0 && threadIdx.z == 0) {
-        /* the first 8 threads of each block are used for spinning on halo data coming
-           in from the 4*2 (dim*dir) neighbors. We figure out next on which neighbors the
-           block actually needs to wait
-        */
+      switch (dim) {
+      case 0:
+        threads_my_dir = (arg.threadDimMapUpper[0] - arg.threadDimMapLower[0]) / 2;
+        threadl = arg.threadDimMapLower[0];
+        break;
+      case 1:
+        threads_my_dir = (arg.threadDimMapUpper[1] - arg.threadDimMapLower[1]) / 2;
+        threadl = arg.threadDimMapLower[1];
+        break;
+      case 2:
+        threads_my_dir = (arg.threadDimMapUpper[2] - arg.threadDimMapLower[2]) / 2;
+        threadl = arg.threadDimMapLower[2];
+        break;
+      case 3:
+        threads_my_dir = (arg.threadDimMapUpper[3] - arg.threadDimMapLower[3]) / 2;
+        threadl = arg.threadDimMapLower[3];
+        break;
+      default: threadl = 0; threads_my_dir = 0;
+      }
+      int dimdir = 2 * dim + dir;
 
-        // for now we can only spin per dimdir for 4d indexing as it ensure unique block->dimdir assignment
-        bool spin = (dslash.pc_type() == QUDA_5D_PC) || (threadIdx.x == dimdir);
-        // figure out which other directions also to spin for (to make corners work)
-        switch (dim) {
-        case 3:
-          if (arg.commDim[3]) {
-            spin = threadIdx.x / 2 < 3 ? arg.commDim[2] : spin;
-            spin = threadIdx.x / 2 < 2 ? arg.commDim[1] : spin;
-            spin = threadIdx.x / 2 < 1 ? arg.commDim[0] : spin;
-          } else {
-            spin = false;
+      constexpr bool shmembarrier = true; // always true for now (arg.shmem & 16);
+
+      if (shmembarrier) {
+
+        if (shmem_interiordone && threadIdx.x == blockDim.x - 1 && threadIdx.y == 0 && threadIdx.z == 0) {
+          auto tst_val = arg.interior_done.load(cuda::std::memory_order_relaxed);
+          while (tst_val < arg.counter - 1) {
+            arg.interior_done.compare_exchange_strong(tst_val, arg.counter - 1, cuda::std::memory_order_relaxed,
+                                                      cuda::std::memory_order_relaxed);
           }
-          break;
-        case 2:
-          if (arg.commDim[2]) {
-            if (arg.commDim[1]) spin = threadIdx.x / 2 < 2 ? true : spin;
-            if (arg.commDim[0]) spin = threadIdx.x / 2 < 1 ? true : spin;
-          }
-          break;
-        case 1:
-          if (arg.commDim[1]) {
-            if (arg.commDim[0]) spin = threadIdx.x / 2 < 1 ? true : spin;
-          }
-          break;
-        case 0: break;
+          arg.interior_done.wait(arg.counter - 1, cuda::std::memory_order_acquire);
         }
 
-        if (getNeighborRank(threadIdx.x, arg) >= 0) {
-          if (spin) { nvshmem_signal_wait_until((arg.sync_arr + threadIdx.x), NVSHMEM_CMP_GE, arg.counter); }
+        if (threadIdx.x < 8 && threadIdx.y == 0 && threadIdx.z == 0) {
+          /* the first 8 threads of each block are used for spinning on halo data coming
+            in from the 4*2 (dim*dir) neighbors. We figure out next on which neighbors the
+            block actually needs to wait
+          */
+
+          // for now we can only spin per dimdir for 4d indexing as it ensure unique block->dimdir assignment
+          bool spin = (dslash.pc_type() == QUDA_5D_PC) || (threadIdx.x == dimdir);
+          // figure out which other directions also to spin for (to make corners work)
+          switch (dim) {
+          case 3:
+            if (arg.commDim[3]) {
+              spin = threadIdx.x / 2 < 3 ? arg.commDim[2] : spin;
+              spin = threadIdx.x / 2 < 2 ? arg.commDim[1] : spin;
+              spin = threadIdx.x / 2 < 1 ? arg.commDim[0] : spin;
+            } else {
+              spin = false;
+            }
+            break;
+          case 2:
+            if (arg.commDim[2]) {
+              if (arg.commDim[1]) spin = threadIdx.x / 2 < 2 ? true : spin;
+              if (arg.commDim[0]) spin = threadIdx.x / 2 < 1 ? true : spin;
+            }
+            break;
+          case 1:
+            if (arg.commDim[1]) {
+              if (arg.commDim[0]) spin = threadIdx.x / 2 < 1 ? true : spin;
+            }
+            break;
+          case 0: break;
+          }
+
+          if (getNeighborRank(threadIdx.x, arg) >= 0) {
+            if (spin) { nvshmem_signal_wait_until((arg.sync_arr + threadIdx.x), NVSHMEM_CMP_GE, arg.counter); }
+          }
         }
+
+        // wait for all threads here as not all threads spin
+        __syncthreads();
+        // do exterior
       }
 
-      // wait for all threads here as not all threads spin
-      __syncthreads();
-      // do exterior
-    }
+      int local_tid = threadIdx.x + blockDim.x * (myblockidx % (blocks_per_dir)); // index within the block
+      int tid = local_tid + threadl + dir * threads_my_dir; // global index corresponfing to local_tid
 
-    int local_tid = threadIdx.x + blockDim.x * (myblockidx % (blocks_per_dir)); // index within the block
-    int tid = local_tid + threadl + dir * threads_my_dir; // global index corresponfing to local_tid
-
-    while (local_tid < threads_my_dir) {
-      // for full fields set parity from z thread index else use arg setting
-      int parity = nParity == 2 ? blockDim.z * blockIdx.z + threadIdx.z : arg.parity;
+      while (local_tid < threads_my_dir) {
+        // for full fields set parity from z thread index else use arg setting
+        int parity = nParity == 2 ? blockDim.z * blockIdx.z + threadIdx.z : arg.parity;
 #ifdef QUDA_DSLASH_FAST_COMPILE
-      dslash.template operator()<EXTERIOR_KERNEL_ALL>(tid, s, parity);
+        dslash.template operator()<EXTERIOR_KERNEL_ALL>(tid, s, parity);
 #else
-      switch (parity) {
-      case 0: dslash.template operator()<EXTERIOR_KERNEL_ALL>(tid, s, 0); break;
-      case 1: dslash.template operator()<EXTERIOR_KERNEL_ALL>(tid, s, 1); break;
-      }
+        switch (parity) {
+        case 0: dslash.template operator()<EXTERIOR_KERNEL_ALL>(tid, s, 0); break;
+        case 1: dslash.template operator()<EXTERIOR_KERNEL_ALL>(tid, s, 1); break;
+        }
 #endif
-      local_tid += blockDim.x * blocks_per_dir;
-      tid += blockDim.x * blocks_per_dir;
+        local_tid += blockDim.x * blocks_per_dir;
+        tid += blockDim.x * blocks_per_dir;
+      }
     }
   }
 #endif
@@ -643,24 +644,24 @@ namespace quda
                && ((kernel_type == EXTERIOR_KERNEL_ALL && arg.exterior_blocks == 0)
                    || (kernel_type == UBER_KERNEL && arg.exterior_blocks > 0
                        && blockIdx.x >= (gridDim.x - arg.exterior_blocks)))) {
-      shmem_exterior<D<nParity, dagger, xpay, kernel_type, Arg>, Arg, nParity>(dslash, arg, s);
+      shmem_exterior<kernel_type, D<nParity, dagger, xpay, kernel_type, Arg>, Arg, nParity>(dslash, arg, s);
 #endif
     } else {
-      const int dslash_block_offset = ((kernel_type == INTERIOR_KERNEL || kernel_type == UBER_KERNEL) ? arg.pack_blocks : 0);
+      const int dslash_block_offset
+        = ((kernel_type == INTERIOR_KERNEL || kernel_type == UBER_KERNEL) ? arg.pack_blocks : 0);
       int x_cb = (blockIdx.x - dslash_block_offset) * blockDim.x + threadIdx.x;
       if (x_cb >= arg.threads) return;
 
-      #ifdef QUDA_DSLASH_FAST_COMPILE
-      // dslash(x_cb, s, partity);
-      dslash.template operator()<kernel_type==UBER_KERNEL ? INTERIOR_KERNEL : kernel_type>(x_cb, s, parity);
+#ifdef QUDA_DSLASH_FAST_COMPILE
+      dslash.template operator()<kernel_type == UBER_KERNEL ? INTERIOR_KERNEL : kernel_type>(x_cb, s, parity);
 #else
       switch (parity) {
-      case 0: dslash.template operator()<kernel_type==UBER_KERNEL ? INTERIOR_KERNEL : kernel_type>(x_cb, s, 0); break;
-      case 1: dslash.template operator()<kernel_type==UBER_KERNEL ? INTERIOR_KERNEL : kernel_type>(x_cb, s, 1); break;
+      case 0: dslash.template operator()<kernel_type == UBER_KERNEL ? INTERIOR_KERNEL : kernel_type>(x_cb, s, 0); break;
+      case 1: dslash.template operator()<kernel_type == UBER_KERNEL ? INTERIOR_KERNEL : kernel_type>(x_cb, s, 1); break;
       }
 #endif
 #ifdef NVSHMEM_COMMS
-      shmem_signalinterior<kernel_type, Arg>(arg);
+      if (kernel_type == UBER_KERNEL) shmem_signalinterior<kernel_type, Arg>(arg);
 #endif
     }
   }

--- a/include/index_helper.cuh
+++ b/include/index_helper.cuh
@@ -504,6 +504,7 @@ namespace quda {
     EXTERIOR_KERNEL_Y = 1,
     EXTERIOR_KERNEL_Z = 2,
     EXTERIOR_KERNEL_T = 3,
+    UBER_KERNEL = 4,
     KERNEL_POLICY = 7
   };
 

--- a/lib/covDev.cu
+++ b/lib/covDev.cu
@@ -62,6 +62,7 @@ namespace quda
         break;
       }
       case INTERIOR_KERNEL:
+      case UBER_KERNEL:
       case KERNEL_POLICY: {
         long long sites = in.Volume();
         flops_ = num_mv_multiply * mv_flops * sites; // SU(3) matrix-vector multiplies
@@ -101,6 +102,7 @@ namespace quda
         break;
       }
       case INTERIOR_KERNEL:
+      case UBER_KERNEL:
       case KERNEL_POLICY: {
         long long sites = in.Volume();
         bytes_ = (gauge_bytes + 2 * spinor_bytes) * sites;

--- a/lib/dslash_domain_wall_5d.cu
+++ b/lib/dslash_domain_wall_5d.cu
@@ -37,6 +37,7 @@ namespace quda
       long long flops = Dslash::flops();
       switch (arg.kernel_type) {
       case INTERIOR_KERNEL:
+      case UBER_KERNEL:
       case KERNEL_POLICY: {
         int Ls = in.X(4);
         long long bulk = (Ls - 2) * (in.Volume() / Ls);
@@ -54,6 +55,7 @@ namespace quda
       long long bytes = Dslash::bytes();
       switch (arg.kernel_type) {
       case INTERIOR_KERNEL:
+      case UBER_KERNEL:
       case KERNEL_POLICY: bytes += 2 * spinor_bytes * in.VolumeCB(); break;
       default: break;
       }

--- a/lib/dslash_improved_staggered.cu
+++ b/lib/dslash_improved_staggered.cu
@@ -76,6 +76,7 @@ namespace quda
         break;
       }
       case INTERIOR_KERNEL:
+      case UBER_KERNEL:
       case KERNEL_POLICY: {
         long long sites = in.Volume();
         flops_ = (2 * num_dir * mv_flops + // SU(3) matrix-vector multiplies
@@ -118,6 +119,7 @@ namespace quda
         break;
       }
       case INTERIOR_KERNEL:
+      case UBER_KERNEL:
       case KERNEL_POLICY: {
         long long sites = in.Volume();
         bytes_ = (num_dir * (gauge_bytes_fat + gauge_bytes_long) + // gauge reads

--- a/lib/dslash_ndeg_twisted_mass.cu
+++ b/lib/dslash_ndeg_twisted_mass.cu
@@ -41,6 +41,7 @@ namespace quda
       long long flops = Dslash::flops();
       switch (arg.kernel_type) {
       case INTERIOR_KERNEL:
+      case UBER_KERNEL:
       case KERNEL_POLICY:
         flops += 2 * in.Ncolor() * 4 * 4 * in.Volume(); // complex * Nc * Ns * fma * vol
         break;

--- a/lib/dslash_ndeg_twisted_mass_preconditioned.cu
+++ b/lib/dslash_ndeg_twisted_mass_preconditioned.cu
@@ -82,6 +82,7 @@ namespace quda
       long long flops = Dslash::flops();
       switch (arg.kernel_type) {
       case INTERIOR_KERNEL:
+      case UBER_KERNEL:
       case KERNEL_POLICY:
         flops += 2 * in.Ncolor() * 4 * 4 * in.Volume(); // complex * Nc * Ns * fma * vol
         break;

--- a/lib/dslash_policy.cuh
+++ b/lib/dslash_policy.cuh
@@ -463,7 +463,7 @@ namespace quda
       setFusedParam(dslashParam, dslash, faceVolumeCB);
 
       DslashCommsPattern pattern(dslashParam.commDim);
-      dslashParam.kernel_type = INTERIOR_KERNEL;
+      dslashParam.kernel_type = (shmem & 64) ? UBER_KERNEL : INTERIOR_KERNEL;
       dslashParam.threads = volume;
       dslash.setShmem(shmem);
       dslashParam.setExteriorDims(shmem & 64);

--- a/lib/dslash_twisted_clover.cu
+++ b/lib/dslash_twisted_clover.cu
@@ -39,6 +39,7 @@ namespace quda
       long long flops = Dslash::flops();
       switch (arg.kernel_type) {
       case INTERIOR_KERNEL:
+      case UBER_KERNEL:
       case KERNEL_POLICY: flops += clover_flops * in.Volume(); break;
       default: break; // all clover flops are in the interior kernel
       }
@@ -52,6 +53,7 @@ namespace quda
       long long bytes = Dslash::bytes();
       switch (arg.kernel_type) {
       case INTERIOR_KERNEL:
+      case UBER_KERNEL:
       case KERNEL_POLICY: bytes += clover_bytes * in.Volume(); break;
       default: break;
       }

--- a/lib/dslash_twisted_clover_preconditioned.cu
+++ b/lib/dslash_twisted_clover_preconditioned.cu
@@ -59,6 +59,7 @@ namespace quda
         flops += clover_flops * 2 * (in.GhostFace()[0] + in.GhostFace()[1] + in.GhostFace()[2] + in.GhostFace()[3]);
         break;
       case INTERIOR_KERNEL:
+      case UBER_KERNEL:
       case KERNEL_POLICY:
         flops += clover_flops * in.Volume();
 
@@ -89,6 +90,7 @@ namespace quda
         bytes += clover_bytes * 2 * (in.GhostFace()[0] + in.GhostFace()[1] + in.GhostFace()[2] + in.GhostFace()[3]);
         break;
       case INTERIOR_KERNEL:
+      case UBER_KERNEL:
       case KERNEL_POLICY:
         bytes += clover_bytes * in.Volume();
 

--- a/lib/dslash_twisted_mass.cu
+++ b/lib/dslash_twisted_mass.cu
@@ -37,6 +37,7 @@ namespace quda
       long long flops = Dslash::flops();
       switch (arg.kernel_type) {
       case INTERIOR_KERNEL:
+      case UBER_KERNEL:
       case KERNEL_POLICY:
         flops += 2 * in.Ncolor() * 4 * 2 * in.Volume(); // complex * Nc * Ns * fma * vol
         break;

--- a/lib/dslash_twisted_mass_preconditioned.cu
+++ b/lib/dslash_twisted_mass_preconditioned.cu
@@ -58,6 +58,7 @@ namespace quda
       long long flops = Dslash::flops();
       switch (arg.kernel_type) {
       case INTERIOR_KERNEL:
+      case UBER_KERNEL:
       case KERNEL_POLICY:
         flops += 2 * in.Ncolor() * 4 * 2 * in.Volume(); // complex * Nc * Ns * fma * vol
         break;

--- a/lib/dslash_wilson_clover.cu
+++ b/lib/dslash_wilson_clover.cu
@@ -40,6 +40,7 @@ namespace quda
 
       switch (arg.kernel_type) {
       case INTERIOR_KERNEL:
+      case UBER_KERNEL:
       case KERNEL_POLICY: flops += clover_flops * in.Volume(); break;
       default: break; // all clover flops are in the interior kernel
       }

--- a/lib/dslash_wilson_clover_hasenbusch_twist.cu
+++ b/lib/dslash_wilson_clover_hasenbusch_twist.cu
@@ -42,6 +42,7 @@ namespace quda
       long long flops = Dslash::flops();
       switch (arg.kernel_type) {
       case INTERIOR_KERNEL:
+      case UBER_KERNEL:
       case KERNEL_POLICY:
         flops += clover_flops * in.Volume();
 
@@ -61,6 +62,7 @@ namespace quda
       long long bytes = Dslash::bytes();
       switch (arg.kernel_type) {
       case INTERIOR_KERNEL:
+      case UBER_KERNEL:
       case KERNEL_POLICY: bytes += clover_bytes * in.Volume(); break;
       default: break;
       }

--- a/lib/dslash_wilson_clover_hasenbusch_twist_preconditioned.cu
+++ b/lib/dslash_wilson_clover_hasenbusch_twist_preconditioned.cu
@@ -61,6 +61,7 @@ namespace quda
           += 2 * (clover_flops + 48) * (in.GhostFace()[0] + in.GhostFace()[1] + in.GhostFace()[2] + in.GhostFace()[3]);
         break;
       case INTERIOR_KERNEL:
+      case UBER_KERNEL:
       case KERNEL_POLICY:
         flops += (clover_flops + 48) * in.Volume();
 
@@ -94,6 +95,7 @@ namespace quda
         bytes += clover_bytes * 2 * (in.GhostFace()[0] + in.GhostFace()[1] + in.GhostFace()[2] + in.GhostFace()[3]);
         break;
       case INTERIOR_KERNEL:
+      case UBER_KERNEL:
       case KERNEL_POLICY:
 
         bytes += clover_bytes * in.Volume();
@@ -209,6 +211,7 @@ namespace quda
           * (in.GhostFace()[0] + in.GhostFace()[1] + in.GhostFace()[2] + in.GhostFace()[3]);
         break;
       case INTERIOR_KERNEL:
+      case UBER_KERNEL:
       case KERNEL_POLICY:
         flops += (2 * clover_flops + 48) * in.Volume();
 
@@ -247,6 +250,7 @@ namespace quda
           * (in.GhostFace()[0] + in.GhostFace()[1] + in.GhostFace()[2] + in.GhostFace()[3]);
         break;
       case INTERIOR_KERNEL:
+      case UBER_KERNEL:
       case KERNEL_POLICY:
 
         bytes += dyn_factor * clover_bytes * in.Volume();

--- a/lib/dslash_wilson_clover_preconditioned.cu
+++ b/lib/dslash_wilson_clover_preconditioned.cu
@@ -58,6 +58,7 @@ namespace quda
         flops += clover_flops * 2 * (in.GhostFace()[0] + in.GhostFace()[1] + in.GhostFace()[2] + in.GhostFace()[3]);
         break;
       case INTERIOR_KERNEL:
+      case UBER_KERNEL:
       case KERNEL_POLICY:
         flops += clover_flops * in.Volume();
 
@@ -87,6 +88,7 @@ namespace quda
         bytes += clover_bytes * 2 * (in.GhostFace()[0] + in.GhostFace()[1] + in.GhostFace()[2] + in.GhostFace()[3]);
         break;
       case INTERIOR_KERNEL:
+      case UBER_KERNEL:
       case KERNEL_POLICY:
         bytes += clover_bytes * in.Volume();
 

--- a/lib/laplace.cu
+++ b/lib/laplace.cu
@@ -70,6 +70,7 @@ namespace quda
         break;
       }
       case INTERIOR_KERNEL:
+      case UBER_KERNEL:
       case KERNEL_POLICY: {
         long long sites = in.Volume();
         flops_ = (num_dir * (in.Nspin() / 4) * in.Ncolor() * in.Nspin() + // spin project (=0 for staggered)
@@ -113,6 +114,7 @@ namespace quda
         break;
       }
       case INTERIOR_KERNEL:
+      case UBER_KERNEL:
       case KERNEL_POLICY: {
         long long sites = in.Volume();
         bytes_ = (num_dir * gauge_bytes + ((num_dir - 2) * spinor_bytes + 2 * proj_spinor_bytes) + spinor_bytes) * sites;

--- a/lib/lattice_field.cpp
+++ b/lib/lattice_field.cpp
@@ -426,6 +426,7 @@ namespace quda {
     cudaIpcMemHandle_t ipcRemoteGhostDestHandle[2][2][QUDA_MAX_DIM];
 
     for (int b=0; b<2; b++) {
+#ifndef NVSHMEM_COMMS
       for (int dim=0; dim<4; ++dim) {
 	if (comm_dim(dim)==1) continue;
 	for (int dir=0; dir<2; ++dir) {
@@ -459,7 +460,7 @@ namespace quda {
       }
 
       checkCudaError();
-
+#endif
       // open the remote memory handles and set the send ghost pointers
       for (int dim = 0; dim < 4; ++dim) {
 #ifndef NVSHMEM_COMMS

--- a/tests/dslash_ctest.cpp
+++ b/tests/dslash_ctest.cpp
@@ -110,6 +110,7 @@ public:
 
 TEST_P(DslashTest, verify)
 {
+  dslash_test_wrapper.dslashRef();
   dslash_test_wrapper.run_test(2);
 
   double deviation = dslash_test_wrapper.verify();

--- a/tests/dslash_test_utils.h
+++ b/tests/dslash_test_utils.h
@@ -1084,10 +1084,7 @@ struct DslashTestWrapper {
     DslashTime dslash_time = dslashCUDA(niter);
     printfQuda("done.\n\n");
 
-    dslashRef();
-
     if (!test_split_grid) {
-
       if (!transfer) *spinorOut = *cudaSpinorOut;
 
       // print timing information

--- a/tests/staggered_dslash_ctest.cpp
+++ b/tests/staggered_dslash_ctest.cpp
@@ -105,6 +105,7 @@ TEST_P(StaggeredDslashTest, verify)
   double deviation = 1.0;
   double tol = getTolerance(dslash_test_wrapper.inv_param.cuda_prec);
   // check for skip_kernel
+  dslash_test_wrapper.dslashRef();
   if (dslash_test_wrapper.spinorRef != nullptr) {
     dslash_test_wrapper.run_test(2);
     deviation = dslash_test_wrapper.verify();

--- a/tests/staggered_dslash_ctest.cpp
+++ b/tests/staggered_dslash_ctest.cpp
@@ -105,7 +105,7 @@ TEST_P(StaggeredDslashTest, verify)
   double deviation = 1.0;
   double tol = getTolerance(dslash_test_wrapper.inv_param.cuda_prec);
   // check for skip_kernel
-  dslash_test_wrapper.dslashRef();
+  dslash_test_wrapper.staggeredDslashRef();
   if (dslash_test_wrapper.spinorRef != nullptr) {
     dslash_test_wrapper.run_test(2);
     deviation = dslash_test_wrapper.verify();

--- a/tests/staggered_dslash_test.cpp
+++ b/tests/staggered_dslash_test.cpp
@@ -10,7 +10,7 @@ static int dslashTest()
   int test_rc = 0;
   dslash_test_wrapper.init_test();
 
-  wrapper.dslashRef();
+  dslash_test_wrapper.staggeredDslashRef();
   int attempts = 1;
   for (int i = 0; i < attempts; i++) {
     dslash_test_wrapper.run_test(niter, /**print_metrics =*/true);

--- a/tests/staggered_dslash_test.cpp
+++ b/tests/staggered_dslash_test.cpp
@@ -10,6 +10,7 @@ static int dslashTest()
   int test_rc = 0;
   dslash_test_wrapper.init_test();
 
+  wrapper.dslashRef();
   int attempts = 1;
   for (int i = 0; i < attempts; i++) {
     dslash_test_wrapper.run_test(niter, /**print_metrics =*/true);

--- a/tests/staggered_dslash_test_utils.h
+++ b/tests/staggered_dslash_test_utils.h
@@ -538,8 +538,6 @@ struct StaggeredDslashTestWrapper {
     DslashTime dslash_time = dslashCUDA(niter);
     *spinorOut = *cudaSpinorOut;
 
-    staggeredDslashRef();
-
     if (print_metrics) {
       printfQuda("%fus per kernel call\n", 1e6 * dslash_time.event_time / niter);
 


### PR DESCRIPTION
This allows to completely remove the exterior path from the  non-uber interior kernels by creating two different template instances for uber and non-user kernels.

WIP as I still need to check perf before this is ready.