### PR TITLE
Fix crash in computeCloverForceQuda.

### DIFF
--- a/include/kernels/clover_outer_product.cuh
+++ b/include/kernels/clover_outer_product.cuh
@@ -73,10 +73,10 @@ namespace quda {
           Spinor B_shift = arg.inB(nbr_idx, 0);
           Spinor D_shift = arg.inD(nbr_idx, 0);
 
-          B_shift = (B_shift.project(dim,1)).reconstruct(dim,1);
+          B_shift = (B_shift.project(dim,-1)).reconstruct(dim,-1);
           Link result = outerProdSpinTrace(B_shift,A);
 
-          D_shift = (D_shift.project(dim,-1)).reconstruct(dim,-1);
+          D_shift = (D_shift.project(dim,1)).reconstruct(dim,1);
           result += outerProdSpinTrace(D_shift,C);
 
           Link temp = arg.force(dim, x_cb, arg.parity);

--- a/include/kernels/clover_trace.cuh
+++ b/include/kernels/clover_trace.cuh
@@ -19,7 +19,7 @@ namespace quda {
     real coeff;
 
     CloverTraceArg(GaugeField& output, const CloverField& clover, double coeff) :
-      kernel_param(dim3(clover.VolumeCB(), 1, 1)),
+      kernel_param(dim3(output.VolumeCB(), 1, 1)),
       output(output),
       clover1(clover, 0),
       clover2(clover, 1),
@@ -31,8 +31,9 @@ namespace quda {
   {
     using real = typename Arg::real;
     real A[72];
-    if (parity==0) arg.clover1.load(A,x,parity);
-    else arg.clover2.load(A,x,parity);
+    // if (parity==0) arg.clover1.load(A,x,parity);
+    // else arg.clover2.load(A,x,parity);
+    arg.clover1.load(A,x,parity);
 
     // load the clover term into memory
     for (int mu=0; mu<4; mu++) {

--- a/include/kernels/clover_trace.cuh
+++ b/include/kernels/clover_trace.cuh
@@ -1,35 +1,67 @@
 #pragma once
 
+#include "clover_field.h"
+#include "complex_quda.h"
+#include "util_quda.h"
+#include <cstring>
 #include <quda_matrix.h>
 #include <gauge_field_order.h>
 #include <clover_field_order.h>
 #include <kernel.h>
+#include <linalg.cuh>
 
 namespace quda {
 
-  template <typename Float, int nColor_>
+  template <typename Float, int nColor_, bool twist_>
   struct CloverTraceArg : kernel_param<> {
     using real = typename mapper<Float>::type;
+    static constexpr bool twist = twist_;
     static constexpr int nColor = nColor_;
+    static constexpr int nSpin = 4;
+    static constexpr bool dynamic_clover = clover::dynamic_inverse();
     using C = typename clover_mapper<Float>::type;
     using G = typename gauge_mapper<Float, QUDA_RECONSTRUCT_NO>::type;
     G output;
-    const C clover;
+    const C clover_inv;
     real coeff;
+    real mu2_minus_epsilon2;
 
     CloverTraceArg(GaugeField& output, const CloverField& clover, double coeff) :
       kernel_param(dim3(output.VolumeCB(), 1, 1)),
       output(output),
-      clover(clover, 0),
-      coeff(coeff) {}
+      clover_inv(clover, dynamic_clover ? false : true),
+      coeff(coeff),
+      mu2_minus_epsilon2(clover.Mu2() - clover.Epsilon2()) {}
   };
 
   template <typename Arg>
   __device__ __host__ void cloverSigmaTraceCompute(const Arg &arg, const int x, int parity)
   {
+    using namespace linalg; // for Cholesky
     using real = typename Arg::real;
-    real A[72];
-    arg.clover.load(A,x,parity);
+    constexpr int N = Arg::nColor * Arg::nSpin / 2;
+    using Mat = HMatrix<real, N>;
+    real A_array[72];
+
+#pragma unroll
+    for (int chirality = 0; chirality < 2; chirality++) {
+      Mat A = arg.clover_inv(x, parity, chirality);
+
+      if (Arg::dynamic_clover) {
+        A *= static_cast<real>(2.0); // factor of two is inherent to QUDA clover storage
+
+        if (Arg::twist) { // Compute (T^2 + mu2 - epsilon2) first, then invert
+          A = A.square();
+          A += arg.mu2_minus_epsilon2;
+        }
+
+        // compute the Cholesky decomposition
+        Cholesky<HMatrix, clover::cholesky_t<real>, N> cholesky(A);
+        A = static_cast<real>(0.5) * cholesky.template invert<Mat>(); // return full inverse
+      }
+
+      for (int i = 0; i < 36; ++i) A_array[chirality * 36 + i] = A.data[i];
+    }
 
     // load the clover term into memory
     for (int mu=0; mu<4; mu++) {
@@ -45,8 +77,8 @@ namespace quda {
 
         for (int ch=0; ch<2; ++ch) {
           // factor of two is inherent to QUDA clover storage
-          for (int i=0; i<6; i++) diag[ch][i] = 2.0*A[ch*36+i];
-          for (int i=0; i<15; i++) tri[ch][idtab[i]] = complex<real>(2.0*A[ch*36+6+2*i], 2.0*A[ch*36+6+2*i+1]);
+          for (int i=0; i<6; i++) diag[ch][i] = 2.0*A_array[ch*36+i];
+          for (int i=0; i<15; i++) tri[ch][idtab[i]] = complex<real>(2.0*A_array[ch*36+6+2*i], 2.0*A_array[ch*36+6+2*i+1]);
         }
 
         // X, Y

--- a/include/kernels/clover_trace.cuh
+++ b/include/kernels/clover_trace.cuh
@@ -14,15 +14,13 @@ namespace quda {
     using C = typename clover_mapper<Float>::type;
     using G = typename gauge_mapper<Float, QUDA_RECONSTRUCT_NO>::type;
     G output;
-    const C clover1;
-    const C clover2;
+    const C clover;
     real coeff;
 
     CloverTraceArg(GaugeField& output, const CloverField& clover, double coeff) :
       kernel_param(dim3(output.VolumeCB(), 1, 1)),
       output(output),
-      clover1(clover, 0),
-      clover2(clover, 1),
+      clover(clover, 0),
       coeff(coeff) {}
   };
 
@@ -31,9 +29,7 @@ namespace quda {
   {
     using real = typename Arg::real;
     real A[72];
-    // if (parity==0) arg.clover1.load(A,x,parity);
-    // else arg.clover2.load(A,x,parity);
-    arg.clover1.load(A,x,parity);
+    arg.clover.load(A,x,parity);
 
     // load the clover term into memory
     for (int mu=0; mu<4; mu++) {

--- a/include/kernels/clover_trace.cuh
+++ b/include/kernels/clover_trace.cuh
@@ -1,9 +1,5 @@
 #pragma once
 
-#include "clover_field.h"
-#include "complex_quda.h"
-#include "util_quda.h"
-#include <cstring>
 #include <quda_matrix.h>
 #include <gauge_field_order.h>
 #include <clover_field_order.h>

--- a/lib/clover_outer_product.cu
+++ b/lib/clover_outer_product.cu
@@ -1,4 +1,3 @@
-#include <enum_quda.h>
 #include <dslash_quda.h>
 #include <tunable_nd.h>
 #include <instantiate.h>
@@ -47,10 +46,10 @@ namespace quda {
         if (!commDimPartitioned(i)) continue;
         strcpy(aux, aux2);
         strcat(aux, ",exterior");
-        if (i==0) strcat(aux, ",dir=0");
-        else if (i==1) strcat(aux, ",dir=1");
-        else if (i==2) strcat(aux, ",dir=2");
-        else if (i==3) strcat(aux, ",dir=3");
+        if (dir==0) strcat(aux, ",dir=0");
+        else if (dir==1) strcat(aux, ",dir=1");
+        else if (dir==2) strcat(aux, ",dir=2");
+        else if (dir==3) strcat(aux, ",dir=3");
         kernel = EXTERIOR;
         dir = i;
         apply(device::get_default_stream());
@@ -143,6 +142,10 @@ namespace quda {
     int dag = 1;
 
     for (unsigned int i=0; i<x.size(); i++) {
+      x[i]->Even().allocateGhostBuffer(1);
+      x[i]->Odd().allocateGhostBuffer(1);
+      p[i]->Even().allocateGhostBuffer(1);
+      p[i]->Odd().allocateGhostBuffer(1);
 
       for (int parity=0; parity<2; parity++) {
 	ColorSpinorField& inA = (parity&1) ? p[i]->Odd() : p[i]->Even();
@@ -150,8 +153,8 @@ namespace quda {
 	ColorSpinorField& inC = (parity&1) ? x[i]->Odd() : x[i]->Even();
 	ColorSpinorField& inD = (parity&1) ? p[i]->Even(): p[i]->Odd();
 
-        inB.exchangeGhost(parity ? QUDA_ODD_PARITY : QUDA_EVEN_PARITY, 1, dag);
-        inD.exchangeGhost(parity ? QUDA_ODD_PARITY : QUDA_EVEN_PARITY, 1, 1 - dag);
+        exchangeGhost(inB, parity, dag);
+        exchangeGhost(inD, parity, 1-dag);
 
         instantiate<CloverForce, ReconstructNo12>(U, force, inA, inB, inC, inD, parity, coeff[i]);
       }

--- a/lib/clover_outer_product.cu
+++ b/lib/clover_outer_product.cu
@@ -1,3 +1,4 @@
+#include <enum_quda.h>
 #include <dslash_quda.h>
 #include <tunable_nd.h>
 #include <instantiate.h>
@@ -46,10 +47,10 @@ namespace quda {
         if (!commDimPartitioned(i)) continue;
         strcpy(aux, aux2);
         strcat(aux, ",exterior");
-        if (dir==0) strcat(aux, ",dir=0");
-        else if (dir==1) strcat(aux, ",dir=1");
-        else if (dir==2) strcat(aux, ",dir=2");
-        else if (dir==3) strcat(aux, ",dir=3");
+        if (i==0) strcat(aux, ",dir=0");
+        else if (i==1) strcat(aux, ",dir=1");
+        else if (i==2) strcat(aux, ",dir=2");
+        else if (i==3) strcat(aux, ",dir=3");
         kernel = EXTERIOR;
         dir = i;
         apply(device::get_default_stream());
@@ -142,10 +143,6 @@ namespace quda {
     int dag = 1;
 
     for (unsigned int i=0; i<x.size(); i++) {
-      x[i]->Even().allocateGhostBuffer(1);
-      x[i]->Odd().allocateGhostBuffer(1);
-      p[i]->Even().allocateGhostBuffer(1);
-      p[i]->Odd().allocateGhostBuffer(1);
 
       for (int parity=0; parity<2; parity++) {
 	ColorSpinorField& inA = (parity&1) ? p[i]->Odd() : p[i]->Even();
@@ -153,8 +150,8 @@ namespace quda {
 	ColorSpinorField& inC = (parity&1) ? x[i]->Odd() : x[i]->Even();
 	ColorSpinorField& inD = (parity&1) ? p[i]->Even(): p[i]->Odd();
 
-        exchangeGhost(inB, parity, dag);
-        exchangeGhost(inD, parity, 1-dag);
+        inB.exchangeGhost(parity ? QUDA_ODD_PARITY : QUDA_EVEN_PARITY, 1, dag);
+        inD.exchangeGhost(parity ? QUDA_ODD_PARITY : QUDA_EVEN_PARITY, 1, 1 - dag);
 
         instantiate<CloverForce, ReconstructNo12>(U, force, inA, inB, inC, inD, parity, coeff[i]);
       }

--- a/lib/clover_trace_quda.cu
+++ b/lib/clover_trace_quda.cu
@@ -28,6 +28,9 @@ namespace quda {
       launch<CloverSigmaTr>(tp, stream, CloverTraceArg<Float, nColor>(output, clover, coeff));
     }
 
+    void preTune() { output.backup(); }
+    void postTune() { output.restore(); }
+
     long long flops() const { return 0; } // Fix this
     long long bytes() const { return clover.Bytes() + output.Bytes(); }
   };

--- a/lib/clover_trace_quda.cu
+++ b/lib/clover_trace_quda.cu
@@ -25,7 +25,14 @@ namespace quda {
 
     void apply(const qudaStream_t &stream){
       TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
-      launch<CloverSigmaTr>(tp, stream, CloverTraceArg<Float, nColor>(output, clover, coeff));
+      if (clover.TwistFlavor() == QUDA_TWIST_SINGLET ||
+          clover.TwistFlavor() == QUDA_TWIST_NONDEG_DOUBLET) {
+        CloverTraceArg<Float, nColor, true> arg(output, clover, coeff);
+        launch<CloverSigmaTr>(tp, stream, arg);
+      } else {
+        CloverTraceArg<Float, nColor, false> arg(output, clover, coeff);
+        launch<CloverSigmaTr>(tp, stream, arg);
+      }
     }
 
     void preTune() { output.backup(); }

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -4876,8 +4876,6 @@ void computeCloverForceQuda(void *h_mom, double dt, void **h_x, void **, double 
   cloverDerivative(cudaForce, *u, *oprodEx, 1.0, QUDA_ODD_PARITY);
   cloverDerivative(cudaForce, *u, *oprodEx, 1.0, QUDA_EVEN_PARITY);
 
-  if (u != &gaugeEx) delete u;
-
   updateMomentum(*cudaMom, -1.0, cudaForce, "clover");
   profileCloverForce.TPSTOP(QUDA_PROFILE_COMPUTE);
 
@@ -4886,6 +4884,9 @@ void computeCloverForceQuda(void *h_mom, double dt, void **h_x, void **, double 
   }
 
   profileCloverForce.TPSTART(QUDA_PROFILE_FREE);
+
+  if (u != &gaugeEx) delete u;
+  delete oprodEx;
 
   if (gauge_param->make_resident_mom) {
     if (momResident != nullptr && momResident != cudaMom) delete momResident;

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -4803,8 +4803,6 @@ void computeCloverForceQuda(void *h_mom, double dt, void **h_x, void **, double 
 		solutionResident.size(), nvector);
   }
 
-  cudaGaugeField &gaugeEx = *extendedGaugeResident;
-
   // create oprod and trace fields
   fParam.geometry = QUDA_TENSOR_GEOMETRY;
   cudaGaugeField oprod(fParam);
@@ -4849,6 +4847,12 @@ void computeCloverForceQuda(void *h_mom, double dt, void **h_x, void **, double 
   }
 
   computeCloverForce(cudaForce, *gaugePrecise, quarkX, quarkP, force_coeff);
+
+  // Make sure extendedGaugeResident has the correct R
+  // TODO: In most situation, deallocation is unnecessery
+  if (extendedGaugeResident) delete extendedGaugeResident;
+  extendedGaugeResident = createExtendedGauge(*gaugePrecise, R, profileGaugeForce);
+  cudaGaugeField &gaugeEx = *extendedGaugeResident;
 
   // In double precision the clover derivative is faster with no reconstruct
   cudaGaugeField *u = &gaugeEx;

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -4829,7 +4829,7 @@ void computeCloverForceQuda(void *h_mom, double dt, void **h_x, void **, double 
       profileCloverForce.TPSTOP(QUDA_PROFILE_H2D);
 
       profileCloverForce.TPSTART(QUDA_PROFILE_COMPUTE);
-      gamma5(x.Even(), x.Even());
+      // gamma5(x.Even(), x.Even());
     } else {
       x.Even() = solutionResident[i];
     }
@@ -4840,8 +4840,8 @@ void computeCloverForceQuda(void *h_mom, double dt, void **h_x, void **, double 
     dirac->Dslash(p.Odd(), p.Even(), QUDA_ODD_PARITY);
     dirac->Dagger(QUDA_DAG_NO);
 
-    gamma5(x, x);
-    gamma5(p, p);
+    // gamma5(x, x);
+    // gamma5(p, p);
 
     force_coeff[i] = 2.0*dt*coeff[i]*kappa2;
   }
@@ -5000,6 +5000,8 @@ void updateGaugeFieldQuda(void* gauge,
   if (param->make_resident_gauge) {
     if (gaugePrecise != nullptr) delete gaugePrecise;
     gaugePrecise = cudaOutGauge;
+    if (extendedGaugeResident) delete extendedGaugeResident;
+    extendedGaugeResident = createExtendedGauge(*gaugePrecise, R, profileGaugeForce);
   } else {
     delete cudaOutGauge;
   }

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -4735,13 +4735,13 @@ void computeCloverForceQuda(void *h_mom, double dt, void **h_x, void **, double 
   fParam.location = QUDA_CPU_FIELD_LOCATION;
   fParam.reconstruct = QUDA_RECONSTRUCT_10;
   fParam.order = gauge_param->gauge_order;
-  cpuGaugeField *cpuMom = !gauge_param->use_resident_gauge ? new cpuGaugeField(fParam) : nullptr;
+  cpuGaugeField *cpuMom = !gauge_param->use_resident_mom ? new cpuGaugeField(fParam) : nullptr;
 
   // create the device momentum field
   fParam.location = QUDA_CUDA_FIELD_LOCATION;
   fParam.create = QUDA_ZERO_FIELD_CREATE;
   fParam.order = QUDA_FLOAT2_GAUGE_ORDER;
-  cudaGaugeField *cudaMom = !gauge_param->use_resident_gauge ? new cudaGaugeField(fParam) : nullptr;
+  cudaGaugeField *cudaMom = !gauge_param->use_resident_mom ? new cudaGaugeField(fParam) : nullptr;
 
   if (gauge_param->use_resident_mom) {
     if (!momResident) errorQuda("No resident mom field allocated");


### PR DESCRIPTION
This might solve crashes in https://github.com/lattice/quda/pull/1330 and https://github.com/lattice/quda/pull/1338, @kostrzewa @Marcogarofalo could you please check this out?

The problem happens in `cloverSigmaTraceCompute`. It seems that `arg.clover2.load(A,x,parity)` is always called, and `clover2(clover, 1)` makes `clover2` here initialized as the inverse of the input clover field. Not sure if I understand the meaning of parameters right.

More tests for correctness are needed.