### PR TITLE
Add some sanity checking on the CPM.cmake download

### DIFF
--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -15,7 +15,13 @@ if(NOT (EXISTS ${CPM_DOWNLOAD_LOCATION}))
   file(DOWNLOAD
        https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
        ${CPM_DOWNLOAD_LOCATION}
+       STATUS status LOG log
   )
+  list(GET status 0 rc)
+  if (${rc})
+    list(GET status 1 msg)
+    message(WARNING "CPM.cmake download failed with message: ${msg}\n${log}")
+  endif()
 endif()
 
 include(${CPM_DOWNLOAD_LOCATION})


### PR DESCRIPTION
It's possible for this download to fail.  An example failure scenario is when CMake is not built with OpenSSL support, and so the https protocol is not supported.

After this change, when it fails the user will be informed:
1.  that it actually failed, as opposed to silently continuing with an empty CPM.cmake file; and
2.  why CMake thinks the failure happened.