### PR TITLE
init offset values in test

### DIFF
--- a/tests/clover_force_test.cpp
+++ b/tests/clover_force_test.cpp
@@ -83,6 +83,7 @@ using test_t = ::testing::tuple<QudaPrecision, QudaDslashType, bool, int, QudaTw
 
 std::tuple<int, double> clover_force_test(test_t param)
 {
+  int nvector = ::testing::get<3>(param);
   gauge_param.cuda_prec = ::testing::get<0>(param);
   inv_param.cuda_prec = ::testing::get<0>(param);
   inv_param.dslash_type = ::testing::get<1>(param);
@@ -90,9 +91,11 @@ std::tuple<int, double> clover_force_test(test_t param)
   if (inv_param.dslash_type == QUDA_TWISTED_CLOVER_DSLASH) {
     inv_param.epsilon = epsilon;
     inv_param.evmax = evmax;
+    if (inv_param.twist_flavor==QUDA_TWIST_NONDEG_DOUBLET){
+      for (int i = 0; i < nvector; i++) inv_param.offset[i] = 0.06 + i * i * 0.1;
+    }
   }
   bool detratio = ::testing::get<2>(param);
-  int nvector = ::testing::get<3>(param);
 
   std::vector<quda::ColorSpinorField> out_nvector(nvector);
   std::vector<void *> in(nvector);
@@ -148,8 +151,6 @@ std::tuple<int, double> clover_force_test(test_t param)
                             &gauge_param, &inv_param, detratio);
     *check_out = compare_floats(mom.data(), mom_ref.data(), 4 * V * mom_site_size, getTolerance(gauge_param.cuda_prec),
                                 gauge_param.cpu_prec);
-    printf("check_out =%d \n", *check_out);
-    // if (compute_force)
     strong_check_mom(mom.data(), mom_ref.data(), 4 * V, gauge_param.cpu_prec);
   }
 

--- a/tests/clover_force_test.cpp
+++ b/tests/clover_force_test.cpp
@@ -91,7 +91,7 @@ std::tuple<int, double> clover_force_test(test_t param)
   if (inv_param.dslash_type == QUDA_TWISTED_CLOVER_DSLASH) {
     inv_param.epsilon = epsilon;
     inv_param.evmax = evmax;
-    if (inv_param.twist_flavor==QUDA_TWIST_NONDEG_DOUBLET){
+    if (inv_param.twist_flavor == QUDA_TWIST_NONDEG_DOUBLET) {
       for (int i = 0; i < nvector; i++) inv_param.offset[i] = 0.06 + i * i * 0.1;
     }
   }


### PR DESCRIPTION
sorry I was too slow in noticing this before #1452 was closed. I initialized the values of `inv_param.offset`, the issue was that they were initialized as 
https://github.com/lattice/quda/blob/a268171626c80d2701685ccbb9035c692d2db628/tests/utils/set_params.cpp#L212-L213
while the test assumes that they are initialized up to `nvector`