### PR TITLE
Hotfix/mg

### DIFF
--- a/include/blas_quda.h
+++ b/include/blas_quda.h
@@ -303,13 +303,6 @@ namespace quda {
     inline double axpyNorm(double a, const ColorSpinorField &x, ColorSpinorField &y) { return axpbyzNorm(a, x, 1.0, y, y); }
 
     /**
-       @brief Compute y -= x and then ||y||^2
-       @param[in] x input vector
-       @param[in,out] y update vector
-    */
-    inline double xmyNorm(const ColorSpinorField &x, ColorSpinorField &y) { return axpbyzNorm(1.0, x, -1.0, y, y); }
-
-    /**
        @brief Compute the complex-valued inner product (x, y)
        @param[in] x input vector
        @param[in] y input vector
@@ -361,12 +354,28 @@ namespace quda {
                                            const ColorSpinorField &w, const ColorSpinorField &u);
 
     /**
+       @brief Compute y = a * x + b * y and then ||y||^2
+       @param[in] a scalar multiplier
+       @param[in] x input vector
+       @param[in] b scalar multiplier
+       @param[in,out] y update vector
+    */
+    double caxpbyNorm(const Complex &a, const ColorSpinorField &x, const Complex &b, ColorSpinorField &y);
+
+    /**
        @brief Compute y += a * x and then ||y||^2
        @param[in] a scalar multiplier
        @param[in] x input vector
        @param[in,out] y update vector
     */
-    double caxpyNorm(const Complex &a, const ColorSpinorField &x, ColorSpinorField &y);
+    inline double caxpyNorm(const Complex &a, const ColorSpinorField &x, ColorSpinorField &y) { return caxpbyNorm(a, x, 1.0, y); }
+
+    /**
+       @brief Compute y -= x and then ||y||^2
+       @param[in] x input vector
+       @param[in,out] y update vector
+    */
+    inline double xmyNorm(const ColorSpinorField &x, ColorSpinorField &y) { return caxpbyNorm(1.0, x, -1.0, y); }
 
     /**
        @brief Compute z = a * b * x + y, x = a * x, and then ||x||^2

--- a/include/blas_quda.h
+++ b/include/blas_quda.h
@@ -368,7 +368,10 @@ namespace quda {
        @param[in] x input vector
        @param[in,out] y update vector
     */
-    inline double caxpyNorm(const Complex &a, const ColorSpinorField &x, ColorSpinorField &y) { return caxpbyNorm(a, x, 1.0, y); }
+    inline double caxpyNorm(const Complex &a, const ColorSpinorField &x, ColorSpinorField &y)
+    {
+      return caxpbyNorm(a, x, 1.0, y);
+    }
 
     /**
        @brief Compute y -= x and then ||y||^2

--- a/include/kernels/reduce_core.cuh
+++ b/include/kernels/reduce_core.cuh
@@ -285,7 +285,7 @@ namespace quda
           norm2_<reduce_t, real>(sum, y[i]);
         }
       }
-      constexpr int flops() const { return 8; }   //! flops per element
+      constexpr int flops() const { return 8; } //! flops per element
     };
 
     /**

--- a/include/kernels/reduce_core.cuh
+++ b/include/kernels/reduce_core.cuh
@@ -274,16 +274,18 @@ namespace quda
       static constexpr memory_access<1, 1> read{ };
       static constexpr memory_access<0, 1> write{ };
       const complex<real> a;
-      caxpyNorm2(const complex<real> &a, const complex<real> &) : a(a) { ; }
+      const complex<real> b;
+      caxpyNorm2(const complex<real> &a, const complex<real> &b) : a(a), b(b) { ; }
       template <typename T> __device__ __host__ void operator()(reduce_t &sum, T &x, T &y, T &, T &, T &) const
       {
 #pragma unroll
         for (int i = 0; i < x.size(); i++) {
+          y[i] *= b;
           y[i] = cmac(a, x[i], y[i]);
           norm2_<reduce_t, real>(sum, y[i]);
         }
       }
-      constexpr int flops() const { return 6; }   //! flops per element
+      constexpr int flops() const { return 8; }   //! flops per element
     };
 
     /**

--- a/include/kernels/restrictor.cuh
+++ b/include/kernels/restrictor.cuh
@@ -31,7 +31,7 @@ namespace quda {
     static constexpr bool from_non_rel = from_non_rel_;
 
     // disable ghost to reduce arg size
-    using F = FieldOrderCB<real, fineSpin, fineColor, 1, colorspinor::getNative<in_t>(fineSpin), in_t, in_t, true, true>;
+    using F = FieldOrderCB<real, fineSpin, fineColor, 1, colorspinor::getNative<in_t>(fineSpin), in_t, in_t, true, isFixed<in_t>::value>;
     using C = FieldOrderCB<real, coarseSpin, coarseColor, 1, colorspinor::getNative<out_t>(coarseSpin), out_t, out_t, true>;
     using V = FieldOrderCB<real, fineSpin, fineColor, coarseColor, colorspinor::getNative<v_t>(fineSpin), v_t>;
 

--- a/include/kernels/restrictor.cuh
+++ b/include/kernels/restrictor.cuh
@@ -21,7 +21,8 @@ namespace quda {
   /** 
       Kernel argument struct
   */
-  template <typename out_t, typename in_t, typename v_t, int fineSpin_, int fineColor_, int coarseSpin_, int coarseColor_, bool from_non_rel_>
+  template <typename out_t, typename in_t, typename v_t, int fineSpin_, int fineColor_, int coarseSpin_,
+            int coarseColor_, bool from_non_rel_>
   struct RestrictArg : kernel_param<> {
     using real = out_t;
     static constexpr int fineSpin = fineSpin_;
@@ -31,8 +32,10 @@ namespace quda {
     static constexpr bool from_non_rel = from_non_rel_;
 
     // disable ghost to reduce arg size
-    using F = FieldOrderCB<real, fineSpin, fineColor, 1, colorspinor::getNative<in_t>(fineSpin), in_t, in_t, true, isFixed<in_t>::value>;
-    using C = FieldOrderCB<real, coarseSpin, coarseColor, 1, colorspinor::getNative<out_t>(coarseSpin), out_t, out_t, true>;
+    using F = FieldOrderCB<real, fineSpin, fineColor, 1, colorspinor::getNative<in_t>(fineSpin), in_t, in_t, true,
+                           isFixed<in_t>::value>;
+    using C
+      = FieldOrderCB<real, coarseSpin, coarseColor, 1, colorspinor::getNative<out_t>(coarseSpin), out_t, out_t, true>;
     using V = FieldOrderCB<real, fineSpin, fineColor, coarseColor, colorspinor::getNative<v_t>(fineSpin), v_t>;
 
     static constexpr unsigned int max_n_src = MAX_MULTI_RHS;

--- a/include/kernels/restrictor.cuh
+++ b/include/kernels/restrictor.cuh
@@ -21,9 +21,9 @@ namespace quda {
   /** 
       Kernel argument struct
   */
-  template <typename Float, typename vFloat, int fineSpin_, int fineColor_, int coarseSpin_, int coarseColor_, bool from_non_rel_>
+  template <typename out_t, typename in_t, typename v_t, int fineSpin_, int fineColor_, int coarseSpin_, int coarseColor_, bool from_non_rel_>
   struct RestrictArg : kernel_param<> {
-    using real = Float;
+    using real = out_t;
     static constexpr int fineSpin = fineSpin_;
     static constexpr int fineColor = fineColor_;
     static constexpr int coarseSpin = coarseSpin_;
@@ -31,9 +31,9 @@ namespace quda {
     static constexpr bool from_non_rel = from_non_rel_;
 
     // disable ghost to reduce arg size
-    using F = FieldOrderCB<Float, fineSpin, fineColor, 1, colorspinor::getNative<Float>(fineSpin), Float, Float, true>;
-    using C = FieldOrderCB<Float, coarseSpin, coarseColor, 1, colorspinor::getNative<Float>(coarseSpin), Float, Float, true>;
-    using V = FieldOrderCB<Float, fineSpin, fineColor, coarseColor, colorspinor::getNative<vFloat>(fineSpin), vFloat>;
+    using F = FieldOrderCB<real, fineSpin, fineColor, 1, colorspinor::getNative<in_t>(fineSpin), in_t, in_t, true, true>;
+    using C = FieldOrderCB<real, coarseSpin, coarseColor, 1, colorspinor::getNative<out_t>(coarseSpin), out_t, out_t, true>;
+    using V = FieldOrderCB<real, fineSpin, fineColor, coarseColor, colorspinor::getNative<v_t>(fineSpin), v_t>;
 
     static constexpr unsigned int max_n_src = MAX_MULTI_RHS;
     const int_fastdiv n_src;

--- a/include/transfer.h
+++ b/include/transfer.h
@@ -47,10 +47,10 @@ namespace quda {
     const QudaPrecision null_precision;
 
     /** CPU copy of the block-normalized null-space components that define the prolongator */
-    mutable ColorSpinorField *V_h = nullptr;
+    mutable ColorSpinorField V_h;
 
     /** GPU copy of the block-normalized null-space components that define the prolongator */
-    mutable ColorSpinorField *V_d = nullptr;
+    mutable ColorSpinorField V_d;
 
     /** A CPU temporary field with fine geometry and fine color we use for changing gamma basis */
     mutable ColorSpinorField fine_tmp_h;
@@ -206,9 +206,9 @@ namespace quda {
     const ColorSpinorField& Vectors(QudaFieldLocation location=QUDA_INVALID_FIELD_LOCATION) const {
       if (location == QUDA_INVALID_FIELD_LOCATION) {
         // if not set then we return the memory space where the input vectors are stored
-        return B[0].Location() == QUDA_CUDA_FIELD_LOCATION ? *V_d : *V_h;
+        return B[0].Location() == QUDA_CUDA_FIELD_LOCATION ? V_d : V_h;
       } else {
-        return location == QUDA_CUDA_FIELD_LOCATION ? *V_d : *V_h;
+        return location == QUDA_CUDA_FIELD_LOCATION ? V_d : V_h;
       }
     }
 

--- a/lib/multigrid.cpp
+++ b/lib/multigrid.cpp
@@ -800,7 +800,7 @@ namespace quda
       transfer->P(fine_tmp, coarse_tmp);
 
       for (auto i = 0; i < param.Nvec; i++) {
-        auto max_deviation = blas::max_deviation(fine_tmp[i], param.B[i]);
+        auto max_deviation = blas::max_deviation(param.B[i], fine_tmp[i]);
         auto l2_deviation = sqrt(xmyNorm(param.B[i], fine_tmp[i]) / norm2(param.B[i]));
 
         logQuda(QUDA_VERBOSE,

--- a/lib/reduce_quda.cu
+++ b/lib/reduce_quda.cu
@@ -155,7 +155,7 @@ namespace quda {
 
     array<double, 2> max_deviation(const ColorSpinorField &x, const ColorSpinorField &y)
     {
-      auto deviation = instantiateReduce<MaxDeviation, false>(0.0, 0.0, 0.0, x, y, y, y, y);
+      auto deviation = instantiateReduce<MaxDeviation, true>(0.0, 0.0, 0.0, x, y, x, x, x);
       // ensure that if the absolute deviation is zero, so is the relative deviation
       return {deviation.diff, deviation.diff > 0.0 ? deviation.diff / deviation.ref : 0.0};
     }
@@ -185,9 +185,9 @@ namespace quda {
       return instantiateReduce<AxpyReDot, false>(a, 0.0, 0.0, x, y, x, x, x);
     }
 
-    double caxpyNorm(const Complex &a, const ColorSpinorField &x, ColorSpinorField &y)
+    double caxpbyNorm(const Complex &a, const ColorSpinorField &x, const Complex &b, ColorSpinorField &y)
     {
-      return instantiateReduce<caxpyNorm2, false>(a, Complex(0.0), Complex(0.0), x, y, x, x, x);
+      return instantiateReduce<caxpyNorm2, true>(a, b, Complex(0.0), x, y, x, x, x);
     }
 
     double cabxpyzAxNorm(double a, const Complex &b, ColorSpinorField &x, const ColorSpinorField &y, ColorSpinorField &z)

--- a/lib/restrictor.in.cu
+++ b/lib/restrictor.in.cu
@@ -14,7 +14,8 @@ namespace quda {
   };
 
   template <typename out_t, typename in_t, typename v_t, int fineSpin, int fineColor, int coarseSpin, int coarseColor>
-  class RestrictLaunch : public TunableBlock2D {
+  class RestrictLaunch : public TunableBlock2D
+  {
     template <bool from_non_rel>
     using Arg = RestrictArg<out_t, in_t, v_t, fineSpin, fineColor, coarseSpin, coarseColor, from_non_rel>;
     cvector_ref<ColorSpinorField> &out;
@@ -125,12 +126,11 @@ namespace quda {
       size_t v_bytes = v.Bytes() / (v.SiteSubset() == in[0].SiteSubset() ? 1 : 2);
       return out.size() * (in[0].Bytes() + out[0].Bytes() + v_bytes + in[0].SiteSubset() * in[0].VolumeCB() * sizeof(int));
     }
-
   };
 
   template <typename store_t, typename in_t, int fineSpin, int fineColor, int coarseColor>
   void Restrict(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in, const ColorSpinorField &v,
-                const int *fine_to_coarse, const int *coarse_to_fine, const int * const * spin_map, int parity)
+                const int *fine_to_coarse, const int *coarse_to_fine, const int *const *spin_map, int parity)
   {
     if (out[0].Nspin() != 2) errorQuda("Unsupported nSpin %d", out[0].Nspin());
     constexpr int coarseSpin = 2;
@@ -143,14 +143,14 @@ namespace quda {
 
     if (v.Precision() == QUDA_HALF_PRECISION) {
       if constexpr (is_enabled(QUDA_HALF_PRECISION)) {
-        RestrictLaunch<store_t, in_t, short, fineSpin, fineColor, coarseSpin, coarseColor>
-          restrictor(out, in, v, fine_to_coarse, coarse_to_fine, parity);
+        RestrictLaunch<store_t, in_t, short, fineSpin, fineColor, coarseSpin, coarseColor> restrictor(
+          out, in, v, fine_to_coarse, coarse_to_fine, parity);
       } else {
         errorQuda("QUDA_PRECISION=%d does not enable half precision", QUDA_PRECISION);
       }
     } else if (v.Precision() == in[0].Precision()) {
-      RestrictLaunch<store_t, in_t, store_t, fineSpin, fineColor, coarseSpin, coarseColor>
-        restrictor(out, in, v, fine_to_coarse, coarse_to_fine, parity);
+      RestrictLaunch<store_t, in_t, store_t, fineSpin, fineColor, coarseSpin, coarseColor> restrictor(
+        out, in, v, fine_to_coarse, coarse_to_fine, parity);
     } else {
       errorQuda("Unsupported V precision %d", v.Precision());
     }
@@ -158,7 +158,7 @@ namespace quda {
 
   template <typename store_t, int fineColor, int coarseColor>
   void Restrict(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in, const ColorSpinorField &v,
-                const int *fine_to_coarse, const int *coarse_to_fine, const int * const * spin_map, int parity)
+                const int *fine_to_coarse, const int *coarse_to_fine, const int *const *spin_map, int parity)
   {
     if (!is_enabled_spin(in[0].Nspin())) errorQuda("nSpin %d has not been built", in[0].Nspin());
 
@@ -168,10 +168,12 @@ namespace quda {
       if (in[0].Nspin() == 4) {
         if constexpr (is_enabled_spin(4)) {
           if (in[0].Precision() == out[0].Precision()) {
-            Restrict<store_t, store_t, 4, fineColor, coarseColor>(out, in, v, fine_to_coarse, coarse_to_fine, spin_map, parity);
-          } else if (in[0].Precision() == QUDA_HALF_PRECISION)  {
+            Restrict<store_t, store_t, 4, fineColor, coarseColor>(out, in, v, fine_to_coarse, coarse_to_fine, spin_map,
+                                                                  parity);
+          } else if (in[0].Precision() == QUDA_HALF_PRECISION) {
             if constexpr (is_enabled(QUDA_HALF_PRECISION)) {
-              Restrict<store_t, short, 4, fineColor, coarseColor>(out, in, v, fine_to_coarse, coarse_to_fine, spin_map, parity);
+              Restrict<store_t, short, 4, fineColor, coarseColor>(out, in, v, fine_to_coarse, coarse_to_fine, spin_map,
+                                                                  parity);
             } else {
               errorQuda("QUDA_PRECISION=%d does not enable half precision", QUDA_PRECISION);
             }

--- a/lib/restrictor.in.cu
+++ b/lib/restrictor.in.cu
@@ -166,7 +166,7 @@ namespace quda {
       Restrict<store_t, store_t, 2, fineColor, coarseColor>(out, in, v, fine_to_coarse, coarse_to_fine, spin_map, parity);
     } else if constexpr (fineColor == 3) {
       if (in[0].Nspin() == 4) {
-        if constexpr (is_enabled_spin(4))
+        if constexpr (is_enabled_spin(4)) {
           if (in[0].Precision() == out[0].Precision()) {
             Restrict<store_t, store_t, 4, fineColor, coarseColor>(out, in, v, fine_to_coarse, coarse_to_fine, spin_map, parity);
           } else if (in[0].Precision() == QUDA_HALF_PRECISION)  {
@@ -178,6 +178,7 @@ namespace quda {
           } else {
             errorQuda("Unsupoort precision %d", in[0].Precision());
           }
+        }
       } else if (in[0].Nspin() == 1) {
         if constexpr (is_enabled_spin(1))
           Restrict<store_t, store_t, 1, fineColor, coarseColor>(out, in, v, fine_to_coarse, coarse_to_fine, spin_map, parity);

--- a/lib/restrictor.in.cu
+++ b/lib/restrictor.in.cu
@@ -13,10 +13,10 @@ namespace quda {
     static constexpr array_type block = array_type();
   };
 
-  template <typename Float, typename vFloat, int fineSpin, int fineColor, int coarseSpin, int coarseColor>
+  template <typename out_t, typename in_t, typename v_t, int fineSpin, int fineColor, int coarseSpin, int coarseColor>
   class RestrictLaunch : public TunableBlock2D {
     template <bool from_non_rel>
-    using Arg = RestrictArg<Float, vFloat, fineSpin, fineColor, coarseSpin, coarseColor, from_non_rel>;
+    using Arg = RestrictArg<out_t, in_t, v_t, fineSpin, fineColor, coarseSpin, coarseColor, from_non_rel>;
     cvector_ref<ColorSpinorField> &out;
     cvector_ref<const ColorSpinorField> &in;
     const ColorSpinorField &v;
@@ -128,7 +128,7 @@ namespace quda {
 
   };
 
-  template <typename Float, int fineSpin, int fineColor, int coarseColor>
+  template <typename store_t, typename in_t, int fineSpin, int fineColor, int coarseColor>
   void Restrict(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in, const ColorSpinorField &v,
                 const int *fine_to_coarse, const int *coarse_to_fine, const int * const * spin_map, int parity)
   {
@@ -143,34 +143,44 @@ namespace quda {
 
     if (v.Precision() == QUDA_HALF_PRECISION) {
       if constexpr (is_enabled(QUDA_HALF_PRECISION)) {
-        RestrictLaunch<Float, short, fineSpin, fineColor, coarseSpin, coarseColor>
+        RestrictLaunch<store_t, in_t, short, fineSpin, fineColor, coarseSpin, coarseColor>
           restrictor(out, in, v, fine_to_coarse, coarse_to_fine, parity);
       } else {
         errorQuda("QUDA_PRECISION=%d does not enable half precision", QUDA_PRECISION);
       }
     } else if (v.Precision() == in[0].Precision()) {
-      RestrictLaunch<Float, Float, fineSpin, fineColor, coarseSpin, coarseColor>
+      RestrictLaunch<store_t, in_t, store_t, fineSpin, fineColor, coarseSpin, coarseColor>
         restrictor(out, in, v, fine_to_coarse, coarse_to_fine, parity);
     } else {
       errorQuda("Unsupported V precision %d", v.Precision());
     }
   }
 
-  template <typename Float, int fineColor, int coarseColor>
+  template <typename store_t, int fineColor, int coarseColor>
   void Restrict(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in, const ColorSpinorField &v,
                 const int *fine_to_coarse, const int *coarse_to_fine, const int * const * spin_map, int parity)
   {
     if (!is_enabled_spin(in[0].Nspin())) errorQuda("nSpin %d has not been built", in[0].Nspin());
 
     if (in[0].Nspin() == 2) {
-      Restrict<Float, 2, fineColor, coarseColor>(out, in, v, fine_to_coarse, coarse_to_fine, spin_map, parity);
+      Restrict<store_t, store_t, 2, fineColor, coarseColor>(out, in, v, fine_to_coarse, coarse_to_fine, spin_map, parity);
     } else if constexpr (fineColor == 3) {
       if (in[0].Nspin() == 4) {
         if constexpr (is_enabled_spin(4))
-          Restrict<Float, 4, fineColor, coarseColor>(out, in, v, fine_to_coarse, coarse_to_fine, spin_map, parity);
+          if (in[0].Precision() == out[0].Precision()) {
+            Restrict<store_t, store_t, 4, fineColor, coarseColor>(out, in, v, fine_to_coarse, coarse_to_fine, spin_map, parity);
+          } else if (in[0].Precision() == QUDA_HALF_PRECISION)  {
+            if constexpr (is_enabled(QUDA_HALF_PRECISION)) {
+              Restrict<store_t, short, 4, fineColor, coarseColor>(out, in, v, fine_to_coarse, coarse_to_fine, spin_map, parity);
+            } else {
+              errorQuda("QUDA_PRECISION=%d does not enable half precision", QUDA_PRECISION);
+            }
+          } else {
+            errorQuda("Unsupoort precision %d", in[0].Precision());
+          }
       } else if (in[0].Nspin() == 1) {
         if constexpr (is_enabled_spin(1))
-          Restrict<Float, 1, fineColor, coarseColor>(out, in, v, fine_to_coarse, coarse_to_fine, spin_map, parity);
+          Restrict<store_t, store_t, 1, fineColor, coarseColor>(out, in, v, fine_to_coarse, coarse_to_fine, spin_map, parity);
       } else {
         errorQuda("Unexpected nSpin = %d", in[0].Nspin());
       }
@@ -187,7 +197,8 @@ namespace quda {
                                         const int *fine_to_coarse, const int *coarse_to_fine, const int * const * spin_map, int parity)
   {
     checkLocation(out[0], in[0], v);
-    QudaPrecision precision = checkPrecision(out[0], in[0]);
+    if (in[0].Nspin() != 4) checkPrecision(in[0], out[0]);
+    QudaPrecision precision = out[0].Precision();
 
     if constexpr (is_enabled_multigrid()) {
       if (precision == QUDA_DOUBLE_PRECISION) {


### PR DESCRIPTION
This is a bugfix PR, and close #1438.  This bug arose because of the temporary removal in #1434, which took care of precision conversion.
* Adds support to the fine-grid restrictor to directly read from half-precision fields
* `blas::caxpyNorm` is now a wrapper to the more general function `blas::caxpbyNorm` function (which support mixed precision)
* `blas::xmyNorm` and `blas::max_deviation` now support mixed precision
