### PR TITLE
use auto& in ColorSpinor<Float,Nc,4>::reconstruct

### DIFF
--- a/include/color_spinor.h
+++ b/include/color_spinor.h
@@ -693,7 +693,7 @@ namespace quda {
     __device__ __host__ inline ColorSpinor<Float, Nc, 4> reconstruct(int dim, int sign) const
     {
       ColorSpinor<Float, Nc, 4> recon;
-      const auto t = *this;
+      const auto &t = *this;
 
       switch (dim) {
       case 0: // x dimension


### PR DESCRIPTION
Other function does this, even though the compiler likely optimizes the copy away.