### PR TITLE
QUDA interface `freeGaugeQuda` clean-up

### DIFF
--- a/include/quda.h
+++ b/include/quda.h
@@ -1104,6 +1104,12 @@ extern "C" {
   void freeGaugeQuda(void);
 
   /**
+   * Free a single type (Wilson, HISQ fat, HISQ long) of internal gauge field.
+   * @param link_type[in] Type of link type to free up
+   */
+  void freeSingleGaugeQuda(QudaLinkType link_type);
+
+  /**
    * Free QUDA's internal smeared gauge field.
    */
   void freeGaugeSmearedQuda(void);

--- a/include/quda.h
+++ b/include/quda.h
@@ -1104,10 +1104,10 @@ extern "C" {
   void freeGaugeQuda(void);
 
   /**
-   * Free a single type (Wilson, HISQ fat, HISQ long) of internal gauge field.
+   * Free a unique type (Wilson, HISQ fat, HISQ long, smeared) of internal gauge field.
    * @param link_type[in] Type of link type to free up
    */
-  void freeSingleGaugeQuda(QudaLinkType link_type);
+  void freeUniqueGaugeQuda(QudaLinkType link_type);
 
   /**
    * Free QUDA's internal smeared gauge field.

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -666,59 +666,20 @@ void loadGaugeQuda(void *h_gauge, QudaGaugeParam *param)
   // creating sloppy fields isn't really compute, but it is work done on the gpu
   profileGauge.TPSTART(QUDA_PROFILE_COMPUTE);
 
-  // switch the parameters for creating the mirror sloppy cuda gauge field
-  gauge_param.reconstruct = param->reconstruct_sloppy;
-  gauge_param.setPrecision(param->cuda_prec_sloppy, true);
+  // Create pointers to store fields in
   cudaGaugeField *sloppy = nullptr;
-  if (param->cuda_prec == param->cuda_prec_sloppy && param->reconstruct == param->reconstruct_sloppy) {
-    sloppy = precise;
-  } else {
-    sloppy = new cudaGaugeField(gauge_param);
-    sloppy->copy(*precise);
-  }
-
-  // switch the parameters for creating the mirror preconditioner cuda gauge field
-  gauge_param.reconstruct = param->reconstruct_precondition;
-  gauge_param.setPrecision(param->cuda_prec_precondition, true);
   cudaGaugeField *precondition = nullptr;
-  if (param->cuda_prec == param->cuda_prec_precondition && param->reconstruct == param->reconstruct_precondition) {
-    precondition = precise;
-  } else if (param->cuda_prec_sloppy == param->cuda_prec_precondition
-             && param->reconstruct_sloppy == param->reconstruct_precondition) {
-    precondition = sloppy;
-  } else {
-    precondition = new cudaGaugeField(gauge_param);
-    precondition->copy(*precise);
-  }
-
-  // switch the parameters for creating the refinement cuda gauge field
-  gauge_param.reconstruct = param->reconstruct_refinement_sloppy;
-  gauge_param.setPrecision(param->cuda_prec_refinement_sloppy, true);
   cudaGaugeField *refinement = nullptr;
-  if (param->cuda_prec_sloppy == param->cuda_prec_refinement_sloppy
-      && param->reconstruct_sloppy == param->reconstruct_refinement_sloppy) {
-    refinement = sloppy;
-  } else {
-    refinement = new cudaGaugeField(gauge_param);
-    refinement->copy(*sloppy);
-  }
-
-  // switch the parameters for creating the eigensolver cuda gauge field
-  gauge_param.reconstruct = param->reconstruct_eigensolver;
-  gauge_param.setPrecision(param->cuda_prec_eigensolver, true);
   cudaGaugeField *eigensolver = nullptr;
-  if (param->cuda_prec == param->cuda_prec_eigensolver && param->reconstruct == param->reconstruct_eigensolver) {
-    eigensolver = precise;
-  } else if (param->cuda_prec_precondition == param->cuda_prec_eigensolver
-             && param->reconstruct_precondition == param->reconstruct_eigensolver) {
-    eigensolver = precondition;
-  } else if (param->cuda_prec_sloppy == param->cuda_prec_eigensolver
-             && param->reconstruct_sloppy == param->reconstruct_eigensolver) {
-    eigensolver = sloppy;
-  } else {
-    eigensolver = new cudaGaugeField(gauge_param);
-    eigensolver->copy(*precise);
-  }
+
+  std::array<QudaPrecision, 4> prec_arr = { param->cuda_prec_sloppy, param->cuda_prec_precondition,
+    param->cuda_prec_refinement_sloppy, param->cuda_prec_eigensolver };
+
+  std::array<QudaReconstructType, 4> recon_arr = { param->reconstruct_sloppy, param->reconstruct_precondition,
+    param->reconstruct_refinement_sloppy, param->reconstruct_eigensolver };
+
+  loadUniqueSloppyGaugeUtility(precise, sloppy, precondition, refinement, eigensolver,
+                               prec_arr, recon_arr);
 
   profileGauge.TPSTOP(QUDA_PROFILE_COMPUTE);
 
@@ -1133,207 +1094,23 @@ void freeGaugeSmearedQuda()
 
 void loadSloppyGaugeQuda(const QudaPrecision *prec, const QudaReconstructType *recon)
 {
+  std::array<QudaPrecision, 4> prec_arr = { prec[0], prec[1], prec[2], prec[3] };
+  std::array<QudaReconstructType, 4> recon_arr = { recon[0], recon[1], recon[2], recon[3] };
+
   // first do SU3 links (if they exist)
-  if (gaugePrecise) {
-    GaugeFieldParam gauge_param(*gaugePrecise);
-    // switch the parameters for creating the mirror sloppy cuda gauge field
-
-    gauge_param.reconstruct = recon[0];
-    gauge_param.setPrecision(prec[0], true);
-
-    if (gaugeSloppy) errorQuda("gaugeSloppy already exists");
-
-    if (gauge_param.Precision() == gaugePrecise->Precision() && gauge_param.reconstruct == gaugePrecise->Reconstruct()) {
-      gaugeSloppy = gaugePrecise;
-    } else {
-      gaugeSloppy = new cudaGaugeField(gauge_param);
-      gaugeSloppy->copy(*gaugePrecise);
-    }
-
-    // switch the parameters for creating the mirror preconditioner cuda gauge field
-    gauge_param.reconstruct = recon[1];
-    gauge_param.setPrecision(prec[1], true);
-
-    if (gaugePrecondition) errorQuda("gaugePrecondition already exists");
-
-    if (gauge_param.Precision() == gaugePrecise->Precision() && gauge_param.reconstruct == gaugePrecise->Reconstruct()) {
-      gaugePrecondition = gaugePrecise;
-    } else if (gauge_param.Precision() == gaugeSloppy->Precision()
-               && gauge_param.reconstruct == gaugeSloppy->Reconstruct()) {
-      gaugePrecondition = gaugeSloppy;
-    } else {
-      gaugePrecondition = new cudaGaugeField(gauge_param);
-      gaugePrecondition->copy(*gaugePrecise);
-    }
-
-    // switch the parameters for creating the mirror refinement cuda gauge field
-    gauge_param.reconstruct = recon[2];
-    gauge_param.setPrecision(prec[2], true);
-
-    if (gaugeRefinement) errorQuda("gaugeRefinement already exists");
-
-    if (gauge_param.Precision() == gaugeSloppy->Precision() && gauge_param.reconstruct == gaugeSloppy->Reconstruct()) {
-      gaugeRefinement = gaugeSloppy;
-    } else {
-      gaugeRefinement = new cudaGaugeField(gauge_param);
-      gaugeRefinement->copy(*gaugeSloppy);
-    }
-
-    // switch the parameters for creating the mirror eigensolver cuda gauge field
-    gauge_param.reconstruct = recon[3];
-    gauge_param.setPrecision(prec[3], true);
-
-    if (gaugeEigensolver) errorQuda("gaugeEigensolver already exists");
-
-    if (gauge_param.Precision() == gaugePrecise->Precision() && gauge_param.reconstruct == gaugePrecise->Reconstruct()) {
-      gaugeEigensolver = gaugePrecise;
-    } else if (gauge_param.Precision() == gaugeSloppy->Precision()
-               && gauge_param.reconstruct == gaugeSloppy->Reconstruct()) {
-      gaugeEigensolver = gaugeSloppy;
-    } else if (gauge_param.Precision() == gaugePrecondition->Precision()
-               && gauge_param.reconstruct == gaugePrecondition->Reconstruct()) {
-      gaugeEigensolver = gaugePrecondition;
-    } else {
-      gaugeEigensolver = new cudaGaugeField(gauge_param);
-      gaugeEigensolver->copy(*gaugePrecise);
-    }
-  }
+  if (gaugePrecise)
+    loadUniqueSloppyGaugeUtility(gaugePrecise, gaugeSloppy, gaugePrecondition, gaugeRefinement,
+                                 gaugeEigensolver, prec_arr, recon_arr);
 
   // fat links (if they exist)
-  if (gaugeFatPrecise) {
-    GaugeFieldParam gauge_param(*gaugeFatPrecise);
-    // switch the parameters for creating the mirror sloppy cuda gauge field
-
-    gauge_param.setPrecision(prec[0], true);
-
-    if (gaugeFatSloppy) errorQuda("gaugeFatSloppy already exists");
-
-    if (gauge_param.Precision() == gaugeFatPrecise->Precision()
-        && gauge_param.reconstruct == gaugeFatPrecise->Reconstruct()) {
-      gaugeFatSloppy = gaugeFatPrecise;
-    } else {
-      gaugeFatSloppy = new cudaGaugeField(gauge_param);
-      gaugeFatSloppy->copy(*gaugeFatPrecise);
-    }
-
-    // switch the parameters for creating the mirror preconditioner cuda gauge field
-    gauge_param.setPrecision(prec[1], true);
-
-    if (gaugeFatPrecondition) errorQuda("gaugeFatPrecondition already exists\n");
-
-    if (gauge_param.Precision() == gaugeFatPrecise->Precision()
-        && gauge_param.reconstruct == gaugeFatPrecise->Reconstruct()) {
-      gaugeFatPrecondition = gaugeFatPrecise;
-    } else if (gauge_param.Precision() == gaugeFatSloppy->Precision()
-               && gauge_param.reconstruct == gaugeFatSloppy->Reconstruct()) {
-      gaugeFatPrecondition = gaugeFatSloppy;
-    } else {
-      gaugeFatPrecondition = new cudaGaugeField(gauge_param);
-      gaugeFatPrecondition->copy(*gaugeFatPrecise);
-    }
-
-    // switch the parameters for creating the mirror refinement cuda gauge field
-    gauge_param.setPrecision(prec[2], true);
-
-    if (gaugeFatRefinement) errorQuda("gaugeFatRefinement already exists\n");
-
-    if (gauge_param.Precision() == gaugeFatSloppy->Precision()
-        && gauge_param.reconstruct == gaugeFatSloppy->Reconstruct()) {
-      gaugeFatRefinement = gaugeFatSloppy;
-    } else {
-      gaugeFatRefinement = new cudaGaugeField(gauge_param);
-      gaugeFatRefinement->copy(*gaugeFatSloppy);
-    }
-
-    // switch the parameters for creating the mirror eigensolver cuda gauge field
-    gauge_param.setPrecision(prec[3], true);
-
-    if (gaugeFatEigensolver) errorQuda("gaugeFatEigensolver already exists");
-
-    if (gauge_param.Precision() == gaugeFatPrecise->Precision()
-        && gauge_param.reconstruct == gaugeFatPrecise->Reconstruct()) {
-      gaugeFatEigensolver = gaugeFatPrecise;
-    } else if (gauge_param.Precision() == gaugeFatSloppy->Precision()
-               && gauge_param.reconstruct == gaugeFatSloppy->Reconstruct()) {
-      gaugeFatEigensolver = gaugeFatSloppy;
-    } else if (gauge_param.Precision() == gaugeFatPrecondition->Precision()
-               && gauge_param.reconstruct == gaugeFatPrecondition->Reconstruct()) {
-      gaugeFatEigensolver = gaugeFatPrecondition;
-    } else {
-      gaugeFatEigensolver = new cudaGaugeField(gauge_param);
-      gaugeFatEigensolver->copy(*gaugeFatPrecise);
-    }
-  }
+  if (gaugeFatPrecise)
+    loadUniqueSloppyGaugeUtility(gaugeFatPrecise, gaugeFatSloppy, gaugeFatPrecondition,
+                                 gaugeFatRefinement, gaugeFatEigensolver, prec_arr, recon_arr);
 
   // long links (if they exist)
-  if (gaugeLongPrecise) {
-    GaugeFieldParam gauge_param(*gaugeLongPrecise);
-    // switch the parameters for creating the mirror sloppy cuda gauge field
-
-    gauge_param.reconstruct = recon[0];
-    gauge_param.setPrecision(prec[0], true);
-
-    if (gaugeLongSloppy) errorQuda("gaugeLongSloppy already exists");
-
-    if (gauge_param.Precision() == gaugeLongPrecise->Precision()
-        && gauge_param.reconstruct == gaugeLongPrecise->Reconstruct()) {
-      gaugeLongSloppy = gaugeLongPrecise;
-    } else {
-      gaugeLongSloppy = new cudaGaugeField(gauge_param);
-      gaugeLongSloppy->copy(*gaugeLongPrecise);
-    }
-
-    // switch the parameters for creating the mirror preconditioner cuda gauge field
-    gauge_param.reconstruct = recon[1];
-    gauge_param.setPrecision(prec[1], true);
-
-    if (gaugeLongPrecondition) errorQuda("gaugeLongPrecondition already exists\n");
-
-    if (gauge_param.Precision() == gaugeLongPrecise->Precision()
-        && gauge_param.reconstruct == gaugeLongPrecise->Reconstruct()) {
-      gaugeLongPrecondition = gaugeLongPrecise;
-    } else if (gauge_param.Precision() == gaugeLongSloppy->Precision()
-               && gauge_param.reconstruct == gaugeLongSloppy->Reconstruct()) {
-      gaugeLongPrecondition = gaugeLongSloppy;
-    } else {
-      gaugeLongPrecondition = new cudaGaugeField(gauge_param);
-      gaugeLongPrecondition->copy(*gaugeLongPrecise);
-    }
-
-    // switch the parameters for creating the mirror refinement cuda gauge field
-    gauge_param.reconstruct = recon[2];
-    gauge_param.setPrecision(prec[2], true);
-
-    if (gaugeLongRefinement) errorQuda("gaugeLongRefinement already exists\n");
-
-    if (gauge_param.Precision() == gaugeLongSloppy->Precision()
-        && gauge_param.reconstruct == gaugeLongSloppy->Reconstruct()) {
-      gaugeLongRefinement = gaugeLongSloppy;
-    } else {
-      gaugeLongRefinement = new cudaGaugeField(gauge_param);
-      gaugeLongRefinement->copy(*gaugeLongSloppy);
-    }
-
-    // switch the parameters for creating the mirror eigensolver cuda gauge field
-    gauge_param.reconstruct = recon[3];
-    gauge_param.setPrecision(prec[3], true);
-
-    if (gaugeLongEigensolver) errorQuda("gaugePrecondition already exists");
-
-    if (gauge_param.Precision() == gaugeLongPrecise->Precision()
-        && gauge_param.reconstruct == gaugeLongPrecise->Reconstruct()) {
-      gaugeLongEigensolver = gaugeLongPrecise;
-    } else if (gauge_param.Precision() == gaugeLongSloppy->Precision()
-               && gauge_param.reconstruct == gaugeLongSloppy->Reconstruct()) {
-      gaugeLongEigensolver = gaugeLongSloppy;
-    } else if (gauge_param.Precision() == gaugeLongPrecondition->Precision()
-               && gauge_param.reconstruct == gaugeLongPrecondition->Reconstruct()) {
-      gaugeLongEigensolver = gaugeLongPrecondition;
-    } else {
-      gaugeLongEigensolver = new cudaGaugeField(gauge_param);
-      gaugeLongEigensolver->copy(*gaugeLongPrecise);
-    }
-  }
+  if (gaugeLongPrecise)
+    loadUniqueSloppyGaugeUtility(gaugeLongPrecise, gaugeLongSloppy, gaugeLongPrecondition,
+                                 gaugeLongRefinement, gaugeLongEigensolver, prec_arr, recon_arr);
 }
 
 /**

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -523,6 +523,10 @@ void initQuda(int dev)
 // possible flag to indicate we need to recompute the clover field
 static bool invalidate_clover = true;
 
+// pre-declare some cleanup utilities
+void freeSingleSloppyGaugeUtility(cudaGaugeField*&, cudaGaugeField*&, cudaGaugeField*&, cudaGaugeField*&, cudaGaugeField*&);
+void freeSingleGaugeUtility(cudaGaugeField*&, cudaGaugeField*&, cudaGaugeField*&, cudaGaugeField*&, cudaGaugeField*&, cudaGaugeField*&, QudaBoolean);
+
 void loadGaugeQuda(void *h_gauge, QudaGaugeParam *param)
 {
   profileGauge.TPSTART(QUDA_PROFILE_TOTAL);
@@ -560,59 +564,16 @@ void loadGaugeQuda(void *h_gauge, QudaGaugeParam *param)
   // free any current gauge field before new allocations to reduce memory overhead
   switch (param->type) {
     case QUDA_WILSON_LINKS:
-      if (gaugeRefinement != gaugeSloppy && gaugeRefinement != gaugeEigensolver && gaugeRefinement)
-        delete gaugeRefinement;
-
-      if (gaugePrecondition != gaugeSloppy && gaugePrecondition != gaugeEigensolver && gaugePrecondition != gaugePrecise
-          && gaugePrecondition)
-        delete gaugePrecondition;
-
-      if (gaugeEigensolver != gaugeSloppy && gaugeEigensolver != gaugePrecise && gaugeEigensolver != gaugePrecondition
-          && gaugeEigensolver)
-        delete gaugeEigensolver;
-
-      if (gaugePrecise != gaugeSloppy && gaugeSloppy) delete gaugeSloppy;
-
-      if (gaugePrecise && !param->use_resident_gauge) delete gaugePrecise;
-
+      freeSingleGaugeUtility(gaugeRefinement, gaugeSloppy, gaugePrecondition, gaugeRefinement, gaugeEigensolver, gaugeExtended, param->use_resident_gauge ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE);
       break;
     case QUDA_ASQTAD_FAT_LINKS:
-      if (gaugeFatRefinement != gaugeFatSloppy && gaugeFatRefinement != gaugeFatEigensolver && gaugeFatRefinement)
-        delete gaugeFatRefinement;
-
-      if (gaugeFatPrecondition != gaugeFatSloppy && gaugeFatPrecondition != gaugeFatEigensolver
-          && gaugeFatPrecondition != gaugeFatPrecise && gaugeFatPrecondition)
-        delete gaugeFatPrecondition;
-
-      if (gaugeFatEigensolver != gaugeFatSloppy && gaugeFatEigensolver != gaugeFatPrecise
-          && gaugeFatEigensolver != gaugeFatPrecondition && gaugeFatEigensolver)
-        delete gaugeFatEigensolver;
-
-      if (gaugeFatPrecise != gaugeFatSloppy && gaugeFatSloppy) delete gaugeFatSloppy;
-
-      if (gaugeFatPrecise && !param->use_resident_gauge) delete gaugeFatPrecise;
-
+      freeSingleGaugeUtility(gaugeFatRefinement, gaugeFatSloppy, gaugeFatPrecondition, gaugeFatRefinement, gaugeFatEigensolver, gaugeFatExtended, param->use_resident_gauge ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE);
       break;
     case QUDA_ASQTAD_LONG_LINKS:
-
-      if (gaugeLongRefinement != gaugeLongSloppy && gaugeLongRefinement != gaugeLongEigensolver && gaugeLongRefinement)
-        delete gaugeLongRefinement;
-
-      if (gaugeLongPrecondition != gaugeLongSloppy && gaugeLongPrecondition != gaugeLongEigensolver
-          && gaugeLongPrecondition != gaugeLongPrecise && gaugeLongPrecondition)
-        delete gaugeLongPrecondition;
-
-      if (gaugeLongEigensolver != gaugeLongSloppy && gaugeLongEigensolver != gaugeLongPrecise
-          && gaugeLongEigensolver != gaugeLongPrecondition && gaugeLongEigensolver)
-        delete gaugeLongEigensolver;
-
-      if (gaugeLongPrecise != gaugeLongSloppy && gaugeLongSloppy) delete gaugeLongSloppy;
-
-      if (gaugeLongPrecise) delete gaugeLongPrecise;
-
+      freeSingleGaugeUtility(gaugeLongRefinement, gaugeLongSloppy, gaugeLongPrecondition, gaugeLongRefinement, gaugeLongEigensolver, gaugeLongExtended, param->use_resident_gauge ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE);
       break;
     case QUDA_SMEARED_LINKS:
-      if (gaugeSmeared) delete gaugeSmeared;
+      freeSingleGaugeQuda(QUDA_SMEARED_LINKS);
       break;
     default:
       errorQuda("Invalid gauge type %d", param->type);
@@ -636,8 +597,7 @@ void loadGaugeQuda(void *h_gauge, QudaGaugeParam *param)
     // copy rather than point at to ensure that the padded region is filled in
     precise->copy(*gaugePrecise);
     precise->exchangeGhost();
-    delete gaugePrecise;
-    gaugePrecise = nullptr;
+    freeSingleGaugeQuda(QUDA_WILSON_LINKS);
     profileGauge.TPSTOP(QUDA_PROFILE_INIT);
   } else {
     profileGauge.TPSTOP(QUDA_PROFILE_INIT);
@@ -1029,99 +989,24 @@ void freeSloppyGaugeQuda()
   if (!initialized) errorQuda("QUDA not initialized");
 
   // Wilson gauges
-  //---------------------------------------------------------------------------
-  // Delete gaugeRefinement if it does not alias gaugeSloppy.
-  if (gaugeRefinement != gaugeSloppy && gaugeRefinement) delete gaugeRefinement;
-
-  // Delete gaugePrecondition if it does not alias gaugePrecise, gaugeSloppy, or gaugeEigensolver.
-  if (gaugePrecondition != gaugeSloppy && gaugePrecondition != gaugePrecise && gaugePrecondition != gaugeEigensolver
-      && gaugePrecondition)
-    delete gaugePrecondition;
-
-  // Delete gaugeEigensolver if it does not alias gaugePrecise or gaugeSloppy.
-  if (gaugeEigensolver != gaugeSloppy && gaugeEigensolver != gaugePrecise && gaugeEigensolver) delete gaugeEigensolver;
-
-  // Delete gaugeSloppy if it does not alias gaugePrecise.
-  if (gaugeSloppy != gaugePrecise && gaugeSloppy) delete gaugeSloppy;
-
-  gaugeEigensolver = nullptr;
-  gaugeRefinement = nullptr;
-  gaugePrecondition = nullptr;
-  gaugeSloppy = nullptr;
-  //---------------------------------------------------------------------------
+  freeSingleSloppyGaugeUtility(gaugePrecise, gaugeSloppy, gaugePrecondition, gaugeRefinement, gaugeEigensolver);
 
   // Long gauges
-  //---------------------------------------------------------------------------
-  // Delete gaugeLongRefinement if it does not alias gaugeLongSloppy.
-  if (gaugeLongRefinement != gaugeLongSloppy && gaugeLongRefinement) delete gaugeLongRefinement;
-
-  // Delete gaugeLongPrecondition if it does not alias gaugeLongPrecise, gaugeLongSloppy, or gaugeLongEigensolver.
-  if (gaugeLongPrecondition != gaugeLongSloppy && gaugeLongPrecondition != gaugeLongPrecise
-      && gaugeLongPrecondition != gaugeLongEigensolver && gaugeLongPrecondition)
-    delete gaugeLongPrecondition;
-
-  // Delete gaugeLongEigensolver if it does not alias gaugeLongPrecise or gaugeLongSloppy.
-  if (gaugeLongEigensolver != gaugeLongSloppy && gaugeLongEigensolver != gaugeLongPrecise && gaugeLongEigensolver)
-    delete gaugeLongEigensolver;
-
-  // Delete gaugeLongSloppy if it does not alias gaugeLongPrecise.
-  if (gaugeLongSloppy != gaugeLongPrecise && gaugeLongSloppy) delete gaugeLongSloppy;
-
-  gaugeLongEigensolver = nullptr;
-  gaugeLongRefinement = nullptr;
-  gaugeLongPrecondition = nullptr;
-  gaugeLongSloppy = nullptr;
-  //---------------------------------------------------------------------------
+  freeSingleSloppyGaugeUtility(gaugeLongPrecise, gaugeLongSloppy, gaugeLongPrecondition, gaugeLongRefinement, gaugeLongEigensolver);
 
   // Fat gauges
-  //---------------------------------------------------------------------------
-  // Delete gaugeFatRefinement if it does not alias gaugeFatSloppy.
-  if (gaugeFatRefinement != gaugeFatSloppy && gaugeFatRefinement) delete gaugeFatRefinement;
-
-  // Delete gaugeFatPrecondition if it does not alias gaugeFatPrecise, gaugeFatSloppy, or gaugeFatEigensolver.
-  if (gaugeFatPrecondition != gaugeFatSloppy && gaugeFatPrecondition != gaugeFatPrecise
-      && gaugeFatPrecondition != gaugeFatEigensolver && gaugeFatPrecondition)
-    delete gaugeFatPrecondition;
-
-  // Delete gaugeFatEigensolver if it does not alias gaugeFatPrecise or gaugeFatSloppy.
-  if (gaugeFatEigensolver != gaugeFatSloppy && gaugeFatEigensolver != gaugeFatPrecise && gaugeFatEigensolver)
-    delete gaugeFatEigensolver;
-
-  // Delete gaugeFatSloppy if it does not alias gaugeFatPrecise.
-  if (gaugeFatSloppy != gaugeFatPrecise && gaugeFatSloppy) delete gaugeFatSloppy;
-
-  gaugeFatEigensolver = nullptr;
-  gaugeFatRefinement = nullptr;
-  gaugeFatPrecondition = nullptr;
-  gaugeFatSloppy = nullptr;
+  freeSingleSloppyGaugeUtility(gaugeFatPrecise, gaugeFatSloppy, gaugeFatPrecondition, gaugeFatRefinement, gaugeFatEigensolver);
 }
 
 void freeGaugeQuda(void)
 {
   if (!initialized) errorQuda("QUDA not initialized");
 
-  freeSloppyGaugeQuda();
+  freeSingleGaugeQuda(QUDA_WILSON_LINKS);
+  freeSingleGaugeQuda(QUDA_ASQTAD_FAT_LINKS);
+  freeSingleGaugeQuda(QUDA_ASQTAD_LONG_LINKS);
+  freeSingleGaugeQuda(QUDA_SMEARED_LINKS);
 
-  if (gaugePrecise) delete gaugePrecise;
-  if (gaugeExtended) delete gaugeExtended;
-
-  gaugePrecise = nullptr;
-  gaugeExtended = nullptr;
-
-  if (gaugeLongPrecise) delete gaugeLongPrecise;
-  if (gaugeLongExtended) delete gaugeLongExtended;
-
-  gaugeLongPrecise = nullptr;
-  gaugeLongExtended = nullptr;
-
-  if (gaugeFatPrecise) delete gaugeFatPrecise;
-
-  gaugeFatPrecise = nullptr;
-  gaugeFatExtended = nullptr;
-
-  if (gaugeSmeared) delete gaugeSmeared;
-
-  gaugeSmeared = nullptr;
   // Need to merge extendedGaugeResident and gaugeFatPrecise/gaugePrecise
   if (extendedGaugeResident) {
     delete extendedGaugeResident;
@@ -1129,12 +1014,67 @@ void freeGaugeQuda(void)
   }
 }
 
-void freeGaugeSmearedQuda()
+void freeSingleSloppyGaugeUtility(cudaGaugeField*& precise, cudaGaugeField*& sloppy, cudaGaugeField*& precondition,
+                                  cudaGaugeField*& refinement, cudaGaugeField*& eigensolver) {
+  if (refinement != sloppy && refinement != eigensolver && refinement)
+    delete refinement;
+  refinement = nullptr;
+
+  if (precondition != sloppy && precondition != precise && precondition != eigensolver && precondition)
+    delete precondition;
+  precondition = nullptr;
+
+  if (eigensolver != sloppy && eigensolver != precise && eigensolver)
+    delete eigensolver;
+  eigensolver = nullptr;
+
+  if (sloppy != precise && sloppy)
+    delete sloppy;
+  sloppy = nullptr;
+}
+
+void freeSingleGaugeUtility(cudaGaugeField*& precise, cudaGaugeField*& sloppy, cudaGaugeField*& precondition,
+                            cudaGaugeField*& refinement, cudaGaugeField*& eigensolver, cudaGaugeField*& extended, QudaBoolean preserve_precise) {
+  freeSingleSloppyGaugeUtility(precise, sloppy, precondition, refinement, eigensolver);
+
+  if (precise && preserve_precise == QUDA_BOOLEAN_FALSE) {
+    delete precise;
+    precise = nullptr;
+  }
+
+  if (extended)
+    delete extended;
+  extended = nullptr;
+}
+
+void freeSingleGaugeQuda(QudaLinkType link_type)
 {
   if (!initialized) errorQuda("QUDA not initialized");
 
-  if( gaugeSmeared ) delete gaugeSmeared;
-  gaugeSmeared = nullptr;
+  // Narrowly free a single type of links
+  switch (link_type) {
+    case QUDA_WILSON_LINKS:
+      freeSingleGaugeUtility(gaugePrecise, gaugeSloppy, gaugePrecondition, gaugeRefinement, gaugeEigensolver, gaugeExtended, QUDA_BOOLEAN_FALSE);
+      break;
+    case QUDA_ASQTAD_FAT_LINKS:
+      freeSingleGaugeUtility(gaugeFatPrecise, gaugeFatSloppy, gaugeFatPrecondition, gaugeFatRefinement, gaugeFatEigensolver, gaugeFatExtended, QUDA_BOOLEAN_FALSE);
+      break;
+   case QUDA_ASQTAD_LONG_LINKS:
+      freeSingleGaugeUtility(gaugeLongPrecise, gaugeLongSloppy, gaugeLongPrecondition, gaugeLongRefinement, gaugeLongEigensolver, gaugeLongExtended, QUDA_BOOLEAN_FALSE);
+      break;
+   case QUDA_SMEARED_LINKS:
+      if (gaugeSmeared) delete gaugeSmeared;
+      gaugeSmeared = nullptr;
+      break;
+    default:
+      errorQuda("Invalid gauge type %d", link_type);
+  }
+}
+
+void freeGaugeSmearedQuda()
+{
+  // thin wrapper
+  freeSingleGaugeQuda(QUDA_SMEARED_LINKS);
 }
 
 void loadSloppyGaugeQuda(const QudaPrecision *prec, const QudaReconstructType *recon)
@@ -3995,7 +3935,7 @@ void computeTwoLinkQuda(void *twolink, void *inlink, QudaGaugeParam *param)
 
   profileGaussianSmear.TPSTART(QUDA_PROFILE_INIT);
 
-  if(gaugeSmeared != nullptr) delete gaugeSmeared;
+  freeSingleGaugeQuda(QUDA_SMEARED_LINKS);
   gaugeSmeared = new cudaGaugeField(gsParam);
 
   
@@ -4012,8 +3952,7 @@ void computeTwoLinkQuda(void *twolink, void *inlink, QudaGaugeParam *param)
 
   profileGaussianSmear.TPSTART(QUDA_PROFILE_FREE);
   
-  delete gaugeSmeared;
-  gaugeSmeared = nullptr;
+  freeSingleGaugeQuda(QUDA_SMEARED_LINKS);
   delete cudaInLinkEx;
 
   profileGaussianSmear.TPSTOP(QUDA_PROFILE_FREE);
@@ -4127,7 +4066,7 @@ int computeGaugeForceQuda(void* mom, void* siteLink,  int*** input_path_buf, int
 
   profileGaugeForce.TPSTART(QUDA_PROFILE_FREE);
   if (qudaGaugeParam->make_resident_gauge) {
-    if (gaugePrecise && gaugePrecise != cudaSiteLink) delete gaugePrecise;
+    if (gaugePrecise && gaugePrecise != cudaSiteLink) freeSingleGaugeQuda(QUDA_WILSON_LINKS);
     gaugePrecise = cudaSiteLink;
   } else {
     delete cudaSiteLink;
@@ -4234,7 +4173,7 @@ int computeGaugePathQuda(void *out, void *siteLink, int ***input_path_buf, int *
 
   profileGaugePath.TPSTART(QUDA_PROFILE_FREE);
   if (qudaGaugeParam->make_resident_gauge) {
-    if (gaugePrecise && gaugePrecise != cudaSiteLink) delete gaugePrecise;
+    if (gaugePrecise && gaugePrecise != cudaSiteLink) freeSingleGaugeQuda(QUDA_WILSON_LINKS);
     gaugePrecise = cudaSiteLink;
     if (extendedGaugeResident) delete extendedGaugeResident;
     extendedGaugeResident = cudaGauge;
@@ -5065,7 +5004,7 @@ void updateGaugeFieldQuda(void* gauge,
 
   profileGaugeUpdate.TPSTART(QUDA_PROFILE_FREE);
   if (param->make_resident_gauge) {
-    if (gaugePrecise != nullptr) delete gaugePrecise;
+    if (gaugePrecise != nullptr) freeSingleGaugeQuda(QUDA_WILSON_LINKS);
     gaugePrecise = cudaOutGauge;
   } else {
     delete cudaOutGauge;
@@ -5136,7 +5075,7 @@ void updateGaugeFieldQuda(void* gauge,
    profileProject.TPSTOP(QUDA_PROFILE_D2H);
 
    if (param->make_resident_gauge) {
-     if (gaugePrecise != nullptr && cudaGauge != gaugePrecise) delete gaugePrecise;
+     if (gaugePrecise != nullptr && cudaGauge != gaugePrecise) freeSingleGaugeQuda(QUDA_WILSON_LINKS);
      gaugePrecise = cudaGauge;
    } else {
      delete cudaGauge;
@@ -5192,7 +5131,7 @@ void updateGaugeFieldQuda(void* gauge,
    profilePhase.TPSTOP(QUDA_PROFILE_D2H);
 
    if (param->make_resident_gauge) {
-     if (gaugePrecise != nullptr && cudaGauge != gaugePrecise) delete gaugePrecise;
+     if (gaugePrecise != nullptr && cudaGauge != gaugePrecise) freeSingleGaugeQuda(QUDA_WILSON_LINKS); 
      gaugePrecise = cudaGauge;
    } else {
      delete cudaGauge;
@@ -5461,7 +5400,7 @@ void performTwoLinkGaussianSmearNStep(void *h_in, QudaQuarkSmearParam *smear_par
   if ( gaugeSmeared == nullptr || smear_param->compute_2link != 0 ) {
   
     if (getVerbosity() >= QUDA_VERBOSE) printfQuda("Gaussian smearing done with gaugeSmeared\n");
-    if ( gaugeSmeared != nullptr) delete gaugeSmeared;
+    freeSingleGaugeQuda(QUDA_SMEARED_LINKS);
     
     GaugeFieldParam gParam(*gaugePrecise);
     //
@@ -5583,8 +5522,7 @@ void performTwoLinkGaussianSmearNStep(void *h_in, QudaQuarkSmearParam *smear_par
 
   if( smear_param->delete_2link != 0 )
   {
-    delete gaugeSmeared;
-    gaugeSmeared = nullptr;
+    freeSingleGaugeQuda(QUDA_SMEARED_LINKS);
   }
 
   profileGaussianSmear.TPSTOP(QUDA_PROFILE_FREE);
@@ -5600,7 +5538,7 @@ void performGaugeSmearQuda(QudaGaugeSmearParam *smear_param, QudaGaugeObservable
   checkGaugeSmearParam(smear_param);
 
   if (gaugePrecise == nullptr) errorQuda("Gauge field must be loaded");
-  if (gaugeSmeared != nullptr) delete gaugeSmeared;
+  freeSingleGaugeQuda(QUDA_SMEARED_LINKS);
   gaugeSmeared = createExtendedGauge(*gaugePrecise, R, profileGaugeSmear);
 
   GaugeFieldParam gParam(*gaugeSmeared);
@@ -5647,7 +5585,7 @@ void performWFlowQuda(QudaGaugeSmearParam *smear_param, QudaGaugeObservableParam
   checkGaugeSmearParam(smear_param);
 
   if (gaugePrecise == nullptr) errorQuda("Gauge field must be loaded");
-  if (gaugeSmeared != nullptr) delete gaugeSmeared;
+  freeSingleGaugeQuda(QUDA_SMEARED_LINKS);
   gaugeSmeared = createExtendedGauge(*gaugePrecise, R, profileWFlow);
 
   GaugeFieldParam gParamEx(*gaugeSmeared);
@@ -5755,7 +5693,7 @@ int computeGaugeFixingOVRQuda(void *gauge, const unsigned int gauge_dir, const u
   GaugeFixOVRQuda.TPSTOP(QUDA_PROFILE_TOTAL);
 
   if (param->make_resident_gauge) {
-    if (gaugePrecise != nullptr) delete gaugePrecise;
+    if (gaugePrecise != nullptr) freeSingleGaugeQuda(QUDA_WILSON_LINKS);
     gaugePrecise = cudaInGauge;
     if (extendedGaugeResident) delete extendedGaugeResident;
     extendedGaugeResident = cudaInGaugeEx;
@@ -5821,7 +5759,7 @@ int computeGaugeFixingFFTQuda(void* gauge, const unsigned int gauge_dir,  const 
   GaugeFixFFTQuda.TPSTOP(QUDA_PROFILE_TOTAL);
 
   if (param->make_resident_gauge) {
-    if (gaugePrecise != nullptr) delete gaugePrecise;
+    if (gaugePrecise != nullptr) freeSingleGaugeQuda(QUDA_WILSON_LINKS);
     gaugePrecise = cudaInGauge;
   } else {
     delete cudaInGauge;

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -592,13 +592,13 @@ void loadGaugeQuda(void *h_gauge, QudaGaugeParam *param)
   // free any current gauge field before new allocations to reduce memory overhead
   switch (param->type) {
     case QUDA_WILSON_LINKS:
-      freeUniqueGaugeUtility(gaugePrecise, gaugeSloppy, gaugePrecondition, gaugeRefinement, gaugeEigensolver, gaugeExtended, param->use_resident_gauge == 0 ? false : true);
+      freeUniqueGaugeUtility(gaugePrecise, gaugeSloppy, gaugePrecondition, gaugeRefinement, gaugeEigensolver, gaugeExtended, param->use_resident_gauge);
       break;
     case QUDA_ASQTAD_FAT_LINKS:
-      freeUniqueGaugeUtility(gaugeFatPrecise, gaugeFatSloppy, gaugeFatPrecondition, gaugeFatRefinement, gaugeFatEigensolver, gaugeFatExtended, param->use_resident_gauge == 0 ? false : true);
+      freeUniqueGaugeUtility(gaugeFatPrecise, gaugeFatSloppy, gaugeFatPrecondition, gaugeFatRefinement, gaugeFatEigensolver, gaugeFatExtended, param->use_resident_gauge);
       break;
     case QUDA_ASQTAD_LONG_LINKS:
-      freeUniqueGaugeUtility(gaugeLongPrecise, gaugeLongSloppy, gaugeLongPrecondition, gaugeLongRefinement, gaugeLongEigensolver, gaugeLongExtended, param->use_resident_gauge == 0 ? false : true);
+      freeUniqueGaugeUtility(gaugeLongPrecise, gaugeLongSloppy, gaugeLongPrecondition, gaugeLongRefinement, gaugeLongEigensolver, gaugeLongExtended, param->use_resident_gauge);
       break;
     case QUDA_SMEARED_LINKS:
       freeUniqueGaugeQuda(QUDA_SMEARED_LINKS);

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -536,8 +536,8 @@ static bool invalidate_clover = true;
  * @param refinement[in/out] Reference the to pointer of a given "refinement" field.
  * @param eigensolver[in/out] Reference then to pointer of a given "eigensolver" field.
  */
-void freeUniqueSloppyGaugeUtility(cudaGaugeField*& precise, cudaGaugeField*& sloppy, cudaGaugeField*& precondition,
-                                  cudaGaugeField*& refinement, cudaGaugeField*& eigensolver);
+void freeUniqueSloppyGaugeUtility(cudaGaugeField *&precise, cudaGaugeField *&sloppy, cudaGaugeField *&precondition,
+                                  cudaGaugeField *&refinement, cudaGaugeField *&eigensolver);
 
 /**
  * Abstraction utility that cleans up the full set of sloppy fields, as well as
@@ -552,8 +552,9 @@ void freeUniqueSloppyGaugeUtility(cudaGaugeField*& precise, cudaGaugeField*& slo
  * @param extended[in/out] Reference to the pointer of a given "extended" field.
  * @param preserve_precise[in] Whether (true) or not (false) to preserve the precise field.
  */
-void freeUniqueGaugeUtility(cudaGaugeField*& precise, cudaGaugeField*& sloppy, cudaGaugeField*& precondition,
-                            cudaGaugeField*& refinement, cudaGaugeField*& eigensolver, cudaGaugeField*& extended, bool preserve_precise);
+void freeUniqueGaugeUtility(cudaGaugeField *&precise, cudaGaugeField *&sloppy, cudaGaugeField *&precondition,
+                            cudaGaugeField *&refinement, cudaGaugeField *&eigensolver, cudaGaugeField *&extended,
+                            bool preserve_precise);
 
 void loadGaugeQuda(void *h_gauge, QudaGaugeParam *param)
 {
@@ -592,17 +593,18 @@ void loadGaugeQuda(void *h_gauge, QudaGaugeParam *param)
   // free any current gauge field before new allocations to reduce memory overhead
   switch (param->type) {
     case QUDA_WILSON_LINKS:
-      freeUniqueGaugeUtility(gaugePrecise, gaugeSloppy, gaugePrecondition, gaugeRefinement, gaugeEigensolver, gaugeExtended, param->use_resident_gauge);
+      freeUniqueGaugeUtility(gaugePrecise, gaugeSloppy, gaugePrecondition, gaugeRefinement, gaugeEigensolver,
+                             gaugeExtended, param->use_resident_gauge);
       break;
     case QUDA_ASQTAD_FAT_LINKS:
-      freeUniqueGaugeUtility(gaugeFatPrecise, gaugeFatSloppy, gaugeFatPrecondition, gaugeFatRefinement, gaugeFatEigensolver, gaugeFatExtended, param->use_resident_gauge);
+      freeUniqueGaugeUtility(gaugeFatPrecise, gaugeFatSloppy, gaugeFatPrecondition, gaugeFatRefinement,
+                             gaugeFatEigensolver, gaugeFatExtended, param->use_resident_gauge);
       break;
     case QUDA_ASQTAD_LONG_LINKS:
-      freeUniqueGaugeUtility(gaugeLongPrecise, gaugeLongSloppy, gaugeLongPrecondition, gaugeLongRefinement, gaugeLongEigensolver, gaugeLongExtended, param->use_resident_gauge);
+      freeUniqueGaugeUtility(gaugeLongPrecise, gaugeLongSloppy, gaugeLongPrecondition, gaugeLongRefinement,
+                             gaugeLongEigensolver, gaugeLongExtended, param->use_resident_gauge);
       break;
-    case QUDA_SMEARED_LINKS:
-      freeUniqueGaugeQuda(QUDA_SMEARED_LINKS);
-      break;
+    case QUDA_SMEARED_LINKS: freeUniqueGaugeQuda(QUDA_SMEARED_LINKS); break;
     default:
       errorQuda("Invalid gauge type %d", param->type);
   }
@@ -1020,10 +1022,12 @@ void freeSloppyGaugeQuda()
   freeUniqueSloppyGaugeUtility(gaugePrecise, gaugeSloppy, gaugePrecondition, gaugeRefinement, gaugeEigensolver);
 
   // Long gauges
-  freeUniqueSloppyGaugeUtility(gaugeLongPrecise, gaugeLongSloppy, gaugeLongPrecondition, gaugeLongRefinement, gaugeLongEigensolver);
+  freeUniqueSloppyGaugeUtility(gaugeLongPrecise, gaugeLongSloppy, gaugeLongPrecondition, gaugeLongRefinement,
+                               gaugeLongEigensolver);
 
   // Fat gauges
-  freeUniqueSloppyGaugeUtility(gaugeFatPrecise, gaugeFatSloppy, gaugeFatPrecondition, gaugeFatRefinement, gaugeFatEigensolver);
+  freeUniqueSloppyGaugeUtility(gaugeFatPrecise, gaugeFatSloppy, gaugeFatPrecondition, gaugeFatRefinement,
+                               gaugeFatEigensolver);
 }
 
 void freeGaugeQuda(void)
@@ -1043,36 +1047,36 @@ void freeGaugeQuda(void)
 }
 
 // These utility functions are declared w/doxygen above
-void freeUniqueSloppyGaugeUtility(cudaGaugeField*& precise, cudaGaugeField*& sloppy, cudaGaugeField*& precondition,
-                                  cudaGaugeField*& refinement, cudaGaugeField*& eigensolver) {
+void freeUniqueSloppyGaugeUtility(cudaGaugeField *&precise, cudaGaugeField *&sloppy, cudaGaugeField *&precondition,
+                                  cudaGaugeField *&refinement, cudaGaugeField *&eigensolver)
+{
   // In theory, we're checking for aliasing and freeing fields in the opposite order
   // from which they were allocated... but in any case, we're doing an all-to-all
   // checking of aliasing, so it doesn't really matter if the order matches.
 
   // The last field to get allocated is the eigensolver
-  if (eigensolver != refinement && eigensolver != precondition && eigensolver != sloppy &&
-      eigensolver != precise && eigensolver)
+  if (eigensolver != refinement && eigensolver != precondition && eigensolver != sloppy && eigensolver != precise
+      && eigensolver)
     delete eigensolver;
   eigensolver = nullptr;
 
   // Second to last: refinement
-  if (refinement != precondition && refinement != sloppy && refinement != precise && refinement)
-    delete refinement;
+  if (refinement != precondition && refinement != sloppy && refinement != precise && refinement) delete refinement;
   refinement = nullptr;
 
   // Third to last: precondition
-  if (precondition != sloppy && precondition != precise && precondition)
-    delete precondition;
+  if (precondition != sloppy && precondition != precise && precondition) delete precondition;
   precondition = nullptr;
 
   // Fourth to last: sloppy
-  if (sloppy != precise && sloppy)
-    delete sloppy;
+  if (sloppy != precise && sloppy) delete sloppy;
   sloppy = nullptr;
 }
 
-void freeUniqueGaugeUtility(cudaGaugeField*& precise, cudaGaugeField*& sloppy, cudaGaugeField*& precondition,
-                            cudaGaugeField*& refinement, cudaGaugeField*& eigensolver, cudaGaugeField*& extended, bool preserve_precise) {
+void freeUniqueGaugeUtility(cudaGaugeField *&precise, cudaGaugeField *&sloppy, cudaGaugeField *&precondition,
+                            cudaGaugeField *&refinement, cudaGaugeField *&eigensolver, cudaGaugeField *&extended,
+                            bool preserve_precise)
+{
   freeUniqueSloppyGaugeUtility(precise, sloppy, precondition, refinement, eigensolver);
 
   if (precise && !preserve_precise) {
@@ -1080,8 +1084,7 @@ void freeUniqueGaugeUtility(cudaGaugeField*& precise, cudaGaugeField*& sloppy, c
     precise = nullptr;
   }
 
-  if (extended)
-    delete extended;
+  if (extended) delete extended;
   extended = nullptr;
 }
 
@@ -1091,21 +1094,23 @@ void freeUniqueGaugeQuda(QudaLinkType link_type)
 
   // Narrowly free a single type of links
   switch (link_type) {
-    case QUDA_WILSON_LINKS:
-      freeUniqueGaugeUtility(gaugePrecise, gaugeSloppy, gaugePrecondition, gaugeRefinement, gaugeEigensolver, gaugeExtended, false);
-      break;
-    case QUDA_ASQTAD_FAT_LINKS:
-      freeUniqueGaugeUtility(gaugeFatPrecise, gaugeFatSloppy, gaugeFatPrecondition, gaugeFatRefinement, gaugeFatEigensolver, gaugeFatExtended, false);
-      break;
-   case QUDA_ASQTAD_LONG_LINKS:
-      freeUniqueGaugeUtility(gaugeLongPrecise, gaugeLongSloppy, gaugeLongPrecondition, gaugeLongRefinement, gaugeLongEigensolver, gaugeLongExtended, false);
-      break;
-   case QUDA_SMEARED_LINKS:
-      if (gaugeSmeared) delete gaugeSmeared;
-      gaugeSmeared = nullptr;
-      break;
-    default:
-      errorQuda("Invalid gauge type %d", link_type);
+  case QUDA_WILSON_LINKS:
+    freeUniqueGaugeUtility(gaugePrecise, gaugeSloppy, gaugePrecondition, gaugeRefinement, gaugeEigensolver,
+                           gaugeExtended, false);
+    break;
+  case QUDA_ASQTAD_FAT_LINKS:
+    freeUniqueGaugeUtility(gaugeFatPrecise, gaugeFatSloppy, gaugeFatPrecondition, gaugeFatRefinement,
+                           gaugeFatEigensolver, gaugeFatExtended, false);
+    break;
+  case QUDA_ASQTAD_LONG_LINKS:
+    freeUniqueGaugeUtility(gaugeLongPrecise, gaugeLongSloppy, gaugeLongPrecondition, gaugeLongRefinement,
+                           gaugeLongEigensolver, gaugeLongExtended, false);
+    break;
+  case QUDA_SMEARED_LINKS:
+    if (gaugeSmeared) delete gaugeSmeared;
+    gaugeSmeared = nullptr;
+    break;
+  default: errorQuda("Invalid gauge type %d", link_type);
   }
 }
 
@@ -3989,7 +3994,7 @@ void computeTwoLinkQuda(void *twolink, void *inlink, QudaGaugeParam *param)
   gaugeSmeared->saveCPUField(cpuTwoLink, profileGaussianSmear);
 
   profileGaussianSmear.TPSTART(QUDA_PROFILE_FREE);
-  
+
   freeUniqueGaugeQuda(QUDA_SMEARED_LINKS);
   delete cudaInLinkEx;
 
@@ -5169,7 +5174,7 @@ void updateGaugeFieldQuda(void* gauge,
    profilePhase.TPSTOP(QUDA_PROFILE_D2H);
 
    if (param->make_resident_gauge) {
-     if (gaugePrecise != nullptr && cudaGauge != gaugePrecise) freeUniqueGaugeQuda(QUDA_WILSON_LINKS); 
+     if (gaugePrecise != nullptr && cudaGauge != gaugePrecise) freeUniqueGaugeQuda(QUDA_WILSON_LINKS);
      gaugePrecise = cudaGauge;
    } else {
      delete cudaGauge;
@@ -5439,7 +5444,7 @@ void performTwoLinkGaussianSmearNStep(void *h_in, QudaQuarkSmearParam *smear_par
   
     if (getVerbosity() >= QUDA_VERBOSE) printfQuda("Gaussian smearing done with gaugeSmeared\n");
     freeUniqueGaugeQuda(QUDA_SMEARED_LINKS);
-    
+
     GaugeFieldParam gParam(*gaugePrecise);
     //
     gParam.create        = QUDA_NULL_FIELD_CREATE;
@@ -5558,10 +5563,7 @@ void performTwoLinkGaussianSmearNStep(void *h_in, QudaQuarkSmearParam *smear_par
 
   smear_param->gflops = dirac.Flops();
 
-  if( smear_param->delete_2link != 0 )
-  {
-    freeUniqueGaugeQuda(QUDA_SMEARED_LINKS);
-  }
+  if (smear_param->delete_2link != 0) { freeUniqueGaugeQuda(QUDA_SMEARED_LINKS); }
 
   profileGaussianSmear.TPSTOP(QUDA_PROFILE_FREE);
   profileGaussianSmear.TPSTOP(QUDA_PROFILE_TOTAL);

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -523,8 +523,24 @@ void initQuda(int dev)
 // possible flag to indicate we need to recompute the clover field
 static bool invalidate_clover = true;
 
-// These utility functions are defined by the other "free" functions, but they
-// are declared here so they can be used in the initial cleanup phase of loadGaugeQuda
+// These utility functions are defined below, but are declared here so they can be used
+// in the various flavors of publicly exposed "load" and "free" functions
+
+/**
+ * Abstraction utility that loads a set of sloppy fields, typically one of Wilson,
+ * HISQ fat, or HISQ long. The utility checks and makes sure all fields have already
+ * been freed, and is smart enough to alias fields as appropriate.
+ * @param precise[in] Pointer to an existing "precise" field, used as a base.
+ * @param sloppy[out] Reference to the pointer of a given "sloppy" field.
+ * @param precondition[out] Reference the to pointer of a given "precondition" field.
+ * @param refinement[out] Reference the to pointer of a given "refinement" field.
+ * @param eigensolver[out] Reference then to pointer of a given "eigensolver" field.
+ * @param prec[in] Desired precisions of the sloppy, etc, fields, in order matching the arguments.
+ * @param recon[in] Desired reconstructs of the sloppy, etc, fields, in order matching the arguments.
+ */
+void loadUniqueSloppyGaugeUtility(cudaGaugeField* precise, cudaGaugeField*& sloppy, cudaGaugeField*& precondition,
+       cudaGaugeField*& refinement, cudaGaugeField*& eigensolver, const std::array<QudaPrecision, 4>& prec,
+       const std::array<QudaReconstructType, 4>& recon);
 
 /**
  * Abstraction utility that cleans up a set of sloppy fields, typically one of Wilson,
@@ -1317,6 +1333,90 @@ void loadSloppyGaugeQuda(const QudaPrecision *prec, const QudaReconstructType *r
       gaugeLongEigensolver = new cudaGaugeField(gauge_param);
       gaugeLongEigensolver->copy(*gaugeLongPrecise);
     }
+  }
+}
+
+/**
+ * Helper that checks if a given field has a precision and reconstruct value matching a GaugeFieldParam
+ * @param field[in] Reference gauge field
+ * @param param[in] Reference gauge field param
+ * @return Whether or not the precision and the reconstruct values of the field and gauge field param agree
+ */
+bool check_prec_recon_matches(const GaugeField& field, const GaugeFieldParam& param) {
+  return (field.Precision() == param.Precision() && field.Reconstruct() == param.reconstruct);
+}
+
+void loadUniqueSloppyGaugeUtility(cudaGaugeField* precise, cudaGaugeField*& sloppy, cudaGaugeField*& precondition,
+       cudaGaugeField*& refinement, cudaGaugeField*& eigensolver, const std::array<QudaPrecision, 4>& prec,
+       const std::array<QudaReconstructType, 4>& recon) {
+  if (precise == nullptr)
+    errorQuda("Precise field does not exist");
+
+  GaugeFieldParam gauge_param(*precise);
+  gauge_param.create = QUDA_NULL_FIELD_CREATE;
+
+  // switch the parameters for creating the mirror sloppy cuda gauge field
+  gauge_param.reconstruct = recon[0];
+  gauge_param.setPrecision(prec[0], true);
+
+  if (sloppy) errorQuda("Sloppy field already exists");
+
+  if (check_prec_recon_matches(*precise, gauge_param)) {
+    sloppy = precise;
+  } else {
+    sloppy = new cudaGaugeField(gauge_param);
+    sloppy->copy(*precise);
+  }
+
+  // switch the parameters for creating the mirror preconditioner cuda gauge field
+  gauge_param.reconstruct = recon[1];
+  gauge_param.setPrecision(prec[1], true);
+
+  if (precondition) errorQuda("Precondition field already exists");
+
+  if (check_prec_recon_matches(*sloppy, gauge_param)) {
+    precondition = sloppy;
+  } else if (check_prec_recon_matches(*precise, gauge_param)) {
+    precondition = precise;
+  } else {
+    precondition = new cudaGaugeField(gauge_param);
+    precondition->copy(*precise);
+  }
+
+  // switch the parameters for creating the mirror refinement cuda gauge field
+  gauge_param.reconstruct = recon[2];
+  gauge_param.setPrecision(prec[2], true);
+
+  if (refinement) errorQuda("Refinement field already exists");
+
+  if (check_prec_recon_matches(*precondition, gauge_param)) {
+    refinement = precondition;
+  } else if (check_prec_recon_matches(*sloppy, gauge_param)) {
+    refinement = sloppy;
+  } else if (check_prec_recon_matches(*precise, gauge_param)) {
+    refinement = precise;
+  } else {
+    refinement = new cudaGaugeField(gauge_param);
+    refinement->copy(*precise);
+  }
+
+  // switch the parameters for creating the mirror eigensolver cuda gauge field
+  gauge_param.reconstruct = recon[3];
+  gauge_param.setPrecision(prec[3], true);
+
+  if (eigensolver) errorQuda("Eigensolver field already exists");
+
+  if (check_prec_recon_matches(*refinement, gauge_param)) {
+    eigensolver = refinement;
+  } else if (check_prec_recon_matches(*precondition, gauge_param)) {
+    eigensolver = precondition;
+  } else if (check_prec_recon_matches(*sloppy, gauge_param)) {
+    eigensolver = sloppy;
+  } else if (check_prec_recon_matches(*precise, gauge_param)) {
+    eigensolver = precise;
+  } else {
+    eigensolver = new cudaGaugeField(gauge_param);
+    eigensolver->copy(*precise);
   }
 }
 

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -553,7 +553,7 @@ void freeUniqueSloppyGaugeUtility(cudaGaugeField*& precise, cudaGaugeField*& slo
  * @param preserve_precise[in] Whether (true) or not (false) to preserve the precise field.
  */
 void freeUniqueGaugeUtility(cudaGaugeField*& precise, cudaGaugeField*& sloppy, cudaGaugeField*& precondition,
-                            cudaGaugeField*& refinement, cudaGaugeField*& eigensolver, cudaGaugeField*& extended, QudaBoolean preserve_precise);
+                            cudaGaugeField*& refinement, cudaGaugeField*& eigensolver, cudaGaugeField*& extended, bool preserve_precise);
 
 void loadGaugeQuda(void *h_gauge, QudaGaugeParam *param)
 {
@@ -1063,10 +1063,10 @@ void freeUniqueSloppyGaugeUtility(cudaGaugeField*& precise, cudaGaugeField*& slo
 }
 
 void freeUniqueGaugeUtility(cudaGaugeField*& precise, cudaGaugeField*& sloppy, cudaGaugeField*& precondition,
-                            cudaGaugeField*& refinement, cudaGaugeField*& eigensolver, cudaGaugeField*& extended, QudaBoolean preserve_precise) {
+                            cudaGaugeField*& refinement, cudaGaugeField*& eigensolver, cudaGaugeField*& extended, bool preserve_precise) {
   freeUniqueSloppyGaugeUtility(precise, sloppy, precondition, refinement, eigensolver);
 
-  if (precise && preserve_precise == QUDA_BOOLEAN_FALSE) {
+  if (precise && !preserve_precise) {
     delete precise;
     precise = nullptr;
   }

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -523,9 +523,37 @@ void initQuda(int dev)
 // possible flag to indicate we need to recompute the clover field
 static bool invalidate_clover = true;
 
-// pre-declare some cleanup utilities
-void freeUniqueSloppyGaugeUtility(cudaGaugeField*&, cudaGaugeField*&, cudaGaugeField*&, cudaGaugeField*&, cudaGaugeField*&);
-void freeUniqueGaugeUtility(cudaGaugeField*&, cudaGaugeField*&, cudaGaugeField*&, cudaGaugeField*&, cudaGaugeField*&, cudaGaugeField*&, QudaBoolean);
+// These utility functions are defined by the other "free" functions, but they
+// are declared here so they can be used in the initial cleanup phase of loadGaugeQuda
+
+/**
+ * Abstraction utility that cleans up a set of sloppy fields, typically one of Wilson,
+ * HISQ fat, or HISQ long. The utility safely frees the fields as appropriate and sets
+ * all of the pointers to nullptr.
+ * @param precise[in] Reference to the pointer of a given "precise" field, used for aliasing checks.
+ * @param sloppy[in/out] Reference to the pointer of a given "sloppy" field.
+ * @param precondition[in/out] Reference the to pointer of a given "precondition" field.
+ * @param refinement[in/out] Reference the to pointer of a given "refinement" field.
+ * @param eigensolver[in/out] Reference then to pointer of a given "eigensolver" field.
+ */
+void freeUniqueSloppyGaugeUtility(cudaGaugeField*& precise, cudaGaugeField*& sloppy, cudaGaugeField*& precondition,
+                                  cudaGaugeField*& refinement, cudaGaugeField*& eigensolver);
+
+/**
+ * Abstraction utility that cleans up the full set of sloppy fields, as well as
+ * precise (unless requested otherwise) and extended fields. The set can correspond
+ * to the internal Wilson, HISQ fat, or HISQ long fields. This utility safely frees the
+ * fields as appropriate and sets all of the pointers to nullptr.
+ * @param precise[in/out] Reference to the pointer of a given "precise" field.
+ * @param sloppy[in/out] Reference to the pointer of a given "sloppy" field.
+ * @param precondition[in/out] Reference to the pointer of a given "precondition" field.
+ * @param refinement[in/out] Reference to the pointer of a given "refinement" field.
+ * @param eigensolver[in/out] Reference to the pointer of a given "eigensolver" field.
+ * @param extended[in/out] Reference to the pointer of a given "extended" field.
+ * @param preserve_precise[in] Whether (true) or not (false) to preserve the precise field.
+ */
+void freeUniqueGaugeUtility(cudaGaugeField*& precise, cudaGaugeField*& sloppy, cudaGaugeField*& precondition,
+                            cudaGaugeField*& refinement, cudaGaugeField*& eigensolver, cudaGaugeField*& extended, QudaBoolean preserve_precise);
 
 void loadGaugeQuda(void *h_gauge, QudaGaugeParam *param)
 {
@@ -1014,6 +1042,7 @@ void freeGaugeQuda(void)
   }
 }
 
+// These utility functions are declared w/doxygen above
 void freeUniqueSloppyGaugeUtility(cudaGaugeField*& precise, cudaGaugeField*& sloppy, cudaGaugeField*& precondition,
                                   cudaGaugeField*& refinement, cudaGaugeField*& eigensolver) {
   if (refinement != sloppy && refinement != eigensolver && refinement)

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -608,13 +608,13 @@ void loadGaugeQuda(void *h_gauge, QudaGaugeParam *param)
   // free any current gauge field before new allocations to reduce memory overhead
   switch (param->type) {
     case QUDA_WILSON_LINKS:
-      freeUniqueGaugeUtility(gaugeRefinement, gaugeSloppy, gaugePrecondition, gaugeRefinement, gaugeEigensolver, gaugeExtended, param->use_resident_gauge ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE);
+      freeUniqueGaugeUtility(gaugePrecise, gaugeSloppy, gaugePrecondition, gaugeRefinement, gaugeEigensolver, gaugeExtended, param->use_resident_gauge == 0 ? false : true);
       break;
     case QUDA_ASQTAD_FAT_LINKS:
-      freeUniqueGaugeUtility(gaugeFatRefinement, gaugeFatSloppy, gaugeFatPrecondition, gaugeFatRefinement, gaugeFatEigensolver, gaugeFatExtended, param->use_resident_gauge ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE);
+      freeUniqueGaugeUtility(gaugeFatPrecise, gaugeFatSloppy, gaugeFatPrecondition, gaugeFatRefinement, gaugeFatEigensolver, gaugeFatExtended, param->use_resident_gauge == 0 ? false : true);
       break;
     case QUDA_ASQTAD_LONG_LINKS:
-      freeUniqueGaugeUtility(gaugeLongRefinement, gaugeLongSloppy, gaugeLongPrecondition, gaugeLongRefinement, gaugeLongEigensolver, gaugeLongExtended, param->use_resident_gauge ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE);
+      freeUniqueGaugeUtility(gaugeLongPrecise, gaugeLongSloppy, gaugeLongPrecondition, gaugeLongRefinement, gaugeLongEigensolver, gaugeLongExtended, param->use_resident_gauge == 0 ? false : true);
       break;
     case QUDA_SMEARED_LINKS:
       freeUniqueGaugeQuda(QUDA_SMEARED_LINKS);
@@ -1069,13 +1069,13 @@ void freeUniqueGaugeQuda(QudaLinkType link_type)
   // Narrowly free a single type of links
   switch (link_type) {
     case QUDA_WILSON_LINKS:
-      freeUniqueGaugeUtility(gaugePrecise, gaugeSloppy, gaugePrecondition, gaugeRefinement, gaugeEigensolver, gaugeExtended, QUDA_BOOLEAN_FALSE);
+      freeUniqueGaugeUtility(gaugePrecise, gaugeSloppy, gaugePrecondition, gaugeRefinement, gaugeEigensolver, gaugeExtended, false);
       break;
     case QUDA_ASQTAD_FAT_LINKS:
-      freeUniqueGaugeUtility(gaugeFatPrecise, gaugeFatSloppy, gaugeFatPrecondition, gaugeFatRefinement, gaugeFatEigensolver, gaugeFatExtended, QUDA_BOOLEAN_FALSE);
+      freeUniqueGaugeUtility(gaugeFatPrecise, gaugeFatSloppy, gaugeFatPrecondition, gaugeFatRefinement, gaugeFatEigensolver, gaugeFatExtended, false);
       break;
    case QUDA_ASQTAD_LONG_LINKS:
-      freeUniqueGaugeUtility(gaugeLongPrecise, gaugeLongSloppy, gaugeLongPrecondition, gaugeLongRefinement, gaugeLongEigensolver, gaugeLongExtended, QUDA_BOOLEAN_FALSE);
+      freeUniqueGaugeUtility(gaugeLongPrecise, gaugeLongSloppy, gaugeLongPrecondition, gaugeLongRefinement, gaugeLongEigensolver, gaugeLongExtended, false);
       break;
    case QUDA_SMEARED_LINKS:
       if (gaugeSmeared) delete gaugeSmeared;

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -1045,18 +1045,27 @@ void freeGaugeQuda(void)
 // These utility functions are declared w/doxygen above
 void freeUniqueSloppyGaugeUtility(cudaGaugeField*& precise, cudaGaugeField*& sloppy, cudaGaugeField*& precondition,
                                   cudaGaugeField*& refinement, cudaGaugeField*& eigensolver) {
-  if (refinement != sloppy && refinement != eigensolver && refinement)
-    delete refinement;
-  refinement = nullptr;
+  // In theory, we're checking for aliasing and freeing fields in the opposite order
+  // from which they were allocated... but in any case, we're doing an all-to-all
+  // checking of aliasing, so it doesn't really matter if the order matches.
 
-  if (precondition != sloppy && precondition != precise && precondition != eigensolver && precondition)
-    delete precondition;
-  precondition = nullptr;
-
-  if (eigensolver != sloppy && eigensolver != precise && eigensolver)
+  // The last field to get allocated is the eigensolver
+  if (eigensolver != refinement && eigensolver != precondition && eigensolver != sloppy &&
+      eigensolver != precise && eigensolver)
     delete eigensolver;
   eigensolver = nullptr;
 
+  // Second to last: refinement
+  if (refinement != precondition && refinement != sloppy && refinement != precise && refinement)
+    delete refinement;
+  refinement = nullptr;
+
+  // Third to last: precondition
+  if (precondition != sloppy && precondition != precise && precondition)
+    delete precondition;
+  precondition = nullptr;
+
+  // Fourth to last: sloppy
   if (sloppy != precise && sloppy)
     delete sloppy;
   sloppy = nullptr;


### PR DESCRIPTION
This PR does a good deal of clean-up/removal of code duplication related to how gauge fields are `free`d in `interface_quda.cpp`, largely by introducing a new function `freeUniqueGaugeQuda(...);` which narrowly frees the "regular" gauge fields, the fat fields, the long fields, and the smeared fields depending on the argument passed in.

This is also a hotfix PR because it fixes a bug introduced in the MILC gauge observable PR. In this PR, the new MILC interface observable routines loaded the gauge field via `loadGaugeQuda`, allocating the precise field and making aliases for the sloppy, refinement, etc field. This conflicted with the existing routine to update the gauge fields, which as part of maintaining/updating residency would narrowly `delete` just the precise field without any consistent clean-up of the sloppy fields, etc. In many cases this skated by on UB --- the host structure memory which was allocated incidentally remained "uncleaned" so the sloppy fields could still be accessed. In recent tests, though, this triggered segfaults due to accessing already free'd memory (as it should).

Since this PR touches the infrastructure to free internal fields in many different places, it needs to be tested across many applications before being merged, so I've tagged multiple people who work on a range of different applications.
