### PR TITLE
added support for incremental smearing in performWFlowQuda

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ Advanced Scientific Computing (PASC21) [arXiv:2104.05615[hep-lat]].
 *  Eloy Romero (William and Mary)
 *  Hauke Sandmeyer (Bielefeld)
 *  Mario Schröck (INFN)
+*  Aniket Sen (HISKP, University of Bonn)
 *  Guochun Shi (NCSA)
 *  Alexei Strelchenko (Fermi National Accelerator Laboratory)
 *  Jiqun Tu (NVIDIA)

--- a/include/quda.h
+++ b/include/quda.h
@@ -848,6 +848,8 @@ extern "C" {
     double rho; /**< Serves as one of the coefficients used in Over Improved Stout smearing, or as the single coefficient used in Stout */
     unsigned int meas_interval;    /**< Perform the requested measurements on the gauge field at this interval */
     QudaGaugeSmearType smear_type; /**< The smearing type to perform */
+    QudaBoolean restart; /**< Used to restart the smearing from existing gaugeSmeared */
+    double t0;  /**< Starting flow time for Wilson flow */
   } QudaGaugeSmearParam;
 
   typedef struct QudaBLASParam_s {

--- a/lib/check_params.h
+++ b/lib/check_params.h
@@ -1100,12 +1100,16 @@ void printQudaGaugeSmearParam(QudaGaugeSmearParam *param)
   P(alpha, 0.0);
   P(rho, 0.0);
   P(epsilon, 0.0);
+  P(restart, QUDA_BOOLEAN_FALSE);
+  P(t0, 0.0);
 #else
   P(n_steps, (unsigned int)INVALID_INT);
   P(meas_interval, (unsigned int)INVALID_INT);
   P(alpha, INVALID_DOUBLE);
   P(rho, INVALID_DOUBLE);
   P(epsilon, INVALID_DOUBLE);
+  P(restart, QUDA_BOOLEAN_INVALID);
+  P(t0, INVALID_DOUBLE);
 #endif
 
 #ifdef INIT_PARAM


### PR DESCRIPTION
Added the ability to do Wilson flow in incremental steps, using the boolean `QudaGaugeSmearParam->restart` . The final gauge after `n_steps` of flow is stored in `gaugeSmeared` so that flow can be restarted. This will facilitate host side computations at the intermediate steps by saving the `gaugeSmeared` back to host, and restart Wilson flow without the need to either repeat the previous flow steps or load the flowed gauge back to device.

Another parameter `t0` is added to `QudaGaugeSmearParam` in order to keep track of the starting flow time.

This can be extended to other smearing techniques if necessary.