### PR TITLE
Feature/multi blas misc

### DIFF
--- a/include/blas_quda.h
+++ b/include/blas_quda.h
@@ -8,16 +8,18 @@
 
 namespace quda {
 
-  namespace reducer {
+  namespace reducer
+  {
 
     /**
        @brief Free any persistent allocations associated with global reduction
      */
     void destroy();
 
-  }
+  } // namespace reducer
 
-  namespace blas {
+  namespace blas
+  {
 
     void setParam(int kernel, int prec, int threads, int blocks);
 

--- a/include/blas_quda.h
+++ b/include/blas_quda.h
@@ -8,11 +8,16 @@
 
 namespace quda {
 
-  namespace blas {
+  namespace reducer {
 
-    // creates and destroys reduction buffers
-    void init();
+    /**
+       @brief Free any persistent allocations associated with global reduction
+     */
     void destroy();
+
+  }
+
+  namespace blas {
 
     void setParam(int kernel, int prec, int threads, int blocks);
 

--- a/include/kernels/multi_blas_core.cuh
+++ b/include/kernels/multi_blas_core.cuh
@@ -181,7 +181,7 @@ namespace quda
     */
     template <typename real>
     struct multicaxpyz_ : public MultiBlasFunctor<complex<real>> {
-      static constexpr memory_access<1, 0, 0, 1> read{ };
+      static constexpr memory_access<1, 1, 0, 0> read{ };
       static constexpr memory_access<0, 0, 0, 1> write{ };
       static constexpr bool use_z = false;
       static constexpr bool use_w = true;

--- a/include/kernels/multi_reduce_core.cuh
+++ b/include/kernels/multi_reduce_core.cuh
@@ -46,7 +46,7 @@ namespace quda
                      std::vector<ColorSpinorField *> &z, std::vector<ColorSpinorField *> &w,
                      Reducer f, int NYW, int length, int nParity) :
         // we have NYW * nParity reductions each of length NXZ
-        ReduceArg<reduce_t>(dim3(length, NYW, 1), NYW),
+        ReduceArg<reduce_t>(dim3(length, 1, NYW), NYW),
         NYW(NYW),
         f(f),
         length_cb(length / nParity),
@@ -86,7 +86,7 @@ namespace quda
       constexpr MultiReduce_(const Arg &arg) : arg(arg) {}
       static constexpr const char *filename() { return KERNEL_FILE; }
 
-      __device__ __host__ inline reduce_t operator()(reduce_t &sum, int tid, int k, int) const
+      __device__ __host__ inline reduce_t operator()(reduce_t &sum, int tid, int, int k) const
       {
         unsigned int parity = tid >= arg.length_cb ? 1 : 0;
         unsigned int i = tid - parity * arg.length_cb;

--- a/include/kernels/multi_reduce_core.cuh
+++ b/include/kernels/multi_reduce_core.cuh
@@ -14,6 +14,19 @@ namespace quda
   {
 
     /**
+       @brief Return the batch block size used for multi reductions.
+       For now, we leave this at 1 unless fast-compilation is enabled,
+       since it provides negligible benefit (but substantially longer
+       tuning).  When fast-compilation is enabled, the increased batch
+       count can dramatically improve performance.
+     */
+#ifndef QUDA_FAST_COMPILE_REDUCE
+    constexpr unsigned int max_n_batch_block_multi_reduce() { return 1; }
+#else
+    constexpr unsigned int max_n_batch_block_multi_reduce() { return 8; }
+#endif
+
+    /**
        @brief Parameter struct for generic multi-reduce blas kernel.
        @tparam real_ The precision of the calculation
        @tparam n_ The number of real elements per thread
@@ -36,6 +49,7 @@ namespace quda
       static constexpr int n = n_;
       static constexpr int NXZ = NXZ_;
       static constexpr int NYW_max = max_YW_size<NXZ, store_t, y_store_t, Reducer>();
+      static constexpr unsigned int max_n_batch_block = max_n_batch_block_multi_reduce();
       const int NYW;
       Reducer f;
 

--- a/include/kernels/reduce_init.cuh
+++ b/include/kernels/reduce_init.cuh
@@ -8,8 +8,8 @@ namespace quda {
     template <typename T_> struct init_arg : kernel_param<> {
       using T = T_;
       T *count;
-      init_arg(T *count) :
-        kernel_param(dim3(max_n_reduce(), 1, 1)),
+      init_arg(T *count, int n_reduce) :
+        kernel_param(dim3(n_reduce, 1, 1)),
         count(count) { }
     };
 

--- a/include/kernels/transform_reduce.cuh
+++ b/include/kernels/transform_reduce.cuh
@@ -18,7 +18,7 @@ namespace quda {
     reducer r;
 
     TransformReduceArg(const std::vector<T *> &v, count_t n_items, transformer h, reduce_t init_value, reducer r) :
-      ReduceArg<reduce_t>(dim3(n_items, v.size(), 1), v.size()),
+      ReduceArg<reduce_t>(dim3(n_items, 1, v.size()), v.size()),
       n_items(n_items),
       n_batch(v.size()),
       init_value(init_value),
@@ -48,7 +48,7 @@ namespace quda {
 
     __device__ __host__ inline reduce_t operator()(reduce_t a, reduce_t b) const { return arg.r(a, b); }
 
-    __device__ __host__ inline reduce_t operator()(reduce_t &value, count_t i, int j, int)
+    __device__ __host__ inline reduce_t operator()(reduce_t &value, count_t i, int, int j)
     {
       auto v = arg.v[j];
       auto t = arg.h(v[i]);

--- a/include/multi_blas_helper.cuh
+++ b/include/multi_blas_helper.cuh
@@ -125,6 +125,19 @@ namespace quda
     */
     constexpr int max_N_multi_1d() { return 24; }
 
+    constexpr int max_N_multi_1d_pow2()
+    {
+      unsigned int v = max_N_multi_1d();
+      v--;
+      v |= v >> 1;
+      v |= v >> 2;
+      v |= v >> 4;
+      v |= v >> 8;
+      v |= v >> 16;
+      v++;
+      return v >> 1;
+    }
+
     /**
        @brief Return the maximum power of two enabled by default for
        multi-blas.  We set a lower limit for multi-reductions, since
@@ -238,7 +251,7 @@ namespace quda
       size_t spinor_x_size = x_fixed ? sizeof(Spinor<short, 4>) : sizeof(Spinor<float, 4>);
       size_t spinor_y_size = y_fixed ? sizeof(Spinor<short, 4>) : sizeof(Spinor<float, 4>);
       size_t spinor_z_size = spinor_x_size;
-      size_t spinor_w_size = x_fixed ? sizeof(Spinor<short, 4>) : sizeof(Spinor<float, 4>);
+      size_t spinor_w_size = spinor_x_size;
 
       // compute the size remaining for the Y and W accessors
       const auto arg_size = (max_arg_size<Functor>()
@@ -271,6 +284,7 @@ namespace quda
 
       if (!is_valid_NXZ(NXZ, f.reducer, x[0]->Precision() < QUDA_SINGLE_PRECISION))
         errorQuda("NXZ=%d is not a valid size ( MAX_MULTI_BLAS_N %d)", NXZ, MAX_MULTI_BLAS_N);
+      if (NXZ != (int)x.size()) errorQuda("Compile-time %d and run-time %lu NXZ do not match", NXZ, x.size());
       if (NYW_max != NYW_max_check) errorQuda("Compile-time %d and run-time %d limits disagree", NYW_max, NYW_max_check);
       if (f.NYW > NYW_max) errorQuda("NYW exceeds max size (%d > %d)", f.NYW, NYW_max);
       if ( !(f.reducer || f.multi_1d) && NXZ * f.NYW * sizeof(typename Functor::coeff_t) > max_array_size())

--- a/include/multi_blas_helper.cuh
+++ b/include/multi_blas_helper.cuh
@@ -125,6 +125,11 @@ namespace quda
     */
     constexpr int max_N_multi_1d() { return 24; }
 
+    /**
+       @brief Return the maximum size supported by multi-blas kernels
+       (max_N_multi_1d()) rounded down to the largest power of two.
+       This is used for the NXZ power-of-two instantiation.
+    */
     constexpr int max_N_multi_1d_pow2()
     {
       unsigned int v = max_N_multi_1d();
@@ -208,23 +213,29 @@ namespace quda
       using SpinorZ = SpinorX;
       using SpinorW = SpinorX;
 
-      // compute the size remaining for the Y and W accessors
-      constexpr auto arg_size = (max_arg_size<Functor>()
-                                 - sizeof(kernel_param<>)                                      // kernel_param parent
-                                 - sizeof(int)                                                 // NYW parameter
-                                 - sizeof(SpinorX[NXZ])                                        // SpinorX array
-                                 - (Functor::use_z ? sizeof(SpinorZ[NXZ]) : sizeof(SpinorZ *)) // SpinorZ array
-                                 - sizeof(Functor)                                             // functor
-                                 - sizeof(dim3)                                                // threads parameter
-                                 - (!Functor::use_w ? sizeof(SpinorW *) : 0)                   // subtract pointer if not using W
-                                 - (Functor::reducer ? sizeof(ReduceArg<device_reduce_t>) : 0) // reduction buffers
-                                 )
-        / (sizeof(SpinorY) + (Functor::use_w ? sizeof(SpinorW) : 0));
+      constexpr auto arg_known_size = (sizeof(kernel_param<>)                                        // kernel_param parent
+                                       + sizeof(int)                                                 // NYW parameter
+                                       + sizeof(SpinorX[NXZ])                                        // SpinorX array
+                                       + (Functor::use_z ? sizeof(SpinorZ[NXZ]) : sizeof(SpinorZ *)) // SpinorZ array
+                                       + sizeof(Functor)                                             // functor
+                                       + sizeof(dim3)                                                // threads parameter
+                                       + (!Functor::use_w ? sizeof(SpinorW *) : 0)                   // subtract pointer if not using W
+                                       + (Functor::reducer ? sizeof(ReduceArg<device_reduce_t>) : 0) // reduction buffers
+                                       );
 
-      // this is the maximum size limit imposed by the coefficient arrays
-      constexpr auto coeff_size = Functor::coeff_mul ? max_array_size() / (NXZ * sizeof(typename Functor::coeff_t)) : arg_size;
+      // size remaining for the Y and W accessors
+      constexpr auto arg_remainder_size = max_arg_size<Functor>() - arg_known_size;
+      static_assert(static_cast<int64_t>(max_arg_size<Functor>()) - static_cast<int64_t>(arg_known_size) > 0, "Remainder size not positive");
 
-      return std::min(arg_size, coeff_size);
+      // maximum NYW size based on max arg size
+      constexpr auto arg_nyw = arg_remainder_size / (sizeof(SpinorY) + (Functor::use_w ? sizeof(SpinorW) : 0));
+      static_assert(arg_nyw != 0, "arg_nyw size is zero");
+
+      // maximum NYW imposed by the coefficients
+      constexpr auto coeff_nyw = Functor::coeff_mul ? max_array_size() / (NXZ * sizeof(typename Functor::coeff_t)) : arg_nyw;
+      static_assert(coeff_nyw != 0, "coeff_nyw is zero");
+
+      return std::min(arg_nyw, coeff_nyw);
     }
 
     /**

--- a/include/multi_blas_helper.cuh
+++ b/include/multi_blas_helper.cuh
@@ -291,9 +291,6 @@ namespace quda
       if (f.NYW > NYW_max) errorQuda("NYW exceeds max size (%d > %d)", f.NYW, NYW_max);
       if ( !(f.reducer || f.multi_1d) && NXZ * f.NYW * sizeof(typename Functor::coeff_t) > max_array_size())
         errorQuda("Coefficient matrix exceeds max size (%lu > %lu)", NXZ * f.NYW * sizeof(typename Functor::coeff_t), max_array_size());
-      if (f.reducer && NXZ * f.NYW > max_n_reduce())
-        errorQuda("NXZ * NYW = %d exceeds maximum number of reductions %d * %d > %d",
-                  NXZ * f.NYW, NXZ, f.NYW, max_n_reduce());
       if (Functor::multi_1d && std::min(NXZ, f.NYW) != 1)
         errorQuda("Expected 1-d multi-blas but appears 2-d (NXZ = %d, NYW = %d)", NXZ, f.NYW);
       if (Functor::multi_1d && std::max(NXZ, f.NYW) > max_N_multi_1d())

--- a/include/multi_blas_helper.cuh
+++ b/include/multi_blas_helper.cuh
@@ -150,16 +150,9 @@ namespace quda
        NXZ unroll for multi-reductions lead to poor performance due to
        register spilling.
        @tparam reducer Whether we using a reducer
-       @tparam fixed Whether we are using fixed point
        @return Max power of two
      */
-#if QUDA_PRECISION <= 3
-    // if we only have a fixed-point build then we need this WAR to avoid some invalid template instantiations
-    // this is temporary - can be removed once the norm and v pointers are fused
-    template <bool reducer, bool fixed> constexpr int max_NXZ_power2() { return reducer ? 16 : 64; }
-#else
-    template <bool reducer, bool fixed> constexpr int max_NXZ_power2() { return reducer ? 16 : (fixed ? 64 : 128); }
-#endif
+    template <bool reducer> constexpr int max_NXZ_power2() { return reducer ? 16 : 128; }
 
     /**
        @brief Return the maximum power of two enabled by default for
@@ -168,10 +161,9 @@ namespace quda
        NXZ unroll for multi-reductions lead to poor performance due to
        register spilling.
        @param[in] reducer Whether we using a reducer
-       @param[in] fixed Whether we are using fixed point
        @return Max power of two
     */
-    inline int max_NXZ_power2(bool reducer, bool fixed = false) { return reducer ? 16 : (fixed ? 64 : 128); }
+    inline int max_NXZ_power2(bool reducer) { return reducer ? 16 : 128; }
 
     /**
        @brief Return if the requested nxz parameter is valid or
@@ -180,10 +172,10 @@ namespace quda
        @param[in] nxz Requested nxz parameter
        @return True if valid, false if not
      */
-    inline bool is_valid_NXZ(int nxz, bool reducer, bool fixed = false)
+    inline bool is_valid_NXZ(int nxz, bool reducer)
     {
       if (nxz <= MAX_MULTI_BLAS_N || // all values below MAX_MULTI_BLAS_N are valid
-          (is_power2(nxz) && nxz <= max_NXZ_power2(reducer, fixed))) {
+          (is_power2(nxz) && nxz <= max_NXZ_power2(reducer))) {
         return true;
       } else {
         return false;
@@ -258,7 +250,7 @@ namespace quda
     {
       bool x_fixed = x_prec < QUDA_SINGLE_PRECISION;
       bool y_fixed = y_prec < QUDA_SINGLE_PRECISION;
-      NXZ = is_valid_NXZ(NXZ, Functor::reducer, x_fixed) ? NXZ : MAX_MULTI_BLAS_N; // ensure NXZ is a valid size
+      NXZ = is_valid_NXZ(NXZ, Functor::reducer) ? NXZ : MAX_MULTI_BLAS_N; // ensure NXZ is a valid size
       size_t spinor_x_size = x_fixed ? sizeof(Spinor<short, 4>) : sizeof(Spinor<float, 4>);
       size_t spinor_y_size = y_fixed ? sizeof(Spinor<short, 4>) : sizeof(Spinor<float, 4>);
       size_t spinor_z_size = spinor_x_size;
@@ -293,8 +285,7 @@ namespace quda
       constexpr int NYW_max = max_YW_size<NXZ, store_t, y_store_t, Functor>();
       const int NYW_max_check = max_YW_size<Functor>(x.size(), x[0]->Precision(), y[0]->Precision());
 
-      if (!is_valid_NXZ(NXZ, f.reducer, x[0]->Precision() < QUDA_SINGLE_PRECISION))
-        errorQuda("NXZ=%d is not a valid size ( MAX_MULTI_BLAS_N %d)", NXZ, MAX_MULTI_BLAS_N);
+      if (!is_valid_NXZ(NXZ, f.reducer)) errorQuda("NXZ=%d is not a valid size ( MAX_MULTI_BLAS_N %d)", NXZ, MAX_MULTI_BLAS_N);
       if (NXZ != (int)x.size()) errorQuda("Compile-time %d and run-time %lu NXZ do not match", NXZ, x.size());
       if (NYW_max != NYW_max_check) errorQuda("Compile-time %d and run-time %d limits disagree", NYW_max, NYW_max_check);
       if (f.NYW > NYW_max) errorQuda("NYW exceeds max size (%d > %d)", f.NYW, NYW_max);

--- a/include/quda_constants.h
+++ b/include/quda_constants.h
@@ -54,10 +54,3 @@
  * increased if needed.
  */
 #define QUDA_MAX_MG_LEVEL 5
-
-/**
- * @def QUDA_MAX_MULTI_REDUCE
- * @brief Maximum number of simultaneous reductions that can take
- * place.  This number may be increased if needed.
- */
-#define QUDA_MAX_MULTI_REDUCE 1024

--- a/include/reducer.h
+++ b/include/reducer.h
@@ -24,9 +24,18 @@ namespace quda
   namespace reducer
   {
     /**
-       @return the reduce buffer size allocated
+       @brief Inititalizes any persistent buffers required for performing global
+       reductions.  If necessary, any previously allocated buffers will be resized.
+       @param n_reduce The number of reductions to perform
+       @param reduce_size Size in bytes of each value
     */
-    size_t buffer_size();
+    void init(int n_reduce, size_t reduce_size);
+
+    /**
+       @brief Free any persistent buffers associated with global
+       reductions.
+    */
+    void destroy();
 
     /**
        @return pointer to device reduction buffer
@@ -58,8 +67,6 @@ namespace quda
      */
     qudaEvent_t &get_event();
   } // namespace reducer
-
-  constexpr int max_n_reduce() { return QUDA_MAX_MULTI_REDUCE; }
 
   /**
      plus reducer, used for conventional sum reductions

--- a/include/targets/cuda/reduce_helper.h
+++ b/include/targets/cuda/reduce_helper.h
@@ -63,7 +63,8 @@ namespace quda
     template <int, int, typename Reducer, typename Arg, typename I>
     friend __device__ void reduce(Arg &, const Reducer &, const I &, const int);
     qudaError_t launch_error; /** only do complete if no launch error to avoid hang */
-    static constexpr unsigned int max_n_batch_block = 1; /** by default reductions do not support batching withing the block */
+    static constexpr unsigned int max_n_batch_block
+      = 1; /** by default reductions do not support batching withing the block */
 
   private:
     const int n_reduce; /** number of reductions of length n_item */
@@ -164,7 +165,8 @@ namespace quda
   template <int block_size_x, int block_size_y, typename Reducer, typename Arg, typename T>
   __device__ inline void reduce(Arg &arg, const Reducer &r, const T &in, const int idx)
   {
-    constexpr auto n_batch_block = std::min(Arg::max_n_batch_block, device::max_block_size() / (block_size_x * block_size_y));
+    constexpr auto n_batch_block
+      = std::min(Arg::max_n_batch_block, device::max_block_size() / (block_size_x * block_size_y));
     using BlockReduce = BlockReduce<T, block_size_x, block_size_y, n_batch_block, true>;
     __shared__ bool isLastBlockDone[n_batch_block];
 

--- a/include/targets/cuda/reduce_helper.h
+++ b/include/targets/cuda/reduce_helper.h
@@ -90,18 +90,14 @@ namespace quda
       launch_error(QUDA_ERROR_UNINITIALIZED),
       n_reduce(n_reduce),
       reset(reset),
-      partial(static_cast<decltype(partial)>(reducer::get_device_buffer())),
-      result_d(static_cast<decltype(result_d)>(reducer::get_mapped_buffer())),
-      result_h(static_cast<decltype(result_h)>(reducer::get_host_buffer())),
-      count {reducer::get_count<count_t>()},
       consumed(false)
     {
-      // check reduction buffers are large enough if requested
-      auto max_reduce_blocks = 2 * device::processor_count();
-      auto reduce_size = max_reduce_blocks * n_reduce * sizeof(*partial);
-      if (reduce_size > reducer::buffer_size())
-        errorQuda("Requested reduction requires a larger buffer %lu than allocated %lu", reduce_size,
-                  reducer::buffer_size());
+      reducer::init(n_reduce, sizeof(*partial));
+      // these buffers may be allocated in init, so we can't set the local copies until now
+      partial = static_cast<decltype(partial)>(reducer::get_device_buffer());
+      result_d = static_cast<decltype(result_d)>(reducer::get_mapped_buffer());
+      result_h = static_cast<decltype(result_h)>(reducer::get_host_buffer());
+      count = reducer::get_count<count_t>();
 
       if (!commAsyncReduction()) {
         // initialize the result buffer so we can test for completion

--- a/include/targets/cuda/reduction_kernel.h
+++ b/include/targets/cuda/reduction_kernel.h
@@ -99,10 +99,10 @@ namespace quda
   /**
      @brief MultiReduction_impl is the implementation of the generic
      multi-reduction kernel.  Functors that utilize this kernel have
-     three parallelization dimensions.  The y thread dimenion is a
-     batch dimension that is not contracted in the reduction.  The z
-     thread dimension is constrained to remain inside the thread block
-     and this dimension is contracted in the reduction.
+     three parallelization dimensions.  The y thread dimension is
+     constrained to remain inside the thread block and this dimension
+     is contracted in the reduction.  The z thread dimension is a
+     batch dimension that is not contracted in the reduction.
 
      @tparam Functor Kernel functor that defines the kernel
      @tparam Arg Kernel argument struct that set any required meta
@@ -118,15 +118,15 @@ namespace quda
     Functor<Arg> t(arg);
 
     auto idx = threadIdx.x + blockIdx.x * blockDim.x;
-    auto j = threadIdx.y + blockIdx.y * blockDim.y;
-    auto k = threadIdx.z;
+    auto k = threadIdx.y;
+    auto j = threadIdx.z + blockIdx.z * blockDim.z;
 
-    if (j >= arg.threads.y) return;
+    if (j >= arg.threads.z) return;
 
     reduce_t value = arg.init();
 
     while (idx < arg.threads.x) {
-      value = t(value, idx, j, k);
+      value = t(value, idx, k, j);
       if (grid_stride)
         idx += blockDim.x * gridDim.x;
       else

--- a/include/targets/generic/reduce_helper.h
+++ b/include/targets/generic/reduce_helper.h
@@ -33,7 +33,8 @@ namespace quda
     template <int, int, typename Reducer, typename Arg, typename I>
     friend __device__ void reduce(Arg &, const Reducer &, const I &, const int);
     qudaError_t launch_error; /** only do complete if no launch error to avoid hang */
-    static constexpr unsigned int max_n_batch_block = 1; /** by default reductions do not support batching withing the block */
+    static constexpr unsigned int max_n_batch_block
+      = 1; /** by default reductions do not support batching withing the block */
 
   private:
     const int n_reduce; /** number of reductions of length n_item */
@@ -49,9 +50,7 @@ namespace quda
        @param[in] n_reduce The number of reductions
     */
     ReduceArg(dim3 threads, int n_reduce = 1, bool = false) :
-      kernel_param<use_kernel_arg>(threads),
-      launch_error(QUDA_ERROR_UNINITIALIZED),
-      n_reduce(n_reduce)
+      kernel_param<use_kernel_arg>(threads), launch_error(QUDA_ERROR_UNINITIALIZED), n_reduce(n_reduce)
     {
       reducer::init(n_reduce, sizeof(*partial));
       // these buffers may be allocated in init, so we can't set the local copies until now
@@ -104,7 +103,8 @@ namespace quda
   template <int block_size_x, int block_size_y, typename Reducer, typename Arg, typename T>
   __device__ inline void reduce(Arg &arg, const Reducer &r, const T &in, const int idx)
   {
-    constexpr auto n_batch_block = std::min(Arg::max_n_batch_block, device::max_block_size() / (block_size_x * block_size_y));
+    constexpr auto n_batch_block
+      = std::min(Arg::max_n_batch_block, device::max_block_size() / (block_size_x * block_size_y));
     using BlockReduce = BlockReduce<T, block_size_x, block_size_y, n_batch_block, true>;
     __shared__ bool isLastBlockDone[n_batch_block];
 

--- a/include/targets/generic/reduce_helper.h
+++ b/include/targets/generic/reduce_helper.h
@@ -33,6 +33,7 @@ namespace quda
     template <int, int, typename Reducer, typename Arg, typename I>
     friend __device__ void reduce(Arg &, const Reducer &, const I &, const int);
     qudaError_t launch_error; /** only do complete if no launch error to avoid hang */
+    static constexpr unsigned int max_n_batch_block = 1; /** by default reductions do not support batching withing the block */
 
   private:
     const int n_reduce; /** number of reductions of length n_item */
@@ -107,10 +108,11 @@ namespace quda
   template <int block_size_x, int block_size_y, typename Reducer, typename Arg, typename T>
   __device__ inline void reduce(Arg &arg, const Reducer &r, const T &in, const int idx)
   {
-    using BlockReduce = BlockReduce<T, block_size_x, block_size_y>;
-    __shared__ bool isLastBlockDone;
+    constexpr auto n_batch_block = std::min(Arg::max_n_batch_block, device::max_block_size() / (block_size_x * block_size_y));
+    using BlockReduce = BlockReduce<T, block_size_x, block_size_y, n_batch_block, true>;
+    __shared__ bool isLastBlockDone[n_batch_block];
 
-    T aggregate = BlockReduce().Reduce(in, r);
+    T aggregate = BlockReduce(target::thread_idx().z).Reduce(in, r);
 
     if (target::thread_idx().x == 0 && target::thread_idx().y == 0) {
       arg.partial[idx * target::grid_dim().x + target::block_idx().x] = aggregate;
@@ -120,13 +122,13 @@ namespace quda
       auto value = atomicInc(&arg.count[idx], target::grid_dim().x);
 
       // determine if last block
-      isLastBlockDone = (value == (target::grid_dim().x - 1));
+      isLastBlockDone[target::thread_idx().z] = (value == (target::grid_dim().x - 1));
     }
 
     __syncthreads();
 
     // finish the reduction if last block
-    if (isLastBlockDone) {
+    if (isLastBlockDone[target::thread_idx().z]) {
       auto i = target::thread_idx().y * block_size_x + target::thread_idx().x;
       T sum = arg.init();
       while (i < target::grid_dim().x) {
@@ -134,7 +136,7 @@ namespace quda
         i += block_size_x * block_size_y;
       }
 
-      sum = BlockReduce().template Reduce<true>(sum, r);
+      sum = BlockReduce(target::thread_idx().z).Reduce(sum, r);
 
       // write out the final reduced value
       if (target::thread_idx().y * block_size_x + target::thread_idx().x == 0) {

--- a/include/tunable_reduction.h
+++ b/include/tunable_reduction.h
@@ -251,7 +251,7 @@ namespace quda
     using TunableReduction2D<block_size_y>::grid_stride;
 
   protected:
-    const int n_batch;
+    const unsigned int n_batch;
 
     /**
        @brief we don't want to inherit TunableReduction2D behaviour
@@ -321,7 +321,7 @@ namespace quda
       if (output_size != input_size) errorQuda("Input %d and output %d length do not match", input_size, output_size);
 
       auto value = MultiReduction_host<Functor, Arg>(arg);
-      for (int j = 0; j < (int)arg.threads.y; j++) {
+      for (int j = 0; j < (int)arg.threads.z; j++) {
         // copy element by element to output vector
         for (int i = 0; i < output_size; i++) {
           reinterpret_cast<typename scalar<T>::type *>(&result[j])[i]
@@ -357,13 +357,13 @@ namespace quda
     }
 
   public:
-    TunableMultiReduction(const LatticeField &field, int n_batch,
+    TunableMultiReduction(const LatticeField &field, unsigned int n_batch,
                           QudaFieldLocation location = QUDA_INVALID_FIELD_LOCATION) :
       TunableReduction2D<block_size_y>(field, location), n_batch(n_batch)
     {
     }
 
-    TunableMultiReduction(size_t n_items, int n_batch, QudaFieldLocation location = QUDA_INVALID_FIELD_LOCATION) :
+    TunableMultiReduction(size_t n_items, unsigned int n_batch, QudaFieldLocation location = QUDA_INVALID_FIELD_LOCATION) :
       TunableReduction2D<block_size_y>(n_items, location), n_batch(n_batch)
     {
     }
@@ -386,15 +386,15 @@ namespace quda
     void initTuneParam(TuneParam &param) const
     {
       Tunable::initTuneParam(param);
-      param.block.y = 1;
-      param.grid.y = n_batch;
+      param.block = {param.block.x, 1, 1};
+      param.grid = {param.grid.x, 1, n_batch};
     }
 
     void defaultTuneParam(TuneParam &param) const
     {
       Tunable::defaultTuneParam(param);
-      param.block.y = 1;
-      param.grid.y = n_batch;
+      param.block = {param.block.x, 1, 1};
+      param.grid = {param.grid.x, 1, n_batch};
     }
   };
 

--- a/include/tunable_reduction.h
+++ b/include/tunable_reduction.h
@@ -387,14 +387,14 @@ namespace quda
     {
       Tunable::initTuneParam(param);
       param.block = {param.block.x, 1, 1};
-      param.grid = {param.grid.x, 1, n_batch};
+      param.grid = {param.grid.x, 1, (n_batch + param.block.z - 1) / param.block.z};
     }
 
     void defaultTuneParam(TuneParam &param) const
     {
       Tunable::defaultTuneParam(param);
       param.block = {param.block.x, 1, 1};
-      param.grid = {param.grid.x, 1, n_batch};
+      param.grid = {param.grid.x, 1, (n_batch + param.block.z - 1) / param.block.z};
     }
   };
 

--- a/include/tunable_reduction.h
+++ b/include/tunable_reduction.h
@@ -304,6 +304,8 @@ namespace quda
     template <template <typename> class Functor, typename T, typename CommReducer = comm_reduce_sum<T>, typename Arg>
     void launch_device(std::vector<T> &result, const TuneParam &tp, const qudaStream_t &stream, Arg &arg)
     {
+      if (n_batch_block_max > Arg::max_n_batch_block)
+        errorQuda("n_batch_block_max = %u greater than maximum supported %u", n_batch_block_max, Arg::max_n_batch_block);
       arg.launch_error = launch<device::max_multi_reduce_block_size<block_size_y>(), Functor>(arg, tp, stream);
 
       if (!commAsyncReduction()) {
@@ -315,6 +317,8 @@ namespace quda
     template <template <typename> class Functor, typename T, typename CommReducer = comm_reduce_sum<T>, typename Arg>
     void launch_host(std::vector<T> &result, const TuneParam &, const qudaStream_t &, Arg &arg)
     {
+      if (n_batch_block_max > Arg::max_n_batch_block)
+        errorQuda("n_batch_block_max = %u greater than maximum supported %u", n_batch_block_max, Arg::max_n_batch_block);
       using reduce_t = typename Functor<Arg>::reduce_t;
 
       int input_size = vec_length<reduce_t>::value;

--- a/include/tunable_reduction.h
+++ b/include/tunable_reduction.h
@@ -364,17 +364,13 @@ namespace quda
   public:
     TunableMultiReduction(const LatticeField &field, unsigned int n_batch, unsigned int n_batch_block_max = 1u,
                           QudaFieldLocation location = QUDA_INVALID_FIELD_LOCATION) :
-      TunableReduction2D<block_size_y>(field, location),
-      n_batch(n_batch),
-      n_batch_block_max(n_batch_block_max)
+      TunableReduction2D<block_size_y>(field, location), n_batch(n_batch), n_batch_block_max(n_batch_block_max)
     {
     }
 
     TunableMultiReduction(size_t n_items, unsigned int n_batch, unsigned int n_batch_block_max = 1u,
                           QudaFieldLocation location = QUDA_INVALID_FIELD_LOCATION) :
-      TunableReduction2D<block_size_y>(n_items, location),
-      n_batch(n_batch),
-      n_batch_block_max(n_batch_block_max)
+      TunableReduction2D<block_size_y>(n_items, location), n_batch(n_batch), n_batch_block_max(n_batch_block_max)
     {
     }
 
@@ -394,9 +390,9 @@ namespace quda
       if (rtn) {
         return true;
       } else {
-        if (param.block.z < n_batch && param.block.z < device::max_threads_per_block_dim(2) &&
-            param.block.x * param.block.y * (param.block.z + 1) <= device::max_threads_per_block() &&
-            param.block.z < n_batch_block_max) {
+        if (param.block.z < n_batch && param.block.z < device::max_threads_per_block_dim(2)
+            && param.block.x * param.block.y * (param.block.z + 1) <= device::max_threads_per_block()
+            && param.block.z < n_batch_block_max) {
           param.block.z++;
           param.grid.z = (n_batch + param.block.z - 1) / param.block.z;
           return true;

--- a/include/tune_quda.h
+++ b/include/tune_quda.h
@@ -146,8 +146,8 @@ namespace quda {
       int nthreads = param.block.x * param.block.y * param.block.z;
       param.shared_bytes = std::max(sharedBytesPerThread() * nthreads, sharedBytesPerBlock(param));
 
-      if (param.block.x > max_threads || param.shared_bytes > max_shared ||
-          param.block.x * param.block.y * param.block.z > device::max_threads_per_block()) {
+      if (param.block.x > max_threads || param.shared_bytes > max_shared
+          || param.block.x * param.block.y * param.block.z > device::max_threads_per_block()) {
         resetBlockDim(param);
         int nthreads = param.block.x * param.block.y * param.block.z;
         param.shared_bytes = std::max(sharedBytesPerThread() * nthreads, sharedBytesPerBlock(param));

--- a/include/tune_quda.h
+++ b/include/tune_quda.h
@@ -146,7 +146,8 @@ namespace quda {
       int nthreads = param.block.x * param.block.y * param.block.z;
       param.shared_bytes = std::max(sharedBytesPerThread() * nthreads, sharedBytesPerBlock(param));
 
-      if (param.block.x > max_threads || param.shared_bytes > max_shared) {
+      if (param.block.x > max_threads || param.shared_bytes > max_shared ||
+          param.block.x * param.block.y * param.block.z > device::max_threads_per_block()) {
         resetBlockDim(param);
         int nthreads = param.block.x * param.block.y * param.block.z;
         param.shared_bytes = std::max(sharedBytesPerThread() * nthreads, sharedBytesPerBlock(param));

--- a/lib/blas_quda.cu
+++ b/lib/blas_quda.cu
@@ -5,11 +5,6 @@
 
 namespace quda {
 
-  namespace reducer {
-    void init();
-    void destroy();
-  }
-  
   namespace blas {
 
     unsigned long long flops;
@@ -149,16 +144,6 @@ namespace quda {
     void zero(ColorSpinorField &a)
     {
       a.zero();
-    }
-
-    void init()
-    {
-      reducer::init();
-    }
-
-    void destroy(void)
-    {
-      reducer::destroy();
     }
 
     void axpbyz(double a, ColorSpinorField &x, double b, ColorSpinorField &y, ColorSpinorField &z)

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -519,7 +519,6 @@ void initQudaMemory()
   createDslashEvents();
 
   blas_lapack::native::init();
-  blas::init();
 
   num_failures_h = static_cast<int *>(mapped_malloc(sizeof(int)));
   num_failures_d = static_cast<int *>(get_mapped_device_pointer(num_failures_h));
@@ -1429,7 +1428,7 @@ void endQuda(void)
 
   blas_lapack::generic::destroy();
   blas_lapack::native::destroy();
-  blas::destroy();
+  reducer::destroy();
 
   pool::flush_pinned();
   pool::flush_device();

--- a/lib/multi_blas_quda.cu
+++ b/lib/multi_blas_quda.cu
@@ -174,7 +174,7 @@ namespace quda {
       {
         // if multi-1d then constrain the templates to no larger than max-1d size
         constexpr int pow2_max = !decltype(f)::multi_1d ? max_NXZ_power2<false, isFixed<store_t>::value>() :
-          std::min(max_N_multi_1d(), max_NXZ_power2<false, isFixed<store_t>::value>());
+          std::min(max_N_multi_1d_pow2(), max_NXZ_power2<false, isFixed<store_t>::value>());
         constexpr int linear_max = !decltype(f)::multi_1d ? MAX_MULTI_BLAS_N : std::min(max_N_multi_1d(), MAX_MULTI_BLAS_N);
 
         if (NXZ <= pow2_max && is_power2(NXZ)) instantiatePow2<pow2_max>(stream);

--- a/lib/multi_reduce_quda.cu
+++ b/lib/multi_reduce_quda.cu
@@ -281,7 +281,7 @@ namespace quda {
         coeff_array<T> a, b, c;
 
 
-        if (x.size() <= tile_size.x && is_valid_NXZ(x.size(), true) && x.size() * y.size() <= (unsigned int)max_n_reduce()) {
+        if (x.size() <= tile_size.x && is_valid_NXZ(x.size(), true)) {
           // problem will fit, so do the computation
           multiReduce<ReducerDiagonal, ReducerOffDiagonal>(tmp_dot, a, b, c, x, y, z, w, i_idx, j_idx);
         } else {
@@ -320,7 +320,7 @@ namespace quda {
         }
 
         // we are at the leaf of the binary tree (e.g., we ran the kernel): perform the row-to-column-major transpose here.
-        if (x.size() <= tile_size.x && is_valid_NXZ(x.size(), true) && x.size() * y.size() <= (unsigned int)max_n_reduce()) {
+        if (x.size() <= tile_size.x && is_valid_NXZ(x.size(), true)) {
           const unsigned int xlen = x.size();
           const unsigned int ylen = y.size();
           for (unsigned int j = 0; j < xlen; j++)

--- a/lib/multi_reduce_quda.cu
+++ b/lib/multi_reduce_quda.cu
@@ -172,7 +172,7 @@ namespace quda {
 
       void apply(const qudaStream_t &stream)
       {
-        constexpr int pow2_max = max_NXZ_power2<true, isFixed<store_t>::value>();
+        constexpr int pow2_max = max_NXZ_power2<true>();
         if (NXZ <= pow2_max && is_power2(NXZ)) instantiatePow2<pow2_max>(stream);
         else if (NXZ <= MAX_MULTI_BLAS_N) instantiateLinear<MAX_MULTI_BLAS_N>(stream);
         else errorQuda("x.size %lu greater than MAX_MULTI_BLAS_N %d", x.size(), MAX_MULTI_BLAS_N);

--- a/lib/multi_reduce_quda.cu
+++ b/lib/multi_reduce_quda.cu
@@ -31,31 +31,12 @@ namespace quda {
         return false;
       }
 
-      bool advanceBlockDim(TuneParam &param) const
-      {
-        if (TunableMultiReduction::advanceBlockDim(param)) {
-          return true;
-        } else {
-          if (param.block.z < n_batch && param.block.z < device::max_threads_per_block_dim(2) &&
-              param.block.x * param.block.y * (param.block.z + 1) <= device::max_threads_per_block() &&
-              param.block.z < max_n_batch_block_multi_reduce()) {
-            param.block.z++;
-            param.grid.z = (n_batch + param.block.z - 1) / param.block.z;
-            return true;
-          } else { // we have run off the end so let's reset
-            param.block.z = 1;
-            param.grid.z = (n_batch + param.block.z - 1) / param.block.z;
-            return false;
-          }
-        }
-      }
-
     public:
       MultiReduce(const T &a, const T &b, const T &c, const ColorSpinorField &, const ColorSpinorField &,
                   std::vector<ColorSpinorField *> &x, std::vector<ColorSpinorField *> &y,
                   std::vector<ColorSpinorField *> &z, std::vector<ColorSpinorField *> &w,
                   host_reduce_t *result) :
-        TunableMultiReduction(*x[0], y.size()),
+        TunableMultiReduction(*x[0], y.size(), max_n_batch_block_multi_reduce()),
         NXZ(x.size()),
         NYW(y.size()),
         r(NXZ, NYW),

--- a/lib/reduce_helper.cu
+++ b/lib/reduce_helper.cu
@@ -18,78 +18,75 @@ namespace quda
   namespace reducer
   {
 
-    // FIXME need to dynamically resize these
     void *get_device_buffer() { return d_reduce; }
     void *get_mapped_buffer() { return hd_reduce; }
     void *get_host_buffer() { return h_reduce; }
     template <> count_t *get_count() { return reduce_count; }
     qudaEvent_t &get_event() { return reduceEnd; }
 
-    size_t buffer_size()
-    {
-      /* we have these different reductions to cater for:
-
-         - regular reductions (reduce_quda.cu) where are reducing to a
-           single vector type (max length 4 presently), and a
-           grid-stride loop with max number of blocks = 2 x SM count
-
-         - multi-reductions where we are reducing to a matrix of size
-           of size QUDA_MAX_MULTI_REDUCE of vectors (max length 4),
-           and a grid-stride loop with maximum number of blocks = 2 x
-           SM count
-      */
-
-      int reduce_size = 4 * sizeof(device_reduce_t);
-      int max_reduce = reduce_size;
-      int max_multi_reduce = max_n_reduce() * reduce_size;
-      int max_reduce_blocks = 2 * device::processor_count();
-
-      // reduction buffer size
-      size_t bytes = max_reduce_blocks * std::max(max_reduce, max_multi_reduce);
-      return bytes;
-    }
+    static size_t allocated_bytes = 0;
+    static int allocated_n_reduce = 0;
 
     template <typename T>
     struct init_reduce : public TunableKernel1D {
       T *reduce_count;
-      long long bytes() const { return max_n_reduce() * sizeof(T); }
-      unsigned int minThreads() const { return max_n_reduce(); }
+      const int n_reduce;
+      long long bytes() const { return n_reduce * sizeof(T); }
+      unsigned int minThreads() const { return n_reduce; }
 
-      init_reduce(T *reduce_count) :
-        TunableKernel1D(max_n_reduce()),
-        reduce_count(reduce_count)
+      init_reduce(T *reduce_count, int n_reduce) :
+        TunableKernel1D(n_reduce, QUDA_CUDA_FIELD_LOCATION),
+        reduce_count(reduce_count),
+        n_reduce(n_reduce)
       { apply(device::get_default_stream()); }
 
       void apply(const qudaStream_t &stream)
       {
-        auto tp = tuneLaunch(*this, getTuning(), getVerbosity());
-        launch_device<init_count>(tp, stream, init_arg<T>(reduce_count));
+        // intentionally do not autotune, since this can be called inside a tuning region
+        auto tp = tuneLaunch(*this, QUDA_TUNE_NO, getVerbosity());
+        launch_device<init_count>(tp, stream, init_arg<T>(reduce_count, n_reduce));
       }
     };
 
-    void init()
+    void init(int n_reduce, size_t reduce_size)
     {
-      auto bytes = buffer_size();
-      if (!d_reduce) d_reduce = (device_reduce_t *)device_malloc(bytes);
+      auto max_reduce_blocks = 2 * device::processor_count();
+      auto bytes = max_reduce_blocks * n_reduce * reduce_size;
 
-      // these arrays are actually oversized currently (only needs to be device_reduce_t x 3)
+      if (allocated_bytes < bytes) {
+        if (getVerbosity() >= QUDA_DEBUG_VERBOSE)
+          printfQuda("reducer::init buffer resizing for n_reduce = %d, reduce_size = %lu, bytes = %lu\n",
+                     n_reduce, reduce_size, bytes);
+        if (d_reduce) device_free(d_reduce);
+        d_reduce = static_cast<device_reduce_t *>(device_malloc(bytes));
 
-      if (!h_reduce) {
-        h_reduce = (device_reduce_t *)mapped_malloc(bytes);
-        hd_reduce = (device_reduce_t *)get_mapped_device_pointer(h_reduce); // set the matching device pointer
+        if (h_reduce) host_free(h_reduce);
+        h_reduce = static_cast<device_reduce_t *>(mapped_malloc(bytes));
+        hd_reduce = static_cast<device_reduce_t *>(get_mapped_device_pointer(h_reduce)); // set the matching device pointer
 
         using system_atomic_t = device_reduce_t;
         size_t n_reduce = bytes / sizeof(system_atomic_t);
         auto *atomic_buf = reinterpret_cast<system_atomic_t *>(h_reduce);
         for (size_t i = 0; i < n_reduce; i++) new (atomic_buf + i) system_atomic_t {0}; // placement new constructor
+
+        allocated_bytes = bytes;
       }
 
-      if (!reduce_count) {
-        reduce_count = static_cast<count_t *>(device_malloc(max_n_reduce() * sizeof(decltype(*reduce_count))));
-        init_reduce<count_t> init(reduce_count);
+      if (allocated_n_reduce < n_reduce) {
+        if (getVerbosity() >= QUDA_DEBUG_VERBOSE)
+          printfQuda("reducer::init count resizing for n_reduce = %d\n", n_reduce);
+        if (reduce_count) device_free(reduce_count);
+        reduce_count = static_cast<count_t *>(device_malloc(n_reduce * sizeof(count_t)));
+        init_reduce<count_t> init(reduce_count, n_reduce);
+
+        allocated_n_reduce = n_reduce;
       }
 
-      reduceEnd = qudaEventCreate();
+      static bool init_event = false;
+      if (!init_event) {
+        reduceEnd = qudaEventCreate();
+        init_event = true;
+      }
     }
 
     void destroy()
@@ -102,13 +99,13 @@ namespace quda
       }
       if (d_reduce) {
         device_free(d_reduce);
-        d_reduce = 0;
+        d_reduce = nullptr;
       }
       if (h_reduce) {
         host_free(h_reduce);
-        h_reduce = 0;
+        h_reduce = nullptr;
       }
-      hd_reduce = 0;
+      hd_reduce = nullptr;
     }
 
   } // namespace reducer

--- a/lib/transform_reduce.cu
+++ b/lib/transform_reduce.cu
@@ -39,7 +39,7 @@ namespace quda
   public:
     TransformReduce(QudaFieldLocation location, std::vector<reduce_t> &result, const std::vector<T *> &v, count_t n_items,
                     transformer &h, reduce_t init, reducer &r) :
-      TunableMultiReduction(n_items, v.size(), location),
+      TunableMultiReduction(n_items, v.size(), Arg::max_n_batch_block, location),
       location(location),
       result(result),
       v(v),

--- a/lib/transform_reduce.cu
+++ b/lib/transform_reduce.cu
@@ -30,12 +30,6 @@ namespace quda
 
     bool tuneSharedBytes() const { return false; }
 
-    void initTuneParam(TuneParam &param) const
-    {
-      Tunable::initTuneParam(param);
-      param.grid.y = v.size();
-    }
-
   public:
     TransformReduce(QudaFieldLocation location, std::vector<reduce_t> &result, const std::vector<T *> &v, count_t n_items,
                     transformer &h, reduce_t init, reducer &r) :

--- a/tests/blas_test.cpp
+++ b/tests/blas_test.cpp
@@ -176,10 +176,7 @@ bool is_site_unroll(Kernel kernel)
 }
 
 // return false if kernel does not support mixed precision (y prec > x prec)
-bool is_mixed(Kernel kernel)
-{
-  return (kernel != Kernel::caxpyz_block);
-}
+bool is_mixed(Kernel kernel) { return (kernel != Kernel::caxpyz_block); }
 
 bool skip_kernel(prec_pair_t pair, Kernel kernel)
 {

--- a/tests/blas_test.cpp
+++ b/tests/blas_test.cpp
@@ -37,7 +37,7 @@ ColorSpinorField *xoH, *yoH, *zoH;
 std::unique_ptr<ColorSpinorField> xD, yD, zD, wD, vD;
 
 // these are pointers to the device multi-fields that have "this precision"
-std::unique_ptr<ColorSpinorField> xmD, ymD, zmD;
+std::unique_ptr<ColorSpinorField> xmD, ymD, zmD, wmD;
 
 // these are pointers to the device fields that have "this precision"
 std::unique_ptr<ColorSpinorField> xoD, yoD, zoD, woD, voD;
@@ -49,6 +49,7 @@ std::unique_ptr<ColorSpinorField> xmoD, ymoD, zmoD;
 std::vector<ColorSpinorField *> xmH;
 std::vector<ColorSpinorField *> ymH;
 std::vector<ColorSpinorField *> zmH;
+std::vector<ColorSpinorField *> wmH;
 int Nspin;
 int Ncolor;
 
@@ -106,6 +107,7 @@ enum class Kernel {
   caxpyBzpx,
   axpy_block,
   caxpy_block,
+  caxpyz_block,
   axpyBzpcx_block,
   reDotProductNorm_block,
   reDotProduct_block,
@@ -149,6 +151,7 @@ const std::map<Kernel, std::string> kernel_map
      {Kernel::caxpyBzpx, "caxpyBzpx"},
      {Kernel::axpy_block, "axpy_block"},
      {Kernel::caxpy_block, "caxpy_block"},
+     {Kernel::caxpyz_block, "caxpyz_block"},
      {Kernel::axpyBzpcx_block, "axpyBzpcx_block"},
      {Kernel::reDotProductNorm_block, "reDotProductNorm_block"},
      {Kernel::reDotProduct_block, "reDotProduct_block"},
@@ -170,6 +173,12 @@ bool is_copy(Kernel kernel) { return (kernel == Kernel::copyHS || kernel == Kern
 bool is_site_unroll(Kernel kernel)
 {
   return (kernel == Kernel::HeavyQuarkResidualNorm || kernel == Kernel::xpyHeavyQuarkResidualNorm);
+}
+
+// return false if kernel does not support mixed precision (y prec > x prec)
+bool is_mixed(Kernel kernel)
+{
+  return (kernel != Kernel::caxpyz_block);
 }
 
 bool skip_kernel(prec_pair_t pair, Kernel kernel)
@@ -196,6 +205,9 @@ bool skip_kernel(prec_pair_t pair, Kernel kernel)
     // only benchmark heavy-quark norm if doing 3 colors
     return true;
   }
+
+  // only test mixed precision if supported
+  if (!is_mixed(kernel) && this_prec != other_prec) return true;
 
   return false;
 }
@@ -248,6 +260,8 @@ void initFields(prec_pair_t prec_pair)
   for (int cid = 0; cid < Msrc; cid++) ymH.push_back(new ColorSpinorField(param));
   zmH.reserve(Nsrc);
   for (int cid = 0; cid < Nsrc; cid++) zmH.push_back(new ColorSpinorField(param));
+  wmH.reserve(Nsrc);
+  for (int cid = 0; cid < Msrc; cid++) wmH.push_back(new ColorSpinorField(param));
 
   vH->Source(QUDA_RANDOM_SOURCE, 0, 0, 0);
   wH->Source(QUDA_RANDOM_SOURCE, 0, 0, 0);
@@ -293,6 +307,9 @@ void initFields(prec_pair_t prec_pair)
   param.composite_dim = Nsrc;
   zmD = std::make_unique<ColorSpinorField>(param);
 
+  param.composite_dim = Msrc;
+  wmD = std::make_unique<ColorSpinorField>(param);
+
   param.setPrecision(prec_other, prec_other, true);
   param.composite_dim = Nsrc;
   xmoD = std::make_unique<ColorSpinorField>(param);
@@ -331,6 +348,7 @@ void freeFields()
   xmD.reset();
   ymD.reset();
   zmD.reset();
+  wmD.reset();
   xmoD.reset();
   ymoD.reset();
   zmoD.reset();
@@ -344,9 +362,11 @@ void freeFields()
   for (int i = 0; i < Nsrc; i++) delete xmH[i];
   for (int i = 0; i < Msrc; i++) delete ymH[i];
   for (int i = 0; i < Nsrc; i++) delete zmH[i];
+  for (int i = 0; i < Msrc; i++) delete wmH[i];
   xmH.clear();
   ymH.clear();
   zmH.clear();
+  wmH.clear();
 }
 
 double benchmark(Kernel kernel, const int niter)
@@ -491,6 +511,10 @@ double benchmark(Kernel kernel, const int niter)
 
     case Kernel::caxpy_block:
       for (int i = 0; i < niter; ++i) blas::caxpy(A, *xmD, *ymoD);
+      break;
+
+    case Kernel::caxpyz_block:
+      for (int i = 0; i < niter; ++i) blas::caxpyz(A, *xmD, *ymD, *wmD);
       break;
 
     case Kernel::axpyBzpcx_block:
@@ -867,12 +891,28 @@ double test(Kernel kernel)
     for (int i = 0; i < Msrc; i++) ymoD->Component(i) = *(ymH[i]);
 
     blas::caxpy(A, *xmD, *ymoD);
-    for (int i = 0; i < Nsrc; i++) {
-      for (int j = 0; j < Msrc; j++) { blas::caxpy(A[Msrc * i + j], *(xmH[i]), *(ymH[j])); }
+    for (int j = 0; j < Msrc; j++) {
+      for (int i = 0; i < Nsrc; i++) { blas::caxpy(A[Msrc * i + j], *(xmH[i]), *(ymH[j])); }
     }
     error = 0;
     for (int i = 0; i < Msrc; i++) {
       error += fabs(blas::norm2((ymoD->Component(i))) - blas::norm2(*(ymH[i]))) / blas::norm2(*(ymH[i]));
+    }
+    error /= Msrc;
+    break;
+
+  case Kernel::caxpyz_block:
+    for (int i = 0; i < Nsrc; i++) xmD->Component(i) = *(xmH[i]);
+    for (int i = 0; i < Msrc; i++) ymD->Component(i) = *(ymH[i]);
+
+    blas::caxpyz(A, *xmD, *ymD, *wmD);
+    for (int j = 0; j < Msrc; j++) {
+      *wmH[j] = *ymH[j];
+      for (int i = 0; i < Nsrc; i++) { blas::caxpy(A[Msrc * i + j], *(xmH[i]), *(wmH[j])); }
+    }
+    error = 0;
+    for (int i = 0; i < Msrc; i++) {
+      error += fabs(blas::norm2((wmD->Component(i))) - blas::norm2(*(wmH[i]))) / blas::norm2(*(wmH[i]));
     }
     error /= Msrc;
     break;


### PR DESCRIPTION
Primarily a quality-of-life and bug-fix PR aimed at the blas, as well as some foundational building blocks for future additions:

### Features
* Reduction buffers are now resized on demand.  This removes any artificial limit on the number of concurrent reductions.
* Multi-reductions now perform batching over the z dimension, e.g., a swizzling of the y-z thread indices
* Add support for batched reductions within the thread block (over the z thread dimension).  Utilized by multi_reduce_quda.cu (but only enabled by default with fast-compilation enabled)

### Bug fixes
* Fix bug with multi-1d multi-blas kernel template instantiation (this fixes BiCGStab(l) for example)
* Improved robustness of multi-blas NYW calculation
* Fix bug in multi `caxpyz` and add this kernel to blas_test (fixes CA-CG)
* Fixed-point (half/quarter) multi-blas kernels now have the same size limit as single/double
* Fix bug in `Tunable::advanceBlockDim` to take into account 3-d block size
* Fix issue with multi-blas when using warp splitting (thread count must be divisible by warp size)
 