### PR TITLE
Extend invert_test_gtest.hpp with testing for HQ CG solves.

### DIFF
--- a/lib/inv_cg_quda.cpp
+++ b/lib/inv_cg_quda.cpp
@@ -941,13 +941,13 @@ namespace quda {
         // we "reset" the solve in a different way.
         if (heavy_quark_restart) {
           // If we're in the HQ residual part of the solve, we just do a hard CG restart.
-          logQuda(QUDA_SUMMARIZE, "HQ restart == hard CG restart\n");
+          logQuda(QUDA_DEBUG_VERBOSE, "HQ restart == hard CG restart\n");
           blas::copy(p, rSloppy);
           heavy_quark_restart = false;
         } else {
           // If we're still in the L2 norm part of the solve, we explicitly restore
           // the orthogonality of the gradient vector, recompute beta, update `p`, and carry on with our lives.
-          logQuda(QUDA_SUMMARIZE, "Regular restart == explicit gradient vector re-orthogonalization\n");
+          logQuda(QUDA_DEBUG_VERBOSE, "Regular restart == explicit gradient vector re-orthogonalization\n");
           Complex rp = blas::cDotProduct(rSloppy, p) / (r2);
           blas::caxpy(-rp, rSloppy, p);
 

--- a/lib/inv_cg_quda.cpp
+++ b/lib/inv_cg_quda.cpp
@@ -834,13 +834,15 @@ namespace quda {
         blas::copy(x, xSloppy); // no op when these pointers alias
         blas::xpy(x, y);
         mat(r, y);
-        blas::copy(rSloppy, r); // no op when these pointers alias
-        blas::zero(xSloppy);
 
         // Recompute the exact residual and heavy quark residual
         r2 = blas::xmyNorm(b, r);
         rNorm = sqrt(r2);
         hq_res = sqrt(blas::HeavyQuarkResidualNorm(y, r).z);
+
+        // Copy and update fields
+        blas::copy(rSloppy, r); // no op when these pointers alias
+        blas::zero(xSloppy);
 
         // Check and see if we're "done" with the L2 norm. This could be because
         // we were already done with it, we never needed it, or the L2 norm has finally converged.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -919,7 +919,7 @@ foreach(prec IN LISTS TEST_PRECS)
     add_test(NAME invert_test_wilson_${prec}
       COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:invert_test> ${MPIEXEC_POSTFLAGS}
       --dslash-type wilson --ngcrkrylov 8
-      --dim 2 4 6 8 --prec ${prec} --tol ${tol} --niter 1000
+      --dim 2 4 6 8 --prec ${prec} --tol ${tol} --tolhq ${tol} --niter 1000
       --enable-testing true
       --gtest_output=xml:invert_test_wilson_${prec}.xml)
   endif()
@@ -928,14 +928,14 @@ foreach(prec IN LISTS TEST_PRECS)
     add_test(NAME invert_test_twisted_mass_sym_${prec}
       COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:invert_test> ${MPIEXEC_POSTFLAGS}
       --dslash-type twisted-mass
-      --dim 2 4 6 8 --prec ${prec} --tol ${tol} --niter 1000 --ngcrkrylov 8
+      --dim 2 4 6 8 --prec ${prec} --tol ${tol} --tolhq ${tol} --niter 1000 --ngcrkrylov 8
       --matpc even-even --enable-testing true
       --gtest_output=xml:invert_test_twisted_mass_sym_${prec}.xml)
 
     add_test(NAME invert_test_twisted_mass_asym_${prec}
       COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:invert_test> ${MPIEXEC_POSTFLAGS}
       --dslash-type twisted-mass
-      --dim 2 4 6 8 --prec ${prec} --tol ${tol} --niter 1000 --ngcrkrylov 8
+      --dim 2 4 6 8 --prec ${prec} --tol ${tol} --tolhq ${tol} --niter 1000 --ngcrkrylov 8
       --matpc even-even-asym --enable-testing true
       --gtest_output=xml:invert_test_twisted_mass_asym_${prec}.xml)    
   endif()
@@ -944,7 +944,7 @@ foreach(prec IN LISTS TEST_PRECS)
     add_test(NAME invert_test_ndeg_twisted_mass_sym_${prec}
       COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:invert_test> ${MPIEXEC_POSTFLAGS}
       --dslash-type twisted-mass
-      --dim 2 4 6 8 --prec ${prec} --tol ${tol} --niter 1000 --ngcrkrylov 8
+      --dim 2 4 6 8 --prec ${prec} --tol ${tol} --tolhq ${tol} --niter 1000 --ngcrkrylov 8
       --matpc even-even --flavor nondeg-doublet
       --enable-testing true
       --gtest_output=xml:invert_test_ndeg_twisted_mass_sym_${prec}.xml)
@@ -952,7 +952,7 @@ foreach(prec IN LISTS TEST_PRECS)
     add_test(NAME invert_test_ndeg_twisted_mass_asym_${prec}
       COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:invert_test> ${MPIEXEC_POSTFLAGS}
       --dslash-type twisted-mass
-      --dim 2 4 6 8 --prec ${prec} --tol ${tol} --niter 1000 --ngcrkrylov 8
+      --dim 2 4 6 8 --prec ${prec} --tol ${tol} --tolhq ${tol} --niter 1000 --ngcrkrylov 8
       --matpc even-even-asym --flavor nondeg-doublet
       --enable-testing true
       --gtest_output=xml:invert_test_ndeg_twisted_mass_asym_${prec}.xml)
@@ -962,14 +962,14 @@ foreach(prec IN LISTS TEST_PRECS)
     add_test(NAME invert_test_clover_sym_${prec}
       COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:invert_test> ${MPIEXEC_POSTFLAGS}
       --dslash-type clover --compute-clover true
-      --dim 2 4 6 8 --prec ${prec} --tol ${tol} --niter 1000 --ngcrkrylov 8
+      --dim 2 4 6 8 --prec ${prec} --tol ${tol} --tolhq ${tol} --niter 1000 --ngcrkrylov 8
       --matpc even-even --enable-testing true
       --gtest_output=xml:invert_test_clover_sym_${prec}.xml)
 
     add_test(NAME invert_test_clover_asym_${prec}
       COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:invert_test> ${MPIEXEC_POSTFLAGS}
       --dslash-type clover --compute-clover true
-      --dim 2 4 6 8 --prec ${prec} --tol ${tol} --niter 1000 --ngcrkrylov 8
+      --dim 2 4 6 8 --prec ${prec} --tol ${tol} --tolhq ${tol} --niter 1000 --ngcrkrylov 8
       --matpc even-even-asym --enable-testing true
       --gtest_output=xml:invert_test_clover_asym_${prec}.xml)
   endif()
@@ -978,14 +978,14 @@ foreach(prec IN LISTS TEST_PRECS)
     add_test(NAME invert_test_twisted_clover_sym_${prec}
       COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:invert_test> ${MPIEXEC_POSTFLAGS}
       --dslash-type twisted-clover --compute-clover true
-      --dim 2 4 6 8 --prec ${prec} --tol ${tol} --niter 1000 --ngcrkrylov 8
+      --dim 2 4 6 8 --prec ${prec} --tol ${tol} --tolhq ${tol} --niter 1000 --ngcrkrylov 8
       --matpc even-even --enable-testing true
       --gtest_output=xml:invert_test_twisted_clover_sym_${prec}.xml)
 
     add_test(NAME invert_test_twisted_clover_asym_${prec}
       COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:invert_test> ${MPIEXEC_POSTFLAGS}
       --dslash-type twisted-clover --compute-clover true
-      --dim 2 4 6 8 --prec ${prec} --tol ${tol} --niter 1000 --ngcrkrylov 8
+      --dim 2 4 6 8 --prec ${prec} --tol ${tol} --tolhq ${tol} --niter 1000 --ngcrkrylov 8
       --matpc even-even-asym --enable-testing true
       --gtest_output=xml:invert_test_twisted_clover_asym_${prec}.xml)
   endif()
@@ -994,7 +994,7 @@ foreach(prec IN LISTS TEST_PRECS)
     add_test(NAME invert_test_ndeg_twisted_clover_sym_${prec}
       COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:invert_test> ${MPIEXEC_POSTFLAGS}
       --dslash-type twisted-clover --compute-clover true
-      --dim 2 4 6 8 --prec ${prec} --tol ${tol} --niter 1000 --ngcrkrylov 8
+      --dim 2 4 6 8 --prec ${prec} --tol ${tol} --tolhq ${tol} --niter 1000 --ngcrkrylov 8
       --matpc even-even --flavor nondeg-doublet
       --enable-testing true
       --gtest_output=xml:invert_test_ndeg_twisted_clover_sym_${prec}.xml)
@@ -1002,7 +1002,7 @@ foreach(prec IN LISTS TEST_PRECS)
     add_test(NAME invert_test_ndeg_twisted_clover_asym_${prec}
       COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:invert_test> ${MPIEXEC_POSTFLAGS}
       --dslash-type twisted-clover --compute-clover true
-      --dim 2 4 6 8 --prec ${prec} --tol ${tol} --niter 1000 --ngcrkrylov 8
+      --dim 2 4 6 8 --prec ${prec} --tol ${tol} --tolhq ${tol} --niter 1000 --ngcrkrylov 8
       --matpc even-even-asym --flavor nondeg-doublet
       --enable-testing true
       --gtest_output=xml:invert_test_ndeg_twisted_clover_asym_${prec}.xml)
@@ -1012,7 +1012,7 @@ foreach(prec IN LISTS TEST_PRECS)
     add_test(NAME invert_test_domain_wall_${prec}
       COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:invert_test> ${MPIEXEC_POSTFLAGS}
       --dslash-type domain-wall
-      --dim 2 4 6 8 --Lsdim 4 --prec ${prec} --tol ${tol} --niter 1000 --ngcrkrylov 8
+      --dim 2 4 6 8 --Lsdim 4 --prec ${prec} --tol ${tol} --tolhq ${tol} --niter 1000 --ngcrkrylov 8
       --matpc even-even
       --enable-testing true
       --gtest_output=xml:invert_test_domain_wall_${prec}.xml)
@@ -1020,7 +1020,7 @@ foreach(prec IN LISTS TEST_PRECS)
     add_test(NAME invert_test_domain_wall_4d_sym_${prec}
       COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:invert_test> ${MPIEXEC_POSTFLAGS}
       --dslash-type domain-wall-4d
-      --dim 2 4 6 8 --Lsdim 4 --prec ${prec} --tol ${tol} --niter 1000 --ngcrkrylov 8
+      --dim 2 4 6 8 --Lsdim 4 --prec ${prec} --tol ${tol} --tolhq ${tol} --niter 1000 --ngcrkrylov 8
       --matpc even-even
       --enable-testing true
       --gtest_output=xml:invert_test_domain_wall_4d_sym_${prec}.xml)
@@ -1028,7 +1028,7 @@ foreach(prec IN LISTS TEST_PRECS)
     add_test(NAME invert_test_domain_wall_4d_asym_${prec}
       COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:invert_test> ${MPIEXEC_POSTFLAGS}
       --dslash-type domain-wall-4d
-      --dim 2 4 6 8 --Lsdim 4 --prec ${prec} --tol ${tol} --niter 1000 --ngcrkrylov 8
+      --dim 2 4 6 8 --Lsdim 4 --prec ${prec} --tol ${tol} --tolhq ${tol} --niter 1000 --ngcrkrylov 8
       --matpc even-even-asym
       --enable-testing true
       --gtest_output=xml:invert_test_domain_wall_4d_asym_${prec}.xml)
@@ -1036,7 +1036,7 @@ foreach(prec IN LISTS TEST_PRECS)
     add_test(NAME invert_test_mobius_sym_${prec}
       COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:invert_test> ${MPIEXEC_POSTFLAGS}
       --dslash-type mobius
-      --dim 2 4 6 8 --Lsdim 4 --prec ${prec} --tol ${tol} --niter 1000 --ngcrkrylov 8
+      --dim 2 4 6 8 --Lsdim 4 --prec ${prec} --tol ${tol} --tolhq ${tol} --niter 1000 --ngcrkrylov 8
       --matpc even-even
       --enable-testing true
       --gtest_output=xml:invert_test_mobius_sym_${prec}.xml)
@@ -1044,7 +1044,7 @@ foreach(prec IN LISTS TEST_PRECS)
     add_test(NAME invert_test_mobius_asym_${prec}
       COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:invert_test> ${MPIEXEC_POSTFLAGS}
       --dslash-type mobius
-      --dim 2 4 6 8 --Lsdim 4 --prec ${prec} --tol ${tol} --niter 1000 --ngcrkrylov 8
+      --dim 2 4 6 8 --Lsdim 4 --prec ${prec} --tol ${tol} --tolhq ${tol} --niter 1000 --ngcrkrylov 8
       --matpc even-even-asym
       --enable-testing true
       --gtest_output=xml:invert_test_mobius_asym_${prec}.xml)
@@ -1052,7 +1052,7 @@ foreach(prec IN LISTS TEST_PRECS)
     add_test(NAME invert_test_mobius_eofa_sym_${prec}
       COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:invert_test> ${MPIEXEC_POSTFLAGS}
       --dslash-type mobius-eofa
-      --dim 2 4 6 8 --Lsdim 4 --prec ${prec} --tol ${tol} --niter 1000 --ngcrkrylov 8
+      --dim 2 4 6 8 --Lsdim 4 --prec ${prec} --tol ${tol} --tolhq ${tol} --niter 1000 --ngcrkrylov 8
       --matpc even-even
       --enable-testing true
       --gtest_output=xml:invert_test_mobius_eofa_sym_${prec}.xml)
@@ -1060,7 +1060,7 @@ foreach(prec IN LISTS TEST_PRECS)
     add_test(NAME invert_test_mobius_eofa_asym_${prec}
       COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:invert_test> ${MPIEXEC_POSTFLAGS}
       --dslash-type mobius-eofa
-      --dim 2 4 6 8 --Lsdim 4 --prec ${prec} --tol ${tol} --niter 1000 --ngcrkrylov 8
+      --dim 2 4 6 8 --Lsdim 4 --prec ${prec} --tol ${tol} --tolhq ${tol} --niter 1000 --ngcrkrylov 8
       --matpc even-even-asym
       --enable-testing true
       --gtest_output=xml:invert_test_mobius_eofa_asym_${prec}.xml)

--- a/tests/host_reference/dslash_reference.cpp
+++ b/tests/host_reference/dslash_reference.cpp
@@ -11,19 +11,19 @@
 #include <command_line_params.h>
 
 // Overload for workflows without multishift
-double verifyInversion(void *spinorOut, void *spinorIn, void *spinorCheck, QudaGaugeParam &gauge_param,
-                       QudaInvertParam &inv_param, void **gauge, void *clover, void *clover_inv)
+std::array<double, 2> verifyInversion(void *spinorOut, void *spinorIn, void *spinorCheck, QudaGaugeParam &gauge_param,
+                                      QudaInvertParam &inv_param, void **gauge, void *clover, void *clover_inv)
 {
   void **spinorOutMulti = nullptr;
   return verifyInversion(spinorOut, spinorOutMulti, spinorIn, spinorCheck, gauge_param, inv_param, gauge, clover,
                          clover_inv);
 }
 
-double verifyInversion(void *spinorOut, void **spinorOutMulti, void *spinorIn, void *spinorCheck,
-                       QudaGaugeParam &gauge_param, QudaInvertParam &inv_param, void **gauge, void *clover,
-                       void *clover_inv)
+std::array<double, 2> verifyInversion(void *spinorOut, void **spinorOutMulti, void *spinorIn, void *spinorCheck,
+                                      QudaGaugeParam &gauge_param, QudaInvertParam &inv_param, void **gauge, void *clover,
+                                      void *clover_inv)
 {
-  double res = std::numeric_limits<double>::max();
+  std::array<double, 2> res = {std::numeric_limits<double>::max(), std::numeric_limits<double>::max()};
   if (dslash_type == QUDA_DOMAIN_WALL_DSLASH || dslash_type == QUDA_DOMAIN_WALL_4D_DSLASH
       || dslash_type == QUDA_MOBIUS_DWF_DSLASH || dslash_type == QUDA_MOBIUS_DWF_EOFA_DSLASH) {
     res = verifyDomainWallTypeInversion(spinorOut, spinorOutMulti, spinorIn, spinorCheck, gauge_param, inv_param, gauge,
@@ -38,9 +38,9 @@ double verifyInversion(void *spinorOut, void **spinorOutMulti, void *spinorIn, v
   return res;
 }
 
-double verifyDomainWallTypeInversion(void *spinorOut, void **, void *spinorIn, void *spinorCheck,
-                                     QudaGaugeParam &gauge_param, QudaInvertParam &inv_param, void **gauge, void *,
-                                     void *)
+std::array<double, 2> verifyDomainWallTypeInversion(void *spinorOut, void **, void *spinorIn, void *spinorCheck,
+                                                    QudaGaugeParam &gauge_param, QudaInvertParam &inv_param, void **gauge, void *,
+                                                    void *)
 {
   if (multishift > 1) errorQuda("Multishift not supported");
 
@@ -165,12 +165,12 @@ double verifyDomainWallTypeInversion(void *spinorOut, void **, void *spinorIn, v
   printfQuda("Residuals: (L2 relative) tol %9.6e, QUDA = %9.6e, host = %9.6e; (heavy-quark) tol %9.6e, QUDA = %9.6e\n",
              inv_param.tol, inv_param.true_res, l2r, inv_param.tol_hq, inv_param.true_res_hq);
 
-  return l2r;
+  return {l2r, inv_param.tol_hq};;
 }
 
-double verifyWilsonTypeInversion(void *spinorOut, void **spinorOutMulti, void *spinorIn, void *spinorCheck,
-                                 QudaGaugeParam &gauge_param, QudaInvertParam &inv_param, void **gauge, void *clover,
-                                 void *clover_inv)
+std::array<double, 2> verifyWilsonTypeInversion(void *spinorOut, void **spinorOutMulti, void *spinorIn, void *spinorCheck,
+                                                QudaGaugeParam &gauge_param, QudaInvertParam &inv_param, void **gauge, void *clover,
+                                                void *clover_inv)
 {
   int vol
     = (inv_param.solution_type == QUDA_MAT_SOLUTION || inv_param.solution_type == QUDA_MATDAG_MAT_SOLUTION ? V : Vh);
@@ -411,7 +411,7 @@ double verifyWilsonTypeInversion(void *spinorOut, void **spinorOutMulti, void *s
       inv_param.tol, inv_param.true_res, l2r, inv_param.tol_hq, inv_param.true_res_hq);
   }
 
-  return l2r_max;
+  return {l2r_max, inv_param.tol_hq};
 }
 
 double verifyWilsonTypeEigenvector(void *spinor, double _Complex lambda, int i, QudaGaugeParam &gauge_param,

--- a/tests/host_reference/dslash_reference.cpp
+++ b/tests/host_reference/dslash_reference.cpp
@@ -20,8 +20,8 @@ std::array<double, 2> verifyInversion(void *spinorOut, void *spinorIn, void *spi
 }
 
 std::array<double, 2> verifyInversion(void *spinorOut, void **spinorOutMulti, void *spinorIn, void *spinorCheck,
-                                      QudaGaugeParam &gauge_param, QudaInvertParam &inv_param, void **gauge, void *clover,
-                                      void *clover_inv)
+                                      QudaGaugeParam &gauge_param, QudaInvertParam &inv_param, void **gauge,
+                                      void *clover, void *clover_inv)
 {
   std::array<double, 2> res = {std::numeric_limits<double>::max(), std::numeric_limits<double>::max()};
   if (dslash_type == QUDA_DOMAIN_WALL_DSLASH || dslash_type == QUDA_DOMAIN_WALL_4D_DSLASH
@@ -39,8 +39,8 @@ std::array<double, 2> verifyInversion(void *spinorOut, void **spinorOutMulti, vo
 }
 
 std::array<double, 2> verifyDomainWallTypeInversion(void *spinorOut, void **, void *spinorIn, void *spinorCheck,
-                                                    QudaGaugeParam &gauge_param, QudaInvertParam &inv_param, void **gauge, void *,
-                                                    void *)
+                                                    QudaGaugeParam &gauge_param, QudaInvertParam &inv_param,
+                                                    void **gauge, void *, void *)
 {
   if (multishift > 1) errorQuda("Multishift not supported");
 
@@ -165,12 +165,13 @@ std::array<double, 2> verifyDomainWallTypeInversion(void *spinorOut, void **, vo
   printfQuda("Residuals: (L2 relative) tol %9.6e, QUDA = %9.6e, host = %9.6e; (heavy-quark) tol %9.6e, QUDA = %9.6e\n",
              inv_param.tol, inv_param.true_res, l2r, inv_param.tol_hq, inv_param.true_res_hq);
 
-  return {l2r, inv_param.tol_hq};;
+  return {l2r, inv_param.tol_hq};
+  ;
 }
 
-std::array<double, 2> verifyWilsonTypeInversion(void *spinorOut, void **spinorOutMulti, void *spinorIn, void *spinorCheck,
-                                                QudaGaugeParam &gauge_param, QudaInvertParam &inv_param, void **gauge, void *clover,
-                                                void *clover_inv)
+std::array<double, 2> verifyWilsonTypeInversion(void *spinorOut, void **spinorOutMulti, void *spinorIn,
+                                                void *spinorCheck, QudaGaugeParam &gauge_param,
+                                                QudaInvertParam &inv_param, void **gauge, void *clover, void *clover_inv)
 {
   int vol
     = (inv_param.solution_type == QUDA_MAT_SOLUTION || inv_param.solution_type == QUDA_MATDAG_MAT_SOLUTION ? V : Vh);

--- a/tests/host_reference/dslash_reference.h
+++ b/tests/host_reference/dslash_reference.h
@@ -86,15 +86,16 @@ static inline void su3Tmul(sFloat *res, const gFloat *mat, const sFloat *vec)
 }
 
 std::array<double, 2> verifyInversion(void *spinorOut, void *spinorIn, void *spinorCheck, QudaGaugeParam &gauge_param,
-                                 QudaInvertParam &inv_param, void **gauge, void *clover, void *clover_inv);
+                                      QudaInvertParam &inv_param, void **gauge, void *clover, void *clover_inv);
 
 std::array<double, 2> verifyInversion(void *spinorOut, void **spinorOutMulti, void *spinorIn, void *spinorCheck,
-                                 QudaGaugeParam &gauge_param, QudaInvertParam &inv_param, void **gauge, void *clover,
-                                 void *clover_inv);
+                                      QudaGaugeParam &gauge_param, QudaInvertParam &inv_param, void **gauge,
+                                      void *clover, void *clover_inv);
 
-std::array<double, 2> verifyDomainWallTypeInversion(void *spinorOut, void **spinorOutMulti, void *spinorIn, void *spinorCheck,
-                                               QudaGaugeParam &gauge_param, QudaInvertParam &inv_param, void **gauge,
-                                               void *clover, void *clover_inv);
+std::array<double, 2> verifyDomainWallTypeInversion(void *spinorOut, void **spinorOutMulti, void *spinorIn,
+                                                    void *spinorCheck, QudaGaugeParam &gauge_param,
+                                                    QudaInvertParam &inv_param, void **gauge, void *clover,
+                                                    void *clover_inv);
 
 double verifyWilsonTypeEigenvector(void *spinor, double _Complex lambda, int i, QudaGaugeParam &gauge_param,
                                    QudaEigParam &eig_param, void **gauge, void *clover, void *clover_inv);
@@ -103,9 +104,9 @@ double verifyWilsonTypeSingularVector(void *spinor_left, void *spinor_right, dou
                                       QudaGaugeParam &gauge_param, QudaEigParam &eig_param, void **gauge, void *clover,
                                       void *clover_inv);
 
-std::array<double, 2> verifyWilsonTypeInversion(void *spinorOut, void **spinorOutMulti, void *spinorIn, void *spinorCheck,
-                                           QudaGaugeParam &gauge_param, QudaInvertParam &inv_param, void **gauge, void *clover,
-                                           void *clover_inv);
+std::array<double, 2> verifyWilsonTypeInversion(void *spinorOut, void **spinorOutMulti, void *spinorIn,
+                                                void *spinorCheck, QudaGaugeParam &gauge_param,
+                                                QudaInvertParam &inv_param, void **gauge, void *clover, void *clover_inv);
 
 double verifyStaggeredInversion(quda::ColorSpinorField &tmp, quda::ColorSpinorField &ref, quda::ColorSpinorField &in,
                                 quda::ColorSpinorField &out, double mass, void *qdp_fatlink[], void *qdp_longlink[],

--- a/tests/host_reference/dslash_reference.h
+++ b/tests/host_reference/dslash_reference.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <host_utils.h>
 #include <comm_quda.h>
 
@@ -84,16 +85,16 @@ static inline void su3Tmul(sFloat *res, const gFloat *mat, const sFloat *vec)
   su3Mul(res, matT, vec);
 }
 
-double verifyInversion(void *spinorOut, void *spinorIn, void *spinorCheck, QudaGaugeParam &gauge_param,
-                       QudaInvertParam &inv_param, void **gauge, void *clover, void *clover_inv);
+std::array<double, 2> verifyInversion(void *spinorOut, void *spinorIn, void *spinorCheck, QudaGaugeParam &gauge_param,
+                                 QudaInvertParam &inv_param, void **gauge, void *clover, void *clover_inv);
 
-double verifyInversion(void *spinorOut, void **spinorOutMulti, void *spinorIn, void *spinorCheck,
-                       QudaGaugeParam &gauge_param, QudaInvertParam &inv_param, void **gauge, void *clover,
-                       void *clover_inv);
+std::array<double, 2> verifyInversion(void *spinorOut, void **spinorOutMulti, void *spinorIn, void *spinorCheck,
+                                 QudaGaugeParam &gauge_param, QudaInvertParam &inv_param, void **gauge, void *clover,
+                                 void *clover_inv);
 
-double verifyDomainWallTypeInversion(void *spinorOut, void **spinorOutMulti, void *spinorIn, void *spinorCheck,
-                                     QudaGaugeParam &gauge_param, QudaInvertParam &inv_param, void **gauge,
-                                     void *clover, void *clover_inv);
+std::array<double, 2> verifyDomainWallTypeInversion(void *spinorOut, void **spinorOutMulti, void *spinorIn, void *spinorCheck,
+                                               QudaGaugeParam &gauge_param, QudaInvertParam &inv_param, void **gauge,
+                                               void *clover, void *clover_inv);
 
 double verifyWilsonTypeEigenvector(void *spinor, double _Complex lambda, int i, QudaGaugeParam &gauge_param,
                                    QudaEigParam &eig_param, void **gauge, void *clover, void *clover_inv);
@@ -102,9 +103,9 @@ double verifyWilsonTypeSingularVector(void *spinor_left, void *spinor_right, dou
                                       QudaGaugeParam &gauge_param, QudaEigParam &eig_param, void **gauge, void *clover,
                                       void *clover_inv);
 
-double verifyWilsonTypeInversion(void *spinorOut, void **spinorOutMulti, void *spinorIn, void *spinorCheck,
-                                 QudaGaugeParam &gauge_param, QudaInvertParam &inv_param, void **gauge, void *clover,
-                                 void *clover_inv);
+std::array<double, 2> verifyWilsonTypeInversion(void *spinorOut, void **spinorOutMulti, void *spinorIn, void *spinorCheck,
+                                           QudaGaugeParam &gauge_param, QudaInvertParam &inv_param, void **gauge, void *clover,
+                                           void *clover_inv);
 
 double verifyStaggeredInversion(quda::ColorSpinorField &tmp, quda::ColorSpinorField &ref, quda::ColorSpinorField &in,
                                 quda::ColorSpinorField &out, double mass, void *qdp_fatlink[], void *qdp_longlink[],

--- a/tests/invert_test.cpp
+++ b/tests/invert_test.cpp
@@ -177,7 +177,7 @@ void init(int argc, char **argv)
   }
 }
 
-std::vector<double> solve(test_t param)
+std::vector<std::array<double,2>> solve(test_t param)
 {
   inv_param.inv_type = ::testing::get<0>(param);
   inv_param.solution_type = ::testing::get<1>(param);
@@ -193,6 +193,8 @@ std::vector<double> solve(test_t param)
   inv_param.inv_type_precondition  = ::testing::get<1>(schwarz_param);
   inv_param.cuda_prec_precondition = ::testing::get<2>(schwarz_param);
   inv_param.clover_cuda_prec_precondition = ::testing::get<2>(schwarz_param);
+
+  inv_param.residual_type = ::testing::get<7>(param);
 
   // reset lambda_max if we're doing a testing loop to ensure correct lambma_max
   if (enable_testing) inv_param.ca_lambda_max = -1.0;
@@ -322,7 +324,7 @@ std::vector<double> solve(test_t param)
   // Compute performance statistics
   if (Nsrc > 1 && !use_split_grid) performanceStats(time, gflops, iter);
 
-  std::vector<double> res(Nsrc);
+  std::vector<std::array<double,2>> res(Nsrc);
   // Perform host side verification of inversion if requested
   if (verify_results) {
     for (int i = 0; i < Nsrc; i++) {
@@ -409,7 +411,8 @@ int main(int argc, char **argv)
     result = RUN_ALL_TESTS();
   } else {
     solve(test_t {inv_type, solution_type, solve_type, prec_sloppy, multishift, solution_accumulator_pipeline,
-                  schwarz_t {precon_schwarz_type, inv_multigrid ? QUDA_MG_INVERTER : precon_type, prec_precondition} } );
+                  schwarz_t {precon_schwarz_type, inv_multigrid ? QUDA_MG_INVERTER : precon_type, prec_precondition},
+                  inv_param.residual_type} );
   }
 
   // finalize the QUDA library

--- a/tests/invert_test.cpp
+++ b/tests/invert_test.cpp
@@ -177,7 +177,7 @@ void init(int argc, char **argv)
   }
 }
 
-std::vector<std::array<double,2>> solve(test_t param)
+std::vector<std::array<double, 2>> solve(test_t param)
 {
   inv_param.inv_type = ::testing::get<0>(param);
   inv_param.solution_type = ::testing::get<1>(param);
@@ -324,7 +324,7 @@ std::vector<std::array<double,2>> solve(test_t param)
   // Compute performance statistics
   if (Nsrc > 1 && !use_split_grid) performanceStats(time, gflops, iter);
 
-  std::vector<std::array<double,2>> res(Nsrc);
+  std::vector<std::array<double, 2>> res(Nsrc);
   // Perform host side verification of inversion if requested
   if (verify_results) {
     for (int i = 0; i < Nsrc; i++) {
@@ -412,7 +412,7 @@ int main(int argc, char **argv)
   } else {
     solve(test_t {inv_type, solution_type, solve_type, prec_sloppy, multishift, solution_accumulator_pipeline,
                   schwarz_t {precon_schwarz_type, inv_multigrid ? QUDA_MG_INVERTER : precon_type, prec_precondition},
-                  inv_param.residual_type} );
+                  inv_param.residual_type});
   }
 
   // finalize the QUDA library

--- a/tests/invert_test_gtest.hpp
+++ b/tests/invert_test_gtest.hpp
@@ -140,8 +140,8 @@ TEST_P(InvertTest, verify)
     tol *= 10;
 
   for (auto rsd : solve(GetParam())) {
-    if (res_t & QUDA_L2_RELATIVE_RESIDUAL) EXPECT_LE(rsd[0], tol);
-    if (res_t & QUDA_HEAVY_QUARK_RESIDUAL) EXPECT_LE(rsd[1], tol_hq);
+    if (res_t & QUDA_L2_RELATIVE_RESIDUAL) { EXPECT_LE(rsd[0], tol); }
+    if (res_t & QUDA_HEAVY_QUARK_RESIDUAL) { EXPECT_LE(rsd[1], tol_hq); }
   }
 }
 

--- a/tests/invert_test_gtest.hpp
+++ b/tests/invert_test_gtest.hpp
@@ -4,7 +4,8 @@
 // tuple containing parameters for Schwarz solver
 using schwarz_t = ::testing::tuple<QudaSchwarzType, QudaInverterType, QudaPrecision>;
 
-using test_t = ::testing::tuple<QudaInverterType, QudaSolutionType, QudaSolveType, QudaPrecision, int, int, schwarz_t, QudaResidualType>;
+using test_t
+  = ::testing::tuple<QudaInverterType, QudaSolutionType, QudaSolveType, QudaPrecision, int, int, schwarz_t, QudaResidualType>;
 
 class InvertTest : public ::testing::TestWithParam<test_t>
 {
@@ -187,84 +188,59 @@ auto no_heavy_quark = Values(QUDA_L2_RELATIVE_RESIDUAL);
 
 // preconditioned normal solves
 INSTANTIATE_TEST_SUITE_P(NormalEvenOdd, InvertTest,
-                         Combine(normal_solvers,
-                                 Values(QUDA_MATPCDAG_MATPC_SOLUTION, QUDA_MAT_SOLUTION),
+                         Combine(normal_solvers, Values(QUDA_MATPCDAG_MATPC_SOLUTION, QUDA_MAT_SOLUTION),
                                  Values(QUDA_NORMOP_PC_SOLVE), sloppy_precisions, Values(1),
-                                 solution_accumulator_pipelines,
-                                 no_schwarz,
-                                 no_heavy_quark),
+                                 solution_accumulator_pipelines, no_schwarz, no_heavy_quark),
                          gettestname);
 
 // full system normal solve
 INSTANTIATE_TEST_SUITE_P(NormalFull, InvertTest,
-                         Combine(normal_solvers, Values(QUDA_MATDAG_MAT_SOLUTION),
-                                 Values(QUDA_NORMOP_SOLVE),
-                                 sloppy_precisions, Values(1),
-                                 solution_accumulator_pipelines,
-                                 no_schwarz,
-                                 no_heavy_quark),
+                         Combine(normal_solvers, Values(QUDA_MATDAG_MAT_SOLUTION), Values(QUDA_NORMOP_SOLVE),
+                                 sloppy_precisions, Values(1), solution_accumulator_pipelines, no_schwarz, no_heavy_quark),
                          gettestname);
 
 // preconditioned direct solves
 INSTANTIATE_TEST_SUITE_P(EvenOdd, InvertTest,
                          Combine(direct_solvers, Values(QUDA_MATPC_SOLUTION, QUDA_MAT_SOLUTION),
                                  Values(QUDA_DIRECT_PC_SOLVE), sloppy_precisions, Values(1),
-                                 solution_accumulator_pipelines,
-                                 no_schwarz,
-                                 no_heavy_quark),
+                                 solution_accumulator_pipelines, no_schwarz, no_heavy_quark),
                          gettestname);
 
 // full system direct solve
 INSTANTIATE_TEST_SUITE_P(Full, InvertTest,
-                         Combine(direct_solvers, Values(QUDA_MAT_SOLUTION),
-                                 Values(QUDA_DIRECT_SOLVE),
-                                 sloppy_precisions, Values(1), solution_accumulator_pipelines,
-                                 no_schwarz,
-                                 no_heavy_quark),
+                         Combine(direct_solvers, Values(QUDA_MAT_SOLUTION), Values(QUDA_DIRECT_SOLVE), sloppy_precisions,
+                                 Values(1), solution_accumulator_pipelines, no_schwarz, no_heavy_quark),
                          gettestname);
 
 // preconditioned multi-shift solves
 INSTANTIATE_TEST_SUITE_P(MultiShiftEvenOdd, InvertTest,
                          Combine(Values(QUDA_CG_INVERTER), Values(QUDA_MATPCDAG_MATPC_SOLUTION),
                                  Values(QUDA_NORMOP_PC_SOLVE), sloppy_precisions, Values(10),
-                                 solution_accumulator_pipelines,
-                                 no_schwarz,
-                                 no_heavy_quark),
+                                 solution_accumulator_pipelines, no_schwarz, no_heavy_quark),
                          gettestname);
 
 // Schwarz-preconditioned normal solves
 INSTANTIATE_TEST_SUITE_P(SchwarzNormal, InvertTest,
-                         Combine(Values(QUDA_PCG_INVERTER),
-                                 Values(QUDA_MATPCDAG_MATPC_SOLUTION),
-                                 Values(QUDA_NORMOP_PC_SOLVE), sloppy_precisions,
-                                 Values(1),
+                         Combine(Values(QUDA_PCG_INVERTER), Values(QUDA_MATPCDAG_MATPC_SOLUTION),
+                                 Values(QUDA_NORMOP_PC_SOLVE), sloppy_precisions, Values(1),
                                  solution_accumulator_pipelines,
-                                 Combine(Values(QUDA_ADDITIVE_SCHWARZ),
-                                         Values(QUDA_CG_INVERTER, QUDA_CA_CG_INVERTER),
+                                 Combine(Values(QUDA_ADDITIVE_SCHWARZ), Values(QUDA_CG_INVERTER, QUDA_CA_CG_INVERTER),
                                          Values(QUDA_HALF_PRECISION, QUDA_QUARTER_PRECISION)),
                                  no_heavy_quark),
                          gettestname);
 
 // Schwarz-preconditioned direct solves
 INSTANTIATE_TEST_SUITE_P(SchwarzEvenOdd, InvertTest,
-                         Combine(Values(QUDA_GCR_INVERTER),
-                                 Values(QUDA_MATPC_SOLUTION),
-                                 Values(QUDA_DIRECT_PC_SOLVE), sloppy_precisions,
-                                 Values(1),
-                                 solution_accumulator_pipelines,
-                                 Combine(Values(QUDA_ADDITIVE_SCHWARZ),
-                                         Values(QUDA_MR_INVERTER, QUDA_CA_GCR_INVERTER),
+                         Combine(Values(QUDA_GCR_INVERTER), Values(QUDA_MATPC_SOLUTION), Values(QUDA_DIRECT_PC_SOLVE),
+                                 sloppy_precisions, Values(1), solution_accumulator_pipelines,
+                                 Combine(Values(QUDA_ADDITIVE_SCHWARZ), Values(QUDA_MR_INVERTER, QUDA_CA_GCR_INVERTER),
                                          Values(QUDA_HALF_PRECISION, QUDA_QUARTER_PRECISION)),
                                  no_heavy_quark),
                          gettestname);
 
 // Heavy-Quark preconditioned solves
 INSTANTIATE_TEST_SUITE_P(HeavyQuarkEvenOdd, InvertTest,
-                         Combine(Values(QUDA_CG_INVERTER),
-                                 Values(QUDA_MATPC_SOLUTION),
-                                 Values(QUDA_NORMOP_PC_SOLVE), sloppy_precisions,
-                                 Values(1),
-                                 solution_accumulator_pipelines,
-                                 no_schwarz,
+                         Combine(Values(QUDA_CG_INVERTER), Values(QUDA_MATPC_SOLUTION), Values(QUDA_NORMOP_PC_SOLVE),
+                                 sloppy_precisions, Values(1), solution_accumulator_pipelines, no_schwarz,
                                  Values(QUDA_L2_RELATIVE_RESIDUAL | QUDA_HEAVY_QUARK_RESIDUAL, QUDA_HEAVY_QUARK_RESIDUAL)),
                          gettestname);

--- a/tests/utils/set_params.cpp
+++ b/tests/utils/set_params.cpp
@@ -193,10 +193,7 @@ void setInvertParam(QudaInvertParam &inv_param)
   inv_param.ca_lambda_max = ca_lambda_max;
   inv_param.tol = tol;
   inv_param.tol_restart = tol_restart;
-  if (tol_hq == 0 && tol == 0) {
-    errorQuda("qudaInvert: requesting zero residual\n");
-    exit(1);
-  }
+  if (tol_hq == 0 && tol == 0)  errorQuda("qudaInvert: requesting zero residual");
 
   // require both L2 relative and heavy quark residual to determine convergence
   inv_param.residual_type = static_cast<QudaResidualType_s>(0);
@@ -844,10 +841,7 @@ void setStaggeredMGInvertParam(QudaInvertParam &inv_param)
 
   inv_param.Ls = 1;
 
-  if (tol_hq == 0 && tol == 0) {
-    errorQuda("qudaInvert: requesting zero residual\n");
-    exit(1);
-  }
+  if (tol_hq == 0 && tol == 0) errorQuda("qudaInvert: requesting zero residual");
 
   // require both L2 relative and heavy quark residual to determine convergence
   inv_param.residual_type = static_cast<QudaResidualType>(QUDA_L2_RELATIVE_RESIDUAL);

--- a/tests/utils/set_params.cpp
+++ b/tests/utils/set_params.cpp
@@ -193,7 +193,7 @@ void setInvertParam(QudaInvertParam &inv_param)
   inv_param.ca_lambda_max = ca_lambda_max;
   inv_param.tol = tol;
   inv_param.tol_restart = tol_restart;
-  if (tol_hq == 0 && tol == 0)  errorQuda("qudaInvert: requesting zero residual");
+  if (tol_hq == 0 && tol == 0) errorQuda("qudaInvert: requesting zero residual");
 
   // require both L2 relative and heavy quark residual to determine convergence
   inv_param.residual_type = static_cast<QudaResidualType_s>(0);


### PR DESCRIPTION
This PR adds support for testing heavy-quark CG solves in the gtest solver testing.  In doing so, I have seemingly discovered a bug in the HQ solver, where it fails to converge in mixed-precision.

The following command
```
tests/invert_test --dslash-type wilson --ngcrkrylov 8 --dim 2 4 6 8 --prec double --prec-sloppy single --tol 1e-7 --tolhq 1e-7
```
fails to converge.
```
CG: Convergence at 161 iterations, L2 relative residual: iterated = 2.738192e+05, true = 2.738192e+05 (requested = 1.000000e-07), heavy-quark residual = 1.085493e+00 (requested = 1.000000e-07)
```
This is seemingly a mixed-precision bug in the HQ CG solver, as convergence is fine for the regular CG solver, and also proceeds as expected in the HQ solver in uni-precision.

@weinbe2 handing this to you to fix this bug, so we can get this test merged in.