### PR TITLE
Enable random momentum field

### DIFF
--- a/include/instantiate.h
+++ b/include/instantiate.h
@@ -21,8 +21,8 @@ namespace quda
 #endif
 
   struct ReconstructFull {
-    static constexpr std::array<QudaReconstructType, 5> recon
-      = {QUDA_RECONSTRUCT_NO, QUDA_RECONSTRUCT_13, QUDA_RECONSTRUCT_12, QUDA_RECONSTRUCT_9, QUDA_RECONSTRUCT_8};
+    static constexpr std::array<QudaReconstructType, 6> recon
+      = {QUDA_RECONSTRUCT_NO, QUDA_RECONSTRUCT_13, QUDA_RECONSTRUCT_12, QUDA_RECONSTRUCT_9, QUDA_RECONSTRUCT_8, QUDA_RECONSTRUCT_10};
   };
 
   struct ReconstructWilson {

--- a/include/kernels/gauge_random.cuh
+++ b/include/kernels/gauge_random.cuh
@@ -85,19 +85,23 @@ namespace quda {
       getCoords(x, x_cb, arg.X, parity);
       for (int dr = 0; dr < 4; ++dr) x[dr] += arg.border[dr]; // extended grid coordinates
 
-      if (arg.group && arg.sigma == 0.0) {
+      if (arg.group and arg.sigma == 0.0) {
         // if sigma = 0 then we just set the output matrix to the identity and finish
         Link I;
         setIdentity(&I);
         for (int mu = 0; mu < 4; mu++) arg.U(mu, linkIndex(x, arg.E), parity) = I;
+      } else if (not arg.group and arg.sigma == 0.0) {
+        // if sigma = 0 then we just set the output matrix to the zero and finish
+        Link O;
+        setZero(&O);
+        for (int mu = 0; mu < 4; mu++) arg.U(mu, linkIndex(x, arg.E), parity) = O;
       } else {
         for (int mu = 0; mu < 4; mu++) {
           RNGState localState = arg.rng[parity * arg.threads.x + x_cb];
 
           // generate Gaussian distributed su(n) fiueld
-          Link u = gauss_su3<real, Link>(localState);
+          Link u = arg.sigma * gauss_su3<real, Link>(localState);
           if (arg.group) {
-            u = arg.sigma * u;
             expsu3<real>(u);
           }
           arg.U(mu, linkIndex(x, arg.E), parity) = u;

--- a/lib/instantiate.cpp
+++ b/lib/instantiate.cpp
@@ -11,7 +11,7 @@ namespace quda
 {
 
   // declared in instantiate.h
-  constexpr std::array<QudaReconstructType, 5> ReconstructFull::recon;
+  constexpr std::array<QudaReconstructType, 6> ReconstructFull::recon;
   constexpr std::array<QudaReconstructType, 3> ReconstructWilson::recon;
   constexpr std::array<QudaReconstructType, 3> ReconstructStaggered::recon;
   constexpr std::array<QudaReconstructType, 2> ReconstructNo12::recon;


### PR DESCRIPTION
This PR
- enables `gauge_random` for momentum field (adds `RECONSTRUCT_10` to `ReconstructFull`)
- makes usage of `sigma` in creating a random algebra (original behavior is maintained for sigma=1)