### PR TITLE
Add "hisq" as a test executable `--dslash-type` argument

### DIFF
--- a/include/enum_quda.h
+++ b/include/enum_quda.h
@@ -89,6 +89,8 @@ typedef enum QudaGaugeFixed_s {
 // Types used in QudaInvertParam
 //
 
+// Note: make sure QudaDslashType has corresponding entries in
+// tests/utils/misc.cpp
 typedef enum QudaDslashType_s {
   QUDA_WILSON_DSLASH,
   QUDA_CLOVER_WILSON_DSLASH,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -949,12 +949,13 @@ endif()
       set_tests_properties(benchmark_dslash_${DIRAC_NAME}_policy${pol2} PROPERTIES ENVIRONMENT QUDA_ENABLE_DSLASH_POLICY=${pol})
     endif()
 
+    # Test setting `--dslash-type hisq`, which implies `--dslash-type asqtad --compute-fat-long true`
+    set(DIRAC_NAME hisq)
     add_test(NAME dslash_${DIRAC_NAME}_build_policy${pol2}
              COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:staggered_dslash_ctest> ${MPIEXEC_POSTFLAGS}
-                     --dslash-type asqtad
+                     --dslash-type ${DIRAC_NAME}
                      --test MatPC
                      --dim 6 8 10 12
-                     --compute-fat-long true
                      --epsilon-naik -0.01
                      --tadpole-coeff 0.9
         --gtest_output=xml:dslash_${DIRAC_NAME}_build_test_pol${pol2}.xml)

--- a/tests/utils/command_line_params.cpp
+++ b/tests/utils/command_line_params.cpp
@@ -513,8 +513,16 @@ std::shared_ptr<QUDAApp> make_app(std::string app_description, std::string app_n
   quda_app->add_option("--device", device_ordinal, "Set the CUDA device to use (default 0, single GPU only)")
     ->check(CLI::Range(0, 16));
 
-  quda_app->add_option("--dslash-type", dslash_type, "Set the dslash type (default wilson or asqtad as appropriate)")
-    ->transform(CLI::QUDACheckedTransformer(dslash_type_map));
+  // Instead of using an enum transformer we create a custom lambda that handles transforming a string
+  // to a QudaDslashType. We take this approach to support a custom string "hisq" that corresponds to 
+  // the ASQTAD dslash plus automatically building the fat/long links
+  quda_app->add_option("--dslash-type", [](std::vector<std::string> val) {
+    if (val.size() == 1) return false;
+    dslash_type = get_dslash_from_str(val[0].c_str());
+    if (!val[0].compare("hisq")) compute_fatlong = true;
+    if (dslash_type == QUDA_INVALID_DSLASH) return false;
+    return true;
+  }, "Set the dslash type (default wilson or asqtad as appropriate)")->expected(1)->check(CLI::IsMember(get_dslash_str_list()));
 
   quda_app->add_option(
     "--distance-pc-alpha0", distance_pc_alpha0,

--- a/tests/utils/command_line_params.cpp
+++ b/tests/utils/command_line_params.cpp
@@ -514,15 +514,21 @@ std::shared_ptr<QUDAApp> make_app(std::string app_description, std::string app_n
     ->check(CLI::Range(0, 16));
 
   // Instead of using an enum transformer we create a custom lambda that handles transforming a string
-  // to a QudaDslashType. We take this approach to support a custom string "hisq" that corresponds to 
+  // to a QudaDslashType. We take this approach to support a custom string "hisq" that corresponds to
   // the ASQTAD dslash plus automatically building the fat/long links
-  quda_app->add_option("--dslash-type", [](std::vector<std::string> val) {
-    if (val.size() == 1) return false;
-    dslash_type = get_dslash_from_str(val[0].c_str());
-    if (!val[0].compare("hisq")) compute_fatlong = true;
-    if (dslash_type == QUDA_INVALID_DSLASH) return false;
-    return true;
-  }, "Set the dslash type (default wilson or asqtad as appropriate)")->expected(1)->check(CLI::IsMember(get_dslash_str_list()));
+  quda_app
+    ->add_option(
+      "--dslash-type",
+      [](std::vector<std::string> val) {
+        if (val.size() == 1) return false;
+        dslash_type = get_dslash_from_str(val[0].c_str());
+        if (!val[0].compare("hisq")) compute_fatlong = true;
+        if (dslash_type == QUDA_INVALID_DSLASH) return false;
+        return true;
+      },
+      "Set the dslash type (default wilson or asqtad as appropriate)")
+    ->expected(1)
+    ->check(CLI::IsMember(get_dslash_str_list()));
 
   quda_app->add_option(
     "--distance-pc-alpha0", distance_pc_alpha0,

--- a/tests/utils/command_line_params.cpp
+++ b/tests/utils/command_line_params.cpp
@@ -520,7 +520,7 @@ std::shared_ptr<QUDAApp> make_app(std::string app_description, std::string app_n
     ->add_option(
       "--dslash-type",
       [](std::vector<std::string> val) {
-        if (val.size() == 1) return false;
+        if (val.size() != 1) return false;
         dslash_type = get_dslash_from_str(val[0].c_str());
         if (!val[0].compare("hisq")) compute_fatlong = true;
         if (dslash_type == QUDA_INVALID_DSLASH) return false;

--- a/tests/utils/command_line_params.h
+++ b/tests/utils/command_line_params.h
@@ -3,6 +3,7 @@
 #include <CLI11.hpp>
 #include <array>
 #include <quda.h>
+#include "misc.h"
 
 // for compatibility while porting - remove later
 extern void usage(char **);

--- a/tests/utils/misc.cpp
+++ b/tests/utils/misc.cpp
@@ -119,6 +119,49 @@ const char *get_dslash_str(QudaDslashType type)
   return ret;
 }
 
+std::vector<const char *> get_dslash_str_list()
+{
+  static std::vector<const char*> dslash_str_list;
+  bool populated = false;
+
+  if (!populated) {
+    dslash_str_list.push_back("wilson");
+    dslash_str_list.push_back("clover");
+    dslash_str_list.push_back("clover-hasenbusch-twist");
+    dslash_str_list.push_back("twisted-mass");
+    dslash_str_list.push_back("twisted-clover");
+    dslash_str_list.push_back("staggered");
+    dslash_str_list.push_back("asqtad");
+    dslash_str_list.push_back("hisq");
+    dslash_str_list.push_back("domain_wall");
+    dslash_str_list.push_back("domain_wall_4d");
+    dslash_str_list.push_back("mobius");
+    dslash_str_list.push_back("mobius_eofa");
+    dslash_str_list.push_back("laplace");
+    populated = true;
+  }
+  return dslash_str_list;
+}
+
+QudaDslashType get_dslash_from_str(const char* str)
+{
+  std::string d_type(str);
+  if (!d_type.compare("wilson")) return QUDA_WILSON_DSLASH;
+  if (!d_type.compare("clover")) return QUDA_CLOVER_WILSON_DSLASH;
+  if (!d_type.compare("clover_hasenbusch_twist") || !d_type.compare("clover-hasenbusch-twist")) return QUDA_CLOVER_HASENBUSCH_TWIST_DSLASH;
+  if (!d_type.compare("twisted_mass") || !d_type.compare("twisted-mass")) return QUDA_TWISTED_MASS_DSLASH;
+  if (!d_type.compare("twisted_clover") || !d_type.compare("twisted-clover")) return QUDA_TWISTED_CLOVER_DSLASH;
+  if (!d_type.compare("staggered")) return QUDA_STAGGERED_DSLASH;
+  if (!d_type.compare("asqtad")) return QUDA_ASQTAD_DSLASH;
+  if (!d_type.compare("hisq")) return QUDA_ASQTAD_DSLASH;
+  if (!d_type.compare("domain_wall") || !d_type.compare("domain-wall")) return QUDA_DOMAIN_WALL_DSLASH;
+  if (!d_type.compare("domain_wall_4d") || !d_type.compare("domain-wall-4d")) return QUDA_DOMAIN_WALL_4D_DSLASH;
+  if (!d_type.compare("mobius")) return QUDA_MOBIUS_DWF_DSLASH;
+  if (!d_type.compare("mobius_eofa") || !d_type.compare("mobius-eofa")) return QUDA_MOBIUS_DWF_EOFA_DSLASH;
+  if (!d_type.compare("laplace")) return QUDA_LAPLACE_DSLASH;
+  return QUDA_INVALID_DSLASH;
+}
+
 const char *get_contract_str(QudaContractType type)
 {
   const char *ret;

--- a/tests/utils/misc.cpp
+++ b/tests/utils/misc.cpp
@@ -121,7 +121,7 @@ const char *get_dslash_str(QudaDslashType type)
 
 std::vector<const char *> get_dslash_str_list()
 {
-  static std::vector<const char*> dslash_str_list;
+  static std::vector<const char *> dslash_str_list;
   bool populated = false;
 
   if (!populated) {
@@ -143,12 +143,13 @@ std::vector<const char *> get_dslash_str_list()
   return dslash_str_list;
 }
 
-QudaDslashType get_dslash_from_str(const char* str)
+QudaDslashType get_dslash_from_str(const char *str)
 {
   std::string d_type(str);
   if (!d_type.compare("wilson")) return QUDA_WILSON_DSLASH;
   if (!d_type.compare("clover")) return QUDA_CLOVER_WILSON_DSLASH;
-  if (!d_type.compare("clover_hasenbusch_twist") || !d_type.compare("clover-hasenbusch-twist")) return QUDA_CLOVER_HASENBUSCH_TWIST_DSLASH;
+  if (!d_type.compare("clover_hasenbusch_twist") || !d_type.compare("clover-hasenbusch-twist"))
+    return QUDA_CLOVER_HASENBUSCH_TWIST_DSLASH;
   if (!d_type.compare("twisted_mass") || !d_type.compare("twisted-mass")) return QUDA_TWISTED_MASS_DSLASH;
   if (!d_type.compare("twisted_clover") || !d_type.compare("twisted-clover")) return QUDA_TWISTED_CLOVER_DSLASH;
   if (!d_type.compare("staggered")) return QUDA_STAGGERED_DSLASH;

--- a/tests/utils/misc.h
+++ b/tests/utils/misc.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <quda.h>
 #include <string>
+#include <vector>
 
 const char *get_quda_ver_str();
 const char *get_recon_str(QudaReconstructType recon);
@@ -14,7 +15,26 @@ const char *get_matpc_str(QudaMatPCType);
 const char *get_solution_str(QudaSolutionType);
 const char *get_solve_str(QudaSolveType);
 const char *get_schwarz_str(QudaSchwarzType);
+
+/**
+   @brief Return a string corresponding to a QudaDslashType enum
+   @param[in] type A QudaDslashType
+   @return Corresponding string
+ */
 const char *get_dslash_str(QudaDslashType type);
+
+/**
+   @brief Return a std::vector of dslash types
+   @return std::vector of all dslash types
+ */
+std::vector<const char *> get_dslash_str_list();
+
+/**
+   @brief Return a QudaDslashType based on a string
+   @param[in] str Name of a dslash type
+   @return Corresponding QudaDslashType
+ */
+QudaDslashType get_dslash_from_str(const char *str);
 const char *get_flavor_str(QudaTwistFlavorType type);
 const char *get_solver_str(QudaInverterType type);
 const char *get_eig_spectrum_str(QudaEigSpectrumType type);


### PR DESCRIPTION
This PR adds support to a custom argument `hisq` that can be passed to the command-line flag to `--dslash-type` which is equivalent to `--dslash-type asqtad --compute-fat-long true`. In other words---this gives you a HISQ that is really HISQ.

This doesn't make any other changes under the hood, it does not add a new `enum` type, it is purely for convenience in the test executables.