### PR TITLE
Fix buffer overflow in Unpack

### DIFF
--- a/include/gauge_field_order.h
+++ b/include/gauge_field_order.h
@@ -1480,7 +1480,7 @@ namespace quda {
             for (int i = 0; i < 9; i++) out[i] = cmul(z, out[i]);
           } else { // stagic phase
 #pragma unroll
-            for (int i = 0; i < 18; i++) { out[i] *= phase; }
+            for (int i = 0; i < 9; i++) { out[i] *= phase; }
           }
         }
       };


### PR DESCRIPTION
This addresses a correctness check failure in various staggered dslash tests.