### PR TITLE
Feature/profile cumulative

### DIFF
--- a/include/atomic.cuh
+++ b/include/atomic.cuh
@@ -10,6 +10,34 @@
    avoid confusion when resolving the native atomicAdd functions.
  */
 
+#if defined(__NVCC__) && defined(__CUDA_ARCH__) && (__COMPUTE_CAPABILITY__ < 600)
+/**
+   @brief Implementation of double-precision atomic addition using
+   compare and swap. Taken from the CUDA programming guide.  This is
+   for pre-Pascal GPUs only, and is only supported on nvcc.
+
+   @param addr Address that stores the atomic variable to be updated
+   @param val Value to be added to the atomic
+*/
+static inline __device__ double atomicAdd(double* address, double val)
+{
+  unsigned long long int* address_as_ull =
+                            (unsigned long long int*)address;
+  unsigned long long int old = *address_as_ull, assumed;
+
+  do {
+    assumed = old;
+    old = atomicCAS(address_as_ull, assumed,
+                    __double_as_longlong(val +
+                           __longlong_as_double(assumed)));
+
+    // Note: uses integer comparison to avoid hang in case of NaN (since NaN != NaN)
+  } while (assumed != old);
+
+  return __longlong_as_double(old);
+}
+#endif
+
 /**
    @brief Implementation of double2 atomic addition using two
    double-precision additions.

--- a/include/kernels/block_orthogonalize.cuh
+++ b/include/kernels/block_orthogonalize.cuh
@@ -135,7 +135,6 @@ namespace quda {
       int x_offset_cb[n_sites_per_thread];
       int x_cb[n_sites_per_thread];
 
-#pragma unroll
       for (int tx = 0; tx < n_sites_per_thread; tx++) {
         int x_fine_offset_tx = x_fine_offset * n_sites_per_thread + tx;
         // all threads with x_fine_offset greater than aggregate_size_cb are second parity
@@ -157,7 +156,6 @@ namespace quda {
 
           ColorSpinor<real, nColor, spinBlock> v[mVec][n_sites_per_thread];
 
-#pragma unroll
           for (int tx = 0; tx < n_sites_per_thread; tx++) {
             if (x_offset_cb[tx] >= arg.aggregate_size_cb) break;
             if (n == 0) { // load from B on first Gram-Schmidt, otherwise V.
@@ -178,7 +176,6 @@ namespace quda {
             ColorSpinor<real, nColor, spinBlock> vi[n_sites_per_thread];
 
             dot_t dot;
-#pragma unroll
             for (int tx = 0; tx < n_sites_per_thread; tx++) {
               if (x_offset_cb[tx] >= arg.aggregate_size_cb) break;
               load(vi[tx], parity[tx], x_cb[tx], chirality, i);
@@ -190,7 +187,6 @@ namespace quda {
             dot = dot_reducer.AllSum(dot);
 
             // subtract the blocks to orthogonalise
-#pragma unroll
             for (int tx = 0; tx < n_sites_per_thread; tx++) {
               if (x_offset_cb[tx] >= arg.aggregate_size_cb) break;
 #pragma unroll
@@ -203,7 +199,6 @@ namespace quda {
           for (int m = 0; m < mVec; m++) {
 
             dot_t dot;
-#pragma unroll
             for (int tx = 0; tx < n_sites_per_thread; tx++) {
               if (x_offset_cb[tx] >= arg.aggregate_size_cb) break;
 #pragma unroll
@@ -213,7 +208,6 @@ namespace quda {
             dot = dot_reducer.AllSum(dot);
             
             sum_t nrm = 0.0;
-#pragma unroll
             for (int tx = 0; tx < n_sites_per_thread; tx++) {
               if (x_offset_cb[tx] >= arg.aggregate_size_cb) break;
 #pragma unroll
@@ -224,14 +218,12 @@ namespace quda {
             nrm = norm_reducer.AllSum(nrm);
             auto nrm_inv = nrm > 0.0 ? quda::rsqrt(nrm) : 0.0;
 
-#pragma unroll
             for (int tx = 0; tx < n_sites_per_thread; tx++) {
               if (x_offset_cb[tx] >= arg.aggregate_size_cb) break;
               v[m][tx] *= nrm_inv;
             }
           }
 
-#pragma unroll
           for (int tx = 0; tx < n_sites_per_thread; tx++) {
             if (x_offset_cb[tx] >= arg.aggregate_size_cb) break;
 #pragma unroll

--- a/lib/tune.cpp
+++ b/lib/tune.cpp
@@ -215,6 +215,8 @@ namespace quda
       if (param.n_calls > 0 && is_policy) async_total_time += param.n_calls * param.time;
     }
 
+    double cumulative_percent = 0;
+    double cumulative_percent_async = 0;
     while (!q.empty()) {
       TuneKey key = q.top().first;
       TuneParam param = q.top().second;
@@ -228,21 +230,30 @@ namespace quda
       // synchronous profile
       if (param.n_calls > 0 && !is_policy && !is_nested_policy) {
         double time = param.n_calls * param.time;
+        double percent = 100 * time / total_time;
+        cumulative_percent += percent;
 
-        out << std::setw(12) << param.n_calls * param.time << "\t" << std::setw(12) << (time / total_time) * 100 << "\t";
-        out << std::setw(12) << param.n_calls << "\t" << std::setw(12) << param.time << "\t" << std::setw(16)
-            << key.volume << "\t";
+        out << std::setw(12) << time << "\t";
+        out << std::setw(12) << percent << "\t";
+        out << std::setw(12) << cumulative_percent << "\t";
+        out << std::setw(12) << param.n_calls << "\t";
+        out << std::setw(12) << param.time << "\t";
+        out << std::setw(16) << key.volume << "\t";
         out << key.name << "\t" << key.aux << "\t" << param.comment; // param.comment ends with a newline
       }
 
       // async policy profile
       if (param.n_calls > 0 && is_policy) {
         double time = param.n_calls * param.time;
+        double percent = 100 * time / async_total_time;
+        cumulative_percent_async += percent;
 
-        async_out << std::setw(12) << param.n_calls * param.time << "\t" << std::setw(12)
-                  << (time / async_total_time) * 100 << "\t";
-        async_out << std::setw(12) << param.n_calls << "\t" << std::setw(12) << param.time << "\t" << std::setw(16)
-                  << key.volume << "\t";
+        async_out << std::setw(12) << time << "\t";
+        async_out << std::setw(12) << percent << "\t";
+        async_out << std::setw(12) << cumulative_percent_async << "\t";
+        async_out << std::setw(12) << param.n_calls << "\t";
+        async_out << std::setw(12) << param.time << "\t";
+        async_out << std::setw(16) << key.volume << "\t";
         async_out << key.name << "\t" << key.aux << "\t" << param.comment; // param.comment ends with a newline
       }
 
@@ -590,11 +601,12 @@ namespace quda
 #ifdef GITVERSION
       profile_file << "\t" << gitversion;
 #else
-    profile_file << "\t" << quda_version;
+      profile_file << "\t" << quda_version;
 #endif
       profile_file << "\t" << quda_hash << "\t# Last updated " << ctime(&now) << std::endl;
       profile_file << std::setw(12) << "total time"
-                   << "\t" << std::setw(12) << "percentage"
+                   << "\t" << std::setw(12) << "percent"
+                   << "\t" << std::setw(12) << "cum. percent"
                    << "\t" << std::setw(12) << "calls"
                    << "\t" << std::setw(12) << "time / call"
                    << "\t" << std::setw(16) << "volume"
@@ -604,11 +616,12 @@ namespace quda
 #ifdef GITVERSION
       async_profile_file << "\t" << gitversion;
 #else
-    async_profile_file << "\t" << quda_version;
+      async_profile_file << "\t" << quda_version;
 #endif
       async_profile_file << "\t" << quda_hash << "\t# Last updated " << ctime(&now) << std::endl;
       async_profile_file << std::setw(12) << "total time"
-                         << "\t" << std::setw(12) << "percentage"
+                         << "\t" << std::setw(12) << "percent"
+                         << "\t" << std::setw(12) << "cum. percent"
                          << "\t" << std::setw(12) << "calls"
                          << "\t" << std::setw(12) << "time / call"
                          << "\t" << std::setw(16) << "volume"


### PR DESCRIPTION
Simple PR that:
* Adds cumulative percentage to profile output (feature request from @bjoo)
* Remove some unnecessary unrolls which causes LLVM to choke when compiling for the host (closes #1193)

I have confirmed that the removal of the loop unrolling has no effect on device performance as expected (loop is length 1 on the device). 