### PR TITLE
Match `x` and `p` in `computeCloverForce` and `computeCloverSigmaOprod`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,10 +264,11 @@ Advanced Scientific Computing (PASC21) [arXiv:2104.05615[hep-lat]].
 *  Marco Garofalo (HISKP, University of Bonn)
 *  Joel Giedt (Rensselaer Polytechnic Institute) 
 *  Steven Gottlieb (Indiana University) 
+*  Anthony Grebe (Fermilab)
 *  Kyriakos Hadjiyiannakou (Cyprus)
 *  Dean Howarth (Lawrence Livermore Lab, Lawrence Berkeley Lab)
 *  Hwancheol Jeong (Indiana University)
-*  Xiangyu Jiang (Chinese Academy of Sciences)
+*  Xiangyu Jiang (ITP, Chinese Academy of Sciences)
 *  Balint Joo (OLCF, Oak Ridge National Laboratory, formerly Jefferson Lab)
 *  Hyung-Jin Kim (Samsung Advanced Institute of Technology)
 *  Bartosz Kostrzewa (HPC/A-Lab, University of Bonn)
@@ -282,13 +283,12 @@ Advanced Scientific Computing (PASC21) [arXiv:2104.05615[hep-lat]].
 *  Jiqun Tu (NVIDIA)
 *  Carsten Urbach (HISKP, University of Bonn)
 *  Alejandro Vaquero (Utah University)
+*  Michael Wagman (Fermilab)
 *  Mathias Wagner (NVIDIA)
 *  Andre Walker-Loud (Lawrence Berkley Laboratory)
 *  Evan Weinberg (NVIDIA)
 *  Frank Winter (Jefferson Lab)
-*  Yi-Bo Yang (Chinese Academy of Sciences)
-*  Anthony Grebe (Fermilab)
-*  Michael Wagman (Fermilab)
+*  Yi-Bo Yang (ITP, Chinese Academy of Sciences)
 
 
 Portions of this software were developed at the Innovative Systems Lab,

--- a/lib/clover_force.cpp
+++ b/lib/clover_force.cpp
@@ -67,7 +67,7 @@ namespace quda
     GaugeField oprod(param);
 
     // derivative of the wilson operator it correspond to deriv_Sb(OE,...) plus  deriv_Sb(EO,...) in tmLQCD
-    computeCloverForce(force, gauge, x, p, coeff);
+    computeCloverForce(force, gauge, inv_param.dagger == QUDA_DAG_YES ? p : x, inv_param.dagger == QUDA_DAG_YES ? x : p, coeff);
     // derivative of the determinant of the sw term, second term of (A12) in hep-lat/0112051,  sw_deriv(EE, mnl->mu) in tmLQCD
     if (!detratio) computeCloverSigmaTrace(oprod, clover, sigma_coeff, other_parity);
 

--- a/lib/clover_outer_product.cu
+++ b/lib/clover_outer_product.cu
@@ -142,10 +142,10 @@ namespace quda {
 
       for (auto i = 0u; i < x.size(); i++) {
         for (int parity = 0; parity < 2; parity++) {
-          const ColorSpinorField &inA = (parity & 1) ? x[i].Odd() : x[i].Even();
-          const ColorSpinorField &inB = (parity & 1) ? p[i].Even() : p[i].Odd();
-          const ColorSpinorField &inC = (parity & 1) ? p[i].Odd() : p[i].Even();
-          const ColorSpinorField &inD = (parity & 1) ? x[i].Even() : x[i].Odd();
+          const ColorSpinorField &inA = (parity & 1) ? p[i].Odd() : p[i].Even();
+          const ColorSpinorField &inB = (parity & 1) ? x[i].Even() : x[i].Odd();
+          const ColorSpinorField &inC = (parity & 1) ? x[i].Odd() : x[i].Even();
+          const ColorSpinorField &inD = (parity & 1) ? p[i].Even() : p[i].Odd();
 
           getProfile().TPSTART(QUDA_PROFILE_COMMS);
           exchangeGhost(inB, parity, dag);

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -912,8 +912,6 @@ void loadCloverQuda(void *h_clover, void *h_clovinv, QudaInvertParam *inv_param)
   popVerbosity();
 }
 
-void freeSloppyCloverQuda();
-
 void loadSloppyCloverQuda(const QudaPrecision *prec)
 {
   freeSloppyCloverQuda();


### PR DESCRIPTION
This small PR revert changes in https://github.com/lattice/quda/commit/fd30fd7790bf094242ccd7670e221a6878469bf6, and uses `QudaInvertParam::dagger` to decide the order of `x` and `p` in `computeCloverForce`. Now the order is consistent in `computeCloverForce` and `computeCloverSigmaOprod` in clover_force.cpp.

I'm trying to get a HMC integrator to return a reasonable delta_H (which should be small). I tried different parameters and noticed that I need to set `QudaInvertParam::dagger = QUDA_DAG_YES` for `computeCloverForceQuda` and `QudaInvertParam::dagger = QUDA_DAG_NO` for `invertQuda` in my HMC program, which makes sense.

But setting `QudaInvertParam::dagger = QUDA_DAG_NO` for `computeCloverForceQuda` and `QudaInvertParam::dagger = QUDA_DAG_YES` for `invertQuda` keeps returning a large delta_H. The order of `x` and `p` is static in `computeCloverForce` and dynamic in `computeCloverSigmaOprod`, which should be the reason why I cannot get a reasonable integrator.

This PR should affect the MILC convention of `computeCloverForceQuda`. I'm not familiar with MILC and need help from a MILC expert to confirm these changes work fine for MILC. (In fact, this PR makes `computeCloverForce` behave the same as before merging #1338).

I didn't change the CPU reference implementation, let me know if I should do that.

`updateGaugeFieldQuda` frees all the sloppy gauge fields in the end, and reallocates `gaugePrecise` only. This leaves all sloppy fields undefined and QUDA will dump in the next `checkGauge`. An extra `loadGaugeQuda(nullptr, param)` should regenerate all sloppy fields, but it cannot handle the `nullptr` correctly if `param->use_resident_gauge == 0`. Please let me know if you have any ideas about it.

A redundant declaration of `freeSloppyCloverQuda` is removed.