### PR TITLE
Hotfix/block ortho float8

### DIFF
--- a/include/color_spinor_field_order.h
+++ b/include/color_spinor_field_order.h
@@ -317,7 +317,8 @@ namespace quda {
         constexpr int M = nSpinBlock * nColor * nVec;
 #pragma unroll
         for (int i = 0; i < M; i++) {
-          vec_t tmp = vector_load<vec_t>(reinterpret_cast<const vec_t *>(in + parity * offset_cb), (chi * M + i) * stride + x_cb);
+          vec_t tmp = vector_load<vec_t>(reinterpret_cast<const vec_t *>(in + parity * offset_cb),
+                                         (chi * M + i) * stride + x_cb);
           memcpy(&out[i], &tmp, sizeof(vec_t));
         }
       }
@@ -361,7 +362,8 @@ namespace quda {
         constexpr int M = (nSpinBlock * nColor * nVec * 2) / 4;
 #pragma unroll
         for (int i = 0; i < M; i++) {
-          vec_t tmp = vector_load<vec_t>(reinterpret_cast<const vec_t *>(in + parity * offset_cb), (chi * M + i) * stride + x_cb);
+          vec_t tmp = vector_load<vec_t>(reinterpret_cast<const vec_t *>(in + parity * offset_cb),
+                                         (chi * M + i) * stride + x_cb);
           memcpy(&out[i * 2], &tmp, sizeof(vec_t));
         }
       }

--- a/include/color_spinor_field_order.h
+++ b/include/color_spinor_field_order.h
@@ -314,9 +314,11 @@ namespace quda {
                                            int parity, int x_cb, int chi) const
       {
         using vec_t = typename VectorType<Float, 2>::type;
-        int M = nSpinBlock * nColor * nVec;
+        constexpr int M = nSpinBlock * nColor * nVec;
+#pragma unroll
         for (int i = 0; i < M; i++) {
-          ((vec_t *)out)[i] = vector_load<vec_t>((vec_t *)(in + parity * offset_cb), (chi * M + i) * stride + x_cb);
+          vec_t tmp = vector_load<vec_t>(reinterpret_cast<const vec_t *>(in + parity * offset_cb), (chi * M + i) * stride + x_cb);
+          memcpy(&out[i], &tmp, sizeof(vec_t));
         }
       }
     };
@@ -356,10 +358,11 @@ namespace quda {
                                            int parity, int x_cb, int chi) const
       {
         using vec_t = typename VectorType<Float, 4>::type;
-        int M = (nSpinBlock * nColor * nVec * 2) / 4;
+        constexpr int M = (nSpinBlock * nColor * nVec * 2) / 4;
 #pragma unroll
         for (int i = 0; i < M; i++) {
-          ((vec_t *)out)[i] = vector_load<vec_t>((vec_t *)(in + parity * offset_cb), (chi * M + i) * stride + x_cb);
+          vec_t tmp = vector_load<vec_t>(reinterpret_cast<const vec_t *>(in + parity * offset_cb), (chi * M + i) * stride + x_cb);
+          memcpy(&out[i * 2], &tmp, sizeof(vec_t));
         }
       }
     };
@@ -407,7 +410,8 @@ namespace quda {
         Float tmp[N];
 #pragma unroll
         for (int i = 0; i < M; i++) {
-          ((vec_t *)tmp)[i] = vector_load<vec_t>((vec_t *)(in + parity * offset_cb), i * stride + x_cb);
+          vec_t ld_tmp = vector_load<vec_t>(reinterpret_cast<const vec_t *>(in + parity * offset_cb), i * stride + x_cb);
+          memcpy(&tmp[i * 8], &ld_tmp, sizeof(vec_t));
         }
         constexpr int N_chi = N / (nSpin / nSpinBlock);
 #pragma unroll

--- a/include/communicator_quda.h
+++ b/include/communicator_quda.h
@@ -548,40 +548,32 @@ struct Communicator {
     Topology *topo = comm_create_topology(ndim, dims, rank_from_coords, map_data, comm_rank());
     comm_set_default_topology(topo);
 
-    
     // determine which GPU this rank will use
     char *hostname_recv_buf = (char *)safe_malloc(128 * comm_size());
     comm_gather_hostname(hostname_recv_buf);
 
-    if( gpuid < 0 ) { 
+    if (gpuid < 0) {
 
       // Try PMI
-      char *local_rankstr = getenv( "PMI_RANK" );
+      char *local_rankstr = getenv("PMI_RANK");
 
       // Try MVapich
-      if ( ! local_rankstr ) {
-        local_rankstr = getenv( "MV2_COMM_WORLD_LOCAL_RANK"  );
-      }
+      if (!local_rankstr) { local_rankstr = getenv("MV2_COMM_WORLD_LOCAL_RANK"); }
 
       // Try OpenMPI
-      if ( ! local_rankstr ) {
-        local_rankstr = getenv( "OMPI_COMM_WORLD_LOCAL_RANK" );
-      }
+      if (!local_rankstr) { local_rankstr = getenv("OMPI_COMM_WORLD_LOCAL_RANK"); }
 
       // Try SLURM
-      if ( ! local_rankstr ) {
-       local_rankstr = getenv( "SLURM_LOCALID" );
-      }
+      if (!local_rankstr) { local_rankstr = getenv("SLURM_LOCALID"); }
 
       int device_count;
       cudaGetDeviceCount(&device_count);
       if (device_count == 0) { errorQuda("No CUDA devices found"); }
-    
-      if ( local_rankstr ) {
-        gpuid  = atoi(local_rankstr);
-      }
-      else {
-    
+
+      if (local_rankstr) {
+        gpuid = atoi(local_rankstr);
+      } else {
+
         // Old fashioned way to get local ID. Relies on hostname working
         // We initialize gpuid if it's still negative.
         gpuid = 0;
@@ -589,8 +581,8 @@ struct Communicator {
           if (!strncmp(comm_hostname(), &hostname_recv_buf[128 * i], 128)) { gpuid++; }
         }
       }
-  
-      // At this point we had either pulled a gpuid from an env var or from the old way.  
+
+      // At this point we had either pulled a gpuid from an env var or from the old way.
       if (gpuid >= device_count) {
         char *enable_mps_env = getenv("QUDA_ENABLE_MPS");
         if (enable_mps_env && strcmp(enable_mps_env, "1") == 0) {

--- a/include/communicator_quda.h
+++ b/include/communicator_quda.h
@@ -548,22 +548,49 @@ struct Communicator {
     Topology *topo = comm_create_topology(ndim, dims, rank_from_coords, map_data, comm_rank());
     comm_set_default_topology(topo);
 
+    
     // determine which GPU this rank will use
     char *hostname_recv_buf = (char *)safe_malloc(128 * comm_size());
     comm_gather_hostname(hostname_recv_buf);
 
-    // We only want one (1) gpuid for all communicators, so gpuid is static.
-    // We initialize gpuid if it's still negative.
-    if (gpuid < 0) {
+    if( gpuid < 0 ) { 
 
-      gpuid = 0;
-      for (int i = 0; i < comm_rank(); i++) {
-        if (!strncmp(comm_hostname(), &hostname_recv_buf[128 * i], 128)) { gpuid++; }
+      // Try PMI
+      char *local_rankstr = getenv( "PMI_RANK" );
+
+      // Try MVapich
+      if ( ! local_rankstr ) {
+        local_rankstr = getenv( "MV2_COMM_WORLD_LOCAL_RANK"  );
+      }
+
+      // Try OpenMPI
+      if ( ! local_rankstr ) {
+        local_rankstr = getenv( "OMPI_COMM_WORLD_LOCAL_RANK" );
+      }
+
+      // Try SLURM
+      if ( ! local_rankstr ) {
+       local_rankstr = getenv( "SLURM_LOCALID" );
       }
 
       int device_count;
       cudaGetDeviceCount(&device_count);
       if (device_count == 0) { errorQuda("No CUDA devices found"); }
+    
+      if ( local_rankstr ) {
+        gpuid  = atoi(local_rankstr);
+      }
+      else {
+    
+        // Old fashioned way to get local ID. Relies on hostname working
+        // We initialize gpuid if it's still negative.
+        gpuid = 0;
+        for (int i = 0; i < comm_rank(); i++) {
+          if (!strncmp(comm_hostname(), &hostname_recv_buf[128 * i], 128)) { gpuid++; }
+        }
+      }
+  
+      // At this point we had either pulled a gpuid from an env var or from the old way.  
       if (gpuid >= device_count) {
         char *enable_mps_env = getenv("QUDA_ENABLE_MPS");
         if (enable_mps_env && strcmp(enable_mps_env, "1") == 0) {
@@ -573,7 +600,7 @@ struct Communicator {
           errorQuda("Too few GPUs available on %s", comm_hostname());
         }
       }
-    }
+    } // -ve gpuid
 
     comm_peer2peer_init(hostname_recv_buf);
 

--- a/include/communicator_quda.h
+++ b/include/communicator_quda.h
@@ -554,32 +554,14 @@ struct Communicator {
 
     if (gpuid < 0) {
 
-      // Try PMI
-      char *local_rankstr = getenv("PMI_RANK");
-
-      // Try MVapich
-      if (!local_rankstr) { local_rankstr = getenv("MV2_COMM_WORLD_LOCAL_RANK"); }
-
-      // Try OpenMPI
-      if (!local_rankstr) { local_rankstr = getenv("OMPI_COMM_WORLD_LOCAL_RANK"); }
-
-      // Try SLURM
-      if (!local_rankstr) { local_rankstr = getenv("SLURM_LOCALID"); }
-
       int device_count;
       cudaGetDeviceCount(&device_count);
       if (device_count == 0) { errorQuda("No CUDA devices found"); }
 
-      if (local_rankstr) {
-        gpuid = atoi(local_rankstr);
-      } else {
-
-        // Old fashioned way to get local ID. Relies on hostname working
-        // We initialize gpuid if it's still negative.
-        gpuid = 0;
-        for (int i = 0; i < comm_rank(); i++) {
-          if (!strncmp(comm_hostname(), &hostname_recv_buf[128 * i], 128)) { gpuid++; }
-        }
+      // We initialize gpuid if it's still negative.
+      gpuid = 0;
+      for (int i = 0; i < comm_rank(); i++) {
+        if (!strncmp(comm_hostname(), &hostname_recv_buf[128 * i], 128)) { gpuid++; }
       }
 
       // At this point we had either pulled a gpuid from an env var or from the old way.

--- a/include/dslash_helper.cuh
+++ b/include/dslash_helper.cuh
@@ -5,6 +5,7 @@
 #include <register_traits.h>
 #include <index_helper.cuh>
 #include <shmem_helper.cuh>
+#include <dslash_quda.h>
 
 namespace quda
 {

--- a/include/kernels/block_orthogonalize.cuh
+++ b/include/kernels/block_orthogonalize.cuh
@@ -268,7 +268,11 @@ namespace quda {
         complex<Float> v[spinBlock][nColor];
         if (n == 0) { // load from B on first Gram-Schmidt, otherwise V.
           complex<Float> v_[spinBlock * nColor];
-          B[j].template load<spinBlock>(v_, parity, x_cb, (nSpin == 1) ? 0 : chirality);
+          if (nSpin == 1 || chirality == 0)
+            B[j].template load<spinBlock>(v_, parity, x_cb, 0);
+          else
+            B[j].template load<spinBlock>(v_, parity, x_cb, 1);
+
 #pragma unroll
           for (int s = 0; s < spinBlock; s++)
           {

--- a/lib/multi_reduce_quda.cu
+++ b/lib/multi_reduce_quda.cu
@@ -348,7 +348,7 @@ namespace quda {
 
         coeff_array<T> a, b, c;
 
-        if (x.size() <= tile_size.x && is_valid_NXZ(x.size(), true) && x.size() * y.size() <= max_n_reduce()) {
+        if (x.size() <= tile_size.x && is_valid_NXZ(x.size(), true) && x.size() * y.size() <= (unsigned int)max_n_reduce()) {
           // problem will fit, so do the computation
           multiReduce<ReducerDiagonal, ReducerOffDiagonal>(tmp_dot, a, b, c, x, y, z, w, i_idx, j_idx);
         } else {
@@ -387,7 +387,7 @@ namespace quda {
         }
 
         // we are at the leaf of the binary tree (e.g., we ran the kernel): perform the row-to-column-major transpose here.
-        if (x.size() <= tile_size.x && is_valid_NXZ(x.size(), true) && x.size() * y.size() <= max_n_reduce()) {
+        if (x.size() <= tile_size.x && is_valid_NXZ(x.size(), true) && x.size() * y.size() <= (unsigned int)max_n_reduce()) {
           const unsigned int xlen = x.size();
           const unsigned int ylen = y.size();
           for (unsigned int j = 0; j < xlen; j++)


### PR DESCRIPTION
Some fixes for block orthogonalize that should be included in the 1.1 release
* Fix local memory overhead with using float-8 ordering in the block orthogonalize kernel (do not pass raw `chirality` value to `load` function else this results in dynamic local indexing
* Remove UB from `load` function in color_spinor_field_order.h (replace raw local array cast with `memcpy`).  This fixes the block orthogonalize kernel when compiled in debug mode.