### PR TITLE
Added -O3 back to RELEASE CXX flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,7 +324,7 @@ set(CMAKE_CXX_FLAGS_STRICT
   "-O3"
   CACHE STRING "Flags used by the C++ compiler during strict jenkins builds.")
 set(CMAKE_CXX_FLAGS_RELEASE
-  "-O3 -w ${CXX_OPT}"
+  "-O3 ${CXX_OPT}"
   CACHE STRING "Flags used by the C++ compiler during release builds.")
 set(CMAKE_CXX_FLAGS_HOSTDEBUG
     "-g"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,7 +324,7 @@ set(CMAKE_CXX_FLAGS_STRICT
   "-O3"
   CACHE STRING "Flags used by the C++ compiler during strict jenkins builds.")
 set(CMAKE_CXX_FLAGS_RELEASE
-  "${CXX_OPT}"
+  "-O3 -w ${CXX_OPT}"
   CACHE STRING "Flags used by the C++ compiler during release builds.")
 set(CMAKE_CXX_FLAGS_HOSTDEBUG
     "-g"


### PR DESCRIPTION
This hotfix re-introduces the `-O3 flag` back to *.cu files in RELEASE builds, accidentally removed in #1306 