### PR TITLE
Some miscellaneous fixes

### DIFF
--- a/include/clover_field.h
+++ b/include/clover_field.h
@@ -544,13 +544,16 @@ namespace quda {
                          void *Out = 0, const void *In = 0);
 
   /**
-     @brief This function compute the Cholesky decomposition of each clover
-     matrix and stores the clover inverse field.
-
-     @param clover The clover field (contains both the field itself and its inverse)
-     @param computeTraceLog Whether to compute the trace logarithm of the clover term
+     @brief This function computes the Cholesky decomposition of each
+     clover matrix and stores the clover inverse field.  The lattice
+     sum of the trace log is computed here, and if the trace log
+     reports as Nan as error is thrown.
+     @param[in,out] clover The clover field (contains both the field
+     itself and its inverse)
+     @param[in] compute_tr_log Whether to only compute the trace log
+     (and not compute the inverse)
   */
-  void cloverInvert(CloverField &clover, bool computeTraceLog);
+  void cloverInvert(CloverField &clover, bool compute_tr_log);
 
   /**
      @brief Driver for the clover force computation.  Eventually the

--- a/include/color_spinor_field.h
+++ b/include/color_spinor_field.h
@@ -183,7 +183,7 @@ namespace quda
               1 :
               4),
       twistFlavor(inv_param.twist_flavor),
-      gammaBasis(inv_param.gamma_basis),
+      gammaBasis(nSpin == 4 ? inv_param.gamma_basis : QUDA_DEGRAND_ROSSI_GAMMA_BASIS),
       create(QUDA_REFERENCE_FIELD_CREATE),
       pc_type(inv_param.dslash_type == QUDA_DOMAIN_WALL_DSLASH ? QUDA_5D_PC : QUDA_4D_PC),
       v(V)

--- a/include/invert_quda.h
+++ b/include/invert_quda.h
@@ -432,7 +432,7 @@ namespace quda {
     /**
        @brief Naive loop over RHS, for solvers that are not yet multi-RHS aware
      */
-    virtual void operator()(cvector_ref<ColorSpinorField> &out, cvector_ref<ColorSpinorField> &in)
+    void operator()(cvector_ref<ColorSpinorField> &out, cvector_ref<ColorSpinorField> &in)
     {
       for (auto i = 0u; i < in.size(); i++) { this->operator()(out[i], in[i]); }
     }

--- a/lib/clover_field.cpp
+++ b/lib/clover_field.cpp
@@ -244,7 +244,7 @@ namespace quda {
       param.reconstruct = false; // we cannot use a compressed field for storing the inverse
       CloverField clover_inverse(param);
       clover_inverse.copy(src, false);
-      cloverInvert(clover_inverse, true);
+      cloverInvert(clover_inverse, false);
       copy(clover_inverse, true);
       dynamic_inverse_copy = false;
       if (src.Location() == QUDA_CUDA_FIELD_LOCATION && location == QUDA_CPU_FIELD_LOCATION) {

--- a/lib/color_spinor_field.cpp
+++ b/lib/color_spinor_field.cpp
@@ -427,7 +427,6 @@ namespace quda
         copyGenericColorSpinor(*this, src, QUDA_CPU_FIELD_LOCATION, buffer, 0);
         qudaMemcpy(v.data(), buffer, bytes, qudaMemcpyDefault);
         pool_pinned_free(buffer);
-
       } else { // reorder on device
 
         if (src.FieldOrder() == QUDA_PADDED_SPACE_SPIN_COLOR_FIELD_ORDER) {
@@ -459,11 +458,10 @@ namespace quda
     } else if (Location() == QUDA_CPU_FIELD_LOCATION && src.Location() == QUDA_CUDA_FIELD_LOCATION) { // D2H
 
       if (reorder_location() == QUDA_CPU_FIELD_LOCATION) { // reorder on the host
-        void *buffer = pool_pinned_malloc(bytes);
-        qudaMemcpy(buffer, v.data(), bytes, qudaMemcpyDefault);
+        void *buffer = pool_pinned_malloc(src.Bytes());
+        qudaMemcpy(buffer, src.data(), src.Bytes(), qudaMemcpyDefault);
         copyGenericColorSpinor(*this, src, QUDA_CPU_FIELD_LOCATION, 0, buffer);
         pool_pinned_free(buffer);
-
       } else { // reorder on the device
 
         if (FieldOrder() == QUDA_PADDED_SPACE_SPIN_COLOR_FIELD_ORDER) {

--- a/lib/dslash_coarse.in.cpp
+++ b/lib/dslash_coarse.in.cpp
@@ -88,7 +88,7 @@ namespace quda
     param.nVec = nVec;
     param.create = QUDA_NULL_FIELD_CREATE;
     param.fieldOrder = order;
-    return std::move(ColorSpinorField(param));
+    return ColorSpinorField(param);
   }
 
   // Apply the coarse Dirac matrix to a coarse grid vector


### PR DESCRIPTION
This is a hotfix PR, nothing too controversial:
* Fixes warnings with GCC 13 as reported by @bjoo 
* Fixes `QUDA_REORDER_LOCATION=CPU` (closes #1466)
* Improves robustness when dealing with `nSpin=1` and `nSpin=2` fields (only set default gamma basis for `nSpin=4` fields to UKQCD basis)
* Improve user experience with clover fermions: always compute the clover field trace log and report if the trace log is not a number (which is symptomatic of invalid parameters) 
