### PR TITLE
replace switch with if constexpr

### DIFF
--- a/include/color_spinor.h
+++ b/include/color_spinor.h
@@ -75,18 +75,18 @@ namespace quda {
       __device__ __host__ inline void operator=(const colorspinor_ghost_wrapper<Float, S> &s);
 
       /**
-	 @brief 2-d accessor functor
-	 @param[in] s Spin index
-	 @param[in] c Color index
-	 @return Complex number at this spin and color index
+         @brief 2-d accessor functor
+         @param[in] s Spin index
+         @param[in] c Color index
+         @return Complex number at this spin and color index
       */
       __device__ __host__ inline complex<Float>& operator()(int s, int c) { return data[s*Nc + c]; }
 
       /**
-	 @brief 2-d accessor functor
-	 @param[in] s Spin index
-	 @param[in] c Color index
-	 @return Complex number at this spin and color index
+         @brief 2-d accessor functor
+         @param[in] s Spin index
+         @param[in] c Color index
+         @return Complex number at this spin and color index
       */
       __device__ __host__ inline const complex<Float>& operator()(int s, int c) const { return data[s*Nc + c]; }
 
@@ -146,120 +146,114 @@ namespace quda {
     }
 
     /**
-	Return this application of gamma_dim to this spinor
-	@param dim Which dimension gamma matrix we are applying
-	@return The new spinor
+        Return this application of gamma_dim to this spinor
+        @param dim Which dimension gamma matrix we are applying
+        @return The new spinor
     */
-    __device__ __host__ inline ColorSpinor<Float,Nc,4> gamma(int dim) {
+    template<int dim>
+    __device__ __host__ inline ColorSpinor<Float,Nc,4> gamma() {
       ColorSpinor<Float,Nc,4> a;
       const auto &t = *this;
 
-      switch (dim) {
-      case 0: // x dimension
+      static_assert(0<=dim && dim<=4, "dim must be 0-4");
+
+      if constexpr (dim==0) { // x dimension
 #pragma unroll
-	for (int i=0; i<Nc; i++) {
+        for (int i=0; i<Nc; i++) {
           a(0, i) = i_(t(3, i));
           a(1, i) = i_(t(2, i));
           a(2, i) = -i_(t(1, i));
           a(3, i) = -i_(t(0, i));
         }
-        break;
-      case 1: // y dimension
+      } else if constexpr (dim==1) { // y dimension
 #pragma unroll
-	for (int i=0; i<Nc; i++) {
+        for (int i=0; i<Nc; i++) {
           a(0, i) = t(3, i);
           a(1, i) = -t(2, i);
           a(2, i) = -t(1, i);
           a(3, i) = t(0, i);
         }
-        break;
-      case 2: // z dimension
+      } else if constexpr (dim==2) { // z dimension
 #pragma unroll
-	for (int i=0; i<Nc; i++) {
+        for (int i=0; i<Nc; i++) {
           a(0, i) = i_(t(2, i));
           a(1, i) = -i_(t(3, i));
           a(2, i) = -i_(t(0, i));
           a(3, i) = i_(t(1, i));
         }
-        break;
-      case 3: // t dimension
+      } else if constexpr (dim==3) { // t dimension
 #pragma unroll
-	for (int i=0; i<Nc; i++) {
+        for (int i=0; i<Nc; i++) {
           a(0, i) = t(0, i);
           a(1, i) = t(1, i);
           a(2, i) = -t(2, i);
           a(3, i) = -t(3, i);
         }
-        break;
-      case 4: // gamma_5
+      } else if constexpr (dim==4) { // gamma_5
 #pragma unroll
-	for (int i=0; i<Nc; i++) {
+        for (int i=0; i<Nc; i++) {
           a(0, i) = t(2, i);
           a(1, i) = t(3, i);
           a(2, i) = t(0, i);
           a(3, i) = t(1, i);
         }
-        break;
       }
 
       return a;
     }
 
     /**
-	Return this application of gamma_dim to this spinor
-	@param dim Which dimension gamma matrix we are applying
-	@return The new spinor
+        Return this application of gamma_dim to this spinor
+        @param dim Which dimension gamma matrix we are applying
+        @return The new spinor
     */
-    __device__ __host__ inline ColorSpinor<Float,Nc,4> igamma(int dim) {
+    template<int dim>
+    __device__ __host__ inline ColorSpinor<Float,Nc,4> igamma() {
       ColorSpinor<Float,Nc,4> a;
       const auto &t = *this;
 
-      switch (dim) {
-      case 0: // x dimension
+      static_assert(0<=dim && dim<=4, "dim must be 0-4");
+
+      if constexpr (dim==0) { // x dimension
 #pragma unroll
-	for (int i=0; i<Nc; i++) {
+        for (int i=0; i<Nc; i++) {
           a(0, i) = -t(3, i);
           a(1, i) = -t(2, i);
           a(2, i) = t(1, i);
           a(3, i) = t(0, i);
         }
-        break;
-      case 1: // y dimension
+      } else if constexpr (dim==1) { // y dimension
 #pragma unroll
-	for (int i=0; i<Nc; i++) {
+        for (int i=0; i<Nc; i++) {
           a(0, i) = i_(t(3, i));
           a(1, i) = -i_(t(2, i));
           a(2, i) = -i_(t(1, i));
           a(3, i) = i_(t(0, i));
         }
-        break;
-      case 2: // z dimension
+      } else if constexpr (dim==2) { // z dimension
 #pragma unroll
-	for (int i=0; i<Nc; i++) {
+        for (int i=0; i<Nc; i++) {
           a(0, i) = -t(2, i);
           a(1, i) = t(3, i);
           a(2, i) = t(0, i);
           a(3, i) = -t(1, i);
         }
-        break;
-      case 3: // t dimension
+      } else if constexpr (dim==3) { // t dimension
 #pragma unroll
-	for (int i=0; i<Nc; i++) {
+        for (int i=0; i<Nc; i++) {
           a(0, i) = i_(t(0, i));
           a(1, i) = i_(t(1, i));
           a(2, i) = -i_(t(2, i));
           a(3, i) = -i_(t(3, i));
         }
-        break;
-      case 4: // gamma_5
+      } else if constexpr (dim==4) { // gamma_5
 #pragma unroll
-	for (int i=0; i<Nc; i++) {
+        for (int i=0; i<Nc; i++) {
           a(0, i) = i_(t(2, i));
           a(1, i) = i_(t(3, i));
           a(2, i) = i_(t(0, i));
           a(3, i) = i_(t(1, i));
         }
-        break;
       }
 
       return a;
@@ -274,9 +268,9 @@ namespace quda {
 #pragma unroll
       for (int s=0; s<Ns/2; s++) {
 #pragma unroll
-	for (int c=0; c<Nc; c++) {
-	  proj(s,c) = (*this)(chirality*Ns/2+s,c);
-	}
+        for (int c=0; c<Nc; c++) {
+          proj(s,c) = (*this)(chirality*Ns/2+s,c);
+        }
       }
       return proj;
     }
@@ -287,101 +281,85 @@ namespace quda {
         @param sign Positive or negative projector
         @return The spin-projected Spinor
     */
-    __device__ __host__ inline ColorSpinor<Float, Nc, 2> project(int dim, int sign) const
+    template<int dim, int sign>
+    __device__ __host__ inline ColorSpinor<Float, Nc, 2> project() const
     {
       ColorSpinor<Float,Nc,2> proj;
       const auto &t = *this;
-      switch (dim) {
-      case 0: // x dimension
-	switch (sign) {
-	case 1: // positive projector
+
+      static_assert(0<=dim && dim<=4, "dim must be 0-4");
+      static_assert(sign==-1 || sign==1, "sign must be -1 or 1");
+
+      if constexpr (dim==0) { // x dimension
+        if constexpr (sign==1) { // positive projector
 #pragma unroll
-	  for (int i=0; i<Nc; i++) {
+          for (int i=0; i<Nc; i++) {
             proj(0, i) = t(0, i) + i_(t(3, i));
             proj(1, i) = t(1, i) + i_(t(2, i));
           }
-          break;
-        case -1: // negative projector
+        } else if constexpr (sign==-1) { // negative projector
 #pragma unroll
-	  for (int i=0; i<Nc; i++) {
+          for (int i=0; i<Nc; i++) {
             proj(0, i) = t(0, i) - i_(t(3, i));
             proj(1, i) = t(1, i) - i_(t(2, i));
           }
-          break;
         }
-	break;
-      case 1: // y dimension
-	switch (sign) {
-	case 1: // positive projector
+      } else if constexpr (dim==1) { // y dimension
+        if constexpr (sign==1) { // positive projector
 #pragma unroll
-	  for (int i=0; i<Nc; i++) {
+          for (int i=0; i<Nc; i++) {
             proj(0, i) = t(0, i) + t(3, i);
             proj(1, i) = t(1, i) - t(2, i);
           }
-          break;
-        case -1: // negative projector
+        } else if constexpr (sign==-1) { // negative projector
 #pragma unroll
-	  for (int i=0; i<Nc; i++) {
+          for (int i=0; i<Nc; i++) {
             proj(0, i) = t(0, i) - t(3, i);
             proj(1, i) = t(1, i) + t(2, i);
           }
-          break;
         }
-      	break;
-      case 2: // z dimension
-	switch (sign) {
-	case 1: // positive projector
+      } else if constexpr (dim==2) { // z dimension
+        if constexpr (sign==1) { // positive projector
 #pragma unroll
-	  for (int i=0; i<Nc; i++) {
+          for (int i=0; i<Nc; i++) {
             proj(0, i) = t(0, i) + i_(t(2, i));
             proj(1, i) = t(1, i) - i_(t(3, i));
           }
-          break;
-        case -1: // negative projector
+        } else if constexpr (sign==-1) { // negative projector
 #pragma unroll
-	  for (int i=0; i<Nc; i++) {
+          for (int i=0; i<Nc; i++) {
             proj(0, i) = t(0, i) - i_(t(2, i));
             proj(1, i) = t(1, i) + i_(t(3, i));
           }
-          break;
         }
-	break;
-      case 3: // t dimension
-	switch (sign) {
-	case 1: // positive projector
+      } else if constexpr (dim==3) { // t dimension
+        if constexpr (sign==1) { // positive projector
 #pragma unroll
-	  for (int i=0; i<Nc; i++) {
+          for (int i=0; i<Nc; i++) {
             proj(0, i) = static_cast<Float>(2.0) * t(0, i);
             proj(1, i) = static_cast<Float>(2.0) * t(1, i);
           }
-          break;
-        case -1: // negative projector
+        } else if constexpr (sign==-1) { // negative projector
 #pragma unroll
-	  for (int i=0; i<Nc; i++) {
+          for (int i=0; i<Nc; i++) {
             proj(0, i) = static_cast<Float>(2.0) * t(2, i);
             proj(1, i) = static_cast<Float>(2.0) * t(3, i);
           }
-          break;
         }
-	break;
-      case 4:
-        switch (sign) {
-        case 1: // positive projector
+      } else if constexpr (dim==4) { // gamma_5
+        if constexpr (sign==1) { // positive projector
 #pragma unroll
           for (int i = 0; i < Nc; i++) {
             proj(0, i) = t(0, i) + t(2, i);
             proj(1, i) = t(1, i) + t(3, i);
           }
-          break;
-        case -1: // negative projector
+        } else if constexpr (sign==-1) { // negative projector
 #pragma unroll
           for (int i = 0; i < Nc; i++) {
             proj(0, i) = t(0, i) - t(2, i);
             proj(1, i) = t(1, i) - t(3, i);
           }
-          break;
         }
-        break;
       }
 
       return proj;
@@ -394,165 +372,149 @@ namespace quda {
 
        sigma(0,1) =  i  0  0  0
                      0 -i  0  0
-		     0  0  i  0
-		     0  0  0 -i
+                     0  0  i  0
+                     0  0  0 -i
 
        sigma(0,2) =  0 -1  0  0
                      1  0  0  0
-		     0  0  0 -1
-		     0  0  1  0
+                     0  0  0 -1
+                     0  0  1  0
 
        sigma(0,3) =  0  0  0 -i
                      0  0 -i  0
-		     0 -i  i  0
-		    -i  0  0  0
+                     0 -i  i  0
+                    -i  0  0  0
 
        sigma(1,2) =  0  i  0  0
                      i  0  0  0
-		     0  0  0  i
-		     0  0  i  0
+                     0  0  0  i
+                     0  0  i  0
 
        sigma(1,3) =  0  0  0 -1
                      0  0  1  0
-		     0 -1  0  0
-		     1  0  0  0
+                     0 -1  0  0
+                     1  0  0  0
 
        sigma(2,3) =  0  0 -i  0
                      0  0  0  i
-		    -i  0  0  0
-		     0  i  0  0
+                    -i  0  0  0
+                     0  i  0  0
     */
-    __device__ __host__ inline ColorSpinor<Float, Nc, 4> sigma(int mu, int nu) const
+    template<int mu, int nu>
+    __device__ __host__ inline ColorSpinor<Float, Nc, 4> sigma() const
     {
       ColorSpinor<Float,Nc,4> a;
       const ColorSpinor<Float, Nc, 4> &b = *this;
       complex<Float> j(0.0,1.0);
 
-      switch(mu) {
-      case 0:
-	switch(nu) {
-	case 1:
+      static_assert(0<=mu && mu<=3, "mu must be 0-3");
+      static_assert(0<=nu && nu<=3, "nu must be 0-3");
+      static_assert(mu!=nu, "mu!=nu");
+
+      if constexpr (mu==0) {
+        if constexpr (nu==1) {
 #pragma unroll
-	  for (int i=0; i<Nc; i++) {
-	    a(0,i) =  j*b(0,i);
-	    a(1,i) = -j*b(1,i);
-	    a(2,i) =  j*b(2,i);
-	    a(3,i) = -j*b(3,i);
-	  }
-	  break;
-	case 2:
+          for (int i=0; i<Nc; i++) {
+            a(0,i) =  j*b(0,i);
+            a(1,i) = -j*b(1,i);
+            a(2,i) =  j*b(2,i);
+            a(3,i) = -j*b(3,i);
+          }
+        } else if constexpr (nu==2) {
 #pragma unroll
-	  for (int i=0; i<Nc; i++) {
-	    a(0,i) = -b(1,i);
-	    a(1,i) =  b(0,i);
-	    a(2,i) = -b(3,i);
-	    a(3,i) =  b(2,i);
-	  }
-	  break;
-	case 3:
+          for (int i=0; i<Nc; i++) {
+            a(0,i) = -b(1,i);
+            a(1,i) =  b(0,i);
+            a(2,i) = -b(3,i);
+            a(3,i) =  b(2,i);
+          }
+        } else if constexpr (nu==3) {
 #pragma unroll
-	  for (int i=0; i<Nc; i++) {
-	    a(0,i) = -j*b(3,i);
-	    a(1,i) = -j*b(2,i);
-	    a(2,i) = -j*b(1,i);
-	    a(3,i) = -j*b(0,i);
-	  }
-	  break;
-	}
-	break;
-      case 1:
-	switch(nu) {
-	case 0:
+          for (int i=0; i<Nc; i++) {
+            a(0,i) = -j*b(3,i);
+            a(1,i) = -j*b(2,i);
+            a(2,i) = -j*b(1,i);
+            a(3,i) = -j*b(0,i);
+          }
+        }
+      } else if constexpr (mu==1) {
+        if constexpr (nu==0) {
 #pragma unroll
-	  for (int i=0; i<Nc; i++) {
-	    a(0,i) = -j*b(0,i);
-	    a(1,i) =  j*b(1,i);
-	    a(2,i) = -j*b(2,i);
-	    a(3,i) =  j*b(3,i);
-	  }
-	  break;
-	case 2:
+          for (int i=0; i<Nc; i++) {
+            a(0,i) = -j*b(0,i);
+            a(1,i) =  j*b(1,i);
+            a(2,i) = -j*b(2,i);
+            a(3,i) =  j*b(3,i);
+          }
+        } else if constexpr (nu==2) {
 #pragma unroll
-	  for (int i=0; i<Nc; i++) {
-	    a(0,i) = j*b(1,i);
-	    a(1,i) = j*b(0,i);
-	    a(2,i) = j*b(3,i);
-	    a(3,i) = j*b(2,i);
-	  }
-	  break;
-	case 3:
+          for (int i=0; i<Nc; i++) {
+            a(0,i) = j*b(1,i);
+            a(1,i) = j*b(0,i);
+            a(2,i) = j*b(3,i);
+            a(3,i) = j*b(2,i);
+          }
+        } else if constexpr (nu==3) {
 #pragma unroll
-	  for (int i=0; i<Nc; i++) {
-	    a(0,i) = -b(3,i);
-	    a(1,i) =  b(2,i);
-	    a(2,i) = -b(1,i);
-	    a(3,i) =  b(0,i);
-	  }
-	  break;
-	}
-	break;
-      case 2:
-	switch(nu) {
-	case 0:
+          for (int i=0; i<Nc; i++) {
+            a(0,i) = -b(3,i);
+            a(1,i) =  b(2,i);
+            a(2,i) = -b(1,i);
+            a(3,i) =  b(0,i);
+          }
+        }
+      } else if constexpr (mu==2) {
+        if constexpr (nu==0) {
 #pragma unroll
-	  for (int i=0; i<Nc; i++) {
-	    a(0,i) =  b(1,i);
-	    a(1,i) = -b(0,i);
-	    a(2,i) =  b(3,i);
-	    a(3,i) = -b(2,i);
-	  }
-	  break;
-	case 1:
+          for (int i=0; i<Nc; i++) {
+            a(0,i) =  b(1,i);
+            a(1,i) = -b(0,i);
+            a(2,i) =  b(3,i);
+            a(3,i) = -b(2,i);
+          }
+        } else if constexpr (nu==1) {
 #pragma unroll
-	  for (int i=0; i<Nc; i++) {
-	    a(0,i) = -j*b(1,i);
-	    a(1,i) = -j*b(0,i);
-	    a(2,i) = -j*b(3,i);
-	    a(3,i) = -j*b(2,i);
-	  }
-	  break;
-	case 3:
+          for (int i=0; i<Nc; i++) {
+            a(0,i) = -j*b(1,i);
+            a(1,i) = -j*b(0,i);
+            a(2,i) = -j*b(3,i);
+            a(3,i) = -j*b(2,i);
+          }
+        } else if constexpr (nu==3) {
 #pragma unroll
-	  for (int i=0; i<Nc; i++) {
-	    a(0,i) = -j*b(2,i);
-	    a(1,i) =  j*b(3,i);
-	    a(2,i) = -j*b(0,i);
-	    a(3,i) =  j*b(1,i);
-	  }
-	  break;
-	}
-	break;
-      case 3:
-	switch(nu) {
-	case 0:
+          for (int i=0; i<Nc; i++) {
+            a(0,i) = -j*b(2,i);
+            a(1,i) =  j*b(3,i);
+            a(2,i) = -j*b(0,i);
+            a(3,i) =  j*b(1,i);
+          }
+        }
+      } else if constexpr (mu==3) {
+        if constexpr (nu==0) {
 #pragma unroll
-	  for (int i=0; i<Nc; i++) {
-	    a(0,i) = j*b(3,i);
-	    a(1,i) = j*b(2,i);
-	    a(2,i) = j*b(1,i);
-	    a(3,i) = j*b(0,i);
-	  }
-	  break;
-	case 1:
+          for (int i=0; i<Nc; i++) {
+            a(0,i) = j*b(3,i);
+            a(1,i) = j*b(2,i);
+            a(2,i) = j*b(1,i);
+            a(3,i) = j*b(0,i);
+          }
+        } else if constexpr (nu==1) {
 #pragma unroll
-	  for (int i=0; i<Nc; i++) {
-	    a(0,i) =  b(3,i);
-	    a(1,i) = -b(2,i);
-	    a(2,i) =  b(1,i);
-	    a(3,i) = -b(0,i);
-	  }
-	  break;
-	case 2:
+          for (int i=0; i<Nc; i++) {
+            a(0,i) =  b(3,i);
+            a(1,i) = -b(2,i);
+            a(2,i) =  b(1,i);
+            a(3,i) = -b(0,i);
+          }
+        } else if constexpr (nu==2) {
 #pragma unroll
-	  for (int i=0; i<Nc; i++) {
-	    a(0,i) =  j*b(2,i);
-	    a(1,i) = -j*b(3,i);
-	    a(2,i) =  j*b(0,i);
-	    a(3,i) = -j*b(1,i);
-	  }
-	  break;
-	}
-	break;
+          for (int i=0; i<Nc; i++) {
+            a(0,i) =  j*b(2,i);
+            a(1,i) = -j*b(3,i);
+            a(2,i) =  j*b(0,i);
+            a(3,i) = -j*b(1,i);
+          }
+        }
       }
       return a;
     }
@@ -607,10 +569,10 @@ namespace quda {
       ColorSpinor<Float,Nc,Ns> a;
 #pragma unroll
       for (int c=0; c<Nc; c++) {
-	a(0,c) =  (*this)(1,c)+(*this)(3,c);
-	a(1,c) = -(*this)(2,c)-(*this)(0,c);
-	a(2,c) = -(*this)(3,c)+(*this)(1,c);
-	a(3,c) = -(*this)(0,c)+(*this)(2,c);
+        a(0,c) =  (*this)(1,c)+(*this)(3,c);
+        a(1,c) = -(*this)(2,c)-(*this)(0,c);
+        a(2,c) = -(*this)(3,c)+(*this)(1,c);
+        a(3,c) = -(*this)(0,c)+(*this)(2,c);
       }
       *this = a;
     }
@@ -622,10 +584,10 @@ namespace quda {
       ColorSpinor<Float,Nc,Ns> a;
 #pragma unroll
       for (int c=0; c<Nc; c++) {
-	a(0,c) = -(*this)(1,c)-(*this)(3,c);
-	a(1,c) =  (*this)(2,c)+(*this)(0,c);
-	a(2,c) =  (*this)(3,c)-(*this)(1,c);
-	a(3,c) =  (*this)(0,c)-(*this)(2,c);
+        a(0,c) = -(*this)(1,c)-(*this)(3,c);
+        a(1,c) =  (*this)(2,c)+(*this)(0,c);
+        a(2,c) =  (*this)(3,c)-(*this)(1,c);
+        a(3,c) =  (*this)(0,c)-(*this)(2,c);
       }
       *this = a;
     }
@@ -633,9 +595,9 @@ namespace quda {
     __device__ __host__ void print() const
     {
       for (int s=0; s<Ns; s++) {
-	for (int c=0; c<Nc; c++) {
-	  printf("s=%d c=%d %e %e\n", s, c, data[s*Nc+c].real(), data[s*Nc+c].imag());
-	}
+        for (int c=0; c<Nc; c++) {
+          printf("s=%d c=%d %e %e\n", s, c, data[s*Nc+c].real(), data[s*Nc+c].imag());
+        }
       }
     }
     };
@@ -677,9 +639,9 @@ namespace quda {
 #pragma unroll
       for (int s=0; s<Ns; s++) {
 #pragma unroll
-	for (int c=0; c<Nc; c++) {
-	  recon(chirality*Ns+s,c) = (*this)(s,c);
-	}
+        for (int c=0; c<Nc; c++) {
+          recon(chirality*Ns+s,c) = (*this)(s,c);
+        }
       }
       return recon;
     }
@@ -690,103 +652,89 @@ namespace quda {
         @param sign Positive or negative projector
         @return The spin-reconstructed Spinor
     */
-    __device__ __host__ inline ColorSpinor<Float, Nc, 4> reconstruct(int dim, int sign) const
+    template<int dim, int sign>
+    __device__ __host__ inline ColorSpinor<Float, Nc, 4> reconstruct() const
     {
       ColorSpinor<Float, Nc, 4> recon;
-      const auto t = *this;
+      const auto &t = *this;
 
-      switch (dim) {
-      case 0: // x dimension
-	switch (sign) {
-	case 1: // positive projector
+      static_assert(sign==1||sign==-1, "sign must be 1 or -1");
+      static_assert(dim==0||dim==1||dim==2||dim==3||dim==4, "dim must be 0-4");
+
+      if constexpr (dim==0) {
+        if constexpr (sign==1) {
 #pragma unroll
-	  for (int i=0; i<Nc; i++) {
+          for (int i=0; i<Nc; i++) {
             recon(0, i) = t(0, i);
             recon(1, i) = t(1, i);
             recon(2, i) = -i_(t(1, i));
             recon(3, i) = -i_(t(0, i));
           }
-          break;
-        case -1: // negative projector
+        } else if constexpr (sign==-1) {
 #pragma unroll
-	  for (int i=0; i<Nc; i++) {
+          for (int i=0; i<Nc; i++) {
             recon(0, i) = t(0, i);
             recon(1, i) = t(1, i);
             recon(2, i) = i_(t(1, i));
             recon(3, i) = i_(t(0, i));
           }
-          break;
         }
-	break;
-      case 1: // y dimension
-	switch (sign) {
-	case 1: // positive projector
+      } else if constexpr (dim==1) {
+        if constexpr (sign==1) {
 #pragma unroll
-	  for (int i=0; i<Nc; i++) {
+          for (int i=0; i<Nc; i++) {
             recon(0, i) = t(0, i);
             recon(1, i) = t(1, i);
             recon(2, i) = -t(1, i);
             recon(3, i) = t(0, i);
           }
-          break;
-        case -1: // negative projector
+        } else if constexpr (sign==-1) {
 #pragma unroll
-	  for (int i=0; i<Nc; i++) {
+          for (int i=0; i<Nc; i++) {
             recon(0, i) = t(0, i);
             recon(1, i) = t(1, i);
             recon(2, i) = t(1, i);
             recon(3, i) = -t(0, i);
           }
-          break;
         }
-        break;
-      case 2: // z dimension
-	switch (sign) {
-	case 1: // positive projector
+      } else if constexpr (dim==2) {
+        if constexpr (sign==1) {
 #pragma unroll
-	  for (int i=0; i<Nc; i++) {
+          for (int i=0; i<Nc; i++) {
             recon(0, i) = t(0, i);
             recon(1, i) = t(1, i);
             recon(2, i) = -i_(t(0, i));
             recon(3, i) = i_(t(1, i));
           }
-          break;
-        case -1: // negative projector
+        } else if constexpr (sign==-1) {
 #pragma unroll
-	  for (int i=0; i<Nc; i++) {
+          for (int i=0; i<Nc; i++) {
             recon(0, i) = t(0, i);
             recon(1, i) = t(1, i);
             recon(2, i) = i_(t(0, i));
             recon(3, i) = -i_(t(1, i));
           }
-          break;
         }
-	break;
-      case 3: // t dimension
-	switch (sign) {
-	case 1: // positive projector
+      } else if constexpr (dim==3) {
+        if constexpr (sign==1) {
 #pragma unroll
-	  for (int i=0; i<Nc; i++) {
+          for (int i=0; i<Nc; i++) {
             recon(0, i) = t(0, i);
             recon(1, i) = t(1, i);
             recon(2, i) = 0;
             recon(3, i) = 0;
           }
-	  break;
-	case -1: // negative projector
+        } else if constexpr (sign==-1) {
 #pragma unroll
-	  for (int i=0; i<Nc; i++) {
-	    recon(0,i) = 0;
-	    recon(1,i) = 0;
+          for (int i=0; i<Nc; i++) {
+            recon(0,i) = 0;
+            recon(1,i) = 0;
             recon(2, i) = t(0, i);
             recon(3, i) = t(1, i);
           }
-          break;
         }
-	break;
-      case 4:
-        switch (sign) {
-        case 1: // positive projector
+      } else if constexpr (dim==4) {
+        if constexpr (sign==1) {
 #pragma unroll
           for (int i = 0; i < Nc; i++) {
             recon(0, i) = t(0, i);
@@ -794,8 +742,7 @@ namespace quda {
             recon(2, i) = t(0, i);
             recon(3, i) = t(1, i);
           }
-          break;
-        case -1: // negative projector
+        } else if constexpr (sign==-1) {
 #pragma unroll
           for (int i = 0; i < Nc; i++) {
             recon(0, i) = t(0, i);
@@ -803,10 +750,9 @@ namespace quda {
             recon(2, i) = -t(0, i);
             recon(3, i) = -t(1, i);
           }
-          break;
         }
-        break;
       }
+
       return recon;
     }
 
@@ -855,9 +801,9 @@ namespace quda {
     __device__ __host__ void print() const
     {
       for (int s=0; s<Ns; s++) {
-	for (int c=0; c<Nc; c++) {
-	  printf("s=%d c=%d %e %e\n", s, c, data[s*Nc+c].real(), data[s*Nc+c].imag());
-	}
+        for (int c=0; c<Nc; c++) {
+          printf("s=%d c=%d %e %e\n", s, c, data[s*Nc+c].real(), data[s*Nc+c].imag());
+        }
       }
     }
   };
@@ -1020,13 +966,13 @@ namespace quda {
         // out(j,i) = a(0,j) * conj(b(0,i));
 
 #pragma unroll
-	for (int s=1; s<Ns; s++) {
-	  out(j,i).real( out(j,i).real() + a(s,j).real() * b(s,i).real() );
-	  out(j,i).real( out(j,i).real() + a(s,j).imag() * b(s,i).imag() );
-	  out(j,i).imag( out(j,i).imag() + a(s,j).imag() * b(s,i).real() );
-	  out(j,i).imag( out(j,i).imag() - a(s,j).real() * b(s,i).imag() );
-	  // out(j,i) += a(s,j) * conj(b(s,i));
-	}
+        for (int s=1; s<Ns; s++) {
+          out(j,i).real( out(j,i).real() + a(s,j).real() * b(s,i).real() );
+          out(j,i).real( out(j,i).real() + a(s,j).imag() * b(s,i).imag() );
+          out(j,i).imag( out(j,i).imag() + a(s,j).imag() * b(s,i).real() );
+          out(j,i).imag( out(j,i).imag() - a(s,j).real() * b(s,i).imag() );
+          // out(j,i) += a(s,j) * conj(b(s,i));
+        }
       }
     }
     return out;
@@ -1076,7 +1022,7 @@ namespace quda {
     for (int i=0; i<Nc; i++) {
 #pragma unroll
       for (int s=0; s<Ns; s++) {
-	z.data[s*Nc + i] = x.data[s*Nc + i] + y.data[s*Nc + i];
+        z.data[s*Nc + i] = x.data[s*Nc + i] + y.data[s*Nc + i];
       }
     }
 
@@ -1098,7 +1044,7 @@ namespace quda {
     for (int i=0; i<Nc; i++) {
 #pragma unroll
       for (int s=0; s<Ns; s++) {
-	z.data[s*Nc + i] = x.data[s*Nc + i] - y.data[s*Nc + i];
+        z.data[s*Nc + i] = x.data[s*Nc + i] - y.data[s*Nc + i];
       }
     }
 
@@ -1120,7 +1066,7 @@ namespace quda {
     for (int i=0; i<Nc; i++) {
 #pragma unroll
       for (int s=0; s<Ns; s++) {
-	y.data[s*Nc + i] = a * x.data[s*Nc + i];
+        y.data[s*Nc + i] = a * x.data[s*Nc + i];
       }
     }
 
@@ -1142,20 +1088,20 @@ namespace quda {
     for (int i=0; i<Nc; i++) {
 #pragma unroll
       for (int s=0; s<Ns; s++) {
-	y.data[s*Nc + i].x  = A(i,0).real() * x.data[s*Nc + 0].real();
-	y.data[s*Nc + i].x -= A(i,0).imag() * x.data[s*Nc + 0].imag();
-	y.data[s*Nc + i].y  = A(i,0).real() * x.data[s*Nc + 0].imag();
-	y.data[s*Nc + i].y += A(i,0).imag() * x.data[s*Nc + 0].real();
+        y.data[s*Nc + i].x  = A(i,0).real() * x.data[s*Nc + 0].real();
+        y.data[s*Nc + i].x -= A(i,0).imag() * x.data[s*Nc + 0].imag();
+        y.data[s*Nc + i].y  = A(i,0).real() * x.data[s*Nc + 0].imag();
+        y.data[s*Nc + i].y += A(i,0).imag() * x.data[s*Nc + 0].real();
       }
 #pragma unroll
       for (int j=1; j<Nc; j++) {
 #pragma unroll
-	for (int s=0; s<Ns; s++) {
-	  y.data[s*Nc + i].x += A(i,j).real() * x.data[s*Nc + j].real();
-	  y.data[s*Nc + i].x -= A(i,j).imag() * x.data[s*Nc + j].imag();
-	  y.data[s*Nc + i].y += A(i,j).real() * x.data[s*Nc + j].imag();
-	  y.data[s*Nc + i].y += A(i,j).imag() * x.data[s*Nc + j].real();
-	}
+        for (int s=0; s<Ns; s++) {
+          y.data[s*Nc + i].x += A(i,j).real() * x.data[s*Nc + j].real();
+          y.data[s*Nc + i].x -= A(i,j).imag() * x.data[s*Nc + j].imag();
+          y.data[s*Nc + i].y += A(i,j).real() * x.data[s*Nc + j].imag();
+          y.data[s*Nc + i].y += A(i,j).imag() * x.data[s*Nc + j].real();
+        }
       }
     }
 
@@ -1214,25 +1160,25 @@ namespace quda {
 #pragma unroll
     for (int i=0; i<N; i++) {
       if (i==0) {
-	y.data[i].x  = A(i,0).real() * x.data[0].real();
-	y.data[i].y  = A(i,0).real() * x.data[0].imag();
+        y.data[i].x  = A(i,0).real() * x.data[0].real();
+        y.data[i].y  = A(i,0).real() * x.data[0].imag();
       } else {
-	y.data[i].x  = A(i,0).real() * x.data[0].real();
-	y.data[i].x -= A(i,0).imag() * x.data[0].imag();
-	y.data[i].y  = A(i,0).real() * x.data[0].imag();
-	y.data[i].y += A(i,0).imag() * x.data[0].real();
+        y.data[i].x  = A(i,0).real() * x.data[0].real();
+        y.data[i].x -= A(i,0).imag() * x.data[0].imag();
+        y.data[i].y  = A(i,0).real() * x.data[0].imag();
+        y.data[i].y += A(i,0).imag() * x.data[0].real();
       }
 #pragma unroll
       for (int j=1; j<N; j++) {
-	if (i==j) {
-	  y.data[i].x += A(i,j).real() * x.data[j].real();
-	  y.data[i].y += A(i,j).real() * x.data[j].imag();
-	} else {
-	  y.data[i].x += A(i,j).real() * x.data[j].real();
-	  y.data[i].x -= A(i,j).imag() * x.data[j].imag();
-	  y.data[i].y += A(i,j).real() * x.data[j].imag();
-	  y.data[i].y += A(i,j).imag() * x.data[j].real();
-	}
+        if (i==j) {
+          y.data[i].x += A(i,j).real() * x.data[j].real();
+          y.data[i].y += A(i,j).real() * x.data[j].imag();
+        } else {
+          y.data[i].x += A(i,j).real() * x.data[j].real();
+          y.data[i].x -= A(i,j).imag() * x.data[j].imag();
+          y.data[i].y += A(i,j).real() * x.data[j].imag();
+          y.data[i].y += A(i,j).imag() * x.data[j].real();
+        }
       }
     }
 

--- a/include/complex_quda.h
+++ b/include/complex_quda.h
@@ -1207,7 +1207,7 @@ lhs.real()*rhs.imag()+lhs.imag()*rhs.real());
   template <typename real> __host__ __device__ inline complex<real> i_(const complex<real> &a)
   {
     // FIXME compiler generates worse code with "optimal" code
-#if 1
+#if 0
     return complex<real>(0.0, 1.0) * a;
 #else
     return complex<real>(-a.imag(), a.real());

--- a/include/complex_quda.h
+++ b/include/complex_quda.h
@@ -1207,7 +1207,7 @@ lhs.real()*rhs.imag()+lhs.imag()*rhs.real());
   template <typename real> __host__ __device__ inline complex<real> i_(const complex<real> &a)
   {
     // FIXME compiler generates worse code with "optimal" code
-#if 0
+#if 1
     return complex<real>(0.0, 1.0) * a;
 #else
     return complex<real>(-a.imag(), a.real());

--- a/include/kernels/clover_outer_product.cuh
+++ b/include/kernels/clover_outer_product.cuh
@@ -63,8 +63,7 @@ namespace quda {
       Spinor A = arg.inA(x_cb, 0);
       Spinor C = arg.inC(x_cb, 0);
 
-#pragma unroll
-      for (int dim=0; dim<4; ++dim) {
+      static_for<0,4>([&]<int dim>{
         int shift[4] = {0, 0, 0, 0};
         shift[dim] = 1;
         const int nbr_idx = neighborIndex(x_cb, shift, arg.partitioned, arg.parity, arg.X);
@@ -73,10 +72,10 @@ namespace quda {
           Spinor B_shift = arg.inB(nbr_idx, 0);
           Spinor D_shift = arg.inD(nbr_idx, 0);
 
-          B_shift = (B_shift.project(dim,1)).reconstruct(dim,1);
+          B_shift = (B_shift.template project<dim,1>()).template reconstruct<dim,1>();
           Link result = outerProdSpinTrace(B_shift,A);
 
-          D_shift = (D_shift.project(dim,-1)).reconstruct(dim,-1);
+          D_shift = (D_shift.template project<dim,-1>()).template reconstruct<dim,-1>();
           result += outerProdSpinTrace(D_shift,C);
 
           Link temp = arg.force(dim, x_cb, arg.parity);
@@ -84,7 +83,7 @@ namespace quda {
           result = temp + U*result*arg.coeff;
           arg.force(dim, x_cb, arg.parity) = result;
         }
-      } // dim
+      }); // dim
     }
   };
 
@@ -107,11 +106,11 @@ namespace quda {
       Spinor C = arg.inC(bulk_cb_idx, 0);
 
       HalfSpinor projected_tmp = arg.inB.Ghost(Arg::dim, 1, x_cb, 0);
-      Spinor B_shift = projected_tmp.reconstruct(Arg::dim, 1);
+      Spinor B_shift = projected_tmp.template reconstruct<Arg::dim, 1>();
       Link result = outerProdSpinTrace(B_shift,A);
 
       projected_tmp = arg.inD.Ghost(Arg::dim, 1, x_cb, 0);
-      Spinor D_shift = projected_tmp.reconstruct(Arg::dim,-1);
+      Spinor D_shift = projected_tmp.template reconstruct<Arg::dim,-1>();
       result += outerProdSpinTrace(D_shift,C);
 
       Link temp = arg.force(Arg::dim, bulk_cb_idx, arg.parity);

--- a/include/kernels/clover_outer_product.cuh
+++ b/include/kernels/clover_outer_product.cuh
@@ -63,7 +63,7 @@ namespace quda {
       Spinor A = arg.inA(x_cb, 0);
       Spinor C = arg.inC(x_cb, 0);
 
-      static_for<0,4>(static_for_var(dim){
+      static_for<0,4>([&](auto dim){
         int shift[4] = {0, 0, 0, 0};
         shift[dim] = 1;
         const int nbr_idx = neighborIndex(x_cb, shift, arg.partitioned, arg.parity, arg.X);

--- a/include/kernels/clover_outer_product.cuh
+++ b/include/kernels/clover_outer_product.cuh
@@ -63,7 +63,7 @@ namespace quda {
       Spinor A = arg.inA(x_cb, 0);
       Spinor C = arg.inC(x_cb, 0);
 
-      static_for<0,4>([&]<int dim>{
+      static_for<0,4>(static_for_var(dim){
         int shift[4] = {0, 0, 0, 0};
         shift[dim] = 1;
         const int nbr_idx = neighborIndex(x_cb, shift, arg.partitioned, arg.parity, arg.X);

--- a/include/kernels/clover_sigma_outer_product.cuh
+++ b/include/kernels/clover_sigma_outer_product.cuh
@@ -51,7 +51,7 @@ namespace quda
     for (int i = 0; i < Arg::nvector; i++) {
       const Spinor A = arg.inA[i](x_cb, parity);
       const Spinor B = arg.inB[i](x_cb, parity);
-      Spinor C = A.sigma(nu, mu); // multiply by sigma_mu_nu
+      Spinor C = A.template sigma<nu, mu>(); // multiply by sigma_mu_nu
       result += arg.coeff[i][parity] * outerProdSpinTrace(C, B);
     }
 

--- a/include/kernels/dslash_domain_wall_5d.cuh
+++ b/include/kernels/dslash_domain_wall_5d.cuh
@@ -55,9 +55,9 @@ namespace quda
           constexpr int proj_dir = dagger ? +1 : -1;
           Vector in = arg.in(fwd_idx, their_spinor_parity);
           if (s == arg.Ls - 1) {
-            out += (-arg.m_f * in.project(d, proj_dir)).reconstruct(d, proj_dir);
+            out += (-arg.m_f * in.template project<d, proj_dir>()).template reconstruct<d, proj_dir>();
           } else {
-            out += in.project(d, proj_dir).reconstruct(d, proj_dir);
+            out += in.template project<d, proj_dir>().template reconstruct<d, proj_dir>();
           }
         }
 
@@ -66,9 +66,9 @@ namespace quda
           constexpr int proj_dir = dagger ? -1 : +1;
           Vector in = arg.in(back_idx, their_spinor_parity);
           if (s == 0) {
-            out += (-arg.m_f * in.project(d, proj_dir)).reconstruct(d, proj_dir);
+            out += (-arg.m_f * in.template project<d, proj_dir>()).template reconstruct<d, proj_dir>();
           } else {
-            out += in.project(d, proj_dir).reconstruct(d, proj_dir);
+            out += in.template project<d, proj_dir>().template reconstruct<d, proj_dir>();
           }
         }
       }

--- a/include/kernels/dslash_domain_wall_m5.cuh
+++ b/include/kernels/dslash_domain_wall_m5.cuh
@@ -226,7 +226,7 @@ namespace quda
         constexpr int proj_dir = dagger ? +1 : -1;
         if (shared) {
           if (sync) { cache.sync(); }
-          cache.save(in.project(4, proj_dir));
+          cache.save(in.template project<4, proj_dir>());
           cache.sync();
         }
         const int fwd_s = (s + 1) % arg.Ls;
@@ -236,12 +236,12 @@ namespace quda
           half_in = cache.load(threadIdx.x, fwd_s, parity);
         } else {
           Vector full_in = arg.in(fwd_idx, parity);
-          half_in = full_in.project(4, proj_dir);
+          half_in = full_in.template project<4, proj_dir>();
         }
         if (s == arg.Ls - 1) {
-          out += (-arg.m_f * half_in).reconstruct(4, proj_dir);
+          out += (-arg.m_f * half_in).template reconstruct<4, proj_dir>();
         } else {
-          out += half_in.reconstruct(4, proj_dir);
+          out += half_in.template reconstruct<4, proj_dir>();
         }
       }
 
@@ -249,7 +249,7 @@ namespace quda
         constexpr int proj_dir = dagger ? -1 : +1;
         if (shared) {
           cache.sync();
-          cache.save(in.project(4, proj_dir));
+          cache.save(in.template project<4, proj_dir>());
           cache.sync();
         }
         const int back_s = (s + arg.Ls - 1) % arg.Ls;
@@ -259,12 +259,12 @@ namespace quda
           half_in = cache.load(threadIdx.x, back_s, parity);
         } else {
           Vector full_in = arg.in(back_idx, parity);
-          half_in = full_in.project(4, proj_dir);
+          half_in = full_in.template project<4, proj_dir>();
         }
         if (s == 0) {
-          out += (-arg.m_f * half_in).reconstruct(4, proj_dir);
+          out += (-arg.m_f * half_in).template reconstruct<4, proj_dir>();
         } else {
-          out += half_in.reconstruct(4, proj_dir);
+          out += half_in.template reconstruct<4, proj_dir>();
         }
       }
 
@@ -284,9 +284,9 @@ namespace quda
         const Vector in = shared ? cache.load(threadIdx.x, fwd_s, parity) : arg.in(fwd_idx, parity);
         constexpr int proj_dir = dagger ? +1 : -1;
         if (s == arg.Ls - 1) {
-          out += (-arg.m_f * in.project(4, proj_dir)).reconstruct(4, proj_dir);
+          out += (-arg.m_f * in.template project<4, proj_dir>()).template reconstruct<4, proj_dir>();
         } else {
-          out += in.project(4, proj_dir).reconstruct(4, proj_dir);
+          out += in.template project<4, proj_dir>().template reconstruct<4, proj_dir>();
         }
       }
 
@@ -296,9 +296,9 @@ namespace quda
         const Vector in = shared ? cache.load(threadIdx.x, back_s, parity) : arg.in(back_idx, parity);
         constexpr int proj_dir = dagger ? -1 : +1;
         if (s == 0) {
-          out += (-arg.m_f * in.project(4, proj_dir)).reconstruct(4, proj_dir);
+          out += (-arg.m_f * in.template project<4, proj_dir>()).template reconstruct<4, proj_dir>();
         } else {
-          out += in.project(4, proj_dir).reconstruct(4, proj_dir);
+          out += in.template project<4, proj_dir>().template reconstruct<4, proj_dir>();
         }
       }
     } // use_half_vector
@@ -395,14 +395,14 @@ namespace quda
         int exp = s_ < s ? arg.Ls - s + s_ : s_ - s;
         real factorR = inv * fpow(k, exp) * (s_ < s ? -arg.m_f : static_cast<real>(1.0));
         constexpr int proj_dir = dagger ? -1 : +1;
-        out += factorR * (in.project(4, proj_dir)).reconstruct(4, proj_dir);
+        out += factorR * (in.template project<4, proj_dir>()).template reconstruct<4, proj_dir>();
       }
 
       {
         int exp = s_ > s ? arg.Ls - s_ + s : s - s_;
         real factorL = inv * fpow(k, exp) * (s_ > s ? -arg.m_f : static_cast<real>(1.0));
         constexpr int proj_dir = dagger ? +1 : -1;
-        out += factorL * (in.project(4, proj_dir)).reconstruct(4, proj_dir);
+        out += factorL * (in.template project<4, proj_dir>()).template reconstruct<4, proj_dir>();
       }
     }
 
@@ -443,7 +443,7 @@ namespace quda
 
         if (shared) {
           if (sync) { cache.sync(); }
-          cache.save(in.project(4, proj_dir));
+          cache.save(in.template project<4, proj_dir>());
           cache.sync();
         }
 
@@ -457,21 +457,21 @@ namespace quda
             r += factorR * cache.load(threadIdx.x, s, parity);
           } else {
             Vector in = arg.in(s * arg.volume_4d_cb + x_cb, parity);
-            r += factorR * in.project(4, proj_dir);
+            r += factorR * in.template project<4, proj_dir>();
           }
 
           R *= coeff.kappa(s);
           s = (s + arg.Ls - 1) % arg.Ls;
         }
 
-        out += r.reconstruct(4, proj_dir);
+        out += r.template reconstruct<4, proj_dir>();
       }
 
       { // second do L
         constexpr int proj_dir = dagger ? +1 : -1;
         if (shared) {
           cache.sync(); // ensure we finish R before overwriting cache
-          cache.save(in.project(4, proj_dir));
+          cache.save(in.template project<4, proj_dir>());
           cache.sync();
         }
 
@@ -485,14 +485,14 @@ namespace quda
             l += factorL * cache.load(threadIdx.x, s, parity);
           } else {
             Vector in = arg.in(s * arg.volume_4d_cb + x_cb, parity);
-            l += factorL * in.project(4, proj_dir);
+            l += factorL * in.template project<4, proj_dir>();
           }
 
           L *= coeff.kappa(s);
           s = (s + 1) % arg.Ls;
         }
 
-        out += l.reconstruct(4, proj_dir);
+        out += l.template reconstruct<4, proj_dir>();
       }
     } else { // use_half_vector
       SharedMemoryCache<Vector> cache(target::block_dim());
@@ -512,13 +512,13 @@ namespace quda
           auto factorR = (s_ < s ? -arg.m_f * R : R);
 
           Vector in = shared ? cache.load(threadIdx.x, s, parity) : arg.in(s * arg.volume_4d_cb + x_cb, parity);
-          r += factorR * in.project(4, proj_dir);
+          r += factorR * in.template project<4, proj_dir>();
 
           R *= coeff.kappa(s);
           s = (s + arg.Ls - 1) % arg.Ls;
         }
 
-        out += r.reconstruct(4, proj_dir);
+        out += r.template reconstruct<4, proj_dir>();
       }
 
       { // second do L
@@ -531,13 +531,13 @@ namespace quda
           auto factorL = (s_ > s ? -arg.m_f * L : L);
 
           Vector in = shared ? cache.load(threadIdx.x, s, parity) : arg.in(s * arg.volume_4d_cb + x_cb, parity);
-          l += factorL * in.project(4, proj_dir);
+          l += factorL * in.template project<4, proj_dir>();
 
           L *= coeff.kappa(s);
           s = (s + 1) % arg.Ls;
         }
 
-        out += l.reconstruct(4, proj_dir);
+        out += l.template reconstruct<4, proj_dir>();
       }
     } // use_half_vector
 

--- a/include/kernels/dslash_gamma_helper.cuh
+++ b/include/kernels/dslash_gamma_helper.cuh
@@ -78,11 +78,11 @@ namespace quda {
     {
       ColorSpinor<typename Arg::real, Arg::nColor, 4> in = arg.in(x_cb, parity);
       switch(arg.d) {
-      case 0: arg.out(x_cb, parity) = in.gamma(0);
-      case 1: arg.out(x_cb, parity) = in.gamma(1);
-      case 2: arg.out(x_cb, parity) = in.gamma(2);
-      case 3: arg.out(x_cb, parity) = in.gamma(3);
-      case 4: arg.out(x_cb, parity) = in.gamma(4);
+      case 0: arg.out(x_cb, parity) = in.template gamma<0>();
+      case 1: arg.out(x_cb, parity) = in.template gamma<1>();
+      case 2: arg.out(x_cb, parity) = in.template gamma<2>();
+      case 3: arg.out(x_cb, parity) = in.template gamma<3>();
+      case 4: arg.out(x_cb, parity) = in.template gamma<4>();
       }
     }
   };
@@ -101,12 +101,12 @@ namespace quda {
       constexpr int d = 4;
       if (!arg.doublet) {
         fermion_t in = arg.in(x_cb, parity);
-        arg.out(x_cb, parity) = arg.a * (in + arg.b * in.igamma(d));
+        arg.out(x_cb, parity) = arg.a * (in + arg.b * in.template igamma<d>());
       } else {
         fermion_t in_1 = arg.in(x_cb+0*arg.volumeCB, parity);
         fermion_t in_2 = arg.in(x_cb+1*arg.volumeCB, parity);
-        arg.out(x_cb + 0 * arg.volumeCB, parity) = arg.a * (in_1 + arg.b * in_1.igamma(d) + arg.c * in_2);
-        arg.out(x_cb + 1 * arg.volumeCB, parity) = arg.a * (in_2 - arg.b * in_2.igamma(d) + arg.c * in_1);
+        arg.out(x_cb + 0 * arg.volumeCB, parity) = arg.a * (in_1 + arg.b * in_1.template igamma<d>() + arg.c * in_2);
+        arg.out(x_cb + 1 * arg.volumeCB, parity) = arg.a * (in_2 - arg.b * in_2.template igamma<d>() + arg.c * in_1);
       }
     }
   };

--- a/include/kernels/dslash_mdw_fused.cuh
+++ b/include/kernels/dslash_mdw_fused.cuh
@@ -211,7 +211,7 @@ namespace quda {
 
       const int index_4d_cb = index_4d_cb_from_coordinate_4d(coordinate, arg.dim);
 
-      static_for<0,4>([&]<int d> // loop over dimension
+      static_for<0,4>(static_for_var(d) // loop over dimension
       {
         int x[4] = {coordinate[0], coordinate[1], coordinate[2], coordinate[3]};
         x[d] = (coordinate[d] == arg.dim[d] - 1 && !arg.comm[d]) ? 0 : coordinate[d] + 1;

--- a/include/kernels/dslash_mdw_fused.cuh
+++ b/include/kernels/dslash_mdw_fused.cuh
@@ -211,7 +211,7 @@ namespace quda {
 
       const int index_4d_cb = index_4d_cb_from_coordinate_4d(coordinate, arg.dim);
 
-      static_for<0,4>(static_for_var(d) // loop over dimension
+      static_for<0,4>([&](auto d) // loop over dimension
       {
         int x[4] = {coordinate[0], coordinate[1], coordinate[2], coordinate[3]};
         x[d] = (coordinate[d] == arg.dim[d] - 1 && !arg.comm[d]) ? 0 : coordinate[d] + 1;

--- a/include/kernels/dslash_mdw_fused.cuh
+++ b/include/kernels/dslash_mdw_fused.cuh
@@ -211,8 +211,7 @@ namespace quda {
 
       const int index_4d_cb = index_4d_cb_from_coordinate_4d(coordinate, arg.dim);
 
-#pragma unroll
-      for (int d = 0; d < 4; d++) // loop over dimension
+      static_for<0,4>([&]<int d> // loop over dimension
       {
         int x[4] = {coordinate[0], coordinate[1], coordinate[2], coordinate[3]};
         x[d] = (coordinate[d] == arg.dim[d] - 1 && !arg.comm[d]) ? 0 : coordinate[d] + 1;
@@ -228,7 +227,7 @@ namespace quda {
 
           const Link U = arg.U(d, index_4d_cb, arg.parity);
           const Vector in = arg.in(fwd_idx, their_spinor_parity);
-          out += (U * in.project(d, proj_dir)).reconstruct(d, proj_dir);
+          out += (U * in.template project<d, proj_dir>()).template reconstruct<d, proj_dir>();
         }
         x[d] = (coordinate[d] == 0 && !arg.comm[d]) ? arg.dim[d] - 1 : coordinate[d] - 1;
         if (!halo || !is_halo_4d(x, arg.dim, arg.halo_shift)) {
@@ -245,9 +244,9 @@ namespace quda {
 
           const Link U = arg.U(d, gauge_idx, 1 - arg.parity);
           const Vector in = arg.in(back_idx, their_spinor_parity);
-          out += (conj(U) * in.project(d, proj_dir)).reconstruct(d, proj_dir);
+          out += (conj(U) * in.template project<d, proj_dir>()).template reconstruct<d, proj_dir>();
         }
-      } // nDim
+      }); // nDim
     }
 
     /**

--- a/include/kernels/dslash_mobius_eofa.cuh
+++ b/include/kernels/dslash_mobius_eofa.cuh
@@ -119,9 +119,9 @@ namespace quda
           const Vector in = cache.load(threadIdx.x, (s + 1) % Ls, threadIdx.z);
           constexpr int proj_dir = Arg::dagger ? +1 : -1;
           if (s == Ls - 1) {
-            out += (-arg.m_f * in.project(4, proj_dir)).reconstruct(4, proj_dir);
+            out += (-arg.m_f * in.template project<4, proj_dir>()).template reconstruct<4, proj_dir>();
           } else {
-            out += in.project(4, proj_dir).reconstruct(4, proj_dir);
+            out += in.template project<4, proj_dir>().template reconstruct<4, proj_dir>();
           }
         }
 
@@ -129,9 +129,9 @@ namespace quda
           const Vector in = cache.load(threadIdx.x, (s + Ls - 1) % Ls, threadIdx.z);
           constexpr int proj_dir = Arg::dagger ? -1 : +1;
           if (s == 0) {
-            out += (-arg.m_f * in.project(4, proj_dir)).reconstruct(4, proj_dir);
+            out += (-arg.m_f * in.template project<4, proj_dir>()).template reconstruct<4, proj_dir>();
           } else {
-            out += in.project(4, proj_dir).reconstruct(4, proj_dir);
+            out += in.template project<4, proj_dir>().template reconstruct<4, proj_dir>();
           }
         }
 
@@ -145,12 +145,12 @@ namespace quda
             if (s == (Arg::pm ? Ls - 1 : 0)) {
               for (int sp = 0; sp < Ls; sp++) {
                 out += (static_cast<real>(0.5) * arg.coeff.u[sp])
-                  * cache.load(threadIdx.x, sp, threadIdx.z).project(4, proj_dir).reconstruct(4, proj_dir);
+                  * cache.load(threadIdx.x, sp, threadIdx.z).template project<4, proj_dir>().template reconstruct<4, proj_dir>();
               }
             }
           } else {
             out += (static_cast<real>(0.5) * arg.coeff.u[s])
-              * cache.load(threadIdx.x, Arg::pm ? Ls - 1 : 0, threadIdx.z).project(4, proj_dir).reconstruct(4, proj_dir);
+              * cache.load(threadIdx.x, Arg::pm ? Ls - 1 : 0, threadIdx.z).template project<4, proj_dir>().template reconstruct<4, proj_dir>();
           }
 
           if (Arg::xpay) { // really axpy
@@ -197,19 +197,19 @@ namespace quda
             int exp = s < sp ? arg.Ls - sp + s : s - sp;
             real factorR = 0.5 * arg.coeff.y[Arg::pm ? arg.Ls - exp - 1 : exp] * (s < sp ? -arg.m_f : static_cast<real>(1.0));
             constexpr int proj_dir = Arg::dagger ? -1 : +1;
-            out += factorR * (in.project(4, proj_dir)).reconstruct(4, proj_dir);
+            out += factorR * (in.template project<4, proj_dir>()).template reconstruct<4, proj_dir>();
           }
           {
             int exp = s > sp ? arg.Ls - s + sp : sp - s;
             real factorL = 0.5 * arg.coeff.y[Arg::pm ? arg.Ls - exp - 1 : exp] * (s > sp ? -arg.m_f : static_cast<real>(1.0));
             constexpr int proj_dir = Arg::dagger ? +1 : -1;
-            out += factorL * (in.project(4, proj_dir)).reconstruct(4, proj_dir);
+            out += factorL * (in.template project<4, proj_dir>()).template reconstruct<4, proj_dir>();
           }
           // The EOFA stuff
           {
             constexpr int proj_dir = Arg::pm ? +1 : -1;
             real t = Arg::dagger ? arg.coeff.y[s] * arg.coeff.x[sp] : arg.coeff.x[s] * arg.coeff.y[sp];
-            out += (t * sherman_morrison) * (in.project(4, proj_dir)).reconstruct(4, proj_dir);
+            out += (t * sherman_morrison) * (in.template project<4, proj_dir>()).template reconstruct<4, proj_dir>();
           }
         }
         if (Arg::xpay) { // really axpy

--- a/include/kernels/dslash_ndeg_twisted_mass.cuh
+++ b/include/kernels/dslash_ndeg_twisted_mass.cuh
@@ -61,11 +61,11 @@ namespace quda
 
         if (flavor == 0) {
           out = x0 + arg.a * out;
-          out += arg.b * x0.igamma(4);
+          out += arg.b * x0.template igamma<4>();
           out += arg.c * x1;
         } else {
           out = x1 + arg.a * out;
-          out += -arg.b * x1.igamma(4);
+          out += -arg.b * x1.template igamma<4>();
           out += arg.c * x0;
         }
 

--- a/include/kernels/dslash_ndeg_twisted_mass_preconditioned.cuh
+++ b/include/kernels/dslash_ndeg_twisted_mass_preconditioned.cuh
@@ -80,9 +80,9 @@ namespace quda
           Vector x0 = arg.x(coord.x_cb + 0 * arg.dc.volume_4d_cb, my_spinor_parity);
           Vector x1 = arg.x(coord.x_cb + 1 * arg.dc.volume_4d_cb, my_spinor_parity);
           if (flavor == 0)
-            out += arg.a_inv * (x0 + arg.b_inv * x0.igamma(4) + arg.c_inv * x1);
+            out += arg.a_inv * (x0 + arg.b_inv * x0.template igamma<4>() + arg.c_inv * x1);
           else
-            out += arg.a_inv * (x1 - arg.b_inv * x1.igamma(4) + arg.c_inv * x0);
+            out += arg.a_inv * (x1 - arg.b_inv * x1.template igamma<4>() + arg.c_inv * x0);
         } else {
           Vector x = arg.x(my_flavor_idx, my_spinor_parity);
           out += x; // just directly add since twist already applied in the dslash
@@ -104,9 +104,9 @@ namespace quda
         cache.sync(); // safe to sync in here since other threads will exit
         if (isComplete<mykernel_type>(arg, coord) && active) {
           if (flavor == 0)
-            out = arg.a * (out + arg.b * out.igamma(4) + arg.c * cache.load_y(1));
+            out = arg.a * (out + arg.b * out.template igamma<4>() + arg.c * cache.load_y(1));
           else
-            out = arg.a * (out - arg.b * out.igamma(4) + arg.c * cache.load_y(0));
+            out = arg.a * (out - arg.b * out.template igamma<4>() + arg.c * cache.load_y(0));
         }
       }
 

--- a/include/kernels/dslash_pack.cuh
+++ b/include/kernels/dslash_pack.cuh
@@ -154,16 +154,16 @@ namespace quda
       constexpr int proj_dir = dagger ? +1 : -1;
       Vector f = arg.in_pack(idx + s * arg.dc.volume_4d_cb, spinor_parity);
       if (twist == 1) {
-        f = arg.twist_a * (f + arg.twist_b * f.igamma(4));
+        f = arg.twist_a * (f + arg.twist_b * f.template igamma<4>());
       } else if (twist == 2) {
         Vector f1 = arg.in_pack(idx + (1 - s) * arg.dc.volume_4d_cb, spinor_parity); // load other flavor
         if (s == 0)
-          f = arg.twist_a * (f + arg.twist_b * f.igamma(4) + arg.twist_c * f1);
+          f = arg.twist_a * (f + arg.twist_b * f.template igamma<4>() + arg.twist_c * f1);
         else
-          f = arg.twist_a * (f - arg.twist_b * f.igamma(4) + arg.twist_c * f1);
+          f = arg.twist_a * (f - arg.twist_b * f.template igamma<4>() + arg.twist_c * f1);
       }
       if (arg.spin_project) {
-        arg.in_pack.Ghost(dim, 0, ghost_idx + s * arg.dc.ghostFaceCB[dim], spinor_parity) = f.project(dim, proj_dir);
+        arg.in_pack.Ghost(dim, 0, ghost_idx + s * arg.dc.ghostFaceCB[dim], spinor_parity) = f.template project<dim, proj_dir>();
       } else {
         arg.in_pack.Ghost(dim, 0, ghost_idx + s * arg.dc.ghostFaceCB[dim], spinor_parity) = f;
       }
@@ -173,16 +173,16 @@ namespace quda
       constexpr int proj_dir = dagger ? -1 : +1;
       Vector f = arg.in_pack(idx + s * arg.dc.volume_4d_cb, spinor_parity);
       if (twist == 1) {
-        f = arg.twist_a * (f + arg.twist_b * f.igamma(4));
+        f = arg.twist_a * (f + arg.twist_b * f.template igamma<4>());
       } else if (twist == 2) {
         Vector f1 = arg.in_pack(idx + (1 - s) * arg.dc.volume_4d_cb, spinor_parity); // load other flavor
         if (s == 0)
-          f = arg.twist_a * (f + arg.twist_b * f.igamma(4) + arg.twist_c * f1);
+          f = arg.twist_a * (f + arg.twist_b * f.template igamma<4>() + arg.twist_c * f1);
         else
-          f = arg.twist_a * (f - arg.twist_b * f.igamma(4) + arg.twist_c * f1);
+          f = arg.twist_a * (f - arg.twist_b * f.template igamma<4>() + arg.twist_c * f1);
       }
       if (arg.spin_project) {
-        arg.in_pack.Ghost(dim, 1, ghost_idx + s * arg.dc.ghostFaceCB[dim], spinor_parity) = f.project(dim, proj_dir);
+        arg.in_pack.Ghost(dim, 1, ghost_idx + s * arg.dc.ghostFaceCB[dim], spinor_parity) = f.template project<dim, proj_dir>();
       } else {
         arg.in_pack.Ghost(dim, 1, ghost_idx + s * arg.dc.ghostFaceCB[dim], spinor_parity) = f;
       }

--- a/include/kernels/dslash_twisted_mass.cuh
+++ b/include/kernels/dslash_twisted_mass.cuh
@@ -51,7 +51,7 @@ namespace quda
 
       if (mykernel_type == INTERIOR_KERNEL) {
         Vector x = arg.x(coord.x_cb, my_spinor_parity);
-        x += arg.b * x.igamma(4);
+        x += arg.b * x.template igamma<4>();
         out = x + arg.a * out;
       } else if (active) {
         Vector x = arg.out(coord.x_cb, my_spinor_parity);

--- a/include/kernels/dslash_twisted_mass_preconditioned.cuh
+++ b/include/kernels/dslash_twisted_mass_preconditioned.cuh
@@ -55,7 +55,7 @@ namespace quda
     typedef Matrix<complex<real>, Arg::nColor> Link;
     const int their_spinor_parity = nParity == 2 ? 1 - parity : 0;
 
-    static_for<0,Arg::nDim>(static_for_var(d){ // loop over dimension
+    static_for<0,Arg::nDim>([&](auto d){ // loop over dimension
       {                              // Forward gather - compute fwd offset for vector fetch
         const int fwd_idx = getNeighborIndexCB(coord, d, +1, arg.dc);
         constexpr int proj_dir = dagger ? +1 : -1;

--- a/include/kernels/dslash_twisted_mass_preconditioned.cuh
+++ b/include/kernels/dslash_twisted_mass_preconditioned.cuh
@@ -55,7 +55,7 @@ namespace quda
     typedef Matrix<complex<real>, Arg::nColor> Link;
     const int their_spinor_parity = nParity == 2 ? 1 - parity : 0;
 
-    static_for<0,Arg::nDim>([&]<int d>{ // loop over dimension
+    static_for<0,Arg::nDim>(static_for_var(d){ // loop over dimension
       {                              // Forward gather - compute fwd offset for vector fetch
         const int fwd_idx = getNeighborIndexCB(coord, d, +1, arg.dc);
         constexpr int proj_dir = dagger ? +1 : -1;

--- a/include/kernels/dslash_twisted_mass_preconditioned.cuh
+++ b/include/kernels/dslash_twisted_mass_preconditioned.cuh
@@ -55,8 +55,7 @@ namespace quda
     typedef Matrix<complex<real>, Arg::nColor> Link;
     const int their_spinor_parity = nParity == 2 ? 1 - parity : 0;
 
-#pragma unroll
-    for (int d = 0; d < Arg::nDim; d++) { // loop over dimension
+    static_for<0,Arg::nDim>([&]<int d>{ // loop over dimension
       {                              // Forward gather - compute fwd offset for vector fetch
         const int fwd_idx = getNeighborIndexCB(coord, d, +1, arg.dc);
         constexpr int proj_dir = dagger ? +1 : -1;
@@ -72,24 +71,24 @@ namespace quda
           Link U = arg.U(d, coord.x_cb, parity);
           HalfVector in = arg.in.Ghost(d, 1, ghost_idx + coord.s * arg.dc.ghostFaceCB[d], their_spinor_parity);
 
-          out += (U * in).reconstruct(d, proj_dir);
+          out += (U * in).template reconstruct<d, proj_dir>();
         } else if (doBulk<kernel_type>() && !ghost) {
 
           Link U = arg.U(d, coord.x_cb, parity);
           Vector in;
           if (twist == 1) {
             in = arg.in(fwd_idx + coord.s * arg.dc.volume_4d_cb, their_spinor_parity);
-            in = arg.a * (in + arg.b * in.igamma(4)); // apply A^{-1} to in
+            in = arg.a * (in + arg.b * in.template igamma<4>()); // apply A^{-1} to in
           } else {                                    // twisted doublet
             Vector in0 = arg.in(fwd_idx + 0 * arg.dc.volume_4d_cb, their_spinor_parity);
             Vector in1 = arg.in(fwd_idx + 1 * arg.dc.volume_4d_cb, their_spinor_parity);
             if (coord.s == 0)
-              in = arg.a * (in0 + arg.b * in0.igamma(4) + arg.c * in1);
+              in = arg.a * (in0 + arg.b * in0.template igamma<4>() + arg.c * in1);
             else
-              in = arg.a * (in1 - arg.b * in1.igamma(4) + arg.c * in0);
+              in = arg.a * (in1 - arg.b * in1.template igamma<4>() + arg.c * in0);
           }
 
-          out += (U * in.project(d, proj_dir)).reconstruct(d, proj_dir);
+          out += (U * in.template project<d, proj_dir>()).template reconstruct<d, proj_dir>();
         }
       }
 
@@ -108,27 +107,27 @@ namespace quda
           Link U = arg.U.Ghost(d, ghost_idx, 1 - parity);
           HalfVector in = arg.in.Ghost(d, 0, ghost_idx + coord.s * arg.dc.ghostFaceCB[d], their_spinor_parity);
 
-          out += (conj(U) * in).reconstruct(d, proj_dir);
+          out += (conj(U) * in).template reconstruct<d, proj_dir>();
         } else if (doBulk<kernel_type>() && !ghost) {
 
           Link U = arg.U(d, gauge_idx, 1 - parity);
           Vector in;
           if (twist == 1) {
             in = arg.in(back_idx + coord.s * arg.dc.volume_4d_cb, their_spinor_parity);
-            in = arg.a * (in + arg.b * in.igamma(4)); // apply A^{-1} to in
+            in = arg.a * (in + arg.b * in.template igamma<4>()); // apply A^{-1} to in
           } else {                                    // twisted doublet
             Vector in0 = arg.in(back_idx + 0 * arg.dc.volume_4d_cb, their_spinor_parity);
             Vector in1 = arg.in(back_idx + 1 * arg.dc.volume_4d_cb, their_spinor_parity);
             if (coord.s == 0)
-              in = arg.a * (in0 + arg.b * in0.igamma(4) + arg.c * in1);
+              in = arg.a * (in0 + arg.b * in0.template igamma<4>() + arg.c * in1);
             else
-              in = arg.a * (in1 - arg.b * in1.igamma(4) + arg.c * in0);
+              in = arg.a * (in1 - arg.b * in1.template igamma<4>() + arg.c * in0);
           }
 
-          out += (conj(U) * in.project(d, proj_dir)).reconstruct(d, proj_dir);
+          out += (conj(U) * in.template project<d, proj_dir>()).template reconstruct<d, proj_dir>();
         }
       }
-    } // nDim
+    }); // nDim
   }
 
   template <int nParity, bool dagger, bool xpay, KernelType kernel_type, typename Arg>
@@ -167,7 +166,7 @@ namespace quda
       if (xpay && mykernel_type == INTERIOR_KERNEL) {
         Vector x = arg.x(coord.x_cb, my_spinor_parity);
         if (!dagger || Arg::asymmetric) {
-          out += arg.a_inv * (x + arg.b_inv * x.igamma(4)); // apply inverse twist which is undone below
+          out += arg.a_inv * (x + arg.b_inv * x.template igamma<4>()); // apply inverse twist which is undone below
         } else {
           out += x; // just directly add since twist already applied in the dslash
         }
@@ -178,7 +177,7 @@ namespace quda
       }
 
       if (isComplete<mykernel_type>(arg, coord) && active) {
-        if (!dagger || Arg::asymmetric) out = arg.a * (out + arg.b * out.igamma(4)); // apply A^{-1} to D*in
+        if (!dagger || Arg::asymmetric) out = arg.a * (out + arg.b * out.template igamma<4>()); // apply A^{-1} to D*in
       }
 
       if (mykernel_type != EXTERIOR_KERNEL_ALL || active) arg.out(coord.x_cb, my_spinor_parity) = out;

--- a/include/kernels/dslash_wilson.cuh
+++ b/include/kernels/dslash_wilson.cuh
@@ -77,7 +77,7 @@ namespace quda
     // parity for gauge field - include residual parity from 5-d => 4-d checkerboarding
     const int gauge_parity = (Arg::nDim == 5 ? (coord.x_cb / arg.dc.volume_4d_cb + parity) % 2 : parity);
 
-    static_for<0,4>([&]<int d>{ // loop over dimension - 4 and not nDim since this is used for DWF as well
+    static_for<0,4>(static_for_var(d){ // loop over dimension - 4 and not nDim since this is used for DWF as well
       {                           // Forward gather - compute fwd offset for vector fetch
         const int fwd_idx = getNeighborIndexCB(coord, d, +1, arg.dc);
         const int gauge_idx = (Arg::nDim == 5 ? coord.x_cb % arg.dc.volume_4d_cb : coord.x_cb);

--- a/include/kernels/dslash_wilson.cuh
+++ b/include/kernels/dslash_wilson.cuh
@@ -77,8 +77,7 @@ namespace quda
     // parity for gauge field - include residual parity from 5-d => 4-d checkerboarding
     const int gauge_parity = (Arg::nDim == 5 ? (coord.x_cb / arg.dc.volume_4d_cb + parity) % 2 : parity);
 
-#pragma unroll
-    for (int d = 0; d < 4; d++) { // loop over dimension - 4 and not nDim since this is used for DWF as well
+    static_for<0,4>([&]<int d>{ // loop over dimension - 4 and not nDim since this is used for DWF as well
       {                           // Forward gather - compute fwd offset for vector fetch
         const int fwd_idx = getNeighborIndexCB(coord, d, +1, arg.dc);
         const int gauge_idx = (Arg::nDim == 5 ? coord.x_cb % arg.dc.volume_4d_cb : coord.x_cb);
@@ -95,13 +94,13 @@ namespace quda
           Link U = arg.U(d, gauge_idx, gauge_parity);
           HalfVector in = arg.in.Ghost(d, 1, ghost_idx + coord.s * arg.dc.ghostFaceCB[d], their_spinor_parity);
 
-          out += (U * in).reconstruct(d, proj_dir);
+          out += (U * in).template reconstruct<d,proj_dir>();
         } else if (doBulk<kernel_type>() && !ghost) {
 
           Link U = arg.U(d, gauge_idx, gauge_parity);
           Vector in = arg.in(fwd_idx + coord.s * arg.dc.volume_4d_cb, their_spinor_parity);
 
-          out += (U * in.project(d, proj_dir)).reconstruct(d, proj_dir);
+          out += (U * in.template project<d, proj_dir>()).template reconstruct<d,proj_dir>();
         }
       }
 
@@ -121,16 +120,16 @@ namespace quda
           Link U = arg.U.Ghost(d, gauge_ghost_idx, 1 - gauge_parity);
           HalfVector in = arg.in.Ghost(d, 0, ghost_idx + coord.s * arg.dc.ghostFaceCB[d], their_spinor_parity);
 
-          out += (conj(U) * in).reconstruct(d, proj_dir);
+          out += (conj(U) * in).template reconstruct<d,proj_dir>();
         } else if (doBulk<kernel_type>() && !ghost) {
 
           Link U = arg.U(d, gauge_idx, 1 - gauge_parity);
           Vector in = arg.in(back_idx + coord.s * arg.dc.volume_4d_cb, their_spinor_parity);
 
-          out += (conj(U) * in.project(d, proj_dir)).reconstruct(d, proj_dir);
+          out += (conj(U) * in.template project<d, proj_dir>()).template reconstruct<d,proj_dir>();
         }
       }
-    } // nDim
+    }); // nDim
   }
 
   template <int nParity, bool dagger, bool xpay, KernelType kernel_type, typename Arg> struct wilson : dslash_default {

--- a/include/kernels/dslash_wilson.cuh
+++ b/include/kernels/dslash_wilson.cuh
@@ -77,7 +77,7 @@ namespace quda
     // parity for gauge field - include residual parity from 5-d => 4-d checkerboarding
     const int gauge_parity = (Arg::nDim == 5 ? (coord.x_cb / arg.dc.volume_4d_cb + parity) % 2 : parity);
 
-    static_for<0,4>(static_for_var(d){ // loop over dimension - 4 and not nDim since this is used for DWF as well
+    static_for<0,4>([&](auto d){ // loop over dimension - 4 and not nDim since this is used for DWF as well
       {                           // Forward gather - compute fwd offset for vector fetch
         const int fwd_idx = getNeighborIndexCB(coord, d, +1, arg.dc);
         const int gauge_idx = (Arg::nDim == 5 ? coord.x_cb % arg.dc.volume_4d_cb : coord.x_cb);

--- a/include/util_quda.h
+++ b/include/util_quda.h
@@ -14,6 +14,15 @@ namespace quda
   constexpr bool str_slant(const char *str) { return *str == '/' ? true : (*str ? str_slant(str + 1) : false); }
   constexpr const char *r_slant(const char *str) { return *str == '/' ? (str + 1) : r_slant(str - 1); }
   constexpr const char *file_name(const char *str) { return str_slant(str) ? r_slant(str_end(str)) : str; }
+
+  template<int A, int B, int D=1, typename F>
+  __attribute__((always_inline)) void static_for(F&&f)
+  {
+    if constexpr (A<B){
+      f.template operator()<A>();
+      __attribute__((musttail)) return static_for<A+D,B,D>(std::forward<F>(f));
+    }
+  }
 } // namespace quda
 
 /**

--- a/include/util_quda.h
+++ b/include/util_quda.h
@@ -27,11 +27,21 @@ namespace quda
   __attribute__((always_inline)) void static_for(F&&f)
   {
     if constexpr (A<B){
+#if __cplusplus < 202002L
+      f(std::integral_constant<int,A>());
+#else
       f.template operator()<A>();
+#endif
       QUDA_MUSTTAIL return static_for<A+D,B,D>(std::forward<F>(f));
     }
   }
 } // namespace quda
+
+#if __cplusplus < 202002L
+#define static_for_var(i) [&](auto i)
+#else
+#define static_for_var(i) [&]<int i>
+#endif
 
 /**
    @brief Query whether autotuning is enabled or not.  Default is enabled but can be overridden by setting QUDA_ENABLE_TUNING=0.

--- a/include/util_quda.h
+++ b/include/util_quda.h
@@ -7,14 +7,6 @@
 #include <tune_key.h>
 #include <malloc_quda.h>
 
-#ifndef QUDA_MUSTTAIL
-#ifdef __clang__
-#define QUDA_MUSTTAIL __attribute__((musttail))
-#else
-#define QUDA_MUSTTAIL
-#endif
-#endif
-
 namespace quda
 {
   // strip path from __FILE__
@@ -27,21 +19,11 @@ namespace quda
   __attribute__((always_inline)) __host__ __device__ inline void static_for(F&&f)
   {
     if constexpr (A<B){
-#if __cplusplus < 202002L
       f(std::integral_constant<int,A>());
-#else
-      f.template operator()<A>();
-#endif
-      QUDA_MUSTTAIL return static_for<A+D,B,D>(std::forward<F>(f));
+      static_for<A+D,B,D>(std::forward<F>(f));
     }
   }
 } // namespace quda
-
-#if __cplusplus < 202002L
-#define static_for_var(i) [&](auto i)
-#else
-#define static_for_var(i) [&]<int i>
-#endif
 
 /**
    @brief Query whether autotuning is enabled or not.  Default is enabled but can be overridden by setting QUDA_ENABLE_TUNING=0.

--- a/include/util_quda.h
+++ b/include/util_quda.h
@@ -7,6 +7,14 @@
 #include <tune_key.h>
 #include <malloc_quda.h>
 
+#ifndef QUDA_MUSTTAIL
+#ifdef __clang__
+#define QUDA_MUSTTAIL __attribute__((musttail))
+#else
+#define QUDA_MUSTTAIL
+#endif
+#endif
+
 namespace quda
 {
   // strip path from __FILE__
@@ -20,7 +28,7 @@ namespace quda
   {
     if constexpr (A<B){
       f.template operator()<A>();
-      __attribute__((musttail)) return static_for<A+D,B,D>(std::forward<F>(f));
+      QUDA_MUSTTAIL return static_for<A+D,B,D>(std::forward<F>(f));
     }
   }
 } // namespace quda

--- a/include/util_quda.h
+++ b/include/util_quda.h
@@ -24,7 +24,7 @@ namespace quda
   constexpr const char *file_name(const char *str) { return str_slant(str) ? r_slant(str_end(str)) : str; }
 
   template<int A, int B, int D=1, typename F>
-  __attribute__((always_inline)) void static_for(F&&f)
+  __attribute__((always_inline)) __host__ __device__ inline void static_for(F&&f)
   {
     if constexpr (A<B){
 #if __cplusplus < 202002L


### PR DESCRIPTION
This PR replaces the switch statements in `color_spinor.h` with `if constexpr`.  In order to supply `constexpr int` to the template parameters, we introduce `static_for` for compile time unrolling the for loop over integer dimensions, along with a macro `static_for_var` to adapt to C++17 or C++20.

Preliminary tests on a single A100-PCIE-40GB shows mild improvement (~2%) in Wilson Dslash performance.

From the `tunecache.tsv`, before,
```
     12x24x24x24        N4quda6WilsonINS_9WilsonArgIdLi3ELi4EL21QudaReconstructType_s12EEEEE    policy_kernel=interior,comm=0000,commDim=0000,parity=1  160     1       1       1037    1       1       41729   -1      -1      -1      -1      0.000172203     # 1271.60 Gflop/s, 2219.51 GB/s, tuning took 0.204862 seconds at Thu Jul 21 21:29:26 2022
     12x24x24x24        N4quda6WilsonINS_9WilsonArgIdLi3ELi4EL21QudaReconstructType_s18EEEEE    policy_kernel=interior,comm=0000,commDim=0000,parity=1  224     1       1       741     1       1       20865   -1      -1      -1      -1      0.000215859     # 1014.42 Gflop/s, 2065.73 GB/s, tuning took 0.254195 seconds at Thu Jul 21 21:28:15 2022
     12x24x24x24        N4quda6WilsonINS_9WilsonArgIdLi3ELi4EL21QudaReconstructType_s8EEEEE     policy_kernel=interior,comm=0000,commDim=0000,parity=1  384     1       1       432     1       1       83457   -1      -1      -1      -1      0.000157696     # 1388.57 Gflop/s, 2154.39 GB/s, tuning took 0.216228 seconds at Thu Jul 21 21:30:28 2022
     12x24x24x24        N4quda6WilsonINS_9WilsonArgIfLi3ELi4EL21QudaReconstructType_s12EEEEE    policy_kernel=interior,comm=0000,commDim=0000,parity=1  32      1       1       5184    1       1       15174   -1      -1      -1      -1      8.61013e-05     # 2543.19 Gflop/s, 2219.51 GB/s, tuning took 0.141542 seconds at Thu Jul 21 21:26:43 2022
     12x24x24x24        N4quda6WilsonINS_9WilsonArgIfLi3ELi4EL21QudaReconstructType_s18EEEEE    policy_kernel=interior,comm=0000,commDim=0000,parity=1  512     1       1       324     1       1       83457   -1      -1      -1      -1      0.000111275     # 1967.85 Gflop/s, 2003.63 GB/s, tuning took 0.189092 seconds at Thu Jul 21 21:25:51 2022
     12x24x24x24        N4quda6WilsonINS_9WilsonArgIfLi3ELi4EL21QudaReconstructType_s8EEEEE     policy_kernel=interior,comm=0000,commDim=0000,parity=1  32      1       1       5184    1       1       8785    -1      -1      -1      -1      7.20457e-05     # 3039.35 Gflop/s, 2357.80 GB/s, tuning took 0.123566 seconds at Thu Jul 21 21:27:29 2022
     12x24x24x24        N4quda6WilsonINS_9WilsonArgIsLi3ELi4EL21QudaReconstructType_s12EEEEE    policy_kernel=interior,comm=0000,commDim=0000,parity=1  64      1       1       2592    1       1       6420    -1      -1      -1      -1      5.12512e-05     # 4272.53 Gflop/s, 1967.95 GB/s, tuning took 0.106338 seconds at Thu Jul 21 21:24:33 2022
     12x24x24x24        N4quda6WilsonINS_9WilsonArgIsLi3ELi4EL21QudaReconstructType_s18EEEEE    policy_kernel=interior,comm=0000,commDim=0000,parity=1  256     1       1       648     1       1       27819   -1      -1      -1      -1      6.6752e-05      # 3280.38 Gflop/s, 1749.54 GB/s, tuning took 0.126687 seconds at Thu Jul 21 21:23:51 2022
     12x24x24x24        N4quda6WilsonINS_9WilsonArgIsLi3ELi4EL21QudaReconstructType_s8EEEEE     policy_kernel=interior,comm=0000,commDim=0000,parity=1  128     1       1       1296    1       1       20865   -1      -1      -1      -1      5.18656e-05     # 4221.92 Gflop/s, 1739.94 GB/s, tuning took 0.110828 seconds at Thu Jul 21 21:25:12 2022
```
after the changes
```
     12x24x24x24        N4quda6WilsonINS_9WilsonArgIdLi3ELi4EL21QudaReconstructType_s12EEEEE    policy_kernel=interior,comm=0000,commDim=0000,parity=1  320     1       1       519     1       1       41729   -1      -1      -1      -1      0.000168448     # 1299.94 Gflop/s, 2268.99 GB/s, tuning took 0.199168 seconds at Fri Jul 22 03:38:56 2022
     12x24x24x24        N4quda6WilsonINS_9WilsonArgIdLi3ELi4EL21QudaReconstructType_s18EEEEE    policy_kernel=interior,comm=0000,commDim=0000,parity=1  320     1       1       519     1       1       0       -1      -1      -1      -1      0.000215245     # 1017.32 Gflop/s, 2071.63 GB/s, tuning took 0.251373 seconds at Fri Jul 22 03:37:46 2022
     12x24x24x24        N4quda6WilsonINS_9WilsonArgIdLi3ELi4EL21QudaReconstructType_s8EEEEE     policy_kernel=interior,comm=0000,commDim=0000,parity=1  384     1       1       432     1       1       0       -1      -1      -1      -1      0.000152722     # 1433.79 Gflop/s, 2224.55 GB/s, tuning took 0.209446 seconds at Fri Jul 22 03:39:58 2022
     12x24x24x24        N4quda6WilsonINS_9WilsonArgIfLi3ELi4EL21QudaReconstructType_s12EEEEE    policy_kernel=interior,comm=0000,commDim=0000,parity=1  32      1       1       5184    1       1       11128   -1      -1      -1      -1      8.48213e-05     # 2581.57 Gflop/s, 2253.01 GB/s, tuning took 0.138615 seconds at Fri Jul 22 03:36:12 2022
     12x24x24x24        N4quda6WilsonINS_9WilsonArgIfLi3ELi4EL21QudaReconstructType_s18EEEEE    policy_kernel=interior,comm=0000,commDim=0000,parity=1  544     1       1       305     1       1       55638   -1      -1      -1      -1      0.000111502     # 1963.84 Gflop/s, 1999.54 GB/s, tuning took 0.187761 seconds at Fri Jul 22 03:35:19 2022
     12x24x24x24        N4quda6WilsonINS_9WilsonArgIfLi3ELi4EL21QudaReconstructType_s8EEEEE     policy_kernel=interior,comm=0000,commDim=0000,parity=1  256     1       1       648     1       1       23845   -1      -1      -1      -1      7.16069e-05     # 3057.98 Gflop/s, 2372.25 GB/s, tuning took 0.123879 seconds at Fri Jul 22 03:36:59 2022
     12x24x24x24        N4quda6WilsonINS_9WilsonArgIsLi3ELi4EL21QudaReconstructType_s12EEEEE    policy_kernel=interior,comm=0000,commDim=0000,parity=1  192     1       1       864     1       1       27819   -1      -1      -1      -1      5.12512e-05     # 4272.53 Gflop/s, 1967.95 GB/s, tuning took 0.105329 seconds at Fri Jul 22 03:34:02 2022
     12x24x24x24        N4quda6WilsonINS_9WilsonArgIsLi3ELi4EL21QudaReconstructType_s18EEEEE    policy_kernel=interior,comm=0000,commDim=0000,parity=1  384     1       1       432     1       1       33383   -1      -1      -1      -1      6.528e-05       # 3354.35 Gflop/s, 1788.99 GB/s, tuning took 0.124695 seconds at Fri Jul 22 03:33:19 2022
     12x24x24x24        N4quda6WilsonINS_9WilsonArgIsLi3ELi4EL21QudaReconstructType_s8EEEEE     policy_kernel=interior,comm=0000,commDim=0000,parity=1  128     1       1       1296    1       1       10433   -1      -1      -1      -1      4.97371e-05     # 4402.59 Gflop/s, 1814.40 GB/s, tuning took 0.107688 seconds at Fri Jul 22 03:34:40 2022
```