### PR TITLE
Made the include of json.hpp come from include/external

### DIFF
--- a/include/json_helper.h
+++ b/include/json_helper.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <json.hpp>
+#include "externals/json.hpp"
 using json = nlohmann::json;
 
 void to_json(json &j, const dim3 &p) { j = json {{"x", p.x}, {"y", p.y}, {"z", p.z}}; }


### PR DESCRIPTION
This circumvents a bug at NERSC where there was an alternate json.hpp file in the same place as the libxml2 headers.
That file was earlier in the include search path and got included causing compile fails. This fix ensures we get the json.hpp from our own include/externals directory
