### PR TITLE
Remove MILC gauge order from HISQ force verification code

### DIFF
--- a/tests/hisq_paths_force_test.cpp
+++ b/tests/hisq_paths_force_test.cpp
@@ -387,8 +387,7 @@ static void display_test_info()
 {
   printfQuda("running the following fermion force computation test:\n");
 
-  printfQuda(
-    "link_precision           link_reconstruct           space_dim(x/y/z)         T_dimension\n");
+  printfQuda("link_precision           link_reconstruct           space_dim(x/y/z)         T_dimension\n");
   printfQuda("%s                       %s                         %d/%d/%d                  %d\n",
              get_prec_str(link_prec), get_recon_str(link_recon), xdim, ydim, zdim, tdim);
 }

--- a/tests/host_reference/hisq_force_reference.h
+++ b/tests/host_reference/hisq_force_reference.h
@@ -13,9 +13,9 @@ void color_matrix_hisq_force_reference(float eps, float weight, void *act_path_c
 
 void computeHisqOuterProduct(void *src, void *dst, QudaPrecision precision);
 
-void computeLinkOrderedOuterProduct(void *src, void *dest, QudaPrecision precision, int gauge_order);
+void computeLinkOrderedOuterProduct(void *src, void *dest, QudaPrecision precision);
 
-void computeLinkOrderedOuterProduct(void *src, void *dest, QudaPrecision precision, size_t separation, int gauge_order);
+void computeLinkOrderedOuterProduct(void *src, void *dest, QudaPrecision precision, size_t separation);
 
 #include <gauge_field.h>
 


### PR DESCRIPTION
This narrow PR removes the plumbing for the MILC gauge order in the HISQ force verification code, since it was unused (and didn't work in the multi-GPU case) anyways.

FWIW, this was originally going to be a `hotfix` branch due to linker errors with an `extern` variable, but around the same time that I finished the work for this PR, it turns out the linker error was just due to a stale build directory. In any case, it doesn't hurt to do this cleanup.