### PR TITLE
Specifying granular masses and tolerances for multishift tests

### DIFF
--- a/tests/invert_test.cpp
+++ b/tests/invert_test.cpp
@@ -239,14 +239,22 @@ std::vector<std::array<double, 2>> solve(test_t param)
   if (multishift > 1) {
     if (use_split_grid) { errorQuda("Split grid does not work with multishift yet."); }
     inv_param.num_offset = multishift;
+
+    // Consistency check for masses, tols, tols_hq size if we're setting custom values
+    if (multishift_masses.size() != 0 && multishift_masses.size() != static_cast<unsigned long>(multishift))
+      errorQuda("Multishift mass count %d does not agree with number of masses passed in %lu\n", multishift, multishift_masses.size());
+    if (multishift_tols.size() != 0 && multishift_tols.size() != static_cast<unsigned long>(multishift))
+      errorQuda("Multishift tolerance count %d does not agree with number of masses passed in %lu\n", multishift, multishift_tols.size());
+    if (multishift_tols_hq.size() != 0 && multishift_tols_hq.size() != static_cast<unsigned long>(multishift))
+      errorQuda("Multishift hq tolerance count %d does not agree with number of masses passed in %lu\n", multishift, multishift_tols_hq.size());
+
+    // Copy offsets and tolerances into inv_param; copy data pointers
     for (int i = 0; i < multishift; i++) {
-      // Set masses and offsets
-      masses[i] = 0.06 + i * i * 0.01;
+      masses[i] = (multishift_masses.size() == 0 ? (mass + i * i * 0.01) : multishift_masses[i]);
       inv_param.offset[i] = 4 * masses[i] * masses[i];
-      // Set tolerances for the heavy quarks, these can be set independently
-      // (functions of i) if desired
-      inv_param.tol_offset[i] = inv_param.tol;
-      inv_param.tol_hq_offset[i] = inv_param.tol_hq;
+      inv_param.tol_offset[i] = (multishift_tols.size() == 0 ? inv_param.tol : multishift_tols[i]);
+      inv_param.tol_hq_offset[i] = (multishift_tols_hq.size() == 0 ? inv_param.tol_hq : multishift_tols_hq[i]);
+
       // Allocate memory and set pointers
       for (int n = 0; n < Nsrc; n++) {
         out_multishift[n * multishift + i] = quda::ColorSpinorField(cs_param);

--- a/tests/invert_test.cpp
+++ b/tests/invert_test.cpp
@@ -231,8 +231,8 @@ std::vector<std::array<double, 2>> solve(test_t param)
   // Vector construct END
   //-----------------------------------------------------------------------------------
 
-  // Quark masses
-  std::vector<double> masses(multishift);
+  // Shifts
+  std::vector<double> shifts(multishift);
 
   // QUDA invert test BEGIN
   //----------------------------------------------------------------------------
@@ -240,9 +240,11 @@ std::vector<std::array<double, 2>> solve(test_t param)
     if (use_split_grid) { errorQuda("Split grid does not work with multishift yet."); }
     inv_param.num_offset = multishift;
 
-    // Consistency check for masses, tols, tols_hq size if we're setting custom values
-    if (multishift_masses.size() != 0 && multishift_masses.size() != static_cast<unsigned long>(multishift))
-      errorQuda("Multishift mass count %d does not agree with number of masses passed in %lu\n", multishift, multishift_masses.size());
+    // Consistency check for shifts, tols, tols_hq size if we're setting custom values
+    if (multishift_masses.size() != 0)
+      errorQuda("Multishift masses are not supported for Wilson-type fermions");
+    if (multishift_shifts.size() != 0 && multishift_shifts.size() != static_cast<unsigned long>(multishift))
+      errorQuda("Multishift shift count %d does not agree with number of shifts passed in %lu\n", multishift, multishift_shifts.size());
     if (multishift_tols.size() != 0 && multishift_tols.size() != static_cast<unsigned long>(multishift))
       errorQuda("Multishift tolerance count %d does not agree with number of masses passed in %lu\n", multishift, multishift_tols.size());
     if (multishift_tols_hq.size() != 0 && multishift_tols_hq.size() != static_cast<unsigned long>(multishift))
@@ -250,8 +252,8 @@ std::vector<std::array<double, 2>> solve(test_t param)
 
     // Copy offsets and tolerances into inv_param; copy data pointers
     for (int i = 0; i < multishift; i++) {
-      masses[i] = (multishift_masses.size() == 0 ? (mass + i * i * 0.01) : multishift_masses[i]);
-      inv_param.offset[i] = 4 * masses[i] * masses[i];
+      shifts[i] = (multishift_shifts.size() == 0 ? (i * i * 0.01) : multishift_shifts[i]);
+      inv_param.offset[i] = shifts[i];
       inv_param.tol_offset[i] = (multishift_tols.size() == 0 ? inv_param.tol : multishift_tols[i]);
       inv_param.tol_hq_offset[i] = (multishift_tols_hq.size() == 0 ? inv_param.tol_hq : multishift_tols_hq[i]);
 

--- a/tests/staggered_invert_test.cpp
+++ b/tests/staggered_invert_test.cpp
@@ -306,25 +306,20 @@ int main(int argc, char **argv)
   std::vector<double> gflops(Nsrc);
   std::vector<int> iter(Nsrc);
 
-  // Pointers for tests 5 and 6
-  // Quark masses
-  std::vector<double> masses(multishift);
-  // Host array for solutions
-  void **outArray = (void **)safe_malloc(multishift * sizeof(void *));
-  // QUDA host array for internal checks and malloc
-  std::vector<ColorSpinorField *> qudaOutArray(multishift);
-
+  // Pointers for split grid tests
   std::vector<quda::ColorSpinorField *> _h_b(Nsrc, nullptr);
   std::vector<quda::ColorSpinorField *> _h_x(Nsrc, nullptr);
 
   // QUDA invert test
   //----------------------------------------------------------------------------
-  switch (test_type) {
-  case 0: // full parity solution, full parity system
-  case 1: // full parity solution, solving EVEN EVEN prec system
-  case 2: // full parity solution, solving ODD ODD prec system
-  case 3: // even parity solution, solving EVEN system
-  case 4: // odd parity solution, solving ODD system
+
+  if (test_type >= 0 && test_type <= 4) {
+    // case 0: // full parity solution, full parity system
+    // case 1: // full parity solution, solving EVEN EVEN prec system
+    // case 2: // full parity solution, solving ODD ODD prec system
+    // case 3: // even parity solution, solving EVEN system
+    // case 4: // odd parity solution, solving ODD system
+
     if (multishift != 1) {
       printfQuda("Multishift not supported for test %d\n", test_type);
       exit(0);
@@ -367,35 +362,48 @@ int main(int argc, char **argv)
         verifyStaggeredInversion(*tmp, *ref, *in[k], *out[k], mass, qdp_fatlink, qdp_longlink, (void **)cpuFat->Ghost(),
                                  (void **)cpuLong->Ghost(), gauge_param, inv_param, 0);
     }
-    break;
+  } else if (test_type == 5 || test_type == 6) {
+    // case 5: // multi mass CG, even parity solution, solving EVEN system
+    // case 6: // multi mass CG, odd parity solution, solving ODD system
 
-  case 5: // multi mass CG, even parity solution, solving EVEN system
-  case 6: // multi mass CG, odd parity solution, solving ODD system
+    if (use_split_grid)
+      errorQuda("Multishift currently doesn't support split grid.\n");
 
-    if (use_split_grid) { errorQuda("Multishift currently doesn't support split grid.\n"); }
-
-    if (multishift < 2) {
-      printfQuda("Multishift inverter requires more than one shift, multishift = %d\n", multishift);
-      exit(0);
-    }
+    if (multishift < 2)
+      errorQuda("Multishift inverter requires more than one shift, multishift = %d\n", multishift);
 
     inv_param.num_offset = multishift;
+
+    // Prepare vectors for masses
+    std::vector<double> masses(multishift);
+
+    // Consistency check for masses, tols, tols_hq size if we're setting custom values
+    if (multishift_masses.size() != 0 && multishift_masses.size() != static_cast<unsigned long>(multishift))
+      errorQuda("Multishift mass count %d does not agree with number of masses passed in %lu\n", multishift, multishift_masses.size());
+    if (multishift_tols.size() != 0 && multishift_tols.size() != static_cast<unsigned long>(multishift))
+      errorQuda("Multishift tolerance count %d does not agree with number of masses passed in %lu\n", multishift, multishift_tols.size());
+    if (multishift_tols_hq.size() != 0 && multishift_tols_hq.size() != static_cast<unsigned long>(multishift))
+      errorQuda("Multishift hq tolerance count %d does not agree with number of masses passed in %lu\n", multishift, multishift_tols_hq.size());
+
+    // Allocate storage of output arrays
+    std::vector<void*> outArray(multishift);
+    std::vector<ColorSpinorField> qudaOutArray(multishift, cs_param);
+
+    // Copy offsets and tolerances into inv_param; copy data pointers into outArray
     for (int i = 0; i < multishift; i++) {
-      // Set masses and offsets
-      masses[i] = 0.06 + i * i * 0.01;
+      masses[i] = (multishift_masses.size() == 0 ? (mass + i * i * 0.01) : multishift_masses[i]);
       inv_param.offset[i] = 4 * masses[i] * masses[i];
-      // Set tolerances for the heavy quarks, these can be set independently
-      // (functions of i) if desired
-      inv_param.tol_offset[i] = inv_param.tol;
-      inv_param.tol_hq_offset[i] = inv_param.tol_hq;
-      // Allocate memory and set pointers
-      qudaOutArray[i] = ColorSpinorField::Create(cs_param);
-      outArray[i] = qudaOutArray[i]->V();
+      inv_param.tol_offset[i] = (multishift_tols.size() == 0 ? inv_param.tol : multishift_tols[i]);
+      inv_param.tol_hq_offset[i] = (multishift_tols_hq.size() == 0 ? inv_param.tol_hq : multishift_tols_hq[i]);
+
+      outArray[i] = qudaOutArray[i].V();
+
+      logQuda(QUDA_VERBOSE, "Multishift mass %d = %e ; tolerance %e ; hq tolerance %e\n", i, masses[i], inv_param.tol_offset[i], inv_param.tol_hq_offset[i]);
     }
 
     for (int k = 0; k < Nsrc; k++) {
       quda::spinorNoise(*in[k], *rng, QUDA_NOISE_UNIFORM);
-      invertMultiShiftQuda((void **)outArray, in[k]->V(), &inv_param);
+      invertMultiShiftQuda((void **)outArray.data(), in[k]->V(), &inv_param);
 
       time[k] = inv_param.secs;
       gflops[k] = inv_param.gflops / inv_param.secs;
@@ -405,16 +413,12 @@ int main(int argc, char **argv)
 
       for (int i = 0; i < multishift; i++) {
         printfQuda("%dth solution: mass=%f, ", i, masses[i]);
-        verifyStaggeredInversion(*tmp, *ref, *in[k], *qudaOutArray[i], masses[i], qdp_fatlink, qdp_longlink,
+        verifyStaggeredInversion(*tmp, *ref, *in[k], qudaOutArray[i], masses[i], qdp_fatlink, qdp_longlink,
                                  (void **)cpuFat->Ghost(), (void **)cpuLong->Ghost(), gauge_param, inv_param, i);
       }
     }
-
-    for (int i = 0; i < multishift; i++) delete qudaOutArray[i];
-    break;
-
-  default: errorQuda("Unsupported test type");
-
+  } else {
+    errorQuda("Unsupported test type");
   } // switch
 
   // Compute timings
@@ -448,7 +452,6 @@ int main(int argc, char **argv)
   for (auto out_vec : out) { delete out_vec; }
   delete ref;
   delete tmp;
-  host_free(outArray);
 
   if (use_split_grid) {
     for (auto p : _h_b) { delete p; }

--- a/tests/staggered_invert_test.cpp
+++ b/tests/staggered_invert_test.cpp
@@ -378,6 +378,8 @@ int main(int argc, char **argv)
     std::vector<double> masses(multishift);
 
     // Consistency check for masses, tols, tols_hq size if we're setting custom values
+    if (multishift_shifts.size() != 0)
+      errorQuda("Multishift shifts are not supported for Wilson-type fermions");
     if (multishift_masses.size() != 0 && multishift_masses.size() != static_cast<unsigned long>(multishift))
       errorQuda("Multishift mass count %d does not agree with number of masses passed in %lu\n", multishift, multishift_masses.size());
     if (multishift_tols.size() != 0 && multishift_tols.size() != static_cast<unsigned long>(multishift))

--- a/tests/utils/command_line_params.cpp
+++ b/tests/utils/command_line_params.cpp
@@ -86,6 +86,7 @@ std::string madwf_param_outfile;
 
 int precon_schwarz_cycle = 1;
 int multishift = 1;
+std::vector<double> multishift_shifts = {};
 std::vector<double> multishift_masses = {};
 std::vector<double> multishift_tols = {};
 std::vector<double> multishift_tols_hq = {};
@@ -510,9 +511,12 @@ std::shared_ptr<QUDAApp> make_app(std::string app_description, std::string app_n
     "--multishift", multishift,
     "Whether to do a multi-shift solver test or not. Default is 1 (single mass)"
     "If a value N > 1 is passed, heavier masses will be constructed and the multi-shift solver will be called");
-    quda_app->add_option(
+  quda_app->add_option(
+    "--multishift-shifts", multishift_shifts,
+    "List of shifts to use in a multi-shift solve; ignored for staggered-type fermions. Default is (i * i * 0.01)");
+  quda_app->add_option(
     "--multishift-masses", multishift_masses,
-    "List of masses to use in a multi-shift solve; this will override the value of mass. Default is (mass + i * i * 0.01)");
+    "List of masses to use in a multi-shift solve; this will override the value of mass; ignored for Wilson-type fermions. Default is (mass + i * i * 0.01)");
   quda_app->add_option(
     "--multishift-tols", multishift_tols,
     "List of tolerances to use in a multi-shift solve. Default is to uniformly use the input tolerance");

--- a/tests/utils/command_line_params.cpp
+++ b/tests/utils/command_line_params.cpp
@@ -86,6 +86,9 @@ std::string madwf_param_outfile;
 
 int precon_schwarz_cycle = 1;
 int multishift = 1;
+std::vector<double> multishift_masses = {};
+std::vector<double> multishift_tols = {};
+std::vector<double> multishift_tols_hq = {};
 bool verify_results = true;
 bool low_mode_check = false;
 bool oblique_proj_check = false;
@@ -507,6 +510,15 @@ std::shared_ptr<QUDAApp> make_app(std::string app_description, std::string app_n
     "--multishift", multishift,
     "Whether to do a multi-shift solver test or not. Default is 1 (single mass)"
     "If a value N > 1 is passed, heavier masses will be constructed and the multi-shift solver will be called");
+    quda_app->add_option(
+    "--multishift-masses", multishift_masses,
+    "List of masses to use in a multi-shift solve; this will override the value of mass. Default is (mass + i * i * 0.01)");
+  quda_app->add_option(
+    "--multishift-tols", multishift_tols,
+    "List of tolerances to use in a multi-shift solve. Default is to uniformly use the input tolerance");
+  quda_app->add_option(
+    "--multishift-tols-hq", multishift_tols_hq,
+    "List of hq tolerances to use in a multi-shift solve. Default is the input hq tolerance (default 0)");
   quda_app->add_option("--ngcrkrylov", gcrNkrylov,
                        "The number of inner iterations to use for GCR, BiCGstab-l, CA-CG, CA-GCR (default 8)");
   quda_app->add_option("--niter", niter, "The number of iterations to perform (default 100)");

--- a/tests/utils/command_line_params.h
+++ b/tests/utils/command_line_params.h
@@ -222,6 +222,7 @@ extern std::string madwf_param_outfile;
 
 extern int precon_schwarz_cycle;
 extern int multishift;
+extern std::vector<double> multishift_shifts;
 extern std::vector<double> multishift_masses;
 extern std::vector<double> multishift_tols;
 extern std::vector<double> multishift_tols_hq;

--- a/tests/utils/command_line_params.h
+++ b/tests/utils/command_line_params.h
@@ -222,6 +222,9 @@ extern std::string madwf_param_outfile;
 
 extern int precon_schwarz_cycle;
 extern int multishift;
+extern std::vector<double> multishift_masses;
+extern std::vector<double> multishift_tols;
+extern std::vector<double> multishift_tols_hq;
 extern bool verify_results;
 extern bool low_mode_check;
 extern bool oblique_proj_check;


### PR DESCRIPTION
This very narrow PR adds command line arguments for specifying custom masses, tolerances, and HQ tolerances for each shift in multishift solves for both staggered and Wilson-type solves. The default behavior is to base masses off the mass (with extended shifts adding `0.01 * i * i`, as before) and to use `tol` and `tol_hq` for all of the shifts, but the flags `--multishift-masses`, `--multishift-tol`, and `multishift-tols-hq` can be used to override this behavior.

Examples below are for staggered; remove the `--dslash-type staggered --compute-fat-long true --test 5` to test Wilson-type operators.

4-shift solve with default masses, tols:
```
./staggered_invert_test --dim 8 8 8 8 --dslash-type staggered --compute-fat-long true --prec double --prec-sloppy single --test 5 --multishift 4
```

4-shift solve with custom masses, default tols:
```
./staggered_invert_test --dim 8 8 8 8 --dslash-type staggered --compute-fat-long true --prec double --prec-sloppy single --test 5 --multishift 4 --multishift-masses 0.01 0.02 0.03 0.04
```

4-shift solve with custom masses and tolerances:
```
./staggered_invert_test --dim 8 8 8 8 --dslash-type staggered --compute-fat-long true --prec double --prec-sloppy single --test 5 --multishift 4 --multishift-masses 0.01 0.02 0.03 0.04 --multishift-tols 1e-4 1e-5 1e-6 1e-7
```

If the number of masses, etc, does not agree with the argument to `--multishift` the tests will intentionally error out.

Outstanding work is minimal:
- [ ] `clang-format`
