### PR TITLE
Feature/power

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,7 +280,6 @@ mark_as_advanced(QUDA_RECONSTRUCT)
 mark_as_advanced(QUDA_CLOVER_CHOLESKY_PROMOTE)
 mark_as_advanced(QUDA_MULTIGRID_DSLASH_PROMOTE)
 mark_as_advanced(QUDA_CTEST_SEP_DSLASH_POLICIES)
-mark_as_advanced(QUDA_OPENMP)
 
 mark_as_advanced(QUDA_BACKWARDS)
 

--- a/include/device.h
+++ b/include/device.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include <quda_api.h>
 
 namespace quda
@@ -11,6 +12,7 @@ namespace quda
     /**
        @brief Create the device context.  Called by initQuda when
        initializing the library.
+       @param[in] dev Device ordinal for which to initialize
      */
     void init(int dev);
 
@@ -20,6 +22,24 @@ namespace quda
        init() has not previously been called.
      */
     void init_thread();
+
+    /**
+       @brief Struct that is used to record the state of the device
+       (or host in the future).  At present this is used for storing
+       the power, clock rate and temperature at a given point in time,
+       but can be expanded as necessary in the future.
+     */
+    struct state_t {
+      std::chrono::time_point<std::chrono::high_resolution_clock> time;
+      float power;
+      unsigned int clock;
+      unsigned int temp;
+    };
+
+    /**
+       @brief Record the present state of the GPU (power, temperature, clock)
+     */
+    state_t get_state();
 
     /**
        @brief Get number of devices present on node

--- a/include/kernels/spin_taste.cuh
+++ b/include/kernels/spin_taste.cuh
@@ -19,16 +19,14 @@ namespace quda
     F out;      /** output vector field */
     const F in; /** input vector field */
 
-    SpinTasteArg(ColorSpinorField &out_, const ColorSpinorField &in_) :
-      kernel_param(dim3(in_.VolumeCB(), in_.SiteSubset(), 1)), out(out_), in(in_)
+    SpinTasteArg(ColorSpinorField &out, const ColorSpinorField &in) :
+      kernel_param(dim3(in.VolumeCB(), in.SiteSubset(), 1)), out(out), in(in)
     {
-      checkOrder(out_, in_);     // check all orders match
-      checkPrecision(out_, in_); // check all precisions match
-      checkLocation(out_, in_);  // check all locations match
-      if (!in_.isNative()) errorQuda("Unsupported field order colorspinor= %d \n", in_.FieldOrder());
-      if (!out_.isNative()) errorQuda("Unsupported field order colorspinor= %d \n", out_.FieldOrder());
-#pragma unroll
-      for (int i = 0; i < 4; i++) { X[i] = in_.X()[i]; }
+      checkOrder(out, in);     // check all orders match
+      checkPrecision(out, in); // check all precisions match
+      checkLocation(out, in);  // check all locations match
+      checkNative(out, in);
+      for (int i = 0; i < 4; i++) { X[i] = in.X()[i]; }
     }
   };
 

--- a/include/monitor.h
+++ b/include/monitor.h
@@ -1,0 +1,26 @@
+namespace quda
+{
+
+  namespace monitor
+  {
+
+    /**
+       @brief Initialize device monitoring if supported.  On CUDA this
+       uses NVML-based monitoring.
+    */
+    void init();
+
+    /**
+       @brief Tear down any state associated with device monitoring
+    */
+    void destroy();
+
+    /**
+       @brief Serlialize the monitor state history to disk.  If
+       QUDA_RESOURCE_PATH is not defined then no action is taken
+    */
+    void serialize();
+
+  } // namespace monitor
+
+} // namespace quda

--- a/include/targets/cuda/atomic_helper.h
+++ b/include/targets/cuda/atomic_helper.h
@@ -81,7 +81,7 @@ namespace quda
   template <bool is_device> struct atomic_fetch_abs_max_impl {
     template <typename T> inline void operator()(T *addr, T val)
     {
-#pragma omp atomic update
+#pragma omp critical
       *addr = std::max(*addr, val);
     }
   };

--- a/include/targets/cuda/device.in.hpp
+++ b/include/targets/cuda/device.in.hpp
@@ -33,6 +33,8 @@ namespace quda
         return 100 * 1024;
 #elif (__COMPUTE_CAPABILITY__ == 900)
         return 228 * 1024;
+#elif (__COMPUTE_CAPABILITY__ == 1000)
+        return 228 * 1024;
 #else
         return 0;
 #endif
@@ -54,6 +56,8 @@ namespace quda
 #elif ((__COMPUTE_CAPABILITY__ > 800) && (__COMPUTE_CAPABILITY__ < 900))
       return 1536;
 #elif (__COMPUTE_CAPABILITY__ == 900)
+      return 2048;
+#elif (__COMPUTE_CAPABILITY__ == 1000)
       return 2048;
 #else
       return 0;

--- a/include/targets/generic/block_reduction_kernel_host.h
+++ b/include/targets/generic/block_reduction_kernel_host.h
@@ -5,6 +5,7 @@ namespace quda
   {
     Functor<Arg> t(arg);
     dim3 block(0, 0, 0);
+#pragma omp parallel for
     for (block.y = 0; block.y < arg.grid_dim.y; block.y++) {
       for (block.x = 0; block.x < arg.grid_dim.x; block.x++) { t(block, dim3(0, 0, 0)); }
     }

--- a/include/targets/generic/kernel_host.h
+++ b/include/targets/generic/kernel_host.h
@@ -6,12 +6,14 @@ namespace quda
   template <template <typename> class Functor, typename Arg> void Kernel1D_host(const Arg &arg)
   {
     Functor<Arg> f(const_cast<Arg &>(arg));
+#pragma omp parallel for
     for (int i = 0; i < static_cast<int>(arg.threads.x); i++) { f(i); }
   }
 
   template <template <typename> class Functor, typename Arg> void Kernel2D_host(const Arg &arg)
   {
     Functor<Arg> f(const_cast<Arg &>(arg));
+#pragma omp parallel for
     for (int i = 0; i < static_cast<int>(arg.threads.x); i++) {
       for (int j = 0; j < static_cast<int>(arg.threads.y); j++) { f(i, j); }
     }
@@ -20,6 +22,7 @@ namespace quda
   template <template <typename> class Functor, typename Arg> void Kernel3D_host(const Arg &arg)
   {
     Functor<Arg> f(const_cast<Arg &>(arg));
+#pragma omp parallel for
     for (int i = 0; i < static_cast<int>(arg.threads.x); i++) {
       for (int j = 0; j < static_cast<int>(arg.threads.y); j++) {
         for (int k = 0; k < static_cast<int>(arg.threads.z); k++) { f(i, j, k); }

--- a/include/targets/generic/reduction_kernel_host.h
+++ b/include/targets/generic/reduction_kernel_host.h
@@ -11,7 +11,7 @@ namespace quda
     Functor<Arg> t(arg);
 
     reduce_t value = t.init();
-
+#pragma omp parallel for collapse(2) reduction(Functor <Arg>::apply : value)
     for (int j = 0; j < static_cast<int>(arg.threads.y); j++) {
       for (int i = 0; i < static_cast<int>(arg.threads.x); i++) { value = t(value, i, j); }
     }
@@ -21,16 +21,24 @@ namespace quda
 
   template <template <typename> class Functor, typename Arg> auto MultiReduction_host(const Arg &arg)
   {
+#pragma omp declare reduction(multi_reduce                                                                             \
+                              : typename Functor <Arg>::reduce_t                                                       \
+                              : omp_out = Functor <Arg>::apply(omp_out, omp_in))                                       \
+  initializer(omp_priv = Functor <Arg>::init())
+
     using reduce_t = typename Functor<Arg>::reduce_t;
     Functor<Arg> t(arg);
 
-    std::vector<reduce_t> value(arg.threads.z);
+    std::vector<reduce_t> value(arg.threads.z, t.init());
     for (int k = 0; k < static_cast<int>(arg.threads.z); k++) {
-      value[k] = t.init();
+      auto val = t.init();
 
+#pragma omp parallel for collapse(2) reduction(multi_reduce : val)
       for (int j = 0; j < static_cast<int>(arg.threads.y); j++) {
-        for (int i = 0; i < static_cast<int>(arg.threads.x); i++) { value[k] = t(value[k], i, j, k); }
+        for (int i = 0; i < static_cast<int>(arg.threads.x); i++) { val = t(val, i, j, k); }
       }
+
+      value[k] = val;
     }
 
     return value;

--- a/include/targets/hip/atomic_helper.h
+++ b/include/targets/hip/atomic_helper.h
@@ -48,7 +48,7 @@ namespace quda
   template <bool is_device> struct atomic_fetch_abs_max_impl {
     template <typename T> inline void operator()(T *addr, T val)
     {
-#pragma omp atomic update
+#pragma omp critical
       *addr = std::max(*addr, val);
     }
   };

--- a/include/tune_quda.h
+++ b/include/tune_quda.h
@@ -43,6 +43,22 @@ namespace quda {
    */
   const std::map<TuneKey, TuneParam> &getTuneCache();
 
+  /**
+     @brief Return a string encoding the QUDA version
+   */
+  const std::string get_quda_version();
+
+  /**
+     @brief Return a string encoding the git hash
+   */
+  const std::string get_quda_hash();
+
+  /**
+     @brief Return the resource path (directory where QUDA read/write
+     tunecache and other internal info
+  */
+  const std::string get_resource_path();
+
   class Tunable {
 
     friend TuneParam tuneLaunch(Tunable &, QudaTune, QudaVerbosity);

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 
 set (QUDA_OBJS
   # cmake-format: sortable
-  dirac_coarse.cpp dslash_coarse.cpp
+  monitor.cpp dirac_coarse.cpp dslash_coarse.cpp
   coarse_op.cpp coarsecoarse_op.cpp
   coarse_op_preconditioned.cpp staggered_coarse_op.cpp
   eig_iram.cpp eig_trlm.cpp eig_block_trlm.cpp vector_io.cpp

--- a/lib/dslash_gamma_helper.cu
+++ b/lib/dslash_gamma_helper.cu
@@ -32,7 +32,6 @@ namespace quda {
 
     void preTune() { out.backup(); }
     void postTune() { out.restore(); }
-    long long flops() const { return 0; }
     long long bytes() const { return out.Bytes() + in.Bytes(); }
   };
 
@@ -86,12 +85,11 @@ namespace quda {
     void apply(const qudaStream_t &stream)
     {
       TuneParam tp = tuneLaunch(*this, getTuning(), getVerbosity());
-      launch<TwistGamma>(tp, stream, GammaArg<Float, nColor>(out, in, d, kappa, mu, epsilon, dagger, type));
+      launch<TwistGamma>(tp, stream, GammaArg<Float, nColor>(out, in, d, 0, kappa, mu, epsilon, dagger, type));
     }
 
     void preTune() { out.backup(); }
     void postTune() { out.restore(); }
-    long long flops() const { return 0; }
     long long bytes() const { return out.Bytes() + in.Bytes(); }
   };
 

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -425,12 +425,6 @@ static void init_default_comms()
 }
 
 
-#define STR_(x) #x
-#define STR(x) STR_(x)
-  static const std::string quda_version = STR(QUDA_VERSION_MAJOR) "." STR(QUDA_VERSION_MINOR) "." STR(QUDA_VERSION_SUBMINOR);
-#undef STR
-#undef STR_
-
 extern char* gitversion;
 
 /*
@@ -447,9 +441,9 @@ void initQudaDevice(int dev)
   profileInit.TPSTART(QUDA_PROFILE_INIT);
 
 #ifdef GITVERSION
-  logQuda(QUDA_SUMMARIZE, "QUDA %s (git %s)\n", quda_version.c_str(), gitversion);
+  logQuda(QUDA_SUMMARIZE, "QUDA %s (git %s)\n", get_quda_version().c_str(), gitversion);
 #else
-  logQuda(QUDA_SUMMARIZE, "QUDA %s\n", quda_version.c_str());
+  logQuda(QUDA_SUMMARIZE, "QUDA %s\n", get_quda_version().c_str());
 #endif
 
 #ifdef MULTI_GPU
@@ -1377,6 +1371,9 @@ void endQuda(void)
 
     initialized = false;
 
+    assertAllMemFree();
+    device::destroy();
+
     comm_finalize();
     comms_initialized = false;
   }
@@ -1426,10 +1423,6 @@ void endQuda(void)
     printPeakMemUsage();
     printfQuda("\n");
   }
-
-  assertAllMemFree();
-
-  device::destroy();
 }
 
 

--- a/lib/monitor.cpp
+++ b/lib/monitor.cpp
@@ -1,0 +1,129 @@
+#include <atomic>
+#include <thread>
+#include <list>
+#include <sstream>
+#include <fstream>
+
+#include "monitor.h"
+#include "device.h"
+#include "quda_api.h"
+#include "util_quda.h"
+#include "tune_quda.h" // hash, version, resource path
+
+namespace quda
+{
+
+  namespace monitor
+  {
+
+    std::thread monitor_thread;
+    std::atomic<int> check(0);
+    std::chrono::time_point<std::chrono::high_resolution_clock> start_time;
+
+    static bool initialized = false;
+
+    double energy = 0.0;
+
+    std::list<device::state_t> state_history;
+
+    void device_monitor()
+    {
+      while (check.load() == 1) {
+        auto state = device::get_state();
+        state_history.push_back(state);
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      }
+    }
+
+    void init()
+    {
+      if (initialized) errorQuda("Monitor thread already initialized");
+
+      start_time = std::chrono::high_resolution_clock::now();
+
+      try { // spawn monitoring thread and release
+        monitor_thread = std::thread([&]() { device_monitor(); });
+        check.store(1);
+      } catch (const std::system_error &e) {
+        std::stringstream error;
+        error << "Caught system_error with code [" << e.code() << "] meaning [" << e.what() << "]";
+        errorQuda("%s", error.str().c_str());
+      }
+      initialized = true;
+    }
+
+    void destroy()
+    {
+      if (!initialized) errorQuda("Monitor thread not present");
+      initialized = false;
+
+      qudaDeviceSynchronize();
+
+      // safely end the monitoring thread
+      check.store(0);
+      monitor_thread.join(); // thread cleanup
+
+      serialize();
+    }
+
+    void serialize()
+    {
+      auto resource_path = get_resource_path();
+      if (resource_path.empty()) {
+        warningQuda("Storing device state disabled");
+        return;
+      }
+
+      // include current time in filename and rank0 time for all ranks
+      std::string serialize_time;
+      size_t size;
+      if (comm_rank() == 0) {
+        auto now_raw = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+        std::stringstream now;
+        now << std::put_time(std::localtime(&now_raw), "%Y_%m_%d_%H:%M:%S");
+        serialize_time = now.str();
+        size = serialize_time.size();
+      }
+      comm_broadcast(&size, sizeof(size), 0);
+      serialize_time.resize(size);
+      comm_broadcast(serialize_time.data(), size, 0);
+
+      std::string rank_str = std::to_string(comm_rank());
+      std::string monitor_path = resource_path + "/monitor_n" + rank_str + "_" + serialize_time + ".tsv";
+      std::ofstream monitor_file;
+      monitor_file.open(monitor_path.c_str());
+      monitor_file << "monitor"
+                   << "\t" << get_quda_version();
+      monitor_file << "\t" << get_quda_hash() << std::endl;
+
+      monitor_file << std::setw(12) << "time\t" << std::setw(12) << "power\t" << std::setw(12) << "energy\t";
+      monitor_file << std::setw(12) << "temperature\t" << std::setw(12) << "sm-clk\t" << std::endl;
+
+      static uint64_t count = 0;
+      static double last_power = 0;
+      static std::chrono::time_point<std::chrono::high_resolution_clock> last_time;
+
+      for (auto &state : state_history) {
+        std::chrono::duration<float, std::chrono::seconds::period> time = state.time - start_time;
+        std::chrono::duration<float, std::chrono::seconds::period> diff = state.time - last_time;
+
+        // trapezoidal integration to compute energy
+        if (count > 0) energy += 0.5 * (state.power + last_power) * diff.count();
+
+        monitor_file << std::setw(12) << time.count() << "\t";
+        monitor_file << std::setw(12) << state.power << "\t";
+        monitor_file << std::setw(12) << energy << "\t";
+        monitor_file << std::setw(12) << state.temp << "\t";
+        monitor_file << std::setw(12) << state.clock << "\t";
+        monitor_file << std::endl;
+
+        last_power = state.power;
+        last_time = state.time;
+        count++;
+      }
+
+      monitor_file.close();
+    }
+
+  } // namespace monitor
+} // namespace quda

--- a/lib/spin_taste.cu
+++ b/lib/spin_taste.cu
@@ -72,7 +72,7 @@ namespace quda
 
   void applySpinTaste(ColorSpinorField &out, const ColorSpinorField &in, QudaSpinTasteGamma gamma)
   {
-    if constexpr(is_enabled<QUDA_STAGGERED_DSLASH>()) {
+    if constexpr (is_enabled<QUDA_STAGGERED_DSLASH>()) {
       instantiate<SpinTastePhase_>(out, in, gamma);
     } else {
       errorQuda("Staggered operator has not been built");

--- a/lib/spin_taste.cu
+++ b/lib/spin_taste.cu
@@ -67,22 +67,16 @@ namespace quda
     void preTune() { out.backup(); }
     void postTune() { out.restore(); }
 
-    long long flops() const { return 0; }
     long long bytes() const { return 2 * in.Bytes(); }
   };
 
-#ifdef GPU_STAGGERED_DIRAC
   void applySpinTaste(ColorSpinorField &out, const ColorSpinorField &in, QudaSpinTasteGamma gamma)
   {
-    instantiate<SpinTastePhase_>(out, in, gamma);
-    //// ensure that ghosts are updated if needed
-    // if (u.GhostExchange() == QUDA_GHOST_EXCHANGE_PAD) u.exchangeGhost();
+    if constexpr(is_enabled<QUDA_STAGGERED_DSLASH>()) {
+      instantiate<SpinTastePhase_>(out, in, gamma);
+    } else {
+      errorQuda("Staggered operator has not been built");
+    }
   }
-#else
-  void applySpinTaste(ColorSpinorField &out, const ColorSpinorField &in, QudaSpinTasteGamma gamma)
-  {
-    errorQuda("Gauge tools are not build");
-  }
-#endif
 
 } // namespace quda

--- a/lib/targets/cuda/device.cpp
+++ b/lib/targets/cuda/device.cpp
@@ -17,12 +17,9 @@ static const int Nstream = 9;
   {									\
     nvmlReturn_t ret = func;						\
     if (ret == NVML_ERROR_NOT_SUPPORTED) {				\
-      static int i=0;							\
-      if (i==0) printf("%s not supported on this GPU\n", #func);	\
-      i++;								\
+      warningQuda("%s not supported on this GPU\n", nvmlErrorString(ret)); \
     } else if (ret != NVML_SUCCESS) {					\
-      printf("Error %s returns %s\n", #func, nvmlErrorString(ret));	\
-      exit(-1);								\
+      errorQuda(" NVML returns %s", nvmlErrorString(ret));              \
     }									\
   }
 
@@ -135,20 +132,20 @@ namespace quda
     }
 
     auto get_power() {
-      unsigned int power;
+      unsigned int power = 0;
       NVML_CHECK(nvmlDeviceGetPowerUsage(monitor_device_id, &power));
       return 1e-3 * power;
     }
 
     auto get_clock() {
       // other clocks available NVML_CLOCK_MEM and NVML_CLOCK_GRAPHICS
-      unsigned int clock;
+      unsigned int clock = 0;
       NVML_CHECK(nvmlDeviceGetClockInfo(monitor_device_id, NVML_CLOCK_SM, &clock));
       return clock;
     }
 
     auto get_temperature() {
-      unsigned int temp;
+      unsigned int temp = 0;
       NVML_CHECK(nvmlDeviceGetTemperature(monitor_device_id, NVML_TEMPERATURE_GPU, &temp));
       return temp;
     }

--- a/lib/targets/cuda/device.cpp
+++ b/lib/targets/cuda/device.cpp
@@ -13,14 +13,14 @@ static const int Nstream = 9;
 #define CHECK_CUDA_ERROR(func)                                                                                         \
   target::cuda::set_runtime_error(func, #func, __func__, __FILE__, __STRINGIFY__(__LINE__));
 
-#define NVML_CHECK(func)						\
-  {									\
-    nvmlReturn_t ret = func;						\
-    if (ret == NVML_ERROR_NOT_SUPPORTED) {				\
-      warningQuda("%s not supported on this GPU\n", nvmlErrorString(ret)); \
-    } else if (ret != NVML_SUCCESS) {					\
-      errorQuda(" NVML returns %s", nvmlErrorString(ret));              \
-    }									\
+#define NVML_CHECK(func)                                                                                               \
+  {                                                                                                                    \
+    nvmlReturn_t ret = func;                                                                                           \
+    if (ret == NVML_ERROR_NOT_SUPPORTED) {                                                                             \
+      warningQuda("%s not supported on this GPU\n", nvmlErrorString(ret));                                             \
+    } else if (ret != NVML_SUCCESS) {                                                                                  \
+      errorQuda(" NVML returns %s", nvmlErrorString(ret));                                                             \
+    }                                                                                                                  \
   }
 
 namespace quda
@@ -131,20 +131,23 @@ namespace quda
       CHECK_CUDA_ERROR(cudaSetDevice(device_id));
     }
 
-    auto get_power() {
+    auto get_power()
+    {
       unsigned int power = 0;
       NVML_CHECK(nvmlDeviceGetPowerUsage(monitor_device_id, &power));
       return 1e-3 * power;
     }
 
-    auto get_clock() {
+    auto get_clock()
+    {
       // other clocks available NVML_CLOCK_MEM and NVML_CLOCK_GRAPHICS
       unsigned int clock = 0;
       NVML_CHECK(nvmlDeviceGetClockInfo(monitor_device_id, NVML_CLOCK_SM, &clock));
       return clock;
     }
 
-    auto get_temperature() {
+    auto get_temperature()
+    {
       unsigned int temp = 0;
       NVML_CHECK(nvmlDeviceGetTemperature(monitor_device_id, NVML_TEMPERATURE_GPU, &temp));
       return temp;

--- a/lib/targets/cuda/target_cuda.cmake
+++ b/lib/targets/cuda/target_cuda.cmake
@@ -325,6 +325,14 @@ target_compile_options(
           -fsanitize=undefined>
           >)
 
+if(QUDA_OPENMP)
+  target_compile_options(
+    quda
+    PRIVATE $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:
+    "-Xcompiler=${OpenMP_CXX_FLAGS}"
+    >)
+endif()
+
 # malloc.cpp uses both the driver and runtime api So we need to find the CUDA_CUDA_LIBRARY (driver api) or the stub
 target_link_libraries(quda PUBLIC CUDA::cuda_driver)
 target_link_libraries(quda PUBLIC CUDA::nvml)

--- a/lib/targets/hip/device.cpp
+++ b/lib/targets/hip/device.cpp
@@ -57,6 +57,11 @@ namespace quda
       CHECK_HIP_ERROR(hipSetDevice(device_id));
     }
 
+    void init_monitor() {}
+
+    // not implemented on HIP at present
+    state_t get_state() { return {}; }
+
     int get_device_count()
     {
       static int device_count = 0;

--- a/lib/targets/hip/device.cpp
+++ b/lib/targets/hip/device.cpp
@@ -57,7 +57,7 @@ namespace quda
       CHECK_HIP_ERROR(hipSetDevice(device_id));
     }
 
-    void init_monitor() {}
+    void init_monitor() { }
 
     // not implemented on HIP at present
     state_t get_state() { return {}; }

--- a/lib/tune.cpp
+++ b/lib/tune.cpp
@@ -624,7 +624,7 @@ namespace quda
 #ifdef GITVERSION
         trace_file << "\t" << gitversion;
 #else
-      trace_file << "\t" << quda_version;
+        trace_file << "\t" << quda_version;
 #endif
         trace_file << "\t" << quda_hash << "\t# Last updated " << ctime(&now) << std::endl;
 

--- a/lib/tune.cpp
+++ b/lib/tune.cpp
@@ -133,7 +133,8 @@ namespace quda
 
 #define STR_(x) #x
 #define STR(x) STR_(x)
-    static const std::string quda_version = STR(QUDA_VERSION_MAJOR) "." STR(QUDA_VERSION_MINOR) "." STR(QUDA_VERSION_SUBMINOR);
+  static const std::string quda_version
+    = STR(QUDA_VERSION_MAJOR) "." STR(QUDA_VERSION_MINOR) "." STR(QUDA_VERSION_SUBMINOR);
 #undef STR
 #undef STR_
 
@@ -395,9 +396,9 @@ namespace quda
                     cache_path.c_str());
 #else
         if (version_check && token.compare(quda_version))
-        errorQuda("Cache file %s does not match current QUDA version. \nPlease delete this file or set the "
-                  "QUDA_RESOURCE_PATH environment variable to point to a new path.",
-                  cache_path.c_str());
+          errorQuda("Cache file %s does not match current QUDA version. \nPlease delete this file or set the "
+                    "QUDA_RESOURCE_PATH environment variable to point to a new path.",
+                    cache_path.c_str());
 #endif
         ls >> token;
         if (version_check && token.compare(quda_hash))


### PR DESCRIPTION
This PR is the initial step towards more power awareness in QUDA, as well as adding OMP threading for host kernels
* Adds power, temperature and clock monitoring
  * Monitoring is enabled with `QUDA_ENABLE_MONITOR=1` (default is off)
  * Monitoring is performed on a spawned thread, maintaining the history in a linked list
  * Default monitoring period is `QUDA_ENABLE_MONITOR_PERIOD=1`
  * Monitor info, together with derived energy usage is dumped to a `monitor_*****.tsv` file, where the **** encodes the rank id, and the date_time of the dump.  All ranks have identical times by construction.   
* Add OpenMP threading support for all CPU kernels
  * Most kernels seem to get reasonable scaling
  * `QUDA_OPENMP` CMake parameter is no longer marked as advanced
* Fixes compiler warning introduced in #1416
* Fixes bug introduced in #1416
* Fixed an issue with `endQuda` if memory leaks were detected when running multi-GPU: `printfQuda` would fail since `comm_rank()` would be called after the comms have been torn down