### PR TITLE
Hotfix/vuv

### DIFF
--- a/lib/coarse_op.cuh
+++ b/lib/coarse_op.cuh
@@ -473,6 +473,7 @@ namespace quda {
 
           arg.shared_atomic = tp.aux.y;
           arg.parity_flip = tp.aux.z;
+          arg.coarse_color_wave = !tp.aux.w;
 
           if (arg.shared_atomic) {
             // check we have a valid problem size for shared atomics

--- a/lib/tune.cpp
+++ b/lib/tune.cpp
@@ -314,12 +314,11 @@ namespace quda
       if (comm_rank_global() == 0) {
         comm_broadcast_global(const_cast<char *>(serialized.str().c_str()), size);
       } else {
-        char *serstr = new char[size + 1];
-        comm_broadcast_global(serstr, size);
+        std::vector<char> serstr(size + 1);
+        comm_broadcast_global(serstr.data(), size);
         serstr[size] = '\0'; // null-terminate
-        serialized.str(serstr);
+        serialized.str(serstr.data());
         deserializeTuneCache(serialized);
-        delete[] serstr;
       }
     }
 #endif
@@ -754,6 +753,7 @@ namespace quda
         push(candidate);
       }
     }
+
     /**
      * @brief Broadcast candidates among ranks to make sure policy tuning does not break.
      *
@@ -761,7 +761,6 @@ namespace quda
     void broadcast()
     {
 #ifdef MULTI_GPU
-
       size_t size;
       std::string serialized;
       if (comm_rank_global() == 0) {
@@ -774,12 +773,11 @@ namespace quda
         if (comm_rank_global() == 0) {
           comm_broadcast_global(const_cast<char *>(serialized.c_str()), size);
         } else {
-          char *serstr = new char[size + 1];
-          comm_broadcast_global(serstr, size);
+          std::vector<char> serstr(size + 1);
+          comm_broadcast_global(serstr.data(), size);
           serstr[size] = '\0'; // null-terminate
-          std::string_view deserialized(serstr);
+          std::string_view deserialized(serstr.data());
           deserialize(deserialized);
-          delete[] serstr;
         }
       }
 #endif
@@ -908,11 +906,11 @@ namespace quda
           qudaDeviceSynchronize();
           tunable.checkLaunchParam(param);
           if (verbosity >= QUDA_DEBUG_VERBOSE) {
-            printfQuda("About to call tunable.apply block=(%d,%d,%d) grid=(%d,%d,%d) shared_bytes=%d aux=(%d,%d,%d)\n",
+            printfQuda("About to call tunable.apply block=(%d,%d,%d) grid=(%d,%d,%d) shared_bytes=%d aux=(%d,%d,%d,%d)\n",
                        static_cast<int>(param.block.x), static_cast<int>(param.block.y),
                        static_cast<int>(param.block.z), static_cast<int>(param.grid.x), static_cast<int>(param.grid.y),
                        static_cast<int>(param.grid.z), static_cast<int>(param.shared_bytes),
-                       static_cast<int>(param.aux.x), static_cast<int>(param.aux.y), static_cast<int>(param.aux.z));
+                       static_cast<int>(param.aux.x), static_cast<int>(param.aux.y), static_cast<int>(param.aux.z), static_cast<int>(param.aux.w));
           }
 
           tunable.apply(stream); // do initial call in case we need to jit compile for these parameters or if policy tuning
@@ -966,11 +964,11 @@ namespace quda
           qudaDeviceSynchronize();
           tunable.checkLaunchParam(param);
           if (verbosity >= QUDA_DEBUG_VERBOSE) {
-            printfQuda("About to call tunable.apply block=(%d,%d,%d) grid=(%d,%d,%d) shared_bytes=%d aux=(%d,%d,%d)\n",
+            printfQuda("About to call tunable.apply block=(%d,%d,%d) grid=(%d,%d,%d) shared_bytes=%d aux=(%d,%d,%d,%d)\n",
                        static_cast<int>(param.block.x), static_cast<int>(param.block.y),
                        static_cast<int>(param.block.z), static_cast<int>(param.grid.x), static_cast<int>(param.grid.y),
                        static_cast<int>(param.grid.z), static_cast<int>(param.shared_bytes),
-                       static_cast<int>(param.aux.x), static_cast<int>(param.aux.y), static_cast<int>(param.aux.z));
+                       static_cast<int>(param.aux.x), static_cast<int>(param.aux.y), static_cast<int>(param.aux.z), static_cast<int>(param.aux.w));
           }
 
           timer.start();
@@ -1014,6 +1012,7 @@ namespace quda
           printfQuda("Tuned %s giving %s for %s with %s\n", tunable.paramString(best_param).c_str(),
                      tunable.perfString(best_time).c_str(), key.name, key.aux);
         }
+
         time(&now);
         best_param.comment = "# " + tunable.perfString(best_time) + tunable.miscString(best_param);
         best_param.comment += ", tuning took " + std::to_string(tune_timer.last()) + " seconds at ";

--- a/lib/tune.cpp
+++ b/lib/tune.cpp
@@ -971,6 +971,7 @@ namespace quda
                        static_cast<int>(param.aux.x), static_cast<int>(param.aux.y), static_cast<int>(param.aux.z), static_cast<int>(param.aux.w));
           }
 
+          tunable.apply(stream);
           timer.start();
           for (int i = 0; i < tuneiterations; i++) {
             tunable.apply(stream); // calls tuneLaunch() again, which simply returns the currently active param
@@ -1011,6 +1012,12 @@ namespace quda
         if (verbosity >= QUDA_VERBOSE) {
           printfQuda("Tuned %s giving %s for %s with %s\n", tunable.paramString(best_param).c_str(),
                      tunable.perfString(best_time).c_str(), key.name, key.aux);
+        }
+
+        auto regression_tol = 1.1;
+        if (best_time > regression_tol * tc.getBestTime() && best_time > 1e-5) {
+          warningQuda("Unexpected regression when tuning candidates for %s: (%g > %g * %g)",
+                      key.name, best_time, regression_tol, tc.getBestTime());
         }
 
         time(&now);


### PR DESCRIPTION
This hotfix fixes the performance of the VUV kernel:
* When two-stage tuning was enabled, it was observed that the VUV kernel seemingly regressed (#1291)
* It turns out this wasn't a regression per se, rather it revealed a long standing issue that the launch parameters of the VUV kernel weren't being set correctly outside of the tuning loop
* Specifically, the `Arg::coarse_color_wave` parameter, which maps to `TuneParam::aux` wasn't being set in the `apply` function, it was only being set during the tuning process.
* So while the kernel autotuned correctly, post tuning, it would not be using the desired parameters, leading to reduced performance.

I have also made some minor changes to the tuning:
* Display a warning if the best second-stage tuning time regresses by more than 10% versus the first stage.  In general we should expect the second stage to be faster than the first stage, since it will generally involve more iterations.  The 10% margin is left due to latency bubbles, etc.
* Even then, this warning can still be triggered if one doesn't lock clocks for small short running kernels.
* Fix a minor bug when printing the `aux` parameter while tuning.
* Replace use of `new`/`delete` with a `std::vector`

Closes #1291