### PR TITLE
Bugfix for single-parity vector inflation in `VectorIO`

### DIFF
--- a/lib/vector_io.cpp
+++ b/lib/vector_io.cpp
@@ -56,8 +56,8 @@ namespace quda
       }
 
       // if we're loading inflated vectors, we need to grab the spinor size from `tmp` instead of `v0`.
-      auto spinor_X = parity_inflate ? tmp[0].X() : v0.X();
-      auto spinor_site_subset = parity_inflate ? tmp[0].SiteSubset() : v0.SiteSubset();
+      auto spinor_X = (create_tmp && parity_inflate) ? tmp[0].X() : v0.X();
+      auto spinor_site_subset = (create_tmp && parity_inflate) ? tmp[0].SiteSubset() : v0.SiteSubset();
 
       // time loading
       quda::host_timer_t host_timer;
@@ -145,8 +145,8 @@ namespace quda
       }
 
       // if we performed parity inflation, we need to grab the spinor size from `tmp` instead of `v0`.
-      auto spinor_X = parity_inflate ? tmp[0].X() : v0.X();
-      auto spinor_site_subset = parity_inflate ? tmp[0].SiteSubset() : v0.SiteSubset();
+      auto spinor_X = (create_tmp && parity_inflate) ? tmp[0].X() : v0.X();
+      auto spinor_site_subset = (create_tmp && parity_inflate) ? tmp[0].SiteSubset() : v0.SiteSubset();
 
       // time saving
       quda::host_timer_t host_timer;

--- a/lib/vector_io.cpp
+++ b/lib/vector_io.cpp
@@ -63,8 +63,8 @@ namespace quda
       quda::host_timer_t host_timer;
       host_timer.start(); // start the timer
 
-      read_spinor_field(filename.c_str(), V.data(), v0.Precision(), spinor_X, spinor_site_subset,
-                        spinor_parity, v0.Ncolor(), v0.Nspin(), Nvec * Ls, 0, nullptr);
+      read_spinor_field(filename.c_str(), V.data(), v0.Precision(), spinor_X, spinor_site_subset, spinor_parity,
+                        v0.Ncolor(), v0.Nspin(), Nvec * Ls, 0, nullptr);
 
       host_timer.stop(); // stop the timer
       logQuda(QUDA_SUMMARIZE, "Time spent loading vectors from %s = %g secs\n", filename.c_str(), host_timer.last());
@@ -152,8 +152,8 @@ namespace quda
       quda::host_timer_t host_timer;
       host_timer.start(); // start the timer
 
-      write_spinor_field(filename.c_str(), V.data(), save_prec, spinor_X, spinor_site_subset, spinor_parity, v0.Ncolor(),
-                         v0.Nspin(), Nvec * Ls, 0, nullptr, partfile);
+      write_spinor_field(filename.c_str(), V.data(), save_prec, spinor_X, spinor_site_subset, spinor_parity,
+                         v0.Ncolor(), v0.Nspin(), Nvec * Ls, 0, nullptr, partfile);
 
       host_timer.stop(); // stop the timer
       logQuda(QUDA_SUMMARIZE, "Time spent saving vectors to %s = %g secs\n", filename.c_str(), host_timer.last());

--- a/lib/vector_io.cpp
+++ b/lib/vector_io.cpp
@@ -55,11 +55,15 @@ namespace quda
         for (int j = 0; j < Ls; j++) { V[i * Ls + j] = v.data<char *>() + j * stride; }
       }
 
+      // if we're loading inflated vectors, we need to grab the spinor size from `tmp` instead of `v0`.
+      auto spinor_X = parity_inflate ? tmp[0].X() : v0.X();
+      auto spinor_site_subset = parity_inflate ? tmp[0].SiteSubset() : v0.SiteSubset();
+
       // time loading
       quda::host_timer_t host_timer;
       host_timer.start(); // start the timer
 
-      read_spinor_field(filename.c_str(), V.data(), v0.Precision(), v0.X(), v0.SiteSubset(),
+      read_spinor_field(filename.c_str(), V.data(), v0.Precision(), spinor_X, spinor_site_subset,
                         spinor_parity, v0.Ncolor(), v0.Nspin(), Nvec * Ls, 0, nullptr);
 
       host_timer.stop(); // stop the timer
@@ -140,11 +144,15 @@ namespace quda
         for (int j = 0; j < Ls; j++) { V[i * Ls + j] = v.data<const char *>() + j * stride; }
       }
 
+      // if we performed parity inflation, we need to grab the spinor size from `tmp` instead of `v0`.
+      auto spinor_X = parity_inflate ? tmp[0].X() : v0.X();
+      auto spinor_site_subset = parity_inflate ? tmp[0].SiteSubset() : v0.SiteSubset();
+
       // time saving
       quda::host_timer_t host_timer;
       host_timer.start(); // start the timer
 
-      write_spinor_field(filename.c_str(), V.data(), save_prec, v0.X(), v0.SiteSubset(), spinor_parity, v0.Ncolor(),
+      write_spinor_field(filename.c_str(), V.data(), save_prec, spinor_X, spinor_site_subset, spinor_parity, v0.Ncolor(),
                          v0.Nspin(), Nvec * Ls, 0, nullptr, partfile);
 
       host_timer.stop(); // stop the timer


### PR DESCRIPTION
This hotfix branch fixes a bug where the flag `--eig-io-parity-inflate yes` (more specifically, the underlying variable set in the eigensolver parameters structure) wasn't being respected when saving vectors from single-parity operators.

As part of fixing this bug, I extended the `io_test` unit tests to explicitly check parity inflation for both even and odd vectors. The test to save an inflated single-parity field, load the resulting full field, and make sure the even or odd subset of the loaded full field (as appropriate) matches the saved field.

This bug was originally reported by @leonhostetler, who has independently verified that this fix addresses the issue he was hitting in his workflow --- thank you for catching it!

(FYI @maddyscientist --- I `clang-format`ed this along the way, so there's no need for a subsequent `clang-format` commit.)