### PR TITLE
Hotfix for injecting `p` vector from multi-shift into 0th refinement solve

### DIFF
--- a/include/invert_quda.h
+++ b/include/invert_quda.h
@@ -709,7 +709,6 @@ namespace quda {
   private:
     // pointers to fields to avoid multiple creation overhead
     ColorSpinorField *yp, *rp, *rnewp, *pp, *App, *tmpp, *tmp2p, *tmp3p, *rSloppyp, *xSloppyp;
-    std::vector<ColorSpinorField*> p;
     bool init;
 
   public:

--- a/include/invert_x_update.h
+++ b/include/invert_x_update.h
@@ -33,8 +33,16 @@ struct XUpdateBatch {
   XUpdateBatch(int Np_, const ColorSpinorField &init, ColorSpinorParam csParam) :
     _Np(Np_), _j(0), _next((_j + 1) % _Np), _ps(_Np), _alphas(_Np)
   {
-    _ps[0] = std::unique_ptr<ColorSpinorField>(new ColorSpinorField(init));
     for (int j = 1; j < _Np; j++) { _ps[j] = std::unique_ptr<ColorSpinorField>(new ColorSpinorField(csParam)); }
+
+    // need to make sure init field is copied in the correct precision
+    if (init.Precision() != csParam.Precision()) {
+      csParam.create = QUDA_COPY_FIELD_CREATE;
+      csParam.field = const_cast<ColorSpinorField*>(&init);
+      _ps[0] = std::unique_ptr<ColorSpinorField>(new ColorSpinorField(csParam));
+    } else {
+      _ps[0] = std::unique_ptr<ColorSpinorField>(new ColorSpinorField(init));
+    }
   }
 
   /**

--- a/lib/inv_cg_quda.cpp
+++ b/lib/inv_cg_quda.cpp
@@ -377,10 +377,10 @@ namespace quda {
     double r2_old = 0.0;
     if (r2_old_init != 0.0 and p_init) {
       r2_old = r2_old_init;
-      Complex rp = blas::cDotProduct(rSloppy, *p_init) / (r2);
-      blas::caxpy(-rp, rSloppy, *p_init);
+      Complex rp = blas::cDotProduct(rSloppy, x_update_batch.get_current_field()) / (r2);
+      blas::caxpy(-rp, rSloppy, x_update_batch.get_current_field());
       beta = r2 / r2_old;
-      blas::xpayz(rSloppy, beta, *p_init, *p_init);
+      blas::xpayz(rSloppy, beta, x_update_batch.get_current_field(), x_update_batch.get_current_field());
     }
 
     const bool use_heavy_quark_res =

--- a/lib/inv_cg_quda.cpp
+++ b/lib/inv_cg_quda.cpp
@@ -40,7 +40,6 @@ namespace quda {
   {
     if (!param.is_preconditioner) profile.TPSTART(QUDA_PROFILE_FREE);
     if ( init ) {
-      for (auto pi : p) if (pi) delete pi;
       if (rp) delete rp;
       if (pp) delete pp;
       if (yp) delete yp;
@@ -378,10 +377,10 @@ namespace quda {
     double r2_old = 0.0;
     if (r2_old_init != 0.0 and p_init) {
       r2_old = r2_old_init;
-      Complex rp = blas::cDotProduct(rSloppy, *p[0]) / (r2);
-      blas::caxpy(-rp, rSloppy, *p[0]);
+      Complex rp = blas::cDotProduct(rSloppy, *p_init) / (r2);
+      blas::caxpy(-rp, rSloppy, *p_init);
       beta = r2 / r2_old;
-      blas::xpayz(rSloppy, beta, *p[0], *p[0]);
+      blas::xpayz(rSloppy, beta, *p_init, *p_init);
     }
 
     const bool use_heavy_quark_res =


### PR DESCRIPTION
This hotfix addresses #1244 .

See title. The issue was the `std::vector<ColorSpinorField> p;` used for pipelining was moved into `XUpdateBatch`, as did its allocation and _almost_ all references from it in `CG::operator(...)` --- the one exception being in the setup when an initial `p` is injected from a multi-shift solve.

This has now been addressed by replacing `p[0]` with `*p_init` during solver start-up (as opposed to `x_update_batch.get_current_field()` for clarity). I also removed the `std::vector<ColorSpinorField*> p;` from the declaration of `CG` as well, and cleaned up a few (harmess) compiler errors downstream from that.

@kostrzewa this passes your minimal repro, and I'm in the process of testing a few other workflows now. That said, I don't expect surprises. I'm sorry about this, again.