### PR TITLE
remove fatbin.ld

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ find_package(PythonInterp)
 if(DEFINED ENV{QUDA_BUILD_TYPE})
   set(DEFBUILD $ENV{QUDA_BUILD_TYPE})
 else()
-  set(DEFBUILD "DEVEL")
+  set(DEFBUILD "RELEASE")
 endif()
 
 set(VALID_BUILD_TYPES
@@ -345,7 +345,7 @@ endif()
 
 set(CPU_ARCH ${CMAKE_HOST_SYSTEM_PROCESSOR})
 if(${CPU_ARCH} STREQUAL "x86_64")
-  set(CXX_OPT "-march=native")
+  set(CXX_OPT "-mtune=native")
 elseif(${CPU_ARCH} STREQUAL "ppc64le")
   set(CXX_OPT "-Ofast -mcpu=native -mtune=native")
 endif()

--- a/lib/targets/cuda/CMakeLists.txt
+++ b/lib/targets/cuda/CMakeLists.txt
@@ -6,14 +6,5 @@ if(QUDA_BACKWARDS)
   set_property(SOURCE malloc.cpp DIRECTORY ${CMAKE_SOURCE_DIR}/lib APPEND PROPERTY COMPILE_DEFINITIONS QUDA_BACKWARDSCPP)
 endif()
 
-file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/fatbin.ld"
-[=[
-SECTIONS
-{
-  .nvFatBinSegment : { *(.nvFatBinSegment) }
-  .nv_fatbin : { *(.nv_fatbin) }
-}
-]=])
-target_link_options(quda PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/fatbin.ld")
 
 target_compile_options(quda PRIVATE $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:-Xfatbin=-compress-all>)


### PR DESCRIPTION
This seems to cause more troubles than it saves space. And for QUDA 2.x we will use better options to control the library.

gold seems to completely fail with it. And It doesn't seem to make a significant impact. I'd rather play it safe for releases.