### PR TITLE
Add gaussMomQuda to quda.h.

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ Advanced Scientific Computing (PASC21) [arXiv:2104.05615[hep-lat]].
 *  Steven Gottlieb (Indiana University) 
 *  Kyriakos Hadjiyiannakou (Cyprus)
 *  Dean Howarth (Lawrence Livermore Lab, Lawrence Berkeley Lab)
+*  Xiangyu Jiang (Chinese Academy of Sciences)
 *  Balint Joo (OLCF, Oak Ridge National Laboratory, formerly Jefferson Lab)
 *  Hyung-Jin Kim (Samsung Advanced Institute of Technology)
 *  Bartosz Kostrzewa (HPC/A-Lab, University of Bonn)

--- a/include/kernels/gauge_random.cuh
+++ b/include/kernels/gauge_random.cuh
@@ -46,7 +46,7 @@ namespace quda {
       rand1[i] = uniform<real>::rand(localState);
       rand2[i] = uniform<real>::rand(localState);
       phi[i] = 2.0 * rand1[i];
-      radius[i] = sqrt(-2.0 * log(rand2[i]));
+      radius[i] = sqrt(-log(rand2[i]));
       quda::sincospi(phi[i], &temp2[i], &temp1[i]);
       temp1[i] *= radius[i];
       temp2[i] *= radius[i];

--- a/include/kernels/gauge_random.cuh
+++ b/include/kernels/gauge_random.cuh
@@ -46,7 +46,7 @@ namespace quda {
       rand1[i] = uniform<real>::rand(localState);
       rand2[i] = uniform<real>::rand(localState);
       phi[i] = 2.0 * rand1[i];
-      radius[i] = sqrt(-log(rand2[i]));
+      radius[i] = sqrt(-2.0 * log(rand2[i]));
       quda::sincospi(phi[i], &temp2[i], &temp1[i]);
       temp1[i] *= radius[i];
       temp2[i] *= radius[i];

--- a/include/quda.h
+++ b/include/quda.h
@@ -1542,16 +1542,28 @@ extern "C" {
 
   /**
      @brief Generate Gaussian distributed fields and store in the
-     resident gauge field.  We create a Gaussian-distributed su(n)
+     resident gauge field. We create a Gaussian-distributed su(n)
      field and exponentiate it, e.g., U = exp(sigma * H), where H is
-     the distributed su(n) field and beta is the width of the
-     distribution (beta = 0 results in a free field, and sigma = 1 has
+     the distributed su(n) field and sigma is the width of the
+     distribution (sigma = 0 results in a free field, and sigma = 1 has
      maximum disorder).
 
      @param seed The seed used for the RNG
      @param sigma Width of Gaussian distrubution
   */
   void gaussGaugeQuda(unsigned long long seed, double sigma);
+
+  /**
+   * @brief Generate Gaussian distributed fields and store in the
+   * resident momentum field. We create a Gaussian-distributed su(n)
+   * field, e.g., sigma * H, where H is the distributed su(n) field
+   * and sigma is the width of the distribution (sigma = 0 results
+   * in a free field, and sigma = 1 has maximum disorder).
+   *
+   * @param seed The seed used for the RNG
+   * @param sigma Width of Gaussian distrubution
+   */
+  void gaussMomQuda(unsigned long long seed, double sigma);
 
   /**
    * Computes the total, spatial and temporal plaquette averages of the loaded gauge configuration.

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -5194,11 +5194,6 @@ void gaussGaugeQuda(unsigned long long seed, double sigma)
 
   cudaGaugeField *data = gaugePrecise;
 
-  GaugeFieldParam param(*data);
-  param.reconstruct = QUDA_RECONSTRUCT_12;
-  param.ghostExchange = QUDA_GHOST_EXCHANGE_NO;
-  cudaGaugeField u(param);
-
   profileGauss.TPSTART(QUDA_PROFILE_COMPUTE);
   quda::gaugeGauss(*data, seed, sigma);
   profileGauss.TPSTOP(QUDA_PROFILE_COMPUTE);

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -5211,6 +5211,21 @@ void gaussGaugeQuda(unsigned long long seed, double sigma)
   profileGauss.TPSTOP(QUDA_PROFILE_TOTAL);
 }
 
+void gaussMomQuda(unsigned long long seed, double sigma)
+{
+  profileGauss.TPSTART(QUDA_PROFILE_TOTAL);
+
+  if (!momResident) errorQuda("Cannot generate Gauss GaugeField as there is no resident momentum field");
+
+  cudaGaugeField *data = momResident;
+
+  profileGauss.TPSTART(QUDA_PROFILE_COMPUTE);
+  quda::gaugeGauss(*data, seed, sigma);
+  profileGauss.TPSTOP(QUDA_PROFILE_COMPUTE);
+
+  profileGauss.TPSTOP(QUDA_PROFILE_TOTAL);
+}
+
 /*
  * Computes the total, spatial and temporal plaquette averages of the loaded gauge configuration.
  */


### PR DESCRIPTION
Recently I'm trying to implement a full GPU HMC routine with QUDA. I can only access functions in `quda.h` as I'm not using C++ to write the code. I noticed `gaussGauge` can be applied to the momentum field but there is no interface in `quda.h`.

This PR added a function to call `gaussGauge` on the resident momentum field.