### PR TITLE
Fix an issue in exponentiate_iQ() from quda_matrix.h.

### DIFF
--- a/include/quda_matrix.h
+++ b/include/quda_matrix.h
@@ -971,6 +971,14 @@ namespace quda {
       real sqrt_c1_inv3 = sqrt(c1 * inv3);
       real c0_max = 2 * (c1 * inv3 * sqrt_c1_inv3); // reuse the sqrt factor for a fast 1.5 power
 
+      //[34] Test for c0 < 0.
+      int parity = 0;
+      if(c0 < 0) {
+	c0 *= -1.0;
+	parity = 1;
+	//calculate fj with c0 > 0 and then convert all fj.
+      }
+
       //[25]
       real theta = acos(c0 / c0_max);
 
@@ -999,14 +1007,6 @@ namespace quda {
 	sinc_w = 1.0 - (w_sq/6.0)*(1 - (w_sq*0.05)*(1 - (w_sq/42.0)*(1 - (w_sq/72.0))));
       } else {
         sinc_w = sinpi(w_p * inv_pi) / w_p;
-      }
-
-      //[34] Test for c0 < 0.
-      int parity = 0;
-      if(c0 < 0) {
-	c0 *= -1.0;
-	parity = 1;
-	//calculate fj with c0 > 0 and then convert all fj.
       }
 
       //Get all the numerators for fj,


### PR DESCRIPTION
The `exponentiate_iQ()` from `quda_matrix.h` has an issue which exists for a pretty long time. This function might return a matrix that slightly deviates from SU(3), with `ErrorSU3()` returning a number around 1e-5 for fp64, while this number should be less than 1e-30 for an accurate SU(3) matrix.

This issue will occur when `c0 < 0`, where `c0` is defined in line [958](https://github.com/lattice/quda/blob/develop/include/quda_matrix.h#L958). The [paper](https://arxiv.org/pdf/hep-lat/0311018v1.pdf) indicates we can use `abs(c0)` to do the calculation and add a parity later, but `quda` seems to do this step at the wrong time. `theta` is calculated by the original `c0` instead of `abs(c0)`, and the following steps finally return an incorrect result. 

This PR makes sure we do the `abs(c0)` step before the calculation of `theta`, and seems to fix the issue.

The STOUT smearing functions and Wilson flow function are affected, which are pretty useful in practice.