### PR TITLE
Feature/stag 128bit

### DIFF
--- a/include/blas_helper.cuh
+++ b/include/blas_helper.cuh
@@ -188,7 +188,7 @@ namespace quda
          @tparam n Complex vector length
       */
       template <bool is_fixed, typename real, int n>
-      __device__ __host__ inline std::enable_if_t<!is_fixed, norm_t> store_norm(const array<complex<real>, n> &, int, int) const
+      __device__ __host__ inline std::enable_if_t<!is_fixed, norm_t> store_norm(const array<complex<real>, n> &, norm_t &) const
       {
         return 1.0;
       }
@@ -199,11 +199,11 @@ namespace quda
          @tparam real Precision of vector we wish to store from
          @tparam n Complex vector length
          @param[in] v elements we wish to find the max abs of for storing
-         @param[in] x checkerboard site index
-         @param[in] parity site parity
+         @param[in] norm The norm we are 
+         @return The scale factor to be applied when packing into fixed point
       */
       template <bool is_fixed, typename real, int n>
-      __device__ __host__ inline std::enable_if_t<is_fixed, norm_t> store_norm(const array<complex<real>, n> &v, int x, int parity) const
+      __device__ __host__ inline std::enable_if_t<is_fixed, norm_t> store_norm(const array<complex<real>, n> &v, norm_t &norm) const
       {
         norm_t max_[n];
         // two-pass to increase ILP (assumes length divisible by two, e.g. complex-valued)
@@ -212,8 +212,7 @@ namespace quda
         norm_t scale = 0.0;
 #pragma unroll
         for (int i = 0; i < n; i++) scale = fmaxf(max_[i], scale);
-        data.norm[x + parity * data.cb_norm_offset] = scale * fixedInvMaxValue<store_t>::value;
-
+        norm = scale * fixedInvMaxValue<store_t>::value;
         return fdividef(fixedMaxValue<store_t>::value, scale);
       }
 
@@ -229,21 +228,42 @@ namespace quda
       __device__ __host__ inline void load(array<complex<real>, n> &v, int x, int parity = 0) const
       {
         constexpr int len = 2 * n; // real-valued length
-        float nrm = load_norm<isFixed<store_t>::value>(x, parity);
 
-        array<real, len> v_;
+        if constexpr (!(n == 3 && isHalf<store_t>::value)) {
+          norm_t nrm = load_norm<isFixed<store_t>::value>(x, parity);
+          array<real, len> v_;
 
-        constexpr int M = len / N;
+          constexpr int M = len / N;
 #pragma unroll
-        for (int i = 0; i < M; i++) {
+          for (int i = 0; i < M; i++) {
+            // first load from memory
+            Vector vecTmp = vector_load<Vector>(data.spinor, parity * data.cb_offset + x + data.stride * i);
+            // now copy into output and scale
+#pragma unroll
+            for (int j = 0; j < N; j++) copy_and_scale(v_[i * N + j], reinterpret_cast<store_t *>(&vecTmp)[j], nrm);
+          }
+
+          for (int i = 0; i < n; i++) { v[i] = complex<real>(v_[2 * i + 0], v_[2 * i + 1]); }
+        } else {
+          // specialized path for half precision staggered
+          using Vector = int4;
+          auto cb_offset = data.cb_norm_offset / 4;
+          norm_t nrm;
+          array<real, len> v_;
+
           // first load from memory
-          Vector vecTmp = vector_load<Vector>(data.spinor, parity * data.cb_offset + x + data.stride * i);
+          Vector vecTmp = vector_load<Vector>(data.spinor, parity * cb_offset + x);
+
+          // extract norm
+          memcpy(&nrm, &vecTmp.w, sizeof(norm_t));
+
           // now copy into output and scale
 #pragma unroll
-          for (int j = 0; j < N; j++) copy_and_scale(v_[i * N + j], reinterpret_cast<store_t *>(&vecTmp)[j], nrm);
-        }
+          for (int i = 0; i < len; i++) copy_and_scale(v_[i], reinterpret_cast<store_t *>(&vecTmp)[i], nrm);
 
-        for (int i = 0; i < n; i++) { v[i] = complex<real>(v_[2 * i + 0], v_[2 * i + 1]); }
+#pragma unroll
+          for (int i = 0; i < n; i++) { v[i] = complex<real>(v_[2 * i + 0], v_[2 * i + 1]); }
+        }
       }
 
       /**
@@ -258,32 +278,54 @@ namespace quda
       __device__ __host__ inline void save(const array<complex<real>, n> &v, int x, int parity = 0) const
       {
         constexpr int len = 2 * n; // real-valued length
-        array<real, len> v_;
 
-        if (isFixed<store_t>::value) {
-          real scale_inv = store_norm<isFixed<store_t>::value, real, n>(v, x, parity);
+        if constexpr (!(n == 3 && isHalf<store_t>::value)) {
+          array<real, len> v_;
+
+          if constexpr (isFixed<store_t>::value) {
+            real scale_inv = store_norm<isFixed<store_t>::value, real, n>(v, data.norm[x + parity * data.cb_norm_offset]);
+#pragma unroll
+            for (int i = 0; i < n; i++) {
+              v_[2 * i + 0] = scale_inv * v[i].real();
+              v_[2 * i + 1] = scale_inv * v[i].imag();
+            }
+          } else {
+#pragma unroll
+            for (int i = 0; i < n; i++) {
+              v_[2 * i + 0] = v[i].real();
+              v_[2 * i + 1] = v[i].imag();
+            }
+          }
+
+          constexpr int M = len / N;
+#pragma unroll
+          for (int i = 0; i < M; i++) {
+            Vector vecTmp;
+            // first do scalar copy converting into storage type
+#pragma unroll
+            for (int j = 0; j < N; j++) copy_scaled(reinterpret_cast<store_t *>(&vecTmp)[j], v_[i * N + j]);
+            // second do vectorized copy into memory
+            vector_store(data.spinor, parity * data.cb_offset + x + data.stride * i, vecTmp);
+          }
+        } else {
+          // specialized path for half precision staggered
+          using Vector = int4;
+          auto cb_offset = data.cb_norm_offset / 4;
+          norm_t norm;
+          norm_t scale_inv = store_norm<isFixed<store_t>::value, real, n>(v, norm);
+          array<real, len> v_;
 #pragma unroll
           for (int i = 0; i < n; i++) {
             v_[2 * i + 0] = scale_inv * v[i].real();
             v_[2 * i + 1] = scale_inv * v[i].imag();
           }
-        } else {
-#pragma unroll
-          for (int i = 0; i < n; i++) {
-            v_[2 * i + 0] = v[i].real();
-            v_[2 * i + 1] = v[i].imag();
-          }
-        }
 
-        constexpr int M = len / N;
-#pragma unroll
-        for (int i = 0; i < M; i++) {
           Vector vecTmp;
-          // first do scalar copy converting into storage type
+          memcpy(&vecTmp.w, &norm, sizeof(norm_t)); // pack the norm
 #pragma unroll
-          for (int j = 0; j < N; j++) copy_scaled(reinterpret_cast<store_t *>(&vecTmp)[j], v_[i * N + j]);
+          for (int i = 0; i < len; i++) copy_scaled(reinterpret_cast<store_t *>(&vecTmp)[i], v_[i]);
           // second do vectorized copy into memory
-          vector_store(data.spinor, parity * data.cb_offset + x + data.stride * i, vecTmp);
+          vector_store(data.spinor, parity * cb_offset + x, vecTmp);
         }
       }
     };

--- a/include/color_spinor_field_order.h
+++ b/include/color_spinor_field_order.h
@@ -1198,6 +1198,217 @@ namespace quda
       }
     };
 
+    /**
+       @brief Accessor routine for ColorSpinorFields in native field
+       order.  Specialization for half-precision staggered QCD fields
+       where we pack each site into a 128-bit word (int4).
+       @tparam N Number of real numbers per short vector.  Ignored in this specialization.
+       @tparam spin_project Whether the ghosts are spin projected or not
+       @tparam huge_alloc Template parameter that enables 64-bit
+       pointer arithmetic for huge allocations (e.g., packed set of
+       vectors).  Default is to use 32-bit pointer arithmetic.
+     */
+    template <int N_, bool spin_project, bool huge_alloc>
+    struct FloatNOrder<short, 1, 3, N_, spin_project, huge_alloc> {
+      using Float = short;
+      static constexpr int Ns = 1;
+      static constexpr int Nc = 3;
+      static constexpr int length = 2 * Ns * Nc;
+      static constexpr int length_ghost = 2 * Ns * Nc;
+      using Accessor = FloatNOrder<Float, Ns, Nc, N_, spin_project, huge_alloc>;
+      using real = typename mapper<Float>::type;
+      using complex = complex<real>;
+      using Vector = int4;      // 128-bit packed type
+      using GhostVector = int4; // 128-bit packed type
+      using AllocInt = typename AllocType<huge_alloc>::type;
+      using norm_type = float;
+      Float *field;
+      const AllocInt offset; // offset can be 32-bit or 64-bit
+      int volumeCB;
+      int faceVolumeCB[4];
+      mutable Float *ghost[8];
+      int nParity;
+      void *backup_h; //! host memory for backing up the field when tuning
+      size_t bytes;
+
+      FloatNOrder(const ColorSpinorField &a, int nFace = 1, Float *buffer = 0, Float **ghost_ = 0) :
+        field(buffer ? buffer : (Float *)a.V()),
+        offset(a.Bytes() / (2 * sizeof(Vector))),
+        volumeCB(a.VolumeCB()),
+        nParity(a.SiteSubset()),
+        backup_h(nullptr),
+        bytes(a.Bytes())
+      {
+        for (int i = 0; i < 4; i++) { faceVolumeCB[i] = a.SurfaceCB(i) * nFace; }
+        resetGhost(ghost_ ? (void **)ghost_ : a.Ghost());
+      }
+
+      void resetGhost(void *const *ghost_) const
+      {
+        for (int dim = 0; dim < 4; dim++) {
+          for (int dir = 0; dir < 2; dir++) {
+            ghost[2 * dim + dir] = comm_dim_partitioned(dim) ? static_cast<Float *>(ghost_[2 * dim + dir]) : nullptr;
+          }
+        }
+      }
+
+      __device__ __host__ inline void load(complex out[length / 2], int x, int parity = 0) const
+      {
+        real v[length];
+        Vector vecTmp = vector_load<Vector>(field, parity * offset + x);
+
+        // extract the norm
+        norm_type nrm;
+        memcpy(&nrm, &vecTmp.w, sizeof(norm_type));
+
+        // now copy into output and scale
+#pragma unroll
+        for (int i = 0; i < length; i++) copy_and_scale(v[i], reinterpret_cast<Float *>(&vecTmp)[i], nrm);
+
+#pragma unroll
+        for (int i = 0; i < length / 2; i++) out[i] = complex(v[2 * i + 0], v[2 * i + 1]);
+      }
+
+      __device__ __host__ inline void save(const complex in[length / 2], int x, int parity = 0) const
+      {
+        real v[length];
+
+#pragma unroll
+        for (int i = 0; i < length / 2; i++) {
+          v[2 * i + 0] = in[i].real();
+          v[2 * i + 1] = in[i].imag();
+        }
+
+        norm_type max_[length / 2];
+        // two-pass to increase ILP (assumes length divisible by two, e.g. complex-valued)
+#pragma unroll
+        for (int i = 0; i < length / 2; i++)
+          max_[i] = fmaxf(fabsf((norm_type)v[i]), fabsf((norm_type)v[i + length / 2]));
+        norm_type scale = 0.0;
+#pragma unroll
+        for (int i = 0; i < length / 2; i++) scale = fmaxf(max_[i], scale);
+        norm_type nrm = scale * fixedInvMaxValue<Float>::value;
+
+        real scale_inv = fdividef(fixedMaxValue<Float>::value, scale);
+#pragma unroll
+        for (int i = 0; i < length; i++) v[i] = v[i] * scale_inv;
+
+        Vector vecTmp;
+        memcpy(&vecTmp.w, &nrm, sizeof(norm_type)); // pack the norm
+
+        // pack the spinor elements
+#pragma unroll
+        for (int i = 0; i < length; i++) copy_scaled(reinterpret_cast<Float *>(&vecTmp)[i], v[i]);
+
+        vector_store(field, parity * offset + x, vecTmp);
+      }
+
+      /**
+         @brief This accessor routine returns a colorspinor_wrapper to this object,
+         allowing us to overload various operators for manipulating at
+         the site level interms of matrix operations.
+         @param[in] x_cb Checkerboarded space-time index we are requesting
+         @param[in] parity Parity we are requesting
+         @return Instance of a colorspinor_wrapper that curries in access to
+         this field at the above coordinates.
+      */
+      __device__ __host__ inline auto operator()(int x_cb, int parity) const
+      {
+        return colorspinor_wrapper<real, Accessor>(*this, x_cb, parity);
+      }
+
+      __device__ __host__ inline void loadGhost(complex out[length_ghost / 2], int x, int dim, int dir, int parity = 0) const
+      {
+        real v[length_ghost];
+        GhostVector vecTmp = vector_load<GhostVector>(ghost[2 * dim + dir], parity * faceVolumeCB[dim] + x);
+
+        // extract the norm
+        norm_type nrm;
+        memcpy(&nrm, &vecTmp.w, sizeof(norm_type));
+
+#pragma unroll
+        for (int i = 0; i < length_ghost; i++) copy_and_scale(v[i], reinterpret_cast<Float *>(&vecTmp)[i], nrm);
+
+#pragma unroll
+        for (int i = 0; i < length_ghost / 2; i++) out[i] = complex(v[2 * i + 0], v[2 * i + 1]);
+      }
+
+      __device__ __host__ inline void saveGhost(const complex in[length_ghost / 2], int x, int dim, int dir,
+                                                int parity = 0) const
+      {
+        real v[length_ghost];
+
+#pragma unroll
+        for (int i = 0; i < length_ghost / 2; i++) {
+          v[2 * i + 0] = in[i].real();
+          v[2 * i + 1] = in[i].imag();
+        }
+
+        norm_type max_[length_ghost / 2];
+        // two-pass to increase ILP (assumes length divisible by two, e.g. complex-valued)
+#pragma unroll
+        for (int i = 0; i < length_ghost / 2; i++)
+          max_[i] = fmaxf(fabsf((norm_type)v[i]), fabsf((norm_type)v[i + length_ghost / 2]));
+        norm_type scale = 0.0;
+#pragma unroll
+        for (int i = 0; i < length_ghost / 2; i++) scale = fmaxf(max_[i], scale);
+        norm_type nrm = scale * fixedInvMaxValue<Float>::value;
+
+        real scale_inv = fdividef(fixedMaxValue<Float>::value, scale);
+#pragma unroll
+        for (int i = 0; i < length_ghost; i++) v[i] = v[i] * scale_inv;
+
+        GhostVector vecTmp;
+        memcpy(&vecTmp.w, &nrm, sizeof(norm_type)); // pack the norm
+
+        // pack the spinor elements
+#pragma unroll
+        for (int i = 0; i < length_ghost; i++) copy_scaled(reinterpret_cast<Float *>(&vecTmp)[i], v[i]);
+        vector_store(ghost[2 * dim + dir], parity * faceVolumeCB[dim] + x, vecTmp);
+      }
+
+      /**
+         @brief This accessor routine returns a const
+         colorspinor_ghost_wrapper to this object, allowing us to
+         overload various operators for manipulating at the site
+         level interms of matrix operations.
+         @param[in] dim Dimensions of the ghost we are requesting
+         @param[in] ghost_idx Checkerboarded space-time ghost index we are requesting
+         @param[in] parity Parity we are requesting
+         @return Instance of a colorspinor_ghost+wrapper that curries in access to
+         this field at the above coordinates.
+      */
+      __device__ __host__ inline auto Ghost(int dim, int dir, int ghost_idx, int parity) const
+      {
+        return colorspinor_ghost_wrapper<real, Accessor>(*this, dim, dir, ghost_idx, parity);
+      }
+
+      /**
+         @brief Backup the field to the host when tuning
+      */
+      void save()
+      {
+        if (backup_h) errorQuda("Already allocated host backup");
+        backup_h = safe_malloc(bytes);
+        qudaMemcpy(backup_h, field, bytes, qudaMemcpyDeviceToHost);
+      }
+
+      /**
+         @brief Restore the field from the host after tuning
+      */
+      void load()
+      {
+        qudaMemcpy(field, backup_h, bytes, qudaMemcpyHostToDevice);
+        host_free(backup_h);
+        backup_h = nullptr;
+      }
+
+      size_t Bytes() const
+      {
+        return nParity * volumeCB * (Nc * Ns * 2 * sizeof(Float) + (isFixed<Float>::value ? sizeof(norm_type) : 0));
+      }
+    };
+
     template <typename Float, int Ns, int Nc> struct SpaceColorSpinorOrder {
       using Accessor = SpaceColorSpinorOrder<Float, Ns, Nc>;
       using real = typename mapper<Float>::type;

--- a/tests/blas_test.cpp
+++ b/tests/blas_test.cpp
@@ -1026,11 +1026,11 @@ protected:
       blas::cDotProduct(B2, xmD, xmD);
       error = 0.0;
       for (int i = 0; i < Nsrc; i++) {
-        for (int j = 0; j < Msrc; j++) {
-          error += std::abs(A2[i * Msrc + j] - B2[i * Msrc + j]) / std::abs(B2[i * Msrc + j]);
+        for (int j = 0; j < Nsrc; j++) {
+          error += std::abs(A2[i * Nsrc + j] - B2[i * Nsrc + j]) / std::abs(B2[i * Nsrc + j]);
         }
       }
-      error /= Nsrc * Msrc;
+      error /= Nsrc * Nsrc;
       break;
 
     case Kernel::caxpyXmazMR:


### PR DESCRIPTION
* Half-precision staggered quark fields now use a single 128-bit struct per site instead of SoAoS (nColor x volume x complex).  This optimizes memory access patterns and gives a small boost to the staggered fermion dslash.
* Bug fix in hDotProduct unit test