### PR TITLE
Alternative `i2f`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,6 +233,8 @@ option(QUDA_CTEST_DISABLE_BENCHMARKS "Disable benchmark test" ON)
 option(QUDA_FAST_COMPILE_REDUCE "enable fast compilation in blas and reduction kernels (single warp per reduction)" OFF)
 option(QUDA_FAST_COMPILE_DSLASH "enable fast compilation in dslash kernels (~20% perf impact)" OFF)
 
+option(QUDA_ALTERNATIVE_I_TO_F "enable using alternative integer-to-float conversion" OFF)
+
 option(QUDA_OPENMP "enable OpenMP" OFF)
 set(QUDA_CXX_STANDARD
     17
@@ -261,6 +263,8 @@ mark_as_advanced(QUDA_INSTALL_ALL_TESTS)
 mark_as_advanced(QUDA_FLOAT8)
 mark_as_advanced(QUDA_FAST_COMPILE_REDUCE)
 mark_as_advanced(QUDA_FAST_COMPILE_DSLASH)
+
+mark_as_advanced(QUDA_ALTERNATIVE_I_TO_F)
 
 mark_as_advanced(QUDA_MAX_MULTI_BLAS_N)
 mark_as_advanced(QUDA_PRECISION)

--- a/include/convert.h
+++ b/include/convert.h
@@ -78,15 +78,12 @@ namespace quda
 
   template <typename T> constexpr float i2f(T a)
   {
-#if 1
+#ifndef QUDA_ALTERNATIVE_I_TO_F
     return static_cast<float>(a);
 #else
     // will work for up to 23-bit int
-    union {
-      int32_t i;
-      float f;
-    };
-    i = a + 0x4B400000;
+    int32_t i = a + 0x4B400000;
+    float &f = reinterpret_cast<float &>(i);
     return f - 12582912.0f;
 #endif
   }

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -440,6 +440,10 @@ if(QUDA_FAST_COMPILE_DSLASH)
   target_compile_definitions(quda PRIVATE QUDA_FAST_COMPILE_DSLASH)
 endif()
 
+if(QUDA_ALTERNATIVE_I_TO_F)
+  target_compile_definitions(quda PRIVATE QUDA_ALTERNATIVE_I_TO_F)
+endif()
+
 if(QUDA_BACKWARDS)
   target_include_directories(quda_cpp SYSTEM PRIVATE ${backward-cpp_SOURCE_DIR})
 


### PR DESCRIPTION
- Add `QUDA_ALTERNATIVE_I_TO_F` as a cmake option.
- Fix the alternative `i2f`: the original code no longer work as described in #1270. In principle the fix is still undefined behavior, but it works for now.

Closes #1270.