### PR TITLE
Hotfix: MILC+QUDA error if MILC is compiled with QUDA_VERBOSITY >= VERBOSE

### DIFF
--- a/lib/milc_interface.cpp
+++ b/lib/milc_interface.cpp
@@ -93,12 +93,15 @@ void qudaSetMPICommHandle(void *mycomm) { setMPICommHandleQuda(mycomm); }
 
 void qudaInit(QudaInitArgs_t input)
 {
+  // Calling qudamilc_called with QUDA_SUMMARIZE hand-baked in is intentional:
+  // if the default verbosity is QUDA_VERBOSE or greater, the printfQuda
+  // inside qudamilc_called will barf because qudaSetLayout hasn't been called yet.
   if (initialized) return;
   setVerbosityQuda(input.verbosity, "", stdout);
-  qudamilc_called<true>(__func__);
+  qudamilc_called<true>(__func__, QUDA_SUMMARIZE);
   qudaSetLayout(input.layout);
   initialized = true;
-  qudamilc_called<false>(__func__);
+  qudamilc_called<false>(__func__, QUDA_SUMMARIZE);
 }
 
 void qudaFinalize()


### PR DESCRIPTION
This hotfix addresses an issue where MILC+QUDA would error out if MILC was compiled with `QUDA_VERBOSITY=VERBOSE` or higher. The core of the issue is in `qudaInit`:

```
void qudaInit(QudaInitArgs_t input)
{
  if (initialized) return;
  setVerbosityQuda(input.verbosity, "", stdout);
  qudamilc_called<true>(__func__);
  qudaSetLayout(input.layout);
  initialized = true;
  qudamilc_called<false>(__func__);
}
```

Here, `qudamilc_called<true>` itself calls `printfQuda` if QUDA's verbosity is >= `QUDA_VERBOSE` --- however, in this case, the default communicator hasn't been initialized yet, and won't be until `qudaSetLayout` is called (...on the next line), so we hit a catch-22 and QUDA errors out.

The easiest WAR is to manually pass `QUDA_SUMMARIZE` as the verbosity to `qudamilc_called`, preventing the call to `printfQuda`.