### PR TITLE
Added manual specification of gauge field locations to heatbath_test, some gauge algorithms

### DIFF
--- a/lib/gauge_observable.cpp
+++ b/lib/gauge_observable.cpp
@@ -34,6 +34,7 @@ namespace quda
     lat_dim_t x;
     for (int i = 0; i < 4; i++) x[i] = u.X()[i] - 2 * u.R()[i];
     GaugeFieldParam tensorParam(x, u.Precision(), QUDA_RECONSTRUCT_NO, 0, QUDA_TENSOR_GEOMETRY);
+    tensorParam.location = QUDA_CUDA_FIELD_LOCATION;
     tensorParam.siteSubset = QUDA_FULL_SITE_SUBSET;
     tensorParam.order = QUDA_FLOAT2_GAUGE_ORDER;
     tensorParam.ghostExchange = QUDA_GHOST_EXCHANGE_NO;

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -5271,6 +5271,7 @@ void performGaugeSmearQuda(QudaGaugeSmearParam *smear_param, QudaGaugeObservable
   gaugeSmeared = createExtendedGauge(*gaugePrecise, R, profileGaugeSmear);
 
   GaugeFieldParam gParam(*gaugeSmeared);
+  gParam.location = QUDA_CUDA_FIELD_LOCATION;
   auto *cudaGaugeTemp = new cudaGaugeField(gParam);
 
   int measurement_n = 0; // The nth measurement to take

--- a/tests/heatbath_test.cpp
+++ b/tests/heatbath_test.cpp
@@ -104,6 +104,7 @@ int main(int argc, char **argv)
   {
     using namespace quda;
     GaugeFieldParam gParam(gauge_param);
+    gParam.location = QUDA_CUDA_FIELD_LOCATION;
     gParam.ghostExchange = QUDA_GHOST_EXCHANGE_NO;
     gParam.create = QUDA_NULL_FIELD_CREATE;
     gParam.link_type = gauge_param.type;
@@ -119,6 +120,7 @@ int main(int argc, char **argv)
     for (int dir = 0; dir < 4; ++dir) y[dir] = gauge_param.X[dir] + 2 * R[dir];
     GaugeFieldParam gParamEx(y, prec, link_recon, pad, QUDA_VECTOR_GEOMETRY, QUDA_GHOST_EXCHANGE_EXTENDED);
     gParamEx.create = QUDA_ZERO_FIELD_CREATE;
+    gParamEx.location = QUDA_CUDA_FIELD_LOCATION;
     gParamEx.order = gParam.order;
     gParamEx.siteSubset = QUDA_FULL_SITE_SUBSET;
     gParamEx.t_boundary = gParam.t_boundary;


### PR DESCRIPTION
This narrow PR manually adds the gauge field location to a few gauge field test executables, which was missed during `feature/colorspinor-default` review.

The reasons aren't necessarily related to incomplete `ctest` coverage: for example, the pieces `heatbath_test` utilizes are covered in the gauge algorithm `ctest`. I'm not exactly sure how the `gaugeObservables` bit squeaked through, though---perhaps more review of coverage in the gauge algorithm test is needed. I'll open an issue to cover this in the interest of quickly getting this hotfix in---I need to generate some gauge configs!