### PR TITLE
Hotfix/dslash ndimcomms

### DIFF
--- a/include/complex_quda.h
+++ b/include/complex_quda.h
@@ -459,7 +459,7 @@ template<>
 {
 public:
   typedef float value_type;
-  __host__ __device__ inline complex<float>() : float2() {};
+  __host__ __device__ inline complex<float>() {};
   __host__ __device__
     inline complex<float>(const float & re, const float& im = float())
     {
@@ -580,7 +580,7 @@ template<>
 {
 public:
   typedef double value_type;
-  __host__ __device__ inline complex<double>() : double2() {};
+  __host__ __device__ inline complex<double>() {};
   __host__ __device__
     inline complex<double>(const double & re, const double& im = double())
     {
@@ -755,7 +755,7 @@ struct complex <short> : public short2
 public:
   typedef short value_type;
 
-  __host__ __device__ inline complex<short>() : short2() {};
+  __host__ __device__ inline complex<short>() {};
 
   __host__ __device__ inline complex<short>(const short & re, const short& im = float())
     {
@@ -801,7 +801,7 @@ struct complex <int> : public int2
 public:
   typedef int value_type;
 
-  __host__ __device__ inline complex<int>() : int2() {};
+  __host__ __device__ inline complex<int>() {};
 
   __host__ __device__ inline complex<int>(const int& re, const int& im = float())
     {

--- a/include/dslash.h
+++ b/include/dslash.h
@@ -90,7 +90,7 @@ namespace quda
        */
       if (arg.kernel_type == EXTERIOR_KERNEL_ALL && arg.shmem > 0) {
         int nDimComms = 0;
-        for (int d = 0; d < in.Ndim(); d++) nDimComms += arg.commDim[d];
+        for (int d = 0; d < 4; d++) nDimComms += arg.commDim[d];
         return ((deviceProp.multiProcessorCount) / (2 * nDimComms)) * (2 * nDimComms);
       } else {
         return TunableVectorYZ::minGridSize();
@@ -102,7 +102,7 @@ namespace quda
       /* see comment for minGridSize above for gridStep choice when using nvshmem */
       if (arg.kernel_type == EXTERIOR_KERNEL_ALL && arg.shmem > 0) {
         int nDimComms = 0;
-        for (int d = 0; d < in.Ndim(); d++) nDimComms += arg.commDim[d];
+        for (int d = 0; d < 4; d++) nDimComms += arg.commDim[d];
         return ((deviceProp.multiProcessorCount) / (2 * nDimComms)) * (2 * nDimComms);
       } else {
         return TunableVectorYZ::gridStep();
@@ -142,8 +142,6 @@ namespace quda
         arg.counter = dslash::get_shmem_sync_counter();
       }
       if (arg.shmem > 0 && arg.kernel_type == EXTERIOR_KERNEL_ALL) {
-        int nDimComms = 0;
-        for (int d = 0; d < in.Ndim(); d++) nDimComms += arg.commDim[d];
         // if we are doing tuning we should not wait on the sync_arr to be set.
         arg.counter = (activeTuning() && !policyTuning()) ? 2 : dslash::get_shmem_sync_counter();
       }
@@ -174,7 +172,7 @@ namespace quda
           max_threads_per_dir = std::max(max_threads_per_dir, (arg.threadDimMapUpper[i] - arg.threadDimMapLower[i]) / 2);
         }
         int nDimComms = 0;
-        for (int d = 0; d < in.Ndim(); d++) nDimComms += arg.commDim[d];
+        for (int d = 0; d < 4; d++) nDimComms += arg.commDim[d];
 
         /* if doing the fused packing + interior kernel we tune how many blocks to use for communication */
         // use up to a quarter of the GPU for packing (but at least up to 4 blocks per dir)

--- a/lib/color_spinor_util.cu
+++ b/lib/color_spinor_util.cu
@@ -225,12 +225,12 @@ namespace quda {
 		fabs(u(parity,x_cb,s,c).imag() - v(parity,x_cb,s,c).imag());
 
 	      for (int f=0; f<fail_check; f++) {
-		if (diff > pow(10.0,-(f+1)/(double)tol)) {
+		if (diff > pow(10.0,-(f+1)/(double)tol) || std::isnan(diff)) {
 		  fail[f]++;
 		}
 	      }
 
-	      if (diff > 1e-3) iter[j]++;
+	      if (diff > 1e-3 || std::isnan(diff)) iter[j]++;
 	    }
 	  }
 	}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -495,10 +495,11 @@ foreach(pol IN LISTS DSLASH_POLICIES)
   endif()
 
   if(QUDA_DIRAC_NDEG_TWISTED_MASS)
+    set(DIRAC_NAME twisted-mass)
     # symmetric preconditioning
     add_test(NAME dslash_ndeg-twisted-mass-sym-policy${pol2}
              COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:dslash_ctest> ${MPIEXEC_POSTFLAGS}
-                     --dslash-type twisted-mass
+                     --dslash-type ${DIRAC_NAME}
                      --test MatPCDagMatPC
                      --matpc even-even
                      --flavor nondeg-doublet
@@ -512,7 +513,7 @@ foreach(pol IN LISTS DSLASH_POLICIES)
     # asymmetric preconditioning
     add_test(NAME dslash_ndeg-twisted-mass-asym-policy${pol2}
              COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:dslash_ctest> ${MPIEXEC_POSTFLAGS}
-                     --dslash-type twisted-mass
+                     --dslash-type ${DIRAC_NAME}
                      --test MatPCDagMatPC
                      --matpc even-even-asym
                      --flavor nondeg-doublet

--- a/tests/blas_test.cpp
+++ b/tests/blas_test.cpp
@@ -1115,6 +1115,7 @@ TEST_P(BlasTest, verify)
   double tol = std::max(tol_x, tol_y);
   tol = is_copy(kernel) ? 5e-2 : tol; // use different tolerance for copy
   EXPECT_LE(deviation, tol) << "CPU and CUDA implementations do not agree";
+  EXPECT_EQ(false, std::isnan(deviation)) << "Nan has propagated into the result";
 }
 
 TEST_P(BlasTest, benchmark)


### PR DESCRIPTION
This fixes a few issues that were recently introduced
* UB fix for overrun of `arg.commDim` in dslash.h (loop limit should be 4 not `in.Ndim()`)
* Fix for ndeg-tm fermions with cmake benchmarks
* Revert initialization in complex default constructor (inhibits composability of complex numbers in `__shared__` objects)

Update: I've also now improved the robustness of the dslash and blas unit tests to check for Nan propagation, to prevent erroneous false positive passes.