### PR TITLE
Hotfix/nvcxx

### DIFF
--- a/include/gauge_fix_ovr_hit_devf.cuh
+++ b/include/gauge_fix_ovr_hit_devf.cuh
@@ -3,7 +3,7 @@
 #include <quda_internal.h>
 #include <quda_matrix.h>
 #include <atomic_helper.h>
-#include <shared_memory_cache_helper.cuh>
+#include <shared_memory_cache_helper.h>
 
 namespace quda {
 

--- a/include/kernels/clover_deriv.cuh
+++ b/include/kernels/clover_deriv.cuh
@@ -1,7 +1,7 @@
 #include <gauge_field_order.h>
 #include <quda_matrix.h>
 #include <index_helper.cuh>
-#include <shared_memory_cache_helper.cuh>
+#include <thread_array.h>
 #include <kernel.h>
 
 namespace quda

--- a/include/kernels/color_spinor_pack.cuh
+++ b/include/kernels/color_spinor_pack.cuh
@@ -3,7 +3,6 @@
 #include <index_helper.cuh>
 #include <fast_intdiv.h>
 #include <kernel.h>
-#include <shared_memory_cache_helper.cuh>
 #include <dslash_quda.h>
 #include <dslash_shmem.h>
 #include <shmem_helper.cuh>

--- a/include/kernels/color_spinor_pack.cuh
+++ b/include/kernels/color_spinor_pack.cuh
@@ -7,6 +7,7 @@
 #include <dslash_shmem.h>
 #include <shmem_helper.cuh>
 #include <shmem_pack_helper.cuh>
+#include <shared_memory_cache_helper.h>
 
 namespace quda {
 

--- a/include/kernels/copy_clover.cuh
+++ b/include/kernels/copy_clover.cuh
@@ -69,7 +69,7 @@ namespace quda {
     __device__ __host__ void operator()(int x_cb, int parity)
     {
       static_assert(Arg::Out::compressed_block == Arg::In::compressed_block, "lengths must match");
-      static constexpr int length = 2 * Arg::Out::compressed_block;
+      constexpr int length = 2 * Arg::Out::compressed_block;
       typename mapper<typename Arg::store_out_t>::type out[length];
       typename mapper<typename Arg::store_in_t>::type in[length];
       arg.in.raw_load(in, x_cb, parity);

--- a/include/kernels/dslash_coarse.cuh
+++ b/include/kernels/dslash_coarse.cuh
@@ -2,7 +2,7 @@
 #include <color_spinor_field_order.h>
 #include <index_helper.cuh>
 #include <array.h>
-#include <shared_memory_cache_helper.cuh>
+#include <shared_memory_cache_helper.h>
 #include <kernel.h>
 #include <warp_collective.h>
 

--- a/include/kernels/dslash_domain_wall_m5.cuh
+++ b/include/kernels/dslash_domain_wall_m5.cuh
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <color_spinor_field_order.h>
-#include <shared_memory_cache_helper.cuh>
+#include <shared_memory_cache_helper.h>
 #include <math_helper.cuh>
 #include <index_helper.cuh>
 #include <kernel.h>

--- a/include/kernels/dslash_mdw_fused.cuh
+++ b/include/kernels/dslash_mdw_fused.cuh
@@ -3,7 +3,7 @@
 #include <mdw_dslash5_tensor_core.cuh>
 #endif
 #include <kernel.h>
-#include <shared_memory_cache_helper.cuh>
+#include <shared_memory_cache_helper.h>
 
 namespace quda {
 

--- a/include/kernels/dslash_mobius_eofa.cuh
+++ b/include/kernels/dslash_mobius_eofa.cuh
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <color_spinor_field_order.h>
-#include <shared_memory_cache_helper.cuh>
+#include <shared_memory_cache_helper.h>
 #include <math_helper.cuh>
 #include <domain_wall_helper.h>
 #include <kernel.h>

--- a/include/kernels/dslash_ndeg_twisted_clover.cuh
+++ b/include/kernels/dslash_ndeg_twisted_clover.cuh
@@ -2,7 +2,7 @@
 
 #include <kernels/dslash_wilson.cuh>
 #include <clover_field_order.h>
-#include <shared_memory_cache_helper.cuh>
+#include <shared_memory_cache_helper.h>
 
 namespace quda
 {

--- a/include/kernels/dslash_ndeg_twisted_clover_preconditioned.cuh
+++ b/include/kernels/dslash_ndeg_twisted_clover_preconditioned.cuh
@@ -2,7 +2,7 @@
 
 #include <clover_field_order.h>
 #include <kernels/dslash_wilson.cuh>
-#include <shared_memory_cache_helper.cuh>
+#include <shared_memory_cache_helper.h>
 #include <linalg.cuh>
 
 namespace quda

--- a/include/kernels/dslash_ndeg_twisted_mass_preconditioned.cuh
+++ b/include/kernels/dslash_ndeg_twisted_mass_preconditioned.cuh
@@ -2,7 +2,7 @@
 
 #include <kernels/dslash_wilson.cuh>
 #include <kernels/dslash_twisted_mass_preconditioned.cuh>
-#include <shared_memory_cache_helper.cuh>
+#include <shared_memory_cache_helper.h>
 
 namespace quda
 {

--- a/include/kernels/field_strength_tensor.cuh
+++ b/include/kernels/field_strength_tensor.cuh
@@ -1,7 +1,7 @@
 #include <gauge_field_order.h>
 #include <index_helper.cuh>
 #include <quda_matrix.h>
-#include <shared_memory_cache_helper.cuh>
+#include <thread_array.h>
 #include <kernel.h>
 
 namespace quda

--- a/include/kernels/gauge_force.cuh
+++ b/include/kernels/gauge_force.cuh
@@ -3,8 +3,8 @@
 #include <gauge_field_order.h>
 #include <quda_matrix.h>
 #include <index_helper.cuh>
+#include <thread_array.h>
 #include <kernel.h>
-#include <shared_memory_cache_helper.cuh>
 
 namespace quda {
 

--- a/include/kernels/gauge_utils.cuh
+++ b/include/kernels/gauge_utils.cuh
@@ -1,7 +1,7 @@
 #include <gauge_field_order.h>
 #include <index_helper.cuh>
 #include <quda_matrix.h>
-#include <shared_memory_cache_helper.cuh>
+#include <thread_array.h>
 
 namespace quda
 {

--- a/include/kernels/madwf_tensor.cuh
+++ b/include/kernels/madwf_tensor.cuh
@@ -2,7 +2,7 @@
 
 #include <color_spinor_field.h>
 #include <color_spinor_field_order.h>
-#include <shared_memory_cache_helper.cuh>
+#include <shared_memory_cache_helper.h>
 #include <reduce_helper.h>
 #include <kernels/madwf_transfer.cuh>
 #include <fast_intdiv.h>

--- a/include/kernels/madwf_transfer.cuh
+++ b/include/kernels/madwf_transfer.cuh
@@ -2,7 +2,7 @@
 
 #include <color_spinor_field.h>
 #include <color_spinor_field_order.h>
-#include <shared_memory_cache_helper.cuh>
+#include <shared_memory_cache_helper.h>
 #include <madwf_transfer.h>
 #include <madwf_ml.h>
 

--- a/include/targets/cuda/math_helper.cuh
+++ b/include/targets/cuda/math_helper.cuh
@@ -108,7 +108,11 @@ namespace quda {
    */
   template<typename T> inline __host__ __device__ T sinpi(T a) { return ::sinpi(a); }
 
+#ifndef _NVHPC_CUDA
   template <bool is_device> struct sinpif_impl { inline float operator()(float a) { return ::sinpif(a); } };
+#else
+  template <bool is_device> struct sinpif_impl { inline float operator()(float a) { return ::sinf(a * static_cast<float>(M_PI)); } };
+#endif
   template <> struct sinpif_impl<true> { __device__ inline float operator()(float a) { return __sinf(a * static_cast<float>(M_PI)); } };
 
   /**
@@ -128,7 +132,11 @@ namespace quda {
    */
   template<typename T> inline __host__ __device__ T cospi(T a) { return ::cospi(a); }
 
+#ifndef _NVHPC_CUDA
   template <bool is_device> struct cospif_impl { inline float operator()(float a) { return ::cospif(a); } };
+#else
+  template <bool is_device> struct cospif_impl { inline float operator()(float a) { return ::cosf(a * static_cast<float>(M_PI)); } };
+#endif
   template <> struct cospif_impl<true> { __device__ inline float operator()(float a) { return __cosf(a * static_cast<float>(M_PI)); } };
 
   /**

--- a/include/targets/cuda/mdw_dslash5_tensor_core.cuh
+++ b/include/targets/cuda/mdw_dslash5_tensor_core.cuh
@@ -6,7 +6,7 @@
 #include <index_helper.cuh>
 #include <inline_ptx.h>
 #include <math_helper.cuh>
-#include <shared_memory_cache_helper.cuh>
+#include <shared_memory_cache_helper.h>
 
 #include <quda_fp16.cuh>
 

--- a/include/targets/cuda/mma_tensor_op/gemm.cuh
+++ b/include/targets/cuda/mma_tensor_op/gemm.cuh
@@ -85,16 +85,16 @@ namespace quda
         auto scale_inv = gmem.scale_inv;
         constexpr bool fixed = GmemAccessor::fixed;
 
-        static constexpr int n_stride = transpose == dagger ? block_y * 1 : block_z * 1;
-        static constexpr int m_stride = transpose == dagger ? block_z * 2 : block_y * 2;
+        constexpr int n_stride = transpose == dagger ? block_y * 1 : block_z * 1;
+        constexpr int m_stride = transpose == dagger ? block_z * 2 : block_y * 2;
         int n_thread_offset = transpose == dagger ? threadIdx.y * 1 : threadIdx.z * 1;
         int m_thread_offset = transpose == dagger ? threadIdx.z * 2 : threadIdx.y * 2;
 
-        static constexpr int n_dim = (bN + n_stride - 1) / n_stride;
-        static constexpr int m_dim = (bM + m_stride - 1) / m_stride;
+        constexpr int n_dim = (bN + n_stride - 1) / n_stride;
+        constexpr int m_dim = (bM + m_stride - 1) / m_stride;
 
-        static constexpr bool check_global_bound = !(M % bM == 0 && N % bN == 0);
-        static constexpr bool check_shared_bound = !(bM % m_stride == 0 && bN % n_stride == 0);
+        constexpr bool check_global_bound = !(M % bM == 0 && N % bN == 0);
+        constexpr bool check_shared_bound = !(bM % m_stride == 0 && bN % n_stride == 0);
 
 #pragma unroll
         for (int n = 0; n < n_dim; n++) {
@@ -155,13 +155,13 @@ namespace quda
 
       template <bool dagger, class SmemObj> __device__ inline void r2s(SmemObj &smem_real, SmemObj &smem_imag)
       {
-        static constexpr int n_stride = transpose == dagger ? block_y * 1 : block_z * 1;
-        static constexpr int m_stride = transpose == dagger ? block_z * 2 : block_y * 2;
+        constexpr int n_stride = transpose == dagger ? block_y * 1 : block_z * 1;
+        constexpr int m_stride = transpose == dagger ? block_z * 2 : block_y * 2;
         int n_thread_offset = transpose == dagger ? threadIdx.y * 1 : threadIdx.z * 1;
         int m_thread_offset = transpose == dagger ? threadIdx.z * 2 : threadIdx.y * 2;
 
-        static constexpr int n_dim = (bN + n_stride - 1) / n_stride;
-        static constexpr int m_dim = (bM + m_stride - 1) / m_stride;
+        constexpr int n_dim = (bN + n_stride - 1) / n_stride;
+        constexpr int m_dim = (bM + m_stride - 1) / m_stride;
 
 #pragma unroll
         for (int n = 0; n < n_dim; n++) {

--- a/include/targets/cuda/shared_memory_cache_helper.h
+++ b/include/targets/cuda/shared_memory_cache_helper.h
@@ -4,7 +4,7 @@
 #include <array.h>
 
 /**
-   @file shared_memory_cache_helper.cuh
+   @file shared_memory_cache_helper.h
 
    Helper functionality for aiding the use of the shared memory for
    sharing data between threads in a thread block.
@@ -137,7 +137,7 @@ namespace quda
        block_size_x.  Otherwise use the block sizes passed into the
        constructor.
 
-       @param[in] block Block dimensions for the 3-d shared memory object 
+       @param[in] block Block dimensions for the 3-d shared memory object
     */
     constexpr SharedMemoryCache(dim3 block = dim3(block_size_x, block_size_y, block_size_z)) :
       block(block),
@@ -256,31 +256,6 @@ namespace quda
        @brief Synchronize the cache
     */
     __device__ __host__ void sync() { target::dispatch<sync_impl>(); }
-  };
-
-  template <typename T, int n>
-  struct thread_array {
-    SharedMemoryCache<array<T, n>, 1, 1, false, false> device_array;
-    int offset;
-    array<T, n> host_array;
-    array<T, n> &array_;
-
-    __device__ __host__ constexpr thread_array() :
-      offset((target::thread_idx().z * target::block_dim().y + target::thread_idx().y) * target::block_dim().x + target::thread_idx().x),
-      array_(target::is_device() ? *(device_array.data() + offset) : host_array)
-    {
-      array_ = array<T, n>(); // call default constructor
-    }
-
-    template <typename ...Ts> __device__ __host__ constexpr thread_array(T first, const Ts... other) :
-      offset((target::thread_idx().z * target::block_dim().y + target::thread_idx().y) * target::block_dim().x + target::thread_idx().x),
-      array_(target::is_device() ? *(device_array.data() + offset) : host_array)
-    {
-      array_ = array<T, n>{first, other...};
-    }
-
-    __device__ __host__ T& operator[](int i) { return array_[i]; }
-    __device__ __host__ const T& operator[](int i) const { return array_[i]; }
   };
 
 } // namespace quda

--- a/include/targets/cuda/thread_array.h
+++ b/include/targets/cuda/thread_array.h
@@ -1,0 +1,44 @@
+#include "shared_memory_cache_helper.h"
+
+namespace quda {
+
+#ifndef _NVHPC_CUDA
+
+  /**
+     @brief Class that provides indexable per-thread storage.  On CUDA
+     this maps to using assigning each thread a unique window of
+     shared memory using the SharedMemoryCache object.
+   */
+  template <typename T, int n>
+  struct thread_array {
+    SharedMemoryCache<array<T, n>, 1, 1, false, false> device_array;
+    int offset;
+    array<T, n> host_array;
+    array<T, n> &array_;
+
+    __device__ __host__ constexpr thread_array() :
+      offset((target::thread_idx().z * target::block_dim().y + target::thread_idx().y) * target::block_dim().x + target::thread_idx().x),
+      array_(target::is_device() ? *(device_array.data() + offset) : host_array)
+    {
+      array_ = array<T, n>(); // call default constructor
+    }
+
+    template <typename ...Ts> __device__ __host__ constexpr thread_array(T first, const Ts... other) :
+      offset((target::thread_idx().z * target::block_dim().y + target::thread_idx().y) * target::block_dim().x + target::thread_idx().x),
+      array_(target::is_device() ? *(device_array.data() + offset) : host_array)
+    {
+      array_ = array<T, n>{first, other...};
+    }
+
+    __device__ __host__ T& operator[](int i) { return array_[i]; }
+    __device__ __host__ const T& operator[](int i) const { return array_[i]; }
+  };
+
+#else
+
+  template <typename T, int n>
+  struct thread_array : array<T, n> { };
+
+#endif
+
+}

--- a/include/targets/cuda/thread_array.h
+++ b/include/targets/cuda/thread_array.h
@@ -1,6 +1,7 @@
 #include "shared_memory_cache_helper.h"
 
-namespace quda {
+namespace quda
+{
 
 #ifndef _NVHPC_CUDA
 
@@ -9,36 +10,38 @@ namespace quda {
      this maps to using assigning each thread a unique window of
      shared memory using the SharedMemoryCache object.
    */
-  template <typename T, int n>
-  struct thread_array {
+  template <typename T, int n> struct thread_array {
     SharedMemoryCache<array<T, n>, 1, 1, false, false> device_array;
     int offset;
     array<T, n> host_array;
     array<T, n> &array_;
 
     __device__ __host__ constexpr thread_array() :
-      offset((target::thread_idx().z * target::block_dim().y + target::thread_idx().y) * target::block_dim().x + target::thread_idx().x),
+      offset((target::thread_idx().z * target::block_dim().y + target::thread_idx().y) * target::block_dim().x
+             + target::thread_idx().x),
       array_(target::is_device() ? *(device_array.data() + offset) : host_array)
     {
       array_ = array<T, n>(); // call default constructor
     }
 
-    template <typename ...Ts> __device__ __host__ constexpr thread_array(T first, const Ts... other) :
-      offset((target::thread_idx().z * target::block_dim().y + target::thread_idx().y) * target::block_dim().x + target::thread_idx().x),
+    template <typename... Ts>
+    __device__ __host__ constexpr thread_array(T first, const Ts... other) :
+      offset((target::thread_idx().z * target::block_dim().y + target::thread_idx().y) * target::block_dim().x
+             + target::thread_idx().x),
       array_(target::is_device() ? *(device_array.data() + offset) : host_array)
     {
-      array_ = array<T, n>{first, other...};
+      array_ = array<T, n> {first, other...};
     }
 
-    __device__ __host__ T& operator[](int i) { return array_[i]; }
-    __device__ __host__ const T& operator[](int i) const { return array_[i]; }
+    __device__ __host__ T &operator[](int i) { return array_[i]; }
+    __device__ __host__ const T &operator[](int i) const { return array_[i]; }
   };
 
 #else
 
-  template <typename T, int n>
-  struct thread_array : array<T, n> { };
+  template <typename T, int n> struct thread_array : array<T, n> {
+  };
 
 #endif
 
-}
+} // namespace quda

--- a/include/targets/hip/shared_memory_cache_helper.h
+++ b/include/targets/hip/shared_memory_cache_helper.h
@@ -1,0 +1,261 @@
+#pragma once
+
+#include <target_device.h>
+#include <array.h>
+
+/**
+   @file shared_memory_cache_helper.h
+
+   Helper functionality for aiding the use of the shared memory for
+   sharing data between threads in a thread block.
+ */
+
+namespace quda
+{
+
+  /**
+     @brief Class which wraps around a shared memory cache for type T,
+     where each thread in the thread block stores a unique value in
+     the cache which any other thread can access.
+
+     This accessor supports both explicit run-time block size and
+     compile-time sizing.
+
+     * For run-time block size, the constructor should be initialied
+       with the desired block size.
+
+     * For compile-time block size, no arguments should be passed to
+       the constructor, and then the second and third template
+       parameters correspond to the y and z dimensions of the block,
+       respectively.  The x dimension of the block will be set
+       according the maximum number of threads possible, given these
+       dimensions.  To prevent shared-memory bank conflicts this width
+       is optionally padded to allow for access along the y and z dimensions.
+   */
+  template <typename T, int block_size_y = 1, int block_size_z = 1, bool pad = false, bool dynamic = true>
+  class SharedMemoryCache
+  {
+    /** maximum number of threads in x given the y and z block sizes */
+    static constexpr int max_block_size_x = device::max_block_size<block_size_y, block_size_z>();
+
+    /** pad in the x dimension width if requested to ensure that it isn't a multiple of the bank width */
+    static constexpr int block_size_x = !pad ? max_block_size_x :
+      ((max_block_size_x + device::shared_memory_bank_width() - 1) /
+       device::shared_memory_bank_width()) * device::shared_memory_bank_width();
+
+    using atom_t = std::conditional_t<sizeof(T) % 16 == 0, int4, std::conditional_t<sizeof(T) % 8 == 0, int2, int>>;
+    static_assert(sizeof(T) % 4 == 0, "Shared memory cache does not support sub-word size types");
+
+    // The number of elements of type atom_t that we break T into for optimal shared-memory access
+    static constexpr int n_element = sizeof(T) / sizeof(atom_t);
+
+    const dim3 block;
+    const int stride;
+
+    /**
+       @brief This is a dummy instantiation for the host compiler
+    */
+    template <bool, typename dummy = void> struct cache_dynamic {
+      atom_t* operator()()
+      {
+        static atom_t *cache_;
+        return reinterpret_cast<atom_t*>(cache_);
+      }
+    };
+
+    template <bool is_device, typename dummy = void> struct cache_static : cache_dynamic<is_device> {};
+
+    /**
+       @brief This is the handle to the shared memory, dynamic specialization
+       @return Shared memory pointer
+     */
+    template <typename dummy> struct cache_dynamic<true, dummy> {
+      __device__ inline atom_t* operator()()
+      {
+        extern __shared__ int cache_[];
+        return reinterpret_cast<atom_t*>(cache_);
+      }
+    };
+
+    /**
+       @brief This is the handle to the shared memory, static specialization
+       @return Shared memory pointer
+     */
+    template <typename dummy> struct cache_static<true, dummy> {
+      __device__ inline atom_t* operator()()
+      {
+        static __shared__ atom_t cache_[n_element * block_size_x * block_size_y * block_size_z];
+        return reinterpret_cast<atom_t*>(cache_);
+      }
+    };
+
+    template <bool dynamic_shared> __device__ __host__ inline std::enable_if_t<dynamic_shared, atom_t*> cache()
+    {
+      return target::dispatch<cache_dynamic>();
+    }
+
+    template <bool dynamic_shared> __device__ __host__ inline std::enable_if_t<!dynamic_shared, atom_t*> cache()
+    {
+      return target::dispatch<cache_static>();
+    }
+
+    __device__ __host__ inline void save_detail(const T &a, int x, int y, int z)
+    {
+      atom_t tmp[n_element];
+      memcpy(tmp, (void*)&a, sizeof(T));
+      int j = (z * block.y + y) * block.x + x;
+#pragma unroll
+      for (int i = 0; i < n_element; i++) cache<dynamic>()[i * stride + j] = tmp[i];
+    }
+
+    __device__ __host__ inline T load_detail(int x, int y, int z)
+    {
+      atom_t tmp[n_element];
+      int j = (z * block.y + y) * block.x + x;
+#pragma unroll
+      for (int i = 0; i < n_element; i++) tmp[i] = cache<dynamic>()[i * stride + j];
+      T a;
+      memcpy((void*)&a, tmp, sizeof(T));
+      return a;
+    }
+
+    /**
+       @brief Dummy instantiation for the host compiler
+    */
+    template <bool is_device, typename dummy = void> struct sync_impl { void operator()() { } };
+
+    /**
+       @brief Synchronize the cache when on the device
+    */
+    template <typename dummy> struct sync_impl<true, dummy> { __device__ inline void operator()() { __syncthreads(); } };
+
+  public:
+    /**
+       @brief constructor for SharedMemory cache.  If no arguments are
+       pass, then the dimensions are set according to the templates
+       block_size_y and block_size_z, together with the derived
+       block_size_x.  Otherwise use the block sizes passed into the
+       constructor.
+
+       @param[in] block Block dimensions for the 3-d shared memory object
+    */
+    constexpr SharedMemoryCache(dim3 block = dim3(block_size_x, block_size_y, block_size_z)) :
+      block(block),
+      stride(block.x * block.y * block.z) {}
+
+    /**
+       @brief Grab the raw base address to shared memory.
+    */
+    __device__ __host__ inline T* data() { return reinterpret_cast<T*>(cache<dynamic>()); }
+
+    /**
+       @brief Save the value into the 3-d shared memory cache.
+       @param[in] a The value to store in the shared memory cache
+       @param[in] x The x index to use
+       @param[in] y The y index to use
+       @param[in] z The z index to use
+     */
+    __device__ __host__ inline void save(const T &a, int x = -1, int y = -1, int z = -1)
+    {
+      auto tid = target::thread_idx();
+      x = (x == -1) ? tid.x : x;
+      y = (y == -1) ? tid.y : y;
+      z = (z == -1) ? tid.z : z;
+      save_detail(a, x, y, z);
+    }
+
+    /**
+       @brief Save the value into the 3-d shared memory cache.
+       @param[in] a The value to store in the shared memory cache
+       @param[in] x The x index to use
+     */
+    __device__ __host__ inline void save_x(const T &a, int x = -1)
+    {
+      auto tid = target::thread_idx();
+      x = (x == -1) ? tid.x : x;
+      save_detail(a, x, tid.y, tid.z);
+    }
+
+    /**
+       @brief Save the value into the 3-d shared memory cache.
+       @param[in] a The value to store in the shared memory cache
+       @param[in] y The y index to use
+     */
+    __device__ __host__ inline void save_y(const T &a, int y = -1)
+    {
+      auto tid = target::thread_idx();
+      y = (y == -1) ? tid.y : y;
+      save_detail(a, tid.x, y, tid.z);
+    }
+
+    /**
+       @brief Save the value into the 3-d shared memory cache.
+       @param[in] a The value to store in the shared memory cache
+       @param[in] z The z index to use
+     */
+    __device__ __host__ inline void save_z(const T &a, int z = -1)
+    {
+      auto tid = target::thread_idx();
+      z = (z == -1) ? tid.z : z;
+      save_detail(a, tid.x, tid.y, z);
+    }
+
+    /**
+       @brief Load a value from the shared memory cache
+       @param[in] x The x index to use
+       @param[in] y The y index to use
+       @param[in] z The z index to use
+       @return The value at coordinates (x,y,z)
+     */
+    __device__ __host__ inline T load(int x = -1, int y = -1, int z = -1)
+    {
+      auto tid = target::thread_idx();
+      x = (x == -1) ? tid.x : x;
+      y = (y == -1) ? tid.y : y;
+      z = (z == -1) ? tid.z : z;
+      return load_detail(x, y, z);
+    }
+
+    /**
+       @brief Load a vector from the shared memory cache
+       @param[in] x The x index to use
+       @return The value at coordinates (x,y,z)
+    */
+    __device__ __host__ inline T load_x(int x = -1)
+    {
+      auto tid = target::thread_idx();
+      x = (x == -1) ? tid.x : x;
+      return load_detail(x, tid.y, tid.z);
+    }
+
+    /**
+       @brief Load a vector from the shared memory cache
+       @param[in] y The y index to use
+       @return The value at coordinates (x,y,z)
+    */
+    __device__ __host__ inline T load_y(int y = -1)
+    {
+      auto tid = target::thread_idx();
+      y = (y == -1) ? tid.y : y;
+      return load_detail(tid.x, y, tid.z);
+    }
+
+    /**
+       @brief Load a vector from the shared memory cache
+       @param[in] z The z index to use
+       @return The value at coordinates (x,y,z)
+    */
+    __device__ __host__ inline T load_z(int z = -1)
+    {
+      auto tid = target::thread_idx();
+      z = (z == -1) ? tid.z : z;
+      return load_detail(tid.x, tid.y, z);
+    }
+
+    /**
+       @brief Synchronize the cache
+    */
+    __device__ __host__ void sync() { target::dispatch<sync_impl>(); }
+  };
+
+} // namespace quda

--- a/include/targets/hip/thread_array.h
+++ b/include/targets/hip/thread_array.h
@@ -1,35 +1,38 @@
 #include "shared_memory_cache_helper.h"
 
-namespace quda {
+namespace quda
+{
 
   /**
      @brief Class that provides indexable per-thread storage.  On HIP
      this maps to using assigning each thread a unique window of
      shared memory using the SharedMemoryCache object.
    */
-  template <typename T, int n>
-  struct thread_array {
+  template <typename T, int n> struct thread_array {
     SharedMemoryCache<array<T, n>, 1, 1, false, false> device_array;
     int offset;
     array<T, n> host_array;
     array<T, n> &array_;
 
     __device__ __host__ constexpr thread_array() :
-      offset((target::thread_idx().z * target::block_dim().y + target::thread_idx().y) * target::block_dim().x + target::thread_idx().x),
+      offset((target::thread_idx().z * target::block_dim().y + target::thread_idx().y) * target::block_dim().x
+             + target::thread_idx().x),
       array_(target::is_device() ? *(device_array.data() + offset) : host_array)
     {
       array_ = array<T, n>(); // call default constructor
     }
 
-    template <typename ...Ts> __device__ __host__ constexpr thread_array(T first, const Ts... other) :
-      offset((target::thread_idx().z * target::block_dim().y + target::thread_idx().y) * target::block_dim().x + target::thread_idx().x),
+    template <typename... Ts>
+    __device__ __host__ constexpr thread_array(T first, const Ts... other) :
+      offset((target::thread_idx().z * target::block_dim().y + target::thread_idx().y) * target::block_dim().x
+             + target::thread_idx().x),
       array_(target::is_device() ? *(device_array.data() + offset) : host_array)
     {
-      array_ = array<T, n>{first, other...};
+      array_ = array<T, n> {first, other...};
     }
 
-    __device__ __host__ T& operator[](int i) { return array_[i]; }
-    __device__ __host__ const T& operator[](int i) const { return array_[i]; }
+    __device__ __host__ T &operator[](int i) { return array_[i]; }
+    __device__ __host__ const T &operator[](int i) const { return array_[i]; }
   };
 
-}
+} // namespace quda

--- a/include/targets/hip/thread_array.h
+++ b/include/targets/hip/thread_array.h
@@ -1,0 +1,35 @@
+#include "shared_memory_cache_helper.h"
+
+namespace quda {
+
+  /**
+     @brief Class that provides indexable per-thread storage.  On HIP
+     this maps to using assigning each thread a unique window of
+     shared memory using the SharedMemoryCache object.
+   */
+  template <typename T, int n>
+  struct thread_array {
+    SharedMemoryCache<array<T, n>, 1, 1, false, false> device_array;
+    int offset;
+    array<T, n> host_array;
+    array<T, n> &array_;
+
+    __device__ __host__ constexpr thread_array() :
+      offset((target::thread_idx().z * target::block_dim().y + target::thread_idx().y) * target::block_dim().x + target::thread_idx().x),
+      array_(target::is_device() ? *(device_array.data() + offset) : host_array)
+    {
+      array_ = array<T, n>(); // call default constructor
+    }
+
+    template <typename ...Ts> __device__ __host__ constexpr thread_array(T first, const Ts... other) :
+      offset((target::thread_idx().z * target::block_dim().y + target::thread_idx().y) * target::block_dim().x + target::thread_idx().x),
+      array_(target::is_device() ? *(device_array.data() + offset) : host_array)
+    {
+      array_ = array<T, n>{first, other...};
+    }
+
+    __device__ __host__ T& operator[](int i) { return array_[i]; }
+    __device__ __host__ const T& operator[](int i) const { return array_[i]; }
+  };
+
+}


### PR DESCRIPTION
This PR is primarily to fix some issues with using nvc++ and some reorganization of the shared memory cache header
* Fix copy_clover kernel with `nvc++` (`length` function variable should just be `constexpr`)
* Work around for `sinpif`, `cospif` and `sincospif` linkage with `nvc++`
* Make `shared_memory_cache_helper.h` target-specific
* Move `thread_array` into its own target-specific header, `thread_array.h`
* Workaround for `nvc++` which doesn't at present support in-class static shared memory (fallback to using a thread-local array)