### PR TITLE
Hotfix to fix compilation on Summit

### DIFF
--- a/lib/targets/cuda/target_cuda.cmake
+++ b/lib/targets/cuda/target_cuda.cmake
@@ -47,17 +47,17 @@ set(CMAKE_CUDA_FLAGS_STRICT
     "-O3"
     CACHE STRING "Flags used by the CUDA compiler during strict jenkins builds.")
 set(CMAKE_CUDA_FLAGS_RELEASE
-    "-O3 ${CXX_OPT}"
+    "-O3 -Xcompiler \"${CXX_OPT}\""
     CACHE STRING "Flags used by the CUDA compiler during release builds.")
 set(CMAKE_CUDA_FLAGS_HOSTDEBUG
     "-g"
-    CACHE STRING "Flags used by the C++ compiler during host-debug builds.")
+    CACHE STRING "Flags used by the CUDA compiler during host-debug builds.")
 set(CMAKE_CUDA_FLAGS_DEBUG
     "-G -g -fno-inline"
-    CACHE STRING "Flags used by the C++ compiler during full (host+device) debug builds.")
+    CACHE STRING "Flags used by the CUDA compiler during full (host+device) debug builds.")
 set(CMAKE_CUDA_FLAGS_SANITIZE
     "-g -fno-inline \"-fsanitize=address,undefined\" "
-    CACHE STRING "Flags used by the C++ compiler during sanitizer debug builds.")
+    CACHE STRING "Flags used by the CUDA compiler during sanitizer debug builds.")
 
 mark_as_advanced(CMAKE_CUDA_FLAGS_DEVEL)
 mark_as_advanced(CMAKE_CUDA_FLAGS_STRICT)


### PR DESCRIPTION
This narrow hotfix PR addresses an issue with compilation that only seemed to creep up on Summit, where the cmake internal variable `CXX_OPT` caused compiler errors (seemingly unrelated to the specialization of `CXX_OPT` for Power9). The issue appeared with https://github.com/lattice/quda/commit/738e4be0f0ce56a7ee33c6cf8af2d70f8a53fa3b (which needs the subsequent commit, https://github.com/lattice/quda/commit/63182d6bfe58ed1a96399f86ebdce13bbd176792 , to compile).

I confirmed that this fixes the compile-time issue on Summit, and "does no harm" on `x86` as verified by looking at the outputs from a `--verbose` compile of QUDA through `nvcc`.

I also fixed a few harmless typos in `CMakeLists.txt`.