### PR TITLE
avoid nonexistent member access in complex template

### DIFF
--- a/include/complex_quda.h
+++ b/include/complex_quda.h
@@ -422,8 +422,8 @@ public:
   __host__ __device__
     inline complex<ValueType>& operator*=(const ValueType z)
     {
-      this->x *= z;
-      this->y *= z;
+      real(real() * z);
+      imag(imag() * z);
       return *this;
     }
 


### PR DESCRIPTION
clang trunk started error out, even though it never got instantiated directly. using member functions should be more correct.