### PR TITLE
Eigensolvers: check and make sure seeding vectors don't have nan or info norms

### DIFF
--- a/lib/eigensolve_quda.cpp
+++ b/lib/eigensolve_quda.cpp
@@ -143,9 +143,10 @@ namespace quda
     // Use 0th vector to extract meta data for the RNG.
     RNG rng(kSpace[0], 1234);
     for (int b = 0; b < block_size; b++) {
-      // If the spinor contains initial data from the user
-      // preserve it, else populate with rands.
-      if (sqrt(blas::norm2(kSpace[b])) == 0.0) { spinorNoise(kSpace[b], rng, QUDA_NOISE_UNIFORM); }
+      // If the spinor contains valid initial data from the user preserve it, else populate with rands.
+      // We use `!isfinite || norm == 0` instead of `isnormal` because subnormal vectors are still numerically legal
+      auto norm = blas::norm2(kSpace[b]);
+      if (!std::isfinite(norm) || norm == 0.0) { spinorNoise(kSpace[b], rng, QUDA_NOISE_UNIFORM); }
     }
 
     bool orthed = false;


### PR DESCRIPTION
By default, the routine that prepared initial guesses for QUDA's eigensolvers only checked to make sure that the initial vector had a non-zero norm. This extends it to checking for `nan` and `inf` as well. Reported by @leonhostetler .

Don't merge until I get confirmation from Leon that this works, the initial "fix" I gave him modified `interface_quda.cpp` instead of checking deeper down in the eigensolver routines.