### PR TITLE
Disable broken MG CPU setup in release/1.1.x

### DIFF
--- a/lib/dirac_coarse.cpp
+++ b/lib/dirac_coarse.cpp
@@ -28,8 +28,7 @@ namespace quda {
     init_cpu(!gpu_setup),
     mapped(mapped)
   {
-    if (gpu_setup == false)
-      errorQuda("CPU setup of the coarse Dirac operator is disabled");
+    if (gpu_setup == false) errorQuda("CPU setup of the coarse Dirac operator is disabled");
     initializeCoarse();
   }
 

--- a/lib/dirac_coarse.cpp
+++ b/lib/dirac_coarse.cpp
@@ -28,6 +28,8 @@ namespace quda {
     init_cpu(!gpu_setup),
     mapped(mapped)
   {
+    if (gpu_setup == false)
+      errorQuda("CPU setup of the coarse Dirac operator is disabled");
     initializeCoarse();
   }
 

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -2571,6 +2571,8 @@ multigrid_solver::multigrid_solver(QudaMultigridParam &mg_param, TimeProfile &pr
   dSmoothSloppy = Dirac::create(diracSmoothSloppyParam);
   mSmoothSloppy = new DiracM(*dSmoothSloppy);
 
+  if (mg_param.setup_location[0] == QUDA_CPU_FIELD_LOCATION)
+    errorQuda("MG setup location %d disabled", mg_param.setup_location[0]);
   ColorSpinorParam csParam(nullptr, *param, cudaGauge->X(), pc_solution, mg_param.setup_location[0]);
   csParam.create = QUDA_NULL_FIELD_CREATE;
   QudaPrecision Bprec = mg_param.precision_null[0];

--- a/lib/multigrid.cpp
+++ b/lib/multigrid.cpp
@@ -55,6 +55,9 @@ namespace quda
     if (param.coarse_grid_solution_type == QUDA_MATPC_SOLUTION && param.smoother_solve_type != QUDA_DIRECT_PC_SOLVE)
       errorQuda("Cannot use preconditioned coarse grid solution without preconditioned smoother solve");
 
+    if (param.mg_global.location[param.level] == QUDA_CPU_FIELD_LOCATION || param.mg_global.location[param.level+1] == QUDA_CPU_FIELD_LOCATION)
+      errorQuda("CPU solver location for MG is disabled");
+
     // allocating vectors
     {
       // create residual vectors
@@ -123,6 +126,11 @@ namespace quda
     pushLevel(param.level);
 
     if (getVerbosity() >= QUDA_VERBOSE) printfQuda("%s level %d\n", transfer ? "Resetting" : "Creating", param.level);
+
+    if (param.mg_global.setup_location[param.level+1] == QUDA_CPU_FIELD_LOCATION)
+      errorQuda("MG setup location %d disabled", param.mg_global.setup_location[param.level+1]);
+    if (param.mg_global.location[param.level+1] == QUDA_CPU_FIELD_LOCATION)
+      errorQuda("MG location %d disabled", param.mg_global.location[param.level+1]);
 
     destroySmoother();
     destroyCoarseSolver();

--- a/lib/multigrid.cpp
+++ b/lib/multigrid.cpp
@@ -55,7 +55,8 @@ namespace quda
     if (param.coarse_grid_solution_type == QUDA_MATPC_SOLUTION && param.smoother_solve_type != QUDA_DIRECT_PC_SOLVE)
       errorQuda("Cannot use preconditioned coarse grid solution without preconditioned smoother solve");
 
-    if (param.mg_global.location[param.level] == QUDA_CPU_FIELD_LOCATION || param.mg_global.location[param.level+1] == QUDA_CPU_FIELD_LOCATION)
+    if (param.mg_global.location[param.level] == QUDA_CPU_FIELD_LOCATION
+        || param.mg_global.location[param.level + 1] == QUDA_CPU_FIELD_LOCATION)
       errorQuda("CPU solver location for MG is disabled");
 
     // allocating vectors
@@ -127,10 +128,10 @@ namespace quda
 
     if (getVerbosity() >= QUDA_VERBOSE) printfQuda("%s level %d\n", transfer ? "Resetting" : "Creating", param.level);
 
-    if (param.mg_global.setup_location[param.level+1] == QUDA_CPU_FIELD_LOCATION)
-      errorQuda("MG setup location %d disabled", param.mg_global.setup_location[param.level+1]);
-    if (param.mg_global.location[param.level+1] == QUDA_CPU_FIELD_LOCATION)
-      errorQuda("MG location %d disabled", param.mg_global.location[param.level+1]);
+    if (param.mg_global.setup_location[param.level + 1] == QUDA_CPU_FIELD_LOCATION)
+      errorQuda("MG setup location %d disabled", param.mg_global.setup_location[param.level + 1]);
+    if (param.mg_global.location[param.level + 1] == QUDA_CPU_FIELD_LOCATION)
+      errorQuda("MG location %d disabled", param.mg_global.location[param.level + 1]);
 
     destroySmoother();
     destroyCoarseSolver();

--- a/tests/utils/command_line_params.cpp
+++ b/tests/utils/command_line_params.cpp
@@ -97,9 +97,6 @@ QudaTboundary fermion_t_boundary = QUDA_ANTI_PERIODIC_T;
 
 int mg_levels = 2;
 
-quda::mgarray<QudaFieldLocation> solver_location = {};
-quda::mgarray<QudaFieldLocation> setup_location = {};
-
 quda::mgarray<int> nu_pre = {};
 quda::mgarray<int> nu_post = {};
 quda::mgarray<int> n_block_ortho = {};
@@ -935,8 +932,6 @@ void add_multigrid_option_group(std::shared_ptr<QUDAApp> quda_app)
   quda_app->add_mgoption(opgroup, "--mg-setup-iters", num_setup_iter, CLI::PositiveNumber,
                          "The number of setup iterations to use for the multigrid (default 1)");
 
-  quda_app->add_mgoption(opgroup, "--mg-setup-location", setup_location, CLI::QUDACheckedTransformer(field_location_map),
-                         "The location where the multigrid setup will be computed (default cuda)");
   quda_app->add_mgoption(
     opgroup, "--mg-setup-maxiter", setup_maxiter, CLI::Validator(),
     "The maximum number of solver iterations to use when relaxing on a null space vector (default 500)");
@@ -968,8 +963,6 @@ void add_multigrid_option_group(std::shared_ptr<QUDAApp> quda_app)
                          "The type of solve to do in smoother (direct, direct-pc (default) )");
   quda_app->add_mgoption(opgroup, "--mg-smoother-tol", smoother_tol, CLI::Validator(),
                          "The smoother tolerance to use for each multigrid (default 0.25)");
-  quda_app->add_mgoption(opgroup, "--mg-solve-location", solver_location, CLI::QUDACheckedTransformer(field_location_map),
-                         "The location where the multigrid solver will run (default cuda)");
 
   quda_app->add_mgoption(opgroup, "--mg-verbosity", mg_verbosity, CLI::QUDACheckedTransformer(verbosity_map),
                          "The verbosity to use on each level of the multigrid (default summarize)");

--- a/tests/utils/command_line_params.h
+++ b/tests/utils/command_line_params.h
@@ -232,9 +232,6 @@ extern QudaTboundary fermion_t_boundary;
 
 extern int mg_levels;
 
-extern quda::mgarray<QudaFieldLocation> solver_location;
-extern quda::mgarray<QudaFieldLocation> setup_location;
-
 extern quda::mgarray<int> nu_pre;
 extern quda::mgarray<int> nu_post;
 extern quda::mgarray<int> n_block_ortho;

--- a/tests/utils/host_utils.cpp
+++ b/tests/utils/host_utils.cpp
@@ -106,8 +106,6 @@ void setQudaDefaultMgTestParams()
     coarse_solver[i] = QUDA_GCR_INVERTER;
     coarse_solver_tol[i] = 0.25;
     coarse_solver_maxiter[i] = 100;
-    solver_location[i] = QUDA_CUDA_FIELD_LOCATION;
-    setup_location[i] = QUDA_CUDA_FIELD_LOCATION;
     nu_pre[i] = 2;
     nu_post[i] = 2;
     n_block_ortho[i] = 1;

--- a/tests/utils/set_params.cpp
+++ b/tests/utils/set_params.cpp
@@ -537,8 +537,9 @@ void setMultigridParam(QudaMultigridParam &mg_param)
 
     mg_param.omega[i] = omega; // over/under relaxation factor
 
-    mg_param.location[i] = solver_location[i];
-    mg_param.setup_location[i] = setup_location[i];
+    // CPU setup disabled in release/1.1.x
+    mg_param.location[i] = QUDA_CUDA_FIELD_LOCATION;
+    mg_param.setup_location[i] = QUDA_CUDA_FIELD_LOCATION;
   }
 
   // whether to run GPU setup but putting temporaries into mapped (slow CPU) memory
@@ -1126,8 +1127,9 @@ void setStaggeredMultigridParam(QudaMultigridParam &mg_param)
 
     mg_param.omega[i] = omega; // over/under relaxation factor
 
-    mg_param.location[i] = solver_location[i];
-    mg_param.setup_location[i] = setup_location[i];
+    // CPU setup disabled in release/1.1.x
+    mg_param.location[i] = QUDA_CUDA_FIELD_LOCATION;
+    mg_param.setup_location[i] = QUDA_CUDA_FIELD_LOCATION;
     nu_pre[i] = 2;
     nu_post[i] = 2;
   }


### PR DESCRIPTION
This hotfix PR formally disables MG CPU setup, which is currently broken, in release/1.1.x.

Since this feature is generally only used for MG code development and debugging as opposed to production workflows, it's by construction not necessary in a formal release, which is why this band-aid is sufficient.