### PR TITLE
Fix for multi-blas tuneKey degeneracy

### DIFF
--- a/lib/multi_blas_quda.cu
+++ b/lib/multi_blas_quda.cu
@@ -99,7 +99,9 @@ namespace quda {
         char NYW_str[8];
         u32toa(NXZ_str, NXZ);
         u32toa(NYW_str, NYW);
-        strcpy(name, NXZ_str);
+        strcpy(name, "Nxz");
+        strcat(name, NXZ_str);
+        strcat(name, "Nyw");
         strcat(name, NYW_str);
         strcat(name, typeid(f).name());
         return TuneKey(x[0]->VolString(), name, aux);

--- a/lib/multi_reduce_quda.cu
+++ b/lib/multi_reduce_quda.cu
@@ -160,7 +160,9 @@ namespace quda {
         char NYW_str[8];
         u32toa(NXZ_str, NXZ);
         u32toa(NYW_str, NYW);
-        strcpy(name, NXZ_str);
+        strcpy(name, "Nxz");
+        strcat(name, NXZ_str);
+        strcat(name, "Nyw");
         strcat(name, NYW_str);
         strcat(name, typeid(r).name());
         return TuneKey(x[0]->VolString(), name, aux);


### PR DESCRIPTION
Fix degeneracy in multi-blas/multi-reduce which could lead to incorrect results, e.g., Nxz=16/Nyw=1 and Nxz=1/Nyw=61 both used the same tuneKey.  This simple fix prevents this.