### PR TITLE
Make QUDA understand memoryType in older ROCms

### DIFF
--- a/lib/targets/hip/malloc.cpp
+++ b/lib/targets/hip/malloc.cpp
@@ -528,15 +528,21 @@ namespace quda
       errorQuda("hipPointerGetAttributes returned error: %s\n", hipGetErrorString(error));
     }
 
-    switch (attr.type) {
 #if HIP_VERSION_MAJOR >= 6
+    switch (attr.type) {
     case hipMemoryTypeUnregistered: return QUDA_CPU_FIELD_LOCATION;
+#else
+    switch (attr.memoryType) {
 #endif  // HIP_VERSION_MAJOR >= 6
     case hipMemoryTypeHost: return QUDA_CPU_FIELD_LOCATION;
     case hipMemoryTypeDevice: return QUDA_CUDA_FIELD_LOCATION;
     case hipMemoryTypeArray: return QUDA_CUDA_FIELD_LOCATION;
     case hipMemoryTypeUnified: return QUDA_CUDA_FIELD_LOCATION; ///< Not used currently
+#if HIP_VERSION_MAJOR >= 6
     default: errorQuda("Unknown memory type %d\n", attr.type); return QUDA_INVALID_FIELD_LOCATION;
+#else
+    default: errorQuda("Unknown memory type %d\n", attr.memoryType); return QUDA_INVALID_FIELD_LOCATION;
+#endif
     }
   }
 


### PR DESCRIPTION
Older ROCms (before 5.5) didn't have the memoryType/type union that was included for forwards compatibility, so we're safeguarding in the case where folks are stuck with an older ROCm version.

I'm hoping this will help address #1432.