### PR TITLE
Hotfix/mpi string

### DIFF
--- a/include/comm_quda.h
+++ b/include/comm_quda.h
@@ -16,6 +16,9 @@ typedef int (*QudaCommsMap)(const int *coords, void *fdata);
 }
 #endif
 
+/** Maximum length in bytes of the host string */
+#define QUDA_MAX_HOSTNAME_STRING 128
+
 namespace quda
 {
 
@@ -203,8 +206,8 @@ namespace quda
   /**
      @brief Gather all hostnames
      @param[out] hostname_recv_buf char array of length
-     128*comm_size() that will be filled in GPU ids for all processes.
-     Each hostname is in rank order, with 128 bytes for each.
+     QUDA_MAX_HOSTNAME_STRING*comm_size() that will be filled in GPU ids for all processes.
+     Each hostname is in rank order, with QUDA_MAX_HOSTNAME_STRING bytes for each.
   */
   void comm_gather_hostname(char *hostname_recv_buf);
 

--- a/include/communicator_quda.h
+++ b/include/communicator_quda.h
@@ -272,7 +272,7 @@ namespace quda
               continue;
 
             // if the neighbors are on the same
-            if (!strncmp(hostname, &hostname_recv_buf[128 * neighbor_rank], 128)) {
+            if (!strncmp(hostname, &hostname_recv_buf[QUDA_MAX_HOSTNAME_STRING * neighbor_rank], QUDA_MAX_HOSTNAME_STRING)) {
               int neighbor_gpuid = gpuid_recv_buf[neighbor_rank];
 
               bool can_access_peer = comm_peer2peer_possible(gpuid, neighbor_gpuid);
@@ -524,7 +524,7 @@ namespace quda
     comm_set_default_topology(topo);
 
     // determine which GPU this rank will use
-    char *hostname_recv_buf = (char *)safe_malloc(128 * comm_size());
+    char *hostname_recv_buf = (char *)safe_malloc(QUDA_MAX_HOSTNAME_STRING * comm_size());
     comm_gather_hostname(hostname_recv_buf);
 
     if (gpuid < 0) {
@@ -534,7 +534,7 @@ namespace quda
       // We initialize gpuid if it's still negative.
       gpuid = 0;
       for (int i = 0; i < comm_rank(); i++) {
-        if (!strncmp(comm_hostname(), &hostname_recv_buf[128 * i], 128)) { gpuid++; }
+        if (!strncmp(comm_hostname(), &hostname_recv_buf[QUDA_MAX_HOSTNAME_STRING * i], QUDA_MAX_HOSTNAME_STRING)) { gpuid++; }
       }
 
       if (gpuid >= device_count) {

--- a/lib/comm_common.cpp
+++ b/lib/comm_common.cpp
@@ -12,11 +12,11 @@ namespace quda
   char *comm_hostname(void)
   {
     static bool cached = false;
-    static char hostname[128];
+    static char hostname[QUDA_MAX_HOSTNAME_STRING];
 
     if (!cached) {
-      gethostname(hostname, 128);
-      hostname[127] = '\0';
+      gethostname(hostname, QUDA_MAX_HOSTNAME_STRING);
+      hostname[QUDA_MAX_HOSTNAME_STRING - 1] = '\0';
       cached = true;
     }
 

--- a/lib/communicator_mpi.cpp
+++ b/lib/communicator_mpi.cpp
@@ -4,7 +4,7 @@
   do {                                                                                                                 \
     int status = mpi_call;                                                                                             \
     if (status != MPI_SUCCESS) {                                                                                       \
-      char err_string[128];                                                                                            \
+      char err_string[MPI_MAX_ERROR_STRING];                                                                           \
       int err_len;                                                                                                     \
       MPI_Error_string(status, err_string, &err_len);                                                                  \
       err_string[127] = '\0';                                                                                          \

--- a/lib/communicator_mpi.cpp
+++ b/lib/communicator_mpi.cpp
@@ -93,7 +93,7 @@ namespace quda
   {
     // determine which GPU this rank will use
     char *hostname = comm_hostname();
-    MPI_CHECK(MPI_Allgather(hostname, 128, MPI_CHAR, hostname_recv_buf, 128, MPI_CHAR, MPI_COMM_HANDLE));
+    MPI_CHECK(MPI_Allgather(hostname, QUDA_MAX_HOSTNAME_STRING, MPI_CHAR, hostname_recv_buf, QUDA_MAX_HOSTNAME_STRING, MPI_CHAR, MPI_COMM_HANDLE));
   }
 
   void Communicator::comm_gather_gpuid(int *gpuid_recv_buf)

--- a/lib/communicator_qmp.cpp
+++ b/lib/communicator_qmp.cpp
@@ -118,17 +118,17 @@ namespace quda
     char *hostname = comm_hostname();
 
 #ifdef USE_MPI_GATHER
-  MPI_CHECK(MPI_Allgather(hostname, 128, MPI_CHAR, hostname_recv_buf, 128, MPI_CHAR, MPI_COMM_HANDLE));
+  MPI_CHECK(MPI_Allgather(hostname, QUDA_MAX_HOSTNAME_STRING, MPI_CHAR, hostname_recv_buf, QUDA_MAX_HOSTNAME_STRING, MPI_CHAR, MPI_COMM_HANDLE));
 #else
   // Abuse reductions to emulate all-gather.  We need to copy the
   // local hostname to all other nodes
   // this isn't very scalable though
   for (int i = 0; i < comm_size(); i++) {
-    int data[128];
-    for (int j = 0; j < 128; j++) {
+    int data[QUDA_MAX_HOSTNAME_STRING];
+    for (int j = 0; j < QUDA_MAX_HOSTNAME_STRING; j++) {
       data[j] = (i == comm_rank()) ? hostname[j] : 0;
       QMP_comm_sum_int(QMP_COMM_HANDLE, data + j);
-      hostname_recv_buf[i * 128 + j] = data[j];
+      hostname_recv_buf[i * QUDA_MAX_HOSTNAME_STRING + j] = data[j];
     }
   }
 #endif

--- a/lib/communicator_qmp.cpp
+++ b/lib/communicator_qmp.cpp
@@ -20,7 +20,7 @@
   do {                                                                                                                 \
     int status = mpi_call;                                                                                             \
     if (status != MPI_SUCCESS) {                                                                                       \
-      char err_string[128];                                                                                            \
+      char err_string[MPI_MAX_ERROR_STRING];                                                                           \
       int err_len;                                                                                                     \
       MPI_Error_string(status, err_string, &err_len);                                                                  \
       err_string[127] = '\0';                                                                                          \

--- a/lib/communicator_single.cpp
+++ b/lib/communicator_single.cpp
@@ -51,7 +51,7 @@ namespace quda
 
   size_t Communicator::comm_size(void) { return 1; }
 
-  void Communicator::comm_gather_hostname(char *hostname_recv_buf) { strncpy(hostname_recv_buf, comm_hostname(), 128); }
+  void Communicator::comm_gather_hostname(char *hostname_recv_buf) { strncpy(hostname_recv_buf, comm_hostname(), QUDA_MAX_HOSTNAME_STRING); }
 
   void Communicator::comm_gather_gpuid(int *gpuid_recv_buf) { gpuid_recv_buf[0] = comm_gpuid(); }
 


### PR DESCRIPTION
This PR addresses the issue raised in #1342:
* Use `MPI_MAX_ERROR_STRING` to safely store MPI error names
* Introduce `QUDA_MAX_HOSTNAME_STRING` to set the max hostname string used in QUDA