### PR TITLE
BlockKernel2D_host: create block inside omp parallel

### DIFF
--- a/include/targets/generic/block_reduction_kernel_host.h
+++ b/include/targets/generic/block_reduction_kernel_host.h
@@ -4,10 +4,11 @@ namespace quda
   template <template <typename> class Functor, typename Arg> void BlockKernel2D_host(const Arg &arg)
   {
     Functor<Arg> t(arg);
-    dim3 block(0, 0, 0);
 #pragma omp parallel for
-    for (block.y = 0; block.y < arg.grid_dim.y; block.y++) {
-      for (block.x = 0; block.x < arg.grid_dim.x; block.x++) { t(block, dim3(0, 0, 0)); }
+    for (unsigned int y = 0; y < arg.grid_dim.y; y++) {
+      for (unsigned int x = 0; x < arg.grid_dim.x; x++) {
+        t(dim3(x, y, 0), dim3(0, 0, 0));
+      }
     }
   }
 


### PR DESCRIPTION
Avoid modifying an automatic variable from outside of the `omp parallel` region.

fix #1483