### PR TITLE
Feature/mrhs prep part deux

### DIFF
--- a/include/blas_helper.cuh
+++ b/include/blas_helper.cuh
@@ -552,4 +552,16 @@ namespace quda
 
   } // namespace blas
 
+  template <typename A, typename B> void check_size(const A &a, const B &b)
+  {
+    if (a.size() != b.size()) errorQuda("Mismatched sizes a=%lu b=%lu", a.size(), b.size());
+  }
+
+  template <typename A, typename B, typename... Args> void check_size(const A &a, const B &b, const Args &...args)
+  {
+    check_size(a, b);
+    check_size(a, args...);
+    check_size(b, args...);
+  }
+
 } // namespace quda

--- a/include/blas_helper.cuh
+++ b/include/blas_helper.cuh
@@ -560,7 +560,6 @@ namespace quda
   template <typename A, typename B, typename... Args> void check_size(const A &a, const B &b, const Args &...args)
   {
     check_size(a, b);
-    check_size(a, args...);
     check_size(b, args...);
   }
 

--- a/include/blas_quda.h
+++ b/include/blas_quda.h
@@ -280,7 +280,7 @@ namespace quda {
        @brief Compute the maximum absolute real element of a field
        @param[in] a The field we are reducing
     */
-    double max(const ColorSpinorField &x);
+    cvector<double> max(cvector_ref<const ColorSpinorField> &x);
 
     /**
        @brief Compute the maximum real-valued deviation between two
@@ -288,19 +288,27 @@ namespace quda {
        @param[in] x The field we want to compare
        @param[in] y The reference field to which we are comparing against
     */
-    array<double, 2> max_deviation(const ColorSpinorField &x, const ColorSpinorField &y);
+    cvector<array<double, 2>> max_deviation(cvector_ref<const ColorSpinorField> &x,
+                                            cvector_ref<const ColorSpinorField> &y);
+
+    inline array<double, 2> max_deviation(const ColorSpinorField &x, const ColorSpinorField &y)
+    {
+      return max_deviation(cvector_ref<const ColorSpinorField>(x), cvector_ref<const ColorSpinorField>(y));
+    }
 
     /**
        @brief Compute the L1 norm of a field
        @param[in] x The field we are reducing
     */
-    double norm1(const ColorSpinorField &x);
+    cvector<double> norm1(cvector_ref<const ColorSpinorField> &x);
 
     /**
        @brief Compute the L2 norm (||x||^2) of a field
        @param[in] x The field we are reducing
     */
-    double norm2(const ColorSpinorField &x);
+    cvector<double> norm2(cvector_ref<const ColorSpinorField> &x);
+
+    inline double norm2(const ColorSpinorField &x) { return norm2(cvector_ref<const ColorSpinorField> {x}); }
 
     /**
        @brief Compute y += a * x and then (x, y)
@@ -308,14 +316,20 @@ namespace quda {
        @param[in] x input vector
        @param[in,out] y update vector
     */
-    double axpyReDot(double a, const ColorSpinorField &x, ColorSpinorField &y);
+    cvector<double> axpyReDot(cvector<double> &a, cvector_ref<const ColorSpinorField> &x,
+                              cvector_ref<ColorSpinorField> &y);
 
     /**
        @brief Compute the real-valued inner product (x, y)
        @param[in] x input vector
        @param[in] y input vector
     */
-    double reDotProduct(const ColorSpinorField &x, const ColorSpinorField &y);
+    cvector<double> reDotProduct(cvector_ref<const ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &y);
+
+    inline double reDotProduct(const ColorSpinorField &x, const ColorSpinorField &y)
+    {
+      return reDotProduct(cvector_ref<const ColorSpinorField> {x}, cvector_ref<const ColorSpinorField> {y});
+    }
 
     /**
        @brief Compute z = a * x + b * y and then ||z||^2
@@ -325,7 +339,8 @@ namespace quda {
        @param[in] y input vector
        @param[in,out] z update vector
     */
-    double axpbyzNorm(double a, const ColorSpinorField &x, double b, const ColorSpinorField &y, ColorSpinorField &z);
+    cvector<double> axpbyzNorm(cvector<double> &a, cvector_ref<const ColorSpinorField> &x, cvector<double> &b,
+                               cvector_ref<const ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z);
 
     /**
        @brief Compute y += a * x and then ||y||^2
@@ -333,31 +348,43 @@ namespace quda {
        @param[in] x input vector
        @param[in,out] y update vector
     */
-    inline double axpyNorm(double a, const ColorSpinorField &x, ColorSpinorField &y) { return axpbyzNorm(a, x, 1.0, y, y); }
+    inline cvector<double> axpyNorm(cvector<double> &a, cvector_ref<const ColorSpinorField> &x,
+                                    cvector_ref<ColorSpinorField> &y)
+    {
+      return axpbyzNorm(a, x, 1.0, y, y);
+    }
 
     /**
        @brief Compute the complex-valued inner product (x, y)
        @param[in] x input vector
        @param[in] y input vector
     */
-    Complex cDotProduct(const ColorSpinorField &x, const ColorSpinorField &y);
+    cvector<Complex> cDotProduct(cvector_ref<const ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &y);
+
+    inline Complex cDotProduct(const ColorSpinorField &x, const ColorSpinorField &y)
+    {
+      return cDotProduct(cvector_ref<const ColorSpinorField> {x}, cvector_ref<const ColorSpinorField> {y});
+    }
 
     /**
        @brief Return complex-valued inner product (x,y), ||x||^2 and ||y||^2
        @param[in] x input vector
        @param[in] y input vector
     */
-    double4 cDotProductNormAB(const ColorSpinorField &x, const ColorSpinorField &y);
+    cvector<double4> cDotProductNormAB(cvector_ref<const ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &y);
 
     /**
        @brief Return complex-valued inner product (x,y) and ||x||^2
        @param[in] x input vector
        @param[in] y input vector
      */
-    inline double3 cDotProductNormA(const ColorSpinorField &x, const ColorSpinorField &y)
+    inline cvector<double3> cDotProductNormA(cvector_ref<const ColorSpinorField> &x,
+                                             cvector_ref<const ColorSpinorField> &y)
     {
       auto a4 = cDotProductNormAB(x, y);
-      return make_double3(a4.x, a4.y, a4.z);
+      vector<double3> a(a4.size());
+      for (auto i = 0u; i < a4.size(); i++) a[i] = {a4[i].x, a4[i].y, a4[i].z};
+      return a;
     }
 
     /**
@@ -365,10 +392,13 @@ namespace quda {
        @param[in] x input vector
        @param[in] y input vector
      */
-    inline double3 cDotProductNormB(const ColorSpinorField &x, const ColorSpinorField &y)
+    inline cvector<double3> cDotProductNormB(cvector_ref<const ColorSpinorField> &x,
+                                             cvector_ref<const ColorSpinorField> &y)
     {
       auto a4 = cDotProductNormAB(x, y);
-      return make_double3(a4.x, a4.y, a4.w);
+      vector<double3> a(a4.size());
+      for (auto i = 0u; i < a4.size(); i++) a[i] = {a4[i].x, a4[i].y, a4[i].w};
+      return a;
     }
 
     /**
@@ -382,9 +412,11 @@ namespace quda {
        @param[in] w input vector
        @param[in] v input vector
     */
-    double3 caxpbypzYmbwcDotProductUYNormY(const Complex &a, const ColorSpinorField &x, const Complex &b,
-                                           ColorSpinorField &y, ColorSpinorField &z,
-                                           const ColorSpinorField &w, const ColorSpinorField &u);
+    cvector<double3> caxpbypzYmbwcDotProductUYNormY(cvector<Complex> &a, cvector_ref<const ColorSpinorField> &x,
+                                                    cvector<Complex> &b, cvector_ref<ColorSpinorField> &y,
+                                                    cvector_ref<ColorSpinorField> &z,
+                                                    cvector_ref<const ColorSpinorField> &w,
+                                                    cvector_ref<const ColorSpinorField> &u);
 
     /**
        @brief Compute y = a * x + b * y and then ||y||^2
@@ -393,7 +425,8 @@ namespace quda {
        @param[in] b scalar multiplier
        @param[in,out] y update vector
     */
-    double caxpbyNorm(const Complex &a, const ColorSpinorField &x, const Complex &b, ColorSpinorField &y);
+    cvector<double> caxpbyNorm(cvector<Complex> &a, cvector_ref<const ColorSpinorField> &x, cvector<Complex> &b,
+                               cvector_ref<ColorSpinorField> &y);
 
     /**
        @brief Compute y += a * x and then ||y||^2
@@ -401,7 +434,8 @@ namespace quda {
        @param[in] x input vector
        @param[in,out] y update vector
     */
-    inline double caxpyNorm(const Complex &a, const ColorSpinorField &x, ColorSpinorField &y)
+    inline cvector<double> caxpyNorm(cvector<Complex> &a, cvector_ref<const ColorSpinorField> &x,
+                                     cvector_ref<ColorSpinorField> &y)
     {
       return caxpbyNorm(a, x, 1.0, y);
     }
@@ -411,18 +445,21 @@ namespace quda {
        @param[in] x input vector
        @param[in,out] y update vector
     */
-    inline double xmyNorm(const ColorSpinorField &x, ColorSpinorField &y) { return caxpbyNorm(1.0, x, -1.0, y); }
+    inline cvector<double> xmyNorm(cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y)
+    {
+      return caxpbyNorm(1.0, x, -1.0, y);
+    }
 
     /**
-       @brief Compute z = a * b * x + y, x = a * x, and then ||x||^2
+       @brief Compute z = a * b * x + y, x = a * x, and then ||z||^2
        @param[in] a scalar multiplier
        @param[in] b scalar multiplier
        @param[in,out] x update vector
        @param[in] y input vector
        @param[in,out] z update vector
     */
-    double cabxpyzAxNorm(double a, const Complex &b, ColorSpinorField &x, const ColorSpinorField &y,
-                         ColorSpinorField &z);
+    cvector<double> cabxpyzAxNorm(cvector<double> &a, cvector<Complex> &b, cvector_ref<ColorSpinorField> &x,
+                                  cvector_ref<const ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z);
 
     /**
        @brief Compute y += a * x and the resulting complex-valued inner product (z, y)
@@ -431,8 +468,8 @@ namespace quda {
        @param[in,out] y update vector
        @param[in] z input vector
     */
-    Complex caxpyDotzy(const Complex &a, const ColorSpinorField &x, ColorSpinorField &y,
-		       const ColorSpinorField &z);
+    cvector<Complex> caxpyDotzy(cvector<Complex> &a, cvector_ref<const ColorSpinorField> &x,
+                                cvector_ref<ColorSpinorField> &y, cvector_ref<const ColorSpinorField> &z);
 
     /**
        @brief Compute y += a * x and then compute ||y||^2 and
@@ -441,7 +478,8 @@ namespace quda {
        @param[in] x input vector
        @param[in,out] y update vector
     */
-    double2 axpyCGNorm(double a, const ColorSpinorField &x, ColorSpinorField &y);
+    cvector<double2> axpyCGNorm(cvector<double> &a, cvector_ref<const ColorSpinorField> &x,
+                                cvector_ref<ColorSpinorField> &y);
 
     /**
        @brief Computes ||x||^2, ||r||^2 and the MILC/FNAL heavy quark
@@ -449,16 +487,31 @@ namespace quda {
        @param[in] x input vector
        @param[in] r input vector (residual vector)
     */
-    double3 HeavyQuarkResidualNorm(const ColorSpinorField &x, const ColorSpinorField &r);
+    cvector<double3> HeavyQuarkResidualNorm(cvector_ref<const ColorSpinorField> &x,
+                                            cvector_ref<const ColorSpinorField> &r);
+
+    inline double3 HeavyQuarkResidualNorm(const ColorSpinorField &x, const ColorSpinorField &r)
+    {
+      return HeavyQuarkResidualNorm(cvector_ref<const ColorSpinorField>(x), cvector_ref<const ColorSpinorField>(r));
+    }
 
     /**
-       @brief Computes y += x, ||y||^2, ||r||^2 and the MILC/FNAL heavy quark
+       @brief Computes ||y + x||^2, ||r||^2 and the MILC/FNAL heavy quark
        residual norm
        @param[in] x input vector
        @param[in,out] y update vector
        @param[in] r input vector (residual vector)
     */
-    double3 xpyHeavyQuarkResidualNorm(const ColorSpinorField &x, ColorSpinorField &y, const ColorSpinorField &r);
+    cvector<double3> xpyHeavyQuarkResidualNorm(cvector_ref<const ColorSpinorField> &x,
+                                               cvector_ref<const ColorSpinorField> &y,
+                                               cvector_ref<const ColorSpinorField> &r);
+
+    inline double3 xpyHeavyQuarkResidualNorm(const ColorSpinorField &x, const ColorSpinorField &y,
+                                             const ColorSpinorField &r)
+    {
+      return xpyHeavyQuarkResidualNorm(cvector_ref<const ColorSpinorField>(x), cvector_ref<const ColorSpinorField>(y),
+                                       cvector_ref<const ColorSpinorField>(r));
+    }
 
     /**
        @brief Computes ||x||^2, ||y||^2, and real-valued inner product (y, z)
@@ -466,7 +519,8 @@ namespace quda {
        @param[in] y input vector
        @param[in] z input vector
     */
-    double3 tripleCGReduction(const ColorSpinorField &x, const ColorSpinorField &y, const ColorSpinorField &z);
+    cvector<double3> tripleCGReduction(cvector_ref<const ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &y,
+                                       cvector_ref<const ColorSpinorField> &z);
 
     /**
        @brief Computes ||x||^2, ||y||^2, the real-valued inner product (y, z), and ||z||^2
@@ -474,7 +528,8 @@ namespace quda {
        @param[in] y input vector
        @param[in] z input vector
     */
-    double4 quadrupleCGReduction(const ColorSpinorField &x, const ColorSpinorField &y, const ColorSpinorField &z);
+    cvector<double4> quadrupleCGReduction(cvector_ref<const ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &y,
+                                          cvector_ref<const ColorSpinorField> &z);
 
     /**
        @brief Computes z = x, w = y, x += a * y, y -= a * v and ||y||^2
@@ -485,8 +540,9 @@ namespace quda {
        @param[in,out] w update vector
        @param[in] v input vector
     */
-    double quadrupleCG3InitNorm(double a, ColorSpinorField &x, ColorSpinorField &y,
-                                ColorSpinorField &z, ColorSpinorField &w, const ColorSpinorField &v);
+    cvector<double> quadrupleCG3InitNorm(cvector<double> &a, cvector_ref<ColorSpinorField> &x,
+                                         cvector_ref<ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z,
+                                         cvector_ref<ColorSpinorField> &w, cvector_ref<const ColorSpinorField> &v);
 
     /**
        @brief Computes x = b * (x + a * y) + ( 1 - b) * z,
@@ -500,8 +556,9 @@ namespace quda {
        @param[in,out] w update vector
        @param[in] v input vector
     */
-    double quadrupleCG3UpdateNorm(double a, double b, ColorSpinorField &x, ColorSpinorField &y,
-                                  ColorSpinorField &z, ColorSpinorField &w, const ColorSpinorField &v);
+    cvector<double> quadrupleCG3UpdateNorm(cvector<double> &a, cvector<double> &b, cvector_ref<ColorSpinorField> &x,
+                                           cvector_ref<ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z,
+                                           cvector_ref<ColorSpinorField> &w, cvector_ref<const ColorSpinorField> &v);
 
     namespace block {
 

--- a/include/blas_quda.h
+++ b/include/blas_quda.h
@@ -39,14 +39,14 @@ namespace quda {
        @param[in] x input vector set
        @param[out] y output vector set
     */
-    void axy(cvector_ref<const double> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y);
+    void axy(cvector<Complex> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y);
 
     /**
        @brief Apply the rescale operation x = a * x
        @param[in] a scalar multiplier set
        @param[in] x set of vectors
     */
-    inline void ax(cvector_ref<const double> &a, cvector_ref<ColorSpinorField> &x) { axy(a, x, x); }
+    inline void ax(cvector<Complex> &a, cvector_ref<ColorSpinorField> &x) { axy(a, x, x); }
 
     /**
        @brief Apply the operation z = a * x + b * y
@@ -56,7 +56,7 @@ namespace quda {
        @param[in] y input vector set
        @param[out] z output vector set
     */
-    void axpbyz(cvector_ref<const double> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<const double> &b,
+    void axpbyz(cvector<double> &a, cvector_ref<const ColorSpinorField> &x, cvector<double> &b,
                 cvector_ref<const ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z);
 
     /**
@@ -85,8 +85,7 @@ namespace quda {
        @param[in] x input vector set
        @param[in,out] y update vector set
     */
-    inline void axpy(cvector_ref<const double> &a, cvector_ref<const ColorSpinorField> &x,
-                     cvector_ref<ColorSpinorField> &y)
+    inline void axpy(cvector<double> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y)
     {
       axpbyz(a, x, 1.0, y, y);
     }
@@ -98,8 +97,8 @@ namespace quda {
        @param[in] b scalar multiplier set
        @param[in,out] y update vector set
     */
-    inline void axpby(cvector_ref<const double> &a, cvector_ref<const ColorSpinorField> &x,
-                      cvector_ref<const double> &b, cvector_ref<ColorSpinorField> &y)
+    inline void axpby(cvector<double> &a, cvector_ref<const ColorSpinorField> &x, cvector<double> &b,
+                      cvector_ref<ColorSpinorField> &y)
     {
       axpbyz(a, x, b, y, y);
     }
@@ -110,8 +109,7 @@ namespace quda {
        @param[in] a scalar multiplier set
        @param[in,out] y update vector set
     */
-    inline void xpay(cvector_ref<const ColorSpinorField> &x, cvector_ref<const double> &a,
-                     cvector_ref<ColorSpinorField> &y)
+    inline void xpay(cvector_ref<const ColorSpinorField> &x, cvector<double> &a, cvector_ref<ColorSpinorField> &y)
     {
       axpbyz(1.0, x, a, y, y);
     }
@@ -123,7 +121,7 @@ namespace quda {
        @param[in] y update vector set
        @param[out] z output vector set
     */
-    inline void xpayz(cvector_ref<const ColorSpinorField> &x, cvector_ref<const double> &a,
+    inline void xpayz(cvector_ref<const ColorSpinorField> &x, cvector<double> &a,
                       cvector_ref<const ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z)
     {
       axpbyz(1.0, x, a, y, z);
@@ -137,8 +135,8 @@ namespace quda {
        @param[in] z input vector set
        @param[in] b scalar multiplier set
     */
-    void axpyZpbx(cvector_ref<const double> &a, cvector_ref<ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y,
-                  cvector_ref<const ColorSpinorField> &z, cvector_ref<const double> &b);
+    void axpyZpbx(cvector<double> &a, cvector_ref<ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y,
+                  cvector_ref<const ColorSpinorField> &z, cvector<double> &b);
 
     /**
        @brief Apply the operation y = a * x + y, x = b * z + c * x
@@ -149,8 +147,8 @@ namespace quda {
        @param[in] z input vector set
        @param[in] c scalar multiplier set
     */
-    void axpyBzpcx(cvector_ref<const double> &a, cvector_ref<ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y,
-                   cvector_ref<const double> &b, cvector_ref<const ColorSpinorField> &z, cvector_ref<const double> &c);
+    void axpyBzpcx(cvector<double> &a, cvector_ref<ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y,
+                   cvector<double> &b, cvector_ref<const ColorSpinorField> &z, cvector<double> &c);
 
     /**
        @brief Apply the operation w = a * x + b * y + c * z
@@ -162,9 +160,9 @@ namespace quda {
        @param[in] z input vector set
        @param[out] w output vector set
     */
-    void axpbypczw(cvector_ref<const double> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<const double> &b,
-                   cvector_ref<const ColorSpinorField> &y, cvector_ref<const double> &c,
-                   cvector_ref<const ColorSpinorField> &z, cvector_ref<ColorSpinorField> &w);
+    void axpbypczw(cvector<double> &a, cvector_ref<const ColorSpinorField> &x, cvector<double> &b,
+                   cvector_ref<const ColorSpinorField> &y, cvector<double> &c, cvector_ref<const ColorSpinorField> &z,
+                   cvector_ref<ColorSpinorField> &w);
 
     /**
        @brief Apply the operation y = a * x + b * y
@@ -174,7 +172,7 @@ namespace quda {
        @param[in] y input vector set
        @param[out] z output vector set
     */
-    void caxpby(cvector_ref<const Complex> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<const Complex> &b,
+    void caxpby(cvector<Complex> &a, cvector_ref<const ColorSpinorField> &x, cvector<Complex> &b,
                 cvector_ref<ColorSpinorField> &y);
 
     /**
@@ -183,7 +181,7 @@ namespace quda {
        @param[in] x input vector set
        @param[in] y update vector set
     */
-    void caxpy(cvector_ref<const Complex> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y);
+    void caxpy(cvector<Complex> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y);
 
     /**
        @brief Apply the operation z = x + a * y + b * z
@@ -193,9 +191,8 @@ namespace quda {
        @param[in] b scalar multiplier set
        @param[in,out] z update vector set
     */
-    void cxpaypbz(cvector_ref<const ColorSpinorField> &x, cvector_ref<const Complex> &a,
-                  cvector_ref<const ColorSpinorField> &y, cvector_ref<const Complex> &b,
-                  cvector_ref<ColorSpinorField> &z);
+    void cxpaypbz(cvector_ref<const ColorSpinorField> &x, cvector<Complex> &a, cvector_ref<const ColorSpinorField> &y,
+                  cvector<Complex> &b, cvector_ref<ColorSpinorField> &z);
 
     /**
        @brief Apply the operation z += a * x + b * y, y-= b * w
@@ -206,8 +203,8 @@ namespace quda {
        @param[in,out] z update vector set
        @param[in] w input vector set
     */
-    void caxpbypzYmbw(cvector_ref<const Complex> &a, cvector_ref<const ColorSpinorField> &x,
-                      cvector_ref<const Complex> &b, cvector_ref<ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z,
+    void caxpbypzYmbw(cvector<Complex> &a, cvector_ref<const ColorSpinorField> &x, cvector<Complex> &b,
+                      cvector_ref<ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z,
                       cvector_ref<const ColorSpinorField> &w);
 
     /**
@@ -218,8 +215,8 @@ namespace quda {
        @param[in] b scalar multiplier set
        @param[in] z input vector set
     */
-    void caxpyBzpx(cvector_ref<const Complex> &a, cvector_ref<ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y,
-                   cvector_ref<const Complex> &b, cvector_ref<const ColorSpinorField> &z);
+    void caxpyBzpx(cvector<Complex> &a, cvector_ref<ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y,
+                   cvector<Complex> &b, cvector_ref<const ColorSpinorField> &z);
 
     /**
        @brief Apply the operation y += a * x, z += b * x
@@ -229,8 +226,8 @@ namespace quda {
        @param[in] b scalar multiplier set
        @param[in,out] z update vector set
     */
-    void caxpyBxpz(cvector_ref<const Complex> &a, cvector_ref<const ColorSpinorField> &x,
-                   cvector_ref<ColorSpinorField> &y, cvector_ref<const Complex> &b, cvector_ref<ColorSpinorField> &z);
+    void caxpyBxpz(cvector<Complex> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y,
+                   cvector<Complex> &b, cvector_ref<ColorSpinorField> &z);
 
     /**
        @brief Apply the operation y += a * b * x, x = a * x
@@ -239,7 +236,7 @@ namespace quda {
        @param[in,out] x update vector set
        @param[in,out] y update vector set
     */
-    void cabxpyAx(cvector_ref<const double> &a, cvector_ref<const Complex> &b, cvector_ref<ColorSpinorField> &x,
+    void cabxpyAx(cvector<double> &a, cvector<Complex> &b, cvector_ref<ColorSpinorField> &x,
                   cvector_ref<ColorSpinorField> &y);
 
     /**
@@ -249,7 +246,7 @@ namespace quda {
        @param[in,out] y update vector set
        @param[in] z input vector set
     */
-    void caxpyXmaz(cvector_ref<const Complex> &a, cvector_ref<ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y,
+    void caxpyXmaz(cvector<Complex> &a, cvector_ref<ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y,
                    cvector_ref<const ColorSpinorField> &z);
 
     /**
@@ -261,7 +258,7 @@ namespace quda {
        @param[in,out] y update vector set
        @param[in] z input vector set
     */
-    void caxpyXmazMR(cvector_ref<const double> &a, cvector_ref<ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y,
+    void caxpyXmazMR(cvector<double> &a, cvector_ref<ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y,
                      cvector_ref<const ColorSpinorField> &z);
 
     /**
@@ -273,9 +270,9 @@ namespace quda {
        @param[in,out] z update vector set
        @param[in,out] w update vector set
     */
-    void tripleCGUpdate(cvector_ref<const double> &a, cvector_ref<const double> &b,
-                        cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y,
-                        cvector_ref<ColorSpinorField> &z, cvector_ref<ColorSpinorField> &w);
+    void tripleCGUpdate(cvector<double> &a, cvector<double> &b, cvector_ref<const ColorSpinorField> &x,
+                        cvector_ref<ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z,
+                        cvector_ref<ColorSpinorField> &w);
 
     // reduction kernels - defined in reduce_quda.cu
 

--- a/include/blas_quda.h
+++ b/include/blas_quda.h
@@ -560,7 +560,8 @@ namespace quda {
                                            cvector_ref<ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z,
                                            cvector_ref<ColorSpinorField> &w, cvector_ref<const ColorSpinorField> &v);
 
-    namespace block {
+    namespace block
+    {
 
       // multi-blas kernels - defined in multi_blas.cu
 
@@ -635,7 +636,8 @@ namespace quda {
          @param x[in] vector of input ColorSpinorFields
          @param y[in,out] vector of input/output ColorSpinorFields
       */
-      void caxpy_U(const std::vector<Complex> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y);
+      void caxpy_U(const std::vector<Complex> &a, cvector_ref<const ColorSpinorField> &x,
+                   cvector_ref<ColorSpinorField> &y);
 
       /**
          @brief Compute the block "caxpy_L" with over the set of
@@ -649,7 +651,8 @@ namespace quda {
          @param x[in] vector of input ColorSpinorFields
          @param y[in,out] vector of input/output ColorSpinorFields
       */
-      void caxpy_L(const std::vector<Complex> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y);
+      void caxpy_L(const std::vector<Complex> &a, cvector_ref<const ColorSpinorField> &x,
+                   cvector_ref<ColorSpinorField> &y);
 
       /**
          @brief Compute the block "axpyz" with over the set of
@@ -769,9 +772,8 @@ namespace quda {
          @param z[in] input ColorSpinorField
          @param c[in] Array of coefficients
       */
-      void axpyBzpcx(const std::vector<double> &a, cvector_ref<ColorSpinorField> &x,
-                     cvector_ref<ColorSpinorField> &y, const std::vector<double> &b, ColorSpinorField &z,
-                     const std::vector<double> &c);
+      void axpyBzpcx(const std::vector<double> &a, cvector_ref<ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y,
+                     const std::vector<double> &b, ColorSpinorField &z, const std::vector<double> &c);
 
       /**
          @brief Compute the vectorized "caxpyBxpz" over the set of
@@ -792,7 +794,6 @@ namespace quda {
       */
       void caxpyBxpz(const std::vector<Complex> &a, cvector_ref<const ColorSpinorField> &x, ColorSpinorField &y,
                      const std::vector<Complex> &b, ColorSpinorField &z);
-
 
       // multi-reduce kernels - defined in multi_reduce.cu
 
@@ -843,7 +844,7 @@ namespace quda {
       */
       void hDotProduct_Anorm(std::vector<Complex> &result, cvector_ref<const ColorSpinorField> &a,
                              cvector_ref<const ColorSpinorField> &b);
-    }
+    } // namespace block
 
     // compatibility wrappers until we switch to
     // std::vector<ColorSpinorField> and

--- a/include/blas_quda.h
+++ b/include/blas_quda.h
@@ -506,286 +506,290 @@ namespace quda {
     double quadrupleCG3UpdateNorm(double a, double b, ColorSpinorField &x, ColorSpinorField &y,
                                   ColorSpinorField &z, ColorSpinorField &w, const ColorSpinorField &v);
 
-    // multi-blas kernels - defined in multi_blas.cu
+    namespace block {
 
-    /**
-       @brief Compute the block "axpy" with over the set of
-              ColorSpinorFields.  E.g., it computes y = x * a + y
-              The dimensions of a can be rectangular, e.g., the width of x and y need not be same.
-       @tparam T The type of a coefficients (double or Complex)
-       @param a[in] Matrix of real coefficients
-       @param x[in] vector of input ColorSpinorFields
-       @param y[in,out] vector of input/output ColorSpinorFields
-    */
-    template <typename T>
-    void axpy(const std::vector<T> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y);
+      // multi-blas kernels - defined in multi_blas.cu
 
-    /**
-       @brief Compute the block "axpy_U" with over the set of
-       ColorSpinorFields.  E.g., it computes
+      /**
+         @brief Compute the block "axpy" with over the set of
+         ColorSpinorFields.  E.g., it computes y = x * a + y
+         The dimensions of a can be rectangular, e.g., the width of x and y need not be same.
+         @tparam T The type of a coefficients (double or Complex)
+         @param a[in] Matrix of real coefficients
+         @param x[in] vector of input ColorSpinorFields
+         @param y[in,out] vector of input/output ColorSpinorFields
+      */
+      template <typename T>
+      void axpy(const std::vector<T> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y);
 
-       y = x * a + y
+      /**
+         @brief Compute the block "axpy_U" with over the set of
+         ColorSpinorFields.  E.g., it computes
 
-       Where 'a' must be a square, upper triangular matrix.
+         y = x * a + y
 
-       @tparam T The type of a coefficients (double or Complex)
-       @param a[in] Matrix of coefficients
-       @param x[in] vector of input ColorSpinorFields
-       @param y[in,out] vector of input/output ColorSpinorFields
-    */
-    template <typename T>
-    void axpy_U(const std::vector<T> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y);
+         Where 'a' must be a square, upper triangular matrix.
 
-    /**
-       @brief Compute the block "axpy_L" with over the set of
-       ColorSpinorFields.  E.g., it computes
+         @tparam T The type of a coefficients (double or Complex)
+         @param a[in] Matrix of coefficients
+         @param x[in] vector of input ColorSpinorFields
+         @param y[in,out] vector of input/output ColorSpinorFields
+      */
+      template <typename T>
+      void axpy_U(const std::vector<T> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y);
 
-       y = x * a + y
+      /**
+         @brief Compute the block "axpy_L" with over the set of
+         ColorSpinorFields.  E.g., it computes
 
-       Where 'a' must be a square, lower triangular matrix.
+         y = x * a + y
 
-       @tparam T The type of a coefficients (double or Complex)
-       @param a[in] Matrix of coefficients
-       @param x[in] vector of input ColorSpinorFields
-       @param y[in,out] vector of input/output ColorSpinorFields
-    */
-    template <typename T>
-    void axpy_L(const std::vector<T> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y);
+         Where 'a' must be a square, lower triangular matrix.
 
-    /**
-       @brief Compute the block "caxpy" with over the set of
-       ColorSpinorFields.  E.g., it computes
+         @tparam T The type of a coefficients (double or Complex)
+         @param a[in] Matrix of coefficients
+         @param x[in] vector of input ColorSpinorFields
+         @param y[in,out] vector of input/output ColorSpinorFields
+      */
+      template <typename T>
+      void axpy_L(const std::vector<T> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y);
 
-       y = x * a + y
+      /**
+         @brief Compute the block "caxpy" with over the set of
+         ColorSpinorFields.  E.g., it computes
 
-       The dimensions of a can be rectangular, e.g., the width of x
-       and y need not be same.
+         y = x * a + y
 
-       @param a[in] Matrix of coefficients
-       @param x[in] vector of input ColorSpinorFields
-       @param y[in,out] vector of input/output ColorSpinorFields
-    */
-    void caxpy(const std::vector<Complex> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y);
+         The dimensions of a can be rectangular, e.g., the width of x
+         and y need not be same.
 
-    /**
-       @brief Compute the block "caxpy_U" with over the set of
-       ColorSpinorFields.  E.g., it computes
+         @param a[in] Matrix of coefficients
+         @param x[in] vector of input ColorSpinorFields
+         @param y[in,out] vector of input/output ColorSpinorFields
+      */
+      void caxpy(const std::vector<Complex> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y);
 
-       y = x * a + y
+      /**
+         @brief Compute the block "caxpy_U" with over the set of
+         ColorSpinorFields.  E.g., it computes
 
-       Where 'a' must be a square, upper triangular matrix.
+         y = x * a + y
 
-       @param a[in] Matrix of coefficients
-       @param x[in] vector of input ColorSpinorFields
-       @param y[in,out] vector of input/output ColorSpinorFields
-    */
-    void caxpy_U(const std::vector<Complex> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y);
+         Where 'a' must be a square, upper triangular matrix.
 
-    /**
-       @brief Compute the block "caxpy_L" with over the set of
-       ColorSpinorFields.  E.g., it computes
+         @param a[in] Matrix of coefficients
+         @param x[in] vector of input ColorSpinorFields
+         @param y[in,out] vector of input/output ColorSpinorFields
+      */
+      void caxpy_U(const std::vector<Complex> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y);
 
-       y = x * a + y
+      /**
+         @brief Compute the block "caxpy_L" with over the set of
+         ColorSpinorFields.  E.g., it computes
 
-       Where 'a' must be a square, lower triangular matrix.
+         y = x * a + y
 
-       @param a[in] Matrix of coefficients
-       @param x[in] vector of input ColorSpinorFields
-       @param y[in,out] vector of input/output ColorSpinorFields
-    */
-    void caxpy_L(const std::vector<Complex> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y);
+         Where 'a' must be a square, lower triangular matrix.
 
-    /**
-       @brief Compute the block "axpyz" with over the set of
-       ColorSpinorFields.  E.g., it computes
+         @param a[in] Matrix of coefficients
+         @param x[in] vector of input ColorSpinorFields
+         @param y[in,out] vector of input/output ColorSpinorFields
+      */
+      void caxpy_L(const std::vector<Complex> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y);
 
-       z = x * a + y
+      /**
+         @brief Compute the block "axpyz" with over the set of
+         ColorSpinorFields.  E.g., it computes
 
-       The dimensions of a can be rectangular, e.g., the width of x
-       and y need not be same, though the maximum width for both is
-       16.
+         z = x * a + y
 
-       @param a[in] Matrix of coefficients
-       @param x[in] vector of input ColorSpinorFields
-       @param y[in] vector of input ColorSpinorFields
-       @param z[out] vector of output ColorSpinorFields
-    */
-    void axpyz(const std::vector<double> &a, cvector_ref<const ColorSpinorField> &x,
-               cvector_ref<const ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z);
+         The dimensions of a can be rectangular, e.g., the width of x
+         and y need not be same, though the maximum width for both is
+         16.
 
-    /**
-       @brief Compute the block "axpyz" with over the set of
-       ColorSpinorFields.  E.g., it computes
-
-       z = x * a + y
-
-       Where 'a' is assumed to be upper triangular.
-
-       @param a[in] Matrix of coefficients
-       @param x[in] vector of input ColorSpinorFields
-       @param y[in] vector of input ColorSpinorFields
-       @param z[out] vector of output ColorSpinorFields
-    */
-    void axpyz_U(const std::vector<double> &a, cvector_ref<const ColorSpinorField> &x,
+         @param a[in] Matrix of coefficients
+         @param x[in] vector of input ColorSpinorFields
+         @param y[in] vector of input ColorSpinorFields
+         @param z[out] vector of output ColorSpinorFields
+      */
+      void axpyz(const std::vector<double> &a, cvector_ref<const ColorSpinorField> &x,
                  cvector_ref<const ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z);
 
-    /**
-       @brief Compute the block "axpyz" with over the set of
-       ColorSpinorFields.  E.g., it computes
+      /**
+         @brief Compute the block "axpyz" with over the set of
+         ColorSpinorFields.  E.g., it computes
 
-       z = x * a + y
+         z = x * a + y
 
-       Where 'a' is assumed to be lower triangular
+         Where 'a' is assumed to be upper triangular.
 
-       @param a[in] Matrix of coefficients
-       @param x[in] vector of input ColorSpinorFields
-       @param y[in] vector of input ColorSpinorFields
-       @param z[out] vector of output ColorSpinorFields
-    */
-    void axpyz_L(const std::vector<double> &a, cvector_ref<const ColorSpinorField> &x,
-                 cvector_ref<const ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z);
+         @param a[in] Matrix of coefficients
+         @param x[in] vector of input ColorSpinorFields
+         @param y[in] vector of input ColorSpinorFields
+         @param z[out] vector of output ColorSpinorFields
+      */
+      void axpyz_U(const std::vector<double> &a, cvector_ref<const ColorSpinorField> &x,
+                   cvector_ref<const ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z);
 
-    /**
-       @brief Compute the block "caxpyz" with over the set of
-       ColorSpinorFields.  E.g., it computes
+      /**
+         @brief Compute the block "axpyz" with over the set of
+         ColorSpinorFields.  E.g., it computes
 
-       z = x * a + y
+         z = x * a + y
 
-       The dimensions of a can be rectangular, e.g., the width of x
-       and y need not be same, though the maximum width for both is
-       16.
+         Where 'a' is assumed to be lower triangular
 
-       @param a[in] Matrix of coefficients
-       @param x[in] vector of input ColorSpinorFields
-       @param y[in] vector of input ColorSpinorFields
-       @param z[out] vector of output ColorSpinorFields
-    */
-    void caxpyz(const std::vector<Complex> &a, cvector_ref<const ColorSpinorField> &x,
-                cvector_ref<const ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z);
+         @param a[in] Matrix of coefficients
+         @param x[in] vector of input ColorSpinorFields
+         @param y[in] vector of input ColorSpinorFields
+         @param z[out] vector of output ColorSpinorFields
+      */
+      void axpyz_L(const std::vector<double> &a, cvector_ref<const ColorSpinorField> &x,
+                   cvector_ref<const ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z);
 
-    /**
-       @brief Compute the block "caxpyz" with over the set of
-       ColorSpinorFields.  E.g., it computes
+      /**
+         @brief Compute the block "caxpyz" with over the set of
+         ColorSpinorFields.  E.g., it computes
 
-       z = x * a + y
+         z = x * a + y
 
-       Where 'a' is assumed to be upper triangular.
+         The dimensions of a can be rectangular, e.g., the width of x
+         and y need not be same, though the maximum width for both is
+         16.
 
-       @param a[in] Matrix of coefficients
-       @param x[in] vector of input ColorSpinorFields
-       @param y[in] vector of input ColorSpinorFields
-       @param z[out] vector of output ColorSpinorFields
-    */
-    void caxpyz_U(const std::vector<Complex> &a, cvector_ref<const ColorSpinorField> &x,
+         @param a[in] Matrix of coefficients
+         @param x[in] vector of input ColorSpinorFields
+         @param y[in] vector of input ColorSpinorFields
+         @param z[out] vector of output ColorSpinorFields
+      */
+      void caxpyz(const std::vector<Complex> &a, cvector_ref<const ColorSpinorField> &x,
                   cvector_ref<const ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z);
 
-    /**
-       @brief Compute the block "caxpyz" with over the set of
-       ColorSpinorFields.  E.g., it computes
+      /**
+         @brief Compute the block "caxpyz" with over the set of
+         ColorSpinorFields.  E.g., it computes
 
-       z = x * a + y
+         z = x * a + y
 
-       Where 'a' is assumed to be lower triangular
+         Where 'a' is assumed to be upper triangular.
 
-       @param a[in] Matrix of coefficients
-       @param x[in] vector of input ColorSpinorFields
-       @param y[in] vector of input ColorSpinorFields
-       @param z[out] vector of output ColorSpinorFields
-    */
-    void caxpyz_L(const std::vector<Complex> &a, cvector_ref<const ColorSpinorField> &x,
-                  cvector_ref<const ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z);
+         @param a[in] Matrix of coefficients
+         @param x[in] vector of input ColorSpinorFields
+         @param y[in] vector of input ColorSpinorFields
+         @param z[out] vector of output ColorSpinorFields
+      */
+      void caxpyz_U(const std::vector<Complex> &a, cvector_ref<const ColorSpinorField> &x,
+                    cvector_ref<const ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z);
 
-    /**
-       @brief Compute the vectorized "axpyBzpcx" with over the set of
-       ColorSpinorFields, where the third vector, z, is constant over the
-       batch.  E.g., it computes
+      /**
+         @brief Compute the block "caxpyz" with over the set of
+         ColorSpinorFields.  E.g., it computes
 
-       y = a * x + y
-       x = b * z + c * x
+         z = x * a + y
 
-       The dimensions of a, b, c are the same as the size of x and y,
-       with a maximum size of 16.
+         Where 'a' is assumed to be lower triangular
 
-       @param a[in] Array of coefficients
-       @param x[in,out] vector of ColorSpinorFields
-       @param y[in,out] vector of ColorSpinorFields
-       @param b[in] Array of coefficients
-       @param z[in] input ColorSpinorField
-       @param c[in] Array of coefficients
-    */
-    void axpyBzpcx(const std::vector<double> &a, cvector_ref<ColorSpinorField> &x,
-                   cvector_ref<ColorSpinorField> &y, const std::vector<double> &b, ColorSpinorField &z,
-                   const std::vector<double> &c);
+         @param a[in] Matrix of coefficients
+         @param x[in] vector of input ColorSpinorFields
+         @param y[in] vector of input ColorSpinorFields
+         @param z[out] vector of output ColorSpinorFields
+      */
+      void caxpyz_L(const std::vector<Complex> &a, cvector_ref<const ColorSpinorField> &x,
+                    cvector_ref<const ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z);
 
-    /**
-       @brief Compute the vectorized "caxpyBxpz" over the set of
-       ColorSpinorFields, where the second and third vector, y and z, is constant over the
-       batch.  E.g., it computes
+      /**
+         @brief Compute the vectorized "axpyBzpcx" with over the set of
+         ColorSpinorFields, where the third vector, z, is constant over the
+         batch.  E.g., it computes
 
-       y = a * x + y
-       z = b * x + z
+         y = a * x + y
+         x = b * z + c * x
 
-       The dimensions of a, b are the same as the size of x,
-       with a maximum size of 16.
+         The dimensions of a, b, c are the same as the size of x and y,
+         with a maximum size of 16.
 
-       @param a[in] Array of coefficients
-       @param x[in] vector of ColorSpinorFields
-       @param y[in,out] input ColorSpinorField
-       @param b[in] Array of coefficients
-       @param z[in,out] input ColorSpinorField
-    */
-    void caxpyBxpz(const std::vector<Complex> &a, cvector_ref<const ColorSpinorField> &x, ColorSpinorField &y,
-                   const std::vector<Complex> &b, ColorSpinorField &z);
+         @param a[in] Array of coefficients
+         @param x[in,out] vector of ColorSpinorFields
+         @param y[in,out] vector of ColorSpinorFields
+         @param b[in] Array of coefficients
+         @param z[in] input ColorSpinorField
+         @param c[in] Array of coefficients
+      */
+      void axpyBzpcx(const std::vector<double> &a, cvector_ref<ColorSpinorField> &x,
+                     cvector_ref<ColorSpinorField> &y, const std::vector<double> &b, ColorSpinorField &z,
+                     const std::vector<double> &c);
 
-    // multi-reduce kernels - defined in multi_reduce.cu
+      /**
+         @brief Compute the vectorized "caxpyBxpz" over the set of
+         ColorSpinorFields, where the second and third vector, y and z, is constant over the
+         batch.  E.g., it computes
 
-    /**
-       @brief Computes the matrix of real inner products between the vector set a and the vector set b
+         y = a * x + y
+         z = b * x + z
 
-       @param result[out] Matrix of inner product result[i][j] = (a[j],b[i])
-       @param a[in] set of input ColorSpinorFields
-       @param b[in] set of input ColorSpinorFields
-    */
-    void reDotProduct(std::vector<double> &result, cvector_ref<const ColorSpinorField> &a,
-                      cvector_ref<const ColorSpinorField> &b);
+         The dimensions of a, b are the same as the size of x,
+         with a maximum size of 16.
 
-    /**
-       @brief Computes the matrix of inner products between the vector set a and the vector set b
+         @param a[in] Array of coefficients
+         @param x[in] vector of ColorSpinorFields
+         @param y[in,out] input ColorSpinorField
+         @param b[in] Array of coefficients
+         @param z[in,out] input ColorSpinorField
+      */
+      void caxpyBxpz(const std::vector<Complex> &a, cvector_ref<const ColorSpinorField> &x, ColorSpinorField &y,
+                     const std::vector<Complex> &b, ColorSpinorField &z);
 
-       @param result[out] Matrix of inner product result[i][j] = (a[j],b[i])
-       @param a[in] set of input ColorSpinorFields
-       @param b[in] set of input ColorSpinorFields
-    */
-    void cDotProduct(std::vector<Complex> &result, cvector_ref<const ColorSpinorField> &a,
-                     cvector_ref<const ColorSpinorField> &b);
 
-    /**
-       @brief Computes the matrix of inner products between the vector
-       set a and the vector set b.  This routine is specifically for
-       the case where the result matrix is guaranteed to be Hermitian.
-       Requires a.size()==b.size().
+      // multi-reduce kernels - defined in multi_reduce.cu
 
-       @param result[out] Matrix of inner product result[i][j] = (a[j],b[i])
-       @param a[in] set of input ColorSpinorFields
-       @param b[in] set of input ColorSpinorFields
-    */
-    void hDotProduct(std::vector<Complex> &result, cvector_ref<const ColorSpinorField> &a,
-                     cvector_ref<const ColorSpinorField> &b);
+      /**
+         @brief Computes the matrix of real inner products between the vector set a and the vector set b
 
-    /**
-        @brief Computes the matrix of inner products between the vector
-        set a and the vector set b.  This routine is specifically for
-        the case where the result matrix is guaranteed to be Hermitian.
-        Uniquely defined for cases like (p, Ap) where the output is Hermitian,
-        but there's an A-norm instead of an L2 norm.
-        Requires a.size()==b.size().
+         @param result[out] Matrix of inner product result[i][j] = (a[j],b[i])
+         @param a[in] set of input ColorSpinorFields
+         @param b[in] set of input ColorSpinorFields
+      */
+      void reDotProduct(std::vector<double> &result, cvector_ref<const ColorSpinorField> &a,
+                        cvector_ref<const ColorSpinorField> &b);
 
-        @param result[out] Matrix of inner product result[i][j] = (a[j],b[i])
-        @param a[in] set of input ColorSpinorFields
-        @param b[in] set of input ColorSpinorFields
-     */
-    void hDotProduct_Anorm(std::vector<Complex> &result, cvector_ref<const ColorSpinorField> &a,
-                           cvector_ref<const ColorSpinorField> &b);
+      /**
+         @brief Computes the matrix of inner products between the vector set a and the vector set b
+
+         @param result[out] Matrix of inner product result[i][j] = (a[j],b[i])
+         @param a[in] set of input ColorSpinorFields
+         @param b[in] set of input ColorSpinorFields
+      */
+      void cDotProduct(std::vector<Complex> &result, cvector_ref<const ColorSpinorField> &a,
+                       cvector_ref<const ColorSpinorField> &b);
+
+      /**
+         @brief Computes the matrix of inner products between the vector
+         set a and the vector set b.  This routine is specifically for
+         the case where the result matrix is guaranteed to be Hermitian.
+         Requires a.size()==b.size().
+
+         @param result[out] Matrix of inner product result[i][j] = (a[j],b[i])
+         @param a[in] set of input ColorSpinorFields
+         @param b[in] set of input ColorSpinorFields
+      */
+      void hDotProduct(std::vector<Complex> &result, cvector_ref<const ColorSpinorField> &a,
+                       cvector_ref<const ColorSpinorField> &b);
+
+      /**
+         @brief Computes the matrix of inner products between the vector
+         set a and the vector set b.  This routine is specifically for
+         the case where the result matrix is guaranteed to be Hermitian.
+         Uniquely defined for cases like (p, Ap) where the output is Hermitian,
+         but there's an A-norm instead of an L2 norm.
+         Requires a.size()==b.size().
+
+         @param result[out] Matrix of inner product result[i][j] = (a[j],b[i])
+         @param a[in] set of input ColorSpinorFields
+         @param b[in] set of input ColorSpinorFields
+      */
+      void hDotProduct_Anorm(std::vector<Complex> &result, cvector_ref<const ColorSpinorField> &a,
+                             cvector_ref<const ColorSpinorField> &b);
+    }
 
     // compatibility wrappers until we switch to
     // std::vector<ColorSpinorField> and

--- a/include/blas_quda.h
+++ b/include/blas_quda.h
@@ -28,218 +28,254 @@ namespace quda {
       for (auto i = 0u; i < x.size(); i++) x[i].zero();
     }
 
-    inline void copy(ColorSpinorField &dst, const ColorSpinorField &src) { dst.copy(src); }
+    inline void copy(cvector_ref<ColorSpinorField> &dst, cvector_ref<const ColorSpinorField> &src)
+    {
+      for (auto i = 0u; i < src.size(); i++) { dst[i].copy(src[i]); }
+    }
 
     /**
        @brief Apply the operation y = a * x
-       @param[in] a scalar multiplier
-       @param[in] x input vector
-       @param[out] y output vector
+       @param[in] a scalar multiplier set
+       @param[in] x input vector set
+       @param[out] y output vector set
     */
-    void axy(double a, const ColorSpinorField &x, ColorSpinorField &y);
+    void axy(cvector_ref<const double> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y);
 
     /**
        @brief Apply the rescale operation x = a * x
-       @param[in] a scalar multiplier
-       @param[in] x input vector
+       @param[in] a scalar multiplier set
+       @param[in] x set of vectors
     */
-    inline void ax(double a, ColorSpinorField &x) { axy(a, x, x); }
+    inline void ax(cvector_ref<const double> &a, cvector_ref<ColorSpinorField> &x) { axy(a, x, x); }
 
     /**
        @brief Apply the operation z = a * x + b * y
-       @param[in] a scalar multiplier
-       @param[in] x input vector
-       @param[in] b scalar multiplier
-       @param[in] y input vector
-       @param[out] z output vector
+       @param[in] a scalar multiplier set
+       @param[in] x input vector set
+       @param[in] b scalar multiplier set
+       @param[in] y input vector set
+       @param[out] z output vector set
     */
-    void axpbyz(double a, const ColorSpinorField &x, double b, const ColorSpinorField &y, ColorSpinorField &z);
+    void axpbyz(cvector_ref<const double> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<const double> &b,
+                cvector_ref<const ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z);
 
     /**
        @brief Apply the operation y += x
-       @param[in] x input vector
-       @param[in,out] y update vector
+       @param[in] x input vector set
+       @param[in,out] y update vector set
     */
-    inline void xpy(const ColorSpinorField &x, ColorSpinorField &y) { axpbyz(1.0, x, 1.0, y, y); }
+    inline void xpy(cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y)
+    {
+      axpbyz(1.0, x, 1.0, y, y);
+    }
 
     /**
        @brief Apply the operation y -= x
-       @param[in] x input vector
-       @param[in,out] y update vector
+       @param[in] x input vector set
+       @param[in,out] y update vector set
     */
-    inline void mxpy(const ColorSpinorField &x, ColorSpinorField &y) { axpbyz(-1.0, x, 1.0, y, y); }
+    inline void mxpy(cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y)
+    {
+      axpbyz(-1.0, x, 1.0, y, y);
+    }
 
     /**
        @brief Apply the operation y += a * x
-       @param[in] a scalar multiplier
-       @param[in] x input vector
-       @param[in,out] y update vector
+       @param[in] a scalar multiplier set
+       @param[in] x input vector set
+       @param[in,out] y update vector set
     */
-    inline void axpy(double a, const ColorSpinorField &x, ColorSpinorField &y) { axpbyz(a, x, 1.0, y, y); }
+    inline void axpy(cvector_ref<const double> &a, cvector_ref<const ColorSpinorField> &x,
+                     cvector_ref<ColorSpinorField> &y)
+    {
+      axpbyz(a, x, 1.0, y, y);
+    }
 
     /**
        @brief Apply the operation y = a * x + b * y
-       @param[in] a scalar multiplier
-       @param[in] x input vector
-       @param[in] b scalar multiplier
-       @param[in,out] y update vector
+       @param[in] a scalar multiplier set
+       @param[in] x input vector set
+       @param[in] b scalar multiplier set
+       @param[in,out] y update vector set
     */
-    inline void axpby(double a, const ColorSpinorField &x, double b, ColorSpinorField &y) { axpbyz(a, x, b, y, y); }
+    inline void axpby(cvector_ref<const double> &a, cvector_ref<const ColorSpinorField> &x,
+                      cvector_ref<const double> &b, cvector_ref<ColorSpinorField> &y)
+    {
+      axpbyz(a, x, b, y, y);
+    }
 
     /**
        @brief Apply the operation y = x + a * y
-       @param[in] x input vector
-       @param[in] a scalar multiplier
-       @param[in,out] y update vector
+       @param[in] x input vector set
+       @param[in] a scalar multiplier set
+       @param[in,out] y update vector set
     */
-    inline void xpay(const ColorSpinorField &x, double a, ColorSpinorField &y) { axpbyz(1.0, x, a, y, y); }
+    inline void xpay(cvector_ref<const ColorSpinorField> &x, cvector_ref<const double> &a,
+                     cvector_ref<ColorSpinorField> &y)
+    {
+      axpbyz(1.0, x, a, y, y);
+    }
 
     /**
        @brief Apply the operation z = x + a * y
-       @param[in] x input vector
-       @param[in] a scalar multiplier
-       @param[in] y update vector
-       @param[out] z output vector
+       @param[in] x input vector set
+       @param[in] a scalar multiplier set
+       @param[in] y update vector set
+       @param[out] z output vector set
     */
-    inline void xpayz(const ColorSpinorField &x, double a, const ColorSpinorField &y, ColorSpinorField &z) { axpbyz(1.0, x, a, y, z); }
+    inline void xpayz(cvector_ref<const ColorSpinorField> &x, cvector_ref<const double> &a,
+                      cvector_ref<const ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z)
+    {
+      axpbyz(1.0, x, a, y, z);
+    }
 
     /**
        @brief Apply the operation y = a * x + y, x = z + b * x
-       @param[in] a scalar multiplier
-       @param[in,out] x update vector
-       @param[in,out] y update vector
-       @param[in] z input vector
-       @param[in] b scalar multiplier
+       @param[in] a scalar multiplier set
+       @param[in,out] x update vector set
+       @param[in,out] y update vector set
+       @param[in] z input vector set
+       @param[in] b scalar multiplier set
     */
-    void axpyZpbx(double a, ColorSpinorField &x, ColorSpinorField &y, const ColorSpinorField &z, double b);
+    void axpyZpbx(cvector_ref<const double> &a, cvector_ref<ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y,
+                  cvector_ref<const ColorSpinorField> &z, cvector_ref<const double> &b);
 
     /**
        @brief Apply the operation y = a * x + y, x = b * z + c * x
-       @param[in] a scalar multiplier
-       @param[in,out] x update vector
-       @param[in,out] y update vector
-       @param[in] b scalar multiplier
-       @param[in] z input vector
-       @param[in] c scalar multiplier
+       @param[in] a scalar multiplier set
+       @param[in,out] x update vector set
+       @param[in,out] y update vector set
+       @param[in] b scalar multiplier set
+       @param[in] z input vector set
+       @param[in] c scalar multiplier set
     */
-    void axpyBzpcx(double a, ColorSpinorField& x, ColorSpinorField& y, double b, const ColorSpinorField& z, double c);
+    void axpyBzpcx(cvector_ref<const double> &a, cvector_ref<ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y,
+                   cvector_ref<const double> &b, cvector_ref<const ColorSpinorField> &z, cvector_ref<const double> &c);
 
     /**
        @brief Apply the operation w = a * x + b * y + c * z
-       @param[in] a scalar multiplier
-       @param[in] x input vector
-       @param[in] b scalar multiplier
-       @param[in] y input vector
-       @param[in] c scalar multiplier
-       @param[in] z input vector
-       @param[out] w output vector
+       @param[in] a scalar multiplier set
+       @param[in] x input vector set
+       @param[in] b scalar multiplier set
+       @param[in] y input vector set
+       @param[in] c scalar multiplier set
+       @param[in] z input vector set
+       @param[out] w output vector set
     */
-    void axpbypczw(double a, const ColorSpinorField &x, double b, const ColorSpinorField &y,
-                   double c, const ColorSpinorField &z, ColorSpinorField &w);
+    void axpbypczw(cvector_ref<const double> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<const double> &b,
+                   cvector_ref<const ColorSpinorField> &y, cvector_ref<const double> &c,
+                   cvector_ref<const ColorSpinorField> &z, cvector_ref<ColorSpinorField> &w);
 
     /**
        @brief Apply the operation y = a * x + b * y
-       @param[in] a scalar multiplier
-       @param[in] x input vector
-       @param[in] b scalar multiplier
-       @param[in] y input vector
-       @param[out] z output vector
+       @param[in] a scalar multiplier set
+       @param[in] x input vector set
+       @param[in] b scalar multiplier set
+       @param[in] y input vector set
+       @param[out] z output vector set
     */
-    void caxpby(const Complex &a, const ColorSpinorField &x, const Complex &b, ColorSpinorField &y);
+    void caxpby(cvector_ref<const Complex> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<const Complex> &b,
+                cvector_ref<ColorSpinorField> &y);
 
     /**
        @brief Apply the operation y += a * x
-       @param[in] a scalar multiplier
-       @param[in] x input vector
-       @param[in] y update vector
+       @param[in] a scalar multiplier set
+       @param[in] x input vector set
+       @param[in] y update vector set
     */
-    void caxpy(const Complex &a, const ColorSpinorField &x, ColorSpinorField &y);
+    void caxpy(cvector_ref<const Complex> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y);
 
     /**
        @brief Apply the operation z = x + a * y + b * z
-       @param[in] x input vector
-       @param[in] a scalar multiplier
-       @param[in] y input vector
-       @param[in] b scalar multiplier
-       @param[in,out] z update vector
+       @param[in] x input vector set
+       @param[in] a scalar multiplier set
+       @param[in] y input vector set
+       @param[in] b scalar multiplier set
+       @param[in,out] z update vector set
     */
-    void cxpaypbz(const ColorSpinorField &x, const Complex &a, const ColorSpinorField &y,
-                  const Complex &b, ColorSpinorField &z);
+    void cxpaypbz(cvector_ref<const ColorSpinorField> &x, cvector_ref<const Complex> &a,
+                  cvector_ref<const ColorSpinorField> &y, cvector_ref<const Complex> &b,
+                  cvector_ref<ColorSpinorField> &z);
 
     /**
        @brief Apply the operation z += a * x + b * y, y-= b * w
-       @param[in] a scalar multiplier
-       @param[in] x input vector
-       @param[in] b scalar multiplier
-       @param[in,out] y update vector
-       @param[in,out] z update vector
-       @param[in] w input vector
+       @param[in] a scalar multiplier set
+       @param[in] x input vector set
+       @param[in] b scalar multiplier set
+       @param[in,out] y update vector set
+       @param[in,out] z update vector set
+       @param[in] w input vector set
     */
-    void caxpbypzYmbw(const Complex &a, const ColorSpinorField &x, const Complex &b, ColorSpinorField &y,
-                      ColorSpinorField &z, const ColorSpinorField &w);
+    void caxpbypzYmbw(cvector_ref<const Complex> &a, cvector_ref<const ColorSpinorField> &x,
+                      cvector_ref<const Complex> &b, cvector_ref<ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z,
+                      cvector_ref<const ColorSpinorField> &w);
 
     /**
        @brief Apply the operation y += a * x, x += b * z
-       @param[in] a scalar multiplier
-       @param[in,out] x update vector
-       @param[in,out] y update vector
-       @param[in] b scalar multiplier
-       @param[in] z input vector
+       @param[in] a scalar multiplier set
+       @param[in,out] x update vector set
+       @param[in,out] y update vector set
+       @param[in] b scalar multiplier set
+       @param[in] z input vector set
     */
-    void caxpyBzpx(const Complex &a, ColorSpinorField &x, ColorSpinorField &y,
-                   const Complex &b, const ColorSpinorField &z);
+    void caxpyBzpx(cvector_ref<const Complex> &a, cvector_ref<ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y,
+                   cvector_ref<const Complex> &b, cvector_ref<const ColorSpinorField> &z);
 
     /**
        @brief Apply the operation y += a * x, z += b * x
-       @param[in] a scalar multiplier
-       @param[in] x input vector
-       @param[in,out] y update vector
-       @param[in] b scalar multiplier
-       @param[in,out] z update vector
+       @param[in] a scalar multiplier set
+       @param[in] x input vector set
+       @param[in,out] y update vector set
+       @param[in] b scalar multiplier set
+       @param[in,out] z update vector set
     */
-    void caxpyBxpz(const Complex &a, const ColorSpinorField &x, ColorSpinorField &y,
-                   const Complex &b, ColorSpinorField &z);
+    void caxpyBxpz(cvector_ref<const Complex> &a, cvector_ref<const ColorSpinorField> &x,
+                   cvector_ref<ColorSpinorField> &y, cvector_ref<const Complex> &b, cvector_ref<ColorSpinorField> &z);
 
     /**
        @brief Apply the operation y += a * b * x, x = a * x
-       @param[in] a real scalar multiplier
-       @param[in] b complex scalar multiplier
-       @param[in,out] x update vector
-       @param[in,out] y update vector
+       @param[in] a real scalar multiplier set
+       @param[in] b complex scalar multiplier set
+       @param[in,out] x update vector set
+       @param[in,out] y update vector set
     */
-    void cabxpyAx(double a, const Complex &b, ColorSpinorField &x, ColorSpinorField &y);
+    void cabxpyAx(cvector_ref<const double> &a, cvector_ref<const Complex> &b, cvector_ref<ColorSpinorField> &x,
+                  cvector_ref<ColorSpinorField> &y);
 
     /**
        @brief Apply the operation y += a * x, x -= a * z
-       @param[in] a scalar multiplier
-       @param[in,out] x update vector
-       @param[in,out] y update vector
-       @param[in] z input vector
+       @param[in] a scalar multiplier set
+       @param[in,out] x update vector set
+       @param[in,out] y update vector set
+       @param[in] z input vector set
     */
-    void caxpyXmaz(const Complex &a, ColorSpinorField &x, ColorSpinorField &y, const ColorSpinorField &z);
+    void caxpyXmaz(cvector_ref<const Complex> &a, cvector_ref<ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y,
+                   cvector_ref<const ColorSpinorField> &z);
 
     /**
        @brief Apply the operation y += a * x, x = x - a * z.  Special
        variant employed by MR solver where the scalar multiplier is
        computed on the fly from device memory.
-       @param[in] a real scalar multiplier
-       @param[in,out] x update vector
-       @param[in,out] y update vector
-       @param[in] z input vector
+       @param[in] a real scalar multiplier set
+       @param[in,out] x update vector set
+       @param[in,out] y update vector set
+       @param[in] z input vector set
     */
-    void caxpyXmazMR(const double &a, ColorSpinorField &x, ColorSpinorField &y, const ColorSpinorField &z);
+    void caxpyXmazMR(cvector_ref<const double> &a, cvector_ref<ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y,
+                     cvector_ref<const ColorSpinorField> &z);
 
     /**
        @brief Apply the operation y += a * w, z -= a * x, w = z + b * w
-       @param[in] a scalar multiplier
-       @param[in] b scalar multiplier
-       @param[in] x input vector
-       @param[in,out] y update vector
-       @param[in,out] z update vector
-       @param[in,out] w update vector
+       @param[in] a scalar multiplier set
+       @param[in] b scalar multiplier set
+       @param[in] x input vector set
+       @param[in,out] y update vector set
+       @param[in,out] z update vector set
+       @param[in,out] w update vector set
     */
-    void tripleCGUpdate(double a, double b, const ColorSpinorField &x,
-			ColorSpinorField &y, ColorSpinorField &z, ColorSpinorField &w);
+    void tripleCGUpdate(cvector_ref<const double> &a, cvector_ref<const double> &b,
+                        cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y,
+                        cvector_ref<ColorSpinorField> &z, cvector_ref<ColorSpinorField> &w);
 
     // reduction kernels - defined in reduce_quda.cu
 
@@ -755,41 +791,43 @@ namespace quda {
     // std::vector<ColorSpinorField> and
     // std::vector<std::reference_wrapper<...>> more broadly
 
-    void axpy(const double *a, std::vector<ColorSpinorField *> &x, std::vector<ColorSpinorField *> &y);
-    void axpy(const double *a, ColorSpinorField &x, ColorSpinorField &y);
-    void axpy_U(const double *a, std::vector<ColorSpinorField *> &x, std::vector<ColorSpinorField *> &y);
-    void axpy_U(const double *a, ColorSpinorField &x, ColorSpinorField &y);
-    void axpy_L(const double *a, std::vector<ColorSpinorField *> &x, std::vector<ColorSpinorField *> &y);
-    void axpy_L(const double *a, ColorSpinorField &x, ColorSpinorField &y);
-    void caxpy(const Complex *a, std::vector<ColorSpinorField *> &x, std::vector<ColorSpinorField *> &y);
-    void caxpy(const Complex *a, ColorSpinorField &x, ColorSpinorField &y);
-    void caxpy_U(const Complex *a, std::vector<ColorSpinorField *> &x, std::vector<ColorSpinorField *> &y);
-    void caxpy_U(const Complex *a, ColorSpinorField &x, ColorSpinorField &y);
-    void caxpy_L(const Complex *a, std::vector<ColorSpinorField *> &x, std::vector<ColorSpinorField *> &y);
-    void caxpy_L(const Complex *a, ColorSpinorField &x, ColorSpinorField &y);
-    void axpyz(const double *a, std::vector<ColorSpinorField *> &x, std::vector<ColorSpinorField *> &y,
-               std::vector<ColorSpinorField *> &z);
-    void axpyz(const double *a, ColorSpinorField &x, ColorSpinorField &y, ColorSpinorField &z);
-    void axpyz_U(const double *a, std::vector<ColorSpinorField *> &x, std::vector<ColorSpinorField *> &y,
+    namespace legacy
+    {
+      void axpy(const double *a, std::vector<ColorSpinorField *> &x, std::vector<ColorSpinorField *> &y);
+      void axpy(const double *a, ColorSpinorField &x, ColorSpinorField &y);
+      void axpy_U(const double *a, std::vector<ColorSpinorField *> &x, std::vector<ColorSpinorField *> &y);
+      void axpy_U(const double *a, ColorSpinorField &x, ColorSpinorField &y);
+      void axpy_L(const double *a, std::vector<ColorSpinorField *> &x, std::vector<ColorSpinorField *> &y);
+      void axpy_L(const double *a, ColorSpinorField &x, ColorSpinorField &y);
+      void caxpy(const Complex *a, std::vector<ColorSpinorField *> &x, std::vector<ColorSpinorField *> &y);
+      void caxpy(const Complex *a, ColorSpinorField &x, ColorSpinorField &y);
+      void caxpy_U(const Complex *a, std::vector<ColorSpinorField *> &x, std::vector<ColorSpinorField *> &y);
+      void caxpy_U(const Complex *a, ColorSpinorField &x, ColorSpinorField &y);
+      void caxpy_L(const Complex *a, std::vector<ColorSpinorField *> &x, std::vector<ColorSpinorField *> &y);
+      void caxpy_L(const Complex *a, ColorSpinorField &x, ColorSpinorField &y);
+      void axpyz(const double *a, std::vector<ColorSpinorField *> &x, std::vector<ColorSpinorField *> &y,
                  std::vector<ColorSpinorField *> &z);
-    void axpyz_L(const double *a, std::vector<ColorSpinorField *> &x, std::vector<ColorSpinorField *> &y,
-                 std::vector<ColorSpinorField *> &z);
-    void caxpyz(const Complex *a, std::vector<ColorSpinorField *> &x, std::vector<ColorSpinorField *> &y,
-                std::vector<ColorSpinorField *> &z);
-    void caxpyz(const Complex *a, ColorSpinorField &x, ColorSpinorField &y, ColorSpinorField &z);
-    void caxpyz_U(const Complex *a, std::vector<ColorSpinorField *> &x, std::vector<ColorSpinorField *> &y,
+      void axpyz(const double *a, ColorSpinorField &x, ColorSpinorField &y, ColorSpinorField &z);
+      void axpyz_U(const double *a, std::vector<ColorSpinorField *> &x, std::vector<ColorSpinorField *> &y,
+                   std::vector<ColorSpinorField *> &z);
+      void axpyz_L(const double *a, std::vector<ColorSpinorField *> &x, std::vector<ColorSpinorField *> &y,
+                   std::vector<ColorSpinorField *> &z);
+      void caxpyz(const Complex *a, std::vector<ColorSpinorField *> &x, std::vector<ColorSpinorField *> &y,
                   std::vector<ColorSpinorField *> &z);
-    void caxpyz_L(const Complex *a, std::vector<ColorSpinorField *> &x, std::vector<ColorSpinorField *> &y,
-                  std::vector<ColorSpinorField *> &z);
-    void axpyBzpcx(const double *a, std::vector<ColorSpinorField *> &x, std::vector<ColorSpinorField *> &y,
-                   const double *b, ColorSpinorField &z, const double *c);
-    void caxpyBxpz(const Complex *a_, std::vector<ColorSpinorField *> &x_, ColorSpinorField &y_, const Complex *b_,
-                   ColorSpinorField &z_);
+      void caxpyz(const Complex *a, ColorSpinorField &x, ColorSpinorField &y, ColorSpinorField &z);
+      void caxpyz_U(const Complex *a, std::vector<ColorSpinorField *> &x, std::vector<ColorSpinorField *> &y,
+                    std::vector<ColorSpinorField *> &z);
+      void caxpyz_L(const Complex *a, std::vector<ColorSpinorField *> &x, std::vector<ColorSpinorField *> &y,
+                    std::vector<ColorSpinorField *> &z);
+      void axpyBzpcx(const double *a, std::vector<ColorSpinorField *> &x, std::vector<ColorSpinorField *> &y,
+                     const double *b, ColorSpinorField &z, const double *c);
+      void caxpyBxpz(const Complex *a_, std::vector<ColorSpinorField *> &x_, ColorSpinorField &y_, const Complex *b_,
+                     ColorSpinorField &z_);
 
-    void reDotProduct(double *result, std::vector<ColorSpinorField *> &a, std::vector<ColorSpinorField *> &b);
-    void cDotProduct(Complex *result, std::vector<ColorSpinorField *> &a, std::vector<ColorSpinorField *> &b);
-    void hDotProduct(Complex *result, std::vector<ColorSpinorField *> &a, std::vector<ColorSpinorField *> &b);
-
+      void reDotProduct(double *result, std::vector<ColorSpinorField *> &a, std::vector<ColorSpinorField *> &b);
+      void cDotProduct(Complex *result, std::vector<ColorSpinorField *> &a, std::vector<ColorSpinorField *> &b);
+      void hDotProduct(Complex *result, std::vector<ColorSpinorField *> &a, std::vector<ColorSpinorField *> &b);
+    } // namespace legacy
   } // namespace blas
 
 } // namespace quda

--- a/include/invert_quda.h
+++ b/include/invert_quda.h
@@ -1483,15 +1483,15 @@ public:
 
       QudaSolutionType solution_type = b.SiteSubset() == QUDA_FULL_SITE_SUBSET ? QUDA_MAT_SOLUTION : QUDA_MATPC_SOLUTION;
 
-      ColorSpinorField *out=nullptr;
-      ColorSpinorField *in=nullptr;
+      ColorSpinorField out;
+      ColorSpinorField in;
 
       if (dirac.hasSpecialMG()) {
-        dirac.prepareSpecialMG(in, out, x, b, solution_type);
+        dirac.prepareSpecialMG(out, in, x, b, solution_type);
       } else {
-        dirac.prepare(in, out, x, b, solution_type);
+        dirac.prepare(out, in, x, b, solution_type);
       }
-      (*solver)(*out, *in);
+      (*solver)(out, in);
       if (dirac.hasSpecialMG()) {
         dirac.reconstructSpecialMG(x, b, solution_type);
       } else {

--- a/include/invert_x_update.h
+++ b/include/invert_x_update.h
@@ -49,7 +49,7 @@ namespace quda
     */
     void accumulate_x(ColorSpinorField &x)
     {
-      blas::axpy<double>({_alphas.begin(), _alphas.begin() + _j + 1}, {_ps.begin(), _ps.begin() + _j + 1}, x);
+      blas::block::axpy<double>({_alphas.begin(), _alphas.begin() + _j + 1}, {_ps.begin(), _ps.begin() + _j + 1}, x);
     }
 
     /**

--- a/include/kernels/blas_core.cuh
+++ b/include/kernels/blas_core.cuh
@@ -114,14 +114,14 @@ namespace quda
     template <typename real> struct axy_ : public BlasFunctor {
       static constexpr memory_access<1, 0> read{ };
       static constexpr memory_access<0, 1> write{ };
-      const real a;
-      axy_(const real &a, const real &, const real &) : a(a) { ; }
+      const complex<real> a;
+      axy_(const complex<real> &a, const complex<real> &, const complex<real> &) : a(a) { ; }
       template <typename T> __device__ __host__ void operator()(T &x, T &y, T &, T &, T &) const
       {
 #pragma unroll
         for (int i = 0; i < x.size(); i++) y[i] = a * x[i];
       }
-      constexpr int flops() const { return 1; }   //! flops per element
+      constexpr int flops() const { return 3; }   //! flops per element
     };
 
     /**

--- a/include/kernels/blas_core.cuh
+++ b/include/kernels/blas_core.cuh
@@ -121,7 +121,7 @@ namespace quda
 #pragma unroll
         for (int i = 0; i < x.size(); i++) y[i] = a * x[i];
       }
-      constexpr int flops() const { return 3; }   //! flops per element
+      constexpr int flops() const { return 3; } //! flops per element
     };
 
     /**

--- a/include/kernels/gauge_fix_fft.cuh
+++ b/include/kernels/gauge_fix_fft.cuh
@@ -193,8 +193,7 @@ namespace quda {
       using matrix = Matrix<complex<typename Arg::real>, 3>;
       int x[4];
       getCoords(x, x_cb, arg.X, parity);
-      matrix delta;
-      setZero(&delta);
+      matrix delta = {};
 
       for (int mu = 0; mu < Arg::gauge_dir; mu++) {
         matrix U = arg.data(mu, x_cb, parity);

--- a/include/kernels/gauge_fix_ovr.cuh
+++ b/include/kernels/gauge_fix_ovr.cuh
@@ -67,8 +67,7 @@ namespace quda {
         x[dr] += arg.border[dr];
         X[dr] += 2 * arg.border[dr];
       }
-      Link delta;
-      setZero(&delta);
+      Link delta = {};
       //load upward links
 #pragma unroll
       for (int mu = 0; mu < Arg::gauge_dir; mu++) {

--- a/include/kernels/gauge_heatbath.cuh
+++ b/include/kernels/gauge_heatbath.cuh
@@ -626,8 +626,7 @@ namespace quda {
       }
       int e_cb = linkIndex(x, X);
 
-      Link staple;
-      setZero(&staple);
+      Link staple = {};
 
       Link U;
 #pragma unroll

--- a/include/kernels/gauge_random.cuh
+++ b/include/kernels/gauge_random.cuh
@@ -89,8 +89,7 @@ namespace quda {
         for (int mu = 0; mu < 4; mu++) arg.U(mu, linkIndex(x, arg.E), parity) = I;
       } else if (not arg.group and arg.sigma == 0.0) {
         // if sigma = 0 then we just set the output matrix to the zero and finish
-        Link O;
-        setZero(&O);
+        Link O = {};
         for (int mu = 0; mu < 4; mu++) arg.U(mu, linkIndex(x, arg.E), parity) = O;
       } else {
         for (int mu = 0; mu < 4; mu++) {

--- a/include/kernels/reduce_core.cuh
+++ b/include/kernels/reduce_core.cuh
@@ -292,7 +292,7 @@ namespace quda
        double cabxpyzAxNorm(float a, complex b, float *x, float *y, float *z){}
        First performs the operation z[i] = y[i] + a*b*x[i]
        Second performs x[i] *= a
-       Third returns the norm of x
+       Third returns the norm of z
     */
     template <typename reduce_t, typename real>
     struct cabxpyzaxnorm : public ReduceFunctor<reduce_t> {

--- a/include/quda_matrix.h
+++ b/include/quda_matrix.h
@@ -13,28 +13,6 @@ namespace quda {
   template <typename T> constexpr bool is_nan(T x) { return x != x; }
 
   template<class T>
-    struct Zero
-    {
-      //static const T val;
-      __device__ __host__ inline
-        static T val();
-    };
-
-  template<>
-    __device__ __host__ inline
-    float2 Zero<float2>::val()
-    {
-      return make_float2(0.,0.);
-    }
-
-  template<>
-    __device__ __host__ inline
-    double2 Zero<double2>::val()
-    {
-      return make_double2(0.,0.);
-    }
-
-  template<class T>
     struct Identity
     {
       __device__  __host__ inline
@@ -678,15 +656,6 @@ namespace quda {
       }
     }
 
-    template <class T, int N> __device__ __host__ inline void setZero(Matrix<T, N> *m)
-    {
-#pragma unroll
-      for (int i = 0; i < N; ++i) {
-#pragma unroll
-        for (int j = 0; j < N; ++j) { (*m)(i, j) = {}; }
-      }
-    }
-
   template<typename Complex,int N>
     __device__ __host__ inline void makeAntiHerm(Matrix<Complex,N> &m) {
     typedef typename Complex::value_type real;
@@ -988,8 +957,7 @@ namespace quda {
       }
 
       //[19] Construct exp{iQ}
-      Matrix<T, 3> exp_iQ;
-      setZero(&exp_iQ);
+      Matrix<T, 3> exp_iQ = {};
       Matrix<T,3> UnitM;
       setIdentity(&UnitM);
       // +f0*I

--- a/include/reference_wrapper_helper.h
+++ b/include/reference_wrapper_helper.h
@@ -320,6 +320,9 @@ namespace quda
   template <class T> struct vector : public std::vector<T> {
     using value_type = T;
 
+    vector() = default;
+    vector(uint64_t size) : std::vector<T>(size) {}
+
     /**
        @brief Constructor using std::vector initialization
        @param[in] u Vector we are copying from
@@ -355,6 +358,16 @@ namespace quda
     template <class U, std::enable_if_t<std::is_same_v<std::complex<U>, T>> * = nullptr>
     vector(const U &u) : std::vector<T>(1, u)
     {
+    }
+
+    /**
+       @brief Cast to scalar.  Only works if the vector size is 1.
+    */
+    operator T() const
+    {
+      if (std::vector<T>::size() != 1)
+        errorQuda("Cast to scalar failed since size = %lu", ::std::vector<T>::size());
+      return std::vector<T>::operator[](0);
     }
   };
 

--- a/include/reference_wrapper_helper.h
+++ b/include/reference_wrapper_helper.h
@@ -321,7 +321,7 @@ namespace quda
     using value_type = T;
 
     vector() = default;
-    vector(uint64_t size) : std::vector<T>(size) {}
+    vector(uint64_t size, const T &value = {}) : std::vector<T>(size, value) {}
 
     /**
        @brief Constructor using std::vector initialization
@@ -341,8 +341,8 @@ namespace quda
     */
     template <class U, std::enable_if_t<std::is_same_v<std::complex<U>, T>> * = nullptr> vector(const vector<U> &u)
     {
-      vector::reserve(u.size());
-      for (auto &v : u) vector::push_back(v);
+      std::vector<T>::reserve(u.size());
+      for (auto &v : u) std::vector<T>::push_back(v);
     }
 
     /**
@@ -366,7 +366,7 @@ namespace quda
     operator T() const
     {
       if (std::vector<T>::size() != 1)
-        errorQuda("Cast to scalar failed since size = %lu", ::std::vector<T>::size());
+        errorQuda("Cast to scalar failed since size = %lu", std::vector<T>::size());
       return std::vector<T>::operator[](0);
     }
   };

--- a/include/reference_wrapper_helper.h
+++ b/include/reference_wrapper_helper.h
@@ -6,6 +6,7 @@
 #include <initializer_list>
 #include <enum_quda.h>
 #include <util_quda.h>
+#include <quda_internal.h>
 
 namespace quda
 {
@@ -268,7 +269,7 @@ namespace quda
     /**
        @brief This overload allows us to directly access the
        underlying reference without needing to invoke get() like would
-       do for the parent method.  Moreover, we intentionally mark this
+       we do for the parent method.  Moreover, we intentionally mark this
        function as const, since it will allow us to return non-const
        references from a constant container if the underlying
        references are themselves non-const.
@@ -311,5 +312,52 @@ namespace quda
     for (auto i = 0u; i < in.size(); i++) out.push_back(parity == QUDA_EVEN_PARITY ? in[i].Even() : in[i].Odd());
     return out;
   }
+
+  /**
+     Derived specializaton of std::vector<T>
+     which allows us to write generic multi-scalar functions.
+   */
+  template <class T> struct vector : public std::vector<T> {
+    using value_type = T;
+
+    /**
+       @brief Constructor using std::vector initialization
+       @param[in] u Vector we are copying from
+    */
+    template <class U, std::enable_if_t<std::is_same_v<U, std::vector<typename U::value_type>>> * = nullptr>
+    vector(const U &u)
+    {
+      std::vector<T>::reserve(u.size());
+      for (auto &v : u) std::vector<T>::push_back(v);
+    }
+
+    /**
+       @brief Constructor using a real-valued vector to initialize a
+       complex-valued vector
+       @param[in] u Real-valued vector input
+    */
+    template <class U, std::enable_if_t<std::is_same_v<std::complex<U>, T>> * = nullptr> vector(const vector<U> &u)
+    {
+      vector::reserve(u.size());
+      for (auto &v : u) vector::push_back(v);
+    }
+
+    /**
+       @brief Constructor using std::vector initialization
+       @param[in] u Scalar we are wrapping a vector around
+    */
+    vector(const T &t) : std::vector<T>(1, t) { }
+
+    /**
+       @brief Constructor using std::vector initialization
+       @param[in] u Scalar we are wrapping a vector around
+    */
+    template <class U, std::enable_if_t<std::is_same_v<std::complex<U>, T>> * = nullptr>
+    vector(const U &u) : std::vector<T>(1, u)
+    {
+    }
+  };
+
+  template <class T> using cvector = const vector<T>;
 
 } // namespace quda

--- a/include/reference_wrapper_helper.h
+++ b/include/reference_wrapper_helper.h
@@ -321,7 +321,7 @@ namespace quda
     using value_type = T;
 
     vector() = default;
-    vector(uint64_t size, const T &value = {}) : std::vector<T>(size, value) {}
+    vector(uint64_t size, const T &value = {}) : std::vector<T>(size, value) { }
 
     /**
        @brief Constructor using std::vector initialization
@@ -365,8 +365,7 @@ namespace quda
     */
     operator T() const
     {
-      if (std::vector<T>::size() != 1)
-        errorQuda("Cast to scalar failed since size = %lu", std::vector<T>::size());
+      if (std::vector<T>::size() != 1) errorQuda("Cast to scalar failed since size = %lu", std::vector<T>::size());
       return std::vector<T>::operator[](0);
     }
   };

--- a/include/reference_wrapper_helper.h
+++ b/include/reference_wrapper_helper.h
@@ -230,7 +230,7 @@ namespace quda
        Unary constructor
        @param[in] v Object to which we are constructing a vector_ref around
      */
-    template <class U> vector_ref(U &v)
+    template <class U> vector_ref(const U &v)
     {
       auto vset = make_set(v);
       vector::reserve(vset.size());

--- a/include/register_traits.h
+++ b/include/register_traits.h
@@ -196,29 +196,6 @@ namespace quda {
     static const int value = 2;
   };
 
-  template<typename, int N> struct vector { };
-
-  template<> struct vector<double, 2> {
-    typedef double2 type;
-    type a;
-    vector(const type &a) { this->a.x = a.x; this->a.y = a.y; }
-    operator type() const { return a; }
-  };
-
-  template<> struct vector<float, 2> {
-    typedef float2 type;
-    float2 a;
-    vector(const double2 &a) { this->a.x = a.x; this->a.y = a.y; }
-    operator type() const { return a; }
-  };
-
-  template<> struct vector<int, 2> {
-    typedef int2 type;
-    int2 a;
-    vector(const int2 &a) { this->a.x = a.x; this->a.y = a.y; }
-    operator type() const { return a; }
-  };
-
   /* Traits used to determine if a variable is half precision or not */
   template< typename T > struct isHalf{ static const bool value = false; };
   template<> struct isHalf<short>{ static const bool value = true; };

--- a/lib/blas_quda.cu
+++ b/lib/blas_quda.cu
@@ -134,18 +134,6 @@ namespace quda {
       }
     };
 
-    template <typename A, typename B> void check_size(const A &a, const B &b)
-    {
-      if (a.size() != b.size()) errorQuda("Mismatched sizes a=%lu b=%lu", a.size(), b.size());
-    }
-
-    template <typename A, typename B, typename... Args> void check_size(const A &a, const B &b, const Args &...args)
-    {
-      check_size(a, b);
-      check_size(a, args...);
-      check_size(b, args...);
-    }
-
     void axpbyz(cvector<double> &a, cvector_ref<const ColorSpinorField> &x, cvector<double> &b,
                 cvector_ref<const ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z)
     {

--- a/lib/blas_quda.cu
+++ b/lib/blas_quda.cu
@@ -134,89 +134,139 @@ namespace quda {
       }
     };
 
-    void axpbyz(double a, const ColorSpinorField &x, double b, const ColorSpinorField &y, ColorSpinorField &z)
+    template <typename A, typename B> void check_size(const A &a, const B &b)
     {
-      instantiate<axpbyz_, Blas, true>(a, b, 0.0, x, y, x, x, z);
+      if (a.size() != b.size()) errorQuda("Mismatched sizes a=%lu b=%lu", a.size(), b.size());
     }
 
-    void axy(double a, const ColorSpinorField &x, ColorSpinorField &y)
+    template <typename A, typename B, typename... Args> void check_size(const A &a, const B &b, const Args &...args)
     {
-      instantiate<axy_, Blas, false>(a, 0.0, 0.0, x, y, y, y, y);
+      check_size(a, b);
+      check_size(a, args...);
+      check_size(b, args...);
     }
 
-    void caxpy(const Complex &a, const ColorSpinorField &x, ColorSpinorField &y)
+    void axpbyz(cvector_ref<const double> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<const double> &b,
+                cvector_ref<const ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z)
     {
-      instantiate<caxpy_, Blas, true>(a, Complex(0.0), Complex(0.0), x, y, x, x, y);
+      check_size(a, x, b, y, z);
+      for (auto i = 0u; i < x.size(); i++)
+        instantiate<axpbyz_, Blas, true>(a[i], b[i], 0.0, x[i], y[i], x[i], x[i], z[i]);
     }
 
-    void caxpby(const Complex &a, const ColorSpinorField &x, const Complex &b, ColorSpinorField &y)
+    void axy(const cvector_ref<const double> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y)
     {
-      instantiate<caxpby_, Blas, false>(a, b, Complex(0.0), x, y, x, x, y);
+      check_size(a, x, y);
+      for (auto i = 0u; i < x.size(); i++) instantiate<axy_, Blas, false>(a[i], 0.0, 0.0, x[i], y[i], y[i], y[i], y[i]);
     }
 
-    void axpbypczw(double a, const ColorSpinorField &x, double b, const ColorSpinorField &y,
-                   double c, const ColorSpinorField &z, ColorSpinorField &w)
+    void caxpy(cvector_ref<const Complex> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y)
     {
-      instantiate<axpbypczw_, Blas, false>(a, b, c, x, y, z, w, y);
+      check_size(a, x, y);
+      for (auto i = 0u; i < x.size(); i++)
+        instantiate<caxpy_, Blas, true>(a[i], Complex(0.0), Complex(0.0), x[i], y[i], x[i], x[i], y[i]);
     }
 
-    void cxpaypbz(const ColorSpinorField &x, const Complex &a, const ColorSpinorField &y,
-                  const Complex &b, ColorSpinorField &z)
+    void caxpby(cvector_ref<const Complex> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<const Complex> &b,
+                cvector_ref<ColorSpinorField> &y)
     {
-      instantiate<cxpaypbz_, Blas, false>(a, b, Complex(0.0), x, y, z, x, y);
+      check_size(a, x, b, y);
+      for (auto i = 0u; i < x.size(); i++)
+        instantiate<caxpby_, Blas, false>(a[i], b[i], Complex(0.0), x[i], y[i], x[i], x[i], y[i]);
     }
 
-    void axpyBzpcx(double a, ColorSpinorField& x, ColorSpinorField& y, double b, const ColorSpinorField& z, double c)
+    void axpbypczw(cvector_ref<const double> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<const double> &b,
+                   cvector_ref<const ColorSpinorField> &y, cvector_ref<const double> &c,
+                   cvector_ref<const ColorSpinorField> &z, cvector_ref<ColorSpinorField> &w)
     {
-      instantiate<axpyBzpcx_, Blas, true>(a, b, c, x, y, z, x, y);
+      check_size(a, x, b, y, c, z, w);
+      for (auto i = 0u; i < x.size(); i++)
+        instantiate<axpbypczw_, Blas, false>(a[i], b[i], c[i], x[i], y[i], z[i], w[i], y[i]);
     }
 
-    void axpyZpbx(double a, ColorSpinorField& x, ColorSpinorField& y, const ColorSpinorField& z, double b)
+    void cxpaypbz(cvector_ref<const ColorSpinorField> &x, cvector_ref<const Complex> &a,
+                  cvector_ref<const ColorSpinorField> &y, cvector_ref<const Complex> &b, cvector_ref<ColorSpinorField> &z)
     {
-      instantiate<axpyZpbx_, Blas, true>(a, b, 0.0, x, y, z, x, y);
+      check_size(x, a, y, b, z);
+      for (auto i = 0u; i < x.size(); i++)
+        instantiate<cxpaypbz_, Blas, false>(a[i], b[i], Complex(0.0), x[i], y[i], z[i], x[i], y[i]);
     }
 
-    void caxpyBzpx(const Complex &a, ColorSpinorField &x, ColorSpinorField &y,
-                   const Complex &b, const ColorSpinorField &z)
+    void axpyBzpcx(cvector_ref<const double> &a, cvector_ref<ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y,
+                   cvector_ref<const double> &b, cvector_ref<const ColorSpinorField> &z, cvector_ref<const double> &c)
     {
-      instantiate<caxpyBzpx_, Blas, true>(a, b, Complex(0.0), x, y, z, x, y);
+      check_size(a, x, y, b, z, c);
+      for (auto i = 0u; i < x.size(); i++)
+        instantiate<axpyBzpcx_, Blas, true>(a[i], b[i], c[i], x[i], y[i], z[i], x[i], y[i]);
     }
 
-    void caxpyBxpz(const Complex &a, const ColorSpinorField &x, ColorSpinorField &y,
-                   const Complex &b, ColorSpinorField &z)
+    void axpyZpbx(cvector_ref<const double> &a, cvector_ref<ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y,
+                  cvector_ref<const ColorSpinorField> &z, cvector_ref<const double> &b)
     {
-      instantiate<caxpyBxpz_, Blas, true>(a, b, Complex(0.0), x, y, z, x, y);
+      check_size(a, x, y, z, b);
+      for (auto i = 0u; i < x.size(); i++)
+        instantiate<axpyZpbx_, Blas, true>(a[i], b[i], 0.0, x[i], y[i], z[i], x[i], y[i]);
     }
 
-    void caxpbypzYmbw(const Complex &a, const ColorSpinorField &x, const Complex &b,
-                      ColorSpinorField &y, ColorSpinorField &z, const ColorSpinorField &w)
+    void caxpyBzpx(cvector_ref<const Complex> &a, cvector_ref<ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y,
+                   cvector_ref<const Complex> &b, cvector_ref<const ColorSpinorField> &z)
     {
-      instantiate<caxpbypzYmbw_, Blas, false>(a, b, Complex(0.0), x, y, z, w, y);
+      check_size(a, x, y, b, z);
+      for (auto i = 0u; i < x.size(); i++)
+        instantiate<caxpyBzpx_, Blas, true>(a[i], b[i], Complex(0.0), x[i], y[i], z[i], x[i], y[i]);
     }
 
-    void cabxpyAx(double a, const Complex &b, ColorSpinorField &x, ColorSpinorField &y)
+    void caxpyBxpz(cvector_ref<const Complex> &a, cvector_ref<const ColorSpinorField> &x,
+                   cvector_ref<ColorSpinorField> &y, cvector_ref<const Complex> &b, cvector_ref<ColorSpinorField> &z)
     {
-      instantiate<cabxpyAx_, Blas, false>(Complex(a), b, Complex(0.0), x, y, x, x, y);
+      check_size(a, x, y, b, z);
+      for (auto i = 0u; i < x.size(); i++)
+        instantiate<caxpyBxpz_, Blas, true>(a[i], b[i], Complex(0.0), x[i], y[i], z[i], x[i], y[i]);
     }
 
-    void caxpyXmaz(const Complex &a, ColorSpinorField &x, ColorSpinorField &y, const ColorSpinorField &z)
+    void caxpbypzYmbw(cvector_ref<const Complex> &a, cvector_ref<const ColorSpinorField> &x,
+                      cvector_ref<const Complex> &b, cvector_ref<ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z,
+                      cvector_ref<const ColorSpinorField> &w)
     {
-      instantiate<caxpyxmaz_, Blas, false>(a, Complex(0.0), Complex(0.0), x, y, z, x, y);
+      check_size(a, x, b, y, z, w);
+      for (auto i = 0u; i < x.size(); i++)
+        instantiate<caxpbypzYmbw_, Blas, false>(a[i], b[i], Complex(0.0), x[i], y[i], z[i], w[i], y[i]);
     }
 
-    void caxpyXmazMR(const double &a, ColorSpinorField &x, ColorSpinorField &y, const ColorSpinorField &z)
+    void cabxpyAx(cvector_ref<const double> &a, cvector_ref<const Complex> &b, cvector_ref<ColorSpinorField> &x,
+                  cvector_ref<ColorSpinorField> &y)
     {
+      check_size(a, b, x, y);
+      for (auto i = 0u; i < x.size(); i++)
+        instantiate<cabxpyAx_, Blas, false>(Complex(a[i]), b[i], Complex(0.0), x[i], y[i], x[i], x[i], y[i]);
+    }
+
+    void caxpyXmaz(cvector_ref<const Complex> &a, cvector_ref<ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y,
+                   cvector_ref<const ColorSpinorField> &z)
+    {
+      check_size(a, x, y, z);
+      for (auto i = 0u; i < x.size(); i++)
+        instantiate<caxpyxmaz_, Blas, false>(a[i], Complex(0.0), Complex(0.0), x[i], y[i], z[i], x[i], y[i]);
+    }
+
+    void caxpyXmazMR(cvector_ref<const double> &a, cvector_ref<ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y,
+                     cvector_ref<const ColorSpinorField> &z)
+    {
+      check_size(a, x, y, z);
       if (!commAsyncReduction())
 	errorQuda("This kernel requires asynchronous reductions to be set");
-      if (x.Location() == QUDA_CPU_FIELD_LOCATION)
-	errorQuda("This kernel cannot be run on CPU fields");
-      instantiate<caxpyxmazMR_, Blas, false>(a, 0.0, 0.0, x, y, z, y, y);
+      if (x[0].Location() == QUDA_CPU_FIELD_LOCATION) errorQuda("This kernel cannot be run on CPU fields");
+      for (auto i = 0u; i < x.size(); i++)
+        instantiate<caxpyxmazMR_, Blas, false>(a[i], 0.0, 0.0, x[i], y[i], z[i], y[i], y[i]);
     }
 
-    void tripleCGUpdate(double a, double b, const ColorSpinorField &x, ColorSpinorField &y,
-                        ColorSpinorField &z, ColorSpinorField &w)
+    void tripleCGUpdate(cvector_ref<const double> &a, cvector_ref<const double> &b,
+                        cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y,
+                        cvector_ref<ColorSpinorField> &z, cvector_ref<ColorSpinorField> &w)
     {
-      instantiate<tripleCGUpdate_, Blas, true>(a, b, 0.0, x, y, z, w, y);
+      check_size(a, b, x, y, z, w);
+      for (auto i = 0u; i < x.size(); i++)
+        instantiate<tripleCGUpdate_, Blas, true>(a[i], b[i], 0.0, x[i], y[i], z[i], w[i], y[i]);
     }
 
   } // namespace blas

--- a/lib/blas_quda.cu
+++ b/lib/blas_quda.cu
@@ -146,7 +146,7 @@ namespace quda {
       check_size(b, args...);
     }
 
-    void axpbyz(cvector_ref<const double> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<const double> &b,
+    void axpbyz(cvector<double> &a, cvector_ref<const ColorSpinorField> &x, cvector<double> &b,
                 cvector_ref<const ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z)
     {
       check_size(a, x, b, y, z);
@@ -154,20 +154,20 @@ namespace quda {
         instantiate<axpbyz_, Blas, true>(a[i], b[i], 0.0, x[i], y[i], x[i], x[i], z[i]);
     }
 
-    void axy(const cvector_ref<const double> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y)
+    void axy(const cvector<Complex> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y)
     {
       check_size(a, x, y);
-      for (auto i = 0u; i < x.size(); i++) instantiate<axy_, Blas, false>(a[i], 0.0, 0.0, x[i], y[i], y[i], y[i], y[i]);
+      for (auto i = 0u; i < x.size(); i++) instantiate<axy_, Blas, false>(a[i], Complex(0.0), Complex(0.0), x[i], y[i], y[i], y[i], y[i]);
     }
 
-    void caxpy(cvector_ref<const Complex> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y)
+    void caxpy(cvector<Complex> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y)
     {
       check_size(a, x, y);
       for (auto i = 0u; i < x.size(); i++)
         instantiate<caxpy_, Blas, true>(a[i], Complex(0.0), Complex(0.0), x[i], y[i], x[i], x[i], y[i]);
     }
 
-    void caxpby(cvector_ref<const Complex> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<const Complex> &b,
+    void caxpby(cvector<Complex> &a, cvector_ref<const ColorSpinorField> &x, cvector<Complex> &b,
                 cvector_ref<ColorSpinorField> &y)
     {
       check_size(a, x, b, y);
@@ -175,8 +175,8 @@ namespace quda {
         instantiate<caxpby_, Blas, false>(a[i], b[i], Complex(0.0), x[i], y[i], x[i], x[i], y[i]);
     }
 
-    void axpbypczw(cvector_ref<const double> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<const double> &b,
-                   cvector_ref<const ColorSpinorField> &y, cvector_ref<const double> &c,
+    void axpbypczw(cvector<double> &a, cvector_ref<const ColorSpinorField> &x, cvector<double> &b,
+                   cvector_ref<const ColorSpinorField> &y, cvector<double> &c,
                    cvector_ref<const ColorSpinorField> &z, cvector_ref<ColorSpinorField> &w)
     {
       check_size(a, x, b, y, c, z, w);
@@ -184,48 +184,48 @@ namespace quda {
         instantiate<axpbypczw_, Blas, false>(a[i], b[i], c[i], x[i], y[i], z[i], w[i], y[i]);
     }
 
-    void cxpaypbz(cvector_ref<const ColorSpinorField> &x, cvector_ref<const Complex> &a,
-                  cvector_ref<const ColorSpinorField> &y, cvector_ref<const Complex> &b, cvector_ref<ColorSpinorField> &z)
+    void cxpaypbz(cvector_ref<const ColorSpinorField> &x, cvector<Complex> &a,
+                  cvector_ref<const ColorSpinorField> &y, cvector<Complex> &b, cvector_ref<ColorSpinorField> &z)
     {
       check_size(x, a, y, b, z);
       for (auto i = 0u; i < x.size(); i++)
         instantiate<cxpaypbz_, Blas, false>(a[i], b[i], Complex(0.0), x[i], y[i], z[i], x[i], y[i]);
     }
 
-    void axpyBzpcx(cvector_ref<const double> &a, cvector_ref<ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y,
-                   cvector_ref<const double> &b, cvector_ref<const ColorSpinorField> &z, cvector_ref<const double> &c)
+    void axpyBzpcx(cvector<double> &a, cvector_ref<ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y,
+                   cvector<double> &b, cvector_ref<const ColorSpinorField> &z, cvector<double> &c)
     {
       check_size(a, x, y, b, z, c);
       for (auto i = 0u; i < x.size(); i++)
         instantiate<axpyBzpcx_, Blas, true>(a[i], b[i], c[i], x[i], y[i], z[i], x[i], y[i]);
     }
 
-    void axpyZpbx(cvector_ref<const double> &a, cvector_ref<ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y,
-                  cvector_ref<const ColorSpinorField> &z, cvector_ref<const double> &b)
+    void axpyZpbx(cvector<double> &a, cvector_ref<ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y,
+                  cvector_ref<const ColorSpinorField> &z, cvector<double> &b)
     {
       check_size(a, x, y, z, b);
       for (auto i = 0u; i < x.size(); i++)
         instantiate<axpyZpbx_, Blas, true>(a[i], b[i], 0.0, x[i], y[i], z[i], x[i], y[i]);
     }
 
-    void caxpyBzpx(cvector_ref<const Complex> &a, cvector_ref<ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y,
-                   cvector_ref<const Complex> &b, cvector_ref<const ColorSpinorField> &z)
+    void caxpyBzpx(cvector<Complex> &a, cvector_ref<ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y,
+                   cvector<Complex> &b, cvector_ref<const ColorSpinorField> &z)
     {
       check_size(a, x, y, b, z);
       for (auto i = 0u; i < x.size(); i++)
         instantiate<caxpyBzpx_, Blas, true>(a[i], b[i], Complex(0.0), x[i], y[i], z[i], x[i], y[i]);
     }
 
-    void caxpyBxpz(cvector_ref<const Complex> &a, cvector_ref<const ColorSpinorField> &x,
-                   cvector_ref<ColorSpinorField> &y, cvector_ref<const Complex> &b, cvector_ref<ColorSpinorField> &z)
+    void caxpyBxpz(cvector<Complex> &a, cvector_ref<const ColorSpinorField> &x,
+                   cvector_ref<ColorSpinorField> &y, cvector<Complex> &b, cvector_ref<ColorSpinorField> &z)
     {
       check_size(a, x, y, b, z);
       for (auto i = 0u; i < x.size(); i++)
         instantiate<caxpyBxpz_, Blas, true>(a[i], b[i], Complex(0.0), x[i], y[i], z[i], x[i], y[i]);
     }
 
-    void caxpbypzYmbw(cvector_ref<const Complex> &a, cvector_ref<const ColorSpinorField> &x,
-                      cvector_ref<const Complex> &b, cvector_ref<ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z,
+    void caxpbypzYmbw(cvector<Complex> &a, cvector_ref<const ColorSpinorField> &x,
+                      cvector<Complex> &b, cvector_ref<ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z,
                       cvector_ref<const ColorSpinorField> &w)
     {
       check_size(a, x, b, y, z, w);
@@ -233,7 +233,7 @@ namespace quda {
         instantiate<caxpbypzYmbw_, Blas, false>(a[i], b[i], Complex(0.0), x[i], y[i], z[i], w[i], y[i]);
     }
 
-    void cabxpyAx(cvector_ref<const double> &a, cvector_ref<const Complex> &b, cvector_ref<ColorSpinorField> &x,
+    void cabxpyAx(cvector<double> &a, cvector<Complex> &b, cvector_ref<ColorSpinorField> &x,
                   cvector_ref<ColorSpinorField> &y)
     {
       check_size(a, b, x, y);
@@ -241,7 +241,7 @@ namespace quda {
         instantiate<cabxpyAx_, Blas, false>(Complex(a[i]), b[i], Complex(0.0), x[i], y[i], x[i], x[i], y[i]);
     }
 
-    void caxpyXmaz(cvector_ref<const Complex> &a, cvector_ref<ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y,
+    void caxpyXmaz(cvector<Complex> &a, cvector_ref<ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y,
                    cvector_ref<const ColorSpinorField> &z)
     {
       check_size(a, x, y, z);
@@ -249,7 +249,7 @@ namespace quda {
         instantiate<caxpyxmaz_, Blas, false>(a[i], Complex(0.0), Complex(0.0), x[i], y[i], z[i], x[i], y[i]);
     }
 
-    void caxpyXmazMR(cvector_ref<const double> &a, cvector_ref<ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y,
+    void caxpyXmazMR(cvector<double> &a, cvector_ref<ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y,
                      cvector_ref<const ColorSpinorField> &z)
     {
       check_size(a, x, y, z);
@@ -260,7 +260,7 @@ namespace quda {
         instantiate<caxpyxmazMR_, Blas, false>(a[i], 0.0, 0.0, x[i], y[i], z[i], y[i], y[i]);
     }
 
-    void tripleCGUpdate(cvector_ref<const double> &a, cvector_ref<const double> &b,
+    void tripleCGUpdate(cvector<double> &a, cvector<double> &b,
                         cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y,
                         cvector_ref<ColorSpinorField> &z, cvector_ref<ColorSpinorField> &w)
     {

--- a/lib/blas_quda.cu
+++ b/lib/blas_quda.cu
@@ -145,7 +145,8 @@ namespace quda {
     void axy(const cvector<Complex> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y)
     {
       check_size(a, x, y);
-      for (auto i = 0u; i < x.size(); i++) instantiate<axy_, Blas, false>(a[i], Complex(0.0), Complex(0.0), x[i], y[i], y[i], y[i], y[i]);
+      for (auto i = 0u; i < x.size(); i++)
+        instantiate<axy_, Blas, false>(a[i], Complex(0.0), Complex(0.0), x[i], y[i], y[i], y[i], y[i]);
     }
 
     void caxpy(cvector<Complex> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y)
@@ -164,16 +165,16 @@ namespace quda {
     }
 
     void axpbypczw(cvector<double> &a, cvector_ref<const ColorSpinorField> &x, cvector<double> &b,
-                   cvector_ref<const ColorSpinorField> &y, cvector<double> &c,
-                   cvector_ref<const ColorSpinorField> &z, cvector_ref<ColorSpinorField> &w)
+                   cvector_ref<const ColorSpinorField> &y, cvector<double> &c, cvector_ref<const ColorSpinorField> &z,
+                   cvector_ref<ColorSpinorField> &w)
     {
       check_size(a, x, b, y, c, z, w);
       for (auto i = 0u; i < x.size(); i++)
         instantiate<axpbypczw_, Blas, false>(a[i], b[i], c[i], x[i], y[i], z[i], w[i], y[i]);
     }
 
-    void cxpaypbz(cvector_ref<const ColorSpinorField> &x, cvector<Complex> &a,
-                  cvector_ref<const ColorSpinorField> &y, cvector<Complex> &b, cvector_ref<ColorSpinorField> &z)
+    void cxpaypbz(cvector_ref<const ColorSpinorField> &x, cvector<Complex> &a, cvector_ref<const ColorSpinorField> &y,
+                  cvector<Complex> &b, cvector_ref<ColorSpinorField> &z)
     {
       check_size(x, a, y, b, z);
       for (auto i = 0u; i < x.size(); i++)
@@ -204,16 +205,16 @@ namespace quda {
         instantiate<caxpyBzpx_, Blas, true>(a[i], b[i], Complex(0.0), x[i], y[i], z[i], x[i], y[i]);
     }
 
-    void caxpyBxpz(cvector<Complex> &a, cvector_ref<const ColorSpinorField> &x,
-                   cvector_ref<ColorSpinorField> &y, cvector<Complex> &b, cvector_ref<ColorSpinorField> &z)
+    void caxpyBxpz(cvector<Complex> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y,
+                   cvector<Complex> &b, cvector_ref<ColorSpinorField> &z)
     {
       check_size(a, x, y, b, z);
       for (auto i = 0u; i < x.size(); i++)
         instantiate<caxpyBxpz_, Blas, true>(a[i], b[i], Complex(0.0), x[i], y[i], z[i], x[i], y[i]);
     }
 
-    void caxpbypzYmbw(cvector<Complex> &a, cvector_ref<const ColorSpinorField> &x,
-                      cvector<Complex> &b, cvector_ref<ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z,
+    void caxpbypzYmbw(cvector<Complex> &a, cvector_ref<const ColorSpinorField> &x, cvector<Complex> &b,
+                      cvector_ref<ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z,
                       cvector_ref<const ColorSpinorField> &w)
     {
       check_size(a, x, b, y, z, w);
@@ -248,9 +249,9 @@ namespace quda {
         instantiate<caxpyxmazMR_, Blas, false>(a[i], 0.0, 0.0, x[i], y[i], z[i], y[i], y[i]);
     }
 
-    void tripleCGUpdate(cvector<double> &a, cvector<double> &b,
-                        cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y,
-                        cvector_ref<ColorSpinorField> &z, cvector_ref<ColorSpinorField> &w)
+    void tripleCGUpdate(cvector<double> &a, cvector<double> &b, cvector_ref<const ColorSpinorField> &x,
+                        cvector_ref<ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z,
+                        cvector_ref<ColorSpinorField> &w)
     {
       check_size(a, b, x, y, z, w);
       for (auto i = 0u; i < x.size(); i++)

--- a/lib/deflation.cpp
+++ b/lib/deflation.cpp
@@ -101,7 +101,7 @@ if( param.eig_global.extlib_type == QUDA_EIGEN_EXTLIB ) {
 
     for (int i = 0; i < n_evs_to_print; i++) {
       zero(*r);
-      blas::caxpy(&projm.get()[i * param.ld], rv, res); // multiblas
+      blas::legacy::caxpy(&projm.get()[i * param.ld], rv, res); // multiblas
       *r_sloppy = *r;
       param.matDeflation(*Av_sloppy, *r_sloppy);
       double3 dotnorm = cDotProductNormA(*r_sloppy, *Av_sloppy);
@@ -133,7 +133,7 @@ if( param.eig_global.extlib_type == QUDA_EIGEN_EXTLIB ) {
     std::vector<ColorSpinorField*> in_;
     in_.push_back(static_cast<ColorSpinorField*>(b_sloppy));
 
-    blas::cDotProduct(vec.get(), rv_, in_);//<i, b>
+    blas::legacy::cDotProduct(vec.get(), rv_, in_);//<i, b>
 
     if (!param.use_inv_ritz) {
       if (param.eig_global.extlib_type == QUDA_EIGEN_EXTLIB) {
@@ -154,7 +154,7 @@ if( param.eig_global.extlib_type == QUDA_EIGEN_EXTLIB ) {
     std::vector<ColorSpinorField*> out_;
     out_.push_back(&x);
 
-    blas::caxpy(vec.get(), rv_, out_); //multiblas
+    blas::legacy::caxpy(vec.get(), rv_, out_); //multiblas
 
     check_nrm2 = norm2(x);
     printfQuda("\nDeflated guess spinor norm (gpu): %1.15e\n", sqrt(check_nrm2));
@@ -198,9 +198,9 @@ if( param.eig_global.extlib_type == QUDA_EIGEN_EXTLIB ) {
         std::vector<ColorSpinorField *> vi_;
         vi_.push_back(accum);
 
-        blas::cDotProduct(alpha.get(), vj_, vi_);
+        blas::legacy::cDotProduct(alpha.get(), vj_, vi_);
         for (int j = 0; j < local_length; j++) alpha[j] = -alpha[j];
-        blas::caxpy(alpha.get(), vj_, vi_); // i-<j,i>j
+        blas::legacy::caxpy(alpha.get(), vj_, vi_); // i-<j,i>j
 
         offset += cdot_pipeline_length;
       }
@@ -224,7 +224,7 @@ if( param.eig_global.extlib_type == QUDA_EIGEN_EXTLIB ) {
         std::vector<ColorSpinorField *> av_;
         av_.push_back(Av_sloppy);
 
-        blas::cDotProduct(alpha.get(), vj_, av_);
+        blas::legacy::cDotProduct(alpha.get(), vj_, av_);
 
         for (int j = 0; j < i; j++) {
           param.matProj[i * param.ld + j] = alpha[j];
@@ -292,7 +292,7 @@ if( param.eig_global.extlib_type == QUDA_EIGEN_EXTLIB ) {
       res.push_back(r);
 
       blas::zero(*r);
-      blas::caxpy(&projm.get()[idx * param.ld], rv, res); // multiblas
+      blas::legacy::caxpy(&projm.get()[idx * param.ld], rv, res); // multiblas
       blas::copy(buff->Component(idx), *r);
 
       if (do_residual_check) { // if tol=0.0 then disable relative residual norm check

--- a/lib/deflation.cpp
+++ b/lib/deflation.cpp
@@ -133,7 +133,7 @@ if( param.eig_global.extlib_type == QUDA_EIGEN_EXTLIB ) {
     std::vector<ColorSpinorField*> in_;
     in_.push_back(static_cast<ColorSpinorField*>(b_sloppy));
 
-    blas::legacy::cDotProduct(vec.get(), rv_, in_);//<i, b>
+    blas::legacy::cDotProduct(vec.get(), rv_, in_); //<i, b>
 
     if (!param.use_inv_ritz) {
       if (param.eig_global.extlib_type == QUDA_EIGEN_EXTLIB) {
@@ -154,7 +154,7 @@ if( param.eig_global.extlib_type == QUDA_EIGEN_EXTLIB ) {
     std::vector<ColorSpinorField*> out_;
     out_.push_back(&x);
 
-    blas::legacy::caxpy(vec.get(), rv_, out_); //multiblas
+    blas::legacy::caxpy(vec.get(), rv_, out_); // multiblas
 
     check_nrm2 = norm2(x);
     printfQuda("\nDeflated guess spinor norm (gpu): %1.15e\n", sqrt(check_nrm2));

--- a/lib/dirac.cpp
+++ b/lib/dirac.cpp
@@ -13,13 +13,25 @@ namespace quda {
     mass(param.mass),
     laplace3D(param.laplace3D),
     matpcType(param.matpcType),
+    this_parity(QUDA_INVALID_PARITY),
+    other_parity(QUDA_INVALID_PARITY),
     dagger(param.dagger),
     type(param.type),
     halo_precision(param.halo_precision),
+    commDim(param.commDim),
     use_mobius_fused_kernel(param.use_mobius_fused_kernel),
     profile("Dirac", false)
   {
-    for (int i=0; i<4; i++) commDim[i] = param.commDim[i];
+    if (matpcType == QUDA_MATPC_EVEN_EVEN || matpcType == QUDA_MATPC_EVEN_EVEN_ASYMMETRIC) {
+      this_parity = QUDA_EVEN_PARITY;
+      other_parity = QUDA_ODD_PARITY;
+    } else if (matpcType == QUDA_MATPC_ODD_ODD || matpcType == QUDA_MATPC_ODD_ODD_ASYMMETRIC) {
+      this_parity = QUDA_ODD_PARITY;
+      other_parity = QUDA_EVEN_PARITY;
+    } else {
+      errorQuda("Invalid matpcType(%d) in function\n", matpcType);
+    }
+    symmetric = (matpcType == QUDA_MATPC_EVEN_EVEN || matpcType == QUDA_MATPC_ODD_ODD);
   }
 
   Dirac::Dirac(const Dirac &dirac) :
@@ -27,12 +39,15 @@ namespace quda {
     kappa(dirac.kappa),
     laplace3D(dirac.laplace3D),
     matpcType(dirac.matpcType),
+    this_parity(dirac.this_parity),
+    other_parity(dirac.other_parity),
+    symmetric(dirac.symmetric),
     dagger(dirac.dagger),
     type(dirac.type),
     halo_precision(dirac.halo_precision),
+    commDim(dirac.commDim),
     profile("Dirac", false)
   {
-    for (int i=0; i<4; i++) commDim[i] = dirac.commDim[i];
   }
 
   // Destroy
@@ -48,10 +63,11 @@ namespace quda {
       kappa = dirac.kappa;
       laplace3D = dirac.laplace3D;
       matpcType = dirac.matpcType;
+      this_parity = dirac.this_parity;
+      other_parity = dirac.other_parity;
+      symmetric = dirac.symmetric;
       dagger = dirac.dagger;
-
-      for (int i=0; i<4; i++) commDim[i] = dirac.commDim[i];
-
+      commDim = dirac.commDim;
       profile = dirac.profile;
 
       if (type != dirac.type) errorQuda("Trying to copy between incompatible types %d %d", type, dirac.type);

--- a/lib/dirac_clover.cpp
+++ b/lib/dirac_clover.cpp
@@ -37,7 +37,7 @@ namespace quda {
     checkParitySpinor(in, out);
     checkSpinorAlias(in, out);
 
-    ApplyWilsonClover(out, in, *gauge, *clover, k, x, parity, dagger, commDim, profile);
+    ApplyWilsonClover(out, in, *gauge, *clover, k, x, parity, dagger, commDim.data, profile);
   }
 
   // Public method to apply the clover term only
@@ -50,7 +50,7 @@ namespace quda {
 
   void DiracClover::M(ColorSpinorField &out, const ColorSpinorField &in) const
   {
-    ApplyWilsonClover(out, in, *gauge, *clover, -kappa, in, QUDA_INVALID_PARITY, dagger, commDim, profile);
+    ApplyWilsonClover(out, in, *gauge, *clover, -kappa, in, QUDA_INVALID_PARITY, dagger, commDim.data, profile);
   }
 
   void DiracClover::MdagM(ColorSpinorField &out, const ColorSpinorField &in) const
@@ -62,19 +62,22 @@ namespace quda {
     Mdag(out, tmp);
   }
 
-  void DiracClover::prepare(ColorSpinorField* &src, ColorSpinorField* &sol,
-			    ColorSpinorField &x, ColorSpinorField &b, 
-			    const QudaSolutionType solType) const
+  void DiracClover::prepare(cvector_ref<ColorSpinorField> &sol, cvector_ref<ColorSpinorField> &src,
+                            cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
+                            const QudaSolutionType solType) const
   {
     if (solType == QUDA_MATPC_SOLUTION || solType == QUDA_MATPCDAG_MATPC_SOLUTION) {
       errorQuda("Preconditioned solution requires a preconditioned solve_type");
     }
 
-    src = &b;
-    sol = &x;
+    for (auto i = 0u; i < b.size(); i++) {
+      src[i] = const_cast<ColorSpinorField &>(b[i]).create_alias();
+      sol[i] = x[i].create_alias();
+    }
   }
 
-  void DiracClover::reconstruct(ColorSpinorField &, const ColorSpinorField &, const QudaSolutionType) const
+  void DiracClover::reconstruct(cvector_ref<ColorSpinorField> &, cvector_ref<const ColorSpinorField> &,
+                                const QudaSolutionType) const
   {
     // do nothing
   }
@@ -135,7 +138,7 @@ namespace quda {
     checkParitySpinor(in, out);
     checkSpinorAlias(in, out);
 
-    ApplyWilsonCloverPreconditioned(out, in, *gauge, *clover, 0.0, in, parity, dagger, commDim, profile);
+    ApplyWilsonCloverPreconditioned(out, in, *gauge, *clover, 0.0, in, parity, dagger, commDim.data, profile);
   }
 
   // xpay version of the above
@@ -146,7 +149,7 @@ namespace quda {
     checkParitySpinor(in, out);
     checkSpinorAlias(in, out);
 
-    ApplyWilsonCloverPreconditioned(out, in, *gauge, *clover, k, x, parity, dagger, commDim, profile);
+    ApplyWilsonCloverPreconditioned(out, in, *gauge, *clover, k, x, parity, dagger, commDim.data, profile);
   }
 
   // Apply the even-odd preconditioned clover-improved Dirac operator
@@ -154,10 +157,6 @@ namespace quda {
   {
     double kappa2 = -kappa*kappa;
     auto tmp = getFieldTmp(in);
-
-    bool symmetric =(matpcType == QUDA_MATPC_EVEN_EVEN || matpcType == QUDA_MATPC_ODD_ODD) ? true : false;
-    int odd_bit = (matpcType == QUDA_MATPC_ODD_ODD || matpcType == QUDA_MATPC_ODD_ODD_ASYMMETRIC) ? 1 : 0;
-    QudaParity parity[2] = {static_cast<QudaParity>((1 + odd_bit) % 2), static_cast<QudaParity>((0 + odd_bit) % 2)};
 
     if (!symmetric) {
 
@@ -167,27 +166,27 @@ namespace quda {
       // the pieces in Dslash and DslashXPay respect the dagger
 
       // DiracCloverPC::Dslash applies A^{-1}Dslash
-      Dslash(tmp, in, parity[0]);
+      Dslash(tmp, in, other_parity);
       // DiracClover::DslashXpay applies (A - kappa^2 D)
-      DiracClover::DslashXpay(out, tmp, parity[1], in, kappa2);
+      DiracClover::DslashXpay(out, tmp, this_parity, in, kappa2);
     } else if (!dagger) { // symmetric preconditioning
       // We need two cases because M = 1-ADAD and M^\dag = 1-D^\dag A D^dag A
       // where A is actually a clover inverse.
 
       // This is the non-dag case: AD
-      Dslash(tmp, in, parity[0]);
+      Dslash(tmp, in, other_parity);
 
       // Then x + AD (AD)
-      DslashXpay(out, tmp, parity[1], in, kappa2);
+      DslashXpay(out, tmp, this_parity, in, kappa2);
     } else { // symmetric preconditioning, dagger
 
       // This is the dagger: 1 - DADA
       //  i) Apply A
-      CloverInv(out, in, parity[1]);
+      CloverInv(out, in, this_parity);
       // ii) Apply A D => ADA
-      Dslash(tmp, out, parity[0]);
+      Dslash(tmp, out, other_parity);
       // iii) Apply  x + D(ADA)
-      DiracWilson::DslashXpay(out, tmp, parity[1], in, kappa2);
+      DiracWilson::DslashXpay(out, tmp, this_parity, in, kappa2);
     }
   }
 
@@ -201,77 +200,50 @@ namespace quda {
     Mdag(out, tmp);
   }
 
-  void DiracCloverPC::prepare(ColorSpinorField* &src, ColorSpinorField* &sol, 
-			      ColorSpinorField &x, ColorSpinorField &b, 
-			      const QudaSolutionType solType) const
+  void DiracCloverPC::prepare(cvector_ref<ColorSpinorField> &sol, cvector_ref<ColorSpinorField> &src,
+                              cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
+                              const QudaSolutionType solType) const
   {
     // we desire solution to preconditioned system
     if (solType == QUDA_MATPC_SOLUTION || solType == QUDA_MATPCDAG_MATPC_SOLUTION) {
-      src = &b;
-      sol = &x;
+      for (auto i = 0u; i < b.size(); i++) {
+        src[i] = const_cast<ColorSpinorField &>(b[i]).create_alias();
+        sol[i] = x[i].create_alias();
+      }
       return;
     }
-
-    auto tmp = getFieldTmp(b.Even());
 
     // we desire solution to full system
-    if (matpcType == QUDA_MATPC_EVEN_EVEN) {
-      // src = A_ee^-1 (b_e + k D_eo A_oo^-1 b_o)
-      src = &(x.Odd());
-      CloverInv(*src, b.Odd(), QUDA_ODD_PARITY);
-      DiracWilson::DslashXpay(tmp, *src, QUDA_EVEN_PARITY, b.Even(), kappa);
-      CloverInv(*src, tmp, QUDA_EVEN_PARITY);
-      sol = &(x.Even());
-    } else if (matpcType == QUDA_MATPC_ODD_ODD) {
-      // src = A_oo^-1 (b_o + k D_oe A_ee^-1 b_e)
-      src = &(x.Even());
-      CloverInv(*src, b.Even(), QUDA_EVEN_PARITY);
-      DiracWilson::DslashXpay(tmp, *src, QUDA_ODD_PARITY, b.Odd(), kappa);
-      CloverInv(*src, tmp, QUDA_ODD_PARITY);
-      sol = &(x.Odd());
-    } else if (matpcType == QUDA_MATPC_EVEN_EVEN_ASYMMETRIC) {
-      // src = b_e + k D_eo A_oo^-1 b_o
-      src = &(x.Odd());
-      CloverInv(tmp, b.Odd(), QUDA_ODD_PARITY); // safe even when tmp = b.odd
-      DiracWilson::DslashXpay(*src, tmp, QUDA_EVEN_PARITY, b.Even(), kappa);
-      sol = &(x.Even());
-    } else if (matpcType == QUDA_MATPC_ODD_ODD_ASYMMETRIC) {
-      // src = b_o + k D_oe A_ee^-1 b_e
-      src = &(x.Even());
-      CloverInv(tmp, b.Even(), QUDA_EVEN_PARITY); // safe even when tmp = b.even
-      DiracWilson::DslashXpay(*src, tmp, QUDA_ODD_PARITY, b.Odd(), kappa);
-      sol = &(x.Odd());
-    } else {
-      errorQuda("MatPCType %d not valid for DiracCloverPC", matpcType);
+    auto tmp = getFieldTmp(b[0].Even());
+    for (auto i = 0u; i < b.size(); i++) {
+      if (symmetric) {
+        // src = A_ee^-1 (b_e + k D_eo A_oo^-1 b_o)
+        src[i] = x[i][other_parity].create_alias();
+        CloverInv(src[i], b[i][other_parity], other_parity);
+        DiracWilson::DslashXpay(tmp, src[i], this_parity, b[i][this_parity], kappa);
+        CloverInv(src[i], tmp, this_parity);
+        sol[i] = x[i][this_parity].create_alias();
+      } else {
+        // src = b_e + k D_eo A_oo^-1 b_o
+        src[i] = x[i][other_parity].create_alias();
+        CloverInv(tmp, b[i][other_parity], other_parity); // safe even when tmp = b.odd
+        DiracWilson::DslashXpay(src[i], tmp, this_parity, b[this_parity], kappa);
+        sol[i] = x[i][this_parity].create_alias();
+      }
     }
-
-    // here we use final solution to store parity solution and parity source
-    // b is now up for grabs if we want
   }
 
-  void DiracCloverPC::reconstruct(ColorSpinorField &x, const ColorSpinorField &b,
-				  const QudaSolutionType solType) const
+  void DiracCloverPC::reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
+                                  const QudaSolutionType solType) const
   {
-    if (solType == QUDA_MATPC_SOLUTION || solType == QUDA_MATPCDAG_MATPC_SOLUTION) {
-      return;
-    }
+    if (solType == QUDA_MATPC_SOLUTION || solType == QUDA_MATPCDAG_MATPC_SOLUTION) return;
 
-    checkFullSpinor(x, b);
-    auto tmp = getFieldTmp(b.Even());
-
-    // create full solution
-    if (matpcType == QUDA_MATPC_EVEN_EVEN ||
-	matpcType == QUDA_MATPC_EVEN_EVEN_ASYMMETRIC) {
+    auto tmp = getFieldTmp(b[0].Even());
+    for (auto i = 0u; i < b.size(); i++) {
+      checkFullSpinor(x[i], b[i]);
       // x_o = A_oo^-1 (b_o + k D_oe x_e)
-      DiracWilson::DslashXpay(tmp, x.Even(), QUDA_ODD_PARITY, b.Odd(), kappa);
-      CloverInv(x.Odd(), tmp, QUDA_ODD_PARITY);
-    } else if (matpcType == QUDA_MATPC_ODD_ODD ||
-	       matpcType == QUDA_MATPC_ODD_ODD_ASYMMETRIC) {
-      // x_e = A_ee^-1 (b_e + k D_eo x_o)
-      DiracWilson::DslashXpay(tmp, x.Odd(), QUDA_EVEN_PARITY, b.Even(), kappa);
-      CloverInv(x.Even(), tmp, QUDA_EVEN_PARITY);
-    } else {
-      errorQuda("MatPCType %d not valid for DiracCloverPC", matpcType);
+      DiracWilson::DslashXpay(tmp, x[i][this_parity], other_parity, b[i][other_parity], kappa);
+      CloverInv(x[i][other_parity], tmp, other_parity);
     }
   }
 
@@ -289,15 +261,11 @@ namespace quda {
   {
     Dirac::prefetch(mem_space, stream);
 
-    bool symmetric = (matpcType == QUDA_MATPC_EVEN_EVEN || matpcType == QUDA_MATPC_ODD_ODD) ? true : false;
-    int odd_bit = (matpcType == QUDA_MATPC_ODD_ODD || matpcType == QUDA_MATPC_ODD_ODD_ASYMMETRIC) ? 1 : 0;
-    QudaParity parity[2] = {static_cast<QudaParity>((1 + odd_bit) % 2), static_cast<QudaParity>((0 + odd_bit) % 2)};
-
     if (symmetric) {
       clover->prefetch(mem_space, stream, CloverPrefetchType::INVERSE_CLOVER_PREFETCH_TYPE);
     } else {
-      clover->prefetch(mem_space, stream, CloverPrefetchType::INVERSE_CLOVER_PREFETCH_TYPE, parity[0]);
-      clover->prefetch(mem_space, stream, CloverPrefetchType::CLOVER_CLOVER_PREFETCH_TYPE, parity[1]);
+      clover->prefetch(mem_space, stream, CloverPrefetchType::INVERSE_CLOVER_PREFETCH_TYPE, other_parity);
+      clover->prefetch(mem_space, stream, CloverPrefetchType::CLOVER_CLOVER_PREFETCH_TYPE, this_parity);
     }
   }
 

--- a/lib/dirac_clover_hasenbusch_twist.cpp
+++ b/lib/dirac_clover_hasenbusch_twist.cpp
@@ -28,32 +28,16 @@ namespace quda
 
   void DiracCloverHasenbuschTwist::M(ColorSpinorField &out, const ColorSpinorField &in) const
   {
-    bool asymmetric = (matpcType == QUDA_MATPC_ODD_ODD_ASYMMETRIC) || (matpcType == QUDA_MATPC_EVEN_EVEN_ASYMMETRIC);
-
-    if (!asymmetric) {
-      if (matpcType == QUDA_MATPC_EVEN_EVEN) {
-        ApplyWilsonCloverHasenbuschTwist(out.Even(), in.Odd(), *gauge, *clover, -kappa, mu, in.Even(), QUDA_EVEN_PARITY,
-                                         dagger, commDim.data, profile);
-        ApplyWilsonClover(out.Odd(), in.Even(), *gauge, *clover, -kappa, in.Odd(), QUDA_ODD_PARITY, dagger, commDim.data,
-                          profile);
-      } else {
-        ApplyWilsonClover(out.Even(), in.Odd(), *gauge, *clover, -kappa, in.Even(), QUDA_EVEN_PARITY, dagger, commDim.data,
-                          profile);
-        ApplyWilsonCloverHasenbuschTwist(out.Odd(), in.Even(), *gauge, *clover, -kappa, mu, in.Odd(), QUDA_ODD_PARITY,
-                                         dagger, commDim.data, profile);
-      }
+    if (symmetric) {
+      ApplyWilsonCloverHasenbuschTwist(out[this_parity], in[other_parity], *gauge, *clover, -kappa, mu, in[this_parity], this_parity,
+                                       dagger, commDim.data, profile);
+      ApplyWilsonClover(out[other_parity], in[this_parity], *gauge, *clover, -kappa, in[other_parity], other_parity, dagger, commDim.data,
+                        profile);
     } else {
-      if (matpcType == QUDA_MATPC_ODD_ODD_ASYMMETRIC) {
-        ApplyWilsonClover(out.Even(), in.Odd(), *gauge, *clover, -kappa, in.Even(), QUDA_EVEN_PARITY, dagger, commDim.data,
-                          profile);
-        ApplyTwistedClover(out.Odd(), in.Even(), *gauge, *clover, -kappa, mu, in.Odd(), QUDA_ODD_PARITY, dagger,
-                           commDim.data, profile);
-      } else {
-        ApplyTwistedClover(out.Even(), in.Odd(), *gauge, *clover, -kappa, mu, in.Even(), QUDA_EVEN_PARITY, dagger,
-                           commDim.data, profile);
-        ApplyWilsonClover(out.Odd(), in.Even(), *gauge, *clover, -kappa, in.Odd(), QUDA_ODD_PARITY, dagger, commDim.data,
-                          profile);
-      }
+      ApplyWilsonClover(out[other_parity], in[this_parity], *gauge, *clover, -kappa, in[other_parity], other_parity, dagger, commDim.data,
+                        profile);
+      ApplyTwistedClover(out[this_parity], in[other_parity], *gauge, *clover, -kappa, mu, in[this_parity], this_parity, dagger,
+                         commDim.data, profile);
     }
   }
 

--- a/lib/dirac_clover_hasenbusch_twist.cpp
+++ b/lib/dirac_clover_hasenbusch_twist.cpp
@@ -33,25 +33,25 @@ namespace quda
     if (!asymmetric) {
       if (matpcType == QUDA_MATPC_EVEN_EVEN) {
         ApplyWilsonCloverHasenbuschTwist(out.Even(), in.Odd(), *gauge, *clover, -kappa, mu, in.Even(), QUDA_EVEN_PARITY,
-                                         dagger, commDim, profile);
-        ApplyWilsonClover(out.Odd(), in.Even(), *gauge, *clover, -kappa, in.Odd(), QUDA_ODD_PARITY, dagger, commDim,
+                                         dagger, commDim.data, profile);
+        ApplyWilsonClover(out.Odd(), in.Even(), *gauge, *clover, -kappa, in.Odd(), QUDA_ODD_PARITY, dagger, commDim.data,
                           profile);
       } else {
-        ApplyWilsonClover(out.Even(), in.Odd(), *gauge, *clover, -kappa, in.Even(), QUDA_EVEN_PARITY, dagger, commDim,
+        ApplyWilsonClover(out.Even(), in.Odd(), *gauge, *clover, -kappa, in.Even(), QUDA_EVEN_PARITY, dagger, commDim.data,
                           profile);
         ApplyWilsonCloverHasenbuschTwist(out.Odd(), in.Even(), *gauge, *clover, -kappa, mu, in.Odd(), QUDA_ODD_PARITY,
-                                         dagger, commDim, profile);
+                                         dagger, commDim.data, profile);
       }
     } else {
       if (matpcType == QUDA_MATPC_ODD_ODD_ASYMMETRIC) {
-        ApplyWilsonClover(out.Even(), in.Odd(), *gauge, *clover, -kappa, in.Even(), QUDA_EVEN_PARITY, dagger, commDim,
+        ApplyWilsonClover(out.Even(), in.Odd(), *gauge, *clover, -kappa, in.Even(), QUDA_EVEN_PARITY, dagger, commDim.data,
                           profile);
         ApplyTwistedClover(out.Odd(), in.Even(), *gauge, *clover, -kappa, mu, in.Odd(), QUDA_ODD_PARITY, dagger,
-                           commDim, profile);
+                           commDim.data, profile);
       } else {
         ApplyTwistedClover(out.Even(), in.Odd(), *gauge, *clover, -kappa, mu, in.Even(), QUDA_EVEN_PARITY, dagger,
-                           commDim, profile);
-        ApplyWilsonClover(out.Odd(), in.Even(), *gauge, *clover, -kappa, in.Odd(), QUDA_ODD_PARITY, dagger, commDim,
+                           commDim.data, profile);
+        ApplyWilsonClover(out.Odd(), in.Even(), *gauge, *clover, -kappa, in.Odd(), QUDA_ODD_PARITY, dagger, commDim.data,
                           profile);
       }
     }
@@ -109,7 +109,7 @@ namespace quda
     checkParitySpinor(in, out);
     checkSpinorAlias(in, out);
 
-    ApplyWilsonCloverHasenbuschTwistPCClovInv(out, in, *gauge, *clover, k, b, x, parity, dagger, commDim, profile);
+    ApplyWilsonCloverHasenbuschTwistPCClovInv(out, in, *gauge, *clover, k, b, x, parity, dagger, commDim.data, profile);
   }
 
   // xpay version of the above
@@ -120,7 +120,7 @@ namespace quda
     checkParitySpinor(in, out);
     checkSpinorAlias(in, out);
 
-    ApplyWilsonCloverHasenbuschTwistPCNoClovInv(out, in, *gauge, *clover, k, b, x, parity, dagger, commDim, profile);
+    ApplyWilsonCloverHasenbuschTwistPCNoClovInv(out, in, *gauge, *clover, k, b, x, parity, dagger, commDim.data, profile);
   }
 
   // Apply the even-odd preconditioned clover-improved Dirac operator
@@ -143,7 +143,7 @@ namespace quda
       Dslash(tmp, in, parity[0]);
 
       // applies (A + imu*g5 - kappa^2 D)-
-      ApplyTwistedClover(out, tmp, *gauge, *clover, kappa2, mu, in, parity[1], dagger, commDim, profile);
+      ApplyTwistedClover(out, tmp, *gauge, *clover, kappa2, mu, in, parity[1], dagger, commDim.data, profile);
     } else if (!dagger) { // symmetric preconditioning
       // We need two cases because M = 1-ADAD and M^\dag = 1-D^\dag A D^dag A
       // where A is actually a clover inverse.

--- a/lib/dirac_clover_hasenbusch_twist.cpp
+++ b/lib/dirac_clover_hasenbusch_twist.cpp
@@ -29,15 +29,15 @@ namespace quda
   void DiracCloverHasenbuschTwist::M(ColorSpinorField &out, const ColorSpinorField &in) const
   {
     if (symmetric) {
-      ApplyWilsonCloverHasenbuschTwist(out[this_parity], in[other_parity], *gauge, *clover, -kappa, mu, in[this_parity], this_parity,
-                                       dagger, commDim.data, profile);
-      ApplyWilsonClover(out[other_parity], in[this_parity], *gauge, *clover, -kappa, in[other_parity], other_parity, dagger, commDim.data,
-                        profile);
+      ApplyWilsonCloverHasenbuschTwist(out[this_parity], in[other_parity], *gauge, *clover, -kappa, mu, in[this_parity],
+                                       this_parity, dagger, commDim.data, profile);
+      ApplyWilsonClover(out[other_parity], in[this_parity], *gauge, *clover, -kappa, in[other_parity], other_parity,
+                        dagger, commDim.data, profile);
     } else {
-      ApplyWilsonClover(out[other_parity], in[this_parity], *gauge, *clover, -kappa, in[other_parity], other_parity, dagger, commDim.data,
-                        profile);
-      ApplyTwistedClover(out[this_parity], in[other_parity], *gauge, *clover, -kappa, mu, in[this_parity], this_parity, dagger,
-                         commDim.data, profile);
+      ApplyWilsonClover(out[other_parity], in[this_parity], *gauge, *clover, -kappa, in[other_parity], other_parity,
+                        dagger, commDim.data, profile);
+      ApplyTwistedClover(out[this_parity], in[other_parity], *gauge, *clover, -kappa, mu, in[this_parity], this_parity,
+                         dagger, commDim.data, profile);
     }
   }
 

--- a/lib/dirac_coarse.cpp
+++ b/lib/dirac_coarse.cpp
@@ -644,8 +644,8 @@ namespace quda {
 #endif
       // x_o = A_oo^{-1} b_o - (A_oo^{-1} D_oe) x_e
       Dslash(tmp, x[i][this_parity], other_parity);
-      CloverInv(x[other_parity], b[other_parity], other_parity);
-      blas::axpy(-1.0, tmp, x[other_parity]);
+      CloverInv(x[i][other_parity], b[i][other_parity], other_parity);
+      blas::axpy(-1.0, tmp, x[i][other_parity]);
     }
   }
 

--- a/lib/dirac_coarse.cpp
+++ b/lib/dirac_coarse.cpp
@@ -368,10 +368,10 @@ namespace quda {
     if (location == QUDA_CUDA_FIELD_LOCATION) {
       auto Y = apply_mma(out, dslash_use_mma) ? Y_aos_d : Y_d;
       auto X = apply_mma(out, dslash_use_mma) ? X_aos_d : X_d;
-      ApplyCoarse(out, in, in, *Y, *X, kappa, parity, false, true, dagger, commDim, QUDA_INVALID_PRECISION,
+      ApplyCoarse(out, in, in, *Y, *X, kappa, parity, false, true, dagger, commDim.data, QUDA_INVALID_PRECISION,
                   dslash_use_mma);
     } else if (location == QUDA_CPU_FIELD_LOCATION) {
-      ApplyCoarse(out, in, in, *Y_h, *X_h, kappa, parity, false, true, dagger, commDim, QUDA_INVALID_PRECISION,
+      ApplyCoarse(out, in, in, *Y_h, *X_h, kappa, parity, false, true, dagger, commDim.data, QUDA_INVALID_PRECISION,
                   dslash_use_mma);
     }
   }
@@ -384,10 +384,10 @@ namespace quda {
     if ( location  == QUDA_CUDA_FIELD_LOCATION ) {
       auto Y = apply_mma(out, dslash_use_mma) ? Y_aos_d : Y_d;
       auto X = apply_mma(out, dslash_use_mma) ? Xinv_aos_d : Xinv_d;
-      ApplyCoarse(out, in, in, *Y, *X, kappa, parity, false, true, dagger, commDim, QUDA_INVALID_PRECISION,
+      ApplyCoarse(out, in, in, *Y, *X, kappa, parity, false, true, dagger, commDim.data, QUDA_INVALID_PRECISION,
                   dslash_use_mma);
     } else if ( location == QUDA_CPU_FIELD_LOCATION ) {
-      ApplyCoarse(out, in, in, *Y_h, *Xinv_h, kappa, parity, false, true, dagger, commDim, QUDA_INVALID_PRECISION,
+      ApplyCoarse(out, in, in, *Y_h, *Xinv_h, kappa, parity, false, true, dagger, commDim.data, QUDA_INVALID_PRECISION,
                   dslash_use_mma);
     }
   }
@@ -401,9 +401,10 @@ namespace quda {
     if ( location == QUDA_CUDA_FIELD_LOCATION ) {
       auto Y = apply_mma(out, dslash_use_mma) ? Y_aos_d : Y_d;
       auto X = apply_mma(out, dslash_use_mma) ? X_aos_d : X_d;
-      ApplyCoarse(out, in, in, *Y, *X, kappa, parity, true, false, dagger, commDim, halo_precision, dslash_use_mma);
+      ApplyCoarse(out, in, in, *Y, *X, kappa, parity, true, false, dagger, commDim.data, halo_precision, dslash_use_mma);
     } else if ( location == QUDA_CPU_FIELD_LOCATION ) {
-      ApplyCoarse(out, in, in, *Y_h, *X_h, kappa, parity, true, false, dagger, commDim, halo_precision, dslash_use_mma);
+      ApplyCoarse(out, in, in, *Y_h, *X_h, kappa, parity, true, false, dagger, commDim.data, halo_precision,
+                  dslash_use_mma);
     }
   }
 
@@ -417,9 +418,10 @@ namespace quda {
     if ( location == QUDA_CUDA_FIELD_LOCATION ) {
       auto Y = apply_mma(out, dslash_use_mma) ? Y_aos_d : Y_d;
       auto X = apply_mma(out, dslash_use_mma) ? X_aos_d : X_d;
-      ApplyCoarse(out, in, x, *Y, *X, kappa, parity, true, true, dagger, commDim, halo_precision, dslash_use_mma);
+      ApplyCoarse(out, in, x, *Y, *X, kappa, parity, true, true, dagger, commDim.data, halo_precision, dslash_use_mma);
     } else if ( location == QUDA_CPU_FIELD_LOCATION ) {
-      ApplyCoarse(out, in, x, *Y_h, *X_h, kappa, parity, true, true, dagger, commDim, halo_precision, dslash_use_mma);
+      ApplyCoarse(out, in, x, *Y_h, *X_h, kappa, parity, true, true, dagger, commDim.data, halo_precision,
+                  dslash_use_mma);
     }
   }
 
@@ -430,10 +432,10 @@ namespace quda {
     if ( location == QUDA_CUDA_FIELD_LOCATION ) {
       auto Y = apply_mma(out, dslash_use_mma) ? Y_aos_d : Y_d;
       auto X = apply_mma(out, dslash_use_mma) ? X_aos_d : X_d;
-      ApplyCoarse(out, in, in, *Y, *X, kappa, QUDA_INVALID_PARITY, true, true, dagger, commDim, halo_precision,
+      ApplyCoarse(out, in, in, *Y, *X, kappa, QUDA_INVALID_PARITY, true, true, dagger, commDim.data, halo_precision,
                   dslash_use_mma);
     } else if ( location == QUDA_CPU_FIELD_LOCATION ) {
-      ApplyCoarse(out, in, in, *Y_h, *X_h, kappa, QUDA_INVALID_PARITY, true, true, dagger, commDim, halo_precision,
+      ApplyCoarse(out, in, in, *Y_h, *X_h, kappa, QUDA_INVALID_PARITY, true, true, dagger, commDim.data, halo_precision,
                   dslash_use_mma);
     }
   }
@@ -445,19 +447,22 @@ namespace quda {
     Mdag(out, tmp);
   }
 
-  void DiracCoarse::prepare(ColorSpinorField* &src, ColorSpinorField* &sol,
-			    ColorSpinorField &x, ColorSpinorField &b,
-			    const QudaSolutionType solType) const
+  void DiracCoarse::prepare(cvector_ref<ColorSpinorField> &sol, cvector_ref<ColorSpinorField> &src,
+                            cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
+                            const QudaSolutionType solType) const
   {
     if (solType == QUDA_MATPC_SOLUTION || solType == QUDA_MATPCDAG_MATPC_SOLUTION) {
       errorQuda("Preconditioned solution requires a preconditioned solve_type");
     }
 
-    src = &b;
-    sol = &x;
+    for (auto i = 0u; i < b.size(); i++) {
+      src[i] = const_cast<ColorSpinorField &>(b[i]).create_alias();
+      sol[i] = x[i].create_alias();
+    }
   }
 
-  void DiracCoarse::reconstruct(ColorSpinorField &, const ColorSpinorField &, const QudaSolutionType) const
+  void DiracCoarse::reconstruct(cvector_ref<ColorSpinorField> &, cvector_ref<const ColorSpinorField> &,
+                                const QudaSolutionType) const
   {
     /* do nothing */
   }
@@ -519,9 +524,9 @@ namespace quda {
     if ( location == QUDA_CUDA_FIELD_LOCATION) {
       auto Y = apply_mma(out, dslash_use_mma) ? Yhat_aos_d : Yhat_d;
       auto X = apply_mma(out, dslash_use_mma) ? X_aos_d : X_d;
-      ApplyCoarse(out, in, in, *Y, *X, kappa, parity, true, false, dagger, commDim, halo_precision, dslash_use_mma);
+      ApplyCoarse(out, in, in, *Y, *X, kappa, parity, true, false, dagger, commDim.data, halo_precision, dslash_use_mma);
     } else if ( location == QUDA_CPU_FIELD_LOCATION ) {
-      ApplyCoarse(out, in, in, *Yhat_h, *X_h, kappa, parity, true, false, dagger, commDim, halo_precision,
+      ApplyCoarse(out, in, in, *Yhat_h, *X_h, kappa, parity, true, false, dagger, commDim.data, halo_precision,
                   dslash_use_mma);
     }
   }
@@ -574,87 +579,63 @@ namespace quda {
     Mdag(out, tmp);
   }
 
-  void DiracCoarsePC::prepare(ColorSpinorField* &src, ColorSpinorField* &sol, ColorSpinorField &x, ColorSpinorField &b,
-			      const QudaSolutionType solType) const
+  void DiracCoarsePC::prepare(cvector_ref<ColorSpinorField> &sol, cvector_ref<ColorSpinorField> &src,
+                              cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
+                              const QudaSolutionType solType) const
   {
     // we desire solution to preconditioned system
     if (solType == QUDA_MATPC_SOLUTION || solType == QUDA_MATPCDAG_MATPC_SOLUTION) {
-      src = &b;
-      sol = &x;
+      for (auto i = 0u; i < b.size(); i++) {
+        src[i] = const_cast<ColorSpinorField &>(b[i]).create_alias();
+        sol[i] = x[i].create_alias();
+      }
       return;
     }
 
-    auto tmp = getFieldTmp(b.Even());
+    auto tmp = getFieldTmp(b[0].Even());
 
     // we desire solution to full system
-    if (matpcType == QUDA_MATPC_EVEN_EVEN) {
-      // src = A_ee^-1 (b_e - D_eo A_oo^-1 b_o)
-      src = &(x.Odd());
-#if 0
-      CloverInv(*src, b.Odd(), QUDA_ODD_PARITY);
-      DiracCoarse::Dslash(tmp, *src, QUDA_EVEN_PARITY);
-      blas::xpay(b.Even(), -1.0, tmp);
-      CloverInv(*src, tmp, QUDA_EVEN_PARITY);
-#endif
-      // src = A_ee^{-1} b_e - (A_ee^{-1} D_eo) A_oo^{-1} b_o
-      CloverInv(*src, b.Odd(), QUDA_ODD_PARITY);
-      Dslash(tmp, *src, QUDA_EVEN_PARITY);
-      CloverInv(*src, b.Even(), QUDA_EVEN_PARITY);
-      blas::axpy(-1.0, tmp, *src);
+    for (auto i = 0u; i < b.size(); i++) {
 
-      sol = &(x.Even());
-    } else if (matpcType == QUDA_MATPC_ODD_ODD) {
-      // src = A_oo^-1 (b_o - D_oe A_ee^-1 b_e)
-      src = &(x.Even());
+      if (symmetric) {
+        // src = A_ee^-1 (b_e - D_eo A_oo^-1 b_o)
+        src[i] = x[i][other_parity].create_alias();
 #if 0
-      CloverInv(*src, b.Even(), QUDA_EVEN_PARITY);
-      DiracCoarse::Dslash(tmp, *src, QUDA_ODD_PARITY);
-      blas::xpay(b.Odd(), -1.0, tmp);
-      CloverInv(*src, tmp, QUDA_ODD_PARITY);
+        CloverInv(src[i], b[other_parity], other_parity);
+        DiracCoarse::Dslash(tmp, src[i], this_parity);
+        blas::xpay(b[i][this_parity], -1.0, tmp);
+        CloverInv(src[i], tmp, this_parity);
 #endif
-      // src = A_oo^{-1} b_o - (A_oo^{-1} D_oe) A_ee^{-1} b_e
-      CloverInv(*src, b.Even(), QUDA_EVEN_PARITY);
-      Dslash(tmp, *src, QUDA_ODD_PARITY);
-      CloverInv(*src, b.Odd(), QUDA_ODD_PARITY);
-      blas::axpy(-1.0, tmp, *src);
+        // src = A_ee^{-1} b_e - (A_ee^{-1} D_eo) A_oo^{-1} b_o
+        CloverInv(src[i], b[i][other_parity], other_parity);
+        Dslash(tmp, src[i], this_parity);
+        CloverInv(src[i], b[i][this_parity], this_parity);
+        blas::axpy(-1.0, tmp, src[i]);
 
-      sol = &(x.Odd());
-    } else if (matpcType == QUDA_MATPC_EVEN_EVEN_ASYMMETRIC) {
-      // src = b_e - D_eo A_oo^-1 b_o
-      src = &(x.Odd());
-      CloverInv(tmp, b.Odd(), QUDA_ODD_PARITY);
-      DiracCoarse::Dslash(*src, tmp, QUDA_EVEN_PARITY);
-      blas::xpay(b.Even(), -1.0, *src);
-      sol = &(x.Even());
-    } else if (matpcType == QUDA_MATPC_ODD_ODD_ASYMMETRIC) {
-      // src = b_o - D_oe A_ee^-1 b_e
-      src = &(x.Even());
-      CloverInv(tmp, b.Even(), QUDA_EVEN_PARITY);
-      DiracCoarse::Dslash(*src, tmp, QUDA_ODD_PARITY);
-      blas::xpay(b.Odd(), -1.0, *src);
-      sol = &(x.Odd());
-    } else {
-      errorQuda("MatPCType %d not valid for DiracCloverPC", matpcType);
+        sol[i] = x[i][this_parity].create_alias();
+      } else {
+        // src = b_e - D_eo A_oo^-1 b_o
+        src[i] = x[i][other_parity].create_alias();
+        CloverInv(tmp, b[i][other_parity], other_parity);
+        DiracCoarse::Dslash(src[i], tmp, this_parity);
+        blas::xpay(b[i][this_parity], -1.0, src[i]);
+        sol[i] = x[i][this_parity].create_alias();
+      }
     }
-
-    // here we use final solution to store parity solution and parity source
-    // b is now up for grabs if we want
   }
 
-  void DiracCoarsePC::reconstruct(ColorSpinorField &x, const ColorSpinorField &b, const QudaSolutionType solType) const
+  void DiracCoarsePC::reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
+                                  const QudaSolutionType solType) const
   {
     if (solType == QUDA_MATPC_SOLUTION || solType == QUDA_MATPCDAG_MATPC_SOLUTION) {
       return;
     }
 
-    checkFullSpinor(x, b);
+    auto tmp = getFieldTmp(b[0].Even());
 
-    auto tmp = getFieldTmp(b.Even());
+    for (auto i = 0u; i < b.size(); i++) {
+      checkFullSpinor(x[i], b[i]);
 
-    // create full solution
-
-    if (matpcType == QUDA_MATPC_EVEN_EVEN ||
-	matpcType == QUDA_MATPC_EVEN_EVEN_ASYMMETRIC) {
 #if 0
       // x_o = A_oo^-1 (b_o - D_oe x_e)
       DiracCoarse::Dslash(tmp, x.Even(), QUDA_ODD_PARITY);
@@ -662,25 +643,9 @@ namespace quda {
       CloverInv(x.Odd(), tmp, QUDA_ODD_PARITY);
 #endif
       // x_o = A_oo^{-1} b_o - (A_oo^{-1} D_oe) x_e
-      Dslash(tmp, x.Even(), QUDA_ODD_PARITY);
-      CloverInv(x.Odd(), b.Odd(), QUDA_ODD_PARITY);
-      blas::axpy(-1.0, tmp, x.Odd());
-
-    } else if (matpcType == QUDA_MATPC_ODD_ODD ||
-	       matpcType == QUDA_MATPC_ODD_ODD_ASYMMETRIC) {
-#if 0
-      // x_e = A_ee^-1 (b_e - D_eo x_o)
-      DiracCoarse::Dslash(tmp, x.Odd(), QUDA_EVEN_PARITY);
-      blas::xpay(b.Even(), -1.0, tmp);
-      CloverInv(x.Even(), tmp, QUDA_EVEN_PARITY);
-#endif
-      // x_e = A_ee^{-1} b_e - (A_ee^{-1} D_eo) x_o
-      Dslash(tmp, x.Odd(), QUDA_EVEN_PARITY);
-      CloverInv(x.Even(), b.Even(), QUDA_EVEN_PARITY);
-      blas::axpy(-1.0, tmp, x.Even());
-
-    } else {
-      errorQuda("MatPCType %d not valid for DiracCoarsePC", matpcType);
+      Dslash(tmp, x[i][this_parity], other_parity);
+      CloverInv(x[other_parity], b[other_parity], other_parity);
+      blas::axpy(-1.0, tmp, x[other_parity]);
     }
   }
 

--- a/lib/dirac_domain_wall.cpp
+++ b/lib/dirac_domain_wall.cpp
@@ -48,7 +48,7 @@ namespace quda {
     checkParitySpinor(in, out);
     checkSpinorAlias(in, out);
 
-    ApplyDomainWall5D(out, in, *gauge, 0.0, mass, in, parity, dagger, commDim, profile);
+    ApplyDomainWall5D(out, in, *gauge, 0.0, mass, in, parity, dagger, commDim.data, profile);
   }
 
   void DiracDomainWall::DslashXpay(ColorSpinorField &out, const ColorSpinorField &in, 
@@ -59,14 +59,14 @@ namespace quda {
     checkParitySpinor(in, out);
     checkSpinorAlias(in, out);
 
-    ApplyDomainWall5D(out, in, *gauge, k, mass, x, parity, dagger, commDim, profile);
+    ApplyDomainWall5D(out, in, *gauge, k, mass, x, parity, dagger, commDim.data, profile);
   }
 
   void DiracDomainWall::M(ColorSpinorField &out, const ColorSpinorField &in) const
   {
     checkFullSpinor(out, in);
 
-    ApplyDomainWall5D(out, in, *gauge, -kappa5, mass, in, QUDA_INVALID_PARITY, dagger, commDim, profile);
+    ApplyDomainWall5D(out, in, *gauge, -kappa5, mass, in, QUDA_INVALID_PARITY, dagger, commDim.data, profile);
   }
 
   void DiracDomainWall::MdagM(ColorSpinorField &out, const ColorSpinorField &in) const
@@ -78,19 +78,22 @@ namespace quda {
     Mdag(out, tmp);
   }
 
-  void DiracDomainWall::prepare(ColorSpinorField* &src, ColorSpinorField* &sol,
-				ColorSpinorField &x, ColorSpinorField &b, 
-				const QudaSolutionType solType) const
+  void DiracDomainWall::prepare(cvector_ref<ColorSpinorField> &sol, cvector_ref<ColorSpinorField> &src,
+                                cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
+                                const QudaSolutionType solType) const
   {
     if (solType == QUDA_MATPC_SOLUTION || solType == QUDA_MATPCDAG_MATPC_SOLUTION) {
       errorQuda("Preconditioned solution requires a preconditioned solve_type");
     }
 
-    src = &b;
-    sol = &x;
+    for (auto i = 0u; i < b.size(); i++) {
+      src[i] = const_cast<ColorSpinorField &>(b[i]).create_alias();
+      sol[i] = x[i].create_alias();
+    }
   }
 
-  void DiracDomainWall::reconstruct(ColorSpinorField &, const ColorSpinorField &, const QudaSolutionType) const
+  void DiracDomainWall::reconstruct(cvector_ref<ColorSpinorField> &, cvector_ref<const ColorSpinorField> &,
+                                    const QudaSolutionType) const
   {
     // do nothing
   }
@@ -146,55 +149,38 @@ namespace quda {
     Mdag(out, tmp);
   }
 
-  void DiracDomainWallPC::prepare(ColorSpinorField* &src, ColorSpinorField* &sol,
-				  ColorSpinorField &x, ColorSpinorField &b, 
-				  const QudaSolutionType solType) const
+  void DiracDomainWallPC::prepare(cvector_ref<ColorSpinorField> &sol, cvector_ref<ColorSpinorField> &src,
+                                  cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
+                                  const QudaSolutionType solType) const
   {
-    // we desire solution to preconditioned system
     if (solType == QUDA_MATPC_SOLUTION || solType == QUDA_MATPCDAG_MATPC_SOLUTION) {
-      src = &b;
-      sol = &x;
-    } else {  
-      // we desire solution to full system
-      if (matpcType == QUDA_MATPC_EVEN_EVEN) {
-        // src = b_e + k D_eo b_o
-        DslashXpay(x.Odd(), b.Odd(), QUDA_EVEN_PARITY, b.Even(), kappa5);
-        src = &(x.Odd());
-        sol = &(x.Even());
-      } else if (matpcType == QUDA_MATPC_ODD_ODD) {
-        // src = b_o + k D_oe b_e
-        DslashXpay(x.Even(), b.Even(), QUDA_ODD_PARITY, b.Odd(), kappa5);
-        src = &(x.Even());
-        sol = &(x.Odd());
-      } else {
-        errorQuda("MatPCType %d not valid for DiracDomainWallPC", matpcType);
+      for (auto i = 0u; i < b.size(); i++) {
+        src[i] = const_cast<ColorSpinorField &>(b[i]).create_alias();
+        sol[i] = x[i].create_alias();
       }
-      // here we use final solution to store parity solution and parity source
-      // b is now up for grabs if we want
+      return;
     }
 
+    // we desire solution to full system
+    for (auto i = 0u; i < b.size(); i++) {
+      // src = b_e + k D_eo b_o
+      DslashXpay(x[i][other_parity], b[i][other_parity], this_parity, b[this_parity], kappa5);
+      src[i] = x[i][other_parity].create_alias();
+      sol[i] = x[i][this_parity].create_alias();
+    }
   }
 
-  void DiracDomainWallPC::reconstruct(ColorSpinorField &x, const ColorSpinorField &b,
-				      const QudaSolutionType solType) const
+  void DiracDomainWallPC::reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
+                                      const QudaSolutionType solType) const
   {
-    if (solType == QUDA_MATPC_SOLUTION || solType == QUDA_MATPCDAG_MATPC_SOLUTION) {
-      return;
-    }				
+    if (solType == QUDA_MATPC_SOLUTION || solType == QUDA_MATPCDAG_MATPC_SOLUTION) return;
 
     // create full solution
-
-    checkFullSpinor(x, b);
-    if (matpcType == QUDA_MATPC_EVEN_EVEN) {
+    for (auto i = 0u; i < b.size(); i++) {
+      checkFullSpinor(x[i], b[i]);
       // x_o = b_o + k D_oe x_e
-      DslashXpay(x.Odd(), x.Even(), QUDA_ODD_PARITY, b.Odd(), kappa5);
-    } else if (matpcType == QUDA_MATPC_ODD_ODD) {
-      // x_e = b_e + k D_eo x_o
-      DslashXpay(x.Even(), x.Odd(), QUDA_EVEN_PARITY, b.Even(), kappa5);
-    } else {
-      errorQuda("MatPCType %d not valid for DiracDomainWallPC", matpcType);
+      DslashXpay(x[i][other_parity], x[i][this_parity], other_parity, b[i][other_parity], kappa5);
     }
   }
-
 
 } // namespace quda

--- a/lib/dirac_improved_staggered_kd.cpp
+++ b/lib/dirac_improved_staggered_kd.cpp
@@ -57,10 +57,10 @@ namespace quda
     if (dagger == QUDA_DAG_NO) {
 
       if (mass == 0.) {
-        ApplyImprovedStaggered(tmp, in, *fatGauge, *longGauge, 0., in, QUDA_INVALID_PARITY, QUDA_DAG_YES, commDim,
+        ApplyImprovedStaggered(tmp, in, *fatGauge, *longGauge, 0., in, QUDA_INVALID_PARITY, QUDA_DAG_YES, commDim.data,
                                profile);
       } else {
-        ApplyImprovedStaggered(tmp, in, *fatGauge, *longGauge, 2. * mass, in, QUDA_INVALID_PARITY, dagger, commDim,
+        ApplyImprovedStaggered(tmp, in, *fatGauge, *longGauge, 2. * mass, in, QUDA_INVALID_PARITY, dagger, commDim.data,
                                profile);
       }
 
@@ -71,11 +71,11 @@ namespace quda
       ApplyStaggeredKahlerDiracInverse(tmp, in, *Xinv, true);
 
       if (mass == 0.) {
-        ApplyImprovedStaggered(out, tmp, *fatGauge, *longGauge, 0., tmp, QUDA_INVALID_PARITY, QUDA_DAG_NO, commDim,
+        ApplyImprovedStaggered(out, tmp, *fatGauge, *longGauge, 0., tmp, QUDA_INVALID_PARITY, QUDA_DAG_NO, commDim.data,
                                profile);
       } else {
-        ApplyImprovedStaggered(out, tmp, *fatGauge, *longGauge, 2. * mass, tmp, QUDA_INVALID_PARITY, dagger, commDim,
-                               profile);
+        ApplyImprovedStaggered(out, tmp, *fatGauge, *longGauge, 2. * mass, tmp, QUDA_INVALID_PARITY, dagger,
+                               commDim.data, profile);
       }
     }
   }
@@ -92,8 +92,9 @@ namespace quda
     ApplyStaggeredKahlerDiracInverse(out, in, *Xinv, dagger == QUDA_DAG_YES);
   }
 
-  void DiracImprovedStaggeredKD::prepare(ColorSpinorField *&src, ColorSpinorField *&sol, ColorSpinorField &x,
-                                         ColorSpinorField &b, const QudaSolutionType solType) const
+  void DiracImprovedStaggeredKD::prepare(cvector_ref<ColorSpinorField> &sol, cvector_ref<ColorSpinorField> &src,
+                                         cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
+                                         const QudaSolutionType solType) const
   {
     // TODO: technically KD is a different type of preconditioning.
     // Should we support "preparing" and "reconstructing"?
@@ -101,46 +102,49 @@ namespace quda
       errorQuda("Preconditioned solution requires a preconditioned solve_type");
     }
 
-    src = &b;
-    sol = &x;
+    for (auto i = 0u; i < b.size(); i++) {
+      src[i] = const_cast<ColorSpinorField &>(b[i]).create_alias();
+      sol[i] = x[i].create_alias();
+    }
   }
 
-  void DiracImprovedStaggeredKD::prepareSpecialMG(ColorSpinorField *&src, ColorSpinorField *&sol, ColorSpinorField &x,
-                                                  ColorSpinorField &b, const QudaSolutionType solType) const
+  void DiracImprovedStaggeredKD::prepareSpecialMG(cvector_ref<ColorSpinorField> &sol,
+                                                  cvector_ref<ColorSpinorField> &src, cvector_ref<ColorSpinorField> &x,
+                                                  cvector_ref<const ColorSpinorField> &b,
+                                                  const QudaSolutionType solType) const
   {
     if (solType == QUDA_MATPC_SOLUTION || solType == QUDA_MATPCDAG_MATPC_SOLUTION) {
       errorQuda("Preconditioned solution requires a preconditioned solve_type");
     }
 
-    checkFullSpinor(x, b);
+    for (auto i = 0u; i < b.size(); i++) {
+      checkFullSpinor(x[i], b[i]);
 
-    // need to modify rhs
-    auto tmp = getFieldTmp(b);
-    KahlerDiracInv(tmp, b);
+      src[i] = getFieldTmp(b[i]);
+      KahlerDiracInv(src[i], b[i]);
 
-    // if we're preconditioning the Schur op, we need to rescale by the mass
-    if (parent_dirac_type == QUDA_ASQTAD_DIRAC) {
-      b = tmp;
-    } else if (parent_dirac_type == QUDA_ASQTADPC_DIRAC) {
-      b = tmp;
-      blas::ax(0.5 / mass, b);
-    } else
-      errorQuda("Unexpected parent Dirac type %d", parent_dirac_type);
+      // if we're preconditioning the Schur op, we need to rescale by the mass
+      // parent could be an ASQTAD operator if we've enabled dropping the long links
+      if (parent_dirac_type == QUDA_STAGGERED_DIRAC || parent_dirac_type == QUDA_ASQTAD_DIRAC) {
+        // do nothing
+      } else if (parent_dirac_type == QUDA_STAGGEREDPC_DIRAC || parent_dirac_type == QUDA_ASQTADPC_DIRAC) {
+        blas::ax(0.5 / mass, src[i]);
+      } else {
+        errorQuda("Unexpected parent Dirac type %d", parent_dirac_type);
+      }
 
-    sol = &x;
-    src = &b;
+      sol[i] = x[i].create_alias();
+    }
   }
 
-  void DiracImprovedStaggeredKD::reconstruct(ColorSpinorField &, const ColorSpinorField &, const QudaSolutionType) const
+  void DiracImprovedStaggeredKD::reconstruct(cvector_ref<ColorSpinorField> &, cvector_ref<const ColorSpinorField> &,
+                                             const QudaSolutionType) const
   {
     // do nothing
-
-    // TODO: technically KD is a different type of preconditioning.
-    // Should we support "preparing" and "reconstructing"?
   }
 
-  void DiracImprovedStaggeredKD::reconstructSpecialMG(ColorSpinorField &, const ColorSpinorField &,
-                                                      const QudaSolutionType) const
+  void DiracImprovedStaggeredKD::reconstructSpecialMG(cvector_ref<ColorSpinorField> &,
+                                                      cvector_ref<const ColorSpinorField> &, const QudaSolutionType) const
   {
     // do nothing
 

--- a/lib/dirac_staggered.cpp
+++ b/lib/dirac_staggered.cpp
@@ -24,7 +24,7 @@ namespace quda {
   {
     checkParitySpinor(in, out);
 
-    ApplyStaggered(out, in, *gauge, 0., in, parity, dagger, commDim, profile);
+    ApplyStaggered(out, in, *gauge, 0., in, parity, dagger, commDim.data, profile);
   }
 
   void DiracStaggered::DslashXpay(ColorSpinorField &out, const ColorSpinorField &in, 
@@ -38,12 +38,12 @@ namespace quda {
       // There's a sign convention difference for Dslash vs DslashXpay, which is
       // triggered by looking for k == 0. We need to hack around this.
       if (dagger == QUDA_DAG_YES) {
-        ApplyStaggered(out, in, *gauge, 0., x, parity, QUDA_DAG_NO, commDim, profile);
+        ApplyStaggered(out, in, *gauge, 0., x, parity, QUDA_DAG_NO, commDim.data, profile);
       } else {
-        ApplyStaggered(out, in, *gauge, 0., x, parity, QUDA_DAG_YES, commDim, profile);
+        ApplyStaggered(out, in, *gauge, 0., x, parity, QUDA_DAG_YES, commDim.data, profile);
       }
     } else {
-      ApplyStaggered(out, in, *gauge, k, x, parity, dagger, commDim, profile);
+      ApplyStaggered(out, in, *gauge, k, x, parity, dagger, commDim.data, profile);
     }
   }
 
@@ -59,12 +59,12 @@ namespace quda {
 
     if (mass == 0.) {
       if (dagger == QUDA_DAG_YES) {
-        ApplyStaggered(out, in, *gauge, 0., in, QUDA_INVALID_PARITY, QUDA_DAG_NO, commDim, profile);
+        ApplyStaggered(out, in, *gauge, 0., in, QUDA_INVALID_PARITY, QUDA_DAG_NO, commDim.data, profile);
       } else {
-        ApplyStaggered(out, in, *gauge, 0., in, QUDA_INVALID_PARITY, QUDA_DAG_YES, commDim, profile);
+        ApplyStaggered(out, in, *gauge, 0., in, QUDA_INVALID_PARITY, QUDA_DAG_YES, commDim.data, profile);
       }
     } else {
-      ApplyStaggered(out, in, *gauge, 2. * mass, in, QUDA_INVALID_PARITY, dagger, commDim, profile);
+      ApplyStaggered(out, in, *gauge, 2. * mass, in, QUDA_INVALID_PARITY, dagger, commDim.data, profile);
     }
   }
 
@@ -81,19 +81,22 @@ namespace quda {
     DslashXpay(out.Odd(), tmp, QUDA_ODD_PARITY, in.Odd(), 4 * mass * mass);
   }
 
-  void DiracStaggered::prepare(ColorSpinorField* &src, ColorSpinorField* &sol,
-			       ColorSpinorField &x, ColorSpinorField &b, 
-			       const QudaSolutionType solType) const
+  void DiracStaggered::prepare(cvector_ref<ColorSpinorField> &sol, cvector_ref<ColorSpinorField> &src,
+                               cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
+                               const QudaSolutionType solType) const
   {
     if (solType == QUDA_MATPC_SOLUTION || solType == QUDA_MATPCDAG_MATPC_SOLUTION) {
       errorQuda("Preconditioned solution requires a preconditioned solve_type");
     }
 
-    src = &b;
-    sol = &x;  
+    for (auto i = 0u; i < b.size(); i++) {
+      src[i] = const_cast<ColorSpinorField &>(b[i]).create_alias();
+      sol[i] = x[i].create_alias();
+    }
   }
 
-  void DiracStaggered::reconstruct(ColorSpinorField &, const ColorSpinorField &, const QudaSolutionType) const
+  void DiracStaggered::reconstruct(cvector_ref<ColorSpinorField> &, cvector_ref<const ColorSpinorField> &,
+                                   const QudaSolutionType) const
   {
     // do nothing
   }
@@ -208,74 +211,53 @@ namespace quda {
     */
   }
 
-  void DiracStaggeredPC::prepare(ColorSpinorField* &src, ColorSpinorField* &sol,
-				 ColorSpinorField &x, ColorSpinorField &b, 
-				 const QudaSolutionType solType) const
+  void DiracStaggeredPC::prepare(cvector_ref<ColorSpinorField> &sol, cvector_ref<ColorSpinorField> &src,
+                                 cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
+                                 const QudaSolutionType solType) const
   {
-    // we desire solution to preconditioned system
     if (solType == QUDA_MATPC_SOLUTION || solType == QUDA_MATPCDAG_MATPC_SOLUTION) {
-      src = &b;
-      sol = &x;
+      for (auto i = 0u; i < b.size(); i++) {
+        // we desire solution to preconditioned system
+        src[i] = const_cast<ColorSpinorField &>(b[i]).create_alias();
+        sol[i] = x[i].create_alias();
+      }
       return;
     }
-  
-    // we desire solution to full system.
-    // See sign convention comment in DiracStaggeredPC::M().
-    if (matpcType == QUDA_MATPC_EVEN_EVEN) {
+
+    for (auto i = 0u; i < b.size(); i++) {
+      // we desire solution to full system.
       // With the convention given in DiracStaggered::M(),
       // the source is src = 2m b_e + D_eo b_o
       // But remember, DslashXpay actually applies
       // -D_eo. Flip the sign on 2m to compensate, and
       // then flip the overall sign.
-      src = &(x.Odd());
-      DslashXpay(*src, b.Odd(), QUDA_EVEN_PARITY, b.Even(), -2*mass);
-      blas::ax(-1.0, *src);
-      sol = &(x.Even());
-    } else if (matpcType == QUDA_MATPC_ODD_ODD) {
-      // See above, permute e <-> o
-      src = &(x.Even());
-      DslashXpay(*src, b.Even(), QUDA_ODD_PARITY, b.Odd(), -2*mass);
-      blas::ax(-1.0, *src);
-      sol = &(x.Odd());
-    } else {
-      errorQuda("MatPCType %d not valid for DiracStaggeredPC", matpcType);
+      src[i] = x[i][other_parity].create_alias();
+      DslashXpay(src[i], b[i][other_parity], this_parity, b[i][this_parity], -2.0 * mass);
+      blas::ax(-1.0, src[i]);
+      sol[i] = x[i][this_parity].create_alias();
     }
-
-    // here we use final solution to store parity solution and parity source
-    // b is now up for grabs if we want
-
   }
 
-  void DiracStaggeredPC::reconstruct(ColorSpinorField &x, const ColorSpinorField &b,
-				     const QudaSolutionType solType) const
+  void DiracStaggeredPC::reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
+                                     const QudaSolutionType solType) const
   {
-
     if (solType == QUDA_MATPC_SOLUTION || solType == QUDA_MATPCDAG_MATPC_SOLUTION) {
       return;
     }
 
-    checkFullSpinor(x, b);
+    for (auto i = 0u; i < b.size(); i++) {
+      checkFullSpinor(x[i], b[i]);
 
-    // create full solution
-    // See sign convention comment in DiracStaggeredPC::M()
-    if (matpcType == QUDA_MATPC_EVEN_EVEN) {
-      
+      // create full solution
       // With the convention given in DiracStaggered::M(),
       // the reconstruct is x_o = 1/(2m) (b_o + D_oe x_e)
-      // But remember: DslashXpay actually applies -D_oe, 
+      // But remember: DslashXpay actually applies -D_oe,
       // so just like above we need to flip the sign
       // on b_o. We then correct this by applying an additional
       // minus sign when we rescale by 2m.
-      DslashXpay(x.Odd(), x.Even(), QUDA_ODD_PARITY, b.Odd(), -1.0);
-      blas::ax(-0.5/mass, x.Odd());
-    } else if (matpcType == QUDA_MATPC_ODD_ODD) {
-      // See above, permute e <-> o
-      DslashXpay(x.Even(), x.Odd(), QUDA_EVEN_PARITY, b.Even(), -1.0);
-      blas::ax(-0.5/mass, x.Even());
-    } else {
-      errorQuda("MatPCType %d not valid for DiracStaggeredPC", matpcType);
+      DslashXpay(x[i][other_parity], x[i][this_parity], other_parity, b[i][other_parity], -1.0);
+      blas::ax(-0.5 / mass, x[i][other_parity]);
     }
-
   }
 
   void DiracStaggeredPC::createCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T, double, double mass, double,

--- a/lib/dirac_staggered_kd.cpp
+++ b/lib/dirac_staggered_kd.cpp
@@ -57,9 +57,9 @@ namespace quda
     if (dagger == QUDA_DAG_NO) {
 
       if (mass == 0.) {
-        ApplyStaggered(tmp, in, *gauge, 0., in, QUDA_INVALID_PARITY, QUDA_DAG_YES, commDim, profile);
+        ApplyStaggered(tmp, in, *gauge, 0., in, QUDA_INVALID_PARITY, QUDA_DAG_YES, commDim.data, profile);
       } else {
-        ApplyStaggered(tmp, in, *gauge, 2. * mass, in, QUDA_INVALID_PARITY, dagger, commDim, profile);
+        ApplyStaggered(tmp, in, *gauge, 2. * mass, in, QUDA_INVALID_PARITY, dagger, commDim.data, profile);
       }
 
       ApplyStaggeredKahlerDiracInverse(out, tmp, *Xinv, false);
@@ -69,9 +69,9 @@ namespace quda
       ApplyStaggeredKahlerDiracInverse(tmp, in, *Xinv, true);
 
       if (mass == 0.) {
-        ApplyStaggered(out, tmp, *gauge, 0., tmp, QUDA_INVALID_PARITY, QUDA_DAG_NO, commDim, profile);
+        ApplyStaggered(out, tmp, *gauge, 0., tmp, QUDA_INVALID_PARITY, QUDA_DAG_NO, commDim.data, profile);
       } else {
-        ApplyStaggered(out, tmp, *gauge, 2. * mass, tmp, QUDA_INVALID_PARITY, dagger, commDim, profile);
+        ApplyStaggered(out, tmp, *gauge, 2. * mass, tmp, QUDA_INVALID_PARITY, dagger, commDim.data, profile);
       }
     }
   }
@@ -88,8 +88,9 @@ namespace quda
     ApplyStaggeredKahlerDiracInverse(out, in, *Xinv, dagger == QUDA_DAG_YES);
   }
 
-  void DiracStaggeredKD::prepare(ColorSpinorField *&src, ColorSpinorField *&sol, ColorSpinorField &x,
-                                 ColorSpinorField &b, const QudaSolutionType solType) const
+  void DiracStaggeredKD::prepare(cvector_ref<ColorSpinorField> &sol, cvector_ref<ColorSpinorField> &src,
+                                 cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
+                                 const QudaSolutionType solType) const
   {
     // TODO: technically KD is a different type of preconditioning.
     // Should we support "preparing" and "reconstructing"?
@@ -97,47 +98,48 @@ namespace quda
       errorQuda("Preconditioned solution requires a preconditioned solve_type");
     }
 
-    sol = &x;
-    src = &b;
+    for (auto i = 0u; i < b.size(); i++) {
+      src[i] = const_cast<ColorSpinorField &>(b[i]).create_alias();
+      sol[i] = x[i].create_alias();
+    }
   }
 
-  void DiracStaggeredKD::prepareSpecialMG(ColorSpinorField *&src, ColorSpinorField *&sol, ColorSpinorField &x,
-                                          ColorSpinorField &b, const QudaSolutionType solType) const
+  void DiracStaggeredKD::prepareSpecialMG(cvector_ref<ColorSpinorField> &sol, cvector_ref<ColorSpinorField> &src,
+                                          cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
+                                          const QudaSolutionType solType) const
   {
     if (solType == QUDA_MATPC_SOLUTION || solType == QUDA_MATPCDAG_MATPC_SOLUTION) {
       errorQuda("Preconditioned solution requires a preconditioned solve_type");
     }
 
-    checkFullSpinor(x, b);
+    for (auto i = 0u; i < b.size(); i++) {
+      checkFullSpinor(x[i], b[i]);
 
-    // need to modify rhs
-    auto tmp = getFieldTmp(b);
+      src[i] = getFieldTmp(b[i]);
+      KahlerDiracInv(src[i], b[i]);
 
-    KahlerDiracInv(tmp, b);
+      // if we're preconditioning the Schur op, we need to rescale by the mass
+      // parent could be an ASQTAD operator if we've enabled dropping the long links
+      if (parent_dirac_type == QUDA_STAGGERED_DIRAC || parent_dirac_type == QUDA_ASQTAD_DIRAC) {
+        // do nothing
+      } else if (parent_dirac_type == QUDA_STAGGEREDPC_DIRAC || parent_dirac_type == QUDA_ASQTADPC_DIRAC) {
+        blas::ax(0.5 / mass, src[i]);
+      } else {
+        errorQuda("Unexpected parent Dirac type %d", parent_dirac_type);
+      }
 
-    // if we're preconditioning the Schur op, we need to rescale by the mass
-    // parent could be an ASQTAD operator if we've enabled dropping the long links
-    if (parent_dirac_type == QUDA_STAGGERED_DIRAC || parent_dirac_type == QUDA_ASQTAD_DIRAC) {
-      b = tmp;
-    } else if (parent_dirac_type == QUDA_STAGGEREDPC_DIRAC || parent_dirac_type == QUDA_ASQTADPC_DIRAC) {
-      blas::axy(0.5 / mass, tmp, b);
-    } else {
-      errorQuda("Unexpected parent Dirac type %d", parent_dirac_type);
+      sol[i] = x[i].create_alias();
     }
-
-    sol = &x;
-    src = &b;
   }
 
-  void DiracStaggeredKD::reconstruct(ColorSpinorField &, const ColorSpinorField &, const QudaSolutionType) const
+  void DiracStaggeredKD::reconstruct(cvector_ref<ColorSpinorField> &, cvector_ref<const ColorSpinorField> &,
+                                     const QudaSolutionType) const
   {
     // do nothing
-
-    // TODO: technically KD is a different type of preconditioning.
-    // Should we support "preparing" and "reconstructing"?
   }
 
-  void DiracStaggeredKD::reconstructSpecialMG(ColorSpinorField &, const ColorSpinorField &, const QudaSolutionType) const
+  void DiracStaggeredKD::reconstructSpecialMG(cvector_ref<ColorSpinorField> &, cvector_ref<const ColorSpinorField> &,
+                                              const QudaSolutionType) const
   {
     // do nothing
 

--- a/lib/dirac_twisted_clover.cpp
+++ b/lib/dirac_twisted_clover.cpp
@@ -73,11 +73,12 @@ namespace quda {
       // k * D * in + (A + i*2*(mu+tm_rho)*kappa*gamma_5) *x
       // tm_rho is a Hasenbusch mass preconditioning parameter applied just like a twisted mass
       // but *not* the inverse of M_ee or M_oo
-      ApplyTwistedClover(out, in, *gauge, *clover, k, 2 * (mu + tm_rho) * kappa, x, parity, dagger, commDim, profile);
+      ApplyTwistedClover(out, in, *gauge, *clover, k, 2 * (mu + tm_rho) * kappa, x, parity, dagger, commDim.data,
+                         profile);
     } else {
       // k * D * in + (A + i*2*mu*kappa*gamma_5 * tau_3 - 2 * kappa * epsilon * tau_1 ) * x
       ApplyNdegTwistedClover(out, in, *gauge, *clover, k, 2 * mu * kappa, -2 * kappa * epsilon, x, parity, dagger,
-                             commDim, profile);
+                             commDim.data, profile);
     }
   }
 
@@ -94,12 +95,12 @@ namespace quda {
 
     if (in.TwistFlavor() == QUDA_TWIST_SINGLET) {
       // (-kappa * D + A + i*2*mu*kappa*gamma_5 ) * in
-      ApplyTwistedClover(out, in, *gauge, *clover, -kappa, 2.0 * kappa * mu, in, QUDA_INVALID_PARITY, dagger, commDim,
-                         profile);
+      ApplyTwistedClover(out, in, *gauge, *clover, -kappa, 2.0 * kappa * mu, in, QUDA_INVALID_PARITY, dagger,
+                         commDim.data, profile);
     } else {
       // (-kappa * D + A + i*2*mu*kappa*gamma_5*tau_3 - 2*epsilon*kappa*tau_1) * in
       ApplyNdegTwistedClover(out, in, *gauge, *clover, -kappa, 2 * kappa * mu, -2 * kappa * epsilon, in,
-                             QUDA_INVALID_PARITY, dagger, commDim, profile);
+                             QUDA_INVALID_PARITY, dagger, commDim.data, profile);
     }
   }
 
@@ -112,18 +113,22 @@ namespace quda {
     Mdag(out, tmp);
   }
 
-  void DiracTwistedClover::prepare(ColorSpinorField *&src, ColorSpinorField *&sol, ColorSpinorField &x,
-                                   ColorSpinorField &b, const QudaSolutionType solType) const
+  void DiracTwistedClover::prepare(cvector_ref<ColorSpinorField> &sol, cvector_ref<ColorSpinorField> &src,
+                                   cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
+                                   const QudaSolutionType solType) const
   {
     if (solType == QUDA_MATPC_SOLUTION || solType == QUDA_MATPCDAG_MATPC_SOLUTION) {
       errorQuda("Preconditioned solution requires a preconditioned solve_type");
     }
 
-    src = &b;
-    sol = &x;
+    for (auto i = 0u; i < b.size(); i++) {
+      src[i] = const_cast<ColorSpinorField &>(b[i]).create_alias();
+      sol[i] = x[i].create_alias();
+    }
   }
 
-  void DiracTwistedClover::reconstruct(ColorSpinorField &, const ColorSpinorField &, const QudaSolutionType) const
+  void DiracTwistedClover::reconstruct(cvector_ref<ColorSpinorField> &, cvector_ref<const ColorSpinorField> &,
+                                       const QudaSolutionType) const
   {
     // do nothing
   }
@@ -181,7 +186,7 @@ namespace quda {
       DiracWilson::DslashXpay(out, in, parity, in, 0.0);
     } else {
       // we need an Ls=plain 2 Wilson dslash, which is exactly what the 4-d preconditioned DWF operator is
-      ApplyDomainWall4D(out, in, *gauge, 0.0, 0.0, nullptr, nullptr, in, parity, dagger, commDim, profile);
+      ApplyDomainWall4D(out, in, *gauge, 0.0, 0.0, nullptr, nullptr, in, parity, dagger, commDim.data, profile);
     }
   }
 
@@ -192,7 +197,7 @@ namespace quda {
       DiracWilson::DslashXpay(out, in, parity, x, k);
     } else {
       // we need an Ls=plain 2 Wilson dslash, which is exactly what the 4-d preconditioned DWF operator is
-      ApplyDomainWall4D(out, in, *gauge, k, 0.0, nullptr, nullptr, x, parity, dagger, commDim, profile);
+      ApplyDomainWall4D(out, in, *gauge, k, 0.0, nullptr, nullptr, x, parity, dagger, commDim.data, profile);
     }
   }
 
@@ -208,7 +213,6 @@ namespace quda {
     if (in.TwistFlavor() == QUDA_TWIST_NO || in.TwistFlavor() == QUDA_TWIST_INVALID)
       errorQuda("Twist flavor not set %d", in.TwistFlavor());
 
-    bool symmetric = (matpcType == QUDA_MATPC_EVEN_EVEN || matpcType == QUDA_MATPC_ODD_ODD) ? true : false;
     if (dagger && symmetric && !reverse) {
       auto tmp = getFieldTmp(in);
       TwistCloverInv(tmp, in, 1 - parity);
@@ -216,10 +220,10 @@ namespace quda {
     } else {
       if (in.TwistFlavor() == QUDA_TWIST_SINGLET) {
         ApplyTwistedCloverPreconditioned(out, in, *gauge, *clover, 1.0, -2.0 * kappa * mu, false, in, parity, dagger,
-                                         commDim, profile);
+                                         commDim.data, profile);
       } else {
         ApplyNdegTwistedCloverPreconditioned(out, in, *gauge, *clover, 1.0, -2.0 * kappa * mu, 2.0 * kappa * epsilon,
-                                             false, in, parity, dagger, commDim, profile);
+                                             false, in, parity, dagger, commDim.data, profile);
       }
     }
   }
@@ -235,7 +239,6 @@ namespace quda {
     if (in.TwistFlavor() == QUDA_TWIST_NO || in.TwistFlavor() == QUDA_TWIST_INVALID)
       errorQuda("Twist flavor not set %d", in.TwistFlavor());
 
-    bool symmetric = (matpcType == QUDA_MATPC_EVEN_EVEN || matpcType == QUDA_MATPC_ODD_ODD) ? true : false;
     if (dagger && symmetric && !reverse) {
       auto tmp = getFieldTmp(in);
       TwistCloverInv(tmp, in, 1 - parity);
@@ -243,10 +246,10 @@ namespace quda {
     } else {
       if (in.TwistFlavor() == QUDA_TWIST_SINGLET) {
         ApplyTwistedCloverPreconditioned(out, in, *gauge, *clover, k, -2.0 * kappa * mu, true, x, parity, dagger,
-                                         commDim, profile);
+                                         commDim.data, profile);
       } else {
         ApplyNdegTwistedCloverPreconditioned(out, in, *gauge, *clover, k, -2.0 * kappa * mu, 2.0 * kappa * epsilon,
-                                             true, x, parity, dagger, commDim, profile);
+                                             true, x, parity, dagger, commDim.data, profile);
       }
     }
   }
@@ -256,22 +259,18 @@ namespace quda {
     double kappa2 = -kappa*kappa;
     auto tmp = getFieldTmp(in);
 
-    bool symmetric =(matpcType == QUDA_MATPC_EVEN_EVEN || matpcType == QUDA_MATPC_ODD_ODD) ? true : false;
-    int odd_bit = (matpcType == QUDA_MATPC_ODD_ODD || matpcType == QUDA_MATPC_ODD_ODD_ASYMMETRIC) ? 1 : 0;
-    QudaParity parity[2] = {static_cast<QudaParity>((1 + odd_bit) % 2), static_cast<QudaParity>((0 + odd_bit) % 2)};
-
     if (!symmetric) { // asymmetric preconditioning
-      Dslash(tmp, in, parity[0]);
-      DiracTwistedClover::DslashXpay(out, tmp, parity[1], in, kappa2);
+      Dslash(tmp, in, other_parity);
+      DiracTwistedClover::DslashXpay(out, tmp, this_parity, in, kappa2);
     } else if (!dagger) { // symmetric preconditioning
-      Dslash(tmp, in, parity[0]);
-      DslashXpay(out, tmp, parity[1], in, kappa2);
+      Dslash(tmp, in, other_parity);
+      DslashXpay(out, tmp, this_parity, in, kappa2);
     } else { // symmetric preconditioning, dagger
-      TwistCloverInv(out, in, parity[1]);
+      TwistCloverInv(out, in, this_parity);
       reverse = true;
-      Dslash(tmp, out, parity[0]);
+      Dslash(tmp, out, other_parity);
       reverse = false;
-      WilsonDslashXpay(out, tmp, parity[1], in, kappa2);
+      WilsonDslashXpay(out, tmp, this_parity, in, kappa2);
     }
   }
 
@@ -283,69 +282,51 @@ namespace quda {
     Mdag(out, tmp);
   }
 
-  void DiracTwistedCloverPC::prepare(ColorSpinorField *&src, ColorSpinorField *&sol, ColorSpinorField &x,
-                                     ColorSpinorField &b, const QudaSolutionType solType) const
+  void DiracTwistedCloverPC::prepare(cvector_ref<ColorSpinorField> &sol, cvector_ref<ColorSpinorField> &src,
+                                     cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
+                                     const QudaSolutionType solType) const
   {
     // we desire solution to preconditioned system
     if (solType == QUDA_MATPC_SOLUTION || solType == QUDA_MATPCDAG_MATPC_SOLUTION) {
-      src = &b;
-      sol = &x;
+      for (auto i = 0u; i < b.size(); i++) {
+        src[i] = const_cast<ColorSpinorField &>(b[i]).create_alias();
+        sol[i] = x[i].create_alias();
+      }
       return;
     }
 
-    auto tmp = getFieldTmp(b.Even());
+    // we desire solution to full system
+    auto tmp = getFieldTmp(b[0].Even());
+    for (auto i = 0u; i < b.size(); i++) {
+      src[i] = x[i][other_parity].create_alias();
+      sol[i] = x[i][this_parity].create_alias();
 
-    bool symmetric = (matpcType == QUDA_MATPC_EVEN_EVEN || matpcType == QUDA_MATPC_ODD_ODD) ? true : false;
-    int odd_bit = (matpcType == QUDA_MATPC_ODD_ODD || matpcType == QUDA_MATPC_ODD_ODD_ASYMMETRIC) ? 1 : 0;
+      TwistCloverInv(!symmetric ? static_cast<ColorSpinorField &>(tmp) : src[i], b[i][other_parity], other_parity);
 
-    src = odd_bit ? &(x.Even()) : &(x.Odd());
-    sol = odd_bit ? &(x.Odd()) : &(x.Even());
+      if (symmetric) {
+        // src = A_ee^-1 (b_e + k D_eo A_oo^-1 b_o)
+        WilsonDslashXpay(tmp, src[i], this_parity, b[i][this_parity], kappa);
+      } else {
+        // src = b_e + k D_eo A_oo^-1 b_o
+        WilsonDslashXpay(src[i], tmp, this_parity, b[i][this_parity], kappa);
+      }
 
-    TwistCloverInv(symmetric ? *src : static_cast<ColorSpinorField &>(tmp), odd_bit ? b.Even() : b.Odd(),
-                   odd_bit ? QUDA_EVEN_PARITY : QUDA_ODD_PARITY);
-
-    if (matpcType == QUDA_MATPC_EVEN_EVEN) {
-      // src = A_ee^-1 (b_e + k D_eo A_oo^-1 b_o)
-      WilsonDslashXpay(tmp, *src, QUDA_EVEN_PARITY, b.Even(), kappa);
-    } else if (matpcType == QUDA_MATPC_ODD_ODD) {
-      // src = A_oo^-1 (b_o + k D_oe A_ee^-1 b_e)
-      WilsonDslashXpay(tmp, *src, QUDA_ODD_PARITY, b.Odd(), kappa);
-    } else if (matpcType == QUDA_MATPC_EVEN_EVEN_ASYMMETRIC) {
-      // src = b_e + k D_eo A_oo^-1 b_o
-      WilsonDslashXpay(*src, tmp, QUDA_EVEN_PARITY, b.Even(), kappa);
-    } else if (matpcType == QUDA_MATPC_ODD_ODD_ASYMMETRIC) {
-      // src = b_o + k D_oe A_ee^-1 b_e
-      WilsonDslashXpay(*src, tmp, QUDA_ODD_PARITY, b.Odd(), kappa);
-    } else {
-      errorQuda("MatPCType %d not valid for DiracTwistedCloverPC", matpcType);
+      if (symmetric) TwistCloverInv(src[i], tmp, this_parity);
     }
-
-    if (symmetric) TwistCloverInv(*src, tmp, odd_bit ? QUDA_ODD_PARITY : QUDA_EVEN_PARITY);
-
-    // here we use final solution to store parity solution and parity source
-    // b is now up for grabs if we want
   }
 
-  void DiracTwistedCloverPC::reconstruct(ColorSpinorField &x, const ColorSpinorField &b,
-					 const QudaSolutionType solType) const
+  void DiracTwistedCloverPC::reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
+                                         const QudaSolutionType solType) const
   {
-    if (solType == QUDA_MATPC_SOLUTION || solType == QUDA_MATPCDAG_MATPC_SOLUTION) { return; }
+    if (solType == QUDA_MATPC_SOLUTION || solType == QUDA_MATPCDAG_MATPC_SOLUTION) return;
 
-    checkFullSpinor(x, b);
-    auto tmp = getFieldTmp(b.Even());
-    int odd_bit = (matpcType == QUDA_MATPC_ODD_ODD || matpcType == QUDA_MATPC_ODD_ODD_ASYMMETRIC) ? 1 : 0;
-
-    if (matpcType == QUDA_MATPC_EVEN_EVEN || matpcType == QUDA_MATPC_EVEN_EVEN_ASYMMETRIC) {
+    auto tmp = getFieldTmp(b[0].Even());
+    for (auto i = 0u; i < b.size(); i++) {
+      checkFullSpinor(x[i], b[i]);
       // x_o = A_oo^-1 (b_o + k D_oe x_e)
-      WilsonDslashXpay(tmp, x.Even(), QUDA_ODD_PARITY, b.Odd(), kappa);
-    } else if (matpcType == QUDA_MATPC_ODD_ODD || matpcType == QUDA_MATPC_ODD_ODD_ASYMMETRIC) {
-      // x_e = A_ee^-1 (b_e + k D_eo x_o)
-      WilsonDslashXpay(tmp, x.Odd(), QUDA_EVEN_PARITY, b.Even(), kappa);
-    } else {
-      errorQuda("MatPCType %d not valid for DiracTwistedCloverPC", matpcType);
+      WilsonDslashXpay(tmp, x[i][this_parity], other_parity, b[i][other_parity], kappa);
+      TwistCloverInv(x[i][other_parity], tmp, other_parity);
     }
-
-    TwistCloverInv(odd_bit ? x.Even() : x.Odd(), tmp, odd_bit ? QUDA_EVEN_PARITY : QUDA_ODD_PARITY);
   }
 
   void DiracTwistedCloverPC::createCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T, double kappa, double,
@@ -362,15 +343,11 @@ namespace quda {
   {
     Dirac::prefetch(mem_space, stream);
 
-    bool symmetric = (matpcType == QUDA_MATPC_EVEN_EVEN || matpcType == QUDA_MATPC_ODD_ODD) ? true : false;
-    int odd_bit = (matpcType == QUDA_MATPC_ODD_ODD || matpcType == QUDA_MATPC_ODD_ODD_ASYMMETRIC) ? 1 : 0;
-    QudaParity parity[2] = {static_cast<QudaParity>((1 + odd_bit) % 2), static_cast<QudaParity>((0 + odd_bit) % 2)};
-
     if (symmetric) {
       clover->prefetch(mem_space, stream, CloverPrefetchType::INVERSE_CLOVER_PREFETCH_TYPE);
     } else {
-      clover->prefetch(mem_space, stream, CloverPrefetchType::INVERSE_CLOVER_PREFETCH_TYPE, parity[0]);
-      clover->prefetch(mem_space, stream, CloverPrefetchType::CLOVER_CLOVER_PREFETCH_TYPE, parity[1]);
+      clover->prefetch(mem_space, stream, CloverPrefetchType::INVERSE_CLOVER_PREFETCH_TYPE, other_parity);
+      clover->prefetch(mem_space, stream, CloverPrefetchType::CLOVER_CLOVER_PREFETCH_TYPE, this_parity);
     }
   }
 } // namespace quda

--- a/lib/dirac_twisted_mass.cpp
+++ b/lib/dirac_twisted_mass.cpp
@@ -49,11 +49,11 @@ namespace quda {
 
     if (in.TwistFlavor() == QUDA_TWIST_SINGLET) {
       // this would really just be a Wilson dslash (not actually instantiated at present)
-      ApplyTwistedMass(out, in, *gauge, 0.0, 2 * mu * kappa, in, parity, dagger, commDim, profile);
+      ApplyTwistedMass(out, in, *gauge, 0.0, 2 * mu * kappa, in, parity, dagger, commDim.data, profile);
     } else {
       // this would really just be a 2-way vectorized Wilson dslash (not actually instantiated at present)
-      ApplyNdegTwistedMass(
-          out, in, *gauge, 0.0, 2 * mu * kappa, -2 * kappa * epsilon, in, parity, dagger, commDim, profile);
+      ApplyNdegTwistedMass(out, in, *gauge, 0.0, 2 * mu * kappa, -2 * kappa * epsilon, in, parity, dagger, commDim.data,
+                           profile);
     }
   }
 
@@ -63,10 +63,11 @@ namespace quda {
 
     if (in.TwistFlavor() == QUDA_TWIST_SINGLET) {
       // k * D * in + (1 + i*2*mu*kappa*gamma_5) *x
-      ApplyTwistedMass(out, in, *gauge, k, 2 * mu * kappa, x, parity, dagger, commDim, profile);
+      ApplyTwistedMass(out, in, *gauge, k, 2 * mu * kappa, x, parity, dagger, commDim.data, profile);
     } else {
       // k * D * in + (1 + i*2*mu*kappa*gamma_5*tau_3 - 2*epsilon*kappa*tau_1) * x
-      ApplyNdegTwistedMass(out, in, *gauge, k, 2 * mu * kappa, -2 * kappa * epsilon, x, parity, dagger, commDim, profile);
+      ApplyNdegTwistedMass(out, in, *gauge, k, 2 * mu * kappa, -2 * kappa * epsilon, x, parity, dagger, commDim.data,
+                           profile);
     }
   }
 
@@ -82,10 +83,10 @@ namespace quda {
     }
 
     if (in.TwistFlavor() == QUDA_TWIST_SINGLET) {
-      ApplyTwistedMass(out, in, *gauge, -kappa, 2 * mu * kappa, in, QUDA_INVALID_PARITY, dagger, commDim, profile);
+      ApplyTwistedMass(out, in, *gauge, -kappa, 2 * mu * kappa, in, QUDA_INVALID_PARITY, dagger, commDim.data, profile);
     } else {
       ApplyNdegTwistedMass(out, in, *gauge, -kappa, 2 * mu * kappa, -2 * kappa * epsilon, in, QUDA_INVALID_PARITY,
-          dagger, commDim, profile);
+                           dagger, commDim.data, profile);
     }
   }
 
@@ -98,18 +99,22 @@ namespace quda {
     Mdag(out, tmp);
   }
 
-  void DiracTwistedMass::prepare(ColorSpinorField *&src, ColorSpinorField *&sol, ColorSpinorField &x,
-      ColorSpinorField &b, const QudaSolutionType solType) const
+  void DiracTwistedMass::prepare(cvector_ref<ColorSpinorField> &sol, cvector_ref<ColorSpinorField> &src,
+                                 cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
+                                 const QudaSolutionType solType) const
   {
     if (solType == QUDA_MATPC_SOLUTION || solType == QUDA_MATPCDAG_MATPC_SOLUTION) {
       errorQuda("Preconditioned solution requires a preconditioned solve_type");
     }
 
-    src = &b;
-    sol = &x;
+    for (auto i = 0u; i < b.size(); i++) {
+      src[i] = const_cast<ColorSpinorField &>(b[i]).create_alias();
+      sol[i] = x[i].create_alias();
+    }
   }
 
-  void DiracTwistedMass::reconstruct(ColorSpinorField &, const ColorSpinorField &, const QudaSolutionType) const
+  void DiracTwistedMass::reconstruct(cvector_ref<ColorSpinorField> &, cvector_ref<const ColorSpinorField> &,
+                                     const QudaSolutionType) const
   {
     // do nothing
   }
@@ -166,7 +171,7 @@ namespace quda {
 
       bool asymmetric
           = (matpcType == QUDA_MATPC_EVEN_EVEN_ASYMMETRIC || matpcType == QUDA_MATPC_ODD_ODD_ASYMMETRIC) && dagger;
-      ApplyTwistedMassPreconditioned(out, in, *gauge, b, a, false, in, parity, dagger, asymmetric, commDim, profile);
+      ApplyTwistedMassPreconditioned(out, in, *gauge, b, a, false, in, parity, dagger, asymmetric, commDim.data, profile);
     } else {//TWIST doublet :
       double a = 2.0 * kappa * mu;
       double b = 2.0 * kappa * epsilon;
@@ -175,7 +180,7 @@ namespace quda {
       bool asymmetric
           = (matpcType == QUDA_MATPC_EVEN_EVEN_ASYMMETRIC || matpcType == QUDA_MATPC_ODD_ODD_ASYMMETRIC) && dagger;
       ApplyNdegTwistedMassPreconditioned(out, in, *gauge, c, -2.0 * mu * kappa, 2.0 * kappa * epsilon, false, in,
-          parity, dagger, asymmetric, commDim, profile);
+                                         parity, dagger, asymmetric, commDim.data, profile);
     }
   }
 
@@ -196,7 +201,7 @@ namespace quda {
       // asymmetric should never be true here since we never need to apply 1 + k * A^{-1} D^\dagger
       bool asymmetric
           = (matpcType == QUDA_MATPC_EVEN_EVEN_ASYMMETRIC || matpcType == QUDA_MATPC_ODD_ODD_ASYMMETRIC) && dagger;
-      ApplyTwistedMassPreconditioned(out, in, *gauge, b, a, true, x, parity, dagger, asymmetric, commDim, profile);
+      ApplyTwistedMassPreconditioned(out, in, *gauge, b, a, true, x, parity, dagger, asymmetric, commDim.data, profile);
     } else {//TWIST_DOUBLET:
       double a = 2.0 * kappa * mu;
       double b = 2.0 * kappa * epsilon;
@@ -205,7 +210,7 @@ namespace quda {
       bool asymmetric
           = (matpcType == QUDA_MATPC_EVEN_EVEN_ASYMMETRIC || matpcType == QUDA_MATPC_ODD_ODD_ASYMMETRIC) && dagger;
       ApplyNdegTwistedMassPreconditioned(out, in, *gauge, k * c, -2 * mu * kappa, 2 * kappa * epsilon, true, x, parity,
-          dagger, asymmetric, commDim, profile);
+                                         dagger, asymmetric, commDim.data, profile);
     }
   }
 
@@ -214,16 +219,12 @@ namespace quda {
     double kappa2 = -kappa*kappa;
     auto tmp = getFieldTmp(in);
 
-    bool symmetric =(matpcType == QUDA_MATPC_EVEN_EVEN || matpcType == QUDA_MATPC_ODD_ODD) ? true : false;
-    int odd_bit = (matpcType == QUDA_MATPC_ODD_ODD || matpcType == QUDA_MATPC_ODD_ODD_ASYMMETRIC) ? 1 : 0;
-    QudaParity parity[2] = {static_cast<QudaParity>((1 + odd_bit) % 2), static_cast<QudaParity>((0 + odd_bit) % 2)};
-
     if (symmetric) {
-      Dslash(tmp, in, parity[0]);
-      DslashXpay(out, tmp, parity[1], in, kappa2);
+      Dslash(tmp, in, other_parity);
+      DslashXpay(out, tmp, this_parity, in, kappa2);
     } else { // asymmetric preconditioning
-      Dslash(tmp, in, parity[0]);
-      DiracTwistedMass::DslashXpay(out, tmp, parity[1], in, kappa2);
+      Dslash(tmp, in, other_parity);
+      DiracTwistedMass::DslashXpay(out, tmp, this_parity, in, kappa2);
     }
   }
 
@@ -235,122 +236,92 @@ namespace quda {
     Mdag(out, tmp);
   }
 
-  void DiracTwistedMassPC::prepare(ColorSpinorField *&src, ColorSpinorField *&sol, ColorSpinorField &x,
-                                   ColorSpinorField &b, const QudaSolutionType solType) const
+  void DiracTwistedMassPC::prepare(cvector_ref<ColorSpinorField> &sol, cvector_ref<ColorSpinorField> &src,
+                                   cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
+                                   const QudaSolutionType solType) const
   {
     // we desire solution to preconditioned system
     if (solType == QUDA_MATPC_SOLUTION || solType == QUDA_MATPCDAG_MATPC_SOLUTION) {
-      src = &b;
-      sol = &x;
+      for (auto i = 0u; i < b.size(); i++) {
+        src[i] = const_cast<ColorSpinorField &>(b[i]).create_alias();
+        sol[i] = x[i].create_alias();
+      }
       return;
     }
 
-    auto tmp = getFieldTmp(b.Even());
-
-    bool symmetric = (matpcType == QUDA_MATPC_EVEN_EVEN || matpcType == QUDA_MATPC_ODD_ODD) ? true : false;
-    int odd_bit = (matpcType == QUDA_MATPC_ODD_ODD || matpcType == QUDA_MATPC_ODD_ODD_ASYMMETRIC) ? 1 : 0;
-
-    src = odd_bit ? &(x.Even()) : &(x.Odd());
-    sol = odd_bit ? &(x.Odd()) : &(x.Even());
-
-    TwistInv(symmetric ? *src : static_cast<ColorSpinorField &>(tmp), odd_bit ? b.Even() : b.Odd());
-
     // we desire solution to full system
-    if (b.TwistFlavor() == QUDA_TWIST_SINGLET) {
+    auto tmp = getFieldTmp(b[0].Even());
+    bool symmetric = (matpcType == QUDA_MATPC_EVEN_EVEN || matpcType == QUDA_MATPC_ODD_ODD) ? true : false;
 
-      if (matpcType == QUDA_MATPC_EVEN_EVEN) {
-        // src = A_ee^-1 (b_e + k D_eo A_oo^-1 b_o)
-        DiracWilson::DslashXpay(tmp, *src, QUDA_EVEN_PARITY, b.Even(), kappa);
-      } else if (matpcType == QUDA_MATPC_ODD_ODD) {
-        // src = A_oo^-1 (b_o + k D_oe A_ee^-1 b_e)
-        DiracWilson::DslashXpay(tmp, *src, QUDA_ODD_PARITY, b.Odd(), kappa);
-      } else if (matpcType == QUDA_MATPC_EVEN_EVEN_ASYMMETRIC) {
-        // src = b_e + k D_eo A_oo^-1 b_o
-        DiracWilson::DslashXpay(*src, tmp, QUDA_EVEN_PARITY, b.Even(), kappa);
-      } else if (matpcType == QUDA_MATPC_ODD_ODD_ASYMMETRIC) {
-        // src = b_o + k D_oe A_ee^-1 b_e
-        DiracWilson::DslashXpay(*src, tmp, QUDA_ODD_PARITY, b.Odd(), kappa);
-      } else {
-        errorQuda("MatPCType %d not valid for DiracTwistedMassPC", matpcType);
-      }
+    for (auto i = 0u; i < b.size(); i++) {
+      src[i] = x[i][other_parity].create_alias();
+      sol[i] = x[i][this_parity].create_alias();
 
-    } else { // doublet:
+      TwistInv(symmetric ? src[i] : static_cast<ColorSpinorField &>(tmp), b[i][other_parity]);
 
-      // repurpose the preconditioned dslash as a vectorized operator: 1+kappa*D
-      double mu_ = mu;
-      mu = 0.0;
-      double epsilon_ = epsilon;
-      epsilon = 0.0;
+      if (b[0].TwistFlavor() == QUDA_TWIST_SINGLET) {
 
-      // we desire solution to full system
-      if (matpcType == QUDA_MATPC_EVEN_EVEN) {
-        // src = A_ee^-1(b_e + k D_eo A_oo^-1 b_o)
-        DslashXpay(tmp, *src, QUDA_EVEN_PARITY, b.Even(), kappa);
-      } else if (matpcType == QUDA_MATPC_ODD_ODD) {
-        // src = A_oo^-1 (b_o + k D_oe A_ee^-1 b_e)
-        DslashXpay(tmp, *src, QUDA_ODD_PARITY, b.Odd(), kappa);
-      } else if (matpcType == QUDA_MATPC_EVEN_EVEN_ASYMMETRIC) {
-        // src = b_e + k D_eo A_oo^-1 b_o
-        DslashXpay(*src, tmp, QUDA_EVEN_PARITY, b.Even(), kappa);
-      } else if (matpcType == QUDA_MATPC_ODD_ODD_ASYMMETRIC) {
-        // src = b_o + k D_oe A_ee^-1 b_e
-        DslashXpay(*src, tmp, QUDA_ODD_PARITY, b.Odd(), kappa);
-      } else {
-        errorQuda("MatPCType %d not valid for DiracTwistedMassPC", matpcType);
-      }
+        if (symmetric) {
+          // src = A_ee^-1 (b_e + k D_eo A_oo^-1 b_o)
+          DiracWilson::DslashXpay(tmp, src[i], this_parity, b[i][this_parity], kappa);
+        } else {
+          // src = b_e + k D_eo A_oo^-1 b_o
+          DiracWilson::DslashXpay(src[i], tmp, this_parity, b[i][this_parity], kappa);
+        }
 
-      mu = mu_;
-      epsilon = epsilon_;
+      } else { // doublet:
 
-    } // end of doublet
+        // repurpose the preconditioned dslash as a vectorized operator: 1+kappa*D
+        double mu_ = mu;
+        mu = 0.0;
+        double epsilon_ = epsilon;
+        epsilon = 0.0;
 
-    if (symmetric) TwistInv(*src, tmp);
+        if (symmetric) {
+          // src = A_ee^-1(b_e + k D_eo A_oo^-1 b_o)
+          DslashXpay(tmp, src[i], this_parity, b[i][this_parity], kappa);
+        } else {
+          // src = b_e + k D_eo A_oo^-1 b_o
+          DslashXpay(src[i], tmp, this_parity, b[i][this_parity], kappa);
+        }
 
-    // here we use final solution to store parity solution and parity source
-    // b is now up for grabs if we want
+        mu = mu_;
+        epsilon = epsilon_;
+
+      } // end of doublet
+
+      if (symmetric) TwistInv(src[i], tmp);
+    }
   }
 
-  void DiracTwistedMassPC::reconstruct(ColorSpinorField &x, const ColorSpinorField &b,
-				       const QudaSolutionType solType) const
+  void DiracTwistedMassPC::reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
+                                       const QudaSolutionType solType) const
   {
-    if (solType == QUDA_MATPC_SOLUTION || solType == QUDA_MATPCDAG_MATPC_SOLUTION) { return; }
+    if (solType == QUDA_MATPC_SOLUTION || solType == QUDA_MATPCDAG_MATPC_SOLUTION) return;
 
-    checkFullSpinor(x, b);
-    auto tmp = getFieldTmp(b.Even());
-    int odd_bit = (matpcType == QUDA_MATPC_ODD_ODD || matpcType == QUDA_MATPC_ODD_ODD_ASYMMETRIC) ? 1 : 0;
+    auto tmp = getFieldTmp(b[0].Even());
+    for (auto i = 0u; i < b.size(); i++) {
+      checkFullSpinor(x[i], b[i]);
 
-    // create full solution
-    if (b.TwistFlavor() == QUDA_TWIST_SINGLET) {
-      if (matpcType == QUDA_MATPC_EVEN_EVEN || matpcType == QUDA_MATPC_EVEN_EVEN_ASYMMETRIC) {
+      // create full solution
+      if (b[0].TwistFlavor() == QUDA_TWIST_SINGLET) {
         // x_o = A_oo^-1 (b_o + k D_oe x_e)
-        DiracWilson::DslashXpay(tmp, x.Even(), QUDA_ODD_PARITY, b.Odd(), kappa);
-      } else if (matpcType == QUDA_MATPC_ODD_ODD ||   matpcType == QUDA_MATPC_ODD_ODD_ASYMMETRIC) {
-        // x_e = A_ee^-1 (b_e + k D_eo x_o)
-        DiracWilson::DslashXpay(tmp, x.Odd(), QUDA_EVEN_PARITY, b.Even(), kappa);
-      } else {
-        errorQuda("MatPCType %d not valid for DiracTwistedMassPC", matpcType);
-      }
-    } else { // twist doublet:
-      double mu_ = mu;
-      mu = 0.0;
-      double epsilon_ = epsilon;
-      epsilon = 0.0;
+        DiracWilson::DslashXpay(tmp, x[i][this_parity], other_parity, b[i][other_parity], kappa);
+      } else { // twist doublet:
+        double mu_ = mu;
+        mu = 0.0;
+        double epsilon_ = epsilon;
+        epsilon = 0.0;
 
-      if (matpcType == QUDA_MATPC_EVEN_EVEN ||  matpcType == QUDA_MATPC_EVEN_EVEN_ASYMMETRIC) {
         // x_o = A_oo^-1 (b_o + k D_oe x_e)
-        DslashXpay(tmp, x.Even(), QUDA_ODD_PARITY, b.Odd(), kappa);
-      } else if (matpcType == QUDA_MATPC_ODD_ODD ||  matpcType == QUDA_MATPC_ODD_ODD_ASYMMETRIC) {
-        // x_e = A_ee^-1 (b_e + k D_eo x_o)
-        DslashXpay(tmp, x.Odd(), QUDA_EVEN_PARITY, b.Even(), kappa);
-      } else {
-        errorQuda("MatPCType %d not valid for DiracTwistedMassPC", matpcType);
+        DslashXpay(tmp, x[i][this_parity], other_parity, b[i][other_parity], kappa);
+
+        mu = mu_;
+        epsilon = epsilon_;
       }
 
-      mu = mu_;
-      epsilon = epsilon_;
-    } // end of twist doublet...
-
-    TwistInv(odd_bit ? x.Even() : x.Odd(), tmp);
+      TwistInv(x[i][other_parity], tmp);
+    }
   }
 
   void DiracTwistedMassPC::createCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T, double kappa, double,

--- a/lib/dirac_wilson.cpp
+++ b/lib/dirac_wilson.cpp
@@ -27,7 +27,7 @@ namespace quda {
     checkParitySpinor(in, out);
     checkSpinorAlias(in, out);
 
-    ApplyWilson(out, in, *gauge, 0.0, in, parity, dagger, commDim, profile);
+    ApplyWilson(out, in, *gauge, 0.0, in, parity, dagger, commDim.data, profile);
   }
 
   void DiracWilson::DslashXpay(ColorSpinorField &out, const ColorSpinorField &in, const QudaParity parity,
@@ -36,14 +36,14 @@ namespace quda {
     checkParitySpinor(in, out);
     checkSpinorAlias(in, out);
 
-    ApplyWilson(out, in, *gauge, k, x, parity, dagger, commDim, profile);
+    ApplyWilson(out, in, *gauge, k, x, parity, dagger, commDim.data, profile);
   }
 
   void DiracWilson::M(ColorSpinorField &out, const ColorSpinorField &in) const
   {
     checkFullSpinor(out, in);
 
-    ApplyWilson(out, in, *gauge, -kappa, in, QUDA_INVALID_PARITY, dagger, commDim, profile);
+    ApplyWilson(out, in, *gauge, -kappa, in, QUDA_INVALID_PARITY, dagger, commDim.data, profile);
   }
 
   void DiracWilson::MdagM(ColorSpinorField &out, const ColorSpinorField &in) const
@@ -54,18 +54,22 @@ namespace quda {
     Mdag(out, tmp);
   }
 
-  void DiracWilson::prepare(ColorSpinorField *&src, ColorSpinorField *&sol, ColorSpinorField &x, ColorSpinorField &b,
+  void DiracWilson::prepare(cvector_ref<ColorSpinorField> &sol, cvector_ref<ColorSpinorField> &src,
+                            cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
                             const QudaSolutionType solType) const
   {
     if (solType == QUDA_MATPC_SOLUTION || solType == QUDA_MATPCDAG_MATPC_SOLUTION) {
       errorQuda("Preconditioned solution requires a preconditioned solve_type");
     }
 
-    src = &b;
-    sol = &x;
+    for (auto i = 0u; i < b.size(); i++) {
+      src[i] = const_cast<ColorSpinorField &>(b[i]).create_alias();
+      sol[i] = x[i].create_alias();
+    }
   }
 
-  void DiracWilson::reconstruct(ColorSpinorField &, const ColorSpinorField &, const QudaSolutionType) const
+  void DiracWilson::reconstruct(cvector_ref<ColorSpinorField> &, cvector_ref<const ColorSpinorField> &,
+                                const QudaSolutionType) const
   {
     // do nothing
   }
@@ -125,50 +129,37 @@ namespace quda {
     Mdag(out, tmp);
   }
 
-  void DiracWilsonPC::prepare(ColorSpinorField *&src, ColorSpinorField *&sol, ColorSpinorField &x, ColorSpinorField &b,
+  void DiracWilsonPC::prepare(cvector_ref<ColorSpinorField> &sol, cvector_ref<ColorSpinorField> &src,
+                              cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
                               const QudaSolutionType solType) const
   {
-    // we desire solution to preconditioned system
     if (solType == QUDA_MATPC_SOLUTION || solType == QUDA_MATPCDAG_MATPC_SOLUTION) {
-      src = &b;
-      sol = &x;
-    } else {
-      // we desire solution to full system
-      if (matpcType == QUDA_MATPC_EVEN_EVEN) {
-	// src = b_e + k D_eo b_o
-	DslashXpay(x.Odd(), b.Odd(), QUDA_EVEN_PARITY, b.Even(), kappa);
-	src = &(x.Odd());
-	sol = &(x.Even());
-      } else if (matpcType == QUDA_MATPC_ODD_ODD) {
-	// src = b_o + k D_oe b_e
-	DslashXpay(x.Even(), b.Even(), QUDA_ODD_PARITY, b.Odd(), kappa);
-	src = &(x.Even());
-	sol = &(x.Odd());
-      } else {
-	errorQuda("MatPCType %d not valid for DiracWilsonPC", matpcType);
+      for (auto i = 0u; i < b.size(); i++) {
+        src[i] = const_cast<ColorSpinorField &>(b[i]).create_alias();
+        sol[i] = x[i].create_alias();
       }
-      // here we use final solution to store parity solution and parity source
-      // b is now up for grabs if we want
+      return;
     }
 
+    // we desire solution to full system
+    for (auto i = 0u; i < b.size(); i++) {
+      // src = b_e + k D_eo b_o
+      DslashXpay(x[i][other_parity], b[i][other_parity], this_parity, b[this_parity], kappa);
+      src[i] = x[i][other_parity].create_alias();
+      sol[i] = x[i][this_parity].create_alias();
+    }
   }
 
-  void DiracWilsonPC::reconstruct(ColorSpinorField &x, const ColorSpinorField &b,
-				  const QudaSolutionType solType) const
+  void DiracWilsonPC::reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
+                                  const QudaSolutionType solType) const
   {
-    if (solType == QUDA_MATPC_SOLUTION || solType == QUDA_MATPCDAG_MATPC_SOLUTION) { return; }
+    if (solType == QUDA_MATPC_SOLUTION || solType == QUDA_MATPCDAG_MATPC_SOLUTION) return;
 
     // create full solution
-
-    checkFullSpinor(x, b);
-    if (matpcType == QUDA_MATPC_EVEN_EVEN) {
+    for (auto i = 0u; i < b.size(); i++) {
+      checkFullSpinor(x[i], b[i]);
       // x_o = b_o + k D_oe x_e
-      DslashXpay(x.Odd(), x.Even(), QUDA_ODD_PARITY, b.Odd(), kappa);
-    } else if (matpcType == QUDA_MATPC_ODD_ODD) {
-      // x_e = b_e + k D_eo x_o
-      DslashXpay(x.Even(), x.Odd(), QUDA_EVEN_PARITY, b.Even(), kappa);
-    } else {
-      errorQuda("MatPCType %d not valid for DiracWilsonPC", matpcType);
+      DslashXpay(x[i][other_parity], x[i][this_parity], other_parity, b[i][other_parity], kappa);
     }
   }
 

--- a/lib/eig_block_trlm.cpp
+++ b/lib/eig_block_trlm.cpp
@@ -245,15 +245,15 @@ namespace quda
       }
 
       if (blocks == 1)
-        blas::caxpy_L(beta_, {v.begin() + start, v.begin() + j}, {r.begin(), r.begin() + block_size});
+        blas::block::caxpy_L(beta_, {v.begin() + start, v.begin() + j}, {r.begin(), r.begin() + block_size});
       else
-        blas::caxpy(beta_, {v.begin() + start, v.begin() + j}, {r.begin(), r.begin() + block_size});
+        blas::block::caxpy(beta_, {v.begin() + start, v.begin() + j}, {r.begin(), r.begin() + block_size});
     }
 
     // a_j = v_j^dag * r
     // Block dot products stored in alpha_block.
     std::vector<Complex> block_alpha_(block_size);
-    blas::cDotProduct(block_alpha_, {v.begin() + j, v.begin() + j + block_size}, {r.begin(), r.end()});
+    blas::block::cDotProduct(block_alpha_, {v.begin() + j, v.begin() + j + block_size}, {r.begin(), r.end()});
     for (auto i = 0u; i < block_alpha_.size(); i++) block_alpha[arrow_offset + i] = block_alpha_[i];
 
     // Use jth_block to negate alpha data and apply block BLAS.
@@ -266,7 +266,7 @@ namespace quda
     }
 
     // r = r - a_j * v_j
-    blas::caxpy(jth_block, {v.begin() + j, v.begin() + j + block_size}, {r.begin(), r.end()});
+    blas::block::caxpy(jth_block, {v.begin() + j, v.begin() + j + block_size}, {r.begin(), r.end()});
 
     // Orthogonalise R[0:block_size] against the Krylov space V[0:j + block_size]
     for (int k = 0; k < 1; k++) blockOrthogonalizeHMGS(v, r, ortho_block_size, j + block_size);

--- a/lib/eig_iram.cpp
+++ b/lib/eig_iram.cpp
@@ -60,12 +60,12 @@ namespace quda
 
     // H_{j,i}_j = v_i^dag * r
     std::vector<Complex> tmp(j + 1);
-    blas::cDotProduct(tmp, {v.begin(), v.begin() + j + 1}, r);
+    blas::block::cDotProduct(tmp, {v.begin(), v.begin() + j + 1}, r);
 
     // Orthogonalise r_{j} against V_{j}.
     // r = r - H_{j,i} * v_j
     for (int i = 0; i < j + 1; i++) tmp[i] *= -1.0;
-    blas::caxpy(tmp, {v.begin(), v.begin() + j + 1}, r);
+    blas::block::caxpy(tmp, {v.begin(), v.begin() + j + 1}, r);
     for (int i = 0; i < j + 1; i++) upperHess[i][j] = -1.0 * tmp[i];
 
     // Re-orthogonalization / Iterative refinement phase
@@ -99,9 +99,9 @@ namespace quda
       // r_{j} = r_{j} - V_{j} * r_{j}
       // and adjust for the correction in the
       // upper Hessenberg matrix.
-      blas::cDotProduct(tmp, {v.begin(), v.begin() + j + 1}, r);
+      blas::block::cDotProduct(tmp, {v.begin(), v.begin() + j + 1}, r);
       for (int i = 0; i < j + 1; i++) tmp[i] *= -1.0;
-      blas::caxpy(tmp, {v.begin(), v.begin() + j + 1}, r);
+      blas::block::caxpy(tmp, {v.begin(), v.begin() + j + 1}, r);
       for (int i = 0; i < j + 1; i++) upperHess[i][j] -= tmp[i];
 
       beta = sqrt(blas::norm2(r[0]));

--- a/lib/eig_trlm.cpp
+++ b/lib/eig_trlm.cpp
@@ -209,7 +209,7 @@ namespace quda
       for (auto & bi : beta_) bi = -bi;
 
       // r = r - b_{j-1} * v_{j-1}
-      blas::axpy(beta_, {v.begin() + start, v.begin() + j}, r[0]);
+      blas::block::axpy(beta_, {v.begin() + start, v.begin() + j}, r[0]);
     }
 
     // Orthogonalise r against the Krylov space

--- a/lib/eigensolve_quda.cpp
+++ b/lib/eigensolve_quda.cpp
@@ -381,9 +381,11 @@ namespace quda
         logQuda(QUDA_DEBUG_VERBOSE, "Current block size = %d\n", array_size);
 
         std::vector<Complex> s(array_size);
-        blas::block::cDotProduct(s, {vecs.begin() + j, vecs.begin() + j + array_size}, vecs[i]); // <j|i> with i normalised.
+        blas::block::cDotProduct(s, {vecs.begin() + j, vecs.begin() + j + array_size},
+                                 vecs[i]); // <j|i> with i normalised.
         for (auto k = 0; k < array_size; k++) s[k] *= -1.0;
-        blas::block::caxpy(s, {vecs.begin() + j, vecs.begin() + j + array_size}, vecs[i]); // i = i - proj_{j}(i) = i - <j|i> * j
+        blas::block::caxpy(s, {vecs.begin() + j, vecs.begin() + j + array_size},
+                           vecs[i]); // i = i - proj_{j}(i) = i - <j|i> * j
       }
       double norm = sqrt(blas::norm2(vecs[i]));
       blas::ax(1.0 / norm, vecs[i]); // i/<i|i>

--- a/lib/gauge_covdev.cpp
+++ b/lib/gauge_covdev.cpp
@@ -63,15 +63,17 @@ namespace quda {
     //do nothing
   }
 
-  void GaugeCovDev::prepare(ColorSpinorField *&, ColorSpinorField *&, ColorSpinorField &, ColorSpinorField &,
+  void GaugeCovDev::prepare(cvector_ref<ColorSpinorField> &, cvector_ref<ColorSpinorField> &,
+                            cvector_ref<ColorSpinorField> &, cvector_ref<const ColorSpinorField> &,
                             const QudaSolutionType) const
   {
-    //do nothing
+    // do nothing
   }
 
-  void GaugeCovDev::reconstruct(ColorSpinorField &, const ColorSpinorField &, const QudaSolutionType) const
+  void GaugeCovDev::reconstruct(cvector_ref<ColorSpinorField> &, cvector_ref<const ColorSpinorField> &,
+                                const QudaSolutionType) const
   {
-    //do nothing
+    // do nothing
   }
 
 } // namespace quda

--- a/lib/gauge_laplace.cpp
+++ b/lib/gauge_laplace.cpp
@@ -31,9 +31,8 @@ namespace quda {
     ApplyLaplace(out, in, *gauge, laplace3D, 1.0, 1.0, in, parity, dagger, comm_dim, profile);
   }
 
-  void GaugeLaplace::DslashXpay(ColorSpinorField &out, const ColorSpinorField &in, 
-			       const QudaParity parity, const ColorSpinorField &x,
-			       const double &k) const
+  void GaugeLaplace::DslashXpay(ColorSpinorField &out, const ColorSpinorField &in, const QudaParity parity,
+                                const ColorSpinorField &x, const double &k) const
   {
     checkSpinorAlias(in, out);
 
@@ -59,19 +58,22 @@ namespace quda {
     Mdag(out, tmp);
   }
 
-  void GaugeLaplace::prepare(ColorSpinorField* &src, ColorSpinorField* &sol,
-			    ColorSpinorField &x, ColorSpinorField &b, 
-			    const QudaSolutionType solType) const
+  void GaugeLaplace::prepare(cvector_ref<ColorSpinorField> &sol, cvector_ref<ColorSpinorField> &src,
+                             cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
+                             const QudaSolutionType solType) const
   {
     if (solType == QUDA_MATPC_SOLUTION || solType == QUDA_MATPCDAG_MATPC_SOLUTION) {
       errorQuda("Preconditioned solution requires a preconditioned solve_type");
     }
 
-    src = &b;
-    sol = &x;
+    for (auto i = 0u; i < b.size(); i++) {
+      src[i] = const_cast<ColorSpinorField &>(b[i]).create_alias();
+      sol[i] = x[i].create_alias();
+    }
   }
 
-  void GaugeLaplace::reconstruct(ColorSpinorField &, const ColorSpinorField &, const QudaSolutionType) const
+  void GaugeLaplace::reconstruct(cvector_ref<ColorSpinorField> &, cvector_ref<const ColorSpinorField> &,
+                                 const QudaSolutionType) const
   {
     // do nothing
   }
@@ -111,52 +113,37 @@ namespace quda {
     Mdag(out, tmp);
   }
 
-  void GaugeLaplacePC::prepare(ColorSpinorField* &src, ColorSpinorField* &sol,
-			      ColorSpinorField &x, ColorSpinorField &b, 
-			      const QudaSolutionType solType) const
+  void GaugeLaplacePC::prepare(cvector_ref<ColorSpinorField> &sol, cvector_ref<ColorSpinorField> &src,
+                               cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
+                               const QudaSolutionType solType) const
   {
     // we desire solution to preconditioned system
     if (solType == QUDA_MATPC_SOLUTION || solType == QUDA_MATPCDAG_MATPC_SOLUTION) {
-      src = &b;
-      sol = &x;
-    } else {
-      // we desire solution to full system
-      if (matpcType == QUDA_MATPC_EVEN_EVEN) {
-	// src = b_e + k D_eo b_o
-	DslashXpay(x.Odd(), b.Odd(), QUDA_EVEN_PARITY, b.Even(), kappa);
-	src = &(x.Odd());
-	sol = &(x.Even());
-      } else if (matpcType == QUDA_MATPC_ODD_ODD) {
-	// src = b_o + k D_oe b_e
-	DslashXpay(x.Even(), b.Even(), QUDA_ODD_PARITY, b.Odd(), kappa);
-	src = &(x.Even());
-	sol = &(x.Odd());
-      } else {
-	errorQuda("MatPCType %d not valid for GaugeLaplacePC", matpcType);
+      for (auto i = 0u; i < b.size(); i++) {
+        src[i] = const_cast<ColorSpinorField &>(b[i]).create_alias();
+        sol[i] = x[i].create_alias();
       }
-      // here we use final solution to store parity solution and parity source
-      // b is now up for grabs if we want
+      return;
     }
 
+    // we desire solution to full system
+    for (auto i = 0u; i < b.size(); i++) {
+      // src = b_e + k D_eo b_o
+      DslashXpay(x[i][other_parity], b[i][other_parity], this_parity, b[i][this_parity], kappa);
+      src[i] = x[i][other_parity].create_alias();
+      sol[i] = x[i][this_parity].create_alias();
+    }
   }
 
-  void GaugeLaplacePC::reconstruct(ColorSpinorField &x, const ColorSpinorField &b,
-				  const QudaSolutionType solType) const
+  void GaugeLaplacePC::reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
+                                   const QudaSolutionType solType) const
   {
-    if (solType == QUDA_MATPC_SOLUTION || solType == QUDA_MATPCDAG_MATPC_SOLUTION) {
-      return;
-    }				
+    if (solType == QUDA_MATPC_SOLUTION || solType == QUDA_MATPCDAG_MATPC_SOLUTION) { return; }
 
-    // create full solution
-    checkFullSpinor(x, b);
-    if (matpcType == QUDA_MATPC_EVEN_EVEN) {
-      // x_o = b_o + k D_oe x_e
-      DslashXpay(x.Odd(), x.Even(), QUDA_ODD_PARITY, b.Odd(), kappa);
-    } else if (matpcType == QUDA_MATPC_ODD_ODD) {
-      // x_e = b_e + k D_eo x_o
-      DslashXpay(x.Even(), x.Odd(), QUDA_EVEN_PARITY, b.Even(), kappa);
-    } else {
-      errorQuda("MatPCType %d not valid for GaugeLaplacePC", matpcType);
+    for (auto i = 0u; i < b.size(); i++) {
+      // create full solution
+      checkFullSpinor(x[i], b[i]);
+      DslashXpay(x[i][other_parity], x[i][this_parity], other_parity, b[i][other_parity], kappa);
     }
   }
 

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -2808,8 +2808,8 @@ void invertQuda(void *hp_x, void *hp_b, QudaInvertParam *param)
     ColorSpinorField tmp(out);
     SolverParam solverParam(*param);
     Solver *solve = Solver::create(solverParam, m, mSloppy, mPre, mEig);
-    (*solve)(tmp, in); // y = (M M^\dag) b
-    dirac.Mdag(out, tmp);  // x = M^dag y
+    (*solve)(tmp, in);    // y = (M M^\dag) b
+    dirac.Mdag(out, tmp); // x = M^dag y
     delete solve;
     solverParam.updateInvertParam(*param);
   }

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -2651,9 +2651,6 @@ void invertQuda(void *hp_x, void *hp_b, QudaInvertParam *param)
   Dirac &diracPre = *dPre;
   Dirac &diracEig = *dEig;
 
-  ColorSpinorField *in = nullptr;
-  ColorSpinorField *out = nullptr;
-
   // wrap CPU host side pointers
   ColorSpinorParam cpuParam(hp_b, *param, cudaGauge->X(), pc_solution, param->input_location);
   ColorSpinorField h_b(cpuParam);
@@ -2724,10 +2721,12 @@ void invertQuda(void *hp_x, void *hp_b, QudaInvertParam *param)
 
   massRescale(b, *param, false);
 
-  dirac.prepare(in, out, x, b, param->solution_type);
+  ColorSpinorField in;
+  ColorSpinorField out;
+  dirac.prepare(out, in, x, b, param->solution_type);
 
-  logQuda(QUDA_VERBOSE, "Prepared source = %g\n", blas::norm2(*in));
-  logQuda(QUDA_VERBOSE, "Prepared solution = %g\n", blas::norm2(*out));
+  logQuda(QUDA_VERBOSE, "Prepared source = %g\n", blas::norm2(in));
+  logQuda(QUDA_VERBOSE, "Prepared solution = %g\n", blas::norm2(out));
 
   // solution_type specifies *what* system is to be solved.
   // solve_type specifies *how* the system is to be solved.
@@ -2753,14 +2752,14 @@ void invertQuda(void *hp_x, void *hp_b, QudaInvertParam *param)
   profileInvert.TPSTOP(QUDA_PROFILE_PREAMBLE);
 
   if (mat_solution && !direct_solve && !norm_error_solve) { // prepare source: b' = A^dag b
-    ColorSpinorField tmp(*in);
-    dirac.Mdag(*in, tmp);
+    ColorSpinorField tmp(in);
+    dirac.Mdag(in, tmp);
   } else if (!mat_solution && direct_solve) { // perform the first of two solves: A^dag y = b
     DiracMdag m(dirac), mSloppy(diracSloppy), mPre(diracPre), mEig(diracEig);
     SolverParam solverParam(*param);
     Solver *solve = Solver::create(solverParam, m, mSloppy, mPre, mEig);
-    (*solve)(*out, *in);
-    blas::copy(*in, *out);
+    (*solve)(out, in);
+    blas::copy(in, out);
     delete solve;
     solverParam.updateInvertParam(*param);
   }
@@ -2773,11 +2772,11 @@ void invertQuda(void *hp_x, void *hp_b, QudaInvertParam *param)
     if (param->chrono_use_resident && chronoResident[param->chrono_index].size() > 0) {
       bool hermitian = false;
       auto &mChrono = param->chrono_precision == param->cuda_prec ? m : mSloppy;
-      chronoExtrapolate(*out, *in, chronoResident[param->chrono_index], mChrono, hermitian);
+      chronoExtrapolate(out, in, chronoResident[param->chrono_index], mChrono, hermitian);
     }
 
     Solver *solve = Solver::create(solverParam, m, mSloppy, mPre, mEig);
-    (*solve)(*out, *in);
+    (*solve)(out, in);
     delete solve;
     solverParam.updateInvertParam(*param);
   } else if (!norm_error_solve) {
@@ -2788,29 +2787,29 @@ void invertQuda(void *hp_x, void *hp_b, QudaInvertParam *param)
     if (param->chrono_use_resident && chronoResident[param->chrono_index].size() > 0) {
       bool hermitian = true;
       auto &mChrono = param->chrono_precision == param->cuda_prec ? m : mSloppy;
-      chronoExtrapolate(*out, *in, chronoResident[param->chrono_index], mChrono, hermitian);
+      chronoExtrapolate(out, in, chronoResident[param->chrono_index], mChrono, hermitian);
     }
 
     // if using a Schwarz preconditioner with a normal operator then we must use the DiracMdagMLocal operator
     if (param->inv_type_precondition != QUDA_INVALID_INVERTER && param->schwarz_type != QUDA_INVALID_SCHWARZ) {
       DiracMdagMLocal mPreLocal(diracPre);
       Solver *solve = Solver::create(solverParam, m, mSloppy, mPreLocal, mEig);
-      (*solve)(*out, *in);
+      (*solve)(out, in);
       delete solve;
       solverParam.updateInvertParam(*param);
     } else {
       Solver *solve = Solver::create(solverParam, m, mSloppy, mPre, mEig);
-      (*solve)(*out, *in);
+      (*solve)(out, in);
       delete solve;
       solverParam.updateInvertParam(*param);
     }
   } else { // norm_error_solve
     DiracMMdag m(dirac), mSloppy(diracSloppy), mPre(diracPre), mEig(diracEig);
-    ColorSpinorField tmp(*out);
+    ColorSpinorField tmp(out);
     SolverParam solverParam(*param);
     Solver *solve = Solver::create(solverParam, m, mSloppy, mPre, mEig);
-    (*solve)(tmp, *in); // y = (M M^\dag) b
-    dirac.Mdag(*out, tmp);  // x = M^dag y
+    (*solve)(tmp, in); // y = (M M^\dag) b
+    dirac.Mdag(out, tmp);  // x = M^dag y
     delete solve;
     solverParam.updateInvertParam(*param);
   }
@@ -2832,7 +2831,7 @@ void invertQuda(void *hp_x, void *hp_b, QudaInvertParam *param)
     if(not param->chrono_replace_last){
       // if we have not filled the space yet just augment
       if ((int)basis.size() < param->chrono_max_dim) {
-        ColorSpinorParam cs_param(*out);
+        ColorSpinorParam cs_param(out);
         cs_param.setPrecision(param->chrono_precision);
         basis.emplace_back(cs_param);
       }
@@ -2840,7 +2839,7 @@ void invertQuda(void *hp_x, void *hp_b, QudaInvertParam *param)
       // shuffle every entry down one and bring the last to the front
       std::rotate(basis.begin(), basis.end() - 1, basis.end());
     }
-    basis[0] = *out; // set first entry to new solution
+    basis[0] = out; // set first entry to new solution
   }
   dirac.reconstruct(x, b, param->solution_type);
 

--- a/lib/inv_bicgstabl_quda.cpp
+++ b/lib/inv_bicgstabl_quda.cpp
@@ -38,7 +38,7 @@ namespace quda {
     auto r_vec = {r.begin(), r.begin() + n_krylov + 1};
 
     std::vector<Complex> r_dagger_dot_r((n_krylov + 1) * n_krylov);
-    blas::block::cDotProduct(r_dagger_dot_r, r_dagger_vec, r_vec) ;
+    blas::block::cDotProduct(r_dagger_dot_r, r_dagger_vec, r_vec);
 
     matrix R_dag_R(n_krylov, n_krylov);
     vector R_dag_r0(n_krylov);
@@ -137,7 +137,7 @@ namespace quda {
     auto r_ = {r.begin() + begin, r.begin() + begin + size};
     auto rj = {r.begin() + j, r.begin() + j + 1};
 
-    blas::block::caxpy(tau_, r_ , rj);
+    blas::block::caxpy(tau_, r_, rj);
   }
 
   /**

--- a/lib/inv_ca_cg.cpp
+++ b/lib/inv_ca_cg.cpp
@@ -554,14 +554,14 @@ namespace quda
           // Compute the beta coefficients for updating Q, AQ
           // 1. compute matrix Q_AS = -Q^\dagger AS
           // 2. Solve Q_AQ beta = Q_AS
-          blas::reDotProduct(Q_AS, AQ, S);
+          blas::block::reDotProduct(Q_AS, AQ, S);
           compute_beta();
 
           // update direction vectors
-          blas::axpyz(beta, Q, S, Qtmp);
+          blas::block::axpyz(beta, Q, S, Qtmp);
           for (int i = 0; i < n_krylov; i++) std::swap(Q[i], Qtmp[i]);
 
-          blas::axpyz(beta, AQ, AS, Qtmp);
+          blas::block::axpyz(beta, AQ, AS, Qtmp);
           for (int i = 0; i < n_krylov; i++) std::swap(AQ[i], Qtmp[i]);
         }
 
@@ -569,17 +569,17 @@ namespace quda
         // 1. Compute Q_AQ = Q^\dagger AQ and g = Q^dagger r = Q^dagger S[0]
         // 2. Solve Q_AQ alpha = g
         {
-          blas::reDotProduct(Q_AQandg, Q, {AQ, S[0]});
+          blas::block::reDotProduct(Q_AQandg, Q, {AQ, S[0]});
           compute_alpha();
         }
 
         // update the solution vector
-        blas::axpy(alpha, Q, x);
+        blas::block::axpy(alpha, Q, x);
 
         for (int i = 0; i < param.Nkrylov; i++) { alpha[i] = -alpha[i]; }
 
         // Can we fuse these? We don't need this reduce in all cases...
-        blas::axpy(alpha, AQ, S[0]);
+        blas::block::axpy(alpha, AQ, S[0]);
         // if (getVerbosity() >= QUDA_VERBOSE) r2 = blas::norm2(S[0]);
         /*else*/ r2 = Q_AQandg[param.Nkrylov]; // actually the old r2... so we do one more iter than needed...
       } else {
@@ -591,11 +591,11 @@ namespace quda
         // We do compute the alpha coefficients: this is the same code as above
         // 1. Compute "Q_AQ" = S^\dagger AS and g = S^dagger r = S^dagger S[0]
         // 2. Solve "Q_AQ" alpha = g
-        blas::reDotProduct(Q_AQandg, S, {AS, S[0]});
+        blas::block::reDotProduct(Q_AQandg, S, {AS, S[0]});
         compute_alpha();
 
         // update the solution vector
-        blas::axpy(alpha, S, x);
+        blas::block::axpy(alpha, S, x);
 
         // no need to update AS
         r2 = Q_AQandg[param.Nkrylov]; // actually the old r2... so we do one more iter than needed...

--- a/lib/inv_ca_gcr.cpp
+++ b/lib/inv_ca_gcr.cpp
@@ -77,7 +77,7 @@ namespace quda
     // Construct the matrix Q* Q = (A P)* (A P) = (q_i, q_j) = (A p_i, A p_j)
     std::vector<Complex> A_(N * (N + 1));
 
-    blas::cDotProduct(A_, q, {q, b});
+    blas::block::cDotProduct(A_, q, {q, b});
     for (int i = 0; i < N; i++) {
       phi(i) = A_[i * (N + 1) + N];
       for (int j = 0; j < N; j++) { A(i, j) = A_[i * (N + 1) + j]; }
@@ -86,12 +86,12 @@ namespace quda
     // two reductions but uses the Hermitian block dot product
     // compute rhs vector phi = Q* b = (q_i, b)
     std::vector<Complex> phi_(N);
-    blas::cDotProduct(phi_, q, b);
+    blas::block::cDotProduct(phi_, q, b);
     for (int i = 0; i < N; i++) phi(i) = phi_[i];
 
     // Construct the matrix Q* Q = (A P)* (A P) = (q_i, q_j) = (A p_i, A p_j)
     std::vector<Complex> A_(N * N);
-    blas::hDotProduct(A_, q, q);
+    blas::block::hDotProduct(A_, q, q);
     for (int i = 0; i < N; i++)
       for (int j = 0; j < N; j++) A(i, j) = A_[i * N + j];
 #endif
@@ -282,14 +282,14 @@ namespace quda
       solve(alpha, q, p[0]);
 
       // need to make sure P is only length n_krylov
-      blas::caxpy(alpha, {p.begin(), p.begin() + n_krylov}, {x});
+      blas::block::caxpy(alpha, {p.begin(), p.begin() + n_krylov}, {x});
 
       // no need to compute residual vector if not returning
       // residual vector and only doing a single fixed iteration
       if (!fixed_iteration || param.return_residual) {
         // update the residual vector
         for (int i = 0; i < n_krylov; i++) alpha[i] = -alpha[i];
-        blas::caxpy(alpha, q, r);
+        blas::block::caxpy(alpha, q, r);
       }
 
       total_iter += n_krylov;

--- a/lib/inv_cg_quda.cpp
+++ b/lib/inv_cg_quda.cpp
@@ -403,7 +403,7 @@ namespace quda {
         x_update_batch.get_current_alpha() = r2 / pAp;
 
         // here we are deploying the alternative beta computation
-        auto cg_norm = blas::axpyCGNorm(-x_update_batch.get_current_alpha(), Ap, rSloppy);
+        double2 cg_norm = blas::axpyCGNorm(-x_update_batch.get_current_alpha(), Ap, rSloppy);
         r2 = cg_norm.x;  // (r_new, r_new)
         sigma = cg_norm.y >= 0.0 ? cg_norm.y : r2;  // use r2 if (r_k+1, r_k+1-r_k) breaks
       }
@@ -691,7 +691,7 @@ namespace quda {
       alpha = r2 / pAp;
 
       // here we are deploying the alternative beta computation
-      auto cg_norm = blas::axpyCGNorm(-alpha, Ap, rSloppy);
+      double2 cg_norm = blas::axpyCGNorm(-alpha, Ap, rSloppy);
       r2 = cg_norm.x;                            // (r_new, r_new)
       sigma = cg_norm.y >= 0.0 ? cg_norm.y : r2; // use r2 if (r_k+1, r_k+1-r_k) breaks
       rNorm = sqrt(r2);

--- a/lib/inv_eigcg_quda.cpp
+++ b/lib/inv_eigcg_quda.cpp
@@ -290,7 +290,7 @@ namespace quda {
     std::vector<ColorSpinorField*> v2k(args.V2k->Components());
 
     RowMajorDenseMatrix Alpha(args.ritzVecs.topLeftCorner(args.m, 2*args.k));
-    blas::legacy::caxpy( static_cast<Complex*>(Alpha.data()), vm , v2k);
+    blas::legacy::caxpy(static_cast<Complex *>(Alpha.data()), vm, v2k);
 
     for(int i = 0; i < 2*args.k; i++)  blas::copy(Vm->Component(i), args.V2k->Component(i));
 

--- a/lib/inv_eigcg_quda.cpp
+++ b/lib/inv_eigcg_quda.cpp
@@ -130,7 +130,7 @@ namespace quda {
 
        std::vector<ColorSpinorField *> v_(v->Components().begin(), v->Components().begin() + 2 * k);
 
-       blas::cDotProduct(s.get(), w_, v_);
+       blas::legacy::cDotProduct(s.get(), w_, v_);
 
        Map<VectorXcd, Unaligned> s_(s.get(), 2 * k);
        s_ *= inv_sqrt_r2;
@@ -290,7 +290,7 @@ namespace quda {
     std::vector<ColorSpinorField*> v2k(args.V2k->Components());
 
     RowMajorDenseMatrix Alpha(args.ritzVecs.topLeftCorner(args.m, 2*args.k));
-    blas::caxpy( static_cast<Complex*>(Alpha.data()), vm , v2k);
+    blas::legacy::caxpy( static_cast<Complex*>(Alpha.data()), vm , v2k);
 
     for(int i = 0; i < 2*args.k; i++)  blas::copy(Vm->Component(i), args.V2k->Component(i));
 

--- a/lib/inv_gcr_quda.cpp
+++ b/lib/inv_gcr_quda.cpp
@@ -24,7 +24,7 @@ namespace quda {
   void GCR::computeBeta(std::vector<Complex> &beta, std::vector<ColorSpinorField> &Ap, int i, int N, int k)
   {
     std::vector<Complex> Beta(N, 0.0);
-    blas::cDotProduct(Beta, {Ap.begin() + i, Ap.begin() + i + N}, Ap[k]); // vectorized dot product
+    blas::block::cDotProduct(Beta, {Ap.begin() + i, Ap.begin() + i + N}, Ap[k]); // vectorized dot product
 
 #if 0
     for (int j=0; j<N; j++) {
@@ -40,7 +40,7 @@ namespace quda {
   {
     std::vector<Complex> beta_(size);
     for (int i = 0; i < size; i++) beta_[i] = -beta[(i + begin) * n_krylov + k];
-    blas::caxpy(beta_, {Ap.begin() + begin, Ap.begin() + begin + size}, Ap[k]);
+    blas::block::caxpy(beta_, {Ap.begin() + begin, Ap.begin() + begin + size}, Ap[k]);
   }
 
   void GCR::orthoDir(std::vector<Complex> &beta, std::vector<ColorSpinorField> &Ap, int k, int pipeline)
@@ -100,7 +100,7 @@ namespace quda {
     // Update the solution vector
     backSubs(alpha, beta, gamma, delta, k);
 
-    blas::caxpy(delta, {p.begin(), p.begin() + k}, x);
+    blas::block::caxpy(delta, {p.begin(), p.begin() + k}, x);
   }
 
   GCR::GCR(const DiracMatrix &mat, const DiracMatrix &matSloppy, const DiracMatrix &matPrecon,

--- a/lib/inv_gmresdr_quda.cpp
+++ b/lib/inv_gmresdr_quda.cpp
@@ -233,14 +233,13 @@ namespace quda {
     std::vector<ColorSpinorField *> x_, r_;
     x_.push_back(x), r_.push_back(r);
 
-    blas::caxpy(static_cast<Complex *>(args.eta.data()), Z_, x_);
+    blas::legacy::caxpy(static_cast<Complex *>(args.eta.data()), Z_, x_);
 
     VectorXcd minusHeta = -(args.H * args.eta);
     Map<VectorXcd, Unaligned> c_(args.c, args.m + 1);
     c_ += minusHeta;
 
-    blas::caxpy(static_cast<Complex *>(minusHeta.data()), V_, r_);
-    return;
+    blas::legacy::caxpy(static_cast<Complex *>(minusHeta.data()), V_, r_);
   }
 
   void GMResDR::RestartVZH()
@@ -268,7 +267,7 @@ namespace quda {
     std::vector<ColorSpinorField *> vm(Vm->Components());
 
     RowMajorDenseMatrix Alpha(Qkp1); // convert Qkp1 to Row-major format first
-    blas::caxpy(static_cast<Complex *>(Alpha.data()), vm, vkp1);
+    blas::legacy::caxpy(static_cast<Complex *>(Alpha.data()), vm, vkp1);
 
     for (int i = 0; i < (args.m + 1); i++) {
       if (i < (args.k + 1)) {
@@ -283,7 +282,7 @@ namespace quda {
       std::vector<ColorSpinorField *> vk(args.Vkp1->Components().begin(), args.Vkp1->Components().begin() + args.k);
 
       RowMajorDenseMatrix Beta(Qkp1.topLeftCorner(args.m, args.k));
-      blas::caxpy(static_cast<Complex *>(Beta.data()), z, vk);
+      blas::legacy::caxpy(static_cast<Complex *>(Beta.data()), z, vk);
 
       for (int i = 0; i < (args.m); i++) {
         if (i < (args.k))
@@ -375,7 +374,7 @@ namespace quda {
       std::vector<ColorSpinorField *> r_;
       r_.push_back(static_cast<ColorSpinorField *>(r_sloppy));
 
-      blas::cDotProduct(args.c, v_, r_);
+      blas::legacy::cDotProduct(args.c, v_, r_);
     }
     return (j - start_idx);
   }
@@ -498,7 +497,7 @@ namespace quda {
           std::vector<ColorSpinorField *> v2_;
           v2_.push_back(static_cast<ColorSpinorField *>(&Vm->Component(l)));
 
-          blas::cDotProduct(col, v1_, v2_);
+          blas::legacy::cDotProduct(col, v1_, v2_);
 
         } // end l-loop
 

--- a/lib/inv_mr_quda.cpp
+++ b/lib/inv_mr_quda.cpp
@@ -109,7 +109,7 @@ namespace quda
           matSloppy(Ar, r_sloppy);
 
           if (param.global_reduction) {
-            auto Ar4 = blas::cDotProductNormAB(Ar, r_sloppy);
+            double4 Ar4 = blas::cDotProductNormAB(Ar, r_sloppy);
             Complex alpha = Complex(Ar4.x, Ar4.y) / Ar4.z;
             r2 = Ar4.w;
             PrintStats("MR (inner)", iter, r2, b2, 0.0);

--- a/lib/inv_mre.cpp
+++ b/lib/inv_mre.cpp
@@ -31,12 +31,12 @@ namespace quda
       // linear system is Hermitian, solve directly
       // compute rhs vector phi = P* b = (q_i, b) and construct the matrix
       // P* Q = P* A P = (p_i, q_j) = (p_i, A p_j)
-      blas::cDotProduct(A_, p, {q, b});
+      blas::block::cDotProduct(A_, p, {q, b});
     } else {
       // linear system is not Hermitian, solve the normal system
       // compute rhs vector phi = Q* b = (q_i, b) and construct the matrix
       // Q* Q = (A P)* (A P) = (q_i, q_j) = (A p_i, A p_j)
-      blas::cDotProduct(A_, q, {q, b});
+      blas::block::cDotProduct(A_, q, {q, b});
     }
 
     for (int i = 0; i < N; i++) {
@@ -93,13 +93,13 @@ namespace quda
 
         if (i + 1 < N) {
           std::vector<Complex> alpha(N - (i + 1));
-          blas::cDotProduct(alpha, {p[i]}, {p.begin() + i + 1, p.end()});
+          blas::block::cDotProduct(alpha, {p[i]}, {p.begin() + i + 1, p.end()});
           for (auto &a : alpha) a = -a;
-          blas::caxpy(alpha, {p[i]}, {p.begin() + i + 1, p.end()});
+          blas::block::caxpy(alpha, {p[i]}, {p.begin() + i + 1, p.end()});
 
           if (!apply_mat) {
             // if not applying the matrix below then orthogonalize q
-            blas::caxpy(alpha, {q[i]}, {q.begin() + i + 1, q.end()});
+            blas::block::caxpy(alpha, {q[i]}, {q.begin() + i + 1, q.end()});
           }
         }
       }
@@ -122,7 +122,7 @@ namespace quda
     }
 
     blas::zero(x);
-    blas::caxpy(alpha, p, x);
+    blas::block::caxpy(alpha, p, x);
 
     if (getVerbosity() >= QUDA_SUMMARIZE) {
       // compute the residual only if we're going to print it

--- a/lib/inv_multi_cg_quda.cpp
+++ b/lib/inv_multi_cg_quda.cpp
@@ -295,7 +295,7 @@ namespace quda {
       r2_old = r2[0];
       r2_old_array[0] = r2_old;
 
-      auto cg_norm = blas::axpyCGNorm(-alpha[j_low], Ap, r_sloppy);
+      double2 cg_norm = blas::axpyCGNorm(-alpha[j_low], Ap, r_sloppy);
       r2[0] = cg_norm.x;
       double zn = cg_norm.y;
 

--- a/lib/inv_multi_cg_quda.cpp
+++ b/lib/inv_multi_cg_quda.cpp
@@ -101,8 +101,9 @@ namespace quda {
       }
 
       if (n_upper > n_lower)
-        blas::block::axpyBzpcx({alpha.begin() + n_lower, alpha.begin() + n_upper}, {p.begin() + n_lower, p.begin() + n_upper},
-                               {x.begin() + n_lower, x.begin() + n_upper}, {zeta.begin() + n_lower, zeta.begin() + n_upper}, r,
+        blas::block::axpyBzpcx({alpha.begin() + n_lower, alpha.begin() + n_upper},
+                               {p.begin() + n_lower, p.begin() + n_upper}, {x.begin() + n_lower, x.begin() + n_upper},
+                               {zeta.begin() + n_lower, zeta.begin() + n_upper}, r,
                                {beta.begin() + n_lower, beta.begin() + n_upper});
 
       if (++count == n_update) count = 0;

--- a/lib/inv_multi_cg_quda.cpp
+++ b/lib/inv_multi_cg_quda.cpp
@@ -101,9 +101,9 @@ namespace quda {
       }
 
       if (n_upper > n_lower)
-        blas::axpyBzpcx({alpha.begin() + n_lower, alpha.begin() + n_upper}, {p.begin() + n_lower, p.begin() + n_upper},
-                        {x.begin() + n_lower, x.begin() + n_upper}, {zeta.begin() + n_lower, zeta.begin() + n_upper}, r,
-                        {beta.begin() + n_lower, beta.begin() + n_upper});
+        blas::block::axpyBzpcx({alpha.begin() + n_lower, alpha.begin() + n_upper}, {p.begin() + n_lower, p.begin() + n_upper},
+                               {x.begin() + n_lower, x.begin() + n_upper}, {zeta.begin() + n_lower, zeta.begin() + n_upper}, r,
+                               {beta.begin() + n_lower, beta.begin() + n_upper});
 
       if (++count == n_update) count = 0;
     }

--- a/lib/inv_pcg_quda.cpp
+++ b/lib/inv_pcg_quda.cpp
@@ -241,7 +241,7 @@ namespace quda
       }
 
       x_update_batch.get_current_alpha() = (K) ? rMinvr / pAp : r2 / pAp;
-      auto cg_norm = axpyCGNorm(-x_update_batch.get_current_alpha(), Ap, r_sloppy);
+      double2 cg_norm = axpyCGNorm(-x_update_batch.get_current_alpha(), Ap, r_sloppy);
       // r --> r - alpha*A*p
       r2_old = r2;
       r2 = cg_norm.x;

--- a/lib/inv_sd_quda.cpp
+++ b/lib/inv_sd_quda.cpp
@@ -55,7 +55,7 @@ namespace quda {
     int k = 0;
     while (k < param.maxiter) {
       mat(Ar, r);
-      auto rAr = blas::cDotProductNormA(r, Ar);
+      double3 rAr = blas::cDotProductNormA(r, Ar);
       auto alpha = rAr.z / rAr.x;
       r2 = rAr.z; // this is r2 from the prior iteration
 

--- a/lib/madwf_ml.cpp
+++ b/lib/madwf_ml.cpp
@@ -217,7 +217,7 @@ namespace quda
         ref(lambda, tmp);
 
         std::vector<Complex> dot(9);
-        blas::cDotProduct(dot, {chi, theta, lambda}, {chi, theta, lambda});
+        blas::block::cDotProduct(dot, {chi, theta, lambda}, {chi, theta, lambda});
 
         a[0] += dot[0].real();
         a[1] += -2.0 * dot[1].real();

--- a/lib/multi_blas_quda.cu
+++ b/lib/multi_blas_quda.cu
@@ -304,6 +304,8 @@ namespace quda {
       } // end if (y.size() > max_YW_size())
     }
 
+    namespace block {
+
     template <>
     void axpy<double>(const std::vector<double> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y)
     {
@@ -597,6 +599,8 @@ namespace quda {
       axpy_L(a_, x_, y_);
     }
 
+  }
+
     namespace legacy {
       void caxpy(const Complex *a, std::vector<ColorSpinorField*> &x, std::vector<ColorSpinorField*> &y) {
         std::vector<Complex> a_(x.size() * y.size());
@@ -605,9 +609,8 @@ namespace quda {
         for (auto &xi : x) x_.push_back(*xi);
         vector_ref<ColorSpinorField> y_;
         for (auto &yi : y) y_.push_back(*yi);
-        blas::caxpy(a_, x_, y_);
+        blas::block::caxpy(a_, x_, y_);
       }
-    }
 
     void caxpy_U(const Complex *a, std::vector<ColorSpinorField*> &x, std::vector<ColorSpinorField*> &y) {
       std::vector<Complex> a_(x.size() * y.size());
@@ -616,7 +619,7 @@ namespace quda {
       for (auto &xi : x) x_.push_back(*xi);
       vector_ref<ColorSpinorField> y_;
       for (auto &yi : y) y_.push_back(*yi);
-      caxpy_U(a_, x_, y_);
+      blas::block::caxpy_U(a_, x_, y_);
     }
 
     void caxpy_L(const Complex *a, std::vector<ColorSpinorField*> &x, std::vector<ColorSpinorField*> &y) {
@@ -626,7 +629,7 @@ namespace quda {
       for (auto &xi : x) x_.push_back(*xi);
       vector_ref<ColorSpinorField> y_;
       for (auto &yi : y) y_.push_back(*yi);
-      caxpy_L(a_, x_, y_);
+      blas::block::caxpy_L(a_, x_, y_);
     }
 
     void axpyz(const double *a, std::vector<ColorSpinorField*> &x, std::vector<ColorSpinorField*> &y,
@@ -640,7 +643,7 @@ namespace quda {
       for (auto &yi : y) y_.push_back(*yi);
       vector_ref<ColorSpinorField> z_;
       for (auto &zi : z) z_.push_back(*zi);
-      axpyz(a_, x_, y_, z_);
+      blas::block::axpyz(a_, x_, y_, z_);
     }
 
     void caxpyz(const Complex *a, std::vector<ColorSpinorField*> &x, std::vector<ColorSpinorField*> &y,
@@ -654,7 +657,7 @@ namespace quda {
       for (auto &yi : y) y_.push_back(*yi);
       vector_ref<ColorSpinorField> z_;
       for (auto &zi : z) z_.push_back(*zi);
-      caxpyz(a_, x_, y_, z_);
+      blas::block::caxpyz(a_, x_, y_, z_);
     }
 
     void axpyBzpcx(const double *a, std::vector<ColorSpinorField *> &x, std::vector<ColorSpinorField *> &y,
@@ -671,7 +674,7 @@ namespace quda {
       for (auto &xi : x) x_.push_back(*xi);
       vector_ref<ColorSpinorField> y_;
       for (auto &yi : y) y_.push_back(*yi);
-      axpyBzpcx(a_, x_, y_, b_, z, c_);
+      blas::block::axpyBzpcx(a_, x_, y_, b_, z, c_);
     }
 
     void caxpyBxpz(const Complex *a, std::vector<ColorSpinorField*> &x, ColorSpinorField &y,
@@ -684,26 +687,9 @@ namespace quda {
 
       vector_ref<const ColorSpinorField> x_;
       for (auto &xi : x) x_.push_back(*xi);
-      caxpyBxpz(a_, x_, y, b_, z);
+      blas::block::caxpyBxpz(a_, x_, y, b_, z);
     }
 
-    // Composite field version
-    void caxpy(const Complex *a, ColorSpinorField &x, ColorSpinorField &y){ caxpy(a, x.Components(), y.Components()); }
-    void caxpy_U(const Complex *a, ColorSpinorField &x, ColorSpinorField &y) { caxpy_U(a, x.Components(), y.Components()); }
-    void caxpy_L(const Complex *a, ColorSpinorField &x, ColorSpinorField &y) { caxpy_L(a, x.Components(), y.Components()); }
-
-    void axpy(const double *a, ColorSpinorField &x, ColorSpinorField &y) { axpy(a, x.Components(), y.Components()); }
-    void axpy_U(const double *a, ColorSpinorField &x, ColorSpinorField &y) { axpy_U(a, x.Components(), y.Components()); }
-    void axpy_L(const double *a, ColorSpinorField &x, ColorSpinorField &y) { axpy_L(a, x.Components(), y.Components()); }
-
-    void axpyz(const double *a, ColorSpinorField &x, ColorSpinorField &y, ColorSpinorField &z)
-    {
-      axpyz(a, x.Components(), y.Components(), z.Components());
-    }
-
-    void caxpyz(const Complex *a, ColorSpinorField &x, ColorSpinorField &y, ColorSpinorField &z)
-    {
-      caxpyz(a, x.Components(), y.Components(), z.Components());
     }
 
   } // namespace blas

--- a/lib/multi_blas_quda.cu
+++ b/lib/multi_blas_quda.cu
@@ -304,305 +304,333 @@ namespace quda {
       } // end if (y.size() > max_YW_size())
     }
 
-    namespace block {
-
-    template <>
-    void axpy<double>(const std::vector<double> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y)
+    namespace block
     {
-      // Enter a recursion.
-      // Pass a, x, y. (0,0) indexes the tiles. false specifies the matrix is unstructured.
-      axpy_recurse<multiaxpy_>(a, x, y, range(0,x.size()), range(0,y.size()), 0);
-    }
 
-    template <>
-    void axpy_U<double>(const std::vector<double> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y)
-    {
-      // Enter a recursion.
-      // Pass a, x, y. (0,0) indexes the tiles. 1 indicates the matrix is upper-triangular,
-      //                                         which lets us skip some tiles.
-      if (x.size() != y.size())
+      template <>
+      void axpy<double>(const std::vector<double> &a, cvector_ref<const ColorSpinorField> &x,
+                        cvector_ref<ColorSpinorField> &y)
       {
-        errorQuda("An optimal block axpy_U with non-square 'a' (%lu != %lu) has not yet been implemented. Use block axpy instead",
-                  x.size(), y.size());
+        // Enter a recursion.
+        // Pass a, x, y. (0,0) indexes the tiles. false specifies the matrix is unstructured.
+        axpy_recurse<multiaxpy_>(a, x, y, range(0, x.size()), range(0, y.size()), 0);
       }
-      axpy_recurse<multiaxpy_>(a, x, y, range(0, x.size()), range(0, y.size()), 1);
-    }
 
-    template <>
-    void axpy_L<double>(const std::vector<double> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y)
-    {
-      // Enter a recursion.
-      // Pass a, x, y. (0,0) indexes the tiles. -1 indicates the matrix is lower-triangular
-      //                                         which lets us skip some tiles.
-      if (x.size() != y.size())
+      template <>
+      void axpy_U<double>(const std::vector<double> &a, cvector_ref<const ColorSpinorField> &x,
+                          cvector_ref<ColorSpinorField> &y)
       {
-        errorQuda("An optimal block axpy_L with non-square 'a' (%lu != %lu) has not yet been implemented. Use block axpy instead",
-                  x.size(), y.size());
+        // Enter a recursion.
+        // Pass a, x, y. (0,0) indexes the tiles. 1 indicates the matrix is upper-triangular,
+        //                                         which lets us skip some tiles.
+        if (x.size() != y.size()) {
+          errorQuda("An optimal block axpy_U with non-square 'a' (%lu != %lu) has not yet been implemented. Use block "
+                    "axpy instead",
+                    x.size(), y.size());
+        }
+        axpy_recurse<multiaxpy_>(a, x, y, range(0, x.size()), range(0, y.size()), 1);
       }
-      axpy_recurse<multiaxpy_>(a, x, y, range(0, x.size()), range(0, y.size()), -1);
-    }
 
-    template <>
-    void axpy<Complex>(const std::vector<Complex> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y)
-    {
-      // Enter a recursion.
-      // Pass a, x, y. (0,0) indexes the tiles. false specifies the matrix is unstructured.
-      axpy_recurse<multicaxpy_>(a, x, y, range(0,x.size()), range(0,y.size()), 0);
-    }
-
-    void caxpy(const std::vector<Complex> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y)
-    {
-      axpy(a, std::move(x), std::move(y));
-    }
-
-    template <>
-    void axpy_U<Complex>(const std::vector<Complex> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y)
-    {
-      // Enter a recursion.
-      // Pass a, x, y. (0,0) indexes the tiles. 1 indicates the matrix is upper-triangular,
-      //                                         which lets us skip some tiles.
-      if (x.size() != y.size()) {
-        errorQuda("An optimal block caxpy_U with non-square 'a' (%lu != %lu) has not yet been implemented. Use block caxpy instead",
-                  x.size(), y.size());
+      template <>
+      void axpy_L<double>(const std::vector<double> &a, cvector_ref<const ColorSpinorField> &x,
+                          cvector_ref<ColorSpinorField> &y)
+      {
+        // Enter a recursion.
+        // Pass a, x, y. (0,0) indexes the tiles. -1 indicates the matrix is lower-triangular
+        //                                         which lets us skip some tiles.
+        if (x.size() != y.size()) {
+          errorQuda("An optimal block axpy_L with non-square 'a' (%lu != %lu) has not yet been implemented. Use block "
+                    "axpy instead",
+                    x.size(), y.size());
+        }
+        axpy_recurse<multiaxpy_>(a, x, y, range(0, x.size()), range(0, y.size()), -1);
       }
-      axpy_recurse<multicaxpy_>(a, x, y, range(0,x.size()), range(0,y.size()), 1);
-    }
 
-    void caxpy_U(const std::vector<Complex> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y)
-    {
-      axpy_U(a, std::move(x), std::move(y));
-    }
-
-    template <>
-    void axpy_L<Complex>(const std::vector<Complex> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y)
-    {
-      // Enter a recursion.
-      // Pass a, x, y. (0,0) indexes the tiles. -1 indicates the matrix is lower-triangular
-      //                                         which lets us skip some tiles.
-      if (x.size() != y.size()) {
-        errorQuda("An optimal block caxpy_L with non-square 'a' (%lu != %lu) has not yet been implemented. Use block caxpy instead",
-                  x.size(), y.size());
+      template <>
+      void axpy<Complex>(const std::vector<Complex> &a, cvector_ref<const ColorSpinorField> &x,
+                         cvector_ref<ColorSpinorField> &y)
+      {
+        // Enter a recursion.
+        // Pass a, x, y. (0,0) indexes the tiles. false specifies the matrix is unstructured.
+        axpy_recurse<multicaxpy_>(a, x, y, range(0, x.size()), range(0, y.size()), 0);
       }
-      axpy_recurse<multicaxpy_>(a, x, y, range(0,x.size()), range(0,y.size()), -1);
-    }
 
-    void caxpy_L(const std::vector<Complex> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y)
-    {
-      axpy_L(a, std::move(x), std::move(y));
-    }
+      void caxpy(const std::vector<Complex> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<ColorSpinorField> &y)
+      {
+        axpy(a, std::move(x), std::move(y));
+      }
 
-    template <template <typename...> class Functor, typename T>
-    void axpyz_recurse(const std::vector<T> &a, cvector_ref<const ColorSpinorField> &x,
-                       cvector_ref<const ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z,
-                       const range &range_x, const range &range_y, int pass, int upper)
-    {
-      if (a.size() != x.size() * y.size())
-        errorQuda("coefficient size %lu does not match vector set %lu * %lu", a.size(), x.size(), y.size());
+      template <>
+      void axpy_U<Complex>(const std::vector<Complex> &a, cvector_ref<const ColorSpinorField> &x,
+                           cvector_ref<ColorSpinorField> &y)
+      {
+        // Enter a recursion.
+        // Pass a, x, y. (0,0) indexes the tiles. 1 indicates the matrix is upper-triangular,
+        //                                         which lets us skip some tiles.
+        if (x.size() != y.size()) {
+          errorQuda("An optimal block caxpy_U with non-square 'a' (%lu != %lu) has not yet been implemented. Use block "
+                    "caxpy instead",
+                    x.size(), y.size());
+        }
+        axpy_recurse<multicaxpy_>(a, x, y, range(0, x.size()), range(0, y.size()), 1);
+      }
 
-      // if greater than max single-kernel size, recurse
-      size_t max_yw_size = y[0].Precision() == QUDA_DOUBLE_PRECISION ?
-        max_YW_size<Functor<double>>(x.size(), x[0].Precision(), y[0].Precision()) :
-        max_YW_size<Functor<float>>(x.size(), x[0].Precision(), y[0].Precision());
+      void caxpy_U(const std::vector<Complex> &a, cvector_ref<const ColorSpinorField> &x,
+                   cvector_ref<ColorSpinorField> &y)
+      {
+        axpy_U(a, std::move(x), std::move(y));
+      }
 
-      if (y.size() > max_yw_size) {
-        // We need to split up 'a' carefully since it's row-major.
-        auto a_ = bisect_col(a, x.size(), y.size() / 2, y.size() - y.size() / 2);
-        auto y_ = bisect(y);
-        auto z_ = bisect(z);
+      template <>
+      void axpy_L<Complex>(const std::vector<Complex> &a, cvector_ref<const ColorSpinorField> &x,
+                           cvector_ref<ColorSpinorField> &y)
+      {
+        // Enter a recursion.
+        // Pass a, x, y. (0,0) indexes the tiles. -1 indicates the matrix is lower-triangular
+        //                                         which lets us skip some tiles.
+        if (x.size() != y.size()) {
+          errorQuda("An optimal block caxpy_L with non-square 'a' (%lu != %lu) has not yet been implemented. Use block "
+                    "caxpy instead",
+                    x.size(), y.size());
+        }
+        axpy_recurse<multicaxpy_>(a, x, y, range(0, x.size()), range(0, y.size()), -1);
+      }
 
-        axpyz_recurse<Functor>(a_.first, x, y_.first, z_.first, range_x, range(range_y.first, range_y.first + y_.first.size()), pass, upper);
-        axpyz_recurse<Functor>(a_.second, x, y_.second, z_.second, range_x, range(range_y.first + y_.first.size(), range_y.second), pass, upper);
-      } else {
-        // if at bottom of recursion check where we are
-        if (is_valid_NXZ(x.size(), false, y[0].Precision())) {
-          // check if tile straddles diagonal for L/U variants
-          bool is_diagonal = (upper != 0) && (range_x.first < range_y.second) && (range_y.first < range_x.second);
-          // check if tile is first to be updated for full matrices
-          bool is_first = (upper == 0) && (range_x.first == 0);
-          // whether to do axpyz
-          bool do_axpyz = (upper != 0 && is_diagonal && pass == 0) || (upper == 0 && is_first);
-          // whether to do axpy
-          bool do_axpy = (upper != 0 && !is_diagonal && pass == 1) || (upper == 0 && !is_first);
+      void caxpy_L(const std::vector<Complex> &a, cvector_ref<const ColorSpinorField> &x,
+                   cvector_ref<ColorSpinorField> &y)
+      {
+        axpy_L(a, std::move(x), std::move(y));
+      }
 
-          if (do_axpyz) {
-            constexpr bool mixed = false;
-            instantiate<Functor, MultiBlas, mixed>(a, std::vector<T>(), std::vector<T>(), x[0], y[0], x, y, x, z);
-          } else if (do_axpy) {
-            // if upper triangular and upper-right tile corner is below diagonal return
-            if (upper == 1 && range_y.first >= range_x.second) { return; }
-            // if lower triangular and lower-left tile corner is above diagonal return
-            if (upper == -1 && range_x.first >= range_y.second) { return; }
+      template <template <typename...> class Functor, typename T>
+      void axpyz_recurse(const std::vector<T> &a, cvector_ref<const ColorSpinorField> &x,
+                         cvector_ref<const ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z, const range &range_x,
+                         const range &range_y, int pass, int upper)
+      {
+        if (a.size() != x.size() * y.size())
+          errorQuda("coefficient size %lu does not match vector set %lu * %lu", a.size(), x.size(), y.size());
 
-            // off diagonal
-            axpy(a, x, z);
+        // if greater than max single-kernel size, recurse
+        size_t max_yw_size = y[0].Precision() == QUDA_DOUBLE_PRECISION ?
+          max_YW_size<Functor<double>>(x.size(), x[0].Precision(), y[0].Precision()) :
+          max_YW_size<Functor<float>>(x.size(), x[0].Precision(), y[0].Precision());
+
+        if (y.size() > max_yw_size) {
+          // We need to split up 'a' carefully since it's row-major.
+          auto a_ = bisect_col(a, x.size(), y.size() / 2, y.size() - y.size() / 2);
+          auto y_ = bisect(y);
+          auto z_ = bisect(z);
+
+          axpyz_recurse<Functor>(a_.first, x, y_.first, z_.first, range_x,
+                                 range(range_y.first, range_y.first + y_.first.size()), pass, upper);
+          axpyz_recurse<Functor>(a_.second, x, y_.second, z_.second, range_x,
+                                 range(range_y.first + y_.first.size(), range_y.second), pass, upper);
+        } else {
+          // if at bottom of recursion check where we are
+          if (is_valid_NXZ(x.size(), false, y[0].Precision())) {
+            // check if tile straddles diagonal for L/U variants
+            bool is_diagonal = (upper != 0) && (range_x.first < range_y.second) && (range_y.first < range_x.second);
+            // check if tile is first to be updated for full matrices
+            bool is_first = (upper == 0) && (range_x.first == 0);
+            // whether to do axpyz
+            bool do_axpyz = (upper != 0 && is_diagonal && pass == 0) || (upper == 0 && is_first);
+            // whether to do axpy
+            bool do_axpy = (upper != 0 && !is_diagonal && pass == 1) || (upper == 0 && !is_first);
+
+            if (do_axpyz) {
+              constexpr bool mixed = false;
+              instantiate<Functor, MultiBlas, mixed>(a, std::vector<T>(), std::vector<T>(), x[0], y[0], x, y, x, z);
+            } else if (do_axpy) {
+              // if upper triangular and upper-right tile corner is below diagonal return
+              if (upper == 1 && range_y.first >= range_x.second) { return; }
+              // if lower triangular and lower-left tile corner is above diagonal return
+              if (upper == -1 && range_x.first >= range_y.second) { return; }
+
+              // off diagonal
+              axpy(a, x, z);
+            }
+          } else {
+            // split the problem in half and recurse
+            auto x_ = bisect(x);
+            auto a_ = bisect(a, y.size() * (x.size() / 2));
+
+            axpyz_recurse<Functor>(a_.first, x_.first, y, z, range(range_x.first, range_x.first + x_.first.size()),
+                                   range_y, pass, upper);
+            axpyz_recurse<Functor>(a_.second, x_.second, y, z, range(range_x.first + x_.first.size(), range_x.second),
+                                   range_y, pass, upper);
           }
+        } // end if (y.size() > max_YW_size())
+      }
+
+      void axpyz(const std::vector<double> &a, cvector_ref<const ColorSpinorField> &x,
+                 cvector_ref<const ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z)
+      {
+        axpyz_recurse<multiaxpyz_>(a, x, y, z, range(0, x.size()), range(0, y.size()), 0, 0);
+      }
+
+      void axpyz_U(const std::vector<double> &a, cvector_ref<const ColorSpinorField> &x,
+                   cvector_ref<const ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z)
+      {
+        if (x.size() != y.size()) {
+          errorQuda("An optimal block axpyz_U with non-square 'a' (%lu != %lu) has not yet been implemented. Use block "
+                    "axpyz instead",
+                    x.size(), y.size());
+        }
+        // a is upper triangular.
+        // first pass does the axpyz on the diagonal
+        axpyz_recurse<multiaxpyz_>(a, x, y, z, range(0, x.size()), range(0, y.size()), 0, 1);
+        // second pass does axpy on the off diagonals
+        axpyz_recurse<multiaxpyz_>(a, x, y, z, range(0, x.size()), range(0, y.size()), 1, 1);
+      }
+
+      void axpyz_L(const std::vector<double> &a, cvector_ref<const ColorSpinorField> &x,
+                   cvector_ref<const ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z)
+      {
+        if (x.size() != y.size()) {
+          errorQuda("An optimal block axpyz_L with non-square 'a' (%lu != %lu) has not yet been implemented. Use block "
+                    "axpyz instead",
+                    x.size(), y.size());
+        }
+        // a is upper triangular.
+        // first pass does the axpyz on the diagonal
+        axpyz_recurse<multiaxpyz_>(a, x, y, z, range(0, x.size()), range(0, y.size()), 0, -1);
+        // second pass does axpy on the off diagonals
+        axpyz_recurse<multiaxpyz_>(a, x, y, z, range(0, x.size()), range(0, y.size()), 1, -1);
+      }
+
+      void caxpyz(const std::vector<Complex> &a, cvector_ref<const ColorSpinorField> &x,
+                  cvector_ref<const ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z)
+      {
+        axpyz_recurse<multicaxpyz_>(a, x, y, z, range(0, x.size()), range(0, y.size()), 0, 0);
+      }
+
+      void caxpyz_U(const std::vector<Complex> &a, cvector_ref<const ColorSpinorField> &x,
+                    cvector_ref<const ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z)
+      {
+        if (x.size() != y.size()) {
+          errorQuda("An optimal block caxpyz_U with non-square 'a' (%lu != %lu) has not yet been implemented. Use "
+                    "block caxpyz instead",
+                    x.size(), y.size());
+        }
+        // a is upper triangular.
+        // first pass does the caxpyz on the diagonal
+        axpyz_recurse<multicaxpyz_>(a, x, y, z, range(0, x.size()), range(0, y.size()), 0, 1);
+        // second pass does caxpy on the off diagonals
+        axpyz_recurse<multicaxpyz_>(a, x, y, z, range(0, x.size()), range(0, y.size()), 1, 1);
+      }
+
+      void axpyz_L(const std::vector<Complex> &a, cvector_ref<const ColorSpinorField> &x,
+                   cvector_ref<const ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z)
+      {
+        if (x.size() != y.size()) {
+          errorQuda("An optimal block axpyz_U with non-square 'a' (%lu != %lu) has not yet been implemented. Use block "
+                    "axpyz instead",
+                    x.size(), y.size());
+        }
+        // a is upper triangular.
+        // first pass does the caxpyz on the diagonal
+        axpyz_recurse<multicaxpyz_>(a, x, y, z, range(0, x.size()), range(0, y.size()), 0, -1);
+        // second pass does caxpy on the off diagonals
+        axpyz_recurse<multicaxpyz_>(a, x, y, z, range(0, x.size()), range(0, y.size()), 1, -1);
+      }
+
+      void axpyBzpcx(const std::vector<double> &a, cvector_ref<ColorSpinorField> &x_, cvector_ref<ColorSpinorField> &y_,
+                     const std::vector<double> &b, ColorSpinorField &z_, const std::vector<double> &c)
+      {
+        if (y_.size() <= (size_t)max_N_multi_1d()) {
+          // swizzle order since we are writing to x_ and y_, but the
+          // multi-blas only allow writing to y and w, and moreover the
+          // block width of y and w must match, and x and z must match.
+          auto &y = y_;
+          auto &w = x_;
+
+          // wrap a container around the third solo vector
+          cvector_ref<ColorSpinorField> x {z_};
+
+          constexpr bool mixed = true;
+          instantiate<multi_axpyBzpcx_, MultiBlas, mixed>(a, b, c, x[0], y[0], x, y, x, w);
         } else {
           // split the problem in half and recurse
-          auto x_ = bisect(x);
-          auto a_ = bisect(a, y.size() * (x.size() / 2));
+          auto a_ = bisect(a);
+          auto b_ = bisect(b);
+          auto c_ = bisect(c);
+          auto x = bisect(x_);
+          auto y = bisect(y_);
 
-          axpyz_recurse<Functor>(a_.first, x_.first, y, z, range(range_x.first, range_x.first + x_.first.size()), range_y, pass, upper);
-          axpyz_recurse<Functor>(a_.second, x_.second, y, z, range(range_x.first + x_.first.size(), range_x.second), range_y, pass, upper);
+          axpyBzpcx(a_.first, x.first, y.first, b_.first, z_, c_.first);
+          axpyBzpcx(a_.second, x.second, y.second, b_.second, z_, c_.second);
         }
-      } // end if (y.size() > max_YW_size())
-    }
-
-    void axpyz(const std::vector<double> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z)
-    {
-      axpyz_recurse<multiaxpyz_>(a, x, y, z, range(0, x.size()), range(0, y.size()), 0, 0);
-    }
-
-    void axpyz_U(const std::vector<double> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z)
-    {
-      if (x.size() != y.size()) {
-        errorQuda("An optimal block axpyz_U with non-square 'a' (%lu != %lu) has not yet been implemented. Use block axpyz instead",
-                  x.size(), y.size());
       }
-      // a is upper triangular.
-      // first pass does the axpyz on the diagonal
-      axpyz_recurse<multiaxpyz_>(a, x, y, z, range(0, x.size()), range(0, y.size()), 0, 1);
-      // second pass does axpy on the off diagonals
-      axpyz_recurse<multiaxpyz_>(a, x, y, z, range(0, x.size()), range(0, y.size()), 1, 1);
-    }
 
-    void axpyz_L(const std::vector<double> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z)
-    {
-      if (x.size() != y.size()) {
-        errorQuda("An optimal block axpyz_L with non-square 'a' (%lu != %lu) has not yet been implemented. Use block axpyz instead",
-                  x.size(), y.size());
-      }
-      // a is upper triangular.
-      // first pass does the axpyz on the diagonal
-      axpyz_recurse<multiaxpyz_>(a, x, y, z, range(0, x.size()), range(0, y.size()), 0, -1);
-      // second pass does axpy on the off diagonals
-      axpyz_recurse<multiaxpyz_>(a, x, y, z, range(0, x.size()), range(0, y.size()), 1, -1);
-    }
-
-    void caxpyz(const std::vector<Complex> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z)
-    {
-      axpyz_recurse<multicaxpyz_>(a, x, y, z, range(0, x.size()), range(0, y.size()), 0, 0);
-    }
-
-    void caxpyz_U(const std::vector<Complex> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z)
-    {
-      if (x.size() != y.size()) {
-        errorQuda("An optimal block caxpyz_U with non-square 'a' (%lu != %lu) has not yet been implemented. Use block caxpyz instead",
-                  x.size(), y.size());
-      }
-      // a is upper triangular.
-      // first pass does the caxpyz on the diagonal
-      axpyz_recurse<multicaxpyz_>(a, x, y, z, range(0, x.size()), range(0, y.size()), 0, 1);
-      // second pass does caxpy on the off diagonals
-      axpyz_recurse<multicaxpyz_>(a, x, y, z, range(0, x.size()), range(0, y.size()), 1, 1);
-    }
-
-    void axpyz_L(const std::vector<Complex> &a, cvector_ref<const ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z)
-    {
-      if (x.size() != y.size()) {
-        errorQuda("An optimal block axpyz_U with non-square 'a' (%lu != %lu) has not yet been implemented. Use block axpyz instead",
-                  x.size(), y.size());
-      }
-      // a is upper triangular.
-      // first pass does the caxpyz on the diagonal
-      axpyz_recurse<multicaxpyz_>(a, x, y, z, range(0, x.size()), range(0, y.size()), 0, -1);
-      // second pass does caxpy on the off diagonals
-      axpyz_recurse<multicaxpyz_>(a, x, y, z, range(0, x.size()), range(0, y.size()), 1, -1);
-    }
-
-    void axpyBzpcx(const std::vector<double> &a, cvector_ref<ColorSpinorField> &x_, cvector_ref<ColorSpinorField> &y_,
-                   const std::vector<double> &b, ColorSpinorField &z_, const std::vector<double> &c)
-    {
-      if (y_.size() <= (size_t)max_N_multi_1d()) {
-        // swizzle order since we are writing to x_ and y_, but the
-	// multi-blas only allow writing to y and w, and moreover the
-	// block width of y and w must match, and x and z must match.
-	auto &y = y_;
-	auto &w = x_;
-
-	// wrap a container around the third solo vector
-	cvector_ref<ColorSpinorField> x{z_};
-
-        constexpr bool mixed = true;
-        instantiate<multi_axpyBzpcx_, MultiBlas, mixed>(a, b, c, x[0], y[0], x, y, x, w);
-      } else {
-        // split the problem in half and recurse
-        auto a_ = bisect(a);
-        auto b_ = bisect(b);
-        auto c_ = bisect(c);
-        auto x = bisect(x_);
-        auto y = bisect(y_);
-
-	axpyBzpcx(a_.first, x.first, y.first, b_.first, z_, c_.first);
-	axpyBzpcx(a_.second, x.second, y.second, b_.second, z_, c_.second);
-      }
-    }
-
-    void caxpyBxpz(const std::vector<Complex> &a, cvector_ref<const ColorSpinorField> &x_, ColorSpinorField &y_,
-                   const std::vector<Complex> &b, ColorSpinorField &z_)
-    {
-      if (x_.size() <= (size_t)max_N_multi_1d() && is_valid_NXZ(x_.size(), false, y_.Precision())) // only split if we have to.
+      void caxpyBxpz(const std::vector<Complex> &a, cvector_ref<const ColorSpinorField> &x_, ColorSpinorField &y_,
+                     const std::vector<Complex> &b, ColorSpinorField &z_)
       {
-        // swizzle order since we are writing to y_ and z_, but the
-        // multi-blas only allow writing to y and w, and moreover the
-        // block width of y and w must match, and x and z must match.
-        // Also, wrap a container around them.
-        cvector_ref<ColorSpinorField> y{y_};
-        cvector_ref<ColorSpinorField> w{z_};
+        if (x_.size() <= (size_t)max_N_multi_1d()
+            && is_valid_NXZ(x_.size(), false, y_.Precision())) // only split if we have to.
+        {
+          // swizzle order since we are writing to y_ and z_, but the
+          // multi-blas only allow writing to y and w, and moreover the
+          // block width of y and w must match, and x and z must match.
+          // Also, wrap a container around them.
+          cvector_ref<ColorSpinorField> y {y_};
+          cvector_ref<ColorSpinorField> w {z_};
 
-        // we're reading from x
-        auto &x = x_;
+          // we're reading from x
+          auto &x = x_;
 
-        constexpr bool mixed = true;
-        instantiate<multi_caxpyBxpz_, MultiBlas, mixed>(a, b, std::vector<Complex>(), x[0], y[0], x, y, x, w);
-      } else {
-        // split the problem in half and recurse
-        auto a_ = bisect(a);
-        auto b_ = bisect(b);
-        auto x = bisect(x_);
+          constexpr bool mixed = true;
+          instantiate<multi_caxpyBxpz_, MultiBlas, mixed>(a, b, std::vector<Complex>(), x[0], y[0], x, y, x, w);
+        } else {
+          // split the problem in half and recurse
+          auto a_ = bisect(a);
+          auto b_ = bisect(b);
+          auto x = bisect(x_);
 
-        caxpyBxpz(a_.first, x.first, y_, b_.first, z_);
-        caxpyBxpz(a_.second, x.second, y_, b_.second, z_);
+          caxpyBxpz(a_.first, x.first, y_, b_.first, z_);
+          caxpyBxpz(a_.second, x.second, y_, b_.second, z_);
+        }
       }
-    }
 
-    // temporary wrappers
-    void axpy(const double *a, std::vector<ColorSpinorField*> &x, std::vector<ColorSpinorField*> &y)
+      // temporary wrappers
+      void axpy(const double *a, std::vector<ColorSpinorField *> &x, std::vector<ColorSpinorField *> &y)
+      {
+        std::vector<double> a_(x.size() * y.size());
+        memcpy(a_.data(), a, x.size() * y.size() * sizeof(double));
+        vector_ref<const ColorSpinorField> x_;
+        for (auto &xi : x) x_.push_back(*xi);
+        vector_ref<ColorSpinorField> y_;
+        for (auto &yi : y) y_.push_back(*yi);
+        axpy(a_, x_, y_);
+      }
+
+      void axpy_U(const double *a, std::vector<ColorSpinorField *> &x, std::vector<ColorSpinorField *> &y)
+      {
+        std::vector<double> a_(x.size() * y.size());
+        memcpy(a_.data(), a, x.size() * y.size() * sizeof(double));
+        vector_ref<const ColorSpinorField> x_;
+        for (auto &xi : x) x_.push_back(*xi);
+        vector_ref<ColorSpinorField> y_;
+        for (auto &yi : y) y_.push_back(*yi);
+        axpy_U(a_, x_, y_);
+      }
+
+      void axpy_L(const double *a, std::vector<ColorSpinorField *> &x, std::vector<ColorSpinorField *> &y)
+      {
+        std::vector<double> a_(x.size() * y.size());
+        memcpy(a_.data(), a, x.size() * y.size() * sizeof(double));
+        vector_ref<const ColorSpinorField> x_;
+        for (auto &xi : x) x_.push_back(*xi);
+        vector_ref<ColorSpinorField> y_;
+        for (auto &yi : y) y_.push_back(*yi);
+        axpy_L(a_, x_, y_);
+      }
+
+    } // namespace block
+
+    namespace legacy
     {
-      std::vector<double> a_(x.size() * y.size());
-      memcpy(a_.data(), a, x.size() * y.size() * sizeof(double));
-      vector_ref<const ColorSpinorField> x_;
-      for (auto &xi : x) x_.push_back(*xi);
-      vector_ref<ColorSpinorField> y_;
-      for (auto &yi : y) y_.push_back(*yi);
-      axpy(a_, x_, y_);
-    }
-
-    void axpy_U(const double *a, std::vector<ColorSpinorField*> &x, std::vector<ColorSpinorField*> &y)
-    {
-      std::vector<double> a_(x.size() * y.size());
-      memcpy(a_.data(), a, x.size() * y.size() * sizeof(double));
-      vector_ref<const ColorSpinorField> x_;
-      for (auto &xi : x) x_.push_back(*xi);
-      vector_ref<ColorSpinorField> y_;
-      for (auto &yi : y) y_.push_back(*yi);
-      axpy_U(a_, x_, y_);
-    }
-
-    void axpy_L(const double *a, std::vector<ColorSpinorField*> &x, std::vector<ColorSpinorField*> &y)
-    {
-      std::vector<double> a_(x.size() * y.size());
-      memcpy(a_.data(), a, x.size() * y.size() * sizeof(double));
-      vector_ref<const ColorSpinorField> x_;
-      for (auto &xi : x) x_.push_back(*xi);
-      vector_ref<ColorSpinorField> y_;
-      for (auto &yi : y) y_.push_back(*yi);
-      axpy_L(a_, x_, y_);
-    }
-
-  }
-
-    namespace legacy {
-      void caxpy(const Complex *a, std::vector<ColorSpinorField*> &x, std::vector<ColorSpinorField*> &y) {
+      void caxpy(const Complex *a, std::vector<ColorSpinorField *> &x, std::vector<ColorSpinorField *> &y)
+      {
         std::vector<Complex> a_(x.size() * y.size());
         memcpy(a_.data(), a, x.size() * y.size() * sizeof(Complex));
         vector_ref<const ColorSpinorField> x_;
@@ -612,85 +640,87 @@ namespace quda {
         blas::block::caxpy(a_, x_, y_);
       }
 
-    void caxpy_U(const Complex *a, std::vector<ColorSpinorField*> &x, std::vector<ColorSpinorField*> &y) {
-      std::vector<Complex> a_(x.size() * y.size());
-      memcpy(a_.data(), a, x.size() * y.size() * sizeof(Complex));
-      vector_ref<const ColorSpinorField> x_;
-      for (auto &xi : x) x_.push_back(*xi);
-      vector_ref<ColorSpinorField> y_;
-      for (auto &yi : y) y_.push_back(*yi);
-      blas::block::caxpy_U(a_, x_, y_);
-    }
+      void caxpy_U(const Complex *a, std::vector<ColorSpinorField *> &x, std::vector<ColorSpinorField *> &y)
+      {
+        std::vector<Complex> a_(x.size() * y.size());
+        memcpy(a_.data(), a, x.size() * y.size() * sizeof(Complex));
+        vector_ref<const ColorSpinorField> x_;
+        for (auto &xi : x) x_.push_back(*xi);
+        vector_ref<ColorSpinorField> y_;
+        for (auto &yi : y) y_.push_back(*yi);
+        blas::block::caxpy_U(a_, x_, y_);
+      }
 
-    void caxpy_L(const Complex *a, std::vector<ColorSpinorField*> &x, std::vector<ColorSpinorField*> &y) {
-      std::vector<Complex> a_(x.size() * y.size());
-      memcpy(a_.data(), a, x.size() * y.size() * sizeof(Complex));
-      vector_ref<const ColorSpinorField> x_;
-      for (auto &xi : x) x_.push_back(*xi);
-      vector_ref<ColorSpinorField> y_;
-      for (auto &yi : y) y_.push_back(*yi);
-      blas::block::caxpy_L(a_, x_, y_);
-    }
+      void caxpy_L(const Complex *a, std::vector<ColorSpinorField *> &x, std::vector<ColorSpinorField *> &y)
+      {
+        std::vector<Complex> a_(x.size() * y.size());
+        memcpy(a_.data(), a, x.size() * y.size() * sizeof(Complex));
+        vector_ref<const ColorSpinorField> x_;
+        for (auto &xi : x) x_.push_back(*xi);
+        vector_ref<ColorSpinorField> y_;
+        for (auto &yi : y) y_.push_back(*yi);
+        blas::block::caxpy_L(a_, x_, y_);
+      }
 
-    void axpyz(const double *a, std::vector<ColorSpinorField*> &x, std::vector<ColorSpinorField*> &y,
-               std::vector<ColorSpinorField*> &z)
-    {
-      std::vector<double> a_(x.size() * y.size());
-      memcpy(a_.data(), a, x.size() * y.size() * sizeof(double));
-      vector_ref<const ColorSpinorField> x_;
-      for (auto &xi : x) x_.push_back(*xi);
-      vector_ref<const ColorSpinorField> y_;
-      for (auto &yi : y) y_.push_back(*yi);
-      vector_ref<ColorSpinorField> z_;
-      for (auto &zi : z) z_.push_back(*zi);
-      blas::block::axpyz(a_, x_, y_, z_);
-    }
+      void axpyz(const double *a, std::vector<ColorSpinorField *> &x, std::vector<ColorSpinorField *> &y,
+                 std::vector<ColorSpinorField *> &z)
+      {
+        std::vector<double> a_(x.size() * y.size());
+        memcpy(a_.data(), a, x.size() * y.size() * sizeof(double));
+        vector_ref<const ColorSpinorField> x_;
+        for (auto &xi : x) x_.push_back(*xi);
+        vector_ref<const ColorSpinorField> y_;
+        for (auto &yi : y) y_.push_back(*yi);
+        vector_ref<ColorSpinorField> z_;
+        for (auto &zi : z) z_.push_back(*zi);
+        blas::block::axpyz(a_, x_, y_, z_);
+      }
 
-    void caxpyz(const Complex *a, std::vector<ColorSpinorField*> &x, std::vector<ColorSpinorField*> &y,
-               std::vector<ColorSpinorField*> &z)
-    {
-      std::vector<Complex> a_(x.size() * y.size());
-      memcpy(a_.data(), a, x.size() * y.size() * sizeof(Complex));
-      vector_ref<const ColorSpinorField> x_;
-      for (auto &xi : x) x_.push_back(*xi);
-      vector_ref<const ColorSpinorField> y_;
-      for (auto &yi : y) y_.push_back(*yi);
-      vector_ref<ColorSpinorField> z_;
-      for (auto &zi : z) z_.push_back(*zi);
-      blas::block::caxpyz(a_, x_, y_, z_);
-    }
+      void caxpyz(const Complex *a, std::vector<ColorSpinorField *> &x, std::vector<ColorSpinorField *> &y,
+                  std::vector<ColorSpinorField *> &z)
+      {
+        std::vector<Complex> a_(x.size() * y.size());
+        memcpy(a_.data(), a, x.size() * y.size() * sizeof(Complex));
+        vector_ref<const ColorSpinorField> x_;
+        for (auto &xi : x) x_.push_back(*xi);
+        vector_ref<const ColorSpinorField> y_;
+        for (auto &yi : y) y_.push_back(*yi);
+        vector_ref<ColorSpinorField> z_;
+        for (auto &zi : z) z_.push_back(*zi);
+        blas::block::caxpyz(a_, x_, y_, z_);
+      }
 
-    void axpyBzpcx(const double *a, std::vector<ColorSpinorField *> &x, std::vector<ColorSpinorField *> &y,
-                   const double *b, ColorSpinorField &z, const double *c)
-    {
-      std::vector<double> a_(x.size());
-      memcpy(a_.data(), a, x.size() * sizeof(double));
-      std::vector<double> b_(x.size());
-      memcpy(b_.data(), b, x.size() * sizeof(double));
-      std::vector<double> c_(x.size());
-      memcpy(c_.data(), c, x.size() * sizeof(double));
+      void axpyBzpcx(const double *a, std::vector<ColorSpinorField *> &x, std::vector<ColorSpinorField *> &y,
+                     const double *b, ColorSpinorField &z, const double *c)
+      {
+        std::vector<double> a_(x.size());
+        memcpy(a_.data(), a, x.size() * sizeof(double));
+        std::vector<double> b_(x.size());
+        memcpy(b_.data(), b, x.size() * sizeof(double));
+        std::vector<double> c_(x.size());
+        memcpy(c_.data(), c, x.size() * sizeof(double));
 
-      vector_ref<ColorSpinorField> x_;
-      for (auto &xi : x) x_.push_back(*xi);
-      vector_ref<ColorSpinorField> y_;
-      for (auto &yi : y) y_.push_back(*yi);
-      blas::block::axpyBzpcx(a_, x_, y_, b_, z, c_);
-    }
+        vector_ref<ColorSpinorField> x_;
+        for (auto &xi : x) x_.push_back(*xi);
+        vector_ref<ColorSpinorField> y_;
+        for (auto &yi : y) y_.push_back(*yi);
+        blas::block::axpyBzpcx(a_, x_, y_, b_, z, c_);
+      }
 
-    void caxpyBxpz(const Complex *a, std::vector<ColorSpinorField*> &x, ColorSpinorField &y,
-		   const Complex *b, ColorSpinorField &z)
-    {
-      std::vector<Complex> a_(x.size());
-      memcpy(a_.data(), a, x.size() * sizeof(Complex));
-      std::vector<Complex> b_(x.size());
-      memcpy(b_.data(), b, x.size() * sizeof(Complex));
+      void caxpyBxpz(const Complex *a, std::vector<ColorSpinorField *> &x, ColorSpinorField &y, const Complex *b,
+                     ColorSpinorField &z)
+      {
+        std::vector<Complex> a_(x.size());
+        memcpy(a_.data(), a, x.size() * sizeof(Complex));
+        std::vector<Complex> b_(x.size());
+        memcpy(b_.data(), b, x.size() * sizeof(Complex));
 
-      vector_ref<const ColorSpinorField> x_;
-      for (auto &xi : x) x_.push_back(*xi);
-      blas::block::caxpyBxpz(a_, x_, y, b_, z);
-    }
+        vector_ref<const ColorSpinorField> x_;
+        for (auto &xi : x) x_.push_back(*xi);
+        blas::block::caxpyBxpz(a_, x_, y, b_, z);
+      }
 
-    }
+    } // namespace legacy
 
   } // namespace blas
 

--- a/lib/multi_blas_quda.cu
+++ b/lib/multi_blas_quda.cu
@@ -597,14 +597,16 @@ namespace quda {
       axpy_L(a_, x_, y_);
     }
 
-    void caxpy(const Complex *a, std::vector<ColorSpinorField*> &x, std::vector<ColorSpinorField*> &y) {
-      std::vector<Complex> a_(x.size() * y.size());
-      memcpy(a_.data(), a, x.size() * y.size() * sizeof(Complex));
-      vector_ref<const ColorSpinorField> x_;
-      for (auto &xi : x) x_.push_back(*xi);
-      vector_ref<ColorSpinorField> y_;
-      for (auto &yi : y) y_.push_back(*yi);
-      caxpy(a_, x_, y_);
+    namespace legacy {
+      void caxpy(const Complex *a, std::vector<ColorSpinorField*> &x, std::vector<ColorSpinorField*> &y) {
+        std::vector<Complex> a_(x.size() * y.size());
+        memcpy(a_.data(), a, x.size() * y.size() * sizeof(Complex));
+        vector_ref<const ColorSpinorField> x_;
+        for (auto &xi : x) x_.push_back(*xi);
+        vector_ref<ColorSpinorField> y_;
+        for (auto &yi : y) y_.push_back(*yi);
+        blas::caxpy(a_, x_, y_);
+      }
     }
 
     void caxpy_U(const Complex *a, std::vector<ColorSpinorField*> &x, std::vector<ColorSpinorField*> &y) {

--- a/lib/multi_reduce_quda.cu
+++ b/lib/multi_reduce_quda.cu
@@ -593,6 +593,8 @@ namespace quda {
       void postTune() override {} // FIXME - use write to determine what needs to be saved
     };
 
+    namespace block {
+
     void reDotProduct(std::vector<double> &result, cvector_ref<const ColorSpinorField> &x,
                       cvector_ref<const ColorSpinorField> &y)
     {
@@ -744,18 +746,21 @@ namespace quda {
           result[i * y.size() + j] = conj(result[j * x.size() + i]);
     }
 
-    void reDotProduct(double *result, std::vector<ColorSpinorField*> &x, std::vector<ColorSpinorField*> &y)
-    {
-      std::vector<double> result_(x.size() * y.size());
-      vector_ref<const ColorSpinorField> x_;
-      for (auto &xi : x) x_.push_back(*xi);
-      vector_ref<const ColorSpinorField> y_;
-      for (auto &yi : y) y_.push_back(*yi);
-      reDotProduct(result_, std::move(x_), std::move(y_));
-      memcpy(result, result_.data(), x.size() * y.size() * sizeof(double));
     }
 
     namespace legacy {
+
+      void reDotProduct(double *result, std::vector<ColorSpinorField*> &x, std::vector<ColorSpinorField*> &y)
+      {
+        std::vector<double> result_(x.size() * y.size());
+        vector_ref<const ColorSpinorField> x_;
+        for (auto &xi : x) x_.push_back(*xi);
+        vector_ref<const ColorSpinorField> y_;
+        for (auto &yi : y) y_.push_back(*yi);
+        blas::block::reDotProduct(result_, std::move(x_), std::move(y_));
+        memcpy(result, result_.data(), x.size() * y.size() * sizeof(double));
+      }
+
       void cDotProduct(Complex *result, std::vector<ColorSpinorField*> &x, std::vector<ColorSpinorField*> &y)
       {
         std::vector<Complex> result_(x.size() * y.size());
@@ -763,20 +768,21 @@ namespace quda {
         for (auto &xi : x) x_.push_back(*xi);
         vector_ref<const ColorSpinorField> y_;
         for (auto &yi : y) y_.push_back(*yi);
-        blas::cDotProduct(result_, std::move(x_), std::move(y_));
+        blas::block::cDotProduct(result_, std::move(x_), std::move(y_));
         memcpy(result, result_.data(), x.size() * y.size() * sizeof(Complex));
       }
-    }
 
-    void hDotProduct(Complex *result, std::vector<ColorSpinorField*> &x, std::vector<ColorSpinorField*> &y)
-    {
-      std::vector<Complex> result_(x.size() * y.size());
-      vector_ref<const ColorSpinorField> x_;
-      for (auto &xi : x) x_.push_back(*xi);
-      vector_ref<const ColorSpinorField> y_;
-      for (auto &yi : y) y_.push_back(*yi);
-      hDotProduct(result_, std::move(x_), std::move(y_));
-      memcpy(result, result_.data(), x.size() * y.size() * sizeof(Complex));
+      void hDotProduct(Complex *result, std::vector<ColorSpinorField*> &x, std::vector<ColorSpinorField*> &y)
+      {
+        std::vector<Complex> result_(x.size() * y.size());
+        vector_ref<const ColorSpinorField> x_;
+        for (auto &xi : x) x_.push_back(*xi);
+        vector_ref<const ColorSpinorField> y_;
+        for (auto &yi : y) y_.push_back(*yi);
+        blas::block::hDotProduct(result_, std::move(x_), std::move(y_));
+        memcpy(result, result_.data(), x.size() * y.size() * sizeof(Complex));
+      }
+
     }
 
   } // namespace blas

--- a/lib/multi_reduce_quda.cu
+++ b/lib/multi_reduce_quda.cu
@@ -755,15 +755,17 @@ namespace quda {
       memcpy(result, result_.data(), x.size() * y.size() * sizeof(double));
     }
 
-    void cDotProduct(Complex *result, std::vector<ColorSpinorField*> &x, std::vector<ColorSpinorField*> &y)
-    {
-      std::vector<Complex> result_(x.size() * y.size());
-      vector_ref<const ColorSpinorField> x_;
-      for (auto &xi : x) x_.push_back(*xi);
-      vector_ref<const ColorSpinorField> y_;
-      for (auto &yi : y) y_.push_back(*yi);
-      cDotProduct(result_, std::move(x_), std::move(y_));
-      memcpy(result, result_.data(), x.size() * y.size() * sizeof(Complex));
+    namespace legacy {
+      void cDotProduct(Complex *result, std::vector<ColorSpinorField*> &x, std::vector<ColorSpinorField*> &y)
+      {
+        std::vector<Complex> result_(x.size() * y.size());
+        vector_ref<const ColorSpinorField> x_;
+        for (auto &xi : x) x_.push_back(*xi);
+        vector_ref<const ColorSpinorField> y_;
+        for (auto &yi : y) y_.push_back(*yi);
+        blas::cDotProduct(result_, std::move(x_), std::move(y_));
+        memcpy(result, result_.data(), x.size() * y.size() * sizeof(Complex));
+      }
     }
 
     void hDotProduct(Complex *result, std::vector<ColorSpinorField*> &x, std::vector<ColorSpinorField*> &y)

--- a/lib/multigrid.cpp
+++ b/lib/multigrid.cpp
@@ -1176,7 +1176,10 @@ namespace quda
         b_tilde = in; // b_tilde holds either a copy of preconditioned source or a pointer to original source
       }
 
-      if (presmoother) (*presmoother)(out, in); else zero(out);
+      if (presmoother)
+        (*presmoother)(out, in);
+      else
+        zero(out);
 
       ColorSpinorField &solution = inner_solution_type == outer_solution_type ? x : x.Even();
       diracSmoother->reconstruct(solution, b, inner_solution_type);
@@ -1239,7 +1242,8 @@ namespace quda
       // we should keep a copy of the prepared right hand side as we've already destroyed it
       //dirac.prepare(in, out, solution, residual, inner_solution_type);
 
-      if (postsmoother) (*postsmoother)(out, in); // for inner solve preconditioned, in the should be the original prepared rhs
+      if (postsmoother)
+        (*postsmoother)(out, in); // for inner solve preconditioned, in the should be the original prepared rhs
 
       if (debug) printfQuda("exited postsmooth, about to reconstruct\n");
 

--- a/lib/multigrid.cpp
+++ b/lib/multigrid.cpp
@@ -1166,18 +1166,17 @@ namespace quda
       // do the pre smoothing
       if (debug) printfQuda("pre-smoothing b2=%e site subset %d\n", norm2(b), b.SiteSubset());
 
-      ColorSpinorField *out=nullptr, *in=nullptr;
-
-      diracSmoother->prepare(in, out, x, b, outer_solution_type);
+      ColorSpinorField out, in;
+      diracSmoother->prepare(out, in, x, b, outer_solution_type);
 
       ColorSpinorField b_tilde;
       // if we're using preconditioning then allocate storage for the preconditioned source vector
       if (param.smoother_solve_type == QUDA_DIRECT_PC_SOLVE) {
         b_tilde = getFieldTmp(r.Even());
-        b_tilde = *in; // b_tilde holds either a copy of preconditioned source or a pointer to original source
+        b_tilde = in; // b_tilde holds either a copy of preconditioned source or a pointer to original source
       }
 
-      if (presmoother) (*presmoother)(*out, *in); else zero(*out);
+      if (presmoother) (*presmoother)(out, in); else zero(out);
 
       ColorSpinorField &solution = inner_solution_type == outer_solution_type ? x : x.Even();
       diracSmoother->reconstruct(solution, b, inner_solution_type);
@@ -1231,16 +1230,16 @@ namespace quda
       // do the post smoothing
       // residual = outer_solution_type == QUDA_MAT_SOLUTION ? r : r.Even(); // refine for outer solution type
       if (param.smoother_solve_type == QUDA_DIRECT_PC_SOLVE) {
-        in = &b_tilde;
+        in = b_tilde.create_alias();
       } else { // this incurs unecessary copying
         r = b;
-        in = &r;
+        in = r.create_alias();
       }
 
       // we should keep a copy of the prepared right hand side as we've already destroyed it
       //dirac.prepare(in, out, solution, residual, inner_solution_type);
 
-      if (postsmoother) (*postsmoother)(*out, *in); // for inner solve preconditioned, in the should be the original prepared rhs
+      if (postsmoother) (*postsmoother)(out, in); // for inner solve preconditioned, in the should be the original prepared rhs
 
       if (debug) printfQuda("exited postsmooth, about to reconstruct\n");
 
@@ -1250,9 +1249,9 @@ namespace quda
 
     } else { // do the coarse grid solve
 
-      ColorSpinorField *out=nullptr, *in=nullptr;
-      diracSmoother->prepare(in, out, x, b, outer_solution_type);
-      if (presmoother) (*presmoother)(*out, *in);
+      ColorSpinorField out, in;
+      diracSmoother->prepare(out, in, x, b, outer_solution_type);
+      if (presmoother) (*presmoother)(out, in);
       diracSmoother->reconstruct(x, b, outer_solution_type);
     }
 
@@ -1437,9 +1436,9 @@ namespace quda
         logQuda(QUDA_VERBOSE, "Initial guess = %g\n", norm2(x));
         logQuda(QUDA_VERBOSE, "Initial rhs = %g\n", norm2(b));
 
-        ColorSpinorField *out=nullptr, *in=nullptr;
-        diracSmoother->prepare(in, out, x, b, QUDA_MAT_SOLUTION);
-        (*solve)(*out, *in);
+        ColorSpinorField out, in;
+        diracSmoother->prepare(out, in, x, b, QUDA_MAT_SOLUTION);
+        (*solve)(out, in);
         diracSmoother->reconstruct(x, b, QUDA_MAT_SOLUTION);
 
         logQuda(QUDA_VERBOSE, "Solution = %g\n", norm2(x));

--- a/lib/reduce_quda.cu
+++ b/lib/reduce_quda.cu
@@ -148,125 +148,230 @@ namespace quda {
       return value;
     }
 
-    double max(const ColorSpinorField &x)
+    cvector<double> max(cvector_ref<const ColorSpinorField> &x)
     {
-      return instantiateReduce<Max, false>(0.0, 0.0, 0.0, x, x, x, x, x);
+      vector<double> max(x.size());
+      for (auto i = 0u; i < x.size(); i++)
+        max[i] = instantiateReduce<Max, false>(0.0, 0.0, 0.0, x[i], x[i], x[i], x[i], x[i]);
+      return max;
     }
 
-    array<double, 2> max_deviation(const ColorSpinorField &x, const ColorSpinorField &y)
+    cvector<array<double, 2>> max_deviation(cvector_ref<const ColorSpinorField> &x,
+                                            cvector_ref<const ColorSpinorField> &y)
     {
-      auto deviation = instantiateReduce<MaxDeviation, true>(0.0, 0.0, 0.0, x, y, x, x, x);
-      // ensure that if the absolute deviation is zero, so is the relative deviation
-      return {deviation.diff, deviation.diff > 0.0 ? deviation.diff / deviation.ref : 0.0};
+      check_size(x, y);
+      vector<array<double, 2>> deviation(x.size());
+      for (auto i = 0u; i < x.size(); i++) {
+        auto dev = instantiateReduce<MaxDeviation, true>(0.0, 0.0, 0.0, x[i], y[i], x[i], x[i], x[i]);
+        // ensure that if the absolute deviation is zero, so is the relative deviation
+        deviation[i] = {dev.diff, dev.diff > 0.0 ? dev.diff / dev.ref : 0.0};
+      }
+      return deviation;
     }
 
-    double norm1(const ColorSpinorField &x)
+    cvector<double> norm1(cvector_ref<const ColorSpinorField> &x)
     {
-      return instantiateReduce<Norm1, false>(0.0, 0.0, 0.0, x, x, x, x, x);
+      vector<double> norm1(x.size());
+      for (auto i = 0u; i < x.size(); i++)
+        norm1[i] = instantiateReduce<Norm1, false>(0.0, 0.0, 0.0, x[i], x[i], x[i], x[i], x[i]);
+      return norm1;
     }
 
-    double norm2(const ColorSpinorField &x)
+    cvector<double> norm2(cvector_ref<const ColorSpinorField> &x)
     {
-      return instantiateReduce<Norm2, false>(0.0, 0.0, 0.0, x, x, x, x, x);
+      vector<double> norm2(x.size());
+      for (auto i = 0u; i < x.size(); i++)
+        norm2[i] = instantiateReduce<Norm2, false>(0.0, 0.0, 0.0, x[i], x[i], x[i], x[i], x[i]);
+      return norm2;
     }
 
-    double reDotProduct(const ColorSpinorField &x, const ColorSpinorField &y)
+    cvector<double> reDotProduct(cvector_ref<const ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &y)
     {
-      return instantiateReduce<Dot, false>(0.0, 0.0, 0.0, x, y, x, x, x);
+      check_size(x, y);
+      vector<double> dot(x.size());
+      for (auto i = 0u; i < x.size(); i++)
+        dot[i] = instantiateReduce<Dot, false>(0.0, 0.0, 0.0, x[i], y[i], x[i], x[i], x[i]);
+      return dot;
     }
 
-    double axpbyzNorm(double a, const ColorSpinorField &x, double b, const ColorSpinorField &y, ColorSpinorField &z)
+    cvector<double> axpbyzNorm(cvector<double> &a, cvector_ref<const ColorSpinorField> &x, cvector<double> &b,
+                               cvector_ref<const ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z)
     {
-      return instantiateReduce<axpbyzNorm2, false>(a, b, 0.0, x, y, z, x, x);
+      check_size(a, x, b, y, z);
+      vector<double> norm(x.size());
+      for (auto i = 0u; i < x.size(); i++)
+        norm[i] = instantiateReduce<axpbyzNorm2, false>(a[i], b[i], 0.0, x[i], y[i], z[i], x[i], x[i]);
+      return norm;
     }
 
-    double axpyReDot(double a, const ColorSpinorField &x, ColorSpinorField &y)
+    cvector<double> axpyReDot(cvector<double> &a, cvector_ref<const ColorSpinorField> &x,
+                              cvector_ref<ColorSpinorField> &y)
     {
-      return instantiateReduce<AxpyReDot, false>(a, 0.0, 0.0, x, y, x, x, x);
+      check_size(a, x, y);
+      vector<double> dot(x.size());
+      for (auto i = 0u; i < x.size(); i++)
+        dot[i] = instantiateReduce<AxpyReDot, false>(a[i], 0.0, 0.0, x[i], y[i], x[i], x[i], x[i]);
+      return dot;
     }
 
-    double caxpbyNorm(const Complex &a, const ColorSpinorField &x, const Complex &b, ColorSpinorField &y)
+    cvector<double> caxpbyNorm(cvector<Complex> &a, cvector_ref<const ColorSpinorField> &x, cvector<Complex> &b,
+                               cvector_ref<ColorSpinorField> &y)
     {
-      return instantiateReduce<caxpyNorm2, true>(a, b, Complex(0.0), x, y, x, x, x);
+      check_size(a, x, b, y);
+      vector<double> norm(x.size());
+      for (auto i = 0u; i < x.size(); i++)
+        norm[i] = instantiateReduce<caxpyNorm2, false>(a[i], b[i], Complex(0.0), x[i], y[i], x[i], x[i], x[i]);
+      return norm;
     }
 
-    double cabxpyzAxNorm(double a, const Complex &b, ColorSpinorField &x, const ColorSpinorField &y, ColorSpinorField &z)
+    cvector<double> cabxpyzAxNorm(cvector<double> &a, cvector<Complex> &b, cvector_ref<ColorSpinorField> &x,
+                                  cvector_ref<const ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z)
     {
-      return instantiateReduce<cabxpyzaxnorm, false>(Complex(a), b, Complex(0.0), x, y, z, x, x);
+      check_size(a, b, x, y, z);
+      vector<double> norm(x.size());
+      for (auto i = 0u; i < x.size(); i++)
+        norm[i]
+          = instantiateReduce<cabxpyzaxnorm, false>(Complex(a[i]), b[i], Complex(0.0), x[i], y[i], z[i], x[i], x[i]);
+      return norm;
     }
 
-    Complex cDotProduct(const ColorSpinorField &x, const ColorSpinorField &y)
+    cvector<Complex> cDotProduct(cvector_ref<const ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &y)
     {
-      auto cdot = instantiateReduce<Cdot, false>(0.0, 0.0, 0.0, x, y, x, x, x);
-      return Complex(cdot[0], cdot[1]);
+      check_size(x, y);
+      vector<Complex> cdots(x.size());
+      for (auto i = 0u; i < x.size(); i++) {
+        auto cdot = instantiateReduce<Cdot, false>(0.0, 0.0, 0.0, x[i], y[i], x[i], x[i], x[i]);
+        cdots[i] = {cdot[0], cdot[1]};
+      }
+      return cdots;
     }
 
-    Complex caxpyDotzy(const Complex &a, const ColorSpinorField &x, ColorSpinorField &y, const ColorSpinorField &z)
+    cvector<Complex> caxpyDotzy(cvector<Complex> &a, cvector_ref<const ColorSpinorField> &x,
+                                cvector_ref<ColorSpinorField> &y, cvector_ref<const ColorSpinorField> &z)
     {
-      auto cdot = instantiateReduce<caxpydotzy, false>(a, Complex(0.0), Complex(0.0), x, y, z, x, x);
-      return Complex(cdot[0], cdot[1]);
+      check_size(a, x, y, z);
+      vector<Complex> cdot(x.size());
+      for (auto i = 0u; i < x.size(); i++) {
+        auto c = instantiateReduce<caxpydotzy, false>(a[i], Complex(0.0), Complex(0.0), x[i], y[i], z[i], x[i], x[i]);
+        cdot[i] = {c[0], c[1]};
+      }
+      return cdot;
     }
 
-    double4 cDotProductNormAB(const ColorSpinorField &x, const ColorSpinorField &y)
+    cvector<double4> cDotProductNormAB(cvector_ref<const ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &y)
     {
-      auto ab = instantiateReduce<CdotNormAB, false>(0.0, 0.0, 0.0, x, y, x, x, x);
-      return make_double4(ab[0], ab[1], ab[2], ab[3]);
+      check_size(x, y);
+      vector<double4> abs(x.size());
+      for (auto i = 0u; i < x.size(); i++) {
+        auto ab = instantiateReduce<CdotNormAB, false>(0.0, 0.0, 0.0, x[i], y[i], x[i], x[i], x[i]);
+        abs[i] = {ab[0], ab[1], ab[2], ab[3]};
+      }
+      return abs;
     }
 
-    double3 caxpbypzYmbwcDotProductUYNormY(const Complex &a, const ColorSpinorField &x, const Complex &b,
-                                           ColorSpinorField &y, ColorSpinorField &z,
-                                           const ColorSpinorField &w, const ColorSpinorField &v)
+    cvector<double3> caxpbypzYmbwcDotProductUYNormY(cvector<Complex> &a, cvector_ref<const ColorSpinorField> &x,
+                                                    cvector<Complex> &b, cvector_ref<ColorSpinorField> &y,
+                                                    cvector_ref<ColorSpinorField> &z,
+                                                    cvector_ref<const ColorSpinorField> &w,
+                                                    cvector_ref<const ColorSpinorField> &v)
     {
-      auto rtn = instantiateReduce<caxpbypzYmbwcDotProductUYNormY_, true>(a, b, Complex(0.0), x, z, y, w, v);
-      return make_double3(rtn[0], rtn[1], rtn[2]);
+      check_size(a, x, b, y, z, w, v);
+      vector<double3> abs(x.size());
+      for (auto i = 0u; i < x.size(); i++) {
+        auto ab = instantiateReduce<caxpbypzYmbwcDotProductUYNormY_, true>(a[i], b[i], Complex(0.0), x[i], z[i], y[i],
+                                                                           w[i], v[i]);
+        abs[i] = {ab[0], ab[1], ab[2]};
+      }
+      return abs;
     }
 
-    double2 axpyCGNorm(double a, const ColorSpinorField &x, ColorSpinorField &y)
+    cvector<double2> axpyCGNorm(cvector<double> &a, cvector_ref<const ColorSpinorField> &x,
+                                cvector_ref<ColorSpinorField> &y)
     {
-      auto cg_norm = instantiateReduce<axpyCGNorm2, true>(a, 0.0, 0.0, x, y, x, x, x);
-      return make_double2(cg_norm[0], cg_norm[1]);
+      check_size(a, x, y);
+      vector<double2> norm(x.size());
+      for (auto i = 0u; i < x.size(); i++) {
+        auto cg_norm = instantiateReduce<axpyCGNorm2, true>(a[i], 0.0, 0.0, x[i], y[i], x[i], x[i], x[i]);
+        norm[i] = {cg_norm[0], cg_norm[1]};
+      }
+      return norm;
     }
 
-    double3 HeavyQuarkResidualNorm(const ColorSpinorField &x, const ColorSpinorField &r)
+    cvector<double3> HeavyQuarkResidualNorm(cvector_ref<const ColorSpinorField> &x,
+                                            cvector_ref<const ColorSpinorField> &r)
     {
-      // in case of x.Ncolor()!=3 (MG mainly) reduce_core do not support this function.
-      if (x.Ncolor() != 3) return make_double3(0.0, 0.0, 0.0);
-      auto rtn = instantiateReduce<HeavyQuarkResidualNorm_, false>(0.0, 0.0, 0.0, x, r, r, r, r);
-      rtn[2] /= (x.Volume()*comm_size());
-      return make_double3(rtn[0], rtn[1], rtn[2]);
+      check_size(x, r);
+      vector<double3> norm(x.size());
+      if (x[0].Ncolor() != 3) // Nc != 3 (MG mainly) not suppored
+        norm = {};
+      else
+        for (auto i = 0u; i < x.size(); i++) {
+          auto n = instantiateReduce<HeavyQuarkResidualNorm_, false>(0.0, 0.0, 0.0, x[i], r[i], x[i], x[i], x[i]);
+          norm[i] = {n[0], n[1], n[2] / (x[0].Volume() * comm_size())};
+        }
+      return norm;
     }
 
-    double3 xpyHeavyQuarkResidualNorm(const ColorSpinorField &x, ColorSpinorField &y, const ColorSpinorField &r)
+    cvector<double3> xpyHeavyQuarkResidualNorm(cvector_ref<const ColorSpinorField> &x,
+                                               cvector_ref<const ColorSpinorField> &y,
+                                               cvector_ref<const ColorSpinorField> &r)
     {
-      // in case of x.Ncolor()!=3 (MG mainly) reduce_core do not support this function.
-      if (x.Ncolor()!=3) return make_double3(0.0, 0.0, 0.0);
-      auto rtn = instantiateReduce<xpyHeavyQuarkResidualNorm_, true>(0.0, 0.0, 0.0, x, y, r, r, r);
-      rtn[2] /= (x.Volume()*comm_size());
-      return make_double3(rtn[0], rtn[1], rtn[2]);
+      check_size(x, y, r);
+      vector<double3> norm(x.size());
+      if (x[0].Ncolor() != 3) // Nc != 3 (MG mainly) not suppored
+        norm = {};
+      else
+        for (auto i = 0u; i < x.size(); i++) {
+          auto n = instantiateReduce<xpyHeavyQuarkResidualNorm_, true>(0.0, 0.0, 0.0, x[i], y[i], r[i], r[i], r[i]);
+          norm[i] = {n[0], n[1], n[2] / (x[0].Volume() * comm_size())};
+        }
+      return norm;
     }
 
-    double3 tripleCGReduction(const ColorSpinorField &x, const ColorSpinorField &y, const ColorSpinorField &z)
+    cvector<double3> tripleCGReduction(cvector_ref<const ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &y,
+                                       cvector_ref<const ColorSpinorField> &z)
     {
-      auto rtn = instantiateReduce<tripleCGReduction_, false>(0.0, 0.0, 0.0, x, y, z, x, x);
-      return make_double3(rtn[0], rtn[1], rtn[2]);
+      check_size(x, y, z);
+      vector<double3> norm(x.size());
+      for (auto i = 0u; i < x.size(); i++) {
+        auto cg = instantiateReduce<tripleCGReduction_, false>(0.0, 0.0, 0.0, x[i], y[i], z[i], x[i], x[i]);
+        norm[i] = {cg[0], cg[1], cg[2]};
+      }
+      return norm;
     }
 
-    double4 quadrupleCGReduction(const ColorSpinorField &x, const ColorSpinorField &y, const ColorSpinorField &z)
+    cvector<double4> quadrupleCGReduction(cvector_ref<const ColorSpinorField> &x,
+                                          cvector_ref<const ColorSpinorField> &y, cvector_ref<const ColorSpinorField> &z)
     {
-      auto red = instantiateReduce<quadrupleCGReduction_, false>(0.0, 0.0, 0.0, x, y, z, x, x);
-      return make_double4(red[0], red[1], red[2], red[3]);
+      check_size(x, y, z);
+      vector<double4> norm(x.size());
+      for (auto i = 0u; i < x.size(); i++) {
+        auto cg = instantiateReduce<quadrupleCGReduction_, false>(0.0, 0.0, 0.0, x[i], y[i], z[i], x[i], x[i]);
+        norm[i] = {cg[0], cg[1], cg[2], cg[3]};
+      }
+      return norm;
     }
 
-    double quadrupleCG3InitNorm(double a, ColorSpinorField &x, ColorSpinorField &y,
-                                ColorSpinorField &z, ColorSpinorField &w, const ColorSpinorField &v)
+    cvector<double> quadrupleCG3InitNorm(cvector<double> &a, cvector_ref<ColorSpinorField> &x,
+                                         cvector_ref<ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z,
+                                         cvector_ref<ColorSpinorField> &w, cvector_ref<const ColorSpinorField> &v)
     {
-      return instantiateReduce<quadrupleCG3InitNorm_, false>(a, 0.0, 0.0, x, y, z, w, v);
+      check_size(a, x, y, z, w, v);
+      vector<double> norm(x.size());
+      for (auto i = 0u; i < x.size(); i++)
+        norm[i] = instantiateReduce<quadrupleCG3InitNorm_, false>(a[i], 0.0, 0.0, x[i], y[i], z[i], w[i], v[i]);
+      return norm;
     }
 
-    double quadrupleCG3UpdateNorm(double a, double b, ColorSpinorField &x, ColorSpinorField &y,
-                                  ColorSpinorField &z, ColorSpinorField &w, const ColorSpinorField &v)
+    cvector<double> quadrupleCG3UpdateNorm(cvector<double> &a, cvector<double> &b, cvector_ref<ColorSpinorField> &x,
+                                           cvector_ref<ColorSpinorField> &y, cvector_ref<ColorSpinorField> &z,
+                                           cvector_ref<ColorSpinorField> &w, cvector_ref<const ColorSpinorField> &v)
     {
-      return instantiateReduce<quadrupleCG3UpdateNorm_, false>(a, b, 0.0, x, y, z, w, v);
+      check_size(a, b, x, y, z, w, v);
+      vector<double> norm(x.size());
+      for (auto i = 0u; i < x.size(); i++)
+        norm[i] = instantiateReduce<quadrupleCG3UpdateNorm_, false>(a[i], b[i], 0.0, x[i], y[i], z[i], w[i], v[i]);
+      return norm;
     }
 
   } // namespace blas

--- a/lib/reduce_quda.cu
+++ b/lib/reduce_quda.cu
@@ -301,14 +301,13 @@ namespace quda {
                                             cvector_ref<const ColorSpinorField> &r)
     {
       check_size(x, r);
-      vector<double3> norm(x.size());
-      if (x[0].Ncolor() != 3) // Nc != 3 (MG mainly) not suppored
-        norm = {};
-      else
+      vector<double3> norm(x.size(), {});
+      if (x[0].Ncolor() == 3) {// Nc != 3 (MG mainly) not suppored
         for (auto i = 0u; i < x.size(); i++) {
           auto n = instantiateReduce<HeavyQuarkResidualNorm_, false>(0.0, 0.0, 0.0, x[i], r[i], x[i], x[i], x[i]);
           norm[i] = {n[0], n[1], n[2] / (x[0].Volume() * comm_size())};
         }
+      }
       return norm;
     }
 
@@ -317,10 +316,8 @@ namespace quda {
                                                cvector_ref<const ColorSpinorField> &r)
     {
       check_size(x, y, r);
-      vector<double3> norm(x.size());
-      if (x[0].Ncolor() != 3) // Nc != 3 (MG mainly) not suppored
-        norm = {};
-      else
+      vector<double3> norm(x.size(), {});
+      if (x[0].Ncolor() == 3) // Nc != 3 (MG mainly) not suppored
         for (auto i = 0u; i < x.size(); i++) {
           auto n = instantiateReduce<xpyHeavyQuarkResidualNorm_, true>(0.0, 0.0, 0.0, x[i], y[i], r[i], r[i], r[i]);
           norm[i] = {n[0], n[1], n[2] / (x[0].Volume() * comm_size())};

--- a/lib/reduce_quda.cu
+++ b/lib/reduce_quda.cu
@@ -220,7 +220,7 @@ namespace quda {
       check_size(a, x, b, y);
       vector<double> norm(x.size());
       for (auto i = 0u; i < x.size(); i++)
-        norm[i] = instantiateReduce<caxpyNorm2, false>(a[i], b[i], Complex(0.0), x[i], y[i], x[i], x[i], x[i]);
+        norm[i] = instantiateReduce<caxpyNorm2, true>(a[i], b[i], Complex(0.0), x[i], y[i], x[i], x[i], x[i]);
       return norm;
     }
 

--- a/lib/reduce_quda.cu
+++ b/lib/reduce_quda.cu
@@ -302,7 +302,7 @@ namespace quda {
     {
       check_size(x, r);
       vector<double3> norm(x.size(), {});
-      if (x[0].Ncolor() == 3) {// Nc != 3 (MG mainly) not suppored
+      if (x[0].Ncolor() == 3) { // Nc != 3 (MG mainly) not suppored
         for (auto i = 0u; i < x.size(); i++) {
           auto n = instantiateReduce<HeavyQuarkResidualNorm_, false>(0.0, 0.0, 0.0, x[i], r[i], x[i], x[i], x[i]);
           norm[i] = {n[0], n[1], n[2] / (x[0].Volume() * comm_size())};

--- a/lib/transfer.cpp
+++ b/lib/transfer.cpp
@@ -163,9 +163,7 @@ namespace quda {
   void Transfer::createTmp() const
   {
     // The CPU temporaries are needed for creating geometry mappings.
-    if ((transfer_type == QUDA_TRANSFER_COARSE_KD || transfer_type == QUDA_TRANSFER_OPTIMIZED_KD
-         || transfer_type == QUDA_TRANSFER_OPTIMIZED_KD_DROP_LONG))
-      return;
+    if (transfer_type == QUDA_TRANSFER_OPTIMIZED_KD || transfer_type == QUDA_TRANSFER_OPTIMIZED_KD_DROP_LONG) return;
 
     if (!fine_tmp_h.empty()) return;
 

--- a/tests/blas_test.cpp
+++ b/tests/blas_test.cpp
@@ -487,43 +487,43 @@ protected:
         break;
 
       case Kernel::axpy_block:
-        for (int i = 0; i < niter; ++i) blas::axpy(Ar, xmD, ymoD);
+        for (int i = 0; i < niter; ++i) blas::block::axpy(Ar, xmD, ymoD);
         break;
 
       case Kernel::caxpy_block:
-        for (int i = 0; i < niter; ++i) blas::caxpy(A, xmD, ymoD);
+        for (int i = 0; i < niter; ++i) blas::block::caxpy(A, xmD, ymoD);
         break;
 
       case Kernel::axpyz_block:
-        for (int i = 0; i < niter; ++i) blas::axpyz(Ar, xmD, ymD, wmD);
+        for (int i = 0; i < niter; ++i) blas::block::axpyz(Ar, xmD, ymD, wmD);
         break;
 
       case Kernel::caxpyz_block:
-        for (int i = 0; i < niter; ++i) blas::caxpyz(A, xmD, ymD, wmD);
+        for (int i = 0; i < niter; ++i) blas::block::caxpyz(A, xmD, ymD, wmD);
         break;
 
       case Kernel::axpyBzpcx_block:
-        for (int i = 0; i < niter; ++i) blas::axpyBzpcx(A1r, xmD, zmoD, B1r, yD, C1r);
+        for (int i = 0; i < niter; ++i) blas::block::axpyBzpcx(A1r, xmD, zmoD, B1r, yD, C1r);
         break;
 
       case Kernel::reDotProductNorm_block:
-        for (int i = 0; i < niter; ++i) blas::reDotProduct(A2r, xmD, xmD);
+        for (int i = 0; i < niter; ++i) blas::block::reDotProduct(A2r, xmD, xmD);
         break;
 
       case Kernel::reDotProduct_block:
-        for (int i = 0; i < niter; ++i) blas::reDotProduct(A2r, xmD, ymoD);
+        for (int i = 0; i < niter; ++i) blas::block::reDotProduct(A2r, xmD, ymoD);
         break;
 
       case Kernel::cDotProductNorm_block:
-        for (int i = 0; i < niter; ++i) blas::cDotProduct(A2, xmD, xmD);
+        for (int i = 0; i < niter; ++i) blas::block::cDotProduct(A2, xmD, xmD);
         break;
 
       case Kernel::cDotProduct_block:
-        for (int i = 0; i < niter; ++i) blas::cDotProduct(A, xmD, ymoD);
+        for (int i = 0; i < niter; ++i) blas::block::cDotProduct(A, xmD, ymoD);
         break;
 
       case Kernel::hDotProduct_block:
-        for (int i = 0; i < niter; ++i) blas::hDotProduct(A2, xmD, xmD);
+        for (int i = 0; i < niter; ++i) blas::block::hDotProduct(A2, xmD, xmD);
         break;
 
       case Kernel::caxpyXmazMR:
@@ -871,7 +871,7 @@ protected:
       for (int i = 0; i < Nsrc; i++) xmD[i] = xmH[i];
       for (int i = 0; i < Msrc; i++) ymoD[i] = ymH[i];
 
-      blas::axpy(Ar, xmD, ymoD);
+      blas::block::axpy(Ar, xmD, ymoD);
       for (int i = 0; i < Nsrc; i++) {
         for (int j = 0; j < Msrc; j++) { blas::axpy(Ar[Msrc * i + j], xmH[i], ymH[j]); }
       }
@@ -887,7 +887,7 @@ protected:
       for (int i = 0; i < Nsrc; i++) xmD[i] = xmH[i];
       for (int i = 0; i < Msrc; i++) ymoD[i] = ymH[i];
 
-      blas::caxpy(A, xmD, ymoD);
+      blas::block::caxpy(A, xmD, ymoD);
       for (int j = 0; j < Msrc; j++) {
         for (int i = 0; i < Nsrc; i++) { blas::caxpy(A[Msrc * i + j], xmH[i], ymH[j]); }
       }
@@ -902,7 +902,7 @@ protected:
       for (int i = 0; i < Nsrc; i++) xmD[i] = xmH[i];
       for (int i = 0; i < Msrc; i++) ymD[i] = ymH[i];
 
-      blas::axpyz(Ar, xmD, ymD, wmD);
+      blas::block::axpyz(Ar, xmD, ymD, wmD);
       for (int j = 0; j < Msrc; j++) {
         wmH[j] = ymH[j];
         for (int i = 0; i < Nsrc; i++) { blas::axpy(Ar[Msrc * i + j], xmH[i], wmH[j]); }
@@ -918,7 +918,7 @@ protected:
       for (int i = 0; i < Nsrc; i++) xmD[i] = xmH[i];
       for (int i = 0; i < Msrc; i++) ymD[i] = ymH[i];
 
-      blas::caxpyz(A, xmD, ymD, wmD);
+      blas::block::caxpyz(A, xmD, ymD, wmD);
       for (int j = 0; j < Msrc; j++) {
         wmH[j] = ymH[j];
         for (int i = 0; i < Nsrc; i++) { blas::caxpy(A[Msrc * i + j], xmH[i], wmH[j]); }
@@ -937,7 +937,7 @@ protected:
       }
       yD = yH;
 
-      blas::axpyBzpcx(A1r, xmD, zmoD, B1r, yD, C1r);
+      blas::block::axpyBzpcx(A1r, xmD, zmoD, B1r, yD, C1r);
 
       for (int i = 0; i < Nsrc; i++) blas::axpyBzpcx(A1r[i], xmH[i], zmH[i], B1r[i], yH, C1r[i]);
 
@@ -951,7 +951,7 @@ protected:
 
     case Kernel::reDotProductNorm_block:
       for (int i = 0; i < Nsrc; i++) xmD[i] = xmH[i];
-      blas::reDotProduct(A2r, xmD, xmD);
+      blas::block::reDotProduct(A2r, xmD, xmD);
       error = 0.0;
       for (int i = 0; i < Nsrc; i++) {
         for (int j = 0; j < Nsrc; j++) {
@@ -966,7 +966,7 @@ protected:
       for (int i = 0; i < Nsrc; i++) xmD[i] = xmH[i];
       for (int i = 0; i < Msrc; i++) ymoD[i] = ymH[i];
       for (int i = 0; i < Msrc; i++) ymD[i] = ymH[i];
-      blas::reDotProduct(Ar, xmD, ymoD);
+      blas::block::reDotProduct(Ar, xmD, ymoD);
       error = 0.0;
       for (int i = 0; i < Nsrc; i++) {
         for (int j = 0; j < Msrc; j++) {
@@ -979,7 +979,7 @@ protected:
 
     case Kernel::cDotProductNorm_block:
       for (int i = 0; i < Nsrc; i++) xmD[i] = xmH[i];
-      blas::cDotProduct(A2, xmD, xmD);
+      blas::block::cDotProduct(A2, xmD, xmD);
       error = 0.0;
       for (int i = 0; i < Nsrc; i++) {
         for (int j = 0; j < Nsrc; j++) {
@@ -994,7 +994,7 @@ protected:
       for (int i = 0; i < Nsrc; i++) xmD[i] = xmH[i];
       for (int i = 0; i < Msrc; i++) ymoD[i] = ymH[i];
       for (int i = 0; i < Msrc; i++) ymD[i] = ymH[i];
-      blas::cDotProduct(A, xmD, ymoD);
+      blas::block::cDotProduct(A, xmD, ymoD);
       error = 0.0;
       for (int i = 0; i < Nsrc; i++) {
         for (int j = 0; j < Msrc; j++) {
@@ -1007,8 +1007,8 @@ protected:
 
     case Kernel::hDotProduct_block:
       for (int i = 0; i < Nsrc; i++) xmD[i] = xmH[i];
-      blas::hDotProduct(A2, xmD, xmD);
-      blas::cDotProduct(B2, xmD, xmD);
+      blas::block::hDotProduct(A2, xmD, xmD);
+      blas::block::cDotProduct(B2, xmD, xmD);
       error = 0.0;
       for (int i = 0; i < Nsrc; i++) {
         for (int j = 0; j < Nsrc; j++) {

--- a/tests/blas_test.cpp
+++ b/tests/blas_test.cpp
@@ -603,7 +603,8 @@ protected:
       xD = xH;
       yoD = yH;
       blas::axpbyz(a, xD, b, yoD, zoD);
-      blas::axpbyz(a, xH, b, yH, zH);
+      blas::axy(a, xH, zH);
+      blas::axpy(b, yH, zH);
       error = ERROR(zo);
       break;
 
@@ -613,22 +614,24 @@ protected:
       zD = zH;
       wD = wH;
       blas::axpbypczw(a, xD, b, yD, c, zD, wD);
-      blas::axpbypczw(a, xH, b, yH, c, zH, wH);
+      blas::axy(a, xH, wH);
+      blas::axpy(b, yH, wH);
+      blas::axpy(c, zH, wH);
       error = ERROR(w);
       break;
 
     case Kernel::ax:
       xD = xH;
       blas::ax(a, xD);
-      blas::ax(a, xH);
-      error = ERROR(x);
+      error = (blas::norm2(xD) - a * a * blas::norm2(xH)) / (a * a * blas::norm2(xH));
       break;
 
     case Kernel::caxpy:
       xD = xH;
       yoD = yH;
       blas::caxpy(a2, xD, yoD);
-      blas::caxpy(a2, xH, yH);
+      blas::axy(a2, xH, xH);
+      blas::xpy(xH, yH);
       error = ERROR(yo);
       break;
 
@@ -636,7 +639,9 @@ protected:
       xD = xH;
       yD = yH;
       blas::caxpby(a2, xD, b2, yD);
-      blas::caxpby(a2, xH, b2, yH);
+      blas::axy(a2, xH, xH);
+      blas::axy(b2, yH, yH);
+      blas::xpy(xH, yH);
       error = ERROR(y);
       break;
 
@@ -645,7 +650,8 @@ protected:
       yD = yH;
       zD = zH;
       blas::cxpaypbz(xD, a2, yD, b2, zD);
-      blas::cxpaypbz(xH, a2, yH, b2, zH);
+      blas::caxpby(1.0, xH, a2, yH);
+      blas::caxpby(1.0, yH, b2, zH);
       error = ERROR(z);
       break;
 
@@ -654,7 +660,8 @@ protected:
       yoD = yH;
       zD = zH;
       blas::axpyBzpcx(a, xD, yoD, b, zD, c);
-      blas::axpyBzpcx(a, xH, yH, b, zH, c);
+      blas::axpy(a, xH, yH);
+      blas::axpby(b, zH, c, xH);
       error = ERROR(x) + ERROR(yo);
       break;
 
@@ -663,7 +670,8 @@ protected:
       yoD = yH;
       zD = zH;
       blas::axpyZpbx(a, xD, yoD, zD, b);
-      blas::axpyZpbx(a, xH, yH, zH, b);
+      blas::axpy(a, xH, yH);
+      blas::xpay(zH, b, xH);
       error = ERROR(x) + ERROR(yo);
       break;
 
@@ -673,7 +681,9 @@ protected:
       zD = zH;
       wD = wH;
       blas::caxpbypzYmbw(a2, xD, b2, yD, zD, wD);
-      blas::caxpbypzYmbw(a2, xH, b2, yH, zH, wH);
+      blas::caxpy(a2, xH, zH);
+      blas::caxpy(b2, yH, zH);
+      blas::caxpy(-b2, wH, yH);
       error = ERROR(z) + ERROR(y);
       break;
 
@@ -681,7 +691,8 @@ protected:
       xD = xH;
       yD = yH;
       blas::cabxpyAx(a, b2, xD, yD);
-      blas::cabxpyAx(a, b2, xH, yH);
+      blas::caxpy(a * b2, xH, yH);
+      blas::ax(a, xH);
       error = ERROR(y) + ERROR(x);
       break;
 
@@ -690,8 +701,9 @@ protected:
       yD = yH;
       zD = zH;
       {
-        blas::caxpyXmaz(a, xD, yD, zD);
-        blas::caxpyXmaz(a, xH, yH, zH);
+        blas::caxpyXmaz(a2, xD, yD, zD);
+        blas::caxpy(a2, xH, yH);
+        blas::caxpy(-a2, zH, xH);
         error = ERROR(y) + ERROR(x);
       }
       break;
@@ -731,8 +743,9 @@ protected:
       xD = xH;
       yD = yH;
       {
-        double d = blas::caxpyNorm(a, xD, yD);
-        double h = blas::caxpyNorm(a, xH, yH);
+        double d = blas::caxpyNorm(a2, xD, yD);
+        blas::caxpy(a2, xH, yH);
+        double h = blas::norm2(yH);
         error = ERROR(y) + fabs(d - h) / fabs(h);
       }
       break;

--- a/tests/dilution_test.cpp
+++ b/tests/dilution_test.cpp
@@ -81,7 +81,7 @@ TEST_P(DilutionTest, verify)
 
     param.create = QUDA_ZERO_FIELD_CREATE;
     ColorSpinorField sum(param);
-    blas::axpy(std::vector<double>(v.size(), 1.0), v, sum); // reassemble the vector
+    blas::block::axpy(std::vector<double>(v.size(), 1.0), v, sum); // reassemble the vector
 
     { // check its norm matches the original
       auto src2 = blas::norm2(src);

--- a/tests/staggered_invert_test_gtest.hpp
+++ b/tests/staggered_invert_test_gtest.hpp
@@ -53,12 +53,12 @@ bool skip_test(test_t param)
     // MR struggles with the staggered and asqtad spectrum, it's not MR's fault
     if (solution_type == QUDA_MAT_SOLUTION && solve_type == QUDA_DIRECT_SOLVE && inverter_type == QUDA_MR_INVERTER)
       return true;
-
-    // CG3 is rather unstable with low precision
-    if ((inverter_type == QUDA_CG3_INVERTER || inverter_type == QUDA_CG3NE_INVERTER || inverter_type == QUDA_CG3NR_INVERTER)
-        && prec_sloppy < QUDA_DOUBLE_PRECISION)
-      return true;
   }
+
+  // CG3 is rather unstable with low precision
+  if ((inverter_type == QUDA_CG3_INVERTER || inverter_type == QUDA_CG3NE_INVERTER || inverter_type == QUDA_CG3NR_INVERTER)
+      && prec_sloppy < QUDA_DOUBLE_PRECISION)
+    return true;
 
   // split-grid doesn't support multigrid at present
   if (use_split_grid && multishift > 1) return true;


### PR DESCRIPTION
This PR continues the multi-RHS scaffolding from #1437:
* All BLAS functions are now multi-RHS aware (albeit for-loop wrappers around single RHS operations)
  * (Future work will fuse these into single kernels)
* BLAS regression tests are much more robust with most of the tests now tested using elementary equivalent compositions, as opposed to simply comparing CPU and GPU
* Block BLAS functions are now in their own namespace `blas::block` to avoid any collisions with the new multi-RHS aware BLAS functions
* Legacy block BLAS functions (those that take a vector of pointers) are now in the `blas::legacy` namespace.
  * Hopefully these will be deleted soon
* `Dirac::prepare` and `Dirac::reconstruct` functions are now multi-RHS aware
* General clean up of the `Dirac` classes to reduce boiler plate