### PR TITLE
Added Dirac-Pauli spin basis

### DIFF
--- a/include/enum_quda.h
+++ b/include/enum_quda.h
@@ -370,13 +370,16 @@ typedef enum QudaFieldCreate_s {
   QUDA_INVALID_FIELD_CREATE = QUDA_INVALID_ENUM
 } QudaFieldCreate;
 
-typedef enum QudaGammaBasis_s {
-  QUDA_DEGRAND_ROSSI_GAMMA_BASIS,
-  QUDA_UKQCD_GAMMA_BASIS,
-  QUDA_CHIRAL_GAMMA_BASIS,
-  QUDA_INVALID_GAMMA_BASIS = QUDA_INVALID_ENUM
+typedef enum QudaGammaBasis_s {          // gamj=((top 2 rows)(bottom 2 rows))  s1,s2,s3 are Pauli spin matrices, 1 is 2x2 identity
+  QUDA_DEGRAND_ROSSI_GAMMA_BASIS,   // gam1=((0,i*s1)(-i*s1,0)) gam2=((0,-i*s2)(i*s2,0)) gam3=((0,i*s3)(-i*s3,0)) gam4=((0,1)(1,0))  gam5=((-1,0)(0,1))
+  QUDA_UKQCD_GAMMA_BASIS,           // gam1=((0,i*s1)(-i*s1,0)) gam2=((0,i*s2)(-i*s2,0)) gam3=((0,i*s3)(-i*s3,0)) gam4=((1,0)(0,-1)) gam5=((0,-1)(-1,0))
+  QUDA_CHIRAL_GAMMA_BASIS,          // gam1=((0,-i*s1)(i*s1,0)) gam2=((0,-i*s2)(i*s2,0)) gam3=((0,-i*s3)(i*s3,0)) gam4=((0,-1)(-1,0))gam5=((1,0)(0,-1))
+  QUDA_DIRAC_PAULI_GAMMA_BASIS,     // gam1=((0,-i*s1)(i*s1,0)) gam2=((0,-i*s2)(i*s2,0)) gam3=((0,-i*s3)(i*s3,0)) gam4=((1,0)(0,-1)) gam5=((0,1)(1,0))
+  QUDA_INVALID_GAMMA_BASIS = QUDA_INVALID_ENUM      //  gam5=gam4*gam1*gam2*gam3
 } QudaGammaBasis;
-
+                                      //  Dirac-Pauli -> DeGrand-Rossi   T = i/sqrt(2)*((s2,-s2)(s2,s2))     field_DR = T * field_DP
+                                      //  UKQCD -> DeGrand-Rossi         T = i/sqrt(2)*((-s2,-s2)(-s2,s2))   field_DR = T * field_UK
+                                      //  Chiral -> DeGrand-Rossi        T = i*((0,-s2)(s2,0))               field_DR = T * field_chiral
 typedef enum QudaSourceType_s {
   QUDA_POINT_SOURCE,
   QUDA_RANDOM_SOURCE,

--- a/include/enum_quda_fortran.h
+++ b/include/enum_quda_fortran.h
@@ -41,8 +41,9 @@
 #define QUDA_QDPJIT_GAUGE_ORDER 11     // expect *gauge[4] even-odd spacetime row-column color
 #define QUDA_CPS_WILSON_GAUGE_ORDER 12 // expect *gauge even-odd spacetime column-row color
 #define QUDA_MILC_GAUGE_ORDER 13       // expect *gauge even-odd mu spacetime row-column order
-#define QUDA_MILC_SITE_GAUGE_ORDER  14 // packed into MILC site AoS [even-odd][spacetime] array, and [dir][row][col] inside
-#define QUDA_BQCD_GAUGE_ORDER 15       // expect *gauge mu even-odd spacetime+halos row-column order
+#define QUDA_MILC_SITE_GAUGE_ORDER                                                                                     \
+  14                             // packed into MILC site AoS [even-odd][spacetime] array, and [dir][row][col] inside
+#define QUDA_BQCD_GAUGE_ORDER 15 // expect *gauge mu even-odd spacetime+halos row-column order
 #define QUDA_TIFR_GAUGE_ORDER 16
 #define QUDA_TIFR_PADDED_GAUGE_ORDER 17
 #define QUDA_INVALID_GAUGE_ORDER QUDA_INVALID_ENUM

--- a/include/enum_quda_fortran.h
+++ b/include/enum_quda_fortran.h
@@ -41,9 +41,8 @@
 #define QUDA_QDPJIT_GAUGE_ORDER 11     // expect *gauge[4] even-odd spacetime row-column color
 #define QUDA_CPS_WILSON_GAUGE_ORDER 12 // expect *gauge even-odd spacetime column-row color
 #define QUDA_MILC_GAUGE_ORDER 13       // expect *gauge even-odd mu spacetime row-column order
-#define QUDA_MILC_SITE_GAUGE_ORDER                                                                                     \
-  14                             // packed into MILC site AoS [even-odd][spacetime] array, and [dir][row][col] inside
-#define QUDA_BQCD_GAUGE_ORDER 15 // expect *gauge mu even-odd spacetime+halos row-column order
+#define QUDA_MILC_SITE_GAUGE_ORDER  14 // packed into MILC site AoS [even-odd][spacetime] array, and [dir][row][col] inside
+#define QUDA_BQCD_GAUGE_ORDER 15       // expect *gauge mu even-odd spacetime+halos row-column order
 #define QUDA_TIFR_GAUGE_ORDER 16
 #define QUDA_TIFR_PADDED_GAUGE_ORDER 17
 #define QUDA_INVALID_GAUGE_ORDER QUDA_INVALID_ENUM
@@ -341,6 +340,7 @@
 #define QUDA_DEGRAND_ROSSI_GAMMA_BASIS 0
 #define QUDA_UKQCD_GAMMA_BASIS 1
 #define QUDA_CHIRAL_GAMMA_BASIS 2
+#define QUDA_DIRAC_PAULI_GAMMA_BASIS 3
 #define QUDA_INVALID_GAMMA_BASIS QUDA_INVALID_ENUM
 
 #define QudaSourceType integer(4)

--- a/include/kernels/copy_color_spinor.cuh
+++ b/include/kernels/copy_color_spinor.cuh
@@ -44,7 +44,7 @@ namespace quda {
     }
   };
 
-  /** Transform from relativistic into non-relavisitic basis */
+  /** Transform from relativistic Degrand-Rossi into non-relativistic UKQCD basis */
   template <int Ns, int Nc>
   struct NonRelBasis {
     template <typename FloatOut, typename FloatIn>
@@ -61,7 +61,7 @@ namespace quda {
     }
   };
 
-  /** Transform from non-relativistic into relavisitic basis */
+  /** Transform from non-relativistic UKQCD into relativistic Degrand-Rossi basis */
   template <int Ns, int Nc>
   struct RelBasis {
     template <typename FloatOut, typename FloatIn>
@@ -78,7 +78,41 @@ namespace quda {
     }
   };
 
-  /** Transform from chiral into non-relavisitic basis */
+  /** Transform from non-relativistic Dirac-Pauli into relativistic Degrand-Rossi basis */
+  template <int Ns, int Nc>
+  struct DegrandRossiToDiracPaulBasis {
+    template <typename FloatOut, typename FloatIn>
+    __device__ __host__ inline void operator()(complex<FloatOut> out[Ns*Nc], const complex<FloatIn> in[Ns*Nc]) const {
+      int s1[4] = {1, 2, 1, 0};
+      int s2[4] = {3, 0, 3, 2};
+      FloatOut K1[4] = {static_cast<FloatOut>(-kU), static_cast<FloatOut>(kU), static_cast<FloatOut>(kU), static_cast<FloatOut>(-kU)};
+      FloatOut K2[4] = {static_cast<FloatOut>(-kU), static_cast<FloatOut>(kU), static_cast<FloatOut>(-kU),  static_cast<FloatOut>(kU)};
+      for (int s=0; s<Ns; s++) {
+	for (int c=0; c<Nc; c++) {
+	  out[s*Nc+c] = K1[s]*static_cast<complex<FloatOut> >(in[s1[s]*Nc+c]) + K2[s]*static_cast<complex<FloatOut> >(in[s2[s]*Nc+c]);
+	}
+      }
+    }
+  };
+
+  /** Transform from relativistic Degrand-Rossi into non-relativistic Dirac-Pauli basis */
+  template <int Ns, int Nc>
+  struct DiracPaulToDegrandRossiBasis {
+    template <typename FloatOut, typename FloatIn>
+    __device__ __host__ inline void operator()(complex<FloatOut> out[Ns*Nc], const complex<FloatIn> in[Ns*Nc]) const {
+      int s1[4] = {1, 2, 1, 0};
+      int s2[4] = {3, 0, 3, 2};
+      FloatOut K1[4] = {static_cast<FloatOut>(kP),  static_cast<FloatOut>(kP),  static_cast<FloatOut>(kP), static_cast<FloatOut>(-kP)};
+      FloatOut K2[4] = {static_cast<FloatOut>(-kP), static_cast<FloatOut>(-kP), static_cast<FloatOut>(kP), static_cast<FloatOut>(-kP)};
+      for (int s=0; s<Ns; s++) {
+	for (int c=0; c<Nc; c++) {
+	  out[s*Nc+c] = K1[s]*static_cast<complex<FloatOut> >(in[s1[s]*Nc+c]) + K2[s]*static_cast<complex<FloatOut> >(in[s2[s]*Nc+c]);
+	}
+      }
+    }
+  };
+
+  /** Transform from chiral into UKQCD non-relativistic basis */
   template <int Ns, int Nc>
   struct ChiralToNonRelBasis {
     template <typename FloatOut, typename FloatIn>
@@ -95,7 +129,7 @@ namespace quda {
     }
   };
 
-  /** Transform from non-relativistic into chiral basis */
+  /** Transform from UKQCD non-relativistic into chiral basis */
   template <int Ns, int Nc>
   struct NonRelToChiralBasis {
     template <typename FloatOut, typename FloatIn>
@@ -107,6 +141,21 @@ namespace quda {
       for (int s=0; s<Ns; s++) {
 	for (int c=0; c<Nc; c++) {
 	  out[s*Nc+c] = K1[s]*static_cast<complex<FloatOut> >(in[s1[s]*Nc+c]) + K2[s]*static_cast<complex<FloatOut> >(in[s2[s]*Nc+c]);
+	}
+      }
+    }
+  };
+
+  /** Transform from chiral into DeGrand-Rossi basis or from DeGrand-Rossi into chiral basis */
+  template <int Ns, int Nc>
+  struct ChiralToFromDegrandRossiBasis {
+    template <typename FloatOut, typename FloatIn>
+    __device__ __host__ inline void operator()(complex<FloatOut> out[Ns*Nc], const complex<FloatIn> in[Ns*Nc]) const {
+      int s1[4] = {3, 2, 1, 0};
+      FloatOut K1[4] = {static_cast<FloatOut>(-1.0), static_cast<FloatOut>(1.0), static_cast<FloatOut>(1.0), static_cast<FloatOut>(-1.0)};
+      for (int s=0; s<Ns; s++) {
+	for (int c=0; c<Nc; c++) {
+	  out[s*Nc+c] = K1[s]*static_cast<complex<FloatOut> >(in[s1[s]*Nc+c]);
 	}
       }
     }

--- a/include/kernels/copy_color_spinor.cuh
+++ b/include/kernels/copy_color_spinor.cuh
@@ -161,6 +161,21 @@ namespace quda {
     }
   };
 
+   /** Transform from UKQCD to Dirac-Pauli and from Dirac-Pauli into UKQCD basis */
+  template <int Ns, int Nc>
+  struct UKQCDToFromDiracPauliBasis {
+    template <typename FloatOut, typename FloatIn>
+    __device__ __host__ inline void operator()(complex<FloatOut> out[Ns*Nc], const complex<FloatIn> in[Ns*Nc]) const {
+      int s1[4] = {0, 1, 2, 3};
+      FloatOut K1[4] = {static_cast<FloatOut>(-1.0), static_cast<FloatOut>(-1.0), static_cast<FloatOut>(1.0), static_cast<FloatOut>(1.0)};
+      for (int s=0; s<Ns; s++) {
+	for (int c=0; c<Nc; c++) {
+	  out[s*Nc+c] = K1[s]*static_cast<complex<FloatOut> >(in[s1[s]*Nc+c]);
+	}
+      }
+    }
+  };
+
   template <typename Arg> struct CopyColorSpinor_ {
     const Arg &arg;
     constexpr CopyColorSpinor_(const Arg &arg): arg(arg) {}

--- a/lib/copy_color_spinor.cuh
+++ b/lib/copy_color_spinor.cuh
@@ -6,11 +6,12 @@
 
 namespace quda {
 
-  template <int Ns, int Nc, typename Out, typename In, typename param_t>
-  class CopyColorSpinor : TunableKernel2D {
+  template <int nSpin, int nColor, typename Out, typename In, typename param_t> class CopyColorSpinor : TunableKernel2D
+  {
     using FloatOut = std::remove_pointer_t<typename std::tuple_element<3, param_t>::type>;
     using FloatIn = std::remove_const_t<std::remove_pointer_t<typename std::tuple_element<4, param_t>::type>>;
-    template <template <int, int> class Basis> using Arg = CopyColorSpinorArg<FloatOut, FloatIn, Ns, Nc, Out, In, Basis>;
+    template <template <int, int> class Basis>
+    using Arg = CopyColorSpinorArg<FloatOut, FloatIn, nSpin, nColor, Out, In, Basis>;
     FloatOut *Out_;
     const FloatIn *In_;
     ColorSpinorField &out;
@@ -18,6 +19,18 @@ namespace quda {
 
     bool advanceSharedBytes(TuneParam &) const { return false; } // Don't tune shared mem
     unsigned int minThreads() const { return in.VolumeCB(); }
+
+    std::string get_basis_str(QudaGammaBasis basis)
+    {
+      switch (basis) {
+      case QUDA_DEGRAND_ROSSI_GAMMA_BASIS: return "degrand_rossi";
+      case QUDA_UKQCD_GAMMA_BASIS: return "ukqcd";
+      case QUDA_CHIRAL_GAMMA_BASIS: return "chiral";
+      case QUDA_DIRAC_PAULI_GAMMA_BASIS: return "dirac_pauli";
+      default: errorQuda("Unknown gamma basis %d", basis);
+      }
+      return "unknown";
+    }
 
   public:
     CopyColorSpinor(ColorSpinorField &out, const ColorSpinorField &in, const param_t &param) :
@@ -28,66 +41,53 @@ namespace quda {
       in(in)
     {
       strcat(aux, out.AuxString().c_str());
-      if (out.GammaBasis()==in.GammaBasis()) strcat(aux, ",PreserveBasis");
-      else if (out.GammaBasis() == QUDA_UKQCD_GAMMA_BASIS && in.GammaBasis() == QUDA_DEGRAND_ROSSI_GAMMA_BASIS) strcat(aux, ",NonRelBasis");
-      else if (out.GammaBasis() == QUDA_DEGRAND_ROSSI_GAMMA_BASIS && in.GammaBasis() == QUDA_UKQCD_GAMMA_BASIS) strcat(aux, ",RelBasis");
-      else if (out.GammaBasis() == QUDA_DIRAC_PAULI_GAMMA_BASIS && in.GammaBasis() == QUDA_DEGRAND_ROSSI_GAMMA_BASIS) strcat(aux, ",DegrandRossiToDiracPaulBasis");
-      else if (out.GammaBasis() == QUDA_DEGRAND_ROSSI_GAMMA_BASIS && in.GammaBasis() == QUDA_DIRAC_PAULI_GAMMA_BASIS) strcat(aux, ",DiracPaulToDegrandRossiBasis");
-      else if (out.GammaBasis() == QUDA_UKQCD_GAMMA_BASIS && in.GammaBasis() == QUDA_CHIRAL_GAMMA_BASIS) strcat(aux, ",ChiralToNonRelBasis");
-      else if (out.GammaBasis() == QUDA_CHIRAL_GAMMA_BASIS && in.GammaBasis() == QUDA_UKQCD_GAMMA_BASIS) strcat(aux, ",NonRelToChiralBasis");
-      else if (out.GammaBasis() == QUDA_CHIRAL_GAMMA_BASIS && in.GammaBasis() == QUDA_DEGRAND_ROSSI_GAMMA_BASIS) strcat(aux, ",ChiralToFromDegrandRossiBasis");
-      else if (out.GammaBasis() == QUDA_DEGRAND_ROSSI_GAMMA_BASIS && in.GammaBasis() == QUDA_CHIRAL_GAMMA_BASIS) strcat(aux, ",ChiralToFromDegrandRossiBasis");
-      else if (out.GammaBasis() == QUDA_DIRAC_PAULI_GAMMA_BASIS && in.GammaBasis() == QUDA_UKQCD_GAMMA_BASIS) strcat(aux, ",UKQCDToFromDiracPauliBasis");
-      else if (out.GammaBasis() == QUDA_UKQCD_GAMMA_BASIS && in.GammaBasis() == QUDA_DIRAC_PAULI_GAMMA_BASIS) strcat(aux, ",UKQCDToFromDiracPauliBasis");
-      else errorQuda("Basis change from %d to %d not supported", in.GammaBasis(), out.GammaBasis());
+      if (out.GammaBasis() != in.GammaBasis()) {
+        strcat(aux, "to_");
+        strcat(aux, get_basis_str(out.GammaBasis()).c_str());
+        strcat(aux, ",from_");
+        strcat(aux, get_basis_str(in.GammaBasis()).c_str());
+      }
 
       apply(device::get_default_stream());
-    }
-
-    template <int nSpin> std::enable_if_t<nSpin != 4, void> Launch(TuneParam &tp, const qudaStream_t &stream)
-    {
-      constexpr bool enable_host = true;
-      if (out.GammaBasis()==in.GammaBasis()) {
-        launch<CopyColorSpinor_, enable_host>(tp, stream, Arg<PreserveBasis>(out, in, Out_, In_));
-      } else {
-        errorQuda("Unexpected basis change from %d to %d", in.GammaBasis(), out.GammaBasis());
-      }
-    }
-
-    template <int nSpin> std::enable_if_t<nSpin == 4, void> Launch(TuneParam &tp, const qudaStream_t &stream)
-    {
-      constexpr bool enable_host = true;
-      if (out.GammaBasis()==in.GammaBasis()) {
-        launch<CopyColorSpinor_, enable_host>(tp, stream, Arg<PreserveBasis>(out, in, Out_, In_));
-      } else if (out.GammaBasis() == QUDA_UKQCD_GAMMA_BASIS && in.GammaBasis() == QUDA_DEGRAND_ROSSI_GAMMA_BASIS) {
-        launch<CopyColorSpinor_, enable_host>(tp, stream, Arg<NonRelBasis>(out, in, Out_, In_));
-      } else if (out.GammaBasis() == QUDA_DEGRAND_ROSSI_GAMMA_BASIS && in.GammaBasis() == QUDA_UKQCD_GAMMA_BASIS) {
-        launch<CopyColorSpinor_, enable_host>(tp, stream, Arg<RelBasis>(out, in, Out_, In_));
-      } else if (out.GammaBasis() == QUDA_DIRAC_PAULI_GAMMA_BASIS && in.GammaBasis() == QUDA_DEGRAND_ROSSI_GAMMA_BASIS) {
-        launch<CopyColorSpinor_, enable_host>(tp, stream, Arg<DegrandRossiToDiracPaulBasis>(out, in, Out_, In_));
-      } else if (out.GammaBasis() == QUDA_DEGRAND_ROSSI_GAMMA_BASIS && in.GammaBasis() == QUDA_DIRAC_PAULI_GAMMA_BASIS) {
-        launch<CopyColorSpinor_, enable_host>(tp, stream, Arg<DiracPaulToDegrandRossiBasis>(out, in, Out_, In_));
-      } else if (out.GammaBasis() == QUDA_UKQCD_GAMMA_BASIS && in.GammaBasis() == QUDA_CHIRAL_GAMMA_BASIS) {
-        launch<CopyColorSpinor_, enable_host>(tp, stream, Arg<ChiralToNonRelBasis>(out, in, Out_, In_));
-      } else if (out.GammaBasis() == QUDA_CHIRAL_GAMMA_BASIS && in.GammaBasis() == QUDA_UKQCD_GAMMA_BASIS) {
-        launch<CopyColorSpinor_, enable_host>(tp, stream, Arg<NonRelToChiralBasis>(out, in, Out_, In_));
-      } else if (out.GammaBasis() == QUDA_CHIRAL_GAMMA_BASIS && in.GammaBasis() == QUDA_DEGRAND_ROSSI_GAMMA_BASIS) {
-        launch<CopyColorSpinor_, enable_host>(tp, stream, Arg<ChiralToFromDegrandRossiBasis>(out, in, Out_, In_));
-      } else if (out.GammaBasis() == QUDA_DEGRAND_ROSSI_GAMMA_BASIS && in.GammaBasis() == QUDA_CHIRAL_GAMMA_BASIS) {
-        launch<CopyColorSpinor_, enable_host>(tp, stream, Arg<ChiralToFromDegrandRossiBasis>(out, in, Out_, In_));
-      } else if (out.GammaBasis() == QUDA_DIRAC_PAULI_GAMMA_BASIS && in.GammaBasis() == QUDA_UKQCD_GAMMA_BASIS) {
-        launch<CopyColorSpinor_, enable_host>(tp, stream, Arg<UKQCDToFromDiracPauliBasis>(out, in, Out_, In_));
-      } else if (out.GammaBasis() == QUDA_UKQCD_GAMMA_BASIS && in.GammaBasis() == QUDA_DIRAC_PAULI_GAMMA_BASIS) {
-        launch<CopyColorSpinor_, enable_host>(tp, stream, Arg<UKQCDToFromDiracPauliBasis>(out, in, Out_, In_));
-      } else {
-        errorQuda("Unexpected basis change from %d to %d", in.GammaBasis(), out.GammaBasis());
-      }
     }
 
     void apply(const qudaStream_t &stream)
     {
       TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
-      Launch<Ns>(tp, stream);
+      constexpr bool enable_host = true;
+      if constexpr (nSpin == 4) {
+        if (out.GammaBasis() == in.GammaBasis()) {
+          launch<CopyColorSpinor_, enable_host>(tp, stream, Arg<PreserveBasis>(out, in, Out_, In_));
+        } else if (out.GammaBasis() == QUDA_UKQCD_GAMMA_BASIS && in.GammaBasis() == QUDA_DEGRAND_ROSSI_GAMMA_BASIS) {
+          launch<CopyColorSpinor_, enable_host>(tp, stream, Arg<NonRelBasis>(out, in, Out_, In_));
+        } else if (out.GammaBasis() == QUDA_DEGRAND_ROSSI_GAMMA_BASIS && in.GammaBasis() == QUDA_UKQCD_GAMMA_BASIS) {
+          launch<CopyColorSpinor_, enable_host>(tp, stream, Arg<RelBasis>(out, in, Out_, In_));
+        } else if (out.GammaBasis() == QUDA_UKQCD_GAMMA_BASIS && in.GammaBasis() == QUDA_CHIRAL_GAMMA_BASIS) {
+          launch<CopyColorSpinor_, enable_host>(tp, stream, Arg<ChiralToNonRelBasis>(out, in, Out_, In_));
+        } else if (out.GammaBasis() == QUDA_CHIRAL_GAMMA_BASIS && in.GammaBasis() == QUDA_UKQCD_GAMMA_BASIS) {
+          launch<CopyColorSpinor_, enable_host>(tp, stream, Arg<NonRelToChiralBasis>(out, in, Out_, In_));
+        } else if (out.GammaBasis() == QUDA_DIRAC_PAULI_GAMMA_BASIS && in.GammaBasis() == QUDA_DEGRAND_ROSSI_GAMMA_BASIS) {
+          launch<CopyColorSpinor_, enable_host>(tp, stream, Arg<DegrandRossiToDiracPaulBasis>(out, in, Out_, In_));
+        } else if (out.GammaBasis() == QUDA_DEGRAND_ROSSI_GAMMA_BASIS && in.GammaBasis() == QUDA_DIRAC_PAULI_GAMMA_BASIS) {
+          launch<CopyColorSpinor_, enable_host>(tp, stream, Arg<DiracPaulToDegrandRossiBasis>(out, in, Out_, In_));
+        } else if (out.GammaBasis() == QUDA_CHIRAL_GAMMA_BASIS && in.GammaBasis() == QUDA_DEGRAND_ROSSI_GAMMA_BASIS) {
+          launch<CopyColorSpinor_, enable_host>(tp, stream, Arg<ChiralToFromDegrandRossiBasis>(out, in, Out_, In_));
+        } else if (out.GammaBasis() == QUDA_DEGRAND_ROSSI_GAMMA_BASIS && in.GammaBasis() == QUDA_CHIRAL_GAMMA_BASIS) {
+          launch<CopyColorSpinor_, enable_host>(tp, stream, Arg<ChiralToFromDegrandRossiBasis>(out, in, Out_, In_));
+        } else if (out.GammaBasis() == QUDA_DIRAC_PAULI_GAMMA_BASIS && in.GammaBasis() == QUDA_UKQCD_GAMMA_BASIS) {
+          launch<CopyColorSpinor_, enable_host>(tp, stream, Arg<UKQCDToFromDiracPauliBasis>(out, in, Out_, In_));
+        } else if (out.GammaBasis() == QUDA_UKQCD_GAMMA_BASIS && in.GammaBasis() == QUDA_DIRAC_PAULI_GAMMA_BASIS) {
+          launch<CopyColorSpinor_, enable_host>(tp, stream, Arg<UKQCDToFromDiracPauliBasis>(out, in, Out_, In_));
+        } else {
+          errorQuda("Unexpected basis change from %d to %d", in.GammaBasis(), out.GammaBasis());
+        }
+      } else {
+        if (out.GammaBasis() == in.GammaBasis()) {
+          launch<CopyColorSpinor_, enable_host>(tp, stream, Arg<PreserveBasis>(out, in, Out_, In_));
+        } else {
+          errorQuda("Unexpected basis change from %d to %d", in.GammaBasis(), out.GammaBasis());
+        }
+      }
     }
 
     long long flops() const { return 0; }

--- a/lib/copy_color_spinor.cuh
+++ b/lib/copy_color_spinor.cuh
@@ -31,8 +31,12 @@ namespace quda {
       if (out.GammaBasis()==in.GammaBasis()) strcat(aux, ",PreserveBasis");
       else if (out.GammaBasis() == QUDA_UKQCD_GAMMA_BASIS && in.GammaBasis() == QUDA_DEGRAND_ROSSI_GAMMA_BASIS) strcat(aux, ",NonRelBasis");
       else if (out.GammaBasis() == QUDA_DEGRAND_ROSSI_GAMMA_BASIS && in.GammaBasis() == QUDA_UKQCD_GAMMA_BASIS) strcat(aux, ",RelBasis");
+      else if (out.GammaBasis() == QUDA_DIRAC_PAULI_GAMMA_BASIS && in.GammaBasis() == QUDA_DEGRAND_ROSSI_GAMMA_BASIS) strcat(aux, ",DegrandRossiToDiracPaulBasis");
+      else if (out.GammaBasis() == QUDA_DEGRAND_ROSSI_GAMMA_BASIS && in.GammaBasis() == QUDA_DIRAC_PAULI_GAMMA_BASIS) strcat(aux, ",DiracPaulToDegrandRossiBasis");
       else if (out.GammaBasis() == QUDA_UKQCD_GAMMA_BASIS && in.GammaBasis() == QUDA_CHIRAL_GAMMA_BASIS) strcat(aux, ",ChiralToNonRelBasis");
       else if (out.GammaBasis() == QUDA_CHIRAL_GAMMA_BASIS && in.GammaBasis() == QUDA_UKQCD_GAMMA_BASIS) strcat(aux, ",NonRelToChiralBasis");
+      else if (out.GammaBasis() == QUDA_CHIRAL_GAMMA_BASIS && in.GammaBasis() == QUDA_DEGRAND_ROSSI_GAMMA_BASIS) strcat(aux, ",ChiralToFromDegrandRossiBasis");
+      else if (out.GammaBasis() == QUDA_DEGRAND_ROSSI_GAMMA_BASIS && in.GammaBasis() == QUDA_CHIRAL_GAMMA_BASIS) strcat(aux, ",ChiralToFromDegrandRossiBasis");
       else errorQuda("Basis change from %d to %d not supported", in.GammaBasis(), out.GammaBasis());
 
       apply(device::get_default_stream());
@@ -57,10 +61,18 @@ namespace quda {
         launch<CopyColorSpinor_, enable_host>(tp, stream, Arg<NonRelBasis>(out, in, Out_, In_));
       } else if (out.GammaBasis() == QUDA_DEGRAND_ROSSI_GAMMA_BASIS && in.GammaBasis() == QUDA_UKQCD_GAMMA_BASIS) {
         launch<CopyColorSpinor_, enable_host>(tp, stream, Arg<RelBasis>(out, in, Out_, In_));
+      } else if (out.GammaBasis() == QUDA_DIRAC_PAULI_GAMMA_BASIS && in.GammaBasis() == QUDA_DEGRAND_ROSSI_GAMMA_BASIS) {
+        launch<CopyColorSpinor_, enable_host>(tp, stream, Arg<DegrandRossiToDiracPaulBasis>(out, in, Out_, In_));
+      } else if (out.GammaBasis() == QUDA_DEGRAND_ROSSI_GAMMA_BASIS && in.GammaBasis() == QUDA_DIRAC_PAULI_GAMMA_BASIS) {
+        launch<CopyColorSpinor_, enable_host>(tp, stream, Arg<DiracPaulToDegrandRossiBasis>(out, in, Out_, In_));
       } else if (out.GammaBasis() == QUDA_UKQCD_GAMMA_BASIS && in.GammaBasis() == QUDA_CHIRAL_GAMMA_BASIS) {
         launch<CopyColorSpinor_, enable_host>(tp, stream, Arg<ChiralToNonRelBasis>(out, in, Out_, In_));
       } else if (out.GammaBasis() == QUDA_CHIRAL_GAMMA_BASIS && in.GammaBasis() == QUDA_UKQCD_GAMMA_BASIS) {
         launch<CopyColorSpinor_, enable_host>(tp, stream, Arg<NonRelToChiralBasis>(out, in, Out_, In_));
+      } else if (out.GammaBasis() == QUDA_CHIRAL_GAMMA_BASIS && in.GammaBasis() == QUDA_DEGRAND_ROSSI_GAMMA_BASIS) {
+        launch<CopyColorSpinor_, enable_host>(tp, stream, Arg<ChiralToFromDegrandRossiBasis>(out, in, Out_, In_));
+      } else if (out.GammaBasis() == QUDA_DEGRAND_ROSSI_GAMMA_BASIS && in.GammaBasis() == QUDA_CHIRAL_GAMMA_BASIS) {
+        launch<CopyColorSpinor_, enable_host>(tp, stream, Arg<ChiralToFromDegrandRossiBasis>(out, in, Out_, In_));
       } else {
         errorQuda("Unexpected basis change from %d to %d", in.GammaBasis(), out.GammaBasis());
       }

--- a/lib/copy_color_spinor.cuh
+++ b/lib/copy_color_spinor.cuh
@@ -37,6 +37,8 @@ namespace quda {
       else if (out.GammaBasis() == QUDA_CHIRAL_GAMMA_BASIS && in.GammaBasis() == QUDA_UKQCD_GAMMA_BASIS) strcat(aux, ",NonRelToChiralBasis");
       else if (out.GammaBasis() == QUDA_CHIRAL_GAMMA_BASIS && in.GammaBasis() == QUDA_DEGRAND_ROSSI_GAMMA_BASIS) strcat(aux, ",ChiralToFromDegrandRossiBasis");
       else if (out.GammaBasis() == QUDA_DEGRAND_ROSSI_GAMMA_BASIS && in.GammaBasis() == QUDA_CHIRAL_GAMMA_BASIS) strcat(aux, ",ChiralToFromDegrandRossiBasis");
+      else if (out.GammaBasis() == QUDA_DIRAC_PAULI_GAMMA_BASIS && in.GammaBasis() == QUDA_UKQCD_GAMMA_BASIS) strcat(aux, ",UKQCDToFromDiracPauliBasis");
+      else if (out.GammaBasis() == QUDA_UKQCD_GAMMA_BASIS && in.GammaBasis() == QUDA_DIRAC_PAULI_GAMMA_BASIS) strcat(aux, ",UKQCDToFromDiracPauliBasis");
       else errorQuda("Basis change from %d to %d not supported", in.GammaBasis(), out.GammaBasis());
 
       apply(device::get_default_stream());
@@ -73,6 +75,10 @@ namespace quda {
         launch<CopyColorSpinor_, enable_host>(tp, stream, Arg<ChiralToFromDegrandRossiBasis>(out, in, Out_, In_));
       } else if (out.GammaBasis() == QUDA_DEGRAND_ROSSI_GAMMA_BASIS && in.GammaBasis() == QUDA_CHIRAL_GAMMA_BASIS) {
         launch<CopyColorSpinor_, enable_host>(tp, stream, Arg<ChiralToFromDegrandRossiBasis>(out, in, Out_, In_));
+      } else if (out.GammaBasis() == QUDA_DIRAC_PAULI_GAMMA_BASIS && in.GammaBasis() == QUDA_UKQCD_GAMMA_BASIS) {
+        launch<CopyColorSpinor_, enable_host>(tp, stream, Arg<UKQCDToFromDiracPauliBasis>(out, in, Out_, In_));
+      } else if (out.GammaBasis() == QUDA_UKQCD_GAMMA_BASIS && in.GammaBasis() == QUDA_DIRAC_PAULI_GAMMA_BASIS) {
+        launch<CopyColorSpinor_, enable_host>(tp, stream, Arg<UKQCDToFromDiracPauliBasis>(out, in, Out_, In_));
       } else {
         errorQuda("Unexpected basis change from %d to %d", in.GammaBasis(), out.GammaBasis());
       }


### PR DESCRIPTION
Added Dirac-Pauli spin basis in the enums and in the copying of color-spin fields.  Also added a chiral <-> Degrand-Rossi basis conversion routine.  Added some comments about the spin basis details in the enum file.   Tested new conversion routines serial/mpi,  cmu nodes and summit, double and single precsion.  Will compare with chroma too.