### PR TITLE
Hotfix/mg single fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Performance Computing, Networking, Storage and Analysis (SC), 2011
 
 When taking advantage of adaptive multigrid, please also cite:
 
-M. A. Clark, A. Strelchenko, M. Cheng, A. Gambhir, and R. Brower,
+M. A. Clark, B. Joo, A. Strelchenko, M. Cheng, A. Gambhir, and R. Brower,
 "Accelerating Lattice QCD Multigrid on GPUs Using Fine-Grained
 Parallelization," International Conference for High Performance
 Computing, Networking, Storage and Analysis (SC), 2016

--- a/lib/block_orthogonalize.cu
+++ b/lib/block_orthogonalize.cu
@@ -72,6 +72,7 @@ namespace quda {
         strcat(aux, geo_str);
         if (d < V.Ndim() - 1) strcat(aux, "x");
       }
+      if (geoBlockSize == 1) errorQuda("Invalid MG aggregate size %d", geoBlockSize);
 
       strcat(aux, ",n_block_ortho=");
       char n_ortho_str[2];

--- a/lib/coarse_op.cu
+++ b/lib/coarse_op.cu
@@ -170,17 +170,25 @@ namespace quda {
       errorQuda("Double precision multigrid has not been enabled");
 #endif
     } else if (Y.Precision() == QUDA_SINGLE_PRECISION) {
+#if QUDA_PRECISION & 4
       if (T.Vectors(X.Location()).Precision() == QUDA_SINGLE_PRECISION) {
         calculateY<float,float>(Y, X, Yatomic, Xatomic, uv, av, T, g, c, kappa, mass, mu, mu_factor, dirac, matpc);
       } else {
         errorQuda("Unsupported precision %d\n", T.Vectors(X.Location()).Precision());
       }
+#else
+      errorQuda("QUDA_PRECISION=%d does not enable single precision", QUDA_PRECISION);
+#endif
     } else if (Y.Precision() == QUDA_HALF_PRECISION) {
+#if QUDA_PRECISION & 2
       if (T.Vectors(X.Location()).Precision() == QUDA_HALF_PRECISION) {
         calculateY<float,short>(Y, X, Yatomic, Xatomic, uv, av, T, g, c, kappa, mass, mu, mu_factor, dirac, matpc);
       } else {
         errorQuda("Unsupported precision %d\n", T.Vectors(X.Location()).Precision());
       }
+#else
+      errorQuda("QUDA_PRECISION=%d does not enable half precision", QUDA_PRECISION);
+#endif
     } else {
       errorQuda("Unsupported precision %d\n", Y.Precision());
     }

--- a/lib/coarsecoarse_op.cu
+++ b/lib/coarsecoarse_op.cu
@@ -273,19 +273,27 @@ namespace quda {
       errorQuda("Double precision multigrid has not been enabled");
 #endif
     } else if (Y.Precision() == QUDA_SINGLE_PRECISION) {
+#if QUDA_PRECISION & 4
       if (T.Vectors(X.Location()).Precision() == QUDA_SINGLE_PRECISION) {
         calculateYcoarse<float, float>(Y, X, Yatomic, Xatomic, uv, T, g, clover, cloverInv, kappa, mass, mu, mu_factor, dirac,
                                        matpc, need_bidirectional, use_mma);
       } else {
 	errorQuda("Unsupported precision %d\n", T.Vectors(X.Location()).Precision());
       }
+#else
+      errorQuda("QUDA_PRECISION=%d does not enable single precision", QUDA_PRECISION);
+#endif
     } else if (Y.Precision() == QUDA_HALF_PRECISION) {
+#if QUDA_PRECISION & 2
       if (T.Vectors(X.Location()).Precision() == QUDA_HALF_PRECISION) {
         calculateYcoarse<float, short>(Y, X, Yatomic, Xatomic, uv, T, g, clover, cloverInv, kappa, mass, mu, mu_factor, dirac,
                                        matpc, need_bidirectional, use_mma);
       } else {
 	errorQuda("Unsupported precision %d\n", T.Vectors(X.Location()).Precision());
       }
+#else
+      errorQuda("QUDA_PRECISION=%d does not enable half precision", QUDA_PRECISION);
+#endif
     } else {
       errorQuda("Unsupported precision %d\n", Y.Precision());
     }

--- a/lib/communicator_single.cpp
+++ b/lib/communicator_single.cpp
@@ -39,6 +39,9 @@ Communicator::~Communicator() { comm_finalize(); }
 
 void Communicator::comm_init(int ndim, const int *dims, QudaCommsMap rank_from_coords, void *map_data)
 {
+  for (int d = 0; d < ndim; d++) {
+    if (dims[d] > 1) errorQuda("Grid dimension grid[%d] = %d greater than 1", d, dims[d]);
+  }
   comm_init_common(ndim, dims, rank_from_coords, map_data);
 }
 

--- a/lib/dslash_coarse.hpp
+++ b/lib/dslash_coarse.hpp
@@ -90,7 +90,7 @@ namespace quda
       return ((color_col_stride == 1 || minThreads() % warp_size == 0) && // active threads must be a multiple of the warp
               param.block.x % warp_size == 0 &&                           // block size must be a multiple of the warp
               Nc % color_col_stride == 0 &&                               // number of colors must be divisible by the split
-              param.grid.x < deviceProp.maxGridSize[0]);                  // ensure the resulting grid size valid
+              param.grid.x < (unsigned)deviceProp.maxGridSize[0]);                  // ensure the resulting grid size valid
     }
 
     bool advanceColorStride(TuneParam &param) const

--- a/tests/dslash_test.cpp
+++ b/tests/dslash_test.cpp
@@ -58,9 +58,7 @@ int main(int argc, char **argv)
   }
 
   initComms(argc, argv, gridsize_from_cmdline);
-  for (int d = 0; d < 4; d++) {
-    if (dim_partitioned[d]) { commDimPartitionedSet(d); }
-  }
+
   // Ensure gtest prints only from rank 0
   ::testing::TestEventListeners &listeners = ::testing::UnitTest::GetInstance()->listeners();
   if (comm_rank() != 0) { delete listeners.Release(listeners.default_result_printer()); }

--- a/tests/staggered_dslash_test.cpp
+++ b/tests/staggered_dslash_test.cpp
@@ -63,9 +63,6 @@ int main(int argc, char **argv)
 
   initComms(argc, argv, gridsize_from_cmdline);
 
-  for (int d = 0; d < 4; d++) {
-    if (dim_partitioned[d]) { commDimPartitionedSet(d); }
-  }
   updateR();
 
   initQuda(device_ordinal);

--- a/tests/utils/host_utils.cpp
+++ b/tests/utils/host_utils.cpp
@@ -279,6 +279,11 @@ void initComms(int argc, char **argv, int *const commDims)
   QudaCommsMap func = rank_order == 0 ? lex_rank_from_coords_t : lex_rank_from_coords_x;
 
   initCommsGridQuda(4, commDims, func, NULL);
+
+  for (int d = 0; d < 4; d++) {
+    if (dim_partitioned[d]) { commDimPartitionedSet(d); }
+  }
+
   initRand();
 
   printfQuda("Rank order is %s major (%s running fastest)\n", rank_order == 0 ? "column" : "row",


### PR DESCRIPTION
* Fix bug in coarse dslash where invalid writes could occur (backported from GK)
* When compiled in single-GPU mode, check at runtime that the grid dimensions are unity (prevents a mysterious segmentation fault otherwise)
* coarse_op.cu and coarsecoarse_op.cu now respect `QUDA_PRECISION` for more targeted compilation
* Catch invalid MG block-size = 1 in block_orthogonalize.cu (prevents divide by zero error)