### PR TITLE
Renamed QUDAVersion.cmake to QUDAConfigVersion.cmake. It is the conve…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -661,9 +661,9 @@ include(CMakePackageConfigHelpers)
 configure_package_config_file(QUDAConfig.cmake.in QUDAConfig.cmake INSTALL_DESTINATION lib/cmake/QUDA)
 
 write_basic_package_version_file(
-	QUDAVersion.cmake
+	QUDAConfigVersion.cmake
 	VERSION ${PACKAGE_VERSION}
 	COMPATIBILITY AnyNewerVersion)
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/QUDAVersion.cmake ${CMAKE_CURRENT_BINARY_DIR}/QUDAConfig.cmake
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/QUDAConfigVersion.cmake ${CMAKE_CURRENT_BINARY_DIR}/QUDAConfig.cmake
 	DESTINATION lib/cmake/QUDA)


### PR DESCRIPTION
…ntion

This is a minor conventional change. I have found that if I actually want to match on a version, the version file CMake looks for is actually 'QUDAConfigVersion.cmake' rather than `QUDAVersion.cmake`