### PR TITLE
Hotfix/stackframe

### DIFF
--- a/include/kernels/dslash_clover_helper.cuh
+++ b/include/kernels/dslash_clover_helper.cuh
@@ -4,6 +4,7 @@
 #include <clover_field_order.h>
 #include "color_spinor.h"
 #include <linalg.cuh>
+#include "shared_memory_cache_helper.h"
 #include "kernel.h"
 
 namespace quda {
@@ -44,7 +45,8 @@ namespace quda {
     CloverArg(ColorSpinorField &out, const ColorSpinorField &in, const CloverField &clover,
 	      int parity, real kappa=0.0, real mu=0.0, real epsilon = 0.0,
 	      bool dagger = false, QudaTwistGamma5Type twist = QUDA_TWIST_GAMMA5_INVALID) :
-      kernel_param(dim3(in.TwistFlavor() == QUDA_TWIST_NONDEG_DOUBLET ? in.VolumeCB()/2 : in.VolumeCB(), in.SiteSubset())),
+      kernel_param(dim3(in.TwistFlavor() == QUDA_TWIST_NONDEG_DOUBLET ? in.VolumeCB()/2 : in.VolumeCB(),
+                        in.TwistFlavor() == QUDA_TWIST_NONDEG_DOUBLET ? 2 : 1, in.SiteSubset())),
       out(out), in(in),
       clover(clover, inverse && !dynamic_clover && twist == QUDA_TWIST_GAMMA5_INVALID), // only inverse if non-twisted clover and !dynamic
       cloverInv(clover, !dynamic_clover), // only inverse if !dynamic
@@ -90,7 +92,7 @@ namespace quda {
     constexpr CloverApply(const Arg &arg) : arg(arg) {}
     static constexpr const char* filename() { return KERNEL_FILE; }
 
-    __device__ __host__ inline void operator()(int x_cb, int parity)
+    __device__ __host__ inline void operator()(int x_cb, int, int parity)
     {
       using namespace linalg; // for Cholesky
       int clover_parity = arg.nParity == 2 ? parity : arg.parity;
@@ -133,7 +135,7 @@ namespace quda {
     constexpr TwistCloverApply(const Arg &arg) : arg(arg) {}
     static constexpr const char* filename() { return KERNEL_FILE; }
 
-    __device__ __host__ inline void operator()(int x_cb, int parity)
+    __device__ __host__ inline void operator()(int x_cb, int, int parity)
     {
       using namespace linalg; // for Cholesky
       int clover_parity = arg.nParity == 2 ? parity : arg.parity;
@@ -184,63 +186,68 @@ namespace quda {
     constexpr NdegTwistCloverApply(const Arg &arg) : arg(arg) {}
     static constexpr const char* filename() { return KERNEL_FILE; }
 
-    __device__ __host__ inline void operator()(int x_cb, int parity)
+    __device__ __host__ inline void operator()(int x_cb, int flavor, int parity)
     {
       using namespace linalg; // for Cholesky
       const int clover_parity = arg.nParity == 2 ? parity : arg.parity;
       const int spinor_parity = arg.nParity == 2 ? parity : 0;
       constexpr int n_flavor = 2;
-      fermion in[n_flavor];
-      fermion out[n_flavor];
 
+      int my_flavor_idx = x_cb + flavor * arg.volumeCB;
+      fermion in = arg.in(my_flavor_idx, spinor_parity);
+      in.toRel(); // change to chiral basis here
+
+      int chirality = flavor; // relabel flavor as chirality
+      // (C + i mu gamma_5 tau_3 - epsilon tau_1 )  [note: appropriate signs carried in arg.a / arg.b]
+      const complex<real> a(0.0, chirality == 0 ? arg.a : -arg.a);
+
+      Mat A = arg.clover(x_cb, clover_parity, chirality);
+
+      SharedMemoryCache<half_fermion> cache(target::block_dim());
+
+      half_fermion in_chi[n_flavor]; // flavor array of chirally projected fermion
+#pragma unroll
+      for (int i = 0; i < n_flavor; i++) in_chi[i] = in.chiral_project(i);
+
+      auto swizzle = [&](half_fermion x[2], int chirality, int reverse) {
+        if (chirality == 0) cache.save_y(x[1], reverse);
+        else                cache.save_y(x[0], 1 - reverse);
+        cache.sync();
+        if (chirality == 0) x[1] = cache.load_y(1 - reverse);
+        else                x[0] = cache.load_y(reverse);
+      };
+
+      swizzle(in_chi, chirality, 0); // apply the flavor-chirality swizzle between threads
+
+      half_fermion out_chi[n_flavor];
 #pragma unroll
       for (int flavor = 0; flavor < n_flavor; flavor++) {
-        in[flavor] = arg.in(x_cb + flavor * arg.volumeCB, spinor_parity);
-        in[flavor].toRel(); // change to chiral basis here
+        out_chi[flavor] = A * in_chi[flavor];
+        out_chi[flavor] += (flavor == 0 ? a : -a) * in_chi[flavor];
+        out_chi[flavor] += arg.b * in_chi[1 - flavor];
       }
 
+      if (arg.inverse) {
+        if (arg.dynamic_clover) {
+          Mat A2 = A.square();
+          A2 += arg.a2_minus_b2;
+          Cholesky<HMatrix, clover::cholesky_t<real>, N> cholesky(A2);
 #pragma unroll
-      for (int chirality = 0; chirality < 2; chirality++) {
-        // (C + i mu gamma_5 tau_3 - epsilon tau_1 )  [note: appropriate signs carried in arg.a / arg.b]
-        const complex<real> a(0.0, chirality == 0 ? arg.a : -arg.a);
-
-        Mat A = arg.clover(x_cb, clover_parity, chirality);
-
-        half_fermion in_chi[n_flavor] = {in[0].chiral_project(chirality), in[1].chiral_project(chirality)};
-        half_fermion out_chi[n_flavor];
-
+          for (int flavor = 0; flavor < n_flavor; flavor++)
+            out_chi[flavor] = static_cast<real>(0.25) * cholesky.backward(cholesky.forward(out_chi[flavor]));
+        } else {
+          Mat Ainv = arg.cloverInv(x_cb, clover_parity, chirality);
 #pragma unroll
-        for (int flavor = 0; flavor < n_flavor; flavor++) {
-          out_chi[flavor] = A * in_chi[flavor];
-          out_chi[flavor] += (flavor == 0 ? a : -a) * in_chi[flavor];
-          out_chi[flavor] += arg.b * in_chi[1 - flavor];
+          for (int flavor = 0; flavor < n_flavor; flavor++)
+            out_chi[flavor] = static_cast<real>(2.0) * (Ainv * out_chi[flavor]);
         }
-
-        if (arg.inverse) {
-          if (arg.dynamic_clover) {
-            Mat A2 = A.square();
-            A2 += arg.a2_minus_b2;
-            Cholesky<HMatrix, clover::cholesky_t<real>, N> cholesky(A2);
-#pragma unroll
-            for (int flavor = 0; flavor < n_flavor; flavor++)
-              out_chi[flavor] = static_cast<real>(0.25) * cholesky.backward(cholesky.forward(out_chi[flavor]));
-          } else {
-            Mat Ainv = arg.cloverInv(x_cb, clover_parity, chirality);
-#pragma unroll
-            for (int flavor = 0; flavor < n_flavor; flavor++)
-              out_chi[flavor] = static_cast<real>(2.0) * (Ainv * out_chi[flavor]);
-          }
-        }
-
-#pragma unroll
-        for (int flavor = 0; flavor < n_flavor; flavor++) out[flavor] += (out_chi[flavor]).chiral_reconstruct(chirality);
       }
 
-#pragma unroll
-      for (int flavor = 0; flavor < n_flavor; flavor++) {
-        out[flavor].toNonRel(); // change basis back
-        arg.out(x_cb + flavor * arg.volumeCB, spinor_parity) = out[flavor];
-      }
+      swizzle(out_chi, chirality, 1); // undo the flavor-chirality swizzle
+      fermion out = out_chi[0].chiral_reconstruct(0) + out_chi[1].chiral_reconstruct(1);
+      out.toNonRel(); // change basis back
+
+      arg.out(my_flavor_idx, spinor_parity) = out;
     }
   };
 

--- a/include/kernels/dslash_clover_helper.cuh
+++ b/include/kernels/dslash_clover_helper.cuh
@@ -209,15 +209,20 @@ namespace quda {
 #pragma unroll
       for (int i = 0; i < n_flavor; i++) in_chi[i] = in.chiral_project(i);
 
-      auto swizzle = [&](half_fermion x[2], int chirality, int reverse) {
-        if (chirality == 0) cache.save_y(x[1], reverse);
-        else                cache.save_y(x[0], 1 - reverse);
-        cache.sync();
-        if (chirality == 0) x[1] = cache.load_y(1 - reverse);
-        else                x[0] = cache.load_y(reverse);
+      enum swizzle_direction {
+        FORWARDS = 0,
+        BACKWARDS = 1
       };
 
-      swizzle(in_chi, chirality, 0); // apply the flavor-chirality swizzle between threads
+      auto swizzle = [&](half_fermion x[2], int chirality, swizzle_direction dir) {
+        if (chirality == 0) cache.save_y(x[1], dir);
+        else                cache.save_y(x[0], 1 - dir);
+        cache.sync();
+        if (chirality == 0) x[1] = cache.load_y(1 - dir);
+        else                x[0] = cache.load_y(dir);
+      };
+
+      swizzle(in_chi, chirality, FORWARDS); // apply the flavor-chirality swizzle between threads
 
       half_fermion out_chi[n_flavor];
 #pragma unroll
@@ -243,7 +248,7 @@ namespace quda {
         }
       }
 
-      swizzle(out_chi, chirality, 1); // undo the flavor-chirality swizzle
+      swizzle(out_chi, chirality, BACKWARDS); // undo the flavor-chirality swizzle
       fermion out = out_chi[0].chiral_reconstruct(0) + out_chi[1].chiral_reconstruct(1);
       out.toNonRel(); // change basis back
 

--- a/include/kernels/dslash_ndeg_twisted_clover_preconditioned.cuh
+++ b/include/kernels/dslash_ndeg_twisted_clover_preconditioned.cuh
@@ -93,15 +93,15 @@ namespace quda
 
         SharedMemoryCache<HalfVector> cache(target::block_dim());
 
-        auto swizzle = [&](int chirality, int reverse) {
-          if (chirality == 0) cache.save_y(out_chi[1], reverse);
-          else                cache.save_y(out_chi[0], 1 - reverse);
+        auto swizzle = [&](HalfVector x[2], int chirality, int reverse) {
+          if (chirality == 0) cache.save_y(x[1], reverse);
+          else                cache.save_y(x[0], 1 - reverse);
           cache.sync();
-          if (chirality == 0) out_chi[1] = cache.load_y(1 - reverse);
-          else                out_chi[0] = cache.load_y(reverse);
+          if (chirality == 0) x[1] = cache.load_y(1 - reverse);
+          else                x[0] = cache.load_y(reverse);
         };
 
-        swizzle(chirality, 0); // apply the flavor-chirality swizzle between threads
+        swizzle(out_chi, chirality, 0); // apply the flavor-chirality swizzle between threads
 
         // load in the clover matrix
         HMat A = arg.A(coord.x_cb, parity, chirality);
@@ -132,7 +132,7 @@ namespace quda
           }
         }
 
-        swizzle(chirality, 1); // undo the flavor-chirality swizzle
+        swizzle(out_chi, chirality, 1); // undo the flavor-chirality swizzle
         Vector tmp = out_chi[0].chiral_reconstruct(0) + out_chi[1].chiral_reconstruct(1);
         tmp.toNonRel(); // switch back to non-chiral basis
 

--- a/include/kernels/gauge_stout.cuh
+++ b/include/kernels/gauge_stout.cuh
@@ -133,7 +133,9 @@ namespace quda
         X[dr] += 2 * arg.border[dr];
       }
 
-      Link U, Stap, Rect, Q;
+      Link U, Q;
+      SharedMemoryCache<Link> Stap(target::block_dim());
+      SharedMemoryCache<Link> Rect(target::block_dim(), sizeof(Link));
 
       // This function gets stap = S_{mu,nu} i.e., the staple of length 3,
       // and the 1x2 and 2x1 rectangles of length 5. From the following paper:
@@ -146,7 +148,7 @@ namespace quda
       // Compute Omega_{mu}=[Sum_{mu neq nu}rho_{mu,nu}C_{mu,nu}]*U_{mu}^dag
       //-------------------------------------------------------------------
       // Compute \rho * staple_coeff * S - \rho * rectangle_coeff * R
-      Q = ((arg.staple_coeff * Stap) - (arg.rectangle_coeff * Rect)) * conj(U);
+      Q = ((arg.staple_coeff * static_cast<const Link &>(Stap)) - (arg.rectangle_coeff * static_cast<const Link &>(Rect))) * conj(U);
       // Compute \Q_{mu} = i/2[Omega_{mu}^dag - Omega_{mu}
       //                      - 1/3 Tr(Omega_{mu}^dag - Omega_{mu})]
       makeHerm(Q);

--- a/include/kernels/gauge_utils.cuh
+++ b/include/kernels/gauge_utils.cuh
@@ -5,6 +5,7 @@
 
 namespace quda
 {
+
   // This function gets stap = S_{mu,nu} i.e., the staple of length 3.
   //
   // |- > -|                /- > -/                /- > -
@@ -18,10 +19,12 @@ namespace quda
   // matrix+matrix = 18 floating-point ops
   // => Total number of floating point ops per function call
   // dims * (2*18 + 4*198) = dims*828
-  template <typename Arg, typename Link, typename Int>
-  __host__ __device__ inline void computeStaple(const Arg &arg, const int *x, const Int *X, const int parity, const int nu, Link &staple, const int dir_ignore)
+  template <typename Arg, typename Staple, typename Int>
+  __host__ __device__ inline void computeStaple(const Arg &arg, const int *x, const Int *X, const int parity, const int nu, Staple &staple, const int dir_ignore)
   {
-    setZero(&staple);
+    using Link = typename get_type<Staple>::type;
+    staple = Link();
+
     thread_array<int, 4> dx = { };
 #pragma unroll
     for (int mu = 0; mu < 4 ; mu++) {
@@ -91,14 +94,15 @@ namespace quda
   // matrix+matrix = 18 floating-point ops
   // => Total number of floating point ops per function call
   // dims * (8*18 + 28*198) = dims*5688
-  template <typename Arg, typename Link, typename Int>
+  template <typename Arg, typename Staple, typename Rectangle, typename Int>
   __host__ __device__ inline void computeStapleRectangle(const Arg &arg, const int *x, const Int *X, const int parity, const int nu,
-                                                         Link &staple, Link &rectangle, const int dir_ignore)
+                                                         Staple &staple, Rectangle &rectangle, const int dir_ignore)
   {
-    setZero(&staple);
-    setZero(&rectangle);
-    thread_array<int, 4> dx = { };
+    using Link = typename get_type<Staple>::type;
+    staple = Link();
+    rectangle = Link();
 
+    thread_array<int, 4> dx = { };
     for (int mu = 0; mu < 4; mu++) { // do not unroll loop to prevent register spilling
       // Identify directions orthogonal to the link.
       // Over-Improved stout is usually done for topological

--- a/include/kernels/laplace.cuh
+++ b/include/kernels/laplace.cuh
@@ -142,7 +142,7 @@ namespace quda
     static constexpr const char *filename() { return KERNEL_FILE; } // this file name - used for run-time compilation
 
     template <KernelType mykernel_type = kernel_type>
-    __device__ __host__ inline void operator()(int idx, int s, int parity)
+    __device__ __host__ __forceinline__ void operator()(int idx, int s, int parity)
     {
       using real = typename mapper<typename Arg::Float>::type;
       using Vector = ColorSpinor<real, Arg::nColor, Arg::nSpin>;

--- a/include/kernels/staggered_quark_smearing.cuh
+++ b/include/kernels/staggered_quark_smearing.cuh
@@ -161,7 +161,7 @@ namespace quda
     static constexpr const char *filename() { return KERNEL_FILE; } // this file name - used for run-time compilation
 
     template <KernelType mykernel_type = kernel_type>
-    __device__ __host__ inline void operator()(int idx, int s, int parity) // Kernel3D_impl
+    __device__ __host__ __forceinline__ void operator()(int idx, int s, int parity) // Kernel3D_impl
     {
       using real = typename mapper<typename Arg::Float>::type;
       using Vector = ColorSpinor<real, Arg::nColor, 1>;

--- a/include/quda_matrix.h
+++ b/include/quda_matrix.h
@@ -668,33 +668,24 @@ namespace quda {
       return uinv;
     }
 
-
-
-  template<class T, int N>
-   __device__ __host__ inline void setIdentity(Matrix<T,N>* m)
-  {
+    template <class T, int N> __device__ __host__ inline void setIdentity(Matrix<T, N> *m)
+    {
 #pragma unroll
-    for (int i=0; i<N; ++i){
-      (*m)(i,i) = 1;
+      for (int i = 0; i < N; ++i) {
+        (*m)(i, i) = 1;
 #pragma unroll
-      for (int j=i+1; j<N; ++j){
-        (*m)(i,j) = (*m)(j,i) = {};
+        for (int j = i + 1; j < N; ++j) { (*m)(i, j) = (*m)(j, i) = {}; }
       }
     }
-  }
 
-  template<class T, int N>
-  __device__ __host__ inline void setZero(Matrix<T,N>* m)
-  {
+    template <class T, int N> __device__ __host__ inline void setZero(Matrix<T, N> *m)
+    {
 #pragma unroll
-    for (int i=0; i<N; ++i){
+      for (int i = 0; i < N; ++i) {
 #pragma unroll
-      for (int j=0; j<N; ++j){
-        (*m)(i,j) = {};
+        for (int j = 0; j < N; ++j) { (*m)(i, j) = {}; }
       }
     }
-  }
-
 
   template<typename Complex,int N>
     __device__ __host__ inline void makeAntiHerm(Matrix<Complex,N> &m) {

--- a/include/quda_matrix.h
+++ b/include/quda_matrix.h
@@ -671,91 +671,29 @@ namespace quda {
 
 
   template<class T, int N>
-    __device__ __host__ inline
-    void setIdentity(Matrix<T,N>* m){
-
+   __device__ __host__ inline void setIdentity(Matrix<T,N>* m)
+  {
 #pragma unroll
-      for (int i=0; i<N; ++i){
-        (*m)(i,i) = 1;
+    for (int i=0; i<N; ++i){
+      (*m)(i,i) = 1;
 #pragma unroll
-        for (int j=i+1; j<N; ++j){
-          (*m)(i,j) = (*m)(j,i) = 0;
-        }
+      for (int j=i+1; j<N; ++j){
+        (*m)(i,j) = (*m)(j,i) = {};
       }
     }
+  }
 
-
-  template<int N>
-    __device__ __host__ inline
-    void setIdentity(Matrix<float2,N>* m){
-
-#pragma unroll
-      for (int i=0; i<N; ++i){
-        (*m)(i,i) = make_float2(1,0);
-#pragma unroll
-        for (int j=i+1; j<N; ++j){
-          (*m)(i,j) = (*m)(j,i) = make_float2(0.,0.);
-        }
-      }
-    }
-
-
-  template<int N>
-    __device__ __host__ inline
-    void setIdentity(Matrix<double2,N>* m){
-
-#pragma unroll
-      for (int i=0; i<N; ++i){
-        (*m)(i,i) = make_double2(1,0);
-#pragma unroll
-        for (int j=i+1; j<N; ++j){
-          (*m)(i,j) = (*m)(j,i) = make_double2(0.,0.);
-        }
-      }
-    }
-
-
-  // Need to write more generic code for this!
   template<class T, int N>
-    __device__ __host__ inline
-    void setZero(Matrix<T,N>* m){
-
+  __device__ __host__ inline void setZero(Matrix<T,N>* m)
+  {
 #pragma unroll
-      for (int i=0; i<N; ++i){
+    for (int i=0; i<N; ++i){
 #pragma unroll
-        for (int j=0; j<N; ++j){
-          (*m)(i,j) = 0;
-        }
+      for (int j=0; j<N; ++j){
+        (*m)(i,j) = {};
       }
     }
-
-
-  template<int N>
-    __device__ __host__ inline
-    void setZero(Matrix<float2,N>* m){
-
-#pragma unroll
-      for (int i=0; i<N; ++i){
-#pragma unroll
-        for (int j=0; j<N; ++j){
-          (*m)(i,j) = make_float2(0.,0.);
-        }
-      }
-    }
-
-
-  template<int N>
-    __device__ __host__ inline
-    void setZero(Matrix<double2,N>* m){
-
-#pragma unroll
-      for (int i=0; i<N; ++i){
-#pragma unroll
-        for (int j=0; j<N; ++j){
-          (*m)(i,j) = make_double2(0.,0.);
-        }
-      }
-    }
+  }
 
 
   template<typename Complex,int N>

--- a/include/targets/cuda/shared_memory_cache_helper.h
+++ b/include/targets/cuda/shared_memory_cache_helper.h
@@ -31,8 +31,7 @@ namespace quda
        according the maximum number of threads possible, given these
        dimensions.
    */
-  template <typename T, int block_size_y_ = 1, int block_size_z_ = 1, bool dynamic_ = true>
-  class SharedMemoryCache
+  template <typename T, int block_size_y_ = 1, int block_size_z_ = 1, bool dynamic_ = true> class SharedMemoryCache
   {
   public:
     using value_type = T;
@@ -73,7 +72,7 @@ namespace quda
       __device__ inline atom_t *operator()(unsigned int offset)
       {
         extern __shared__ int cache_[];
-        return reinterpret_cast<atom_t *>(reinterpret_cast<char*>(cache_) + offset);
+        return reinterpret_cast<atom_t *>(reinterpret_cast<char *>(cache_) + offset);
       }
     };
 
@@ -157,7 +156,8 @@ namespace quda
        memory base pointer (used when we have multiple caches in
        scope).  Need to include block size to actual offset.
     */
-    constexpr SharedMemoryCache(dim3 block = dim3(block_size_x, block_size_y, block_size_z), unsigned int thread_offset = 0) :
+    constexpr SharedMemoryCache(dim3 block = dim3(block_size_x, block_size_y, block_size_z),
+                                unsigned int thread_offset = 0) :
       block(block), stride(block.x * block.y * block.z), offset(stride * thread_offset)
     {
     }

--- a/include/targets/cuda/shared_memory_cache_helper.h
+++ b/include/targets/cuda/shared_memory_cache_helper.h
@@ -92,27 +92,17 @@ namespace quda
       }
     };
 
-    template <bool dynamic_shared> __device__ __host__ inline std::enable_if_t<dynamic_shared, atom_t*> cache()
+    template <bool dynamic_shared> __device__ __host__ inline std::enable_if_t<dynamic_shared, atom_t *> cache() const
     {
       return target::dispatch<cache_dynamic>(offset);
     }
 
-    template <bool dynamic_shared> __device__ __host__ inline std::enable_if_t<!dynamic_shared, atom_t*> cache()
+    template <bool dynamic_shared> __device__ __host__ inline std::enable_if_t<!dynamic_shared, atom_t *> cache() const
     {
       return target::dispatch<cache_static>();
     }
 
-    template <bool dynamic_shared> __device__ __host__ inline std::enable_if_t<dynamic_shared, atom_t const *> cache() const
-    {
-      return target::dispatch<cache_dynamic>(offset);
-    }
-
-    template <bool dynamic_shared> __device__ __host__ inline std::enable_if_t<!dynamic_shared, atom_t const *> cache() const
-    {
-      return target::dispatch<cache_static>();
-    }
-
-    __device__ __host__ inline void save_detail(const T &a, int x, int y, int z)
+    __device__ __host__ inline void save_detail(const T &a, int x, int y, int z) const
     {
       atom_t tmp[n_element];
       memcpy(tmp, (void *)&a, sizeof(T));
@@ -167,7 +157,7 @@ namespace quda
     /**
        @brief Grab the raw base address to shared memory.
     */
-    __device__ __host__ inline T *data() { return reinterpret_cast<T *>(cache<dynamic>()); }
+    __device__ __host__ inline auto data() const { return reinterpret_cast<T *>(cache<dynamic>()); }
 
     /**
        @brief Save the value into the 3-d shared memory cache.
@@ -176,7 +166,7 @@ namespace quda
        @param[in] y The y index to use
        @param[in] z The z index to use
      */
-    __device__ __host__ inline void save(const T &a, int x = -1, int y = -1, int z = -1)
+    __device__ __host__ inline void save(const T &a, int x = -1, int y = -1, int z = -1) const
     {
       auto tid = target::thread_idx();
       x = (x == -1) ? tid.x : x;
@@ -190,7 +180,7 @@ namespace quda
        @param[in] a The value to store in the shared memory cache
        @param[in] x The x index to use
      */
-    __device__ __host__ inline void save_x(const T &a, int x = -1)
+    __device__ __host__ inline void save_x(const T &a, int x = -1) const
     {
       auto tid = target::thread_idx();
       x = (x == -1) ? tid.x : x;
@@ -202,7 +192,7 @@ namespace quda
        @param[in] a The value to store in the shared memory cache
        @param[in] y The y index to use
      */
-    __device__ __host__ inline void save_y(const T &a, int y = -1)
+    __device__ __host__ inline void save_y(const T &a, int y = -1) const
     {
       auto tid = target::thread_idx();
       y = (y == -1) ? tid.y : y;
@@ -214,7 +204,7 @@ namespace quda
        @param[in] a The value to store in the shared memory cache
        @param[in] z The z index to use
      */
-    __device__ __host__ inline void save_z(const T &a, int z = -1)
+    __device__ __host__ inline void save_z(const T &a, int z = -1) const
     {
       auto tid = target::thread_idx();
       z = (z == -1) ? tid.z : z;
@@ -276,7 +266,7 @@ namespace quda
     /**
        @brief Synchronize the cache
     */
-    __device__ __host__ void sync() { target::dispatch<sync_impl>(); }
+    __device__ __host__ void sync() const { target::dispatch<sync_impl>(); }
 
     /**
        @brief Cast operator to allow cache objects to be used where T
@@ -288,7 +278,7 @@ namespace quda
        @brief Assignment operator to allow cache objects to be used on
        the lhs where T is otherwise expected.
      */
-    __device__ __host__ void operator=(const T& src) { save(src); }
+    __device__ __host__ void operator=(const T &src) const { save(src); }
   };
 
 } // namespace quda

--- a/include/targets/cuda/shared_memory_cache_helper.h
+++ b/include/targets/cuda/shared_memory_cache_helper.h
@@ -85,7 +85,7 @@ namespace quda
        @return Shared memory pointer
      */
     template <typename dummy> struct cache_static<true, dummy> {
-      __device__ inline atom_t *operator()()
+      __device__ inline atom_t *operator()(unsigned = 0)
       {
         static __shared__ atom_t cache_[n_element * block_size_x * block_size_y * block_size_z];
         return reinterpret_cast<atom_t *>(cache_);

--- a/include/targets/cuda/shared_memory_cache_helper.h
+++ b/include/targets/cuda/shared_memory_cache_helper.h
@@ -291,53 +291,7 @@ namespace quda
     __device__ __host__ void operator=(const T& src) { save(src); }
   };
 
-  // Convenience overloads to allow SharedMemoryCache objects to appear in simple expressions
-
-  template <typename T, int by, int bz, bool dynamic>
-  __device__ __host__ inline T operator+(const SharedMemoryCache<T, by, bz, dynamic> &a, const T &b)
-  {
-    return static_cast<const T&>(a) + b;
-  }
-
-  template <typename T, int by, int bz, bool dynamic>
-  __device__ __host__ inline T operator+(const T &a, const SharedMemoryCache<T, by, bz, dynamic> &b)
-  {
-    return a + static_cast<const T&>(b);
-  }
-
-  template <typename T, int by, int bz, bool dynamic>
-  __device__ __host__ inline T operator-(const SharedMemoryCache<T, by, bz, dynamic> &a, const T &b)
-  {
-    return static_cast<const T&>(a) - b;
-  }
-
-  template <typename T, int by, int bz, bool dynamic>
-  __device__ __host__ inline T operator-(const T &a, const SharedMemoryCache<T, by, bz, dynamic> &b)
-  {
-    return a - static_cast<const T&>(b);
-  }
-
-  template <typename T, int by, int bz, bool dynamic>
-  __device__ __host__ inline auto operator+=(SharedMemoryCache<T, by, bz, dynamic> &a, const T &b)
-  {
-    a.save(static_cast<const T&>(a) + b);
-    return a;
-  }
-
-  template <typename T, int by, int bz, bool dynamic>
-  __device__ __host__ inline auto operator-=(SharedMemoryCache<T, by, bz, dynamic> &a, const T &b)
-  {
-    a.save(static_cast<const T&>(a) - b);
-    return a;
-  }
-
-  /**
-     @brief Uniform helper for exposing type T, whether we are dealing
-     with an instance of T or SharedMemoryCache<T>
-   */
-  template <class T, class enable = void> struct get_type { using type = T; };
-  template <class T> struct get_type<T, std::enable_if_t<std::is_same_v<T, SharedMemoryCache<typename T::value_type, T::block_size_y, T::block_size_z, T::dynamic> >>> {
-    using type = typename T::value_type;
-  };
-
 } // namespace quda
+
+// include overloads
+#include "../generic/shared_memory_cache_helper.h"

--- a/include/targets/generic/shared_memory_cache_helper.h
+++ b/include/targets/generic/shared_memory_cache_helper.h
@@ -6,59 +6,64 @@
    include/targets/cuda/shared_memory_cache_helper.h, etc.
  */
 
-namespace quda {
+namespace quda
+{
 
   template <typename T, int by, int bz, bool dynamic>
   __device__ __host__ inline T operator+(const SharedMemoryCache<T, by, bz, dynamic> &a, const T &b)
   {
-    return static_cast<const T&>(a) + b;
+    return static_cast<const T &>(a) + b;
   }
 
   template <typename T, int by, int bz, bool dynamic>
   __device__ __host__ inline T operator+(const T &a, const SharedMemoryCache<T, by, bz, dynamic> &b)
   {
-    return a + static_cast<const T&>(b);
+    return a + static_cast<const T &>(b);
   }
 
   template <typename T, int by, int bz, bool dynamic>
   __device__ __host__ inline T operator-(const SharedMemoryCache<T, by, bz, dynamic> &a, const T &b)
   {
-    return static_cast<const T&>(a) - b;
+    return static_cast<const T &>(a) - b;
   }
 
   template <typename T, int by, int bz, bool dynamic>
   __device__ __host__ inline T operator-(const T &a, const SharedMemoryCache<T, by, bz, dynamic> &b)
   {
-    return a - static_cast<const T&>(b);
+    return a - static_cast<const T &>(b);
   }
 
   template <typename T, int by, int bz, bool dynamic>
   __device__ __host__ inline auto operator+=(SharedMemoryCache<T, by, bz, dynamic> &a, const T &b)
   {
-    a.save(static_cast<const T&>(a) + b);
+    a.save(static_cast<const T &>(a) + b);
     return a;
   }
 
   template <typename T, int by, int bz, bool dynamic>
   __device__ __host__ inline auto operator-=(SharedMemoryCache<T, by, bz, dynamic> &a, const T &b)
   {
-    a.save(static_cast<const T&>(a) - b);
+    a.save(static_cast<const T &>(a) - b);
     return a;
   }
 
   template <typename T, int by, int bz, bool dynamic>
   __device__ __host__ inline auto conj(const SharedMemoryCache<T, by, bz, dynamic> &a)
   {
-    return conj(static_cast<const T&>(a));
+    return conj(static_cast<const T &>(a));
   }
 
   /**
      @brief Uniform helper for exposing type T, whether we are dealing
      with an instance of T or SharedMemoryCache<T>
    */
-  template <class T, class enable = void> struct get_type { using type = T; };
-  template <class T> struct get_type<T, std::enable_if_t<std::is_same_v<T, SharedMemoryCache<typename T::value_type, T::block_size_y, T::block_size_z, T::dynamic> >>> {
+  template <class T, class enable = void> struct get_type {
+    using type = T;
+  };
+  template <class T>
+  struct get_type<
+    T, std::enable_if_t<std::is_same_v<T, SharedMemoryCache<typename T::value_type, T::block_size_y, T::block_size_z, T::dynamic>>>> {
     using type = typename T::value_type;
   };
 
-}
+} // namespace quda

--- a/include/targets/generic/shared_memory_cache_helper.h
+++ b/include/targets/generic/shared_memory_cache_helper.h
@@ -1,0 +1,64 @@
+/**
+   @file shared_memory_cache_helper.h
+   @brief Convenience overloads to allow SharedMemoryCache objects to
+   appear in simple expressions.  The actual implementation of
+   SharedMemoryCache is target specific, and located in e.g.,
+   include/targets/cuda/shared_memory_cache_helper.h, etc.
+ */
+
+namespace quda {
+
+  template <typename T, int by, int bz, bool dynamic>
+  __device__ __host__ inline T operator+(const SharedMemoryCache<T, by, bz, dynamic> &a, const T &b)
+  {
+    return static_cast<const T&>(a) + b;
+  }
+
+  template <typename T, int by, int bz, bool dynamic>
+  __device__ __host__ inline T operator+(const T &a, const SharedMemoryCache<T, by, bz, dynamic> &b)
+  {
+    return a + static_cast<const T&>(b);
+  }
+
+  template <typename T, int by, int bz, bool dynamic>
+  __device__ __host__ inline T operator-(const SharedMemoryCache<T, by, bz, dynamic> &a, const T &b)
+  {
+    return static_cast<const T&>(a) - b;
+  }
+
+  template <typename T, int by, int bz, bool dynamic>
+  __device__ __host__ inline T operator-(const T &a, const SharedMemoryCache<T, by, bz, dynamic> &b)
+  {
+    return a - static_cast<const T&>(b);
+  }
+
+  template <typename T, int by, int bz, bool dynamic>
+  __device__ __host__ inline auto operator+=(SharedMemoryCache<T, by, bz, dynamic> &a, const T &b)
+  {
+    a.save(static_cast<const T&>(a) + b);
+    return a;
+  }
+
+  template <typename T, int by, int bz, bool dynamic>
+  __device__ __host__ inline auto operator-=(SharedMemoryCache<T, by, bz, dynamic> &a, const T &b)
+  {
+    a.save(static_cast<const T&>(a) - b);
+    return a;
+  }
+
+  template <typename T, int by, int bz, bool dynamic>
+  __device__ __host__ inline auto conj(const SharedMemoryCache<T, by, bz, dynamic> &a)
+  {
+    return conj(static_cast<const T&>(a));
+  }
+
+  /**
+     @brief Uniform helper for exposing type T, whether we are dealing
+     with an instance of T or SharedMemoryCache<T>
+   */
+  template <class T, class enable = void> struct get_type { using type = T; };
+  template <class T> struct get_type<T, std::enable_if_t<std::is_same_v<T, SharedMemoryCache<typename T::value_type, T::block_size_y, T::block_size_z, T::dynamic> >>> {
+    using type = typename T::value_type;
+  };
+
+}

--- a/include/targets/hip/shared_memory_cache_helper.h
+++ b/include/targets/hip/shared_memory_cache_helper.h
@@ -31,8 +31,7 @@ namespace quda
        according the maximum number of threads possible, given these
        dimensions.
    */
-  template <typename T, int block_size_y_ = 1, int block_size_z_ = 1, bool dynamic_ = true>
-  class SharedMemoryCache
+  template <typename T, int block_size_y_ = 1, int block_size_z_ = 1, bool dynamic_ = true> class SharedMemoryCache
   {
   public:
     using value_type = T;
@@ -73,7 +72,7 @@ namespace quda
       __device__ inline atom_t *operator()(unsigned int offset)
       {
         extern __shared__ int cache_[];
-        return reinterpret_cast<atom_t *>(reinterpret_cast<char*>(cache_) + offset);
+        return reinterpret_cast<atom_t *>(reinterpret_cast<char *>(cache_) + offset);
       }
     };
 
@@ -157,7 +156,8 @@ namespace quda
        memory base pointer (used when we have multiple caches in
        scope).  Need to include block size to actual offset.
     */
-    constexpr SharedMemoryCache(dim3 block = dim3(block_size_x, block_size_y, block_size_z), unsigned int thread_offset = 0) :
+    constexpr SharedMemoryCache(dim3 block = dim3(block_size_x, block_size_y, block_size_z),
+                                unsigned int thread_offset = 0) :
       block(block), stride(block.x * block.y * block.z), offset(stride * thread_offset)
     {
     }

--- a/include/targets/hip/shared_memory_cache_helper.h
+++ b/include/targets/hip/shared_memory_cache_helper.h
@@ -92,27 +92,17 @@ namespace quda
       }
     };
 
-    template <bool dynamic_shared> __device__ __host__ inline std::enable_if_t<dynamic_shared, atom_t*> cache()
+    template <bool dynamic_shared> __device__ __host__ inline std::enable_if_t<dynamic_shared, atom_t *> cache() const
     {
       return target::dispatch<cache_dynamic>(offset);
     }
 
-    template <bool dynamic_shared> __device__ __host__ inline std::enable_if_t<!dynamic_shared, atom_t*> cache()
+    template <bool dynamic_shared> __device__ __host__ inline std::enable_if_t<!dynamic_shared, atom_t *> cache() const
     {
       return target::dispatch<cache_static>();
     }
 
-    template <bool dynamic_shared> __device__ __host__ inline std::enable_if_t<dynamic_shared, atom_t const *> cache() const
-    {
-      return target::dispatch<cache_dynamic>(offset);
-    }
-
-    template <bool dynamic_shared> __device__ __host__ inline std::enable_if_t<!dynamic_shared, atom_t const *> cache() const
-    {
-      return target::dispatch<cache_static>();
-    }
-
-    __device__ __host__ inline void save_detail(const T &a, int x, int y, int z)
+    __device__ __host__ inline void save_detail(const T &a, int x, int y, int z) const
     {
       atom_t tmp[n_element];
       memcpy(tmp, (void *)&a, sizeof(T));
@@ -167,7 +157,7 @@ namespace quda
     /**
        @brief Grab the raw base address to shared memory.
     */
-    __device__ __host__ inline T *data() { return reinterpret_cast<T *>(cache<dynamic>()); }
+    __device__ __host__ inline auto data() const { return reinterpret_cast<T *>(cache<dynamic>()); }
 
     /**
        @brief Save the value into the 3-d shared memory cache.
@@ -176,7 +166,7 @@ namespace quda
        @param[in] y The y index to use
        @param[in] z The z index to use
      */
-    __device__ __host__ inline void save(const T &a, int x = -1, int y = -1, int z = -1)
+    __device__ __host__ inline void save(const T &a, int x = -1, int y = -1, int z = -1) const
     {
       auto tid = target::thread_idx();
       x = (x == -1) ? tid.x : x;
@@ -190,7 +180,7 @@ namespace quda
        @param[in] a The value to store in the shared memory cache
        @param[in] x The x index to use
      */
-    __device__ __host__ inline void save_x(const T &a, int x = -1)
+    __device__ __host__ inline void save_x(const T &a, int x = -1) const
     {
       auto tid = target::thread_idx();
       x = (x == -1) ? tid.x : x;
@@ -202,7 +192,7 @@ namespace quda
        @param[in] a The value to store in the shared memory cache
        @param[in] y The y index to use
      */
-    __device__ __host__ inline void save_y(const T &a, int y = -1)
+    __device__ __host__ inline void save_y(const T &a, int y = -1) const
     {
       auto tid = target::thread_idx();
       y = (y == -1) ? tid.y : y;
@@ -214,7 +204,7 @@ namespace quda
        @param[in] a The value to store in the shared memory cache
        @param[in] z The z index to use
      */
-    __device__ __host__ inline void save_z(const T &a, int z = -1)
+    __device__ __host__ inline void save_z(const T &a, int z = -1) const
     {
       auto tid = target::thread_idx();
       z = (z == -1) ? tid.z : z;
@@ -276,7 +266,7 @@ namespace quda
     /**
        @brief Synchronize the cache
     */
-    __device__ __host__ void sync() { target::dispatch<sync_impl>(); }
+    __device__ __host__ void sync() const { target::dispatch<sync_impl>(); }
 
     /**
        @brief Cast operator to allow cache objects to be used where T
@@ -288,7 +278,7 @@ namespace quda
        @brief Assignment operator to allow cache objects to be used on
        the lhs where T is otherwise expected.
      */
-    __device__ __host__ void operator=(const T& src) { save(src); }
+    __device__ __host__ void operator=(const T &src) const { save(src); }
   };
 
 } // namespace quda

--- a/include/targets/hip/shared_memory_cache_helper.h
+++ b/include/targets/hip/shared_memory_cache_helper.h
@@ -85,7 +85,7 @@ namespace quda
        @return Shared memory pointer
      */
     template <typename dummy> struct cache_static<true, dummy> {
-      __device__ inline atom_t *operator()()
+      __device__ inline atom_t *operator()(unsigned = 0)
       {
         static __shared__ atom_t cache_[n_element * block_size_x * block_size_y * block_size_z];
         return reinterpret_cast<atom_t *>(cache_);

--- a/include/targets/hip/shared_memory_cache_helper.h
+++ b/include/targets/hip/shared_memory_cache_helper.h
@@ -291,53 +291,7 @@ namespace quda
     __device__ __host__ void operator=(const T& src) { save(src); }
   };
 
-  // Convenience overloads to allow SharedMemoryCache objects to appear in simple expressions
-
-  template <typename T, int by, int bz, bool dynamic>
-  __device__ __host__ inline T operator+(const SharedMemoryCache<T, by, bz, dynamic> &a, const T &b)
-  {
-    return static_cast<const T&>(a) + b;
-  }
-
-  template <typename T, int by, int bz, bool dynamic>
-  __device__ __host__ inline T operator+(const T &a, const SharedMemoryCache<T, by, bz, dynamic> &b)
-  {
-    return a + static_cast<const T&>(b);
-  }
-
-  template <typename T, int by, int bz, bool dynamic>
-  __device__ __host__ inline T operator-(const SharedMemoryCache<T, by, bz, dynamic> &a, const T &b)
-  {
-    return static_cast<const T&>(a) - b;
-  }
-
-  template <typename T, int by, int bz, bool dynamic>
-  __device__ __host__ inline T operator-(const T &a, const SharedMemoryCache<T, by, bz, dynamic> &b)
-  {
-    return a - static_cast<const T&>(b);
-  }
-
-  template <typename T, int by, int bz, bool dynamic>
-  __device__ __host__ inline auto operator+=(SharedMemoryCache<T, by, bz, dynamic> &a, const T &b)
-  {
-    a.save(static_cast<const T&>(a) + b);
-    return a;
-  }
-
-  template <typename T, int by, int bz, bool dynamic>
-  __device__ __host__ inline auto operator-=(SharedMemoryCache<T, by, bz, dynamic> &a, const T &b)
-  {
-    a.save(static_cast<const T&>(a) - b);
-    return a;
-  }
-
-  /**
-     @brief Uniform helper for exposing type T, whether we are dealing
-     with an instance of T or SharedMemoryCache<T>
-   */
-  template <class T, class enable = void> struct get_type { using type = T; };
-  template <class T> struct get_type<T, std::enable_if_t<std::is_same_v<T, SharedMemoryCache<typename T::value_type, T::block_size_y, T::block_size_z, T::dynamic> >>> {
-    using type = typename T::value_type;
-  };
-
 } // namespace quda
+
+// include overloads
+#include "../generic/shared_memory_cache_helper.h"

--- a/include/targets/hip/tunable_kernel.h
+++ b/include/targets/hip/tunable_kernel.h
@@ -75,7 +75,7 @@ namespace quda
     {
       strcpy(vol, field.VolString().c_str());
       strcpy(aux, compile_type_str(field, location));
-      if (this->location == QUDA_CUDA_FIELD_LOCATION && device::use_constant_memory_arg<>::value) strcat(aux, "cmem,");
+      if (this->location == QUDA_CUDA_FIELD_LOCATION && use_constant_memory()) strcat(aux, "cmem,");
       if (this->location == QUDA_CPU_FIELD_LOCATION) strcat(aux, getOmpThreadStr());
       strcat(aux, field.AuxString().c_str());
     }
@@ -84,7 +84,7 @@ namespace quda
     {
       u64toa(vol, n_items);
       strcpy(aux, compile_type_str(location));
-      if (location == QUDA_CUDA_FIELD_LOCATION && device::use_constant_memory_arg<>::value) strcat(aux, "cmem,");
+      if (location == QUDA_CUDA_FIELD_LOCATION && use_constant_memory()) strcat(aux, "cmem,");
       if (this->location == QUDA_CPU_FIELD_LOCATION) strcat(aux, getOmpThreadStr());
     }
 

--- a/lib/clover_deriv_quda.cu
+++ b/lib/clover_deriv_quda.cu
@@ -13,11 +13,6 @@ namespace quda {
     int parity;
     unsigned int minThreads() const { return gauge.LocalVolumeCB(); }
 
-    unsigned int sharedBytesPerThread() const
-    {
-      return gauge.Ncolor() * gauge.Ncolor() * 2 * sizeof(typename mapper<Float>::type);
-    }
-
   public:
     DerivativeClover(GaugeField &force, GaugeField &gauge, GaugeField &oprod, double coeff, int parity) :
       TunableKernel3D(gauge, 2, 4),

--- a/lib/clover_deriv_quda.cu
+++ b/lib/clover_deriv_quda.cu
@@ -13,6 +13,11 @@ namespace quda {
     int parity;
     unsigned int minThreads() const { return gauge.LocalVolumeCB(); }
 
+    unsigned int sharedBytesPerThread() const
+    {
+      return gauge.Ncolor() * gauge.Ncolor() * 2 * sizeof(typename mapper<Float>::type);
+    }
+
   public:
     DerivativeClover(GaugeField &force, GaugeField &gauge, GaugeField &oprod, double coeff, int parity) :
       TunableKernel3D(gauge, 2, 4),

--- a/lib/dslash_clover_helper.cu
+++ b/lib/dslash_clover_helper.cu
@@ -7,7 +7,7 @@
 
 namespace quda {
 
-  template <typename Float, int nColor> class Clover : public TunableKernel2D {
+  template <typename Float, int nColor> class Clover : public TunableKernel3D {
     ColorSpinorField &out;
     const ColorSpinorField &in;
     const CloverField &clover;
@@ -17,7 +17,7 @@ namespace quda {
 
   public:
     Clover(ColorSpinorField &out, const ColorSpinorField &in, const CloverField &clover, bool inverse, int parity) :
-      TunableKernel2D(in, in.SiteSubset()),
+      TunableKernel3D(in, 1, in.SiteSubset()),
       out(out),
       in(in),
       clover(clover),
@@ -55,7 +55,7 @@ namespace quda {
   }
 #endif // GPU_CLOVER_DIRAC
 
-  template <typename Float, int nColor> class TwistClover : public TunableKernel2D {
+  template <typename Float, int nColor> class TwistClover : public TunableKernel3D {
     ColorSpinorField &out;
     const ColorSpinorField &in;
     const CloverField &clover;
@@ -68,10 +68,15 @@ namespace quda {
     QudaTwistGamma5Type twist;
     unsigned int minThreads() const { return in.VolumeCB(); }
 
+    unsigned int sharedBytesPerThread() const
+    {
+      return (in.Nspin() / 2) * in.Ncolor() * 2 * sizeof(typename mapper<Float>::type);
+    }
+
   public:
     TwistClover(ColorSpinorField &out, const ColorSpinorField &in, const CloverField &clover,
                 double kappa, double mu, double epsilon, int parity, int dagger, QudaTwistGamma5Type twist) :
-      TunableKernel2D(in, in.SiteSubset()),
+      TunableKernel3D(in, in.TwistFlavor(), in.SiteSubset()),
       out(out),
       in(in),
       clover(clover),
@@ -85,6 +90,8 @@ namespace quda {
     {
       if (in.Nspin() != 4 || out.Nspin() != 4) errorQuda("Unsupported nSpin=%d %d", out.Nspin(), in.Nspin());
       strcat(aux, inverse ? ",inverse" : ",direct");
+      resizeVector(2, in.SiteSubset());
+      resizeStep(2, 1); // this will force flavor to be contained in the block
       apply(device::get_default_stream());
     }
 

--- a/lib/dslash_ndeg_twisted_clover_preconditioned.cu
+++ b/lib/dslash_ndeg_twisted_clover_preconditioned.cu
@@ -22,7 +22,7 @@ namespace quda
 
       unsigned int sharedBytesPerThread() const
       {
-        return 2 * in.Ncolor() * 2 * sizeof(typename mapper<typename Arg::Float>::type);
+        return (in.Nspin() / 2) * in.Ncolor() * 2 * sizeof(typename mapper<typename Arg::Float>::type);
       }
       
     public:

--- a/lib/gauge_stout.cu
+++ b/lib/gauge_stout.cu
@@ -15,6 +15,13 @@ namespace quda {
     const int stoutDim;
     unsigned int minThreads() const { return in.LocalVolumeCB(); }
 
+    unsigned int maxSharedBytesPerBlock() const { return maxDynamicSharedBytesPerBlock(); }
+    unsigned int sharedBytesPerThread() const
+    {
+      // use SharedMemoryCache if using over improvement for two link fields
+      return improved ? 2 * in.Ncolor() * in.Ncolor() * 2 * sizeof(typename mapper<Float>::type) : 0;
+    }
+
   public:
     // (2,3): 2 for parity in the y thread dim, 3 corresponds to mapping direction to the z thread dim
     GaugeSTOUT(GaugeField &out, const GaugeField &in, bool improved, double rho, double epsilon = 0.0) :
@@ -37,6 +44,7 @@ namespace quda {
       if (!improved) {
         launch<STOUT>(tp, stream, STOUTArg<Float, nColor, recon, 3>(out, in, rho));
       } else if (improved) {
+        tp.set_max_shared_bytes = true;
         launch<OvrImpSTOUT>(tp, stream, STOUTArg<Float, nColor, recon, 4>(out, in, rho, epsilon));
       }
     }

--- a/lib/gauge_wilson_flow.cu
+++ b/lib/gauge_wilson_flow.cu
@@ -58,7 +58,6 @@ namespace quda {
     void apply(const qudaStream_t &stream)
     {
       TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
-      tp.set_max_shared_bytes = wflow_type == QUDA_GAUGE_SMEAR_SYMANZIK_FLOW ? true :false;
 
       switch (wflow_type) {
       case QUDA_GAUGE_SMEAR_WILSON_FLOW:
@@ -75,6 +74,7 @@ namespace quda {
         }
         break;
       case QUDA_GAUGE_SMEAR_SYMANZIK_FLOW:
+        tp.set_max_shared_bytes = true;
         switch (step_type) {
         case WFLOW_STEP_W1:
           launch<WFlow>(tp, stream, Arg<QUDA_GAUGE_SMEAR_SYMANZIK_FLOW, WFLOW_STEP_W1>(out, temp, in, epsilon));

--- a/lib/gauge_wilson_flow.cu
+++ b/lib/gauge_wilson_flow.cu
@@ -18,7 +18,9 @@ namespace quda {
     const WFlowStepType step_type;
 
     unsigned int minThreads() const { return in.LocalVolumeCB(); }
-    unsigned int maxSharedBytesPerBlock() const { return maxDynamicSharedBytesPerBlock(); }
+    unsigned int maxSharedBytesPerBlock() const {
+      return wflow_type == QUDA_GAUGE_SMEAR_SYMANZIK_FLOW ? maxDynamicSharedBytesPerBlock() : TunableKernel3D::maxSharedBytesPerBlock();
+    }
 
     unsigned int sharedBytesPerThread() const
     {

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -5962,6 +5962,7 @@ void contractQuda(const void *hp_x, const void *hp_y, void *h_result, const Quda
   qudaMemcpy(h_result, d_result, data_bytes, qudaMemcpyDeviceToHost);
   profileContract.TPSTOP(QUDA_PROFILE_D2H);
 
+  pool_device_free(d_result);
   profileContract.TPSTOP(QUDA_PROFILE_TOTAL);
 }
 

--- a/tests/staggered_dslash_test_utils.h
+++ b/tests/staggered_dslash_test_utils.h
@@ -79,8 +79,8 @@ struct StaggeredDslashTestWrapper {
   char **argv_copy;
 
   // Split grid options
-  int num_src;
-  int test_split_grid;
+  bool test_split_grid = false;
+  int num_src = 1;
 
   void staggeredDslashRef()
   {
@@ -154,7 +154,6 @@ struct StaggeredDslashTestWrapper {
 
     num_src = grid_partition[0] * grid_partition[1] * grid_partition[2] * grid_partition[3];
     test_split_grid = num_src > 1;
-
     if (test_split_grid) { dtest_type = dslash_test_type::Dslash; }
 
     inv_param.dagger = dagger ? QUDA_DAG_YES : QUDA_DAG_NO;


### PR DESCRIPTION
This PR primarily serves to remove the induced stack frame in a number of kernels
* Use flavor/chirality swizzle trick in non-degenerate Twisted-mass preconditioned clover application kernel
* Laplace and Staggered quark smearing kernel with NVSHMEM (lack of `__force_inline__`)
* Use `SharedMemoryCache` to act as virtual registers (Symanzik improved Wilson-flow and STOUT kernels)
  * In doing so we add support for multiple concurrent dynamic cache objects through use of an offset to the base shared-memory pointer
* Reordering of clover derivative kernel to reduce register pressure

Some other minor changes:
* Fix for HIP compilation which was broken by #1364 
* Remove some unused legacy `Matrix` functions