### PR TITLE
Mixed precision staggered KD setup

### DIFF
--- a/include/dirac_quda.h
+++ b/include/dirac_quda.h
@@ -367,6 +367,24 @@ namespace quda {
      */
     virtual QudaDiracType getDiracType() const = 0;
 
+    /** @brief Return the one-hop field for staggered operators for MG setup
+
+        @return Error for non-staggered operators
+    */
+    virtual cudaGaugeField* getStaggeredShortLinkField() const {
+      errorQuda("Invalid dirac type %d", getDiracType());
+      return nullptr;
+    }
+
+    /** @brief return the long link field for staggered operators for MG setup, if it exists
+
+        @return Error for non-improved staggered operators
+    */
+    virtual cudaGaugeField* getStaggeredLongLinkField() const {
+      errorQuda("Invalid dirac type %d", getDiracType());
+      return nullptr;
+    }
+
     /**
      *  @brief Update the internal gauge, fat gauge, long gauge, clover field pointer as appropriate.
      *  These are pointers as opposed to references to support passing in `nullptr`.
@@ -1274,12 +1292,13 @@ public:
 
     virtual QudaDiracType getDiracType() const { return QUDA_STAGGERED_DIRAC; }
 
-    /**
-     * @brief Get the fine gauge field for MG setup.
-     *
-     * @return gauge field
-     */
-    virtual const cudaGaugeField *getGaugeField() const { return gauge; }
+     /** @brief Return the one-hop field for staggered operators for MG setup
+
+        @return Gauge field
+    */
+    virtual cudaGaugeField* getStaggeredShortLinkField() const override {
+      return gauge;
+    }
 
     /**
      * @brief Create the coarse staggered operator.
@@ -1471,19 +1490,21 @@ public:
 
     virtual QudaDiracType getDiracType() const { return QUDA_ASQTAD_DIRAC; }
 
-    /**
-     * @brief Get the fat link field for MG setup.
-     *
-     * @return fat link field
-     */
-    virtual const cudaGaugeField *getFatLinkField() const { return fatGauge; }
+    /** @brief Return the one-hop field for staggered operators for MG setup
 
-    /**
-     * @brief Get the long link field for MG setup.
-     *
-     * @return long link field
-     */
-    virtual const cudaGaugeField *getLongLinkField() const { return longGauge; }
+        @return fat link field
+    */
+    virtual cudaGaugeField* getStaggeredShortLinkField() const override {
+      return fatGauge;
+    }
+
+    /** @brief return the long link field for staggered operators for MG setup
+
+        @return long link field
+    */
+    virtual cudaGaugeField* getStaggeredLongLinkField() const override {
+      return longGauge;
+    }
 
     /**
      *  @brief Update the internal gauge, fat gauge, long gauge, clover field pointer as appropriate.

--- a/include/dirac_quda.h
+++ b/include/dirac_quda.h
@@ -367,7 +367,8 @@ namespace quda {
      */
     virtual QudaDiracType getDiracType() const = 0;
 
-    /** @brief Return the one-hop field for staggered operators for MG setup
+    /**
+        @brief Return the one-hop field for staggered operators for MG setup
 
         @return Error for non-staggered operators
     */
@@ -376,7 +377,8 @@ namespace quda {
       return nullptr;
     }
 
-    /** @brief return the long link field for staggered operators for MG setup, if it exists
+    /**
+        @brief return the long link field for staggered operators for MG setup, if it exists
 
         @return Error for non-improved staggered operators
     */
@@ -1292,7 +1294,8 @@ public:
 
     virtual QudaDiracType getDiracType() const { return QUDA_STAGGERED_DIRAC; }
 
-     /** @brief Return the one-hop field for staggered operators for MG setup
+     /**
+        @brief Return the one-hop field for staggered operators for MG setup
 
         @return Gauge field
     */
@@ -1490,7 +1493,8 @@ public:
 
     virtual QudaDiracType getDiracType() const { return QUDA_ASQTAD_DIRAC; }
 
-    /** @brief Return the one-hop field for staggered operators for MG setup
+    /**
+        @brief Return the one-hop field for staggered operators for MG setup
 
         @return fat link field
     */
@@ -1498,7 +1502,8 @@ public:
       return fatGauge;
     }
 
-    /** @brief return the long link field for staggered operators for MG setup
+    /**
+        @brief return the long link field for staggered operators for MG setup
 
         @return long link field
     */

--- a/include/dirac_quda.h
+++ b/include/dirac_quda.h
@@ -1296,7 +1296,7 @@ public:
 
         @return Gauge field
     */
-    virtual cudaGaugeField* getStaggeredShortLinkField() const override {
+    virtual cudaGaugeField* getStaggeredShortLinkField() const  {
       return gauge;
     }
 
@@ -1494,7 +1494,7 @@ public:
 
         @return fat link field
     */
-    virtual cudaGaugeField* getStaggeredShortLinkField() const override {
+    virtual cudaGaugeField* getStaggeredShortLinkField() const {
       return fatGauge;
     }
 
@@ -1502,7 +1502,7 @@ public:
 
         @return long link field
     */
-    virtual cudaGaugeField* getStaggeredLongLinkField() const override {
+    virtual cudaGaugeField* getStaggeredLongLinkField() const {
       return longGauge;
     }
 

--- a/include/dirac_quda.h
+++ b/include/dirac_quda.h
@@ -372,7 +372,8 @@ namespace quda {
 
         @return Error for non-staggered operators
     */
-    virtual cudaGaugeField* getStaggeredShortLinkField() const {
+    virtual cudaGaugeField *getStaggeredShortLinkField() const
+    {
       errorQuda("Invalid dirac type %d", getDiracType());
       return nullptr;
     }
@@ -382,7 +383,8 @@ namespace quda {
 
         @return Error for non-improved staggered operators
     */
-    virtual cudaGaugeField* getStaggeredLongLinkField() const {
+    virtual cudaGaugeField *getStaggeredLongLinkField() const
+    {
       errorQuda("Invalid dirac type %d", getDiracType());
       return nullptr;
     }
@@ -1294,14 +1296,12 @@ public:
 
     virtual QudaDiracType getDiracType() const { return QUDA_STAGGERED_DIRAC; }
 
-     /**
-        @brief Return the one-hop field for staggered operators for MG setup
+    /**
+       @brief Return the one-hop field for staggered operators for MG setup
 
-        @return Gauge field
-    */
-    virtual cudaGaugeField* getStaggeredShortLinkField() const  {
-      return gauge;
-    }
+       @return Gauge field
+   */
+    virtual cudaGaugeField *getStaggeredShortLinkField() const { return gauge; }
 
     /**
      * @brief Create the coarse staggered operator.
@@ -1498,18 +1498,14 @@ public:
 
         @return fat link field
     */
-    virtual cudaGaugeField* getStaggeredShortLinkField() const {
-      return fatGauge;
-    }
+    virtual cudaGaugeField *getStaggeredShortLinkField() const { return fatGauge; }
 
     /**
         @brief return the long link field for staggered operators for MG setup
 
         @return long link field
     */
-    virtual cudaGaugeField* getStaggeredLongLinkField() const {
-      return longGauge;
-    }
+    virtual cudaGaugeField *getStaggeredLongLinkField() const { return longGauge; }
 
     /**
      *  @brief Update the internal gauge, fat gauge, long gauge, clover field pointer as appropriate.

--- a/include/multigrid.h
+++ b/include/multigrid.h
@@ -334,6 +334,7 @@ namespace quda {
               the KD inverse
      */
     void resetStaggeredKD(cudaGaugeField *gauge_in, cudaGaugeField *fat_gauge_in, cudaGaugeField *long_gauge_in,
+                          cudaGaugeField *gauge_sloppy_in, cudaGaugeField *fat_gauge_sloppy_in, cudaGaugeField *long_gauge_sloppy_in,
                           double mass);
 
     /**

--- a/include/multigrid.h
+++ b/include/multigrid.h
@@ -334,8 +334,8 @@ namespace quda {
               the KD inverse
      */
     void resetStaggeredKD(cudaGaugeField *gauge_in, cudaGaugeField *fat_gauge_in, cudaGaugeField *long_gauge_in,
-                          cudaGaugeField *gauge_sloppy_in, cudaGaugeField *fat_gauge_sloppy_in, cudaGaugeField *long_gauge_sloppy_in,
-                          double mass);
+                          cudaGaugeField *gauge_sloppy_in, cudaGaugeField *fat_gauge_sloppy_in,
+                          cudaGaugeField *long_gauge_sloppy_in, double mass);
 
     /**
        @brief Dump the null-space vectors to disk.  Will recurse dumping all levels.
@@ -430,15 +430,16 @@ namespace quda {
     /**
       @brief Return if we're on a fine grid right now
     */
-    bool is_fine_grid() const {
-      
+    bool is_fine_grid() const
+    {
+
       // Check if we're on a KD fine grid
-      bool kd_nearnull_gen = ((param.level == 1) && (param.mg_global.transfer_type[0] == QUDA_TRANSFER_OPTIMIZED_KD
-            || param.mg_global.transfer_type[0] == QUDA_TRANSFER_OPTIMIZED_KD_DROP_LONG));
+      bool kd_nearnull_gen = ((param.level == 1)
+                              && (param.mg_global.transfer_type[0] == QUDA_TRANSFER_OPTIMIZED_KD
+                                  || param.mg_global.transfer_type[0] == QUDA_TRANSFER_OPTIMIZED_KD_DROP_LONG));
 
       return (param.level == 0 || kd_nearnull_gen);
     }
-
   };
 
   /**

--- a/include/multigrid.h
+++ b/include/multigrid.h
@@ -251,8 +251,17 @@ namespace quda {
     /** Coarse temporary vector */
     ColorSpinorField *tmp2_coarse;
 
+    /** Sloppy coarse temporary vector */
+    ColorSpinorField *tmp_coarse_sloppy;
+
+    /** Sloppy coarse temporary vector */
+    ColorSpinorField *tmp2_coarse_sloppy;
+
     /** Kahler-Dirac Xinv */
-    std::unique_ptr<GaugeField> xInvKD;
+    std::shared_ptr<GaugeField> xInvKD;
+
+    /** Kahler-Dirac Xinv, sloppy field */
+    std::shared_ptr<GaugeField> xInvKD_sloppy;
 
     /** The fine operator used for computing inter-grid residuals */
     const Dirac *diracResidual;
@@ -348,6 +357,11 @@ namespace quda {
     void createCoarseDirac();
 
     /**
+       @brief Create the optimized KD operator
+    */
+    void createOptimizedKdDirac();
+
+    /**
        @brief Create the solver wrapper
     */
     void createCoarseSolver();
@@ -411,6 +425,18 @@ namespace quda {
        @brief Return the total flops done on this and all coarser levels.
      */
     double flops() const;
+
+    /**
+      @brief Return if we're on a fine grid right now
+    */
+    bool is_fine_grid() const {
+      
+      // Check if we're on a KD fine grid
+      bool kd_nearnull_gen = ((param.level == 1) && (param.mg_global.transfer_type[0] == QUDA_TRANSFER_OPTIMIZED_KD
+            || param.mg_global.transfer_type[0] == QUDA_TRANSFER_OPTIMIZED_KD_DROP_LONG));
+
+      return (param.level == 0 || kd_nearnull_gen);
+    }
 
   };
 

--- a/include/staggered_kd_build_xinv.h
+++ b/include/staggered_kd_build_xinv.h
@@ -34,7 +34,7 @@ namespace quda
      @param dagger_approximation[in] Whether or not to use the dagger approximation, using the dagger of X instead of Xinv
      @return constructed Xinv
   */
-  std::unique_ptr<GaugeField> AllocateAndBuildStaggeredKahlerDiracInverse(const cudaGaugeField &gauge, const double mass,
+  std::shared_ptr<GaugeField> AllocateAndBuildStaggeredKahlerDiracInverse(const cudaGaugeField &gauge, const double mass,
                                                                           const bool dagger_approximation);
 
 } // namespace quda

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -2514,8 +2514,8 @@ void updateMultigridQuda(void *mg_, QudaMultigridParam *mg_param)
         || mg_param->transfer_type[0] == QUDA_TRANSFER_OPTIMIZED_KD_DROP_LONG) {
       if (param->overlap) errorQuda("Updating the staggered/asqtad KD field with param->overlap set is not supported");
 
-      mg->mg->resetStaggeredKD(gaugeSloppy, gaugeFatSloppy, gaugeLongSloppy,
-                               gaugePrecondition, gaugeFatPrecondition, gaugeLongPrecondition, param->mass);
+      mg->mg->resetStaggeredKD(gaugeSloppy, gaugeFatSloppy, gaugeLongSloppy, gaugePrecondition, gaugeFatPrecondition,
+                               gaugeLongPrecondition, param->mass);
     }
 
   } else {

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -2514,7 +2514,8 @@ void updateMultigridQuda(void *mg_, QudaMultigridParam *mg_param)
         || mg_param->transfer_type[0] == QUDA_TRANSFER_OPTIMIZED_KD_DROP_LONG) {
       if (param->overlap) errorQuda("Updating the staggered/asqtad KD field with param->overlap set is not supported");
 
-      mg->mg->resetStaggeredKD(gaugeSloppy, gaugeFatSloppy, gaugeLongSloppy, param->mass);
+      mg->mg->resetStaggeredKD(gaugeSloppy, gaugeFatSloppy, gaugeLongSloppy,
+                               gaugePrecondition, gaugeFatPrecondition, gaugeLongPrecondition, param->mass);
     }
 
   } else {

--- a/lib/multigrid.cpp
+++ b/lib/multigrid.cpp
@@ -253,8 +253,8 @@ namespace quda
   }
 
   void MG::resetStaggeredKD(cudaGaugeField *gauge_in, cudaGaugeField *fat_gauge_in, cudaGaugeField *long_gauge_in,
-                            cudaGaugeField *gauge_sloppy_in, cudaGaugeField *fat_gauge_sloppy_in, cudaGaugeField *long_gauge_sloppy_in,
-                            double mass)
+                            cudaGaugeField *gauge_sloppy_in, cudaGaugeField *fat_gauge_sloppy_in,
+                            cudaGaugeField *long_gauge_sloppy_in, double mass)
   {
     if (param.level != 0) errorQuda("The staggered KD operator can only be updated from level 0");
 
@@ -339,8 +339,10 @@ namespace quda
     param_presmooth->use_init_guess = QUDA_USE_INIT_GUESS_NO;
 
     param_presmooth->precision = param.mg_global.invert_param->cuda_prec_sloppy;
-    param_presmooth->precision_sloppy = (is_fine_grid()) ? param.mg_global.invert_param->cuda_prec_precondition : param.mg_global.invert_param->cuda_prec_sloppy;
-    param_presmooth->precision_precondition = (is_fine_grid()) ? param.mg_global.invert_param->cuda_prec_precondition : param.mg_global.invert_param->cuda_prec_sloppy;
+    param_presmooth->precision_sloppy = (is_fine_grid()) ? param.mg_global.invert_param->cuda_prec_precondition :
+                                                           param.mg_global.invert_param->cuda_prec_sloppy;
+    param_presmooth->precision_precondition = (is_fine_grid()) ? param.mg_global.invert_param->cuda_prec_precondition :
+                                                                 param.mg_global.invert_param->cuda_prec_sloppy;
 
     param_presmooth->inv_type = param.smoother;
     param_presmooth->inv_type_precondition = QUDA_INVALID_INVERTER;
@@ -411,7 +413,7 @@ namespace quda
     if (param.level == 0
         && (param.mg_global.transfer_type[param.level] == QUDA_TRANSFER_OPTIMIZED_KD
             || param.mg_global.transfer_type[param.level] == QUDA_TRANSFER_OPTIMIZED_KD_DROP_LONG)) {
-      
+
       createOptimizedKdDirac();
 
     } else {
@@ -491,7 +493,8 @@ namespace quda
     popLevel();
   }
 
-  void MG::createOptimizedKdDirac() {
+  void MG::createOptimizedKdDirac()
+  {
 
     pushLevel(param.level);
 
@@ -503,7 +506,8 @@ namespace quda
     }
 
     // Determine if we're doing a mixed precision solve for setup or not
-    bool mixed_precision_setup = (param.mg_global.invert_param->cuda_prec_precondition != param.mg_global.invert_param->cuda_prec_sloppy);
+    bool mixed_precision_setup
+      = (param.mg_global.invert_param->cuda_prec_precondition != param.mg_global.invert_param->cuda_prec_sloppy);
 
     // Allocate and build the KD inverse block (inverse coarse clover)
     auto fine_dirac_type = diracSmoother->getDiracType();
@@ -514,7 +518,8 @@ namespace quda
     bool is_naive_staggered = (dirac_type == QUDA_STAGGERED_DIRAC || dirac_type == QUDA_STAGGEREDPC_DIRAC);
     bool is_improved_staggered = (dirac_type == QUDA_ASQTAD_DIRAC || dirac_type == QUDA_ASQTADPC_DIRAC);
 
-    bool is_coarse_naive_staggered = is_naive_staggered || (is_improved_staggered && param.mg_global.transfer_type[param.level] == QUDA_TRANSFER_OPTIMIZED_KD_DROP_LONG);
+    bool is_coarse_naive_staggered = is_naive_staggered
+      || (is_improved_staggered && param.mg_global.transfer_type[param.level] == QUDA_TRANSFER_OPTIMIZED_KD_DROP_LONG);
 
     cudaGaugeField *fine_gauge = diracSmoother->getStaggeredShortLinkField();
     cudaGaugeField *sloppy_gauge = mixed_precision_setup ? diracSmootherSloppy->getStaggeredShortLinkField() : fine_gauge;
@@ -530,7 +535,7 @@ namespace quda
       // true is to force FLOAT2
       xinv_param.setPrecision(param.mg_global.invert_param->cuda_prec_precondition, true);
 
-      xInvKD_sloppy = std::shared_ptr<GaugeField>(reinterpret_cast<GaugeField*>(new cudaGaugeField(xinv_param)));
+      xInvKD_sloppy = std::shared_ptr<GaugeField>(reinterpret_cast<GaugeField *>(new cudaGaugeField(xinv_param)));
       xInvKD_sloppy->copy(*xInvKD);
 
       ColorSpinorParam sloppy_tmp_param(*tmp_coarse);

--- a/lib/multigrid.cpp
+++ b/lib/multigrid.cpp
@@ -253,6 +253,7 @@ namespace quda
   }
 
   void MG::resetStaggeredKD(cudaGaugeField *gauge_in, cudaGaugeField *fat_gauge_in, cudaGaugeField *long_gauge_in,
+                            cudaGaugeField *gauge_sloppy_in, cudaGaugeField *fat_gauge_sloppy_in, cudaGaugeField *long_gauge_sloppy_in,
                             double mass)
   {
     if (param.level != 0) errorQuda("The staggered KD operator can only be updated from level 0");
@@ -269,12 +270,12 @@ namespace quda
       // last nullptr is for the clover field
       diracCoarseResidual->updateFields(fat_gauge_in, fat_gauge_in, long_gauge_in, nullptr);
       diracCoarseSmoother->updateFields(fat_gauge_in, fat_gauge_in, long_gauge_in, nullptr);
-      diracCoarseSmootherSloppy->updateFields(fat_gauge_in, fat_gauge_in, long_gauge_in, nullptr);
+      diracCoarseSmootherSloppy->updateFields(fat_gauge_sloppy_in, fat_gauge_sloppy_in, long_gauge_sloppy_in, nullptr);
     } else {
       // last nullptr is for the clover field
       diracCoarseResidual->updateFields(gauge_in, fat_gauge_in, long_gauge_in, nullptr);
       diracCoarseSmoother->updateFields(gauge_in, fat_gauge_in, long_gauge_in, nullptr);
-      diracCoarseSmootherSloppy->updateFields(gauge_in, fat_gauge_in, long_gauge_in, nullptr);
+      diracCoarseSmootherSloppy->updateFields(gauge_sloppy_in, fat_gauge_sloppy_in, long_gauge_sloppy_in, nullptr);
     }
 
     diracCoarseResidual->setMass(mass);
@@ -516,6 +517,9 @@ namespace quda
   }
 
   void MG::createOptimizedKdDirac() {
+
+    pushLevel(param.level);
+
     auto dirac_type = diracSmoother->getDiracType();
 
     auto smoother_solve_type = param.mg_global.smoother_solve_type[param.level + 1];
@@ -617,6 +621,8 @@ namespace quda
     } else {
       errorQuda("Invalid dirac_type %d", dirac_type);
     }
+
+    popLevel();
   }
 
   void MG::destroyCoarseSolver() {

--- a/lib/multigrid.cpp
+++ b/lib/multigrid.cpp
@@ -36,7 +36,10 @@ namespace quda
     x_coarse(nullptr),
     tmp_coarse(nullptr),
     tmp2_coarse(nullptr),
+    tmp_coarse_sloppy(nullptr),
+    tmp2_coarse_sloppy(nullptr),
     xInvKD(nullptr),
+    xInvKD_sloppy(nullptr),
     diracResidual(param.matResidual->Expose()),
     diracSmoother(param.matSmooth->Expose()),
     diracSmootherSloppy(param.matSmoothSloppy->Expose()),
@@ -335,8 +338,8 @@ namespace quda
     param_presmooth->use_init_guess = QUDA_USE_INIT_GUESS_NO;
 
     param_presmooth->precision = param.mg_global.invert_param->cuda_prec_sloppy;
-    param_presmooth->precision_sloppy = (param.level == 0) ? param.mg_global.invert_param->cuda_prec_precondition : param.mg_global.invert_param->cuda_prec_sloppy;
-    param_presmooth->precision_precondition = (param.level == 0) ? param.mg_global.invert_param->cuda_prec_precondition : param.mg_global.invert_param->cuda_prec_sloppy;
+    param_presmooth->precision_sloppy = (is_fine_grid()) ? param.mg_global.invert_param->cuda_prec_precondition : param.mg_global.invert_param->cuda_prec_sloppy;
+    param_presmooth->precision_precondition = (is_fine_grid()) ? param.mg_global.invert_param->cuda_prec_precondition : param.mg_global.invert_param->cuda_prec_sloppy;
 
     param_presmooth->inv_type = param.smoother;
     param_presmooth->inv_type_precondition = QUDA_INVALID_INVERTER;
@@ -407,73 +410,8 @@ namespace quda
     if (param.level == 0
         && (param.mg_global.transfer_type[param.level] == QUDA_TRANSFER_OPTIMIZED_KD
             || param.mg_global.transfer_type[param.level] == QUDA_TRANSFER_OPTIMIZED_KD_DROP_LONG)) {
-      auto dirac_type = diracSmoother->getDiracType();
-
-      auto smoother_solve_type = param.mg_global.smoother_solve_type[param.level + 1];
-      if (smoother_solve_type != QUDA_DIRECT_SOLVE) {
-        errorQuda("Invalid solve type %d for optimized KD operator", smoother_solve_type);
-      }
-
-      // Allocate and build the KD inverse block (inverse coarse clover)
-      auto fine_dirac_type = diracSmoother->getDiracType();
-      if (fine_dirac_type != dirac_type)
-        errorQuda("Input dirac type %d does not match smoother type %d\n", dirac_type, fine_dirac_type);
-
-      cudaGaugeField *fine_gauge = nullptr;
-      if (dirac_type == QUDA_STAGGERED_DIRAC || dirac_type == QUDA_STAGGEREDPC_DIRAC)
-        fine_gauge
-          = const_cast<cudaGaugeField *>(reinterpret_cast<const DiracStaggered *>(diracSmoother)->getGaugeField());
-      if (dirac_type == QUDA_ASQTAD_DIRAC || dirac_type == QUDA_ASQTADPC_DIRAC)
-        fine_gauge = const_cast<cudaGaugeField *>(
-          reinterpret_cast<const DiracImprovedStaggered *>(diracSmoother)->getFatLinkField());
-
-      xInvKD = AllocateAndBuildStaggeredKahlerDiracInverse(
-        *fine_gauge, diracSmoother->Mass(), param.mg_global.staggered_kd_dagger_approximation == QUDA_BOOLEAN_TRUE);
-
-      DiracParam diracParamKD;
-      diracParamKD.kappa
-        = -1.0; // Cancels automatic kappa in Y field application, which may be relevant if it propagates down
-      diracParamKD.mass = diracSmoother->Mass();
-      diracParamKD.mu = diracSmoother->Mu(); // doesn't matter
-      diracParamKD.mu_factor = 1.0;          // doesn't matter
-      diracParamKD.dagger = QUDA_DAG_NO;
-      diracParamKD.matpcType = QUDA_MATPC_EVEN_EVEN; // We can use this to track left vs right block jacobi in the future
-      diracParamKD.gauge = const_cast<cudaGaugeField *>(fine_gauge);
-      diracParamKD.xInvKD = xInvKD.get(); // FIXME: pulling a raw unmanaged pointer out of a unique_ptr...
-      diracParamKD.dirac
-        = const_cast<Dirac *>(diracSmoother); // used to determine if the outer solve is preconditioned or not
-
-      diracParamKD.tmp1 = tmp_coarse;
-      diracParamKD.tmp2 = tmp2_coarse;
-
-      if (dirac_type == QUDA_STAGGERED_DIRAC || dirac_type == QUDA_STAGGEREDPC_DIRAC) {
-        diracParamKD.type = QUDA_STAGGEREDKD_DIRAC;
-
-        diracCoarseResidual = new DiracStaggeredKD(diracParamKD);
-        diracCoarseSmoother = new DiracStaggeredKD(diracParamKD);
-        diracCoarseSmootherSloppy = new DiracStaggeredKD(diracParamKD);
-      } else if (dirac_type == QUDA_ASQTAD_DIRAC || dirac_type == QUDA_ASQTADPC_DIRAC) {
-        if (param.mg_global.transfer_type[param.level] == QUDA_TRANSFER_OPTIMIZED_KD) {
-          diracParamKD.type = QUDA_ASQTADKD_DIRAC;
-
-          diracParamKD.fatGauge = fine_gauge;
-          diracParamKD.longGauge = const_cast<cudaGaugeField *>(
-            reinterpret_cast<const DiracImprovedStaggered *>(diracSmoother)->getLongLinkField());
-
-          diracCoarseResidual = new DiracImprovedStaggeredKD(diracParamKD);
-          diracCoarseSmoother = new DiracImprovedStaggeredKD(diracParamKD);
-          diracCoarseSmootherSloppy = new DiracImprovedStaggeredKD(diracParamKD);
-        } else {
-          // param.transfer_type == QUDA_TRANSFER_OPTIMIZED_KD_DROP_LONG
-          diracParamKD.type = QUDA_STAGGEREDKD_DIRAC;
-
-          diracCoarseResidual = new DiracStaggeredKD(diracParamKD);
-          diracCoarseSmoother = new DiracStaggeredKD(diracParamKD);
-          diracCoarseSmootherSloppy = new DiracStaggeredKD(diracParamKD);
-        }
-      } else {
-        errorQuda("Invalid dirac_type %d", dirac_type);
-      }
+      
+      createOptimizedKdDirac();
 
     } else {
 
@@ -550,6 +488,135 @@ namespace quda
     if (getVerbosity() >= QUDA_VERBOSE) printfQuda("Coarse Dirac operator done\n");
 
     popLevel();
+  }
+
+  // get "one link" gauge field
+  cudaGaugeField* getStaggeredShortGaugeField(const Dirac& dirac, QudaDiracType dirac_type) {
+    switch (dirac_type) {
+      case QUDA_STAGGERED_DIRAC: return const_cast<cudaGaugeField *>(reinterpret_cast<const DiracStaggered&>(dirac).getGaugeField());
+      case QUDA_STAGGEREDPC_DIRAC: return const_cast<cudaGaugeField *>(reinterpret_cast<const DiracStaggeredPC&>(dirac).getGaugeField());
+      case QUDA_STAGGEREDKD_DIRAC: return const_cast<cudaGaugeField *>(reinterpret_cast<const DiracStaggeredKD&>(dirac).getGaugeField());
+      case QUDA_ASQTAD_DIRAC: return const_cast<cudaGaugeField *>(reinterpret_cast<const DiracImprovedStaggered&>(dirac).getFatLinkField());
+      case QUDA_ASQTADPC_DIRAC: return const_cast<cudaGaugeField *>(reinterpret_cast<const DiracImprovedStaggeredPC&>(dirac).getFatLinkField());
+      case QUDA_ASQTADKD_DIRAC: return const_cast<cudaGaugeField *>(reinterpret_cast<const DiracImprovedStaggeredKD&>(dirac).getFatLinkField());
+      default: errorQuda("Invalid dirac type %d", dirac_type);
+    }
+    return nullptr;
+  }
+
+  // get "long link" gauge field
+  cudaGaugeField* getStaggeredLongGaugeField(const Dirac& dirac, QudaDiracType dirac_type) {
+    switch (dirac_type) {
+      case QUDA_ASQTAD_DIRAC: return const_cast<cudaGaugeField *>(reinterpret_cast<const DiracImprovedStaggered&>(dirac).getLongLinkField());
+      case QUDA_ASQTADPC_DIRAC: return const_cast<cudaGaugeField *>(reinterpret_cast<const DiracImprovedStaggeredPC&>(dirac).getLongLinkField());
+      case QUDA_ASQTADKD_DIRAC: return const_cast<cudaGaugeField *>(reinterpret_cast<const DiracImprovedStaggeredKD&>(dirac).getLongLinkField());
+      default: errorQuda("Invalid dirac type %d", dirac_type);
+    }
+    return nullptr;
+  }
+
+  void MG::createOptimizedKdDirac() {
+    auto dirac_type = diracSmoother->getDiracType();
+
+    auto smoother_solve_type = param.mg_global.smoother_solve_type[param.level + 1];
+    if (smoother_solve_type != QUDA_DIRECT_SOLVE) {
+      errorQuda("Invalid solve type %d for optimized KD operator", smoother_solve_type);
+    }
+
+    // Determine if we're doing a mixed precision solve for setup or not
+    bool mixed_precision_setup = (param.mg_global.invert_param->cuda_prec_precondition != param.mg_global.invert_param->cuda_prec_sloppy);
+
+    // Allocate and build the KD inverse block (inverse coarse clover)
+    auto fine_dirac_type = diracSmoother->getDiracType();
+    if (fine_dirac_type != dirac_type)
+      errorQuda("Input dirac type %d does not match smoother type %d\n", dirac_type, fine_dirac_type);
+
+    // Determine if the dirac_type is naive staggered
+    bool is_naive_staggered = (dirac_type == QUDA_STAGGERED_DIRAC || dirac_type == QUDA_STAGGEREDPC_DIRAC);
+    bool is_improved_staggered = (dirac_type == QUDA_ASQTAD_DIRAC || dirac_type == QUDA_ASQTADPC_DIRAC);
+
+    bool is_coarse_naive_staggered = is_naive_staggered || (is_improved_staggered && param.mg_global.transfer_type[param.level] == QUDA_TRANSFER_OPTIMIZED_KD_DROP_LONG);
+
+    cudaGaugeField *fine_gauge = getStaggeredShortGaugeField(*diracSmoother, dirac_type);
+    cudaGaugeField *sloppy_gauge = getStaggeredShortGaugeField(mixed_precision_setup ? *diracSmootherSloppy : *diracSmoother, dirac_type);
+
+    xInvKD = AllocateAndBuildStaggeredKahlerDiracInverse(
+      *fine_gauge, diracSmoother->Mass(), param.mg_global.staggered_kd_dagger_approximation == QUDA_BOOLEAN_TRUE);
+
+    // Unique to the KD operator as a "coarse level", we can do a mixed-precision
+    // near null generation.
+    if (mixed_precision_setup) {
+      GaugeFieldParam xinv_param(*xInvKD);
+
+      // true is to force FLOAT2
+      xinv_param.setPrecision(param.mg_global.invert_param->cuda_prec_precondition, true);
+
+      xInvKD_sloppy = std::shared_ptr<GaugeField>(reinterpret_cast<GaugeField*>(new cudaGaugeField(xinv_param)));
+      xInvKD_sloppy->copy(*xInvKD);
+
+      ColorSpinorParam sloppy_tmp_param(*tmp_coarse);
+      sloppy_tmp_param.setPrecision(param.mg_global.invert_param->cuda_prec_precondition);
+
+      tmp_coarse_sloppy = new ColorSpinorField(sloppy_tmp_param);
+      tmp2_coarse_sloppy = new ColorSpinorField(sloppy_tmp_param);
+
+    } else {
+      // We can just alias fields
+      xInvKD_sloppy = xInvKD;
+    }
+
+    DiracParam diracParamKD;
+    diracParamKD.kappa
+      = -1.0; // Cancels automatic kappa in Y field application, which may be relevant if it propagates down
+    diracParamKD.mass = diracSmoother->Mass();
+    diracParamKD.mu = diracSmoother->Mu(); // doesn't matter
+    diracParamKD.mu_factor = 1.0;          // doesn't matter
+    diracParamKD.dagger = QUDA_DAG_NO;
+    diracParamKD.matpcType = QUDA_MATPC_EVEN_EVEN; // We can use this to track left vs right block jacobi in the future
+    diracParamKD.gauge = const_cast<cudaGaugeField *>(fine_gauge);
+    diracParamKD.xInvKD = xInvKD.get(); // FIXME: pulling a raw unmanaged pointer out of a unique_ptr...
+    diracParamKD.dirac
+      = const_cast<Dirac *>(diracSmoother); // used to determine if the outer solve is preconditioned or not
+
+    diracParamKD.tmp1 = tmp_coarse;
+    diracParamKD.tmp2 = tmp2_coarse;
+
+    if (is_coarse_naive_staggered) {
+      diracParamKD.type = QUDA_STAGGEREDKD_DIRAC;
+
+      diracCoarseResidual = new DiracStaggeredKD(diracParamKD);
+      diracCoarseSmoother = new DiracStaggeredKD(diracParamKD);
+      if (mixed_precision_setup) {
+        diracParamKD.gauge = sloppy_gauge;
+        diracParamKD.xInvKD = xInvKD_sloppy.get();
+        diracParamKD.dirac = nullptr;
+        diracParamKD.tmp1 = tmp_coarse_sloppy;
+        diracParamKD.tmp2 = tmp2_coarse_sloppy;
+      }
+      diracCoarseSmootherSloppy = new DiracStaggeredKD(diracParamKD);
+
+    } else if (is_improved_staggered) {
+      diracParamKD.type = QUDA_ASQTADKD_DIRAC;
+
+      diracParamKD.fatGauge = fine_gauge;
+      diracParamKD.longGauge = getStaggeredLongGaugeField(*diracSmoother, dirac_type);
+
+      diracCoarseResidual = new DiracImprovedStaggeredKD(diracParamKD);
+      diracCoarseSmoother = new DiracImprovedStaggeredKD(diracParamKD);
+
+      if (mixed_precision_setup) {
+        diracParamKD.fatGauge = sloppy_gauge;
+        diracParamKD.longGauge = getStaggeredLongGaugeField(*diracSmootherSloppy, dirac_type);
+        diracParamKD.xInvKD = xInvKD_sloppy.get();
+        diracParamKD.dirac = nullptr;
+        diracParamKD.tmp1 = tmp_coarse_sloppy;
+        diracParamKD.tmp2 = tmp2_coarse_sloppy;
+      }
+
+      diracCoarseSmootherSloppy = new DiracImprovedStaggeredKD(diracParamKD);
+    } else {
+      errorQuda("Invalid dirac_type %d", dirac_type);
+    }
   }
 
   void MG::destroyCoarseSolver() {
@@ -761,6 +828,8 @@ namespace quda
     if (x_coarse) delete x_coarse;
     if (tmp_coarse) delete tmp_coarse;
     if (tmp2_coarse) delete tmp2_coarse;
+    if (tmp_coarse_sloppy) delete tmp_coarse_sloppy;
+    if (tmp2_coarse_sloppy) delete tmp2_coarse_sloppy;
 
     if (param_coarse) delete param_coarse;
 
@@ -1380,12 +1449,13 @@ namespace quda
       = (solverParam.inv_type == QUDA_BICGSTAB_INVERTER ? 0 : 4); // FIXME: pipeline != 0 breaks BICGSTAB
     solverParam.precision = r->Precision();
 
-    if (param.level == 0) { // this enables half precision on the fine grid only if set
+    if (is_fine_grid()) {
       solverParam.precision_sloppy = param.mg_global.invert_param->cuda_prec_precondition;
       solverParam.precision_precondition = param.mg_global.invert_param->cuda_prec_precondition;
     } else {
       solverParam.precision_precondition = solverParam.precision;
     }
+
     solverParam.residual_type = static_cast<QudaResidualType>(QUDA_L2_RELATIVE_RESIDUAL);
     solverParam.compute_null_vector = QUDA_COMPUTE_NULL_VECTOR_YES;
     ColorSpinorParam csParam(*B[0]);                            // Create spinor field parameters:

--- a/lib/staggered_kd_build_xinv.cu
+++ b/lib/staggered_kd_build_xinv.cu
@@ -265,7 +265,7 @@ namespace quda {
 
 
   // Allocates and calculates the inverse KD block, returning Xinv
-  std::unique_ptr<GaugeField> AllocateAndBuildStaggeredKahlerDiracInverse(const cudaGaugeField &gauge, const double mass, const bool dagger_approximation)
+  std::shared_ptr<GaugeField> AllocateAndBuildStaggeredKahlerDiracInverse(const cudaGaugeField &gauge, const double mass, const bool dagger_approximation)
   {
     GaugeFieldParam gParam(gauge);
     gParam.reconstruct = QUDA_RECONSTRUCT_NO;
@@ -279,7 +279,7 @@ namespace quda {
     // latter true is to force FLOAT2
     gParam.setPrecision(gauge.Precision(), true);
 
-    std::unique_ptr<GaugeField> Xinv(reinterpret_cast<GaugeField*>(new cudaGaugeField(gParam)));
+    std::shared_ptr<GaugeField> Xinv(reinterpret_cast<GaugeField*>(new cudaGaugeField(gParam)));
 
     BuildStaggeredKahlerDiracInverse(*Xinv, gauge, mass, dagger_approximation);
 


### PR DESCRIPTION
This PR adds support for running near-null generation with the staggered KD op in mixed precision (single/half), which was "overlooked" in the past. This happens transparently, similar to how it's done when setting up the `SmootherSloppy` operator in the outermost setup in `interface_quda.cpp`.

It's been verified to work as expected through both QUDA test executables and the MILC HISQ MG interface.

Reference command:

```
./staggered_invert_test \
            --prec double --prec-sloppy single --prec-null half --prec-precondition half \
            --mass 0.01 --recon 13 --recon-sloppy 9 --recon-precondition 9 \
            --dim 16 16 16 16 --gridsize 1 1 1 1 --load-gauge l16t16b7p0 --partition 15 \
            --dslash-type asqtad --compute-fat-long true --tadpole-coeff 0.905160183 --tol 1e-10 \
            --verbosity verbose --solve-type direct --solution-type mat --inv-type gcr \
            --inv-multigrid true --mg-levels 4 --mg-staggered-coarsen-type kd-optimized \
            --mg-block-size 0 1 1 1 1 --mg-nvec 0 3 \
            --mg-block-size 1 4 4 4 4 --mg-nvec 1 64 \
            --mg-block-size 2 2 2 2 2 --mg-nvec 2 96 \
            --mg-setup-tol 1 1e-6 --mg-setup-maxiter 1 50 --mg-setup-inv 1 cgnr --mg-save-vec 1 null \
            --mg-setup-tol 2 1e-6 --mg-setup-maxiter 2 50 --mg-setup-inv 2 cgnr --mg-save-vec 2 null \
            --nsrc 1 --niter 1 \
            --mg-use-mma true \
            --mg-smoother 0 ca-gcr --mg-smoother-solve-type 0 direct    --mg-nu-pre 0 0 --mg-nu-post 0 4 \
            --mg-smoother 1 ca-gcr --mg-smoother-solve-type 1 direct --mg-nu-pre 1 0 --mg-nu-post 1 4 \
            --mg-smoother 2 ca-gcr --mg-smoother-solve-type 2 direct-pc --mg-nu-pre 2 0 --mg-nu-post 2 4 \
            --mg-coarse-solver 1 gcr --mg-coarse-solve-type 1 direct --mg-coarse-solver-tol 1 0.35 --mg-coarse-solver-maxiter 1 8 \
            --mg-coarse-solver 2 gcr --mg-coarse-solve-type 2 direct-pc --mg-coarse-solver-tol 2 0.35 --mg-coarse-solver-maxiter 2 8 \
            --mg-coarse-solver 3 ca-cgnr --mg-coarse-solve-type 3 direct-pc --mg-coarse-solver-tol 3 0.01 --mg-coarse-solver-maxiter 3 20 \
            --mg-verbosity 0 verbose --mg-verbosity 1 verbose --mg-verbosity 2 verbose --mg-verbosity 3 verbose
```

This fix reduces setup time for the MILC spectrum KPP 144^3 configuration on 144 nodes by ~100 seconds.

`clang-format` outstanding, will do as a last step.