### PR TITLE
Staggered `Mat` host verify

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -801,14 +801,24 @@ endif()
 
   if(QUDA_DIRAC_STAGGERED)
     set(DIRAC_NAME staggered)
-    add_test(NAME dslash_${DIRAC_NAME}_policy${pol2}
+    add_test(NAME dslash_${DIRAC_NAME}_matpc_policy${pol2}
              COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:staggered_dslash_ctest> ${MPIEXEC_POSTFLAGS}
                      --dslash-type ${DIRAC_NAME}
                      --test MatPC
                      --dim 2 4 6 8
-                     --gtest_output=xml:dslash_${DIRAC_NAME}_test_pol${pol2}.xml)
+                     --gtest_output=xml:dslash_${DIRAC_NAME}_matpc_test_pol${pol2}.xml)
     if(polenv)
-      set_tests_properties(dslash_${DIRAC_NAME}_policy${pol2} PROPERTIES ENVIRONMENT QUDA_ENABLE_DSLASH_POLICY=${pol2})
+      set_tests_properties(dslash_${DIRAC_NAME}_matpc_policy${pol2} PROPERTIES ENVIRONMENT QUDA_ENABLE_DSLASH_POLICY=${pol2})
+    endif()
+
+    add_test(NAME dslash_${DIRAC_NAME}_mat_policy${pol2}
+             COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:staggered_dslash_ctest> ${MPIEXEC_POSTFLAGS}
+                     --dslash-type ${DIRAC_NAME}
+                     --test Mat
+                     --dim 2 4 6 8
+                     --gtest_output=xml:dslash_${DIRAC_NAME}_mat_test_pol${pol2}.xml)
+    if(polenv)
+      set_tests_properties(dslash_${DIRAC_NAME}_mat_policy${pol2} PROPERTIES ENVIRONMENT QUDA_ENABLE_DSLASH_POLICY=${pol2})
     endif()
 
     add_test(NAME benchmark_dslash_${DIRAC_NAME}_policy${pol2}
@@ -824,15 +834,26 @@ endif()
     endif()
 
     set(DIRAC_NAME asqtad)
-    add_test(NAME dslash_${DIRAC_NAME}_policy${pol2}
+    add_test(NAME dslash_${DIRAC_NAME}_matpc_policy${pol2}
              COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:staggered_dslash_ctest> ${MPIEXEC_POSTFLAGS}
                      --dslash-type ${DIRAC_NAME}
                      --all-partitions 1
                      --test MatPC
                      --dim 6 8 10 12
-                     --gtest_output=xml:dslash_${DIRAC_NAME}_test_pol${pol2}.xml)
+                     --gtest_output=xml:dslash_${DIRAC_NAME}_matpc_test_pol${pol2}.xml)
     if(polenv)
-      set_tests_properties(dslash_${DIRAC_NAME}_policy${pol2} PROPERTIES ENVIRONMENT QUDA_ENABLE_DSLASH_POLICY=${pol2})
+      set_tests_properties(dslash_${DIRAC_NAME}_matpc_policy${pol2} PROPERTIES ENVIRONMENT QUDA_ENABLE_DSLASH_POLICY=${pol2})
+    endif()
+
+    add_test(NAME dslash_${DIRAC_NAME}_mat_policy${pol2}
+             COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:staggered_dslash_ctest> ${MPIEXEC_POSTFLAGS}
+                     --dslash-type ${DIRAC_NAME}
+                     --all-partitions 1
+                     --test Mat
+                     --dim 6 8 10 12
+                     --gtest_output=xml:dslash_${DIRAC_NAME}_mat_test_pol${pol2}.xml)
+    if(polenv)
+      set_tests_properties(dslash_${DIRAC_NAME}_mat_policy${pol2} PROPERTIES ENVIRONMENT QUDA_ENABLE_DSLASH_POLICY=${pol2})
     endif()
 
     add_test(NAME benchmark_dslash_${DIRAC_NAME}_policy${pol2}

--- a/tests/host_reference/staggered_dslash_reference.cpp
+++ b/tests/host_reference/staggered_dslash_reference.cpp
@@ -116,10 +116,10 @@ void staggeredDslashReference(sFloat *res, gFloat **fatlink, gFloat **longlink, 
           sub(&res[offset], &res[offset], gaugedSpinor, stag_spinor_site_size);
         }
       }
+    } // forward/backward in all four directions
 
-      if (daggerBit) negx(&res[offset], stag_spinor_site_size);
-    } // 4-d volume
-  }   // right-hand-side
+    if (daggerBit) negx(&res[offset], stag_spinor_site_size);
+  } // 4-d volume
 }
 
 void staggeredDslash(ColorSpinorField &out, void **fatlink, void **longlink, void **ghost_fatlink,


### PR DESCRIPTION
This narrow hotfix fixes a bug with the host verify of the staggered/asqtad `Mat` operator introduced in https://github.com/lattice/quda/commit/931680a5003b135d4222cb0c1737e2516a9774a6 , where a "dagger" was not appropriately applied due to a misplaced curly brace.

This PR also adds a `ctest` for the `Mat` operator so this is caught in the future.

I attempted a `clang-format` but this PR already satisfies the formatting requirements as is.

Closes #1391 .