### PR TITLE
Commended out hipDeviceSetCacheConfig call 

### DIFF
--- a/lib/targets/hip/device.cpp
+++ b/lib/targets/hip/device.cpp
@@ -41,8 +41,9 @@ namespace quda
 
       CHECK_HIP_ERROR(hipSetDevice(dev));
 
-      CHECK_HIP_ERROR(hipDeviceSetCacheConfig(hipFuncCachePreferL1));
-      // hipDeviceSetSharedMemConfig(hipSharedMemBankSizeEightByte);
+      // FIXME: Commenting this out now until it is fixed in a newer ROCm as it seems
+      // Broken in recent ROCms. I am not sure it does anything anyway on RedTeam
+      // CHECK_HIP_ERROR(hipDeviceSetCacheConfig(hipFuncCachePreferL1));
       CHECK_HIP_ERROR(hipGetDeviceProperties(&deviceProp, dev));
     }
 


### PR DESCRIPTION
In a recent ROCm, this call stopped returning hipSuccess. Since we check the error code, it basically stops the code from running right at the outset. I am commenting it out here. I am told it will be fixed in a future ROCm, but actually I am not sure if it does anything in the first place. 