### PR TITLE
Optimizations to smearing interface

### DIFF
--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -4941,8 +4941,7 @@ void performTwoLinkGaussianSmearNStep(void *h_in, QudaQuarkSmearParam *smear_par
     if (i > 0) std::swap(in, out);
 
     qsmear_op.Expose()->SmearOp(out, in, a, 0.0, smear_param->t0, parity);
-    if (getVerbosity() >= QUDA_DEBUG_VERBOSE)
-      logQuda(QUDA_DEBUG_VERBOSE, "Step %d, vector norm %e\n", i, blas::norm2(out));
+    logQuda(QUDA_DEBUG_VERBOSE, "Step %d, vector norm %e\n", i, blas::norm2(out));
     blas::axpby(a * ftmp, in, -ftmp, out);
   }
 

--- a/lib/milc_interface.cpp
+++ b/lib/milc_interface.cpp
@@ -3118,7 +3118,7 @@ void qudaTwoLinkGaussianSmear( int external_precision, int quda_precision, void 
 
   // Load gauge field
   if( qsmear_args.compute_2link == 0 ) gaugeParam.use_resident_gauge = 1;
-  loadGaugeQuda( const_cast<void *>(h_gauge), &gaugeParam );
+  else loadGaugeQuda( const_cast<void *>(h_gauge), &gaugeParam );
   
   // quark smearing parameters
   QudaQuarkSmearParam qsmearParam;

--- a/lib/milc_interface.cpp
+++ b/lib/milc_interface.cpp
@@ -3117,9 +3117,11 @@ void qudaTwoLinkGaussianSmear( int external_precision, int quda_precision, void 
   //--------------------------- gauge setup
 
   // Load gauge field
-  if( qsmear_args.compute_2link == 0 ) gaugeParam.use_resident_gauge = 1;
-  else loadGaugeQuda( const_cast<void *>(h_gauge), &gaugeParam );
-  
+  if (qsmear_args.compute_2link == 0)
+    gaugeParam.use_resident_gauge = 1;
+  else
+    loadGaugeQuda(const_cast<void *>(h_gauge), &gaugeParam);
+
   // quark smearing parameters
   QudaQuarkSmearParam qsmearParam;
   qsmearParam.inv_param = &invertParam;


### PR DESCRIPTION
I have been computing two-link smearing with QUDA and have made two optimizations to the smearing interface:
1) In `lib/milc_interface.cpp`, skip the call to `loadGaugeQuda` if the `useResidentGauge` flag is set (since in this case, the 2-link field is already computed)
2) Simplify the four linear algebra operations in the loop in `performTwoLinkGaussianSmearNStep` in `lib/interface_quda.cpp` to a single operation
I have tested that this agrees with the previous implementation (using QUDA driven by MILC on a single GPU), and overall these changes increase performance by a factor of about 2 in our project.