### PR TITLE
Fix missing libmpi_cxx dependency when linking tests.

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -458,6 +458,7 @@ endif()
 if(QUDA_QMP)
   target_compile_definitions(quda PUBLIC QMP_COMMS)
   target_link_libraries(quda PUBLIC QMP::qmp)
+  target_link_libraries(quda PUBLIC MPI::MPI_CXX)
 endif()
 
 if(QUDA_NVSHMEM)


### PR DESCRIPTION
Change fixes missing libmpi_cxx dependency when linking tests.