### PR TITLE
Make 1024 the default launch bounds for AMD GPUs

### DIFF
--- a/lib/gauge_fix_ovr.cu
+++ b/lib/gauge_fix_ovr.cu
@@ -68,6 +68,9 @@ namespace quda {
     unsigned long threads;
     bool halo;
 
+    virtual int blockStep() const { return 32; }
+    virtual int blockMin() const { return 32; }
+
     bool advanceAux(TuneParam &param) const
     {
       param.aux.x = (param.aux.x + 1) % 6;


### PR DESCRIPTION
This matches the current default used by the rocm compiler, and this fixes an issue where gauge_alg_double was failing due to picking an invalid launch configuration that satisfied the device max threads per block but violated the 256 launch bounds attribute.