### PR TITLE
Fix for new thrust/cub namespace control

### DIFF
--- a/include/thrust_helper.cuh
+++ b/include/thrust_helper.cuh
@@ -13,6 +13,9 @@
 #define CUB_USE_COOPERATIVE_GROUPS
 #endif
 
+// needed for newer versions of thrust/cub
+#define CUB_NS_QUALIFIER cub
+
 // hack required to silence a thrust complaint with clang-11
 #if defined(__clang__) && defined(__CUDA__)
 #define _CubLog(...)


### PR DESCRIPTION
Trivial fix for new CUDA TK thrust/cub libraries.  Without this macro setting, we will have a build error on CUDA >11.4.