### PR TITLE
Hotfix/overflow test fixes

### DIFF
--- a/lib/dslash_policy.cuh
+++ b/lib/dslash_policy.cuh
@@ -1736,7 +1736,7 @@ namespace quda
   inline void enable_policy(QudaDslashPolicy p)
   {
     size_t p_idx = static_cast<std::size_t>(p);
-    if (p > QudaDslashPolicy::QUDA_DSLASH_POLICY_DISABLED) errorQuda("Invalid policy %lu", p_idx);
+    if (p >= QudaDslashPolicy::QUDA_DSLASH_POLICY_DISABLED) errorQuda("Invalid policy %lu", p_idx);
     policies[p_idx] = p;
   }
 

--- a/lib/dslash_policy.cuh
+++ b/lib/dslash_policy.cuh
@@ -1733,7 +1733,12 @@ namespace quda
     }
   };
 
-  inline void enable_policy(QudaDslashPolicy p) { policies[static_cast<std::size_t>(p)] = p; }
+  inline void enable_policy(QudaDslashPolicy p)
+  {
+    size_t p_idx = static_cast<std::size_t>(p);
+    if (p > QudaDslashPolicy::QUDA_DSLASH_POLICY_DISABLED) errorQuda("Invalid policy %lu", p_idx);
+    policies[p_idx] = p;
+  }
 
   inline void disable_policy(QudaDslashPolicy p)
   {

--- a/tests/contract_test.cpp
+++ b/tests/contract_test.cpp
@@ -120,12 +120,12 @@ int test(int contractionType, QudaPrecision test_prec)
   void *d_result = safe_malloc(2 * V * 16 * data_size);
 
   if (test_prec == QUDA_SINGLE_PRECISION) {
-    for (int i = 0; i < V * spinor_site_size; i++) {
+    for (size_t i = 0; i < V * spinor_site_size; i++) {
       ((float *)spinorX)[i] = rand() / (float)RAND_MAX;
       ((float *)spinorY)[i] = rand() / (float)RAND_MAX;
     }
   } else {
-    for (int i = 0; i < V * spinor_site_size; i++) {
+    for (size_t i = 0; i < V * spinor_site_size; i++) {
       ((double *)spinorX)[i] = rand() / (double)RAND_MAX;
       ((double *)spinorY)[i] = rand() / (double)RAND_MAX;
     }

--- a/tests/contract_test.cpp
+++ b/tests/contract_test.cpp
@@ -120,12 +120,12 @@ int test(int contractionType, QudaPrecision test_prec)
   void *d_result = safe_malloc(2 * V * 16 * data_size);
 
   if (test_prec == QUDA_SINGLE_PRECISION) {
-    for (size_t i = 0; i < V * spinor_site_size; i++) {
+    for (auto i = 0lu; i < V * spinor_site_size; i++) {
       ((float *)spinorX)[i] = rand() / (float)RAND_MAX;
       ((float *)spinorY)[i] = rand() / (float)RAND_MAX;
     }
   } else {
-    for (size_t i = 0; i < V * spinor_site_size; i++) {
+    for (auto i = 0lu; i < V * spinor_site_size; i++) {
       ((double *)spinorX)[i] = rand() / (double)RAND_MAX;
       ((double *)spinorY)[i] = rand() / (double)RAND_MAX;
     }

--- a/tests/deflated_invert_test.cpp
+++ b/tests/deflated_invert_test.cpp
@@ -169,10 +169,10 @@ int main(int argc, char **argv)
 
     if (inv_param.cpu_prec == QUDA_SINGLE_PRECISION) {
       //((float*)spinorIn)[i] = 1.0;
-      for (size_t i = 0; i < inv_param.Ls * V * spinor_site_size; i++) ((float *)spinorIn)[i] = rand() / (float)RAND_MAX;
+      for (auto i = 0lu; i < inv_param.Ls * V * spinor_site_size; i++) ((float *)spinorIn)[i] = rand() / (float)RAND_MAX;
     } else {
       //((double*)spinorIn)[i] = 1.0;
-      for (size_t i = 0; i < inv_param.Ls * V * spinor_site_size; i++) ((double *)spinorIn)[i] = rand() / (double)RAND_MAX;
+      for (auto i = 0lu; i < inv_param.Ls * V * spinor_site_size; i++) ((double *)spinorIn)[i] = rand() / (double)RAND_MAX;
     }
 
     invertQuda(spinorOut, spinorIn, &inv_param);

--- a/tests/deflated_invert_test.cpp
+++ b/tests/deflated_invert_test.cpp
@@ -169,10 +169,10 @@ int main(int argc, char **argv)
 
     if (inv_param.cpu_prec == QUDA_SINGLE_PRECISION) {
       //((float*)spinorIn)[i] = 1.0;
-      for (int i = 0; i < inv_param.Ls * V * spinor_site_size; i++) ((float *)spinorIn)[i] = rand() / (float)RAND_MAX;
+      for (size_t i = 0; i < inv_param.Ls * V * spinor_site_size; i++) ((float *)spinorIn)[i] = rand() / (float)RAND_MAX;
     } else {
       //((double*)spinorIn)[i] = 1.0;
-      for (int i = 0; i < inv_param.Ls * V * spinor_site_size; i++) ((double *)spinorIn)[i] = rand() / (double)RAND_MAX;
+      for (size_t i = 0; i < inv_param.Ls * V * spinor_site_size; i++) ((double *)spinorIn)[i] = rand() / (double)RAND_MAX;
     }
 
     invertQuda(spinorOut, spinorIn, &inv_param);

--- a/tests/host_reference/covdev_reference.cpp
+++ b/tests/host_reference/covdev_reference.cpp
@@ -39,7 +39,7 @@ void display_link_internal(Float* link)
 template <typename sFloat, typename gFloat>
 void covdevReference(sFloat *res, gFloat **link, const sFloat *spinorField, int oddBit, int daggerBit, int mu)
 {
-  for (int i = 0; i < Vh * spinor_site_size; i++) res[i] = 0.0;
+  for (size_t i = 0; i < Vh * spinor_site_size; i++) res[i] = 0.0;
 
   gFloat *linkEven[4], *linkOdd[4];
 
@@ -49,7 +49,7 @@ void covdevReference(sFloat *res, gFloat **link, const sFloat *spinorField, int 
   }
 
   for (int sid = 0; sid < Vh; sid++) {
-    int offset = spinor_site_size * sid;
+    auto offset = spinor_site_size * sid;
 
     sFloat gaugedSpinor[spinor_site_size];
 
@@ -172,7 +172,7 @@ void covdevReference_mg4dir(sFloat *res, gFloat **link, gFloat **ghostLink, cons
   auto fwd_nbr_spinor = reinterpret_cast<sFloat **>(in.fwdGhostFaceBuffer);
   auto back_nbr_spinor = reinterpret_cast<sFloat **>(in.backGhostFaceBuffer);
 
-  for (int i = 0; i < Vh * spinor_site_size; i++) res[i] = 0.0;
+  for (size_t i = 0; i < Vh * spinor_site_size; i++) res[i] = 0.0;
 
   gFloat *linkEven[4], *linkOdd[4];
   gFloat *ghostLinkEven[4], *ghostLinkOdd[4];

--- a/tests/host_reference/covdev_reference.cpp
+++ b/tests/host_reference/covdev_reference.cpp
@@ -39,7 +39,7 @@ void display_link_internal(Float* link)
 template <typename sFloat, typename gFloat>
 void covdevReference(sFloat *res, gFloat **link, const sFloat *spinorField, int oddBit, int daggerBit, int mu)
 {
-  for (size_t i = 0; i < Vh * spinor_site_size; i++) res[i] = 0.0;
+  for (auto i = 0lu; i < Vh * spinor_site_size; i++) res[i] = 0.0;
 
   gFloat *linkEven[4], *linkOdd[4];
 
@@ -172,7 +172,7 @@ void covdevReference_mg4dir(sFloat *res, gFloat **link, gFloat **ghostLink, cons
   auto fwd_nbr_spinor = reinterpret_cast<sFloat **>(in.fwdGhostFaceBuffer);
   auto back_nbr_spinor = reinterpret_cast<sFloat **>(in.backGhostFaceBuffer);
 
-  for (size_t i = 0; i < Vh * spinor_site_size; i++) res[i] = 0.0;
+  for (auto i = 0lu; i < Vh * spinor_site_size; i++) res[i] = 0.0;
 
   gFloat *linkEven[4], *linkOdd[4];
   gFloat *ghostLinkEven[4], *ghostLinkOdd[4];

--- a/tests/host_reference/domain_wall_dslash_reference.cpp
+++ b/tests/host_reference/domain_wall_dslash_reference.cpp
@@ -329,7 +329,7 @@ template <QudaPCType type, typename sFloat, typename gFloat>
 void dslashReference_4d_mgpu(sFloat *res, gFloat **gaugeFull, gFloat **ghostGauge, sFloat *spinorField,
                              sFloat **fwdSpinor, sFloat **backSpinor, int oddBit, int daggerBit)
 {
-  for (size_t i = 0; i < V5h * spinor_site_size; i++) res[i] = 0.0;
+  for (auto i = 0lu; i < V5h * spinor_site_size; i++) res[i] = 0.0;
 
   gFloat *gaugeEven[4], *gaugeOdd[4];
   gFloat *ghostGaugeEven[4], *ghostGaugeOdd[4];
@@ -1173,7 +1173,7 @@ void dw_4d_matpc(void *out, void **gauge, void *in, double kappa, QudaMatPCType 
   void *tmp = safe_malloc(V5h * spinor_site_size * precision);
   //------------------------------------------
   double *output = (double*)out;
-  for (size_t k = 0; k < V5h * spinor_site_size; k++) output[k] = 0.0;
+  for (auto k = 0lu; k < V5h * spinor_site_size; k++) output[k] = 0.0;
   //------------------------------------------
 
   int odd_bit = (matpc_type == QUDA_MATPC_ODD_ODD || matpc_type == QUDA_MATPC_ODD_ODD_ASYMMETRIC) ? 1 : 0;

--- a/tests/host_reference/domain_wall_dslash_reference.cpp
+++ b/tests/host_reference/domain_wall_dslash_reference.cpp
@@ -329,7 +329,7 @@ template <QudaPCType type, typename sFloat, typename gFloat>
 void dslashReference_4d_mgpu(sFloat *res, gFloat **gaugeFull, gFloat **ghostGauge, sFloat *spinorField,
                              sFloat **fwdSpinor, sFloat **backSpinor, int oddBit, int daggerBit)
 {
-  for (int i = 0; i < V5h * spinor_site_size; i++) res[i] = 0.0;
+  for (size_t i = 0; i < V5h * spinor_site_size; i++) res[i] = 0.0;
 
   gFloat *gaugeEven[4], *gaugeOdd[4];
   gFloat *ghostGaugeEven[4], *ghostGaugeOdd[4];
@@ -1173,7 +1173,7 @@ void dw_4d_matpc(void *out, void **gauge, void *in, double kappa, QudaMatPCType 
   void *tmp = safe_malloc(V5h * spinor_site_size * precision);
   //------------------------------------------
   double *output = (double*)out;
-  for (int k = 0; k < V5h * spinor_site_size; k++) output[k] = 0.0;
+  for (size_t k = 0; k < V5h * spinor_site_size; k++) output[k] = 0.0;
   //------------------------------------------
 
   int odd_bit = (matpc_type == QUDA_MATPC_ODD_ODD || matpc_type == QUDA_MATPC_ODD_ODD_ASYMMETRIC) ? 1 : 0;

--- a/tests/host_reference/staggered_dslash_reference.cpp
+++ b/tests/host_reference/staggered_dslash_reference.cpp
@@ -42,7 +42,7 @@ void staggeredDslashReference(sFloat *res, gFloat **fatlink, gFloat **longlink, 
                               sFloat **, sFloat **, int oddBit, int daggerBit, int nSrc, QudaDslashType dslash_type)
 #endif
 {
-  for (int i = 0; i < Vh * stag_spinor_site_size * nSrc; i++) res[i] = 0.0;
+  for (size_t i = 0; i < Vh * stag_spinor_site_size * nSrc; i++) res[i] = 0.0;
 
   gFloat *fatlinkEven[4], *fatlinkOdd[4];
   gFloat *longlinkEven[4], *longlinkOdd[4];

--- a/tests/host_reference/staggered_dslash_reference.cpp
+++ b/tests/host_reference/staggered_dslash_reference.cpp
@@ -42,7 +42,7 @@ void staggeredDslashReference(sFloat *res, gFloat **fatlink, gFloat **longlink, 
                               sFloat **, sFloat **, int oddBit, int daggerBit, int nSrc, QudaDslashType dslash_type)
 #endif
 {
-  for (size_t i = 0; i < Vh * stag_spinor_site_size * nSrc; i++) res[i] = 0.0;
+  for (auto i = 0lu; i < Vh * stag_spinor_site_size * nSrc; i++) res[i] = 0.0;
 
   gFloat *fatlinkEven[4], *fatlinkOdd[4];
   gFloat *longlinkEven[4], *longlinkOdd[4];

--- a/tests/host_reference/wilson_dslash_reference.cpp
+++ b/tests/host_reference/wilson_dslash_reference.cpp
@@ -102,7 +102,7 @@ template <typename Float> void multiplySpinorByDiracProjector(Float *res, int pr
 template <typename sFloat, typename gFloat>
 void dslashReference(sFloat *res, gFloat **gaugeFull, sFloat *spinorField, int oddBit, int daggerBit)
 {
-  for (int i = 0; i < Vh * spinor_site_size; i++) res[i] = 0.0;
+  for (size_t i = 0; i < Vh * spinor_site_size; i++) res[i] = 0.0;
 
   gFloat *gaugeEven[4], *gaugeOdd[4];
   for (int dir = 0; dir < 4; dir++) {  
@@ -135,7 +135,7 @@ template <typename sFloat, typename gFloat>
 void dslashReference(sFloat *res, gFloat **gaugeFull, gFloat **ghostGauge, sFloat *spinorField, sFloat **fwdSpinor,
                      sFloat **backSpinor, int oddBit, int daggerBit)
 {
-  for (int i = 0; i < Vh * spinor_site_size; i++) res[i] = 0.0;
+  for (size_t i = 0; i < Vh * spinor_site_size; i++) res[i] = 0.0;
 
   gFloat *gaugeEven[4], *gaugeOdd[4];
   gFloat *ghostGaugeEven[4], *ghostGaugeOdd[4];

--- a/tests/host_reference/wilson_dslash_reference.cpp
+++ b/tests/host_reference/wilson_dslash_reference.cpp
@@ -102,7 +102,7 @@ template <typename Float> void multiplySpinorByDiracProjector(Float *res, int pr
 template <typename sFloat, typename gFloat>
 void dslashReference(sFloat *res, gFloat **gaugeFull, sFloat *spinorField, int oddBit, int daggerBit)
 {
-  for (size_t i = 0; i < Vh * spinor_site_size; i++) res[i] = 0.0;
+  for (auto i = 0lu; i < Vh * spinor_site_size; i++) res[i] = 0.0;
 
   gFloat *gaugeEven[4], *gaugeOdd[4];
   for (int dir = 0; dir < 4; dir++) {  
@@ -135,7 +135,7 @@ template <typename sFloat, typename gFloat>
 void dslashReference(sFloat *res, gFloat **gaugeFull, gFloat **ghostGauge, sFloat *spinorField, sFloat **fwdSpinor,
                      sFloat **backSpinor, int oddBit, int daggerBit)
 {
-  for (size_t i = 0; i < Vh * spinor_site_size; i++) res[i] = 0.0;
+  for (auto i = 0lu; i < Vh * spinor_site_size; i++) res[i] = 0.0;
 
   gFloat *gaugeEven[4], *gaugeOdd[4];
   gFloat *ghostGaugeEven[4], *ghostGaugeOdd[4];

--- a/tests/unitarize_link_test.cpp
+++ b/tests/unitarize_link_test.cpp
@@ -104,7 +104,7 @@ static int unitarize_link_test(int &test_rc)
     for(int dir=0; dir<4; ++dir){
       double* slink = reinterpret_cast<double*>(sitelink[dir]);
       for(int i=0; i<V; ++i){
-        for (unsigned int j = 0; j < gauge_site_size; j++) {
+        for (auto j = 0lu; j < gauge_site_size; j++) {
           link[(i * 4 + dir) * gauge_site_size + j] = slink[i * gauge_site_size + j];
         }
       }
@@ -114,7 +114,7 @@ static int unitarize_link_test(int &test_rc)
     for(int dir=0; dir<4; ++dir){
       float* slink = reinterpret_cast<float*>(sitelink[dir]);
       for(int i=0; i<V; ++i){
-        for (unsigned int j = 0; j < gauge_site_size; j++) {
+        for (auto j = 0lu; j < gauge_site_size; j++) {
           link[(i * 4 + dir) * gauge_site_size + j] = slink[i * gauge_site_size + j];
         }
       }

--- a/tests/unitarize_link_test.cpp
+++ b/tests/unitarize_link_test.cpp
@@ -104,7 +104,7 @@ static int unitarize_link_test(int &test_rc)
     for(int dir=0; dir<4; ++dir){
       double* slink = reinterpret_cast<double*>(sitelink[dir]);
       for(int i=0; i<V; ++i){
-        for (int j = 0; j < gauge_site_size; j++) {
+        for (unsigned int j = 0; j < gauge_site_size; j++) {
           link[(i * 4 + dir) * gauge_site_size + j] = slink[i * gauge_site_size + j];
         }
       }
@@ -114,7 +114,7 @@ static int unitarize_link_test(int &test_rc)
     for(int dir=0; dir<4; ++dir){
       float* slink = reinterpret_cast<float*>(sitelink[dir]);
       for(int i=0; i<V; ++i){
-        for (int j = 0; j < gauge_site_size; j++) {
+        for (unsigned int j = 0; j < gauge_site_size; j++) {
           link[(i * 4 + dir) * gauge_site_size + j] = slink[i * gauge_site_size + j];
         }
       }

--- a/tests/utils/host_utils.cpp
+++ b/tests/utils/host_utils.cpp
@@ -981,13 +981,13 @@ template <typename Float> void applyGaugeFieldScaling(Float **gauge, int Vh, Qud
 {
   // Apply spatial scaling factor (u0) to spatial links
   for (int d = 0; d < 3; d++) {
-    for (int i = 0; i < gauge_site_size * Vh * 2; i++) { gauge[d][i] /= param->anisotropy; }
+    for (unsigned int i = 0; i < gauge_site_size * Vh * 2; i++) { gauge[d][i] /= param->anisotropy; }
   }
 
   // Apply boundary conditions to temporal links
   if (param->t_boundary == QUDA_ANTI_PERIODIC_T && last_node_in_t()) {
     for (int j = (Z[0] / 2) * Z[1] * Z[2] * (Z[3] - 1); j < Vh; j++) {
-      for (int i = 0; i < gauge_site_size; i++) {
+      for (unsigned int i = 0; i < gauge_site_size; i++) {
         gauge[3][j * gauge_site_size + i] *= -1.0;
         gauge[3][(Vh + j) * gauge_site_size + i] *= -1.0;
       }
@@ -1203,7 +1203,7 @@ template <typename Float> void constructCloverField(Float *res, double norm, dou
 
   Float c = 2.0 * norm / RAND_MAX;
 
-  for (int i = 0; i < V; i++) {
+  for (size_t i = 0; i < (size_t)V; i++) {
     for (int j = 0; j < 72; j++) { res[i * 72 + j] = c * rand() - norm; }
 
     // impose clover symmetry on each chiral block
@@ -1355,17 +1355,17 @@ void createSiteLinkCPU(void **link, QudaPrecision precision, int phase)
 
 #if 1
   for (int dir = 0; dir < 4; dir++) {
-    for (int i = 0; i < V * gauge_site_size; i++) {
+    for (size_t i = 0; i < V * gauge_site_size; i++) {
       if (precision == QUDA_SINGLE_PRECISION) {
         float *f = (float *)link[dir];
         if (f[i] != f[i] || (fabsf(f[i]) > 1.e+3)) {
-          fprintf(stderr, "ERROR:  %dth: bad number(%f) in function %s \n", i, f[i], __FUNCTION__);
+          fprintf(stderr, "ERROR:  %luth: bad number(%f) in function %s \n", i, f[i], __FUNCTION__);
           exit(1);
         }
       } else {
         double *f = (double *)link[dir];
         if (f[i] != f[i] || (fabs(f[i]) > 1.e+3)) {
-          fprintf(stderr, "ERROR:  %dth: bad number(%f) in function %s \n", i, f[i], __FUNCTION__);
+          fprintf(stderr, "ERROR:  %luth: bad number(%f) in function %s \n", i, f[i], __FUNCTION__);
           exit(1);
         }
       }
@@ -1468,7 +1468,7 @@ void createMomCPU(void *mom, QudaPrecision precision)
     if (precision == QUDA_DOUBLE_PRECISION) {
       for (int dir = 0; dir < 4; dir++) {
         double *thismom = (double *)mom;
-        for (int k = 0; k < mom_site_size; k++) {
+        for (unsigned int k = 0; k < mom_site_size; k++) {
           thismom[(4 * i + dir) * mom_site_size + k] = 1.0 * rand() / RAND_MAX;
           if (k == mom_site_size - 1) thismom[(4 * i + dir) * mom_site_size + k] = 0.0;
         }
@@ -1476,7 +1476,7 @@ void createMomCPU(void *mom, QudaPrecision precision)
     } else {
       for (int dir = 0; dir < 4; dir++) {
         float *thismom = (float *)mom;
-        for (int k = 0; k < mom_site_size; k++) {
+        for (unsigned int k = 0; k < mom_site_size; k++) {
           thismom[(4 * i + dir) * mom_site_size + k] = 1.0 * rand() / RAND_MAX;
           if (k == mom_site_size - 1) thismom[(4 * i + dir) * mom_site_size + k] = 0.0;
         }
@@ -1494,12 +1494,12 @@ void createHwCPU(void *hw, QudaPrecision precision)
     if (precision == QUDA_DOUBLE_PRECISION) {
       for (int dir = 0; dir < 4; dir++) {
         double *thishw = (double *)hw;
-        for (int k = 0; k < hw_site_size; k++) { thishw[(4 * i + dir) * hw_site_size + k] = 1.0 * rand() / RAND_MAX; }
+        for (unsigned int k = 0; k < hw_site_size; k++) { thishw[(4 * i + dir) * hw_site_size + k] = 1.0 * rand() / RAND_MAX; }
       }
     } else {
       for (int dir = 0; dir < 4; dir++) {
         float *thishw = (float *)hw;
-        for (int k = 0; k < hw_site_size; k++) { thishw[(4 * i + dir) * hw_site_size + k] = 1.0 * rand() / RAND_MAX; }
+        for (unsigned int k = 0; k < hw_site_size; k++) { thishw[(4 * i + dir) * hw_site_size + k] = 1.0 * rand() / RAND_MAX; }
       }
     }
   }
@@ -1514,10 +1514,10 @@ template <typename Float> int compare_mom(Float *momA, Float *momB, int len)
   for (int f = 0; f < fail_check; f++) fail[f] = 0;
 
   int iter[mom_site_size];
-  for (int i = 0; i < mom_site_size; i++) iter[i] = 0;
+  for (unsigned int i = 0; i < mom_site_size; i++) iter[i] = 0;
 
   for (int i = 0; i < len; i++) {
-    for (int j = 0; j < mom_site_size - 1; j++) {
+    for (unsigned int j = 0; j < mom_site_size - 1; j++) {
       int is = i * mom_site_size + j;
       double diff = fabs(momA[is] - momB[is]);
       for (int f = 0; f < fail_check; f++)
@@ -1532,7 +1532,7 @@ template <typename Float> int compare_mom(Float *momA, Float *momB, int len)
     if (fail[f] == 0) { accuracy_level = f + 1; }
   }
 
-  for (int i = 0; i < mom_site_size; i++) printfQuda("%d fails = %d\n", i, iter[i]);
+  for (unsigned i = 0; i < mom_site_size; i++) printfQuda("%u fails = %d\n", i, iter[i]);
 
   for (int f = 0; f < fail_check; f++) {
     printfQuda("%e Failures: %d / %d  = %e\n", pow(10.0, -(f + 1)), fail[f], len * 9, fail[f] / (double)(len * 9));

--- a/tests/utils/host_utils.cpp
+++ b/tests/utils/host_utils.cpp
@@ -981,13 +981,13 @@ template <typename Float> void applyGaugeFieldScaling(Float **gauge, int Vh, Qud
 {
   // Apply spatial scaling factor (u0) to spatial links
   for (int d = 0; d < 3; d++) {
-    for (unsigned int i = 0; i < gauge_site_size * Vh * 2; i++) { gauge[d][i] /= param->anisotropy; }
+    for (auto i = 0lu; i < gauge_site_size * Vh * 2; i++) { gauge[d][i] /= param->anisotropy; }
   }
 
   // Apply boundary conditions to temporal links
   if (param->t_boundary == QUDA_ANTI_PERIODIC_T && last_node_in_t()) {
     for (int j = (Z[0] / 2) * Z[1] * Z[2] * (Z[3] - 1); j < Vh; j++) {
-      for (unsigned int i = 0; i < gauge_site_size; i++) {
+      for (auto i = 0lu; i < gauge_site_size; i++) {
         gauge[3][j * gauge_site_size + i] *= -1.0;
         gauge[3][(Vh + j) * gauge_site_size + i] *= -1.0;
       }
@@ -1203,7 +1203,7 @@ template <typename Float> void constructCloverField(Float *res, double norm, dou
 
   Float c = 2.0 * norm / RAND_MAX;
 
-  for (size_t i = 0; i < (size_t)V; i++) {
+  for (auto i = 0lu; i < static_cast<size_t>(V); i++) {
     for (int j = 0; j < 72; j++) { res[i * 72 + j] = c * rand() - norm; }
 
     // impose clover symmetry on each chiral block
@@ -1355,7 +1355,7 @@ void createSiteLinkCPU(void **link, QudaPrecision precision, int phase)
 
 #if 1
   for (int dir = 0; dir < 4; dir++) {
-    for (size_t i = 0; i < V * gauge_site_size; i++) {
+    for (auto i = 0lu; i < V * gauge_site_size; i++) {
       if (precision == QUDA_SINGLE_PRECISION) {
         float *f = (float *)link[dir];
         if (f[i] != f[i] || (fabsf(f[i]) > 1.e+3)) {
@@ -1468,7 +1468,7 @@ void createMomCPU(void *mom, QudaPrecision precision)
     if (precision == QUDA_DOUBLE_PRECISION) {
       for (int dir = 0; dir < 4; dir++) {
         double *thismom = (double *)mom;
-        for (unsigned int k = 0; k < mom_site_size; k++) {
+        for (auto k = 0lu; k < mom_site_size; k++) {
           thismom[(4 * i + dir) * mom_site_size + k] = 1.0 * rand() / RAND_MAX;
           if (k == mom_site_size - 1) thismom[(4 * i + dir) * mom_site_size + k] = 0.0;
         }
@@ -1476,7 +1476,7 @@ void createMomCPU(void *mom, QudaPrecision precision)
     } else {
       for (int dir = 0; dir < 4; dir++) {
         float *thismom = (float *)mom;
-        for (unsigned int k = 0; k < mom_site_size; k++) {
+        for (auto k = 0lu; k < mom_site_size; k++) {
           thismom[(4 * i + dir) * mom_site_size + k] = 1.0 * rand() / RAND_MAX;
           if (k == mom_site_size - 1) thismom[(4 * i + dir) * mom_site_size + k] = 0.0;
         }
@@ -1494,12 +1494,12 @@ void createHwCPU(void *hw, QudaPrecision precision)
     if (precision == QUDA_DOUBLE_PRECISION) {
       for (int dir = 0; dir < 4; dir++) {
         double *thishw = (double *)hw;
-        for (unsigned int k = 0; k < hw_site_size; k++) { thishw[(4 * i + dir) * hw_site_size + k] = 1.0 * rand() / RAND_MAX; }
+        for (auto k = 0lu; k < hw_site_size; k++) { thishw[(4 * i + dir) * hw_site_size + k] = 1.0 * rand() / RAND_MAX; }
       }
     } else {
       for (int dir = 0; dir < 4; dir++) {
         float *thishw = (float *)hw;
-        for (unsigned int k = 0; k < hw_site_size; k++) { thishw[(4 * i + dir) * hw_site_size + k] = 1.0 * rand() / RAND_MAX; }
+        for (auto k = 0lu; k < hw_site_size; k++) { thishw[(4 * i + dir) * hw_site_size + k] = 1.0 * rand() / RAND_MAX; }
       }
     }
   }
@@ -1514,10 +1514,10 @@ template <typename Float> int compare_mom(Float *momA, Float *momB, int len)
   for (int f = 0; f < fail_check; f++) fail[f] = 0;
 
   int iter[mom_site_size];
-  for (unsigned int i = 0; i < mom_site_size; i++) iter[i] = 0;
+  for (auto i = 0lu; i < mom_site_size; i++) iter[i] = 0;
 
   for (int i = 0; i < len; i++) {
-    for (unsigned int j = 0; j < mom_site_size - 1; j++) {
+    for (auto j = 0lu; j < mom_site_size - 1; j++) {
       int is = i * mom_site_size + j;
       double diff = fabs(momA[is] - momB[is]);
       for (int f = 0; f < fail_check; f++)
@@ -1532,7 +1532,7 @@ template <typename Float> int compare_mom(Float *momA, Float *momB, int len)
     if (fail[f] == 0) { accuracy_level = f + 1; }
   }
 
-  for (unsigned i = 0; i < mom_site_size; i++) printfQuda("%u fails = %d\n", i, iter[i]);
+  for (auto i = 0u; i < mom_site_size; i++) printfQuda("%u fails = %d\n", i, iter[i]);
 
   for (int f = 0; f < fail_check; f++) {
     printfQuda("%e Failures: %d / %d  = %e\n", pow(10.0, -(f + 1)), fail[f], len * 9, fail[f] / (double)(len * 9));

--- a/tests/utils/host_utils.h
+++ b/tests/utils/host_utils.h
@@ -6,12 +6,12 @@
 #include <random_quda.h>
 #include <color_spinor_field.h>
 
-#define gauge_site_size 18      // real numbers per link
-#define spinor_site_size 24     // real numbers per wilson spinor
-#define stag_spinor_site_size 6 // real numbers per staggered 'spinor'
-#define clover_site_size 72     // real numbers per block-diagonal clover matrix
-#define mom_site_size 10        // real numbers per momentum
-#define hw_site_size 12         // real numbers per half wilson
+constexpr size_t gauge_site_size = 18;      // real numbers per link
+constexpr size_t spinor_site_size = 24;     // real numbers per wilson spinor
+constexpr size_t stag_spinor_site_size = 6; // real numbers per staggered 'spinor'
+constexpr size_t clover_site_size = 72;     // real numbers per block-diagonal clover matrix
+constexpr size_t mom_site_size = 10;        // real numbers per momentum
+constexpr size_t hw_site_size = 12;         // real numbers per half wilson
 
 extern int Z[4];
 extern int V;

--- a/tests/utils/staggered_host_utils.cpp
+++ b/tests/utils/staggered_host_utils.cpp
@@ -166,7 +166,7 @@ void constructFatLongGaugeField(void **fatlink, void **longlink, int type, QudaP
       const complex<double> z = std::polar(1.0, phase);
       for (int dir = 0; dir < 4; ++dir) {
         for (int i = 0; i < V; ++i) {
-          for (int j = 0; j < gauge_site_size; j += 2) {
+          for (unsigned int j = 0; j < gauge_site_size; j += 2) {
             if (precision == QUDA_DOUBLE_PRECISION) {
               complex<double> *l = (complex<double> *)(&(((double *)longlink[dir])[i * gauge_site_size + j]));
               *l *= z;
@@ -187,7 +187,7 @@ void constructFatLongGaugeField(void **fatlink, void **longlink, int type, QudaP
   if (dslash_type == QUDA_STAGGERED_DSLASH) {
     for (int dir = 0; dir < 4; ++dir) {
       for (int i = 0; i < V; ++i) {
-        for (int j = 0; j < gauge_site_size; j += 2) {
+        for (unsigned int j = 0; j < gauge_site_size; j += 2) {
           if (precision == QUDA_DOUBLE_PRECISION) {
             ((double *)longlink[dir])[i * gauge_site_size + j] = 0.0;
             ((double *)longlink[dir])[i * gauge_site_size + j + 1] = 0.0;
@@ -762,7 +762,7 @@ void applyGaugeFieldScaling_long(Float **gauge, int Vh, QudaGaugeParam *param, Q
   // rescale long links by the appropriate coefficient
   if (dslash_type == QUDA_ASQTAD_DSLASH) {
     for (int d = 0; d < 4; d++) {
-      for (int i = 0; i < V * gauge_site_size; i++) {
+      for (size_t i = 0; i < V * gauge_site_size; i++) {
         gauge[d][i] /= (-24 * param->tadpole_coeff * param->tadpole_coeff);
       }
     }

--- a/tests/utils/staggered_host_utils.cpp
+++ b/tests/utils/staggered_host_utils.cpp
@@ -187,7 +187,7 @@ void constructFatLongGaugeField(void **fatlink, void **longlink, int type, QudaP
   if (dslash_type == QUDA_STAGGERED_DSLASH) {
     for (int dir = 0; dir < 4; ++dir) {
       for (int i = 0; i < V; ++i) {
-        for (unsigned int j = 0; j < gauge_site_size; j += 2) {
+        for (auto j = 0lu; j < gauge_site_size; j += 2) {
           if (precision == QUDA_DOUBLE_PRECISION) {
             ((double *)longlink[dir])[i * gauge_site_size + j] = 0.0;
             ((double *)longlink[dir])[i * gauge_site_size + j + 1] = 0.0;

--- a/tests/utils/staggered_host_utils.cpp
+++ b/tests/utils/staggered_host_utils.cpp
@@ -166,7 +166,7 @@ void constructFatLongGaugeField(void **fatlink, void **longlink, int type, QudaP
       const complex<double> z = std::polar(1.0, phase);
       for (int dir = 0; dir < 4; ++dir) {
         for (int i = 0; i < V; ++i) {
-          for (unsigned int j = 0; j < gauge_site_size; j += 2) {
+          for (auto j = 0lu; j < gauge_site_size; j += 2) {
             if (precision == QUDA_DOUBLE_PRECISION) {
               complex<double> *l = (complex<double> *)(&(((double *)longlink[dir])[i * gauge_site_size + j]));
               *l *= z;


### PR DESCRIPTION
Quick fix PR:
* Check dslash policy is valid when enabling it
* Use 64-bit variables for `*_site_size` variables in the host reference code: this fixes a variety of 32-bit overflow in the host reference code, and for example enables use to run clover fermions at a volume of 72^4, where previously the limit was < 70^4