### PR TITLE
Fix failure check counter overflow

### DIFF
--- a/include/communicator_quda.h
+++ b/include/communicator_quda.h
@@ -741,6 +741,8 @@ namespace quda
 
   void comm_allreduce_sum_array(double *data, size_t size);
 
+  void comm_allreduce_sum(size_t &a);
+
   void comm_allreduce_max_array(double *data, size_t size);
 
   void comm_allreduce_max_array(deviation_t<double> *data, size_t size);

--- a/lib/color_spinor_util.in.cu
+++ b/lib/color_spinor_util.in.cu
@@ -191,7 +191,7 @@ namespace quda {
   int compareSpinor(const U &u, const V &v, const int tol)
   {
     int fail_check = 16*tol;
-    std::vector<int> fail(fail_check);
+    std::vector<size_t> fail(fail_check);
     for (int f=0; f<fail_check; f++) fail[f] = 0;
 
     int N = 2*u.Nspin()*u.Ncolor();
@@ -226,7 +226,7 @@ namespace quda {
     for (int i=0; i<N; i++) comm_allreduce_int(iter[i]);
     for (int f=0; f<fail_check; f++) comm_allreduce_int(fail[f]);
 
-    for (int i=0; i<N; i++) printfQuda("%d fails = %d\n", i, iter[i]);
+    for (int i=0; i<N; i++) printfQuda("%d fails = %lu\n", i, iter[i]);
 
     int accuracy_level =0;
     for (int f=0; f<fail_check; f++) {
@@ -235,7 +235,7 @@ namespace quda {
 
     size_t total = u.Nparity()*u.VolumeCB()*N*comm_size();
     for (int f=0; f<fail_check; f++) {
-      printfQuda("%e Failures: %d / %lu  = %e\n", pow(10.0,-(f+1)/(double)tol),
+      printfQuda("%e Failures: %lu / %lu  = %e\n", pow(10.0,-(f+1)/(double)tol),
 		 fail[f], total, fail[f] / (double)total);
     }
 

--- a/lib/color_spinor_util.in.cu
+++ b/lib/color_spinor_util.in.cu
@@ -224,9 +224,9 @@ namespace quda {
 
     // reduce over all processes
     for (int i=0; i<N; i++) comm_allreduce_int(iter[i]);
-    for (int f=0; f<fail_check; f++) comm_allreduce_sum(fail[f]);
+    for (int f = 0; f < fail_check; f++) comm_allreduce_sum(fail[f]);
 
-    for (int i = 0; i < N; i++) printfQuda("%d fails = %lu\n", i, iter[i]);
+    for (int i = 0; i < N; i++) printfQuda("%d fails = %d\n", i, iter[i]);
 
     int accuracy_level =0;
     for (int f=0; f<fail_check; f++) {

--- a/lib/color_spinor_util.in.cu
+++ b/lib/color_spinor_util.in.cu
@@ -224,7 +224,7 @@ namespace quda {
 
     // reduce over all processes
     for (int i=0; i<N; i++) comm_allreduce_int(iter[i]);
-    for (int f=0; f<fail_check; f++) comm_allreduce_int(fail[f]);
+    for (int f=0; f<fail_check; f++) comm_allreduce_sum(fail[f]);
 
     for (int i = 0; i < N; i++) printfQuda("%d fails = %lu\n", i, iter[i]);
 

--- a/lib/color_spinor_util.in.cu
+++ b/lib/color_spinor_util.in.cu
@@ -226,7 +226,7 @@ namespace quda {
     for (int i=0; i<N; i++) comm_allreduce_int(iter[i]);
     for (int f=0; f<fail_check; f++) comm_allreduce_int(fail[f]);
 
-    for (int i=0; i<N; i++) printfQuda("%d fails = %lu\n", i, iter[i]);
+    for (int i = 0; i < N; i++) printfQuda("%d fails = %lu\n", i, iter[i]);
 
     int accuracy_level =0;
     for (int f=0; f<fail_check; f++) {
@@ -235,8 +235,8 @@ namespace quda {
 
     size_t total = u.Nparity()*u.VolumeCB()*N*comm_size();
     for (int f=0; f<fail_check; f++) {
-      printfQuda("%e Failures: %lu / %lu  = %e\n", pow(10.0,-(f+1)/(double)tol),
-		 fail[f], total, fail[f] / (double)total);
+      printfQuda("%e Failures: %lu / %lu  = %e\n", pow(10.0, -(f + 1) / (double)tol), fail[f], total,
+                 fail[f] / (double)total);
     }
 
     return accuracy_level;

--- a/lib/communicator_mpi.cpp
+++ b/lib/communicator_mpi.cpp
@@ -291,6 +291,16 @@ namespace quda
     }
   }
 
+  void Communicator::comm_allreduce_sum(size_t &a)
+  {
+    if (sizeof(size_t) != sizeof(unsigned long)) {
+      errorQuda("sizeof(size_t) != sizeof(unsigned long): %lu != %lu\n", sizeof(size_t), sizeof(unsigned long));
+    }
+    size_t recv;
+    MPI_CHECK(MPI_Allreduce(&a, &recv, 1, MPI_UNSIGNED_LONG, MPI_SUM, MPI_COMM_HANDLE));
+    a = recv;
+  }
+
   void Communicator::comm_allreduce_max_array(deviation_t<double> *data, size_t size)
   {
     size_t n = comm_size();

--- a/lib/communicator_qmp.cpp
+++ b/lib/communicator_qmp.cpp
@@ -318,6 +318,14 @@ void Communicator::comm_allreduce_sum_array(double *data, size_t size)
   }
 }
 
+void Communicator::comm_allreduce_sum(size_t &a)
+{
+  if (sizeof(size_t) != sizeof(uint64_t)) {
+    errorQuda("sizeof(size_t) != sizeof(uint64_t): %lu != %lu\n", sizeof(size_t), sizeof(uint64_t));
+  }
+  QMP_CHECK(QMP_comm_sum_uint64_t(QMP_COMM_HANDLE, reinterpret_cast<uint64_t *>(&a)));
+}
+
 void Communicator::comm_allreduce_max_array(deviation_t<double> *data, size_t size)
 {
   size_t n = comm_size();

--- a/lib/communicator_single.cpp
+++ b/lib/communicator_single.cpp
@@ -83,7 +83,7 @@ namespace quda
 
   void Communicator::comm_allreduce_sum_array(double *, size_t) { }
 
-  void Communicator::comm_allreduce_sum(size_t &a) { }
+  void Communicator::comm_allreduce_sum(size_t &) { }
 
   void Communicator::comm_allreduce_max_array(deviation_t<double> *, size_t) { }
 

--- a/lib/communicator_single.cpp
+++ b/lib/communicator_single.cpp
@@ -83,6 +83,8 @@ namespace quda
 
   void Communicator::comm_allreduce_sum_array(double *, size_t) { }
 
+  void Communicator::comm_allreduce_sum(size_t &a) { }
+
   void Communicator::comm_allreduce_max_array(deviation_t<double> *, size_t) { }
 
   void Communicator::comm_allreduce_max_array(double *, size_t) { }

--- a/lib/communicator_stack.cpp
+++ b/lib/communicator_stack.cpp
@@ -216,9 +216,7 @@ namespace quda
 
   template <> void comm_allreduce_sum<double>(double &a) { comm_allreduce_sum_array(&a, 1); }
 
-  template <> void comm_allreduce_sum<size_t>(size_t &a) {
-    get_current_communicator().comm_allreduce_sum(a);
-  }
+  template <> void comm_allreduce_sum<size_t>(size_t &a) { get_current_communicator().comm_allreduce_sum(a); }
 
   void comm_allreduce_max_array(double *data, size_t size)
   {

--- a/lib/communicator_stack.cpp
+++ b/lib/communicator_stack.cpp
@@ -216,6 +216,10 @@ namespace quda
 
   template <> void comm_allreduce_sum<double>(double &a) { comm_allreduce_sum_array(&a, 1); }
 
+  template <> void comm_allreduce_sum<size_t>(size_t &a) {
+    get_current_communicator().comm_allreduce_sum(a);
+  }
+
   void comm_allreduce_max_array(double *data, size_t size)
   {
     get_current_communicator().comm_allreduce_max_array(data, size);


### PR DESCRIPTION
Large global volume causes the failure check counter (currently as `int`) in the tests to overflow. As a result negative numbers are shown in the logs, e.g.,
```
1.000000e-01 Failures: 0 / 2415919104  = 0.000000e+00
1.000000e-02 Failures: 0 / 2415919104  = 0.000000e+00
1.000000e-03 Failures: 0 / 2415919104  = 0.000000e+00
1.000000e-04 Failures: 0 / 2415919104  = 0.000000e+00
1.000000e-05 Failures: 537582906 / 2415919104  = 2.225169e-01
1.000000e-06 Failures: -2115317401 / 2415919104  = -8.755746e-01
1.000000e-07 Failures: -1902728577 / 2415919104  = -7.875796e-01
1.000000e-08 Failures: -1881416472 / 2415919104  = -7.787581e-01
1.000000e-09 Failures: -1879284507 / 2415919104  = -7.778756e-01
1.000000e-10 Failures: -1879071778 / 2415919104  = -7.777875e-01
1.000000e-11 Failures: -1879050525 / 2415919104  = -7.777787e-01
1.000000e-12 Failures: -1879048416 / 2415919104  = -7.777779e-01
1.000000e-13 Failures: -1879048211 / 2415919104  = -7.777778e-01
1.000000e-14 Failures: -1879048197 / 2415919104  = -7.777778e-01
1.000000e-15 Failures: -1879048192 / 2415919104  = -7.777778e-01
1.000000e-16 Failures: -1879048192 / 2415919104  = -7.777778e-01
```

- [x] Check an MPI build works.
- [x] Check an QMP build works.