### PR TITLE
CTestTestfile install helper

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -656,7 +656,7 @@ endif()
                      --Lsdim 4
         --gtest_output=xml:dslash_${DIRAC_NAME}_test_pol${pol2}.xml)
     if(polenv)
-      set_tests_properties(dslash_${DIRAC_NAME}_asym_policy${pol2} PROPERTIES ENVIRONMENT QUDA_ENABLE_DSLASH_POLICY=${pol})
+      set_tests_properties(dslash_${DIRAC_NAME}_sym_policy${pol2} PROPERTIES ENVIRONMENT QUDA_ENABLE_DSLASH_POLICY=${pol})
     endif()
 
     # asymmetric 4-d preconditioning

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1062,3 +1062,13 @@ foreach(prec IN LISTS TEST_PRECS)
   endif()
 
 endforeach(prec)
+
+# This generates a little helper script that copies a modified CTestTestfile to the installation directory
+# in order to run ctest after installation. Note that this is not called by default.
+option(QUDA_CTEST_INSTALL "Configure helper script for copying CTestTestfile to install directory" OFF)
+mark_as_advanced(QUDA_CTEST_INSTALL)
+
+if(QUDA_CTEST_INSTALL)
+  configure_file(install_CTestTestfile.sh.in install_CTestTestfile.sh)
+endif()
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1063,6 +1063,10 @@ foreach(prec IN LISTS TEST_PRECS)
 
 endforeach(prec)
 
+# For CUDA >= 11.7 lazy module loading can speed up testing quite a bit
+get_directory_property(QUDA_ALL_TESTS  TESTS)
+set_property(TEST ${QUDA_ALL_TESTS} APPEND PROPERTY ENVIRONMENT CUDA_MODULE_LOADING=LAZY)
+
 # This generates a little helper script that copies a modified CTestTestfile to the installation directory
 # in order to run ctest after installation. Note that this is not called by default.
 option(QUDA_CTEST_INSTALL "Configure helper script for copying CTestTestfile to install directory" OFF)

--- a/tests/install_CTestTestfile.sh.in
+++ b/tests/install_CTestTestfile.sh.in
@@ -1,0 +1,4 @@
+#! /bin/sh
+
+sed  s+"${CMAKE_CURRENT_BINARY_DIR}"+"${CMAKE_INSTALL_PREFIX}/bin/"+  ${CMAKE_CURRENT_BINARY_DIR}/CTestTestfile.cmake > ${CMAKE_INSTALL_PREFIX}/bin/CTestTestfile.cmake
+


### PR DESCRIPTION
This generates a little helper script that copies a modified CTestTestfile to the installation directory
in order to run ctest after installation. Note that this is not called by default. and controlled by
`QUDA_CTEST_INSTALL`.

Background:
CMake does not support installing the tests and this is a workaround so we can compile on machines without GPUs, install QUDA and then run CI on a machine with GPUs after install.
