### PR TITLE
Fix crash while using computeGaugeLoopTraceQuda.

### DIFF
--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -5253,10 +5253,8 @@ void computeGaugeLoopTraceQuda(double _Complex *traces, int **input_path_buf, in
 {
   if (!gaugePrecise) errorQuda("Cannot compute gauge loop traces as there is no resident gauge field");
 
-  if (extendedGaugeResident) {
-    delete extendedGaugeResident;
-    extendedGaugeResident = createExtendedGauge(*gaugePrecise, R, profileGaugeObs);
-  }
+  if (extendedGaugeResident) delete extendedGaugeResident;
+  extendedGaugeResident = createExtendedGauge(*gaugePrecise, R, profileGaugeObs);
 
   // informed by gauge path code; apply / remove gauge as appropriate
   if (extendedGaugeResident->StaggeredPhaseApplied()) extendedGaugeResident->removeStaggeredPhase();


### PR DESCRIPTION
QUDA will crash when calling `computeGaugeLoopTraceQuda` if `extendedGaugeResident` is not set. For example, this will happen if you call `computeGaugeLoopTraceQuda` just after `loadGaugeQuda`.

This PR fixed the issue.