### PR TITLE
Fix a bug in `DiracWilsonPC::prepare`.

### DIFF
--- a/lib/dirac_wilson.cpp
+++ b/lib/dirac_wilson.cpp
@@ -144,7 +144,7 @@ namespace quda {
     // we desire solution to full system
     for (auto i = 0u; i < b.size(); i++) {
       // src = b_e + k D_eo b_o
-      DslashXpay(x[i][other_parity], b[i][other_parity], this_parity, b[this_parity], kappa);
+      DslashXpay(x[i][other_parity], b[i][other_parity], this_parity, b[i][this_parity], kappa);
       src[i] = x[i][other_parity].create_alias();
       sol[i] = x[i][this_parity].create_alias();
     }


### PR DESCRIPTION
`./invert_test --solution-type mat --matpc odd-odd` fails in the recent commit. This PR fixes it.