### PR TITLE
Implemented changes to Gaussian smearing routines to resolve issue #681

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,8 @@ Advanced Scientific Computing (PASC21) [arXiv:2104.05615[hep-lat]].
 *  Evan Weinberg (NVIDIA)
 *  Frank Winter (Jefferson Lab)
 *  Yi-Bo Yang (Chinese Academy of Sciences)
+*  Anthony Grebe (Fermilab)
+*  Michael Wagman (Fermilab)
 
 
 Portions of this software were developed at the Innovative Systems Lab,


### PR DESCRIPTION
This is a modification to lib/interface_quda.cpp to fix the two bugs described by Yi-Bo Yang in issue #681:
1. The calls to profileWuppertal are removed, as they threw an error when the timer was started twice, once here and once in the subroutine called.  (There might be a more elegant way to fix this than simply deleting the profiler calls, but I'm not familiar enough with the quda repository to do this.)
2. The comm_override passed to ApplyLaplace is changed from nullptr to the bug fix given in Yang's comment in the issue tracker.
With these changes implemented, quda compiles and runs without errors, and the smeared pion correlator on a test lattice agrees with a CPU implementation of Gaussian smearing in a different codebase (qlua).