### PR TITLE
Reduce ctest time by not testing all partitions for all Dirac operators

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -331,9 +331,10 @@ foreach(pol IN LISTS DSLASH_POLICIES)
 
   if(QUDA_DIRAC_WILSON)
     set(DIRAC_NAME wilson)
-    add_test(NAME dslash_wilson_policy${pol2}
+    add_test(NAME dslash_${DIRAC_NAME}_policy${pol2}
              COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:dslash_ctest> ${MPIEXEC_POSTFLAGS}
                      --dslash-type ${DIRAC_NAME}
+                     --all-partitions 1
                      --test MatPCDagMatPC
                      --dim 2 4 6 8
                      --gtest_output=xml:dslash_${DIRAC_NAME}_test_pol${pol2}.xml)
@@ -344,6 +345,7 @@ foreach(pol IN LISTS DSLASH_POLICIES)
     add_test(NAME benchmark_dslash_${DIRAC_NAME}_policy${pol2}
              COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:dslash_ctest> ${MPIEXEC_POSTFLAGS}
                      --dslash-type ${DIRAC_NAME}
+                     --all-partitions 1
                      --test 0
                      --dim 20 20 20 20
                      --gtest_output=json:dslash_${DIRAC_NAME}_benchmark_pol${pol2}.json
@@ -801,6 +803,7 @@ endif()
     add_test(NAME dslash_${DIRAC_NAME}_policy${pol2}
              COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:staggered_dslash_ctest> ${MPIEXEC_POSTFLAGS}
                      --dslash-type ${DIRAC_NAME}
+                     --all-partitions 1
                      --test MatPC
                      --dim 6 8 10 12
                      --gtest_output=xml:dslash_${DIRAC_NAME}_test_pol${pol2}.xml)
@@ -811,6 +814,7 @@ endif()
     add_test(NAME benchmark_dslash_${DIRAC_NAME}_policy${pol2}
     COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:staggered_dslash_ctest> ${MPIEXEC_POSTFLAGS}
             --dslash-type ${DIRAC_NAME}
+            --all-partitions 1
             --test 0
             --dim 20 20 20 20
             --gtest_output=json:dslash_${DIRAC_NAME}_benchmark_pol${pol2}.json

--- a/tests/dslash_ctest.cpp
+++ b/tests/dslash_ctest.cpp
@@ -6,6 +6,7 @@ using namespace quda;
 int argc_copy;
 char **argv_copy;
 dslash_test_type dtest_type = dslash_test_type::Dslash;
+bool ctest_all_partitions = false;
 
 // For googletest names must be non-empty, unique, and may only contain ASCII
 // alphanumeric characters or underscore
@@ -37,6 +38,10 @@ protected:
     }
 
     if (::testing::get<2>(GetParam()) > 0 && dslash_test_wrapper.test_split_grid) { return true; }
+
+    const std::array<bool, 16> partition_enabled {true, true,  true,  true,  true,  false, false, true,
+                                                  true, false, false, false, false, false, false, true};
+    if (!ctest_all_partitions && !partition_enabled[::testing::get<2>(GetParam())]) return true;
 
     return false;
   }
@@ -125,6 +130,7 @@ int main(int argc, char **argv)
   // command line options
   auto app = make_app();
   app->add_option("--test", dtest_type, "Test method")->transform(CLI::CheckedTransformer(dtest_type_map));
+  app->add_option("--all-partitions", ctest_all_partitions, "Test all instead of reduced combination of partitions");
   add_comms_option_group(app);
   try {
     app->parse(argc, argv);

--- a/tests/dslash_ctest.cpp
+++ b/tests/dslash_ctest.cpp
@@ -39,8 +39,8 @@ protected:
 
     if (::testing::get<2>(GetParam()) > 0 && dslash_test_wrapper.test_split_grid) { return true; }
 
-    const std::array<bool, 16> partition_enabled {true, true,  true,  true,  true,  false, false, true,
-                                                  true, false, false, false, false, false, false, true};
+    const std::array<bool, 16> partition_enabled {true, true, true,  false,  true,  false, false, false,
+                                                  true, false, false, false, true, false, true, true};
     if (!ctest_all_partitions && !partition_enabled[::testing::get<2>(GetParam())]) return true;
 
     return false;

--- a/tests/staggered_dslash_ctest.cpp
+++ b/tests/staggered_dslash_ctest.cpp
@@ -5,6 +5,7 @@ using namespace quda;
 StaggeredDslashTestWrapper dslash_test_wrapper;
 
 bool gauge_loaded = false;
+bool ctest_all_partitions = false;
 
 void display_test_info(int precision, QudaReconstructType link_recon)
 {
@@ -50,6 +51,10 @@ protected:
       warningQuda("Fixed precision unsupported for Laplace operator, skipping...");
       return true;
     }
+
+    const std::array<bool, 16> partition_enabled {true, true,  true,  true,  true,  false, false, true,
+                                                  true, false, false, false, false, false, false, true};
+    if (!ctest_all_partitions && !partition_enabled[::testing::get<2>(GetParam())]) return true;
 
     if (::testing::get<2>(GetParam()) > 0 && dslash_test_wrapper.test_split_grid) { return true; }
     return false;
@@ -115,6 +120,7 @@ int main(int argc, char **argv)
   ::testing::InitGoogleTest(&argc, argv);
   auto app = make_app();
   app->add_option("--test", dtest_type, "Test method")->transform(CLI::CheckedTransformer(dtest_type_map));
+  app->add_option("--all-partitions", ctest_all_partitions, "Test all instead of reduced combination of partitions");
   add_comms_option_group(app);
   try {
     app->parse(argc, argv);

--- a/tests/staggered_dslash_ctest.cpp
+++ b/tests/staggered_dslash_ctest.cpp
@@ -52,8 +52,8 @@ protected:
       return true;
     }
 
-    const std::array<bool, 16> partition_enabled {true, true,  true,  true,  true,  false, false, true,
-                                                  true, false, false, false, false, false, false, true};
+    const std::array<bool, 16> partition_enabled {true, true, true,  false,  true,  false, false, false,
+                                                  true, false, false, false, true, false, true, true};
     if (!ctest_all_partitions && !partition_enabled[::testing::get<2>(GetParam())]) return true;
 
     if (::testing::get<2>(GetParam()) > 0 && dslash_test_wrapper.test_split_grid) { return true; }


### PR DESCRIPTION
modify (staggered)_dslash_ctest to only run partitions 0, 1, 2, 3, 4, 7, 8, 15 by default.
New option `--all-partitions' add to these tests to enable all partitions.

ctest will test all-partitions for  wilson and asqtad.

