### PR TITLE
Suppress warnings for non DWF builds

### DIFF
--- a/lib/dslash_domain_wall_4d_m5inv.cu
+++ b/lib/dslash_domain_wall_4d_m5inv.cu
@@ -10,18 +10,23 @@ namespace quda
   // Apply the 4-d preconditioned domain-wall Dslash operator
   //   i.e. out(x) = M*in = in(x) + a*\sum_mu U_{-\mu}(x)in(x+mu) + U^\dagger_mu(x-mu)in(x-mu)
   // ... and then m5inv
+#ifdef GPU_DOMAIN_WALL_DIRAC
   void ApplyDomainWall4DM5inv(ColorSpinorField &out, const ColorSpinorField &in, const GaugeField &U, double a,
                               double m_5, const Complex *b_5, const Complex *c_5, const ColorSpinorField &x,
                               ColorSpinorField &y, int parity, bool dagger, const int *comm_override, double m_f,
                               TimeProfile &profile)
   {
-#ifdef GPU_DOMAIN_WALL_DIRAC
     auto dummy_list = Dslash5TypeList<Dslash5Type::M5_INV_MOBIUS>();
     instantiate<DomainWall4DApplyFusedM5>(out, in, U, a, m_5, b_5, c_5, x, y, parity, dagger, comm_override, m_f,
                                           dummy_list, profile);
+}
 #else
-    errorQuda("Domain-wall dslash has not been built");
+  void ApplyDomainWall4DM5inv(ColorSpinorField &, const ColorSpinorField &, const GaugeField &, double,
+                              double, const Complex *, const Complex *, const ColorSpinorField &,
+                              ColorSpinorField &, int, bool, const int *, double,
+                              TimeProfile &)
+  {
+  errorQuda("Domain-wall dslash has not been built");
+}
 #endif // GPU_DOMAIN_WALL_DIRAC
-  }
-
 } // namespace quda

--- a/lib/dslash_domain_wall_4d_m5inv.cu
+++ b/lib/dslash_domain_wall_4d_m5inv.cu
@@ -19,14 +19,14 @@ namespace quda
     auto dummy_list = Dslash5TypeList<Dslash5Type::M5_INV_MOBIUS>();
     instantiate<DomainWall4DApplyFusedM5>(out, in, U, a, m_5, b_5, c_5, x, y, parity, dagger, comm_override, m_f,
                                           dummy_list, profile);
-}
+  }
 #else
   void ApplyDomainWall4DM5inv(ColorSpinorField &, const ColorSpinorField &, const GaugeField &, double,
                               double, const Complex *, const Complex *, const ColorSpinorField &,
                               ColorSpinorField &, int, bool, const int *, double,
                               TimeProfile &)
   {
-  errorQuda("Domain-wall dslash has not been built");
-}
+    errorQuda("Domain-wall dslash has not been built");
+  }
 #endif // GPU_DOMAIN_WALL_DIRAC
 } // namespace quda

--- a/lib/dslash_domain_wall_4d_m5inv_m5inv.cu
+++ b/lib/dslash_domain_wall_4d_m5inv_m5inv.cu
@@ -10,18 +10,23 @@ namespace quda
   // Apply the 4-d preconditioned domain-wall Dslash operator
   //   i.e. out(x) = M*in = in(x) + a*\sum_mu U_{-\mu}(x)in(x+mu) + U^\dagger_mu(x-mu)in(x-mu)
   // ... and then m5inv + m5inv-dagger
+#ifdef GPU_DOMAIN_WALL_DIRAC
   void ApplyDomainWall4DM5invM5inv(ColorSpinorField &out, const ColorSpinorField &in, const GaugeField &U, double a,
                                    double m_5, const Complex *b_5, const Complex *c_5, const ColorSpinorField &x,
                                    ColorSpinorField &y, int parity, bool dagger, const int *comm_override, double m_f,
                                    TimeProfile &profile)
   {
-#ifdef GPU_DOMAIN_WALL_DIRAC
     auto dummy_list = Dslash5TypeList<Dslash5Type::M5_INV_MOBIUS_M5_INV_DAG>();
     instantiate<DomainWall4DApplyFusedM5>(out, in, U, a, m_5, b_5, c_5, x, y, parity, dagger, comm_override, m_f,
                                           dummy_list, profile);
+}
 #else
-    errorQuda("Domain-wall dslash has not been built");
+  void ApplyDomainWall4DM5invM5inv(ColorSpinorField &, const ColorSpinorField &, const GaugeField &, double,
+                                   double, const Complex *, const Complex *, const ColorSpinorField &,
+                                   ColorSpinorField &, int, bool, const int *, double,
+                                   TimeProfile &)
+  {
+  errorQuda("Domain-wall dslash has not been built");
+}
 #endif // GPU_DOMAIN_WALL_DIRAC
-  }
-
 } // namespace quda

--- a/lib/dslash_domain_wall_4d_m5inv_m5inv.cu
+++ b/lib/dslash_domain_wall_4d_m5inv_m5inv.cu
@@ -19,14 +19,14 @@ namespace quda
     auto dummy_list = Dslash5TypeList<Dslash5Type::M5_INV_MOBIUS_M5_INV_DAG>();
     instantiate<DomainWall4DApplyFusedM5>(out, in, U, a, m_5, b_5, c_5, x, y, parity, dagger, comm_override, m_f,
                                           dummy_list, profile);
-}
+  }
 #else
   void ApplyDomainWall4DM5invM5inv(ColorSpinorField &, const ColorSpinorField &, const GaugeField &, double,
                                    double, const Complex *, const Complex *, const ColorSpinorField &,
                                    ColorSpinorField &, int, bool, const int *, double,
                                    TimeProfile &)
   {
-  errorQuda("Domain-wall dslash has not been built");
-}
+    errorQuda("Domain-wall dslash has not been built");
+  }
 #endif // GPU_DOMAIN_WALL_DIRAC
 } // namespace quda

--- a/lib/dslash_domain_wall_4d_m5inv_m5pre.cu
+++ b/lib/dslash_domain_wall_4d_m5inv_m5pre.cu
@@ -10,18 +10,23 @@ namespace quda
   // Apply the 4-d preconditioned domain-wall Dslash operator
   //   i.e. out(x) = M*in = in(x) + a*\sum_mu U_{-\mu}(x)in(x+mu) + U^\dagger_mu(x-mu)in(x-mu)
   // ... and then m5inv + m5pre
+#ifdef GPU_DOMAIN_WALL_DIRAC
   void ApplyDomainWall4DM5invM5pre(ColorSpinorField &out, const ColorSpinorField &in, const GaugeField &U, double a,
                                    double m_5, const Complex *b_5, const Complex *c_5, const ColorSpinorField &x,
                                    ColorSpinorField &y, int parity, bool dagger, const int *comm_override, double m_f,
                                    TimeProfile &profile)
   {
-#ifdef GPU_DOMAIN_WALL_DIRAC
     auto dummy_list = Dslash5TypeList<Dslash5Type::M5_INV_MOBIUS_M5_PRE>();
     instantiate<DomainWall4DApplyFusedM5>(out, in, U, a, m_5, b_5, c_5, x, y, parity, dagger, comm_override, m_f,
                                           dummy_list, profile);
-#else
-    errorQuda("Domain-wall dslash has not been built");
-#endif // GPU_DOMAIN_WALL_DIRAC
   }
-
+#else
+  void ApplyDomainWall4DM5invM5pre(ColorSpinorField &, const ColorSpinorField &, const GaugeField &, double,
+                                   double, const Complex *, const Complex *, const ColorSpinorField &,
+                                   ColorSpinorField &, int, bool, const int *, double,
+                                   TimeProfile &)
+  {
+  errorQuda("Domain-wall dslash has not been built");
+}
+#endif // GPU_DOMAIN_WALL_DIRAC
 } // namespace quda

--- a/lib/dslash_domain_wall_4d_m5inv_m5pre.cu
+++ b/lib/dslash_domain_wall_4d_m5inv_m5pre.cu
@@ -26,7 +26,7 @@ namespace quda
                                    ColorSpinorField &, int, bool, const int *, double,
                                    TimeProfile &)
   {
-  errorQuda("Domain-wall dslash has not been built");
-}
+    errorQuda("Domain-wall dslash has not been built");
+  }
 #endif // GPU_DOMAIN_WALL_DIRAC
 } // namespace quda

--- a/lib/dslash_domain_wall_4d_m5mob.cu
+++ b/lib/dslash_domain_wall_4d_m5mob.cu
@@ -10,18 +10,24 @@ namespace quda
   // Apply the 4-d preconditioned domain-wall Dslash operator
   //   i.e. out(x) = M*in = in(x) + a*\sum_mu U_{-\mu}(x)in(x+mu) + U^\dagger_mu(x-mu)in(x-mu)
   // ... and then m5
+#ifdef GPU_DOMAIN_WALL_DIRAC
   void ApplyDomainWall4DM5mob(ColorSpinorField &out, const ColorSpinorField &in, const GaugeField &U, double a,
                               double m_5, const Complex *b_5, const Complex *c_5, const ColorSpinorField &x,
                               ColorSpinorField &y, int parity, bool dagger, const int *comm_override, double m_f,
                               TimeProfile &profile)
   {
-#ifdef GPU_DOMAIN_WALL_DIRAC
+
     auto dummy_list = Dslash5TypeList<Dslash5Type::DSLASH5_MOBIUS>();
     instantiate<DomainWall4DApplyFusedM5>(out, in, U, a, m_5, b_5, c_5, x, y, parity, dagger, comm_override, m_f,
                                           dummy_list, profile);
+}
 #else
+  void ApplyDomainWall4DM5mob(ColorSpinorField &, const ColorSpinorField &, const GaugeField &, double,
+                              double, const Complex *, const Complex *, const ColorSpinorField &,
+                              ColorSpinorField &, int, bool, const int *, double,
+                              TimeProfile &)
+  {
     errorQuda("Domain-wall dslash has not been built");
+}
 #endif // GPU_DOMAIN_WALL_DIRAC
-  }
-
 } // namespace quda

--- a/lib/dslash_domain_wall_4d_m5mob.cu
+++ b/lib/dslash_domain_wall_4d_m5mob.cu
@@ -20,7 +20,7 @@ namespace quda
     auto dummy_list = Dslash5TypeList<Dslash5Type::DSLASH5_MOBIUS>();
     instantiate<DomainWall4DApplyFusedM5>(out, in, U, a, m_5, b_5, c_5, x, y, parity, dagger, comm_override, m_f,
                                           dummy_list, profile);
-}
+  }
 #else
   void ApplyDomainWall4DM5mob(ColorSpinorField &, const ColorSpinorField &, const GaugeField &, double,
                               double, const Complex *, const Complex *, const ColorSpinorField &,
@@ -28,6 +28,6 @@ namespace quda
                               TimeProfile &)
   {
     errorQuda("Domain-wall dslash has not been built");
-}
+  }
 #endif // GPU_DOMAIN_WALL_DIRAC
 } // namespace quda

--- a/lib/dslash_domain_wall_4d_m5pre.cu
+++ b/lib/dslash_domain_wall_4d_m5pre.cu
@@ -19,14 +19,14 @@ namespace quda
     auto dummy_list = Dslash5TypeList<Dslash5Type::DSLASH5_MOBIUS_PRE>();
     instantiate<DomainWall4DApplyFusedM5>(out, in, U, a, m_5, b_5, c_5, x, y, parity, dagger, comm_override, m_f,
                                           dummy_list, profile);
-}
+  }
 #else
   void ApplyDomainWall4DM5pre(ColorSpinorField &, const ColorSpinorField &, const GaugeField &, double,
                               double, const Complex *, const Complex *, const ColorSpinorField &,
                               ColorSpinorField &, int, bool, const int *, double,
                               TimeProfile &)
   {
-  errorQuda("Domain-wall dslash has not been built");
-}
+    errorQuda("Domain-wall dslash has not been built");
+  }
 #endif // GPU_DOMAIN_WALL_DIRAC
 } // namespace quda

--- a/lib/dslash_domain_wall_4d_m5pre.cu
+++ b/lib/dslash_domain_wall_4d_m5pre.cu
@@ -10,18 +10,23 @@ namespace quda
   // Apply the 4-d preconditioned domain-wall Dslash operator
   //   i.e. out(x) = M*in = in(x) + a*\sum_mu U_{-\mu}(x)in(x+mu) + U^\dagger_mu(x-mu)in(x-mu)
   // ... and then m5pre
+#ifdef GPU_DOMAIN_WALL_DIRAC
   void ApplyDomainWall4DM5pre(ColorSpinorField &out, const ColorSpinorField &in, const GaugeField &U, double a,
                               double m_5, const Complex *b_5, const Complex *c_5, const ColorSpinorField &x,
                               ColorSpinorField &y, int parity, bool dagger, const int *comm_override, double m_f,
                               TimeProfile &profile)
   {
-#ifdef GPU_DOMAIN_WALL_DIRAC
     auto dummy_list = Dslash5TypeList<Dslash5Type::DSLASH5_MOBIUS_PRE>();
     instantiate<DomainWall4DApplyFusedM5>(out, in, U, a, m_5, b_5, c_5, x, y, parity, dagger, comm_override, m_f,
                                           dummy_list, profile);
+}
 #else
-    errorQuda("Domain-wall dslash has not been built");
+  void ApplyDomainWall4DM5pre(ColorSpinorField &, const ColorSpinorField &, const GaugeField &, double,
+                              double, const Complex *, const Complex *, const ColorSpinorField &,
+                              ColorSpinorField &, int, bool, const int *, double,
+                              TimeProfile &)
+  {
+  errorQuda("Domain-wall dslash has not been built");
+}
 #endif // GPU_DOMAIN_WALL_DIRAC
-  }
-
 } // namespace quda

--- a/lib/dslash_domain_wall_4d_m5pre_m5inv.cu
+++ b/lib/dslash_domain_wall_4d_m5pre_m5inv.cu
@@ -19,12 +19,12 @@ namespace quda
     auto dummy_list = Dslash5TypeList<Dslash5Type::M5_PRE_MOBIUS_M5_INV>();
     instantiate<DomainWall4DApplyFusedM5>(out, in, U, a, m_5, b_5, c_5, x, y, parity, dagger, comm_override, m_f,
                                           dummy_list, profile);
-}
+  }
 #else
   void ApplyDomainWall4DM5preM5inv(ColorSpinorField &, const ColorSpinorField &, const GaugeField &, double,
-                              double, const Complex *, const Complex *, const ColorSpinorField &,
-                              ColorSpinorField &, int, bool, const int *, double,
-                              TimeProfile &)
+                                   double, const Complex *, const Complex *, const ColorSpinorField &,
+                                   ColorSpinorField &, int, bool, const int *, double,
+                                   TimeProfile &)
   {
     errorQuda("Domain-wall dslash has not been built");
   }

--- a/lib/dslash_domain_wall_4d_m5pre_m5inv.cu
+++ b/lib/dslash_domain_wall_4d_m5pre_m5inv.cu
@@ -10,18 +10,23 @@ namespace quda
   // Apply the 4-d preconditioned domain-wall Dslash operator
   //   i.e. out(x) = M*in = in(x) + a*\sum_mu U_{-\mu}(x)in(x+mu) + U^\dagger_mu(x-mu)in(x-mu)
   // ... and then m5pre + m5inv
+#ifdef GPU_DOMAIN_WALL_DIRAC
   void ApplyDomainWall4DM5preM5inv(ColorSpinorField &out, const ColorSpinorField &in, const GaugeField &U, double a,
                                    double m_5, const Complex *b_5, const Complex *c_5, const ColorSpinorField &x,
                                    ColorSpinorField &y, int parity, bool dagger, const int *comm_override, double m_f,
                                    TimeProfile &profile)
   {
-#ifdef GPU_DOMAIN_WALL_DIRAC
     auto dummy_list = Dslash5TypeList<Dslash5Type::M5_PRE_MOBIUS_M5_INV>();
     instantiate<DomainWall4DApplyFusedM5>(out, in, U, a, m_5, b_5, c_5, x, y, parity, dagger, comm_override, m_f,
                                           dummy_list, profile);
+}
 #else
+  void ApplyDomainWall4DM5preM5inv(ColorSpinorField &, const ColorSpinorField &, const GaugeField &, double,
+                              double, const Complex *, const Complex *, const ColorSpinorField &,
+                              ColorSpinorField &, int, bool, const int *, double,
+                              TimeProfile &)
+  {
     errorQuda("Domain-wall dslash has not been built");
-#endif // GPU_DOMAIN_WALL_DIRAC
   }
-
+#endif // GPU_DOMAIN_WALL_DIRAC
 } // namespace quda

--- a/lib/dslash_domain_wall_4d_m5pre_m5mob.cu
+++ b/lib/dslash_domain_wall_4d_m5pre_m5mob.cu
@@ -19,14 +19,14 @@ namespace quda
     auto dummy_list = Dslash5TypeList<Dslash5Type::DSLASH5_MOBIUS_PRE_M5_MOB>();
     instantiate<DomainWall4DApplyFusedM5>(out, in, U, a, m_5, b_5, c_5, x, y, parity, dagger, comm_override, m_f,
                                           dummy_list, profile);
-}
+  }
 #else
   void ApplyDomainWall4DM5preM5mob(ColorSpinorField &, const ColorSpinorField &, const GaugeField &, double,
-                              double, const Complex *, const Complex *, const ColorSpinorField &,
-                              ColorSpinorField &, int, bool, const int *, double,
-                              TimeProfile &)
+				   double, const Complex *, const Complex *, const ColorSpinorField &,
+				   ColorSpinorField &, int, bool, const int *, double,
+				   TimeProfile &)
   {
-  errorQuda("Domain-wall dslash has not been built");
-}
+    errorQuda("Domain-wall dslash has not been built");
+  }
 #endif // GPU_DOMAIN_WALL_DIRAC
 } // namespace quda

--- a/lib/dslash_domain_wall_4d_m5pre_m5mob.cu
+++ b/lib/dslash_domain_wall_4d_m5pre_m5mob.cu
@@ -10,18 +10,23 @@ namespace quda
   // Apply the 4-d preconditioned domain-wall Dslash operator
   //   i.e. out(x) = M*in = in(x) + a*\sum_mu U_{-\mu}(x)in(x+mu) + U^\dagger_mu(x-mu)in(x-mu)
   // ... and then m5pre + m5
+#ifdef GPU_DOMAIN_WALL_DIRAC
   void ApplyDomainWall4DM5preM5mob(ColorSpinorField &out, const ColorSpinorField &in, const GaugeField &U, double a,
                                    double m_5, const Complex *b_5, const Complex *c_5, const ColorSpinorField &x,
                                    ColorSpinorField &y, int parity, bool dagger, const int *comm_override, double m_f,
                                    TimeProfile &profile)
   {
-#ifdef GPU_DOMAIN_WALL_DIRAC
     auto dummy_list = Dslash5TypeList<Dslash5Type::DSLASH5_MOBIUS_PRE_M5_MOB>();
     instantiate<DomainWall4DApplyFusedM5>(out, in, U, a, m_5, b_5, c_5, x, y, parity, dagger, comm_override, m_f,
                                           dummy_list, profile);
+}
 #else
-    errorQuda("Domain-wall dslash has not been built");
+  void ApplyDomainWall4DM5preM5mob(ColorSpinorField &, const ColorSpinorField &, const GaugeField &, double,
+                              double, const Complex *, const Complex *, const ColorSpinorField &,
+                              ColorSpinorField &, int, bool, const int *, double,
+                              TimeProfile &)
+  {
+  errorQuda("Domain-wall dslash has not been built");
+}
 #endif // GPU_DOMAIN_WALL_DIRAC
-  }
-
 } // namespace quda


### PR DESCRIPTION
This PR adds function definitions with blank signatures to the MDWF files to suppress `unused-variable` warnings when not building with MDWF support.