### PR TITLE
Removed '#include <complex.h>'

### DIFF
--- a/tests/gauge_path_test.cpp
+++ b/tests/gauge_path_test.cpp
@@ -11,7 +11,6 @@
 #include <gauge_path_quda.h>
 #include <timer.h>
 #include <gtest/gtest.h>
-#include <complex>
 
 static QudaGaugeFieldOrder gauge_order = QUDA_QDP_GAUGE_ORDER;
 

--- a/tests/gauge_path_test.cpp
+++ b/tests/gauge_path_test.cpp
@@ -1,7 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <complex.h>
 
 #include <quda.h>
 #include <host_utils.h>
@@ -12,6 +11,7 @@
 #include <gauge_path_quda.h>
 #include <timer.h>
 #include <gtest/gtest.h>
+#include <complex>
 
 static QudaGaugeFieldOrder gauge_order = QUDA_QDP_GAUGE_ORDER;
 


### PR DESCRIPTION
To avoid a #define conflict between <complex.h> and gtest.h when using hipcc compiler. This fixes a local issue Venkitesh Ayyar raised on Crysger at OLCF which prevented `gauge_path_test.cpp` from compiling with the following #define clash:

```
shared/ayyar/builds_crusher/install_oct17_2022/QUDA/src/quda/tests/googletest/include/gtest/internal/gtest-internal.h:1154:21: error: expected ')'
template <size_t... I, size_t sizeofT>
                    ^
/usr/include/complex.h:53:11: note: expanded from macro 'I'
#define I _Complex_I
          ^
/usr/include/complex.h:48:21: note: expanded from macro '_Complex_I'
#define _Complex_I      (__extension__ 1.0iF)
                         ^
/gpfs/alpine/lgt104/proj-shared/ayyar/builds_crusher/install_oct17_2022/QUDA/src/quda/tests/googletest/include/gtest/internal/gtest-internal.h:1154:21: note: to match this '('
/usr/include/complex.h:53:11: note: expanded from macro 'I'
#define I _Complex_I
          ^
/usr/include/complex.h:48:20: note: expanded from macro '_Complex_I'
#define _Complex_I      (__extension__ 1.0iF)
```

Also I changed from `#include <complex.h>` to the more C++
`#include <complex>`
