### PR TITLE
Hotfix/blas interface lu test

### DIFF
--- a/include/enum_quda.h
+++ b/include/enum_quda.h
@@ -481,7 +481,7 @@ typedef enum QudaBLASType_s {
   QUDA_BLAS_LU_INV = 1,
   QUDA_BLAS_INVALID = QUDA_INVALID_ENUM
 } QudaBLASType;
-  
+
 typedef enum QudaBLASOperation_s {
   QUDA_BLAS_OP_N = 0, // No transpose
   QUDA_BLAS_OP_T = 1, // Transpose only

--- a/include/enum_quda.h
+++ b/include/enum_quda.h
@@ -476,6 +476,12 @@ typedef enum QudaBoolean_s {
 #define QUDA_BOOLEAN_NO QUDA_BOOLEAN_FALSE
 #define QUDA_BOOLEAN_YES QUDA_BOOLEAN_TRUE
 
+typedef enum QudaBLASType_s {
+  QUDA_BLAS_GEMM = 0,
+  QUDA_BLAS_LU_INV = 1,
+  QUDA_BLAS_INVALID = QUDA_INVALID_ENUM
+} QudaBLASType;
+  
 typedef enum QudaBLASOperation_s {
   QUDA_BLAS_OP_N = 0, // No transpose
   QUDA_BLAS_OP_T = 1, // Transpose only

--- a/include/quda.h
+++ b/include/quda.h
@@ -850,7 +850,7 @@ extern "C" {
     int inv_mat_size; /**< The rank of the square matrix in the LU inversion */
     int inv_offset;   /**< position of the LU inversion array from which begin read/write. */
     int inv_stride;   /**< stride of the LU inversion array in strided(batched) mode */
-    
+
     // Common params
     int batch_count; /**< number of pointers contained in arrayA, arrayB and arrayC. */
     QudaBLASDataType data_type;   /**< Specifies if using S(C) or D(Z) BLAS type */

--- a/include/quda.h
+++ b/include/quda.h
@@ -828,6 +828,7 @@ extern "C" {
 
     QudaBLASType blas_type; /**< Type of BLAS computation to perfrom */
 
+    // GEMM params
     QudaBLASOperation trans_a; /**< operation op(A) that is non- or (conj.) transpose. */
     QudaBLASOperation trans_b; /**< operation op(B) that is non- or (conj.) transpose. */
     int m;                     /**< number of rows of matrix op(A) and C. */
@@ -842,15 +843,19 @@ extern "C" {
     int a_stride;              /**< stride of the A array in strided(batched) mode */
     int b_stride;              /**< stride of the B array in strided(batched) mode */
     int c_stride;              /**< stride of the C array in strided(batched) mode */
-
     double_complex alpha; /**< scalar used for multiplication. */
     double_complex beta;  /**< scalar used for multiplication. If beta==0, C does not have to be a valid input. */
 
+    // LU inversion params
+    int inv_mat_size; /**< The rank of the square matrix in the LU inversion */
+    int inv_offset;   /**< position of the LU inversion array from which begin read/write. */
+    int inv_stride;   /**< stride of the LU inversion array in strided(batched) mode */
+    
+    // Common params
     int batch_count; /**< number of pointers contained in arrayA, arrayB and arrayC. */
-
     QudaBLASDataType data_type;   /**< Specifies if using S(C) or D(Z) BLAS type */
     QudaBLASDataOrder data_order; /**< Specifies if using Row or Column major */
-    int inv_mat_size;             /**< The rank of the square matrix in the LU batched inversion */
+
   } QudaBLASParam;
 
   /*

--- a/include/quda.h
+++ b/include/quda.h
@@ -852,7 +852,7 @@ extern "C" {
     int inv_stride;   /**< stride of the LU inversion array in strided(batched) mode */
 
     // Common params
-    int batch_count; /**< number of pointers contained in arrayA, arrayB and arrayC. */
+    int batch_count;              /**< number of pointers contained in arrayA, arrayB and arrayC. */
     QudaBLASDataType data_type;   /**< Specifies if using S(C) or D(Z) BLAS type */
     QudaBLASDataOrder data_order; /**< Specifies if using Row or Column major */
 

--- a/include/quda.h
+++ b/include/quda.h
@@ -826,6 +826,8 @@ extern "C" {
   typedef struct QudaBLASParam_s {
     size_t struct_size; /**< Size of this struct in bytes.  Used to ensure that the host application and QUDA see the same struct*/
 
+    QudaBLASType blas_type;    /**< Type of BLAS computation to perfrom */
+    
     QudaBLASOperation trans_a; /**< operation op(A) that is non- or (conj.) transpose. */
     QudaBLASOperation trans_b; /**< operation op(B) that is non- or (conj.) transpose. */
     int m;                     /**< number of rows of matrix op(A) and C. */
@@ -848,6 +850,7 @@ extern "C" {
 
     QudaBLASDataType data_type;   /**< Specifies if using S(C) or D(Z) BLAS type */
     QudaBLASDataOrder data_order; /**< Specifies if using Row or Column major */
+    int inv_mat_size; /**< The rank of the square matrix in the LU batched inversion */
   } QudaBLASParam;
 
   /*
@@ -1621,13 +1624,22 @@ extern "C" {
   /**
    * @brief Strided Batched GEMM
    * @param[in] arrayA The array containing the A matrix data
-   * @param[in] arrayB The array containing the A matrix data
-   * @param[in] arrayC The array containing the A matrix data
-   * @param[in] native boolean to use either the native or generic version
+   * @param[in] arrayB The array containing the B matrix data
+   * @param[in] arrayC The array containing the C matrix data
+   * @param[in] native Boolean to use either the native or generic version
    * @param[in] param The data defining the problem execution.
    */
   void blasGEMMQuda(void *arrayA, void *arrayB, void *arrayC, QudaBoolean native, QudaBLASParam *param);
 
+  /**
+   * @brief Strided Batched in-place matrix inversion via LU
+   * @param[in] Ainv The array containing the A inverse matrix data
+   * @param[in] A The array containing the A matrix data
+   * @param[in] use_native Boolean to use either the native or generic version
+   * @param[in] param The data defining the problem execution.
+   */
+  void blasLUInvQuda(void *Ainv, void *A, QudaBoolean use_native, QudaBLASParam *param);
+  
   /**
    * @brief Flush the chronological history for the given index
    * @param[in] index Index for which we are flushing

--- a/include/quda.h
+++ b/include/quda.h
@@ -826,8 +826,8 @@ extern "C" {
   typedef struct QudaBLASParam_s {
     size_t struct_size; /**< Size of this struct in bytes.  Used to ensure that the host application and QUDA see the same struct*/
 
-    QudaBLASType blas_type;    /**< Type of BLAS computation to perfrom */
-    
+    QudaBLASType blas_type; /**< Type of BLAS computation to perfrom */
+
     QudaBLASOperation trans_a; /**< operation op(A) that is non- or (conj.) transpose. */
     QudaBLASOperation trans_b; /**< operation op(B) that is non- or (conj.) transpose. */
     int m;                     /**< number of rows of matrix op(A) and C. */
@@ -850,7 +850,7 @@ extern "C" {
 
     QudaBLASDataType data_type;   /**< Specifies if using S(C) or D(Z) BLAS type */
     QudaBLASDataOrder data_order; /**< Specifies if using Row or Column major */
-    int inv_mat_size; /**< The rank of the square matrix in the LU batched inversion */
+    int inv_mat_size;             /**< The rank of the square matrix in the LU batched inversion */
   } QudaBLASParam;
 
   /*
@@ -1639,7 +1639,7 @@ extern "C" {
    * @param[in] param The data defining the problem execution.
    */
   void blasLUInvQuda(void *Ainv, void *A, QudaBoolean use_native, QudaBLASParam *param);
-  
+
   /**
    * @brief Flush the chronological history for the given index
    * @param[in] index Index for which we are flushing

--- a/include/quda.h
+++ b/include/quda.h
@@ -848,8 +848,6 @@ extern "C" {
 
     // LU inversion params
     int inv_mat_size; /**< The rank of the square matrix in the LU inversion */
-    int inv_offset;   /**< position of the LU inversion array from which begin read/write. */
-    int inv_stride;   /**< stride of the LU inversion array in strided(batched) mode */
 
     // Common params
     int batch_count;              /**< number of pointers contained in arrayA, arrayB and arrayC. */

--- a/lib/check_params.h
+++ b/lib/check_params.h
@@ -1120,6 +1120,7 @@ void printQudaBLASParam(QudaBLASParam *param)
   P(batch_count, 1);
   P(data_type, QUDA_BLAS_DATATYPE_S);
   P(data_order, QUDA_BLAS_DATAORDER_ROW);
+  P(blas_type, QUDA_BLAS_INVALID);
   P(inv_mat_size, INVALID_INT);
 #else
   P(trans_a, QUDA_BLAS_OP_INVALID);
@@ -1139,6 +1140,7 @@ void printQudaBLASParam(QudaBLASParam *param)
   P(batch_count, INVALID_INT);
   P(data_type, QUDA_BLAS_DATATYPE_INVALID);
   P(data_order, QUDA_BLAS_DATAORDER_INVALID);
+  P(blas_type, QUDA_BLAS_INVALID);
   P(inv_mat_size, INVALID_INT);
 #endif
 

--- a/lib/check_params.h
+++ b/lib/check_params.h
@@ -1120,8 +1120,6 @@ void printQudaBLASParam(QudaBLASParam *param)
   P(batch_count, 1);
   P(data_type, QUDA_BLAS_DATATYPE_S);
   P(data_order, QUDA_BLAS_DATAORDER_ROW);
-  P(inv_offset, 0);
-  P(inv_stride, 1);
   P(inv_mat_size, INVALID_INT);
 #else
   P(trans_a, QUDA_BLAS_OP_INVALID);
@@ -1141,8 +1139,6 @@ void printQudaBLASParam(QudaBLASParam *param)
   P(batch_count, INVALID_INT);
   P(data_type, QUDA_BLAS_DATATYPE_INVALID);
   P(data_order, QUDA_BLAS_DATAORDER_INVALID);
-  P(inv_offset, INVALID_INT);
-  P(inv_stride, INVALID_INT);
   P(inv_mat_size, INVALID_INT);
 #endif
 

--- a/lib/check_params.h
+++ b/lib/check_params.h
@@ -1120,6 +1120,9 @@ void printQudaBLASParam(QudaBLASParam *param)
   P(batch_count, 1);
   P(data_type, QUDA_BLAS_DATATYPE_S);
   P(data_order, QUDA_BLAS_DATAORDER_ROW);
+  P(inv_offset, 0);
+  P(inv_stride, 1);
+  P(inv_mat_size, INVALID_INT);
 #else
   P(trans_a, QUDA_BLAS_OP_INVALID);
   P(trans_b, QUDA_BLAS_OP_INVALID);
@@ -1138,6 +1141,9 @@ void printQudaBLASParam(QudaBLASParam *param)
   P(batch_count, INVALID_INT);
   P(data_type, QUDA_BLAS_DATATYPE_INVALID);
   P(data_order, QUDA_BLAS_DATAORDER_INVALID);
+  P(inv_offset, INVALID_INT);
+  P(inv_stride, INVALID_INT);
+  P(inv_mat_size, INVALID_INT);
 #endif
 
 #ifdef INIT_PARAM

--- a/lib/interface/blas_interface.cpp
+++ b/lib/interface/blas_interface.cpp
@@ -121,7 +121,7 @@ void blasGEMMQuda(void *arrayA, void *arrayB, void *arrayC, QudaBoolean use_nati
     void *A_d = pool_device_malloc(A_bytes);
     void *B_d = pool_device_malloc(B_bytes);
     void *C_d = pool_device_malloc(C_bytes);
-    if (getVerbosity() >= QUDA_VERBOSE) printfQuda("QUDA: arrays allocated sucessfully.\n");
+    if (getVerbosity() >= QUDA_VERBOSE) printfQuda("QUDA: arrays allocated successfully.\n");
     getProfileBLAS().TPSTOP(QUDA_PROFILE_INIT);
 
     // Transfer host data to device
@@ -129,7 +129,7 @@ void blasGEMMQuda(void *arrayA, void *arrayB, void *arrayC, QudaBoolean use_nati
     qudaMemcpy(A_d, arrayA, A_bytes, qudaMemcpyHostToDevice);
     qudaMemcpy(B_d, arrayB, B_bytes, qudaMemcpyHostToDevice);
     qudaMemcpy(C_d, arrayC, C_bytes, qudaMemcpyHostToDevice);
-    if (getVerbosity() >= QUDA_VERBOSE) printfQuda("QUDA: arrays copied susessfully.\n");
+    if (getVerbosity() >= QUDA_VERBOSE) printfQuda("QUDA: arrays copied successfully.\n");
     getProfileBLAS().TPSTOP(QUDA_PROFILE_H2D);
 
     // Compute Batched GEMM
@@ -153,6 +153,34 @@ void blasGEMMQuda(void *arrayA, void *arrayB, void *arrayC, QudaBoolean use_nati
     getProfileBLAS().TPSTOP(QUDA_PROFILE_FREE);
   }
 
+  getProfileBLAS().TPSTOP(QUDA_PROFILE_TOTAL);
+  saveTuneCache();
+}
+
+void blasLUInvQuda(void *Ainv, void *A, QudaBoolean use_native, QudaBLASParam *blas_param)
+{
+  getProfileBLAS().TPSTART(QUDA_PROFILE_TOTAL);
+  checkBLASParam(*blas_param);
+  
+  if (use_native == QUDA_BOOLEAN_FALSE) {
+    getProfileBLAS().TPSTART(QUDA_PROFILE_INIT);
+    const int n = blas_param->inv_mat_size;
+    const uint64_t batches = blas_param->batch_count;
+    QudaPrecision prec = QUDA_INVALID_PRECISION;
+    switch (blas_param->data_type) {
+    case QUDA_BLAS_DATATYPE_Z : prec = QUDA_DOUBLE_PRECISION; break;
+    case QUDA_BLAS_DATATYPE_C : prec = QUDA_SINGLE_PRECISION; break;
+    case QUDA_BLAS_DATATYPE_D :
+    case QUDA_BLAS_DATATYPE_S :
+    default : errorQuda("LU inversion not supported for data type %d", blas_param->data_type);
+    }
+    getProfileBLAS().TPSTOP(QUDA_PROFILE_INIT);
+    getProfileBLAS().TPSTART(QUDA_PROFILE_COMPUTE);
+    blas_lapack::generic::BatchInvertMatrix(Ainv, A, n, batches, prec, QUDA_CPU_FIELD_LOCATION);
+    getProfileBLAS().TPSTOP(QUDA_PROFILE_COMPUTE);
+  } else {
+    
+  }  
   getProfileBLAS().TPSTOP(QUDA_PROFILE_TOTAL);
   saveTuneCache();
 }

--- a/lib/interface/blas_interface.cpp
+++ b/lib/interface/blas_interface.cpp
@@ -161,26 +161,27 @@ void blasLUInvQuda(void *Ainv, void *A, QudaBoolean use_native, QudaBLASParam *b
 {
   getProfileBLAS().TPSTART(QUDA_PROFILE_TOTAL);
   checkBLASParam(*blas_param);
-  
-  if (use_native == QUDA_BOOLEAN_FALSE) {
-    getProfileBLAS().TPSTART(QUDA_PROFILE_INIT);
-    const int n = blas_param->inv_mat_size;
-    const uint64_t batches = blas_param->batch_count;
-    QudaPrecision prec = QUDA_INVALID_PRECISION;
-    switch (blas_param->data_type) {
-    case QUDA_BLAS_DATATYPE_Z : prec = QUDA_DOUBLE_PRECISION; break;
-    case QUDA_BLAS_DATATYPE_C : prec = QUDA_SINGLE_PRECISION; break;
-    case QUDA_BLAS_DATATYPE_D :
-    case QUDA_BLAS_DATATYPE_S :
-    default : errorQuda("LU inversion not supported for data type %d", blas_param->data_type);
-    }
-    getProfileBLAS().TPSTOP(QUDA_PROFILE_INIT);
-    getProfileBLAS().TPSTART(QUDA_PROFILE_COMPUTE);
+
+  getProfileBLAS().TPSTART(QUDA_PROFILE_INIT);
+  const int n = blas_param->inv_mat_size;
+  const uint64_t batches = blas_param->batch_count;
+  QudaPrecision prec = QUDA_INVALID_PRECISION;
+  switch (blas_param->data_type) {
+  case QUDA_BLAS_DATATYPE_Z : prec = QUDA_DOUBLE_PRECISION; break;
+  case QUDA_BLAS_DATATYPE_C : prec = QUDA_SINGLE_PRECISION; break;
+  case QUDA_BLAS_DATATYPE_D :
+  case QUDA_BLAS_DATATYPE_S :
+  default : errorQuda("LU inversion not supported for data type %d", blas_param->data_type);
+  }
+  getProfileBLAS().TPSTOP(QUDA_PROFILE_INIT);
+
+  getProfileBLAS().TPSTART(QUDA_PROFILE_COMPUTE);
+  if (use_native == QUDA_BOOLEAN_FALSE)
     blas_lapack::generic::BatchInvertMatrix(Ainv, A, n, batches, prec, QUDA_CPU_FIELD_LOCATION);
-    getProfileBLAS().TPSTOP(QUDA_PROFILE_COMPUTE);
-  } else {
-    
-  }  
+  else
+    blas_lapack::native::BatchInvertMatrix(Ainv, A, n, batches, prec, QUDA_CPU_FIELD_LOCATION);
+  
+  getProfileBLAS().TPSTOP(QUDA_PROFILE_COMPUTE);
   getProfileBLAS().TPSTOP(QUDA_PROFILE_TOTAL);
   saveTuneCache();
 }

--- a/lib/interface/blas_interface.cpp
+++ b/lib/interface/blas_interface.cpp
@@ -167,11 +167,11 @@ void blasLUInvQuda(void *Ainv, void *A, QudaBoolean use_native, QudaBLASParam *b
   const uint64_t batches = blas_param->batch_count;
   QudaPrecision prec = QUDA_INVALID_PRECISION;
   switch (blas_param->data_type) {
-  case QUDA_BLAS_DATATYPE_Z : prec = QUDA_DOUBLE_PRECISION; break;
-  case QUDA_BLAS_DATATYPE_C : prec = QUDA_SINGLE_PRECISION; break;
-  case QUDA_BLAS_DATATYPE_D :
-  case QUDA_BLAS_DATATYPE_S :
-  default : errorQuda("LU inversion not supported for data type %d", blas_param->data_type);
+  case QUDA_BLAS_DATATYPE_Z: prec = QUDA_DOUBLE_PRECISION; break;
+  case QUDA_BLAS_DATATYPE_C: prec = QUDA_SINGLE_PRECISION; break;
+  case QUDA_BLAS_DATATYPE_D:
+  case QUDA_BLAS_DATATYPE_S:
+  default: errorQuda("LU inversion not supported for data type %d", blas_param->data_type);
   }
   getProfileBLAS().TPSTOP(QUDA_PROFILE_INIT);
 
@@ -180,7 +180,7 @@ void blasLUInvQuda(void *Ainv, void *A, QudaBoolean use_native, QudaBLASParam *b
     blas_lapack::generic::BatchInvertMatrix(Ainv, A, n, batches, prec, QUDA_CPU_FIELD_LOCATION);
   else
     blas_lapack::native::BatchInvertMatrix(Ainv, A, n, batches, prec, QUDA_CPU_FIELD_LOCATION);
-  
+
   getProfileBLAS().TPSTOP(QUDA_PROFILE_COMPUTE);
   getProfileBLAS().TPSTOP(QUDA_PROFILE_TOTAL);
   saveTuneCache();

--- a/lib/targets/cuda/blas_lapack_cublas.cpp
+++ b/lib/targets/cuda/blas_lapack_cublas.cpp
@@ -46,7 +46,7 @@ namespace quda
 #ifdef NATIVE_LAPACK_LIB
           cublasStatus_t error = cublasDestroy(handle);
           if (error != CUBLAS_STATUS_SUCCESS)
-            errorQuda("\nError indestroying cublas context, error code = %d\n", error);
+            errorQuda("\nError in destroying cublas context, error code = %d\n", error);
           cublas_init = false;
 #endif
         }
@@ -93,10 +93,19 @@ namespace quda
 
 #ifdef _DEBUG
         // Debug code: Copy original A matrix to host
-        std::complex<float> *A_h
-          = (location == QUDA_CUDA_FIELD_LOCATION ? static_cast<std::complex<float> *>(pool_pinned_malloc(size)) :
-                                                    static_cast<std::complex<float> *>(A_d));
-        if (location == QUDA_CUDA_FIELD_LOCATION) qudaMemcpy((void *)A_h, A_d, size, qudaMemcpyDeviceToHost);
+	if (prec == QUDA_SINGLE_PRECISION) {
+	  std::complex<float> *A_h
+	    = (location == QUDA_CUDA_FIELD_LOCATION ? static_cast<std::complex<float> *>(pool_pinned_malloc(size)) :
+	       static_cast<std::complex<float> *>(A_d));
+	  if (location == QUDA_CUDA_FIELD_LOCATION) qudaMemcpy((void *)A_h, A_d, size, qudaMemcpyDeviceToHost);
+	} else if (prec == QUDA_DOUBLE_PRECISION) {
+	  std::complex<double> *A_h
+	    = (location == QUDA_CUDA_FIELD_LOCATION ? static_cast<std::complex<double> *>(pool_pinned_malloc(size)) :
+	       static_cast<std::complex<double> *>(A_d));
+	  if (location == QUDA_CUDA_FIELD_LOCATION) qudaMemcpy((void *)A_h, A_d, size, qudaMemcpyDeviceToHost);
+	} else {
+	  errorQuda("%s not implemented for precision=%d", __func__, prec);
+	}
 #endif
 
         int *dipiv = static_cast<int *>(pool_device_malloc(batch * n * sizeof(int)));
@@ -161,10 +170,67 @@ namespace quda
           pool_pinned_free(Ainv_h);
           pool_pinned_free(A_h);
 #endif
-        } else {
+        } else if (prec == QUDA_DOUBLE_PRECISION) {
+          typedef cuDoubleComplex Z;
+          Z **A_array = static_cast<Z **>(pool_device_malloc(2 * batch * sizeof(Z *)));
+          Z **Ainv_array = A_array + batch;
+          Z **A_array_h = static_cast<Z **>(pool_pinned_malloc(2 * batch * sizeof(Z *)));
+          Z **Ainv_array_h = A_array_h + batch;
+          for (uint64_t i = 0; i < batch; i++) {
+            A_array_h[i] = static_cast<Z *>(A_d) + i * n * n;
+            Ainv_array_h[i] = static_cast<Z *>(Ainv_d) + i * n * n;
+          }
+          qudaMemcpy(A_array, A_array_h, 2 * batch * sizeof(Z *), qudaMemcpyHostToDevice);
+
+          cublasStatus_t error = cublasZgetrfBatched(handle, n, A_array, n, dipiv, dinfo_array, batch);
+          flops += batch * FLOPS_ZGETRF(n, n);
+
+          if (error != CUBLAS_STATUS_SUCCESS)
+            errorQuda("\nError in LU decomposition (cublasZgetrfBatched), error code = %d\n", error);
+
+          qudaMemcpy(info_array, dinfo_array, batch * sizeof(int), qudaMemcpyDeviceToHost);
+          for (uint64_t i = 0; i < batch; i++) {
+            if (info_array[i] < 0) {
+              errorQuda("%lu argument had an illegal value or another error occured, such as memory allocation failed",
+                        i);
+            } else if (info_array[i] > 0) {
+              errorQuda("%lu factorization completed but the factor U is exactly singular", i);
+            }
+          }
+
+          error = cublasZgetriBatched(handle, n, (const Z **)A_array, n, dipiv, Ainv_array, n, dinfo_array, batch);
+          flops += batch * FLOPS_CGETRI(n);
+
+          if (error != CUBLAS_STATUS_SUCCESS)
+            errorQuda("\nError in matrix inversion (cublasCgetriBatched), error code = %d\n", error);
+
+          qudaMemcpy(info_array, dinfo_array, batch * sizeof(int), qudaMemcpyDeviceToHost);
+
+          for (uint64_t i = 0; i < batch; i++) {
+            if (info_array[i] < 0) {
+              errorQuda("%lu argument had an illegal value or another error occured, such as memory allocation failed",
+                        i);
+            } else if (info_array[i] > 0) {
+              errorQuda("%lu factorization completed but the factor U is exactly singular", i);
+            }
+          }
+
+          pool_device_free(A_array);
+          pool_pinned_free(A_array_h);
+
+#ifdef _DEBUG
+          // Debug code: Copy computed Ainv to host
+          std::complex<double> *Ainv_h = static_cast<std::complex<double> *>(pool_pinned_malloc(size));
+          qudaMemcpy((void *)Ainv_h, Ainv_d, size, qudaMemcpyDeviceToHost);
+
+          for (uint64_t i = 0; i < batch; i++) { checkEigen<MatrixXcd, double>(A_h, Ainv_h, n, i); }
+          pool_pinned_free(Ainv_h);
+          pool_pinned_free(A_h);
+#endif
+	} else {
           errorQuda("%s not implemented for precision=%d", __func__, prec);
         }
-
+	
         if (location == QUDA_CPU_FIELD_LOCATION) {
           qudaMemcpy(Ainv, Ainv_d, size, qudaMemcpyDeviceToHost);
           pool_device_free(Ainv_d);

--- a/lib/targets/cuda/blas_lapack_cublas.cpp
+++ b/lib/targets/cuda/blas_lapack_cublas.cpp
@@ -93,19 +93,19 @@ namespace quda
 
 #ifdef _DEBUG
         // Debug code: Copy original A matrix to host
-	if (prec == QUDA_SINGLE_PRECISION) {
-	  std::complex<float> *A_h
-	    = (location == QUDA_CUDA_FIELD_LOCATION ? static_cast<std::complex<float> *>(pool_pinned_malloc(size)) :
-	       static_cast<std::complex<float> *>(A_d));
-	  if (location == QUDA_CUDA_FIELD_LOCATION) qudaMemcpy((void *)A_h, A_d, size, qudaMemcpyDeviceToHost);
-	} else if (prec == QUDA_DOUBLE_PRECISION) {
-	  std::complex<double> *A_h
-	    = (location == QUDA_CUDA_FIELD_LOCATION ? static_cast<std::complex<double> *>(pool_pinned_malloc(size)) :
-	       static_cast<std::complex<double> *>(A_d));
-	  if (location == QUDA_CUDA_FIELD_LOCATION) qudaMemcpy((void *)A_h, A_d, size, qudaMemcpyDeviceToHost);
-	} else {
-	  errorQuda("%s not implemented for precision=%d", __func__, prec);
-	}
+        if (prec == QUDA_SINGLE_PRECISION) {
+          std::complex<float> *A_h
+            = (location == QUDA_CUDA_FIELD_LOCATION ? static_cast<std::complex<float> *>(pool_pinned_malloc(size)) :
+                                                      static_cast<std::complex<float> *>(A_d));
+          if (location == QUDA_CUDA_FIELD_LOCATION) qudaMemcpy((void *)A_h, A_d, size, qudaMemcpyDeviceToHost);
+        } else if (prec == QUDA_DOUBLE_PRECISION) {
+          std::complex<double> *A_h
+            = (location == QUDA_CUDA_FIELD_LOCATION ? static_cast<std::complex<double> *>(pool_pinned_malloc(size)) :
+                                                      static_cast<std::complex<double> *>(A_d));
+          if (location == QUDA_CUDA_FIELD_LOCATION) qudaMemcpy((void *)A_h, A_d, size, qudaMemcpyDeviceToHost);
+        } else {
+          errorQuda("%s not implemented for precision=%d", __func__, prec);
+        }
 #endif
 
         int *dipiv = static_cast<int *>(pool_device_malloc(batch * n * sizeof(int)));
@@ -227,10 +227,10 @@ namespace quda
           pool_pinned_free(Ainv_h);
           pool_pinned_free(A_h);
 #endif
-	} else {
+        } else {
           errorQuda("%s not implemented for precision=%d", __func__, prec);
         }
-	
+
         if (location == QUDA_CPU_FIELD_LOCATION) {
           qudaMemcpy(Ainv, Ainv_d, size, qudaMemcpyDeviceToHost);
           pool_device_free(Ainv_d);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -271,17 +271,17 @@ endif()
 if(QUDA_BUILD_NATIVE_LAPACK)
   add_test(NAME blas_interface_test
     COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:blas_interface_test> ${MPIEXEC_POSTFLAGS}
-    --blas-mnk 64 64 64
-    --blas-leading-dims 128 128 128
-    --blas-offsets 16 16 16
+    --blas-gemm-mnk 64 64 64
+    --blas-gemm-leading-dims 128 128 128
+    --blas-gemm-offsets 16 16 16
+    --blas-gemm-alpha 1.0 2.0
+    --blas-gemm-beta -3.0 1.5
+    --blas-gemm-trans-a T
+    --blas-gemm-trans-b C
+    --blas-lu-inv-mat-size 96
     --blas-data-type Z
     --blas-data-order row
     --blas-batch 20
-    --blas-alpha 1.0 2.0
-    --blas-beta -3.0 1.5
-    --blas-trans-a T
-    --blas-trans-b C
-    --blas-inv-mat-size 96
     --enable-testing true
     --gtest_output=xml:blas_interface_test.xml)
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -281,6 +281,7 @@ if(QUDA_BUILD_NATIVE_LAPACK)
     --blas-beta -3.0 1.5
     --blas-trans-a T
     --blas-trans-b C
+    --enable-testing true
     --gtest_output=xml:blas_interface_test.xml)
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -281,6 +281,7 @@ if(QUDA_BUILD_NATIVE_LAPACK)
     --blas-beta -3.0 1.5
     --blas-trans-a T
     --blas-trans-b C
+    --blas-inv-mat-size 96
     --enable-testing true
     --gtest_output=xml:blas_interface_test.xml)
 endif()

--- a/tests/blas_interface_test.cpp
+++ b/tests/blas_interface_test.cpp
@@ -33,8 +33,6 @@ std::array<int, 3> blas_gemm_strides = {1, 1, 1};
 std::array<double, 2> blas_gemm_alpha_re_im = {M_PI, M_E};
 std::array<double, 2> blas_gemm_beta_re_im = {M_LN2, M_LN10};
 
-int blas_lu_inv_offset = 0;
-int blas_lu_inv_stride = 1;
 int blas_lu_inv_mat_size = 128;
 
 namespace quda
@@ -270,15 +268,7 @@ double lu_inv_test(test_t test_param)
 
   // Sanity checks on parameters
   //-------------------------------------------------------------------------
-  // Leading dims are irrelevant for LU inversions as matrices must be square
-
-  // If the user passes a negative stride, we error out as this has no meaning.
-  int min_stride = blas_param.inv_stride;
-  if (min_stride < 0) { errorQuda("BLAS strides must be positive or zero: inv_stride=%d", blas_param.inv_stride); }
-
-  // If the user passes a negative offset, we error out as this has no meaning.
-  int min_offset = blas_param.inv_offset;
-  if (min_offset < 0) { errorQuda("BLAS offsets must be positive or zero: inv_offset=%d", blas_param.inv_offset); }
+  // Leading dims, strides, and offsets are irrelevant for LU inversions.
 
   // If the batch value is non-positve, we error out
   if (blas_param.batch_count <= 0) { errorQuda("Batches must be positive: batches=%d", blas_param.batch_count); }
@@ -287,11 +277,7 @@ double lu_inv_test(test_t test_param)
   // Reference data is always in complex double
   size_t data_in_size = sizeof(double);
 
-  // If the user passes non-zero offsets, add one extra
-  // matrix to the test data.
-  int batches_extra = 0;
-  if (blas_param.inv_offset > 0) { batches_extra++; }
-  int batches = blas_param.batch_count + batches_extra;
+  int batches = blas_param.batch_count;
   uint64_t array_size = blas_param.inv_mat_size * blas_param.inv_mat_size;
 
   // Create host data reference arrays
@@ -398,10 +384,6 @@ void add_blas_interface_option_group(std::shared_ptr<QUDAApp> quda_app)
   opgroup
     ->add_option("--blas-gemm-strides", blas_gemm_strides, "Set the strides for GEMM matrices A, B, and C (default 1 1 1)")
     ->expected(3);
-
-  opgroup->add_option("--blas-lu-inv-offset", blas_lu_inv_offset, "Set the offset for LU inversion array (default 0)");
-
-  opgroup->add_option("--blas-lu-inv-stride", blas_lu_inv_stride, "Set the stride for LU inversion array (default 1)");
 
   opgroup->add_option("--blas-batch", blas_batch, "Set the number of batches for GEMM or LU inversion (default 16)");
 

--- a/tests/blas_interface_test.cpp
+++ b/tests/blas_interface_test.cpp
@@ -67,7 +67,8 @@ void display_test_info(QudaBLASParam &param)
              dimPartitioned(3));
 }
 
-void setBLASParam(QudaBLASParam &blas_param) {
+void setBLASParam(QudaBLASParam &blas_param)
+{
   blas_param.trans_a = blas_trans_a;
   blas_param.trans_b = blas_trans_b;
   blas_param.m = blas_mnk[0];
@@ -94,7 +95,7 @@ void setBLASParam(QudaBLASParam &blas_param) {
 double gemm_test(test_t test_param)
 {
   blas_data_type = ::testing::get<1>(test_param);
-  
+
   QudaBLASParam blas_param = newQudaBLASParam();
   blas_param.trans_a = blas_trans_a;
   blas_param.trans_b = blas_trans_b;
@@ -119,7 +120,7 @@ double gemm_test(test_t test_param)
   blas_param.inv_mat_size = blas_inv_mat_size;
 
   display_test_info(blas_param);
-  
+
   // Sanity checks on parameters
   //-------------------------------------------------------------------------
   // If the user passes non positive M,N, or K, we error out
@@ -186,7 +187,7 @@ double gemm_test(test_t test_param)
 
   // Reference data is always in complex double
   size_t data_in_size = sizeof(double);
-  
+
   // If the user passes non-zero offsets, add one extra
   // matrix to the test data.
   int batches_extra = 0;
@@ -224,16 +225,20 @@ double gemm_test(test_t test_param)
     refC_size = blas_param.ldc * blas_param.m; // C_mn
   }
 
-  void *refA = pinned_malloc(batches * refA_size * 2 * data_in_size);;
-  void *refB = pinned_malloc(batches * refB_size * 2 * data_in_size);;
-  void *refC = pinned_malloc(batches * refC_size * 2 * data_in_size);;
-  void *refCcopy = pinned_malloc(batches * refC_size * 2 * data_in_size);;
-  
+  void *refA = pinned_malloc(batches * refA_size * 2 * data_in_size);
+  ;
+  void *refB = pinned_malloc(batches * refB_size * 2 * data_in_size);
+  ;
+  void *refC = pinned_malloc(batches * refC_size * 2 * data_in_size);
+  ;
+  void *refCcopy = pinned_malloc(batches * refC_size * 2 * data_in_size);
+  ;
+
   prepare_ref_array(refA, batches, refA_size, data_in_size, blas_data_type);
   prepare_ref_array(refB, batches, refB_size, data_in_size, blas_data_type);
   prepare_ref_array(refC, batches, refC_size, data_in_size, blas_data_type);
   prepare_ref_array(refCcopy, batches, refC_size, data_in_size, blas_data_type);
-  
+
   // Create new arrays appropriate for the requested problem, and copy over the data.
   void *arrayA = nullptr;
   void *arrayB = nullptr;
@@ -242,7 +247,7 @@ double gemm_test(test_t test_param)
   size_t data_out_size = 0;
   // Reference data is always complex, but test data can be either real or complex
   int re_im = 0;
-  
+
   switch (blas_data_type) {
   case QUDA_BLAS_DATATYPE_S:
     data_out_size = sizeof(float);
@@ -267,12 +272,12 @@ double gemm_test(test_t test_param)
   arrayB = pinned_malloc(batches * refB_size * re_im * data_out_size);
   arrayC = pinned_malloc(batches * refC_size * re_im * data_out_size);
   arrayCcopy = pinned_malloc(batches * refC_size * re_im * data_out_size);
-  
+
   copy_array(arrayA, refA, batches, refA_size, data_out_size, blas_data_type);
   copy_array(arrayB, refB, batches, refB_size, data_out_size, blas_data_type);
   copy_array(arrayC, refC, batches, refC_size, data_out_size, blas_data_type);
   copy_array(arrayCcopy, refC, batches, refC_size, data_out_size, blas_data_type);
-  
+
   // Perform device GEMM Blas operation
   blasGEMMQuda(arrayA, arrayB, arrayC, native_blas_lapack ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE, &blas_param);
 
@@ -300,9 +305,9 @@ double lu_inv_test(test_t test_param)
   blas_data_type = ::testing::get<1>(test_param);
   blas_test_type = ::testing::get<0>(test_param);
   setBLASParam(blas_param);
-  
+
   display_test_info(blas_param);
-  
+
   // Sanity checks on parameters
   //-------------------------------------------------------------------------
   // If the user passes a negative stride, we error out as this has no meaning.
@@ -325,7 +330,7 @@ double lu_inv_test(test_t test_param)
 
   // Reference data is always in complex double
   size_t data_in_size = sizeof(double);
-  
+
   // If the user passes non-zero offsets, add one extra
   // matrix to the test data.
   int batches_extra = 0;
@@ -333,25 +338,21 @@ double lu_inv_test(test_t test_param)
   int batches = blas_param.batch_count + batches_extra;
   uint64_t array_size = blas_param.inv_mat_size * blas_param.inv_mat_size;
 
-  // Create host data reference arrays 
+  // Create host data reference arrays
   void *ref_array = pinned_malloc(batches * array_size * 2 * data_in_size);
-  void *ref_array_inv = pinned_malloc(batches * array_size * 2 * data_in_size);  
+  void *ref_array_inv = pinned_malloc(batches * array_size * 2 * data_in_size);
   prepare_ref_array(ref_array, batches, array_size, data_in_size, blas_data_type);
-  
+
   // Create device array appropriate for the requested problem.
   void *dev_array = nullptr;
   void *dev_array_inv = nullptr;
   size_t data_out_size = 0;
   // For now, data is always complex for LU inversion.
   int re_im = 2;
-  
+
   switch (blas_data_type) {
-  case QUDA_BLAS_DATATYPE_C:
-    data_out_size = sizeof(float);
-    break;
-  case QUDA_BLAS_DATATYPE_Z:
-    data_out_size = sizeof(double);
-    break;
+  case QUDA_BLAS_DATATYPE_C: data_out_size = sizeof(float); break;
+  case QUDA_BLAS_DATATYPE_Z: data_out_size = sizeof(double); break;
   case QUDA_BLAS_DATATYPE_S:
   case QUDA_BLAS_DATATYPE_D:
   default: errorQuda("Unsupported data type %d\n", blas_data_type);
@@ -359,16 +360,14 @@ double lu_inv_test(test_t test_param)
 
   dev_array = pinned_malloc(batches * array_size * re_im * data_out_size);
   dev_array_inv = pinned_malloc(batches * array_size * re_im * data_out_size);
-  
+
   copy_array(dev_array, ref_array, batches, array_size, data_out_size, blas_data_type);
-  
+
   // Perform device LU inversion
   blasLUInvQuda(dev_array_inv, dev_array, native_blas_lapack ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE, &blas_param);
 
   double deviation = 0.0;
-  if (verify_results) {
-    deviation = blasLUInvQudaVerify(ref_array, dev_array_inv, array_size, &blas_param);
-  }
+  if (verify_results) { deviation = blasLUInvQudaVerify(ref_array, dev_array_inv, array_size, &blas_param); }
 
   host_free(ref_array);
   host_free(ref_array_inv);
@@ -387,12 +386,11 @@ void add_blas_interface_option_group(std::shared_ptr<QUDAApp> quda_app)
 
   CLI::TransformPairs<QudaBLASOperation> blas_op_map {{"N", QUDA_BLAS_OP_N}, {"T", QUDA_BLAS_OP_T}, {"C", QUDA_BLAS_OP_C}};
 
-  CLI::TransformPairs<QudaBLASType> blas_type_map {{"gemm", QUDA_BLAS_GEMM},
-      {"lu-inv", QUDA_BLAS_LU_INV}};
-  
-  // Option group for BLAS test related options  
+  CLI::TransformPairs<QudaBLASType> blas_type_map {{"gemm", QUDA_BLAS_GEMM}, {"lu-inv", QUDA_BLAS_LU_INV}};
+
+  // Option group for BLAS test related options
   auto opgroup = quda_app->add_option_group("BLAS Interface", "Options controlling BLAS interface tests");
-  
+
   opgroup
     ->add_option("--blas-data-type", blas_data_type,
                  "Whether to use single(S), double(D), and/or complex(C/Z) data types (default C)")
@@ -402,7 +400,7 @@ void add_blas_interface_option_group(std::shared_ptr<QUDAApp> quda_app)
     ->add_option("--blas-test-type", blas_test_type,
                  "Whether to perform the GEMM test or LU Inversion test (default GEMM)")
     ->transform(CLI::QUDACheckedTransformer(blas_type_map));
-  
+
   opgroup
     ->add_option("--blas-data-order", blas_data_order, "Whether data is in row major or column major order (default row)")
     ->transform(CLI::QUDACheckedTransformer(blas_data_order_map));
@@ -442,7 +440,8 @@ void add_blas_interface_option_group(std::shared_ptr<QUDAApp> quda_app)
 
   opgroup->add_option("--blas-batch", blas_batch, "Set the number of batches for GEMM or LU inversion (default 16)");
 
-  opgroup->add_option("--blas-inv-mat-size", blas_inv_mat_size, "Set the size of the square matrix to invert via LU (default 128)");
+  opgroup->add_option("--blas-inv-mat-size", blas_inv_mat_size,
+                      "Set the size of the square matrix to invert via LU (default 128)");
 }
 
 int main(int argc, char **argv)
@@ -490,16 +489,17 @@ int main(int argc, char **argv)
   } else {
     // Perform the BLAS op specified by the command line
     switch (blas_test_type) {
-    case QUDA_BLAS_GEMM : {      
+    case QUDA_BLAS_GEMM: {
       switch (blas_data_type) {
       case QUDA_BLAS_DATATYPE_S: gemm_test(test_t {QUDA_BLAS_GEMM, QUDA_BLAS_DATATYPE_S}); break;
       case QUDA_BLAS_DATATYPE_D: gemm_test(test_t {QUDA_BLAS_GEMM, QUDA_BLAS_DATATYPE_D}); break;
       case QUDA_BLAS_DATATYPE_C: gemm_test(test_t {QUDA_BLAS_GEMM, QUDA_BLAS_DATATYPE_C}); break;
       case QUDA_BLAS_DATATYPE_Z: gemm_test(test_t {QUDA_BLAS_GEMM, QUDA_BLAS_DATATYPE_Z}); break;
       default: errorQuda("Undefined QUDA BLAS data type %d\n", blas_data_type);
-      } break;
+      }
+      break;
     }
-    case QUDA_BLAS_LU_INV : {
+    case QUDA_BLAS_LU_INV: {
       switch (blas_data_type) {
       case QUDA_BLAS_DATATYPE_C: lu_inv_test(test_t {QUDA_BLAS_LU_INV, QUDA_BLAS_DATATYPE_C}); break;
       case QUDA_BLAS_DATATYPE_Z: lu_inv_test(test_t {QUDA_BLAS_LU_INV, QUDA_BLAS_DATATYPE_Z}); break;

--- a/tests/blas_interface_test.cpp
+++ b/tests/blas_interface_test.cpp
@@ -274,16 +274,12 @@ double lu_inv_test(test_t test_param)
 
   // If the user passes a negative stride, we error out as this has no meaning.
   int min_stride = blas_param.inv_stride;
-  if (min_stride < 0) {
-    errorQuda("BLAS strides must be positive or zero: inv_stride=%d", blas_param.inv_stride);
-  }
-  
+  if (min_stride < 0) { errorQuda("BLAS strides must be positive or zero: inv_stride=%d", blas_param.inv_stride); }
+
   // If the user passes a negative offset, we error out as this has no meaning.
   int min_offset = blas_param.inv_offset;
-  if (min_offset < 0) {
-    errorQuda("BLAS offsets must be positive or zero: inv_offset=%d", blas_param.inv_offset);
-  }
-  
+  if (min_offset < 0) { errorQuda("BLAS offsets must be positive or zero: inv_offset=%d", blas_param.inv_offset); }
+
   // If the batch value is non-positve, we error out
   if (blas_param.batch_count <= 0) { errorQuda("Batches must be positive: batches=%d", blas_param.batch_count); }
   //-------------------------------------------------------------------------
@@ -377,14 +373,17 @@ void add_blas_interface_option_group(std::shared_ptr<QUDAApp> quda_app)
       "Whether to leave the B GEMM matrix as is (N), to transpose (T) or transpose conjugate (C) (default N) ")
     ->transform(CLI::QUDACheckedTransformer(blas_op_map));
 
-  opgroup->add_option("--blas-gemm-alpha", blas_gemm_alpha_re_im, "Set the complex value of alpha for GEMM (default {1.0,0.0}")
-    ->expected(2);
-
-  opgroup->add_option("--blas-gemm-beta", blas_gemm_beta_re_im, "Set the complex value of beta for GEMM (default {1.0,0.0}")
+  opgroup
+    ->add_option("--blas-gemm-alpha", blas_gemm_alpha_re_im, "Set the complex value of alpha for GEMM (default {1.0,0.0}")
     ->expected(2);
 
   opgroup
-    ->add_option("--blas-gemm-mnk", blas_gemm_mnk, "Set the dimensions of the A, B, and C matrices GEMM (default 128 128 128)")
+    ->add_option("--blas-gemm-beta", blas_gemm_beta_re_im, "Set the complex value of beta for GEMM (default {1.0,0.0}")
+    ->expected(2);
+
+  opgroup
+    ->add_option("--blas-gemm-mnk", blas_gemm_mnk,
+                 "Set the dimensions of the A, B, and C matrices GEMM (default 128 128 128)")
     ->expected(3);
 
   opgroup
@@ -392,16 +391,18 @@ void add_blas_interface_option_group(std::shared_ptr<QUDAApp> quda_app)
                  "Set the leading dimensions A, B, and C matrices GEMM (default 128 128 128) ")
     ->expected(3);
 
-  opgroup->add_option("--blas-gemm-offsets", blas_gemm_offsets, "Set the offsets for GEMM matrices A, B, and C (default 0 0 0)")
+  opgroup
+    ->add_option("--blas-gemm-offsets", blas_gemm_offsets, "Set the offsets for GEMM matrices A, B, and C (default 0 0 0)")
     ->expected(3);
 
-  opgroup->add_option("--blas-gemm-strides", blas_gemm_strides, "Set the strides for GEMM matrices A, B, and C (default 1 1 1)")
+  opgroup
+    ->add_option("--blas-gemm-strides", blas_gemm_strides, "Set the strides for GEMM matrices A, B, and C (default 1 1 1)")
     ->expected(3);
 
   opgroup->add_option("--blas-lu-inv-offset", blas_lu_inv_offset, "Set the offset for LU inversion array (default 0)");
 
   opgroup->add_option("--blas-lu-inv-stride", blas_lu_inv_stride, "Set the stride for LU inversion array (default 1)");
-  
+
   opgroup->add_option("--blas-batch", blas_batch, "Set the number of batches for GEMM or LU inversion (default 16)");
 
   opgroup->add_option("--blas-lu-inv-mat-size", blas_lu_inv_mat_size,

--- a/tests/blas_interface_test_gtest.hpp
+++ b/tests/blas_interface_test_gtest.hpp
@@ -86,12 +86,12 @@ TEST_P(BLASTest, verify)
   case QUDA_BLAS_LU_INV: {
     auto deviation_lu_inv = lu_inv_test(param);
     decltype(deviation_lu_inv) tol_lu_inv;
-    // We allow a factor of 500 (50x more than the gemm tolerance factor)
-    // due to variations in algorithmic implemntation and order of arithmetic
-    // operations.
+    // We allow a factor of 5000 (500x more than the gemm tolerance factor)
+    // due to variations in algorithmic implemntation, order of arithmetic
+    // operations, and possible near singular eigenvalues or degeneracies.
     switch (data_type) {
-    case 2: tol_lu_inv = 500 * std::numeric_limits<float>::epsilon(); break;
-    case 3: tol_lu_inv = 500 * std::numeric_limits<double>::epsilon(); break;
+    case 2: tol_lu_inv = 5000 * std::numeric_limits<float>::epsilon(); break;
+    case 3: tol_lu_inv = 5000 * std::numeric_limits<double>::epsilon(); break;
     case 0:
     case 1:
     default: errorQuda("Unexpected BLAS data type %d", data_type);

--- a/tests/blas_interface_test_gtest.hpp
+++ b/tests/blas_interface_test_gtest.hpp
@@ -9,7 +9,6 @@ protected:
 
 public:
   BLASTest() : param(GetParam()) { }
-  // virtual ~BLASTest() { }
 };
 
 bool skip_test(test_t param)
@@ -74,10 +73,10 @@ TEST_P(BLASTest, verify)
     auto deviation_gemm = gemm_test(param);
     decltype(deviation_gemm) tol_gemm;
     switch (data_type) {
-    case 0:
-    case 2: tol_gemm = 10 * std::numeric_limits<float>::epsilon(); break;
-    case 1:
-    case 3: tol_gemm = 10 * std::numeric_limits<double>::epsilon(); break;
+    case QUDA_BLAS_DATATYPE_S:
+    case QUDA_BLAS_DATATYPE_C: tol_gemm = 10 * std::numeric_limits<float>::epsilon(); break;
+    case QUDA_BLAS_DATATYPE_D:
+    case QUDA_BLAS_DATATYPE_Z: tol_gemm = 10 * std::numeric_limits<double>::epsilon(); break;
     default: errorQuda("Unexpected BLAS data type %d", data_type);
     }
     EXPECT_LE(deviation_gemm, tol_gemm) << "CPU and CUDA GEMM implementations do not agree";
@@ -87,13 +86,13 @@ TEST_P(BLASTest, verify)
     auto deviation_lu_inv = lu_inv_test(param);
     decltype(deviation_lu_inv) tol_lu_inv;
     // We allow a factor of 5000 (500x more than the gemm tolerance factor)
-    // due to variations in algorithmic implemntation, order of arithmetic
+    // due to variations in algorithmic implementation, order of arithmetic
     // operations, and possible near singular eigenvalues or degeneracies.
     switch (data_type) {
-    case 2: tol_lu_inv = 5000 * std::numeric_limits<float>::epsilon(); break;
-    case 3: tol_lu_inv = 5000 * std::numeric_limits<double>::epsilon(); break;
-    case 0:
-    case 1:
+    case QUDA_BLAS_DATATYPE_C: tol_lu_inv = 5000 * std::numeric_limits<float>::epsilon(); break;
+    case QUDA_BLAS_DATATYPE_Z: tol_lu_inv = 5000 * std::numeric_limits<double>::epsilon(); break;
+    case QUDA_BLAS_DATATYPE_S:
+    case QUDA_BLAS_DATATYPE_D:
     default: errorQuda("Unexpected BLAS data type %d", data_type);
     }
     EXPECT_LE(deviation_lu_inv, tol_lu_inv) << "CPU and CUDA LU Inversion implementations do not agree";

--- a/tests/blas_interface_test_gtest.hpp
+++ b/tests/blas_interface_test_gtest.hpp
@@ -1,0 +1,121 @@
+#include <gtest/gtest.h>
+
+using test_t = ::testing::tuple<QudaBLASType, QudaBLASDataType>;
+  
+class BLASTest : public ::testing::TestWithParam<test_t>
+{
+protected:
+  test_t param;
+
+public:
+  BLASTest() : param(GetParam()) { }
+  //virtual ~BLASTest() { }
+};
+
+bool skip_test(test_t param)
+{
+  if(::testing::get<0>(param) == QUDA_BLAS_LU_INV &&
+     (::testing::get<1>(param) == QUDA_BLAS_DATATYPE_D ||
+      ::testing::get<1>(param) == QUDA_BLAS_DATATYPE_S))
+    return true;  
+  else
+    return false;  
+}
+
+// For googletest, names must be non-empty, unique, and may only contain ASCII
+// alphanumeric characters or underscore.
+const char *data_type_str[] = {
+  "realSingle",
+  "realDouble",
+  "complexSingle",
+  "complexDouble",
+};
+
+const char *test_type_str[] = {
+  "GEMM",
+  "LUInvert",
+};
+
+// Helper function to construct the test name
+std::string getBLASDataName(testing::TestParamInfo<test_t> param)
+{
+  auto data_type = ::testing::get<1>(param.param);
+  std::string str(data_type_str[data_type]);
+  return str;
+}
+
+// Helper function to construct the test name
+std::string getBLASTestName(testing::TestParamInfo<test_t> param)
+{
+  auto test_type = ::testing::get<0>(param.param);
+  std::string str(test_type_str[test_type]);
+  return str;
+}
+
+
+// The following tests gets each BLAS type and precision using google testing framework
+using ::testing::Bool;
+using ::testing::Combine;
+using ::testing::Range;
+using ::testing::TestWithParam;
+using ::testing::Values;
+
+double gemm_test(test_t test_param);
+double lu_inv_test(test_t test_param);
+
+// Sets up the Google test
+TEST_P(BLASTest, verify)
+{
+  if (skip_test(GetParam())) GTEST_SKIP();
+  
+  auto param = GetParam();
+  auto test_type = ::testing::get<0>(param);
+  auto data_type = ::testing::get<1>(param);
+  switch (test_type) {
+  case QUDA_BLAS_GEMM: {
+    auto deviation_gemm = gemm_test(param);
+    decltype(deviation_gemm) tol_gemm;
+    switch (data_type) {
+    case 0:
+    case 2: tol_gemm = 10 * std::numeric_limits<float>::epsilon(); break;
+    case 1:
+    case 3: tol_gemm = 10 * std::numeric_limits<double>::epsilon(); break;
+    default: errorQuda("Unexpected BLAS data type %d", data_type);
+    }
+    EXPECT_LE(deviation_gemm, tol_gemm) << "CPU and CUDA GEMM implementations do not agree";
+    break;
+  }
+  case QUDA_BLAS_LU_INV: {
+    auto deviation_lu_inv = lu_inv_test(param);
+    decltype(deviation_lu_inv) tol_lu_inv;
+    switch (data_type) {
+    case 2: tol_lu_inv = 10 * std::numeric_limits<float>::epsilon(); break;
+    case 3: tol_lu_inv = 10 * std::numeric_limits<double>::epsilon(); break;
+    case 0:
+    case 1:
+    default: errorQuda("Unexpected BLAS data type %d", data_type);
+    }
+    EXPECT_LE(deviation_lu_inv, tol_lu_inv) << "CPU and CUDA LU Inversion implementations do not agree";
+    break;
+  }
+  default: errorQuda("Unexpected BLAS test type %d", test_type);
+  }
+  
+}
+
+// BLAS test type
+auto blas_test_type_value = Values(QUDA_BLAS_GEMM, QUDA_BLAS_LU_INV);
+
+// BLAS data type
+auto blas_data_type_value = Values(QUDA_BLAS_DATATYPE_Z, QUDA_BLAS_DATATYPE_C,
+				   QUDA_BLAS_DATATYPE_D, QUDA_BLAS_DATATYPE_S);
+
+std::string gettestname(::testing::TestParamInfo<test_t> param)
+{
+  std::string name = "BLASTest";
+  name += std::string("_") + getBLASTestName(param) + std::string("_") + getBLASDataName(param);
+  return name;
+}
+
+// BLAS tests
+INSTANTIATE_TEST_SUITE_P(BLASTest, BLASTest, ::testing::Combine(blas_test_type_value, blas_data_type_value), gettestname);

--- a/tests/blas_interface_test_gtest.hpp
+++ b/tests/blas_interface_test_gtest.hpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 
 using test_t = ::testing::tuple<QudaBLASType, QudaBLASDataType>;
-  
+
 class BLASTest : public ::testing::TestWithParam<test_t>
 {
 protected:
@@ -9,17 +9,16 @@ protected:
 
 public:
   BLASTest() : param(GetParam()) { }
-  //virtual ~BLASTest() { }
+  // virtual ~BLASTest() { }
 };
 
 bool skip_test(test_t param)
 {
-  if(::testing::get<0>(param) == QUDA_BLAS_LU_INV &&
-     (::testing::get<1>(param) == QUDA_BLAS_DATATYPE_D ||
-      ::testing::get<1>(param) == QUDA_BLAS_DATATYPE_S))
-    return true;  
+  if (::testing::get<0>(param) == QUDA_BLAS_LU_INV
+      && (::testing::get<1>(param) == QUDA_BLAS_DATATYPE_D || ::testing::get<1>(param) == QUDA_BLAS_DATATYPE_S))
+    return true;
   else
-    return false;  
+    return false;
 }
 
 // For googletest, names must be non-empty, unique, and may only contain ASCII
@@ -52,7 +51,6 @@ std::string getBLASTestName(testing::TestParamInfo<test_t> param)
   return str;
 }
 
-
 // The following tests gets each BLAS type and precision using google testing framework
 using ::testing::Bool;
 using ::testing::Combine;
@@ -67,7 +65,7 @@ double lu_inv_test(test_t test_param);
 TEST_P(BLASTest, verify)
 {
   if (skip_test(GetParam())) GTEST_SKIP();
-  
+
   auto param = GetParam();
   auto test_type = ::testing::get<0>(param);
   auto data_type = ::testing::get<1>(param);
@@ -100,15 +98,14 @@ TEST_P(BLASTest, verify)
   }
   default: errorQuda("Unexpected BLAS test type %d", test_type);
   }
-  
 }
 
 // BLAS test type
 auto blas_test_type_value = Values(QUDA_BLAS_GEMM, QUDA_BLAS_LU_INV);
 
 // BLAS data type
-auto blas_data_type_value = Values(QUDA_BLAS_DATATYPE_Z, QUDA_BLAS_DATATYPE_C,
-				   QUDA_BLAS_DATATYPE_D, QUDA_BLAS_DATATYPE_S);
+auto blas_data_type_value
+  = Values(QUDA_BLAS_DATATYPE_Z, QUDA_BLAS_DATATYPE_C, QUDA_BLAS_DATATYPE_D, QUDA_BLAS_DATATYPE_S);
 
 std::string gettestname(::testing::TestParamInfo<test_t> param)
 {

--- a/tests/blas_interface_test_gtest.hpp
+++ b/tests/blas_interface_test_gtest.hpp
@@ -86,9 +86,12 @@ TEST_P(BLASTest, verify)
   case QUDA_BLAS_LU_INV: {
     auto deviation_lu_inv = lu_inv_test(param);
     decltype(deviation_lu_inv) tol_lu_inv;
+    // We allow a factor of 500 (50x more than the gemm tolerance factor)
+    // due to variations in algorithmic implemntation and order of arithmetic
+    // operations.
     switch (data_type) {
-    case 2: tol_lu_inv = 10 * std::numeric_limits<float>::epsilon(); break;
-    case 3: tol_lu_inv = 10 * std::numeric_limits<double>::epsilon(); break;
+    case 2: tol_lu_inv = 500 * std::numeric_limits<float>::epsilon(); break;
+    case 3: tol_lu_inv = 500 * std::numeric_limits<double>::epsilon(); break;
     case 0:
     case 1:
     default: errorQuda("Unexpected BLAS data type %d", data_type);

--- a/tests/host_reference/blas_reference.cpp
+++ b/tests/host_reference/blas_reference.cpp
@@ -27,6 +27,35 @@ void fillEigenArray(MatrixXcd &EigenArr, complex<double> *arr, int rows, int col
   }
 }
 
+void prepare_ref_array(void *array, int batches, uint64_t array_size, size_t data_size, QudaBLASDataType data_type) {  
+  memset(array, 0, batches * array_size * data_size);
+  // Populate the real part with rands
+  for (uint64_t i = 0; i < 2 * array_size * batches; i += 2) { ((double *)array)[i] = rand() / (double)RAND_MAX; }
+  // Populate the imaginary part with rands if needed
+  if (data_type == QUDA_BLAS_DATATYPE_C || data_type == QUDA_BLAS_DATATYPE_Z) {
+    for (uint64_t i = 1; i < 2 * array_size * batches; i += 2) { ((double *)array)[i] = rand() / (double)RAND_MAX; }
+  }
+}
+
+void copy_array(void *array_out, void *array_in, int batches, uint64_t array_size, size_t data_out_size, QudaBLASDataType data_type) {
+  // Copy the real part only
+  if (data_type == QUDA_BLAS_DATATYPE_S || data_type == QUDA_BLAS_DATATYPE_D) {
+    for (uint64_t i = 0; i < 2 * array_size * batches; i += 2) {    
+      if(data_out_size == sizeof(float)) ((float *)array_out)[i / 2] = ((double *)array_in)[i];
+      else if(data_out_size == sizeof(double)) ((double *)array_out)[i / 2] = ((double *)array_in)[i];
+      else errorQuda("Unsupported data out size %lu", data_out_size);
+    }
+  }  
+  // Copy both the real and the imaginary parts
+  if (data_type == QUDA_BLAS_DATATYPE_C || data_type == QUDA_BLAS_DATATYPE_Z) {
+    for (uint64_t i = 0; i < 2 * array_size * batches; i++) {
+      if(data_out_size == sizeof(float)) ((float *)array_out)[i] = ((double *)array_in)[i]; 
+      else if(data_out_size == sizeof(double)) ((double *)array_out)[i] = ((double *)array_in)[i];
+      else errorQuda("Unsupported data out size %lu", data_out_size);
+    }
+  }
+}
+
 double blasGEMMEigenVerify(void *A_data, void *B_data, void *C_data_copy, void *C_data, uint64_t refA_size,
                            uint64_t refB_size, uint64_t refC_size, QudaBLASParam *blas_param)
 {
@@ -282,4 +311,116 @@ double blasGEMMQudaVerify(void *arrayA, void *arrayB, void *arrayC, void *arrayC
   host_free(checkCcopy);
 
   return deviation;
+}
+
+double blasLUInvEigenVerify(void *ref_array, void *dev_inv_array, uint64_t array_size, QudaBLASParam *blas_param){
+
+  // Sanity checks on parameters
+  //-------------------------------------------------------------------------
+  // If the user passes a negative stride, we error out as this has no meaning.
+  int min_stride = blas_param->a_stride;
+  if (min_stride < 0) {
+    errorQuda("BLAS strides must be positive or zero: a_stride=%d", blas_param->a_stride);
+  }
+
+  // If the user passes a negative offset, we error out as this has no meaning.
+  int min_offset = blas_param->a_offset;
+  if (min_offset < 0) {
+    errorQuda("BLAS offsets must be positive or zero: a_offset=%d\n", blas_param->a_offset);
+  }
+  
+  // If the batch value is non-positve, we error out
+  if (blas_param->batch_count <= 0) { errorQuda("Batches must be positive: batches=%d", blas_param->batch_count); }
+  //-------------------------------------------------------------------------
+
+  // Parse parameters for Eigen
+  //-------------------------------------------------------------------------
+  // Problem parameters
+  int a_stride = blas_param->a_stride;
+  int a_offset = blas_param->a_offset;
+  int batches = blas_param->batch_count;
+  int mat_rank = blas_param->inv_mat_size;
+  
+  // Eigen objects to store data
+  MatrixXcd ref = MatrixXd::Zero(mat_rank, mat_rank);
+  MatrixXcd ref_inv = MatrixXd::Zero(mat_rank, mat_rank);
+  MatrixXcd dev_inv = MatrixXd::Zero(mat_rank, mat_rank);
+  MatrixXcd inv_resid = MatrixXd::Zero(mat_rank, mat_rank);
+
+  // Pointers to data
+  complex<double> *ref_ptr = (complex<double> *)(&ref_array)[0];
+  complex<double> *dev_inv_ptr = (complex<double> *)(&dev_inv_array)[0];
+
+  // Get maximum stride length to deduce the number of batches in the
+  // computation
+  int max_stride = a_stride;
+
+  // If the user gives strides of 0 for all arrays, we are essentially performing
+  // an LU inversion on the first matrices in the array N_{batch} times.
+  // Give them what they ask for, YMMV...
+  // If the strides have not been set, we are just using strides of 1.
+  if (max_stride <= 0) max_stride = 1;
+
+  printfQuda("Computing Eigen matrix operation ref_inv{%lu,%lu} = ref_{%lu,%lu}^(-1)\n",
+             ref.rows(), ref.cols(), ref_inv.rows(), ref_inv.cols());
+
+  double max_relative_deviation = 0.0;
+  for (int batch = 0; batch < batches; batch += max_stride) {
+
+    // Populate Eigen objects
+    fillEigenArray(ref, ref_ptr, mat_rank, mat_rank, mat_rank, a_offset);
+    fillEigenArray(dev_inv, dev_inv_ptr, mat_rank, mat_rank, mat_rank, a_offset);
+
+    // Check Eigen result against blas
+    ref_inv = ref.inverse();
+    inv_resid = dev_inv - ref_inv;
+    
+    double deviation = inv_resid.norm();
+    double relative_deviation = deviation / ref_inv.norm();
+    max_relative_deviation = std::max(max_relative_deviation, relative_deviation);
+    
+    printfQuda("batch %d: (ref_inv_host - dev_inv_gpu) Frobenius norm = %e. Relative deviation = %e\n", batch, deviation,
+               relative_deviation);
+    
+    a_offset += array_size * a_stride;
+  }
+  
+  return max_relative_deviation;
+}
+
+double blasLUInvQudaVerify(void *ref_array, void *dev_array_inv, uint64_t array_size, QudaBLASParam *blas_param)
+{
+  // Reference data is always in complex double, but real data may
+  // be supported in the future.
+  size_t data_out_size = sizeof(double);
+  int re_im = 2;
+  
+  // If the user passes non-zero offsets, add one extra
+  // matrix to the test data.
+  int batches_extra = 0;
+  if (blas_param->a_offset + blas_param->b_offset + blas_param->c_offset > 0) { batches_extra++; }
+  int batches = blas_param->batch_count + batches_extra;
+
+  // Copy data from problem sized array to reference sized array.
+  void *dev_array_inv_copy = pinned_malloc(array_size * re_im * data_out_size * batches);
+
+  size_t data_in_size = 0;
+  switch (blas_param->data_type) {
+  case QUDA_BLAS_DATATYPE_C: data_in_size = sizeof(float); break;
+  case QUDA_BLAS_DATATYPE_Z: data_in_size = sizeof(double); break;
+  case QUDA_BLAS_DATATYPE_S:
+  case QUDA_BLAS_DATATYPE_D:
+  default: errorQuda("Unsupported data type %d\n", blas_param->data_type);
+  }
+  
+  for (uint64_t i = 0; i < 2 * array_size * batches; i++) {
+    if(data_in_size == sizeof(float)) ((double *)dev_array_inv_copy)[i] = ((float *)dev_array_inv)[i];
+    else if(data_in_size == sizeof(double)) ((double *)dev_array_inv_copy)[i] = ((double *)dev_array_inv)[i]; 
+    else errorQuda("Unsupported data-in size %lu", data_in_size);
+  }
+  
+  auto deviation = blasLUInvEigenVerify(ref_array, dev_array_inv_copy, array_size, blas_param);
+
+  host_free(dev_array_inv_copy);
+  return deviation;  
 }

--- a/tests/host_reference/blas_reference.cpp
+++ b/tests/host_reference/blas_reference.cpp
@@ -328,12 +328,12 @@ double blasLUInvEigenVerify(void *ref_array, void *dev_inv_array, uint64_t array
   // Sanity checks on parameters
   //-------------------------------------------------------------------------
   // If the user passes a negative stride, we error out as this has no meaning.
-  int min_stride = blas_param->a_stride;
-  if (min_stride < 0) { errorQuda("BLAS strides must be positive or zero: a_stride=%d", blas_param->a_stride); }
+  int min_stride = blas_param->inv_stride;
+  if (min_stride < 0) { errorQuda("BLAS strides must be positive or zero: inv_stride=%d", blas_param->inv_stride); }
 
   // If the user passes a negative offset, we error out as this has no meaning.
-  int min_offset = blas_param->a_offset;
-  if (min_offset < 0) { errorQuda("BLAS offsets must be positive or zero: a_offset=%d\n", blas_param->a_offset); }
+  int min_offset = blas_param->inv_offset;
+  if (min_offset < 0) { errorQuda("BLAS offsets must be positive or zero: inv_offset=%d\n", blas_param->inv_offset); }
 
   // If the batch value is non-positve, we error out
   if (blas_param->batch_count <= 0) { errorQuda("Batches must be positive: batches=%d", blas_param->batch_count); }
@@ -342,8 +342,8 @@ double blasLUInvEigenVerify(void *ref_array, void *dev_inv_array, uint64_t array
   // Parse parameters for Eigen
   //-------------------------------------------------------------------------
   // Problem parameters
-  int a_stride = blas_param->a_stride;
-  int a_offset = blas_param->a_offset;
+  int inv_stride = blas_param->inv_stride;
+  int inv_offset = blas_param->inv_offset;
   int batches = blas_param->batch_count;
   int mat_rank = blas_param->inv_mat_size;
 
@@ -359,7 +359,7 @@ double blasLUInvEigenVerify(void *ref_array, void *dev_inv_array, uint64_t array
 
   // Get maximum stride length to deduce the number of batches in the
   // computation
-  int max_stride = a_stride;
+  int max_stride = inv_stride;
 
   // If the user gives strides of 0 for all arrays, we are essentially performing
   // an LU inversion on the first matrices in the array N_{batch} times.
@@ -374,8 +374,8 @@ double blasLUInvEigenVerify(void *ref_array, void *dev_inv_array, uint64_t array
   for (int batch = 0; batch < batches; batch += max_stride) {
 
     // Populate Eigen objects
-    fillEigenArray(ref, ref_ptr, mat_rank, mat_rank, mat_rank, a_offset);
-    fillEigenArray(dev_inv, dev_inv_ptr, mat_rank, mat_rank, mat_rank, a_offset);
+    fillEigenArray(ref, ref_ptr, mat_rank, mat_rank, mat_rank, inv_offset);
+    fillEigenArray(dev_inv, dev_inv_ptr, mat_rank, mat_rank, mat_rank, inv_offset);
 
     // Check Eigen result against blas
     ref_inv = ref.inverse();

--- a/tests/host_reference/blas_reference.cpp
+++ b/tests/host_reference/blas_reference.cpp
@@ -366,8 +366,8 @@ double blasLUInvEigenVerify(void *ref_array, void *dev_inv_array, uint64_t array
     double relative_deviation = deviation / ref_inv.norm();
     max_relative_deviation = std::max(max_relative_deviation, relative_deviation);
 
-    printfQuda("batch %d: (ref_inv - dev_inv) Frobenius norm = %e. Relative deviation = %e\n", batch,
-               deviation, relative_deviation);
+    printfQuda("batch %d: (ref_inv - dev_inv) Frobenius norm = %e. Relative deviation = %e\n", batch, deviation,
+               relative_deviation);
 
     offset += array_size;
   }

--- a/tests/host_reference/blas_reference.cpp
+++ b/tests/host_reference/blas_reference.cpp
@@ -388,7 +388,7 @@ double blasLUInvEigenVerify(void *ref_array, void *dev_inv_array, uint64_t array
     printfQuda("batch %d: (ref_inv_host - dev_inv_gpu) Frobenius norm = %e. Relative deviation = %e\n", batch,
                deviation, relative_deviation);
 
-    a_offset += array_size * a_stride;
+    inv_offset += array_size * inv_stride;
   }
 
   return max_relative_deviation;
@@ -404,7 +404,7 @@ double blasLUInvQudaVerify(void *ref_array, void *dev_array_inv, uint64_t array_
   // If the user passes non-zero offsets, add one extra
   // matrix to the test data.
   int batches_extra = 0;
-  if (blas_param->a_offset + blas_param->b_offset + blas_param->c_offset > 0) { batches_extra++; }
+  if (blas_param->inv_offset > 0) { batches_extra++; }
   int batches = blas_param->batch_count + batches_extra;
 
   // Copy data from problem sized array to reference sized array.

--- a/tests/host_reference/blas_reference.h
+++ b/tests/host_reference/blas_reference.h
@@ -5,4 +5,5 @@ double blasLUInvQudaVerify(void *ref_array, void *dev_array_inv, uint64_t array_
 
 void prepare_ref_array(void *array, int batches, uint64_t array_size, size_t data_size, QudaBLASDataType data_type);
 
-void copy_array(void *array_out, void *array_in, int batches, uint64_t array_size, size_t data_out_size, QudaBLASDataType data_type);
+void copy_array(void *array_out, void *array_in, int batches, uint64_t array_size, size_t data_out_size,
+                QudaBLASDataType data_type);

--- a/tests/host_reference/blas_reference.h
+++ b/tests/host_reference/blas_reference.h
@@ -1,2 +1,8 @@
 double blasGEMMQudaVerify(void *arrayA, void *arrayB, void *arrayC, void *arrayCcopy, uint64_t refA_size,
                           uint64_t refB_size, uint64_t refC_size, QudaBLASParam *blas_param);
+
+double blasLUInvQudaVerify(void *ref_array, void *dev_array_inv, uint64_t array_size, QudaBLASParam *blas_param);
+
+void prepare_ref_array(void *array, int batches, uint64_t array_size, size_t data_size, QudaBLASDataType data_type);
+
+void copy_array(void *array_out, void *array_in, int batches, uint64_t array_size, size_t data_out_size, QudaBLASDataType data_type);

--- a/tests/utils/misc.cpp
+++ b/tests/utils/misc.cpp
@@ -358,6 +358,17 @@ std::string get_dilution_type_str(QudaDilutionType type)
   case QUDA_DILUTION_SPIN_COLOR_EVEN_ODD: s = std::string("spin_color_even_odd"); break;
   default: fprintf(stderr, "Error: invalid dilution type\n"); exit(1);
   }
+  return s;
+}
+  
+const char *get_blas_type_str(QudaBLASType type)
+{
+  const char *s;
 
+  switch (type) {
+  case QUDA_BLAS_GEMM: s = "gemm"; break;
+  case QUDA_BLAS_LU_INV: s = "lu-inv"; break;    
+  default: fprintf(stderr, "Error: invalid BLAS type\n"); exit(1);
+  }
   return s;
 }

--- a/tests/utils/misc.cpp
+++ b/tests/utils/misc.cpp
@@ -360,14 +360,14 @@ std::string get_dilution_type_str(QudaDilutionType type)
   }
   return s;
 }
-  
+
 const char *get_blas_type_str(QudaBLASType type)
 {
   const char *s;
 
   switch (type) {
   case QUDA_BLAS_GEMM: s = "gemm"; break;
-  case QUDA_BLAS_LU_INV: s = "lu-inv"; break;    
+  case QUDA_BLAS_LU_INV: s = "lu-inv"; break;
   default: fprintf(stderr, "Error: invalid BLAS type\n"); exit(1);
   }
   return s;

--- a/tests/utils/misc.h
+++ b/tests/utils/misc.h
@@ -24,6 +24,7 @@ const char *get_memory_type_str(QudaMemoryType type);
 const char *get_contract_str(QudaContractType type);
 const char *get_gauge_smear_str(QudaGaugeSmearType type);
 std::string get_dilution_type_str(QudaDilutionType type);
+const char *get_blas_type_str(QudaBLASType type);
 
 #define XUP 0
 #define YUP 1


### PR DESCRIPTION
This PR adds complex double and complex single batched, strided inversion via LU decomposition on the device. The test file 'blas_interface_test.cpp` invokes the test via:
```
./blas_interface_test --blas-test-type lu-inv --blas-lu-inv-mat-size <N>  --blas-data-type <C/Z>
``` 
where `<N>` is rank of the square matrix.

GEMM command line parameters and QUDA param struct values now contain the respective strings `-gemm-` and `_gemm_` to delineate.

For the LU inversion we allow a tolerance of 5000x of the `std::numeric_limits<float/double>::epsilon();` to account for the near degeneracy/singularities introduced by pure random data, as well as minor variations between host and device algorithms and order of arithmetic operations.

The ctest suite has been updated to include the new BLAS functions, and can be invoked (for the blas test only) via
```
ctest -R blas_interface_test -V
```