### PR TITLE
Hotfix/nvshmem 11.5

### DIFF
--- a/include/dslash_helper.cuh
+++ b/include/dslash_helper.cuh
@@ -7,6 +7,7 @@
 #include <shmem_helper.cuh>
 #include <fast_intdiv.h>
 #include <dslash_quda.h>
+#include <dslash_shmem.h>
 #include <shmem_pack_helper.cuh>
 
 #if defined(_NVHPC_CUDA)

--- a/include/dslash_quda.h
+++ b/include/dslash_quda.h
@@ -8,10 +8,6 @@
 #include <domain_wall_helper.h>
 #include <fast_intdiv.h>
 
-#ifdef NVSHMEM_COMMS
-#include <cuda/atomic>
-#endif
-
 namespace quda
 {
 
@@ -63,82 +59,6 @@ namespace quda
 
   void createDslashEvents();
   void destroyDslashEvents();
-
-  namespace dslash
-  {
-    /**
-     * @brief type used for shmem signaling
-     */
-    using shmem_sync_t = uint64_t;
-
-    /**
-     * @brief Get the shmem sync counter
-     *
-     * @return shmem_sync_t
-     */
-    shmem_sync_t get_dslash_shmem_sync_counter();
-    shmem_sync_t get_exchangeghost_shmem_sync_counter();
-    /**
-     * @brief Set the shmem sync counter to count
-     *
-     * @param count
-     * @return shmem_sync_t
-     */
-    shmem_sync_t set_dslash_shmem_sync_counter(shmem_sync_t count);
-    shmem_sync_t set_exchangeghost_shmem_sync_counter(shmem_sync_t count);
-    /**
-     * @brief increase the shmem sync counter for the next dslash application
-     *
-     * @return shmem_sync_t
-     */
-    shmem_sync_t inc_dslash_shmem_sync_counter();
-    shmem_sync_t inc_exchangeghost_shmem_sync_counter();
-
-#ifdef NVSHMEM_COMMS
-
-    void shmem_signal_wait_all();
-
-    using shmem_retcount_intra_t = cuda::atomic<int, cuda::thread_scope_system>;
-    using shmem_retcount_inter_t = cuda::atomic<int, cuda::thread_scope_device>;
-    using shmem_interior_done_t = cuda::atomic<shmem_sync_t, cuda::thread_scope_device>;
-    using shmem_interior_count_t = cuda::atomic<int, cuda::thread_scope_block>;
-
-    /**
-     * @brief Get the shmem sync arr which is used for signaling which exterior halos have arrived
-     *
-     * @return shmem_sync_t*
-     */
-    shmem_sync_t *get_dslash_shmem_sync_arr();
-    shmem_sync_t *get_exchangeghost_shmem_sync_arr();
-    /**
-     * @brief Get the array[2*QUDA_MAX_DIM] of atomic to count which intra node packing blocks have finished per dim/dir
-     *
-     * @return shmem_retcount_intra_t*
-     */
-    shmem_retcount_intra_t *get_shmem_retcount_intra();
-
-    /**
-     * @brief Get the array[2*QUDA_MAX_DIM] of atomic to count which inter node packing blocks have finished per dim/dir
-     *
-     * @return shmem_retcount_inter_t*
-     */
-    shmem_retcount_inter_t *get_shmem_retcount_inter();
-
-    /**
-     * @brief Get the atomic object used for signaling that the interior Dslash has been applied. Used in the uber kernel.
-     *
-     * @return shmem_interior_done_t*
-     */
-    shmem_interior_done_t *get_shmem_interior_done();
-
-    /**
-     * @brief Get the atomic counter for tracking how many of the interior blocks have finished. See also above.
-     *
-     * @return shmem_interior_count_t*
-     */
-    shmem_interior_count_t *get_shmem_interior_count();
-#endif
-  } // namespace dslash
 
   /**
      @brief Driver for applying the Wilson stencil

--- a/include/dslash_shmem.h
+++ b/include/dslash_shmem.h
@@ -1,0 +1,82 @@
+#include <shmem_helper.cuh>
+
+namespace quda {
+
+  namespace dslash
+  {
+    /**
+     * @brief type used for shmem signaling
+     */
+    using shmem_sync_t = uint64_t;
+
+    /**
+     * @brief Get the shmem sync counter
+     *
+     * @return shmem_sync_t
+     */
+    shmem_sync_t get_dslash_shmem_sync_counter();
+    shmem_sync_t get_exchangeghost_shmem_sync_counter();
+    /**
+     * @brief Set the shmem sync counter to count
+     *
+     * @param count
+     * @return shmem_sync_t
+     */
+    shmem_sync_t set_dslash_shmem_sync_counter(shmem_sync_t count);
+    shmem_sync_t set_exchangeghost_shmem_sync_counter(shmem_sync_t count);
+    /**
+     * @brief increase the shmem sync counter for the next dslash application
+     *
+     * @return shmem_sync_t
+     */
+    shmem_sync_t inc_dslash_shmem_sync_counter();
+    shmem_sync_t inc_exchangeghost_shmem_sync_counter();
+
+#ifdef NVSHMEM_COMMS
+
+    void shmem_signal_wait_all();
+
+    using shmem_retcount_intra_t = cuda::atomic<int, cuda::thread_scope_system>;
+    using shmem_retcount_inter_t = cuda::atomic<int, cuda::thread_scope_device>;
+    using shmem_interior_done_t = cuda::atomic<shmem_sync_t, cuda::thread_scope_device>;
+    using shmem_interior_count_t = cuda::atomic<int, cuda::thread_scope_block>;
+
+    /**
+     * @brief Get the shmem sync arr which is used for signaling which exterior halos have arrived
+     *
+     * @return shmem_sync_t*
+     */
+    shmem_sync_t *get_dslash_shmem_sync_arr();
+    shmem_sync_t *get_exchangeghost_shmem_sync_arr();
+    /**
+     * @brief Get the array[2*QUDA_MAX_DIM] of atomic to count which intra node packing blocks have finished per dim/dir
+     *
+     * @return shmem_retcount_intra_t*
+     */
+    shmem_retcount_intra_t *get_shmem_retcount_intra();
+
+    /**
+     * @brief Get the array[2*QUDA_MAX_DIM] of atomic to count which inter node packing blocks have finished per dim/dir
+     *
+     * @return shmem_retcount_inter_t*
+     */
+    shmem_retcount_inter_t *get_shmem_retcount_inter();
+
+    /**
+     * @brief Get the atomic object used for signaling that the interior Dslash has been applied. Used in the uber kernel.
+     *
+     * @return shmem_interior_done_t*
+     */
+    shmem_interior_done_t *get_shmem_interior_done();
+
+    /**
+     * @brief Get the atomic counter for tracking how many of the interior blocks have finished. See also above.
+     *
+     * @return shmem_interior_count_t*
+     */
+    shmem_interior_count_t *get_shmem_interior_count();
+#endif
+
+  } // namespace dslash
+
+}

--- a/include/dslash_shmem.h
+++ b/include/dslash_shmem.h
@@ -1,6 +1,7 @@
 #include <shmem_helper.cuh>
 
-namespace quda {
+namespace quda
+{
 
   namespace dslash
   {
@@ -79,4 +80,4 @@ namespace quda {
 
   } // namespace dslash
 
-}
+} // namespace quda

--- a/include/kernels/color_spinor_pack.cuh
+++ b/include/kernels/color_spinor_pack.cuh
@@ -5,6 +5,7 @@
 #include <kernel.h>
 #include <shared_memory_cache_helper.cuh>
 #include <dslash_quda.h>
+#include <dslash_shmem.h>
 #include <shmem_helper.cuh>
 #include <shmem_pack_helper.cuh>
 

--- a/include/kernels/dslash_shmem_helper.cuh
+++ b/include/kernels/dslash_shmem_helper.cuh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "kernel.h"
+#include "dslash_shmem.h"
 
 namespace quda {
 

--- a/lib/color_spinor_pack.cu
+++ b/lib/color_spinor_pack.cu
@@ -284,7 +284,7 @@ namespace quda {
   inline void genericPackGhost(void **ghost, const ColorSpinorField &a, QudaParity parity, int nFace, int dagger,
                                MemoryLocation *destination, int shmem)
 #else
-  inline void genericPackGhost(void **, const ColorSpinorField &a, QudaParity, int, int, MemoryLocation *)
+  inline void genericPackGhost(void **, const ColorSpinorField &a, QudaParity, int, int, MemoryLocation *, int)
 #endif
   {
     if (a.Nspin() == 4) {

--- a/lib/dslash_coarse.hpp
+++ b/lib/dslash_coarse.hpp
@@ -7,6 +7,7 @@
 #include <kernels/dslash_coarse.cuh>
 #include <shmem_helper.cuh>
 #include <dslash_quda.h>
+#include <dslash_shmem.h>
 
 namespace quda {
 

--- a/lib/dslash_policy.cuh
+++ b/lib/dslash_policy.cuh
@@ -3,6 +3,7 @@
 #include <index_helper.cuh>
 #include <timer.h>
 #include <dslash_quda.h>
+#include <dslash_shmem.h>
 
 namespace quda
 {

--- a/lib/dslash_quda.cu
+++ b/lib/dslash_quda.cu
@@ -1,5 +1,6 @@
 #include "color_spinor_field.h"
 #include "dslash_quda.h"
+#include "dslash_shmem.h"
 #include <dslash_policy.cuh>
 #include "tunable_nd.h"
 #include "instantiate.h"


### PR DESCRIPTION
This PR fixes some regressions introduced with #1228 
* Move shmem dslash bits from `dslash_quda.h` to its own header  `dslash_shmem.h` which is only included in device target files (fixes issues with CUDA 11.5 `cuda/atomic` when compiled by gcc)
* Fix compilation of color_spinor_pack.cu which was broken if no fermion types are enabled