### PR TITLE
Hotfix for weird heavy quark residual behavior during MG setup

### DIFF
--- a/lib/inv_cg_quda.cpp
+++ b/lib/inv_cg_quda.cpp
@@ -567,7 +567,7 @@ namespace quda {
         }
 
         // if L2 broke down already we turn off reliable updates and restart the CG
-        if (ru.reliable_heavy_quark_break(L2breakdown, heavy_quark_res, heavy_quark_res_old, heavy_quark_restart)) {
+        if (use_heavy_quark_res && ru.reliable_heavy_quark_break(L2breakdown, heavy_quark_res, heavy_quark_res_old, heavy_quark_restart)) {
           break;
         }
 


### PR DESCRIPTION
This narrow PR is a hotfix for the issue reported in #1323. I had hit this issue previously and fixed it in #1283 (which has not yet been merged), commit https://github.com/lattice/quda/commit/f954cec3b97ba65add2736301eae3b5d02b575ae . I assumed, at the time, that the need for that fix was related to my other changes in MG setup and not something already lurking in `develop` (or maybe something introduced since then), which is why I didn't make a hotfix branch in the first place.

That commit is much bigger than just the narrow heavy quark residual fix so it can't just be "cherry-pick"ed out.

While this issue appearing is indeed weird, I think the logic of the fix is reasonable, so I don't see a need to investigate it more deeply at this time.