### PR TITLE
Cleaned up isWilson/isStaggered/isDwf/getStencilSteps routines

### DIFF
--- a/include/dirac_quda.h
+++ b/include/dirac_quda.h
@@ -201,9 +201,9 @@ namespace quda {
     }
 
     /**
-      @brief static function that returns if a Dirac type is staggered-type depending on a QudaDiracType
-     */
-    static bool is_staggered(QudaDiracType);
+      @brief Whether the Dirac object is the DiracCoarse.
+    */
+    virtual bool isCoarse() const { return false; }
 
     /**
       @brief static function that returns if a Dirac type is staggered-type depending on a QudaDiracType
@@ -211,14 +211,9 @@ namespace quda {
     static bool is_wilson_type(QudaDiracType);
 
     /**
-      @brief static function that returns if a Dirac type is a domain wall operator (5-dimensional) depending on a QudaDiracType
+      @brief static function that returns if a Dslash type is staggered-type depending on a QudaDslashType
      */
-    static bool is_dwf(QudaDiracType);
-
-    /**
-      @brief Whether the Dirac object is the DiracCoarse.
-    */
-    virtual bool isCoarse() const { return false; }
+    static bool is_wilson_type(QudaDslashType);
 
     /**
       @brief return if the operator is a Wilson-type 4-d operator
@@ -226,14 +221,34 @@ namespace quda {
     bool isWilsonType() const { return Dirac::is_wilson_type(getDiracType()); }
 
     /**
+      @brief static function that returns if a Dirac type is staggered-type depending on a QudaDiracType
+     */
+    static bool is_staggered_type(QudaDiracType);
+
+    /**
+      @brief static function that returns if a Dslash type is staggered-type depending on a QudaDslashType
+     */
+    static bool is_staggered_type(QudaDslashType);
+
+    /**
       @brief return if the operator is a staggered operator
      */
-    virtual bool isStaggered() const { return Dirac::is_staggered(getDiracType()); }
+    bool isStaggered() const { return Dirac::is_staggered_type(getDiracType()); }
+
+    /**
+      @brief static function that returns if a Dirac type is a domain wall operator (5-dimensional) depending on a QudaDiracType
+     */
+    static bool is_dwf(QudaDiracType);
+
+    /**
+      @brief static function that returns if a Dslash type is a domain wall operator (5-dimensional) depending on a QudaDslashType
+     */
+    static bool is_dwf(QudaDslashType);
 
     /**
       @brief return if the operator is a domain wall operator, that is, 5-dimensional
      */
-    virtual bool isDwf() const { return Dirac::is_dwf(getDiracType()); }
+    bool isDwf() const { return Dirac::is_dwf(getDiracType()); }
 
     /**
         @brief Check parity spinors are usable (check geometry ?)
@@ -424,6 +439,17 @@ namespace quda {
         @return Dirac type
      */
     virtual QudaDiracType getDiracType() const = 0;
+
+    /** @brief returns the Dslash type
+
+        @return Dslash type
+     */
+    QudaDslashType getDslashType() const { return dirac_to_dslash_type(getDiracType()); }
+
+    /**
+      @brief static function that returns the QudaDslashType corresponding to a QudaDiracType
+     */
+    static QudaDslashType dirac_to_dslash_type(QudaDiracType);
 
     /**
         @brief Return the one-hop field for staggered operators for MG setup

--- a/include/dirac_quda.h
+++ b/include/dirac_quda.h
@@ -490,25 +490,25 @@ namespace quda {
     DiracWilson& operator=(const DiracWilson &dirac);
 
     virtual void Dslash(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in,
-                        QudaParity parity) const;
+                        QudaParity parity) const override;
 
     virtual void DslashXpay(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in,
-                            QudaParity parity, cvector_ref<const ColorSpinorField> &x, double k) const;
+                            QudaParity parity, cvector_ref<const ColorSpinorField> &x, double k) const override;
 
-    virtual void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
-    virtual void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
+    virtual void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
+    virtual void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
 
     virtual void prepare(cvector_ref<ColorSpinorField> &out, cvector_ref<ColorSpinorField> &in,
                          cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                         const QudaSolutionType solType) const;
+                         const QudaSolutionType solType) const override;
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                             const QudaSolutionType solType) const;
+                             const QudaSolutionType solType) const override;
 
-    virtual int getStencilSteps() const { return 1; }
-    virtual QudaDiracType getDiracType() const { return QUDA_WILSON_DIRAC; }
+    virtual int getStencilSteps() const override { return 1; }
+    virtual QudaDiracType getDiracType() const override { return QUDA_WILSON_DIRAC; }
     // neither isWilsonType nor isDwf are final because DiracDomainWall inherits from DiracWilson
-    virtual bool isWilsonType() const { return true; }
-    virtual bool isDwf() const { return false; }
+    virtual bool isWilsonType() const override { return true; }
+    virtual bool isDwf() const override { return false; }
     bool isStaggered() const final { return false; }
 
     /**
@@ -529,7 +529,7 @@ namespace quda {
      * @param allow_truncation [in] whether or not we let coarsening drop improvements, none available for Wilson operator
      */
     virtual void createCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T, double kappa, double mass = 0.,
-                                double mu = 0., double mu_factor = 0., bool allow_truncation = false) const;
+                                double mu = 0., double mu_factor = 0., bool allow_truncation = false) const override;
   };
 
   // Even-odd preconditioned Wilson
@@ -543,17 +543,17 @@ namespace quda {
     virtual ~DiracWilsonPC();
     DiracWilsonPC& operator=(const DiracWilsonPC &dirac);
 
-    void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
-    void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
+    void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
+    void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
 
     virtual void prepare(cvector_ref<ColorSpinorField> &out, cvector_ref<ColorSpinorField> &in,
                          cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                         const QudaSolutionType solType) const;
+                         const QudaSolutionType solType) const override;
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                             const QudaSolutionType solType) const;
+                             const QudaSolutionType solType) const override;
 
-    virtual int getStencilSteps() const { return 2; }
-    virtual QudaDiracType getDiracType() const { return QUDA_WILSONPC_DIRAC; }
+    virtual int getStencilSteps() const override { return 2; }
+    virtual QudaDiracType getDiracType() const override { return QUDA_WILSONPC_DIRAC; }
     bool isWilsonType() const final { return DiracWilson::isWilsonType(); }
     bool isDwf() const final { return DiracWilson::isDwf(); }
   };
@@ -563,7 +563,7 @@ namespace quda {
 
   protected:
     CloverField *clover;
-    void checkParitySpinor(cvector_ref<const ColorSpinorField> &, cvector_ref<const ColorSpinorField> &) const;
+    void checkParitySpinor(cvector_ref<const ColorSpinorField> &, cvector_ref<const ColorSpinorField> &) const override;
     void initConstants();
 
   public:
@@ -576,19 +576,19 @@ namespace quda {
     void Clover(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in, QudaParity parity) const;
 
     virtual void DslashXpay(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in,
-                            QudaParity parity, cvector_ref<const ColorSpinorField> &x, double k) const;
+                            QudaParity parity, cvector_ref<const ColorSpinorField> &x, double k) const override;
 
-    virtual void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
-    virtual void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
+    virtual void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
+    virtual void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
 
     virtual void prepare(cvector_ref<ColorSpinorField> &out, cvector_ref<ColorSpinorField> &in,
                          cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                         const QudaSolutionType solType) const;
+                         const QudaSolutionType solType) const override;
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                             const QudaSolutionType solType) const;
+                             const QudaSolutionType solType) const override;
 
-    virtual int getStencilSteps() const { return 1; }
-    virtual QudaDiracType getDiracType() const { return QUDA_CLOVER_DIRAC; }
+    virtual int getStencilSteps() const override { return 1; }
+    virtual QudaDiracType getDiracType() const override { return QUDA_CLOVER_DIRAC; }
     bool isWilsonType() const final { return DiracWilson::isWilsonType(); }
     bool isDwf() const final { return DiracWilson::isDwf(); }
 
@@ -601,7 +601,7 @@ namespace quda {
      *  @param long_gauge_in Updated long links
      *  @param clover_in Updated clover field
      */
-    virtual void updateFields(GaugeField *gauge_in, GaugeField *, GaugeField *, CloverField *clover_in)
+    virtual void updateFields(GaugeField *gauge_in, GaugeField *, GaugeField *, CloverField *clover_in) override
     {
       DiracWilson::updateFields(gauge_in, nullptr, nullptr, nullptr);
       clover = clover_in;
@@ -625,7 +625,7 @@ namespace quda {
      * @param allow_truncation [in] whether or not we let coarsening drop improvements, none available for clover operator
      */
     void createCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T, double kappa, double mass = 0., double mu = 0.,
-                        double mu_factor = 0., bool allow_truncation = false) const;
+                        double mu_factor = 0., bool allow_truncation = false) const override;
 
     /**
       @brief If managed memory and prefetch is enabled, prefetch
@@ -634,7 +634,7 @@ namespace quda {
       @param[in] mem_space Memory space we are prefetching to
       @param[in] stream Which stream to run the prefetch in (default 0)
     */
-    virtual void prefetch(QudaFieldLocation mem_space, qudaStream_t stream = device::get_default_stream()) const;
+    virtual void prefetch(QudaFieldLocation mem_space, qudaStream_t stream = device::get_default_stream()) const override;
   };
 
   // Even-odd preconditioned clover
@@ -653,27 +653,27 @@ namespace quda {
 
     // Dslash is redefined as A_pp^{-1} D_p\bar{p}
     virtual void Dslash(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in,
-                        QudaParity parity) const;
+                        QudaParity parity) const override;
 
     // out = x + k A_pp^{-1} D_p\bar{p}
     virtual void DslashXpay(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in,
-                            QudaParity parity, cvector_ref<const ColorSpinorField> &x, double k) const;
+                            QudaParity parity, cvector_ref<const ColorSpinorField> &x, double k) const override;
 
     // Can implement: M as e.g. :  i) tmp_e = A^{-1}_ee D_eo in_o  (Dslash)
     //                            ii) out_o = in_o + A_oo^{-1} D_oe tmp_e (AXPY)
-    void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
+    void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
 
     // squared op
-    void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
+    void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
 
     virtual void prepare(cvector_ref<ColorSpinorField> &out, cvector_ref<ColorSpinorField> &in,
                          cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                         const QudaSolutionType solType) const;
+                         const QudaSolutionType solType) const override;
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                             const QudaSolutionType solType) const;
+                             const QudaSolutionType solType) const override;
 
-    virtual int getStencilSteps() const { return 2; }
-    virtual QudaDiracType getDiracType() const { return QUDA_CLOVERPC_DIRAC; }
+    virtual int getStencilSteps() const override { return 2; }
+    virtual QudaDiracType getDiracType() const override { return QUDA_CLOVERPC_DIRAC; }
 
     /**
      * @brief Create the coarse even-odd preconditioned clover
@@ -689,7 +689,7 @@ namespace quda {
      * @param allow_truncation [in] whether or not we let coarsening drop improvements, none available for clover operator
      */
     void createCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T, double kappa, double mass = 0., double mu = 0.,
-                        double mu_factor = 0., bool allow_truncation = false) const;
+                        double mu_factor = 0., bool allow_truncation = false) const override;
 
     /**
       @brief If managed memory and prefetch is enabled, prefetch
@@ -700,7 +700,7 @@ namespace quda {
       @param[in] mem_space Memory space we are prefetching to
       @param[in] stream Which stream to run the prefetch in (default 0)
     */
-    virtual void prefetch(QudaFieldLocation mem_space, qudaStream_t stream = device::get_default_stream()) const;
+    virtual void prefetch(QudaFieldLocation mem_space, qudaStream_t stream = device::get_default_stream()) const override;
   };
 
   // Full clover with Hasenbusch Twist
@@ -722,15 +722,15 @@ namespace quda {
     virtual ~DiracCloverHasenbuschTwist();
     DiracCloverHasenbuschTwist &operator=(const DiracCloverHasenbuschTwist &dirac);
 
-    virtual void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
-    virtual void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
+    virtual void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
+    virtual void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
 
-    virtual int getStencilSteps() const
+    virtual int getStencilSteps() const override
     {
       // implemented as separate even, odd D_{eo} D_{oe}
       return 2;
     }
-    virtual QudaDiracType getDiracType() const { return QUDA_CLOVER_HASENBUSCH_TWIST_DIRAC; }
+    virtual QudaDiracType getDiracType() const override { return QUDA_CLOVER_HASENBUSCH_TWIST_DIRAC; }
 
     /**
      * @brief Create the coarse clover operator
@@ -743,7 +743,7 @@ namespace quda {
      * @param allow_truncation [in] whether or not we let coarsening drop improvements, none available for clover
      */
     void createCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T, double kappa, double mass = 0., double mu = 0.,
-                        double mu_factor = 0., bool allow_truncation = false) const;
+                        double mu_factor = 0., bool allow_truncation = false) const override;
   };
 
   // Even-odd preconditioned clover
@@ -776,13 +776,13 @@ namespace quda {
 
     // Can implement: M as e.g. :  i) tmp_e = A^{-1}_ee D_eo in_o  (Dslash)
     //                            ii) out_o = in_o + A_oo^{-1} D_oe tmp_e (AXPY)
-    void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
+    void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
 
     // squared op
-    void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
+    void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
 
-    virtual int getStencilSteps() const { return 2; }
-    virtual QudaDiracType getDiracType() const { return QUDA_CLOVER_HASENBUSCH_TWISTPC_DIRAC; }
+    virtual int getStencilSteps() const override { return 2; }
+    virtual QudaDiracType getDiracType() const override { return QUDA_CLOVER_HASENBUSCH_TWISTPC_DIRAC; }
 
     /**
      * @brief Create the coarse even-odd preconditioned clover
@@ -798,7 +798,7 @@ namespace quda {
      * @param allow_truncation [in] whether or not we let coarsening drop improvements, none available for clover hasenbusch
      */
     void createCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T, double kappa, double mass = 0., double mu = 0.,
-                        double mu_factor = 0., bool allow_truncation = false) const;
+                        double mu_factor = 0., bool allow_truncation = false) const override;
   };
 
   // Full domain wall
@@ -822,22 +822,22 @@ namespace quda {
     virtual ~DiracDomainWall();
     DiracDomainWall& operator=(const DiracDomainWall &dirac);
 
-    void Dslash(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in, QudaParity parity) const;
+    void Dslash(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in, QudaParity parity) const override;
 
     void DslashXpay(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in, QudaParity parity,
-                    cvector_ref<const ColorSpinorField> &x, double k) const;
+                    cvector_ref<const ColorSpinorField> &x, double k) const override;
 
-    virtual void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
-    virtual void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
+    virtual void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
+    virtual void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
 
     virtual void prepare(cvector_ref<ColorSpinorField> &out, cvector_ref<ColorSpinorField> &in,
                          cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                         const QudaSolutionType solType) const;
+                         const QudaSolutionType solType) const override;
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                             const QudaSolutionType solType) const;
+                             const QudaSolutionType solType) const override;
 
-    virtual int getStencilSteps() const { return 1; }
-    virtual QudaDiracType getDiracType() const { return QUDA_DOMAIN_WALL_DIRAC; }
+    virtual int getStencilSteps() const override { return 1; }
+    virtual QudaDiracType getDiracType() const override { return QUDA_DOMAIN_WALL_DIRAC; }
     bool isWilsonType() const final { return false; }
     bool isDwf() const final { return true; }
   };
@@ -853,17 +853,17 @@ namespace quda {
     virtual ~DiracDomainWallPC();
     DiracDomainWallPC& operator=(const DiracDomainWallPC &dirac);
 
-    void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
-    void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
+    void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
+    void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
 
     virtual void prepare(cvector_ref<ColorSpinorField> &out, cvector_ref<ColorSpinorField> &in,
                          cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                         const QudaSolutionType solType) const;
+                         const QudaSolutionType solType) const override;
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                             const QudaSolutionType solType) const;
+                             const QudaSolutionType solType) const override;
 
-    virtual int getStencilSteps() const { return 2; }
-    virtual QudaDiracType getDiracType() const { return QUDA_DOMAIN_WALLPC_DIRAC; }
+    virtual int getStencilSteps() const override { return 2; }
+    virtual QudaDiracType getDiracType() const override { return QUDA_DOMAIN_WALLPC_DIRAC; }
   };
 
   // Full domain wall, but with 4-d parity ordered fields
@@ -876,24 +876,24 @@ namespace quda {
     virtual ~DiracDomainWall4D();
     DiracDomainWall4D &operator=(const DiracDomainWall4D &dirac);
 
-    void Dslash4(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in, QudaParity parity) const;
+    void Dslash4(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in, QudaParity parity) const override;
     void Dslash5(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
     void Dslash4Xpay(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in, QudaParity parity,
                      cvector_ref<const ColorSpinorField> &x, double k) const;
     void Dslash5Xpay(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in,
                      cvector_ref<const ColorSpinorField> &x, double k) const;
 
-    void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
-    void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
+    void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
+    void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
 
     virtual void prepare(cvector_ref<ColorSpinorField> &out, cvector_ref<ColorSpinorField> &in,
                          cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                         const QudaSolutionType solType) const;
+                         const QudaSolutionType solType) const override;
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                             const QudaSolutionType solType) const;
+                             const QudaSolutionType solType) const override;
 
-    virtual int getStencilSteps() const { return 1; }
-    virtual QudaDiracType getDiracType() const { return QUDA_DOMAIN_WALL_4D_DIRAC; }
+    virtual int getStencilSteps() const override { return 1; }
+    virtual QudaDiracType getDiracType() const override { return QUDA_DOMAIN_WALL_4D_DIRAC; }
   };
 
   // 4d Even-odd preconditioned domain wall
@@ -910,17 +910,17 @@ namespace quda {
     void M5invXpay(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in,
                    cvector_ref<const ColorSpinorField> &x, double k) const;
 
-    void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
-    void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
+    void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
+    void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
 
     virtual void prepare(cvector_ref<ColorSpinorField> &out, cvector_ref<ColorSpinorField> &in,
                          cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                         const QudaSolutionType solType) const;
+                         const QudaSolutionType solType) const override;
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                             const QudaSolutionType solType) const;
+                             const QudaSolutionType solType) const override;
 
-    virtual int getStencilSteps() const { return 2; }
-    virtual QudaDiracType getDiracType() const { return QUDA_DOMAIN_WALL_4DPC_DIRAC; }
+    virtual int getStencilSteps() const override { return 2; }
+    virtual QudaDiracType getDiracType() const override { return QUDA_DOMAIN_WALL_4DPC_DIRAC; }
   };
 
   // Full Mobius
@@ -928,48 +928,48 @@ namespace quda {
 
   protected:
     //Mobius coefficients
-      Complex b_5[QUDA_MAX_DWF_LS];
-      Complex c_5[QUDA_MAX_DWF_LS];
+    Complex b_5[QUDA_MAX_DWF_LS];
+    Complex c_5[QUDA_MAX_DWF_LS];
 
-      /**
-         Whether we are using classical Mobius with constant real-valued
-         b and c coefficients, or zMobius with complex-valued variable
-         coefficients
-      */
-      bool zMobius;
+    /**
+       Whether we are using classical Mobius with constant real-valued
+        b and c coefficients, or zMobius with complex-valued variable
+        coefficients
+    */
+    bool zMobius;
 
-      double mobius_kappa_b;
-      double mobius_kappa_c;
-      double mobius_kappa;
+    double mobius_kappa_b;
+    double mobius_kappa_c;
+    double mobius_kappa;
 
-    public:
-      DiracMobius(const DiracParam &param);
-      // DiracMobius(const DiracMobius &dirac);
-      // virtual ~DiracMobius();
-      // DiracMobius& operator=(const DiracMobius &dirac);
+  public:
+    DiracMobius(const DiracParam &param);
+    // DiracMobius(const DiracMobius &dirac);
+    // virtual ~DiracMobius();
+    // DiracMobius& operator=(const DiracMobius &dirac);
 
-      void Dslash4(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in, QudaParity parity) const;
-      void Dslash4pre(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
-      void Dslash5(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
+    void Dslash4(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in, QudaParity parity) const override;
+    void Dslash4pre(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
+    void Dslash5(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
 
-      void Dslash4Xpay(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in, QudaParity parity,
-                       cvector_ref<const ColorSpinorField> &x, double k) const;
-      void Dslash4preXpay(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in,
-                          cvector_ref<const ColorSpinorField> &x, double k) const;
-      void Dslash5Xpay(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in,
-                       cvector_ref<const ColorSpinorField> &x, double k) const;
+    void Dslash4Xpay(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in, QudaParity parity,
+                      cvector_ref<const ColorSpinorField> &x, double k) const;
+    void Dslash4preXpay(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in,
+                        cvector_ref<const ColorSpinorField> &x, double k) const;
+    void Dslash5Xpay(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in,
+                      cvector_ref<const ColorSpinorField> &x, double k) const;
 
-      virtual void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
-      virtual void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
+    virtual void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
+    virtual void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
 
-      virtual void prepare(cvector_ref<ColorSpinorField> &out, cvector_ref<ColorSpinorField> &in,
-                           cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                           const QudaSolutionType solType) const;
-      virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                               const QudaSolutionType solType) const;
+    virtual void prepare(cvector_ref<ColorSpinorField> &out, cvector_ref<ColorSpinorField> &in,
+                          cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
+                          const QudaSolutionType solType) const override;
+    virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
+                              const QudaSolutionType solType) const override;
 
-      virtual int getStencilSteps() const { return 1; }
-      virtual QudaDiracType getDiracType() const { return QUDA_MOBIUS_DOMAIN_WALL_DIRAC; }
+    virtual int getStencilSteps() const override { return 1; }
+    virtual QudaDiracType getDiracType() const override { return QUDA_MOBIUS_DOMAIN_WALL_DIRAC; }
   };
 
   // 4d even-odd preconditioned Mobius domain wall
@@ -1005,21 +1005,21 @@ namespace quda {
                                QudaParity parity, cvector_ref<const ColorSpinorField> &x, double a,
                                cvector_ref<ColorSpinorField> &y) const;
 
-    void MdagMLocal(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
+    void MdagMLocal(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
 
-    void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
-    void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
+    void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
+    void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
     // this needs to be specialized for Mobius since we have a fused MdagM kernel
-    void MMdag(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
+    void MMdag(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
 
     virtual void prepare(cvector_ref<ColorSpinorField> &out, cvector_ref<ColorSpinorField> &in,
                          cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                         const QudaSolutionType solType) const;
+                         const QudaSolutionType solType) const override;
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                             const QudaSolutionType solType) const;
+                             const QudaSolutionType solType) const override;
 
-    virtual int getStencilSteps() const { return 2; }
-    virtual QudaDiracType getDiracType() const { return QUDA_MOBIUS_DOMAIN_WALLPC_DIRAC; }
+    virtual int getStencilSteps() const override { return 2; }
+    virtual QudaDiracType getDiracType() const override { return QUDA_MOBIUS_DOMAIN_WALLPC_DIRAC; }
   };
 
   // Full Mobius EOFA
@@ -1046,17 +1046,17 @@ namespace quda {
     void m5_eofa_xpay(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in,
                       cvector_ref<const ColorSpinorField> &x, double a = -1.) const;
 
-    virtual void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
-    virtual void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
+    virtual void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
+    virtual void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
 
     virtual void prepare(cvector_ref<ColorSpinorField> &out, cvector_ref<ColorSpinorField> &in,
                          cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                         const QudaSolutionType solType) const;
+                         const QudaSolutionType solType) const override;
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                             const QudaSolutionType solType) const;
+                             const QudaSolutionType solType) const override;
 
-    virtual int getStencilSteps() const { return 1; }
-    virtual QudaDiracType getDiracType() const { return QUDA_MOBIUS_DOMAIN_WALL_EOFA_DIRAC; }
+    virtual int getStencilSteps() const override { return 1; }
+    virtual QudaDiracType getDiracType() const override { return QUDA_MOBIUS_DOMAIN_WALL_EOFA_DIRAC; }
   };
 
   // 4d Even-odd preconditioned Mobius domain wall with EOFA
@@ -1070,20 +1070,20 @@ namespace quda {
     void m5inv_eofa_xpay(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in,
                          cvector_ref<const ColorSpinorField> &x, double a = -1.) const;
 
-    void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
-    void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
+    void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
+    void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
 
     // ye = Mee * xe + Meo * xo, yo = Moo * xo + Moe * xe
     void full_dslash(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
 
     virtual void prepare(cvector_ref<ColorSpinorField> &out, cvector_ref<ColorSpinorField> &in,
                          cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                         const QudaSolutionType solType) const;
+                         const QudaSolutionType solType) const override;
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                             const QudaSolutionType solType) const;
+                             const QudaSolutionType solType) const override;
 
-    virtual int getStencilSteps() const { return 2; }
-    virtual QudaDiracType getDiracType() const { return QUDA_MOBIUS_DOMAIN_WALLPC_EOFA_DIRAC; }
+    virtual int getStencilSteps() const override { return 2; }
+    virtual QudaDiracType getDiracType() const override { return QUDA_MOBIUS_DOMAIN_WALLPC_EOFA_DIRAC; }
   };
 
   void gamma5(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in);
@@ -1105,9 +1105,9 @@ namespace quda {
     void twistedApply(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in,
                       const QudaTwistGamma5Type twistType) const;
     virtual void Dslash(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in,
-                        QudaParity parity) const;
+                        QudaParity parity) const override;
     virtual void DslashXpay(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in,
-                            QudaParity parity, cvector_ref<const ColorSpinorField> &x, double k) const;
+                            QudaParity parity, cvector_ref<const ColorSpinorField> &x, double k) const override;
 
   public:
     DiracTwistedMass(const DiracTwistedMass &dirac);
@@ -1117,21 +1117,21 @@ namespace quda {
 
     void Twist(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
 
-    virtual void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
-    virtual void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
+    virtual void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
+    virtual void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
 
     virtual void prepare(cvector_ref<ColorSpinorField> &out, cvector_ref<ColorSpinorField> &in,
                          cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                         const QudaSolutionType solType) const;
+                         const QudaSolutionType solType) const override;
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                             const QudaSolutionType solType) const;
+                             const QudaSolutionType solType) const override;
 
-    virtual int getStencilSteps() const { return 1; }
-    virtual QudaDiracType getDiracType() const { return QUDA_TWISTED_MASS_DIRAC; }
+    virtual int getStencilSteps() const override { return 1; }
+    virtual QudaDiracType getDiracType() const override { return QUDA_TWISTED_MASS_DIRAC; }
     bool isWilsonType() const final { return DiracWilson::isWilsonType(); }
     bool isDwf() const final { return DiracWilson::isDwf(); }
 
-    double Mu() const { return mu; }
+    double Mu() const override { return mu; }
 
     /**
      * @brief Create the coarse twisted-mass operator
@@ -1154,7 +1154,7 @@ namespace quda {
      * @param allow_truncation [in] whether or not we let coarsening drop improvements, none available for twisted mass
      */
     void createCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T, double kappa, double mass, double mu,
-                        double mu_factor = 0., bool allow_trunation = false) const;
+                        double mu_factor = 0., bool allow_trunation = false) const override;
   };
 
   // Even-odd preconditioned twisted mass
@@ -1170,20 +1170,20 @@ namespace quda {
     void TwistInv(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
 
     virtual void Dslash(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in,
-                        QudaParity parity) const;
+                        QudaParity parity) const override;
     virtual void DslashXpay(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in,
-                            QudaParity parity, cvector_ref<const ColorSpinorField> &x, double k) const;
-    void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
-    void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
+                            QudaParity parity, cvector_ref<const ColorSpinorField> &x, double k) const override;
+    void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
+    void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
 
     virtual void prepare(cvector_ref<ColorSpinorField> &out, cvector_ref<ColorSpinorField> &in,
                          cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                         const QudaSolutionType solType) const;
+                         const QudaSolutionType solType) const override;
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                             const QudaSolutionType solType) const;
+                             const QudaSolutionType solType) const override;
 
-    virtual int getStencilSteps() const { return 2; }
-    virtual QudaDiracType getDiracType() const { return QUDA_TWISTED_MASSPC_DIRAC; }
+    virtual int getStencilSteps() const override { return 2; }
+    virtual QudaDiracType getDiracType() const override { return QUDA_TWISTED_MASSPC_DIRAC; }
 
     /**
      * @brief Create the coarse even-odd preconditioned twisted-mass
@@ -1199,7 +1199,7 @@ namespace quda {
      * @param allow_truncation [in] whether or not we let coarsening drop improvements, none available for twisted mass
      */
     void createCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T, double kappa, double mass, double mu,
-                        double mu_factor = 0., bool allow_truncation = false) const;
+                        double mu_factor = 0., bool allow_truncation = false) const override;
   };
 
   // Full twisted mass with a clover term
@@ -1210,7 +1210,7 @@ namespace quda {
     double epsilon;
     double tm_rho;
     CloverField *clover;
-    void checkParitySpinor(cvector_ref<const ColorSpinorField> &, cvector_ref<const ColorSpinorField> &) const;
+    void checkParitySpinor(cvector_ref<const ColorSpinorField> &, cvector_ref<const ColorSpinorField> &) const override;
     void twistedCloverApply(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in,
                             QudaTwistGamma5Type twistType, QudaParity parity) const;
 
@@ -1223,22 +1223,22 @@ namespace quda {
     void TwistClover(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in, QudaParity parity) const;
 
     virtual void Dslash(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in,
-                        QudaParity parity) const;
+                        QudaParity parity) const override;
     virtual void DslashXpay(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in,
-                            QudaParity parity, cvector_ref<const ColorSpinorField> &x, double k) const;
-    virtual void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
-    virtual void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
+                            QudaParity parity, cvector_ref<const ColorSpinorField> &x, double k) const override;
+    virtual void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
+    virtual void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
 
     virtual void prepare(cvector_ref<ColorSpinorField> &out, cvector_ref<ColorSpinorField> &in,
                          cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                         const QudaSolutionType solType) const;
+                         const QudaSolutionType solType) const override;
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                             const QudaSolutionType solType) const;
+                             const QudaSolutionType solType) const override;
 
-    virtual int getStencilSteps() const { return 1; }
-    virtual QudaDiracType getDiracType() const { return QUDA_TWISTED_CLOVER_DIRAC; }
+    virtual int getStencilSteps() const override { return 1; }
+    virtual QudaDiracType getDiracType() const override { return QUDA_TWISTED_CLOVER_DIRAC; }
 
-    double Mu() const { return mu; }
+    double Mu() const override { return mu; }
 
     /**
      *  @brief Update the internal gauge, fat gauge, long gauge, clover field pointer as appropriate.
@@ -1249,7 +1249,7 @@ namespace quda {
      *  @param long_gauge_in Updated long links
      *  @param clover_in Updated clover field
      */
-    virtual void updateFields(GaugeField *gauge_in, GaugeField *, GaugeField *, CloverField *clover_in)
+    virtual void updateFields(GaugeField *gauge_in, GaugeField *, GaugeField *, CloverField *clover_in) override
     {
       DiracWilson::updateFields(gauge_in, nullptr, nullptr, nullptr);
       clover = clover_in;
@@ -1276,7 +1276,7 @@ namespace quda {
      * @param allow_truncation [in] whether or not we let coarsening drop improvements, none available for twisted clover
      */
     void createCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T, double kappa, double mass, double mu,
-                        double mu_factor = 0., bool allow_truncation = false) const;
+                        double mu_factor = 0., bool allow_truncation = false) const override;
 
     /**
       @brief If managed memory and prefetch is enabled, prefetch
@@ -1285,7 +1285,7 @@ namespace quda {
       @param[in] mem_space Memory space we are prefetching to
       @param[in] stream Which stream to run the prefetch in (default 0)
     */
-    virtual void prefetch(QudaFieldLocation mem_space, qudaStream_t stream = device::get_default_stream()) const;
+    virtual void prefetch(QudaFieldLocation mem_space, qudaStream_t stream = device::get_default_stream()) const override;
   };
 
   // Even-odd preconditioned twisted mass with a clover term
@@ -1316,20 +1316,20 @@ public:
                           QudaParity parity, cvector_ref<const ColorSpinorField> &x, double k) const;
 
     virtual void Dslash(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in,
-                        QudaParity parity) const;
+                        QudaParity parity) const override;
     virtual void DslashXpay(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in,
-                            QudaParity parity, cvector_ref<const ColorSpinorField> &x, double k) const;
-    void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
-    void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
+                            QudaParity parity, cvector_ref<const ColorSpinorField> &x, double k) const override;
+    void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
+    void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
 
     virtual void prepare(cvector_ref<ColorSpinorField> &out, cvector_ref<ColorSpinorField> &in,
                          cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                         const QudaSolutionType solType) const;
+                         const QudaSolutionType solType) const override;
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                             const QudaSolutionType solType) const;
+                             const QudaSolutionType solType) const override;
 
-    virtual int getStencilSteps() const { return 2; }
-    virtual QudaDiracType getDiracType() const { return QUDA_TWISTED_CLOVERPC_DIRAC; }
+    virtual int getStencilSteps() const override { return 2; }
+    virtual QudaDiracType getDiracType() const override { return QUDA_TWISTED_CLOVERPC_DIRAC; }
 
     /**
      * @brief Create the coarse even-odd preconditioned twisted-clover
@@ -1347,7 +1347,7 @@ public:
      * @param allow_truncation [in] whether or not we let coarsening drop improvements, none available for twisted clover
      */
     void createCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T, double kappa, double mass, double mu,
-                        double mu_factor = 0., bool allow_truncation = false) const;
+                        double mu_factor = 0., bool allow_truncation = false) const override;
 
     /**
       @brief If managed memory and prefetch is enabled, prefetch
@@ -1358,7 +1358,7 @@ public:
       @param[in] mem_space Memory space we are prefetching to
       @param[in] stream Which stream to run the prefetch in (default 0)
     */
-    virtual void prefetch(QudaFieldLocation mem_space, qudaStream_t stream = device::get_default_stream()) const;
+    virtual void prefetch(QudaFieldLocation mem_space, qudaStream_t stream = device::get_default_stream()) const override;
   };
 
   // Full staggered
@@ -1373,20 +1373,20 @@ public:
     DiracStaggered& operator=(const DiracStaggered &dirac);
 
     virtual void Dslash(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in,
-                        QudaParity parity) const;
+                        QudaParity parity) const override;
     virtual void DslashXpay(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in,
-                            QudaParity parity, cvector_ref<const ColorSpinorField> &x, double k) const;
-    virtual void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
-    virtual void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
+                            QudaParity parity, cvector_ref<const ColorSpinorField> &x, double k) const override;
+    virtual void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
+    virtual void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
 
     virtual void prepare(cvector_ref<ColorSpinorField> &out, cvector_ref<ColorSpinorField> &in,
                          cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                         const QudaSolutionType solType) const;
+                         const QudaSolutionType solType) const override;
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                             const QudaSolutionType solType) const;
+                             const QudaSolutionType solType) const override;
 
-    virtual int getStencilSteps() const { return 1; }
-    virtual QudaDiracType getDiracType() const { return QUDA_STAGGERED_DIRAC; }
+    virtual int getStencilSteps() const override { return 1; }
+    virtual QudaDiracType getDiracType() const override { return QUDA_STAGGERED_DIRAC; }
     bool isWilsonType() const final { return false; }
     bool isStaggered() const final { return true; }
     bool isDwf() const final { return false; }
@@ -1396,7 +1396,7 @@ public:
 
        @return Gauge field
    */
-    virtual GaugeField *getStaggeredShortLinkField() const { return gauge; }
+    virtual GaugeField *getStaggeredShortLinkField() const override { return gauge; }
 
     /**
      * @brief Create the coarse staggered operator.
@@ -1420,7 +1420,7 @@ public:
      * @param allow_truncation [in] whether or not we let coarsening drop improvements, none available for staggered
      */
     void createCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T, double kappa, double mass, double mu = 0.,
-                        double mu_factor = 0., bool allow_truncation = false) const;
+                        double mu_factor = 0., bool allow_truncation = false) const override;
 
     /**
      * @brief Create two-link staggered quark smearing operator
@@ -1433,7 +1433,7 @@ public:
      * @param[in] parity Parity flag
      */
     void SmearOp(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in, double a, double b,
-                 int t0, QudaParity parity) const;
+                 int t0, QudaParity parity) const override;
   };
 
   // Even-odd preconditioned staggered
@@ -1448,19 +1448,19 @@ public:
     virtual ~DiracStaggeredPC();
     DiracStaggeredPC& operator=(const DiracStaggeredPC &dirac);
 
-    virtual void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
-    virtual void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
+    virtual void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
+    virtual void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
 
     virtual void prepare(cvector_ref<ColorSpinorField> &out, cvector_ref<ColorSpinorField> &in,
                          cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                         const QudaSolutionType solType) const;
+                         const QudaSolutionType solType) const override;
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                             const QudaSolutionType solType) const;
+                             const QudaSolutionType solType) const override;
 
-    virtual int getStencilSteps() const { return 2; }
-    virtual QudaDiracType getDiracType() const { return QUDA_STAGGEREDPC_DIRAC; }
+    virtual int getStencilSteps() const override { return 2; }
+    virtual QudaDiracType getDiracType() const override { return QUDA_STAGGEREDPC_DIRAC; }
 
-    virtual bool hermitian() const { return true; }
+    virtual bool hermitian() const override { return true; }
 
     /**
      * @brief Create the coarse staggered operator.
@@ -1484,7 +1484,7 @@ public:
      * @param allow_truncation [in] whether or not we let coarsening drop improvements, none available for staggered
      */
     void createCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T, double kappa, double mass, double mu = 0.,
-                        double mu_factor = 0., bool allow_truncation = false) const;
+                        double mu_factor = 0., bool allow_truncation = false) const override;
   };
 
   // Kahler-Dirac preconditioned staggered
@@ -1502,32 +1502,32 @@ public:
     virtual ~DiracStaggeredKD();
     DiracStaggeredKD &operator=(const DiracStaggeredKD &dirac);
 
-    virtual bool hasDslash() const { return false; }
+    virtual bool hasDslash() const override { return false; }
 
     virtual void Dslash(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in,
-                        QudaParity parity) const;
+                        QudaParity parity) const override;
     virtual void DslashXpay(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in,
-                            QudaParity parity, cvector_ref<const ColorSpinorField> &x, double k) const;
-    virtual void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
-    virtual void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
+                            QudaParity parity, cvector_ref<const ColorSpinorField> &x, double k) const override;
+    virtual void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
+    virtual void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
 
     void KahlerDiracInv(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
 
     virtual void prepare(cvector_ref<ColorSpinorField> &out, cvector_ref<ColorSpinorField> &in,
                          cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                         const QudaSolutionType solType) const;
+                         const QudaSolutionType solType) const override;
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                             const QudaSolutionType solType) const;
+                             const QudaSolutionType solType) const override;
     virtual void prepareSpecialMG(cvector_ref<ColorSpinorField> &out, cvector_ref<ColorSpinorField> &in,
                                   cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                                  const QudaSolutionType solType) const;
+                                  const QudaSolutionType solType) const override;
     virtual void reconstructSpecialMG(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                                      const QudaSolutionType solType) const;
+                                      const QudaSolutionType solType) const override;
 
-    virtual bool hasSpecialMG() const { return true; }
+    virtual bool hasSpecialMG() const override { return true; }
 
-    virtual int getStencilSteps() const { return 1; }
-    virtual QudaDiracType getDiracType() const { return QUDA_STAGGEREDKD_DIRAC; }
+    virtual int getStencilSteps() const override { return 1; }
+    virtual QudaDiracType getDiracType() const override { return QUDA_STAGGEREDKD_DIRAC; }
 
     /**
      *  @brief Update the internal gauge, fat gauge, long gauge, clover field pointer as appropriate.
@@ -1539,7 +1539,7 @@ public:
      *  @param clover_in Updated clover field
      */
     virtual void updateFields(GaugeField *gauge_in, GaugeField *fat_gauge_in, GaugeField *long_gauge_in,
-                              CloverField *clover_in);
+                              CloverField *clover_in) override;
 
     /**
      * @brief Create the coarse staggered KD operator.
@@ -1561,7 +1561,7 @@ public:
      * @param allow_truncation [in] whether or not we let coarsening drop improvements, none available for staggered
      */
     void createCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T, double kappa, double mass, double mu = 0.,
-                        double mu_factor = 0., bool allow_truncation = false) const;
+                        double mu_factor = 0., bool allow_truncation = false) const override;
 
     /**
       @brief If managed memory and prefetch is enabled, prefetch
@@ -1572,7 +1572,7 @@ public:
       @param[in] mem_space Memory space we are prefetching to
       @param[in] stream Which stream to run the prefetch in (default 0)
     */
-    virtual void prefetch(QudaFieldLocation mem_space, qudaStream_t stream = device::get_default_stream()) const;
+    virtual void prefetch(QudaFieldLocation mem_space, qudaStream_t stream = device::get_default_stream()) const override;
   };
 
   // Full staggered
@@ -1589,20 +1589,20 @@ public:
     DiracImprovedStaggered& operator=(const DiracImprovedStaggered &dirac);
 
     virtual void Dslash(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in,
-                        QudaParity parity) const;
+                        QudaParity parity) const override;
     virtual void DslashXpay(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in,
-                            QudaParity parity, cvector_ref<const ColorSpinorField> &x, double k) const;
-    virtual void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
-    virtual void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
+                            QudaParity parity, cvector_ref<const ColorSpinorField> &x, double k) const override;
+    virtual void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
+    virtual void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
 
     virtual void prepare(cvector_ref<ColorSpinorField> &out, cvector_ref<ColorSpinorField> &in,
                          cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                         const QudaSolutionType solType) const;
+                         const QudaSolutionType solType) const override;
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                             const QudaSolutionType solType) const;
+                             const QudaSolutionType solType) const override;
 
-    virtual int getStencilSteps() const { return 1; }
-    virtual QudaDiracType getDiracType() const { return QUDA_ASQTAD_DIRAC; }
+    virtual int getStencilSteps() const override { return 1; }
+    virtual QudaDiracType getDiracType() const override { return QUDA_ASQTAD_DIRAC; }
     bool isWilsonType() const final { return false; }
     bool isStaggered() const final { return true; }
     bool isDwf() const final { return false; }
@@ -1612,14 +1612,14 @@ public:
 
         @return fat link field
     */
-    virtual GaugeField *getStaggeredShortLinkField() const { return fatGauge; }
+    virtual GaugeField *getStaggeredShortLinkField() const override { return fatGauge; }
 
     /**
         @brief return the long link field for staggered operators for MG setup
 
         @return long link field
     */
-    virtual GaugeField *getStaggeredLongLinkField() const { return longGauge; }
+    virtual GaugeField *getStaggeredLongLinkField() const override { return longGauge; }
 
     /**
      *  @brief Update the internal gauge, fat gauge, long gauge, clover field pointer as appropriate.
@@ -1630,7 +1630,7 @@ public:
      *  @param long_gauge_in Updated long links
      *  @param clover_in Updated clover field
      */
-    virtual void updateFields(GaugeField *, GaugeField *fat_gauge_in, GaugeField *long_gauge_in, CloverField *)
+    virtual void updateFields(GaugeField *, GaugeField *fat_gauge_in, GaugeField *long_gauge_in, CloverField *) override
     {
       Dirac::updateFields(fat_gauge_in, nullptr, nullptr, nullptr);
       fatGauge = fat_gauge_in;
@@ -1660,7 +1660,7 @@ public:
      * @param allow_truncation [in] whether or not we let coarsening drop improvements, dropping long links here
      */
     void createCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T, double kappa, double mass, double mu,
-                        double mu_factor, bool allow_truncation) const;
+                        double mu_factor, bool allow_truncation) const override;
 
     /**
       @brief If managed memory and prefetch is enabled, prefetch
@@ -1669,7 +1669,7 @@ public:
       @param[in] mem_space Memory space we are prefetching to
       @param[in] stream Which stream to run the prefetch in (default 0)
     */
-    virtual void prefetch(QudaFieldLocation mem_space, qudaStream_t stream = device::get_default_stream()) const;
+    virtual void prefetch(QudaFieldLocation mem_space, qudaStream_t stream = device::get_default_stream()) const override;
 
     /**
      * @brief Create two-link staggered quark smearing operator
@@ -1682,7 +1682,7 @@ public:
      * @param[in] parity Parity flag
      */
     void SmearOp(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in, double a, double b,
-                 int t0, QudaParity parity) const;
+                 int t0, QudaParity parity) const override;
   };
 
   // Even-odd preconditioned staggered
@@ -1696,19 +1696,19 @@ public:
     virtual ~DiracImprovedStaggeredPC();
     DiracImprovedStaggeredPC& operator=(const DiracImprovedStaggeredPC &dirac);
 
-    virtual void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
-    virtual void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
+    virtual void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
+    virtual void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
 
     virtual void prepare(cvector_ref<ColorSpinorField> &out, cvector_ref<ColorSpinorField> &in,
                          cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                         const QudaSolutionType solType) const;
+                         const QudaSolutionType solType) const override;
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                             const QudaSolutionType solType) const;
+                             const QudaSolutionType solType) const override;
 
-    virtual int getStencilSteps() const { return 2; }
-    virtual QudaDiracType getDiracType() const { return QUDA_ASQTADPC_DIRAC; }
+    virtual int getStencilSteps() const override { return 2; }
+    virtual QudaDiracType getDiracType() const override { return QUDA_ASQTADPC_DIRAC; }
 
-    virtual bool hermitian() const { return true; }
+    virtual bool hermitian() const override { return true; }
 
     /**
      * @brief Create the coarse staggered operator.
@@ -1732,7 +1732,7 @@ public:
      * @param allow_truncation [in] whether or not we let coarsening drop improvements, dropping long links here
      */
     void createCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T, double kappa, double mass, double mu,
-                        double mu_factor, bool allow_truncation) const;
+                        double mu_factor, bool allow_truncation) const override;
   };
 
   // Kahler-Dirac preconditioned staggered
@@ -1749,32 +1749,32 @@ public:
     virtual ~DiracImprovedStaggeredKD();
     DiracImprovedStaggeredKD &operator=(const DiracImprovedStaggeredKD &dirac);
 
-    virtual bool hasDslash() const { return false; }
+    virtual bool hasDslash() const override { return false; }
 
     virtual void Dslash(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in,
-                        QudaParity parity) const;
+                        QudaParity parity) const override;
     virtual void DslashXpay(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in,
-                            QudaParity parity, cvector_ref<const ColorSpinorField> &x, double k) const;
-    virtual void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
-    virtual void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
+                            QudaParity parity, cvector_ref<const ColorSpinorField> &x, double k) const override;
+    virtual void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
+    virtual void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
 
     void KahlerDiracInv(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
 
     virtual void prepare(cvector_ref<ColorSpinorField> &out, cvector_ref<ColorSpinorField> &in,
                          cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                         const QudaSolutionType solType) const;
+                         const QudaSolutionType solType) const override;
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                             const QudaSolutionType solType) const;
+                             const QudaSolutionType solType) const override;
     virtual void prepareSpecialMG(cvector_ref<ColorSpinorField> &out, cvector_ref<ColorSpinorField> &in,
                                   cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                                  const QudaSolutionType solType) const;
+                                  const QudaSolutionType solType) const override;
     virtual void reconstructSpecialMG(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                                      const QudaSolutionType solType) const;
+                                      const QudaSolutionType solType) const override;
 
-    virtual bool hasSpecialMG() const { return true; }
+    virtual bool hasSpecialMG() const override { return true; }
 
-    virtual int getStencilSteps() const { return 1; }
-    virtual QudaDiracType getDiracType() const { return QUDA_ASQTADKD_DIRAC; }
+    virtual int getStencilSteps() const override { return 1; }
+    virtual QudaDiracType getDiracType() const override { return QUDA_ASQTADKD_DIRAC; }
 
     /**
      *  @brief Update the internal gauge, fat gauge, long gauge, clover field pointer as appropriate.
@@ -1786,7 +1786,7 @@ public:
      *  @param clover_in Updated clover field
      */
     virtual void updateFields(GaugeField *gauge_in, GaugeField *fat_gauge_in, GaugeField *long_gauge_in,
-                              CloverField *clover_in);
+                              CloverField *clover_in) override;
 
     /**
      * @brief Create the coarse improved staggered KD operator.
@@ -1808,7 +1808,7 @@ public:
      * @param allow_truncation [in] whether or not we let coarsening drop improvements, dropping long for asqtad
      */
     void createCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T, double kappa, double mass, double mu,
-                        double mu_factor, bool allow_truncation) const;
+                        double mu_factor, bool allow_truncation) const override;
 
     /**
       @brief If managed memory and prefetch is enabled, prefetch
@@ -1819,7 +1819,7 @@ public:
       @param[in] mem_space Memory space we are prefetching to
       @param[in] stream Which stream to run the prefetch in (default 0)
     */
-    virtual void prefetch(QudaFieldLocation mem_space, qudaStream_t stream = device::get_default_stream()) const;
+    virtual void prefetch(QudaFieldLocation mem_space, qudaStream_t stream = device::get_default_stream()) const override;
   };
 
   /**
@@ -1888,10 +1888,10 @@ public:
     void createYhat(bool gpu = true) const;
 
   public:
-    double Mass() const { return mass; }
-    double Mu() const { return mu; }
-    double MuFactor() const { return mu_factor; }
-    bool AllowTruncation() const { return allow_truncation; }
+    double Mass() const override { return mass; }
+    double Mu() const override { return mu; }
+    double MuFactor() const override { return mu_factor; }
+    bool AllowTruncation() const override { return allow_truncation; }
 
     /**
        @param[in] param Parameters defining this operator
@@ -1923,7 +1923,7 @@ public:
     DiracCoarse(const DiracCoarse &dirac, const DiracParam &param);
     virtual ~DiracCoarse();
 
-    virtual bool isCoarse() const { return true; }
+    virtual bool isCoarse() const override { return true; }
 
     /**
        @brief Apply the coarse clover operator
@@ -1948,7 +1948,7 @@ public:
        @param[parity] parity Parity which we are applying the operator to
      */
     virtual void Dslash(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in,
-                        QudaParity parity) const;
+                        QudaParity parity) const override;
 
     /**
        @brief Apply DslashXpay out = (D * in + A * x)
@@ -1959,35 +1959,35 @@ public:
        @param[in] k scalar multiplier
      */
     virtual void DslashXpay(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in,
-                            QudaParity parity, cvector_ref<const ColorSpinorField> &x, double k) const;
+                            QudaParity parity, cvector_ref<const ColorSpinorField> &x, double k) const override;
 
     /**
        @brief Apply the full operator
        @param[out] out output vector, out = M * in
        @param[in] in input vector
      */
-    virtual void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
+    virtual void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
 
     /**
        @brief Apply the normal full operator
        @param[out] out output vector, out = M * in
        @param[in] in input vector
      */
-    virtual void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
+    virtual void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
 
     virtual void prepare(cvector_ref<ColorSpinorField> &out, cvector_ref<ColorSpinorField> &in,
                          cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                         const QudaSolutionType solType) const;
+                         const QudaSolutionType solType) const override;
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                             const QudaSolutionType solType) const;
+                             const QudaSolutionType solType) const override;
 
-    virtual int getStencilSteps() const { return 1; }
-    virtual QudaDiracType getDiracType() const { return QUDA_COARSE_DIRAC; }
+    virtual int getStencilSteps() const override { return 1; }
+    virtual QudaDiracType getDiracType() const override { return QUDA_COARSE_DIRAC; }
     bool isWilsonType() const final { return false; }
     bool isStaggered() const final { return false; }
     bool isDwf() const final { return false; }
 
-    virtual void updateFields(GaugeField *gauge_in, GaugeField *, GaugeField *, CloverField *)
+    virtual void updateFields(GaugeField *gauge_in, GaugeField *, GaugeField *, CloverField *) override
     {
       Dirac::updateFields(gauge_in, nullptr, nullptr, nullptr);
       warningQuda("Coarse gauge links cannot be trivially updated for DiracCoarse(PC). Perform an MG update instead.");
@@ -2006,7 +2006,7 @@ public:
      * @param allow_truncation [in] whether or not we let coarsening drop improvements, none available for coarse op
      */
     void createCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T, double kappa, double mass, double mu,
-                        double mu_factor = 0., bool allow_truncation = false) const;
+                        double mu_factor = 0., bool allow_truncation = false) const override;
 
     /**
      * @brief Create the precondtioned coarse operator
@@ -2025,7 +2025,7 @@ public:
       @param[in] mem_space Memory space we are prefetching to
       @param[in] stream Which stream to run the prefetch in (default 0)
     */
-    virtual void prefetch(QudaFieldLocation mem_space, qudaStream_t stream = device::get_default_stream()) const;
+    virtual void prefetch(QudaFieldLocation mem_space, qudaStream_t stream = device::get_default_stream()) const override;
 
     /**
       @brief If use_mma and the batch size is larger than 1, actually apply coarse dslash with MMA
@@ -2078,7 +2078,7 @@ public:
        @param[in] in Input field
        @param[parity] parity Parity which we are applying the operator to
      */
-    void Dslash(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in, QudaParity parity) const;
+    void Dslash(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in, QudaParity parity) const override;
 
     /**
        @brief Apply preconditioned DslashXpay out = (x + k * D * in)
@@ -2089,30 +2089,30 @@ public:
        @param[in] k scalar multiplier
      */
     void DslashXpay(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in, QudaParity parity,
-                    cvector_ref<const ColorSpinorField> &x, double k) const;
+                    cvector_ref<const ColorSpinorField> &x, double k) const override;
 
     /**
        @brief Apply the preconditioned operator
        @param[out] out output vector, out = M * in
        @param[in] in input vector
      */
-    void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
+    void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
 
     /**
        @brief Apply the preconditioned full operator
        @param[out] out output vector, out = M * in
        @param[in] in input vector
      */
-    void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
+    void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
 
     virtual void prepare(cvector_ref<ColorSpinorField> &out, cvector_ref<ColorSpinorField> &in,
                          cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                         const QudaSolutionType solType) const;
+                         const QudaSolutionType solType) const override;
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                             const QudaSolutionType solType) const;
+                             const QudaSolutionType solType) const override;
 
-    virtual int getStencilSteps() const { return 2; }
-    virtual QudaDiracType getDiracType() const { return QUDA_COARSEPC_DIRAC; }
+    virtual int getStencilSteps() const override { return 2; }
+    virtual QudaDiracType getDiracType() const override { return QUDA_COARSEPC_DIRAC; }
 
     /**
      * @brief Create the coarse even-odd preconditioned coarse
@@ -2130,7 +2130,7 @@ public:
      * @param allow_truncation [in] whether or not we let coarsening drop improvements, none available for coarse op
      */
     void createCoarseOp(GaugeField &Y, GaugeField &X, const Transfer &T, double kappa, double mass, double mu,
-                        double mu_factor = 0., bool allow_truncation = false) const;
+                        double mu_factor = 0., bool allow_truncation = false) const override;
 
     /**
       @brief If managed memory and prefetch is enabled, prefetch
@@ -2139,7 +2139,7 @@ public:
       @param[in] mem_space Memory space we are prefetching to
       @param[in] stream Which stream to run the prefetch in (default 0)
     */
-    virtual void prefetch(QudaFieldLocation mem_space, qudaStream_t stream = device::get_default_stream()) const;
+    virtual void prefetch(QudaFieldLocation mem_space, qudaStream_t stream = device::get_default_stream()) const override;
   };
 
   /**
@@ -2157,21 +2157,21 @@ public:
     GaugeLaplace& operator=(const GaugeLaplace &laplace);
 
     virtual void Dslash(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in,
-                        QudaParity parity) const;
+                        QudaParity parity) const override;
     virtual void DslashXpay(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in,
-                            QudaParity parity, cvector_ref<const ColorSpinorField> &x, double k) const;
-    virtual void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
-    virtual void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
+                            QudaParity parity, cvector_ref<const ColorSpinorField> &x, double k) const override;
+    virtual void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
+    virtual void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
 
     virtual void prepare(cvector_ref<ColorSpinorField> &out, cvector_ref<ColorSpinorField> &in,
                          cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                         const QudaSolutionType solType) const;
+                         const QudaSolutionType solType) const override;
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                             const QudaSolutionType solType) const;
-    virtual bool hermitian() const { return true; }
+                             const QudaSolutionType solType) const override;
+    virtual bool hermitian() const override { return true; }
 
-    virtual int getStencilSteps() const { return 1; }
-    virtual QudaDiracType getDiracType() const { return QUDA_GAUGE_LAPLACE_DIRAC; }
+    virtual int getStencilSteps() const override { return 1; }
+    virtual QudaDiracType getDiracType() const override { return QUDA_GAUGE_LAPLACE_DIRAC; }
     bool isWilsonType() const final { return false; }
     bool isStaggered() const final { return false; }
     bool isDwf() const final { return false; }
@@ -2188,18 +2188,18 @@ public:
     virtual ~GaugeLaplacePC();
     GaugeLaplacePC& operator=(const GaugeLaplacePC &laplace);
 
-    void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
-    void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
+    void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
+    void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
 
     virtual void prepare(cvector_ref<ColorSpinorField> &out, cvector_ref<ColorSpinorField> &in,
                          cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                         const QudaSolutionType solType) const;
+                         const QudaSolutionType solType) const override;
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                             const QudaSolutionType solType) const;
-    virtual bool hermitian() const { return true; }
+                             const QudaSolutionType solType) const override;
+    virtual bool hermitian() const override { return true; }
 
-    virtual int getStencilSteps() const { return 2; }
-    virtual QudaDiracType getDiracType() const { return QUDA_GAUGE_LAPLACEPC_DIRAC; }
+    virtual int getStencilSteps() const override { return 2; }
+    virtual QudaDiracType getDiracType() const override { return QUDA_GAUGE_LAPLACEPC_DIRAC; }
   };
 
   /**
@@ -2226,20 +2226,20 @@ public:
     virtual void MdagMCD(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in, const int mu) const;
 
     virtual void Dslash(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in,
-                        QudaParity parity) const;
+                        QudaParity parity) const override;
     virtual void DslashXpay(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in,
-                            QudaParity parity, cvector_ref<const ColorSpinorField> &x, double k) const;
-    virtual void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
-    virtual void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
+                            QudaParity parity, cvector_ref<const ColorSpinorField> &x, double k) const override;
+    virtual void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
+    virtual void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
 
     virtual void prepare(cvector_ref<ColorSpinorField> &out, cvector_ref<ColorSpinorField> &in,
                          cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                         const QudaSolutionType solType) const;
+                         const QudaSolutionType solType) const override;
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                             const QudaSolutionType solType) const;
+                             const QudaSolutionType solType) const override;
 
-    virtual int getStencilSteps() const { return 1; }
-    virtual QudaDiracType getDiracType() const { return QUDA_GAUGE_COVDEV_DIRAC; }
+    virtual int getStencilSteps() const override { return 1; }
+    virtual QudaDiracType getDiracType() const override { return QUDA_GAUGE_COVDEV_DIRAC; }
     bool isWilsonType() const final { return false; }
     bool isStaggered() const final { return false; }
     bool isDwf() const final { return false; }
@@ -2316,14 +2316,14 @@ public:
        @param[out] out The vector of output fields
        @param[in] in The vector of input fields
      */
-    void operator()(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const
+    void operator()(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override
     {
       dirac->M(out, in);
       for (auto i = 0u; i < in.size(); i++)
         if (shift != 0.0) blas::axpy(shift, in[i], out[i]);
     }
 
-    int getStencilSteps() const
+    int getStencilSteps() const override
     {
       return dirac->getStencilSteps();
     }
@@ -2341,19 +2341,19 @@ public:
        @param[out] out The vector of output fields
        @param[out] out The vector of input fields
      */
-    void operator()(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const
+    void operator()(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override
     {
       dirac->MdagM(out, in);
       for (auto i = 0u; i < in.size(); i++)
         if (shift != 0.0) blas::axpy(shift, in[i], out[i]);
     }
 
-    int getStencilSteps() const
+    int getStencilSteps() const override
     {
       return 2*dirac->getStencilSteps(); // 2 for M and M dagger
     }
 
-    virtual bool hermitian() const { return true; } // normal op is always Hermitian
+    virtual bool hermitian() const override { return true; } // normal op is always Hermitian
   };
 
   /* Gloms onto a DiracOp and provides an operator() which applies its MdagMLocal */
@@ -2369,12 +2369,12 @@ public:
        @param[out] out The vector of output fields
        @param[in] in The vector of input fields
      */
-    void operator()(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const
+    void operator()(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override
     {
       dirac->MdagMLocal(out, in);
     }
 
-    int getStencilSteps() const
+    int getStencilSteps() const override
     {
       return 2 * dirac->getStencilSteps(); // 2 for M and M dagger
     }
@@ -2393,19 +2393,19 @@ public:
        @param[out] out The vector of output fields
        @param[in] in The vector of input fields
      */
-    void operator()(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const
+    void operator()(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override
     {
       dirac->MMdag(out, in);
       for (auto i = 0u; i < in.size(); i++)
         if (shift != 0.0) blas::axpy(shift, in[i], out[i]);
     }
 
-    int getStencilSteps() const
+    int getStencilSteps() const override
     {
       return 2*dirac->getStencilSteps(); // 2 for M and M dagger
     }
 
-    virtual bool hermitian() const { return true; } // normal op is always Hermitian
+    virtual bool hermitian() const override { return true; } // normal op is always Hermitian
   };
 
   /* Gloms onto a DiracMatrix and provides an  operator() for its Mdag method */
@@ -2420,14 +2420,14 @@ public:
        @param[out] out The vector of output fields
        @param[in] in The vector of input fields
      */
-    void operator()(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const
+    void operator()(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override
     {
       dirac->Mdag(out, in);
       for (auto i = 0u; i < in.size(); i++)
         if (shift != 0.0) blas::axpy(shift, in[i], out[i]);
     }
 
-    int getStencilSteps() const
+    int getStencilSteps() const override
     {
       return dirac->getStencilSteps();
     }
@@ -2449,14 +2449,14 @@ public:
        @param[out] out The vector of output fields
        @param[in] in The vector of input fields
      */
-    void operator()(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const
+    void operator()(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override
     {
       dirac->flipDagger();
       mat(std::move(out), std::move(in));
       dirac->flipDagger();
     }
 
-    int getStencilSteps() const
+    int getStencilSteps() const override
     {
       return mat.getStencilSteps();
     }
@@ -2551,7 +2551,7 @@ public:
        @param[out] out The vector of output fields
        @param[in] in The vector of input fields
      */
-    void operator()(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const
+    void operator()(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override
     {
       dirac->M(out, in);
       for (auto i = 0u; i < in.size(); i++) {
@@ -2560,12 +2560,12 @@ public:
       }
     }
 
-    int getStencilSteps() const { return dirac->getStencilSteps(); }
+    int getStencilSteps() const override { return dirac->getStencilSteps(); }
 
     /**
        @brief return if the operator is HPD
     */
-    virtual bool hermitian() const
+    virtual bool hermitian() const override
     {
       auto dirac_type = dirac->getDiracType();
       auto pc_type = dirac->getMatPCType();

--- a/include/dirac_quda.h
+++ b/include/dirac_quda.h
@@ -506,9 +506,10 @@ namespace quda {
 
     virtual int getStencilSteps() const { return 1; }
     virtual QudaDiracType getDiracType() const { return QUDA_WILSON_DIRAC; }
-    virtual bool isWilsonType() const { return true; }
-    virtual bool isStaggered() const { return false; }
-    virtual bool isDwf() const { return false; }
+    // neither isWilsonType nor isDwf are final because DiracDomainWall inherits from DiracWilson
+    virtual bool isWilsonType() const override { return true; }
+    virtual bool isDwf() const override { return false; }
+    bool isStaggered() const final { return false; }
 
     /**
      * @brief Create the coarse Wilson operator.
@@ -553,9 +554,8 @@ namespace quda {
 
     virtual int getStencilSteps() const { return 2; }
     virtual QudaDiracType getDiracType() const { return QUDA_WILSONPC_DIRAC; }
-    virtual bool isWilsonType() const { return true; }
-    virtual bool isStaggered() const { return false; }
-    virtual bool isDwf() const { return false; }
+    bool isWilsonType() const final { return DiracWilson::isWilsonType(); }
+    bool isDwf() const final { return DiracWilson::isDwf(); }
   };
 
   // Full clover
@@ -589,9 +589,8 @@ namespace quda {
 
     virtual int getStencilSteps() const { return 1; }
     virtual QudaDiracType getDiracType() const { return QUDA_CLOVER_DIRAC; }
-    virtual bool isWilsonType() const { return true; }
-    virtual bool isStaggered() const { return false; }
-    virtual bool isDwf() const { return false; }
+    bool isWilsonType() const final { return DiracWilson::isWilsonType(); }
+    bool isDwf() const final { return DiracWilson::isDwf(); }
 
     /**
      *  @brief Update the internal gauge, fat gauge, long gauge, clover field pointer as appropriate.
@@ -675,9 +674,6 @@ namespace quda {
 
     virtual int getStencilSteps() const { return 2; }
     virtual QudaDiracType getDiracType() const { return QUDA_CLOVERPC_DIRAC; }
-    virtual bool isWilsonType() const { return true; }
-    virtual bool isStaggered() const { return false; }
-    virtual bool isDwf() const { return false; }
 
     /**
      * @brief Create the coarse even-odd preconditioned clover
@@ -735,9 +731,6 @@ namespace quda {
       return 2;
     }
     virtual QudaDiracType getDiracType() const { return QUDA_CLOVER_HASENBUSCH_TWIST_DIRAC; }
-    virtual bool isWilsonType() const { return true; }
-    virtual bool isStaggered() const { return false; }
-    virtual bool isDwf() const { return false; }
 
     /**
      * @brief Create the coarse clover operator
@@ -790,9 +783,6 @@ namespace quda {
 
     virtual int getStencilSteps() const { return 2; }
     virtual QudaDiracType getDiracType() const { return QUDA_CLOVER_HASENBUSCH_TWISTPC_DIRAC; }
-    virtual bool isWilsonType() const { return true; }
-    virtual bool isStaggered() const { return false; }
-    virtual bool isDwf() const { return false; }
 
     /**
      * @brief Create the coarse even-odd preconditioned clover
@@ -848,9 +838,8 @@ namespace quda {
 
     virtual int getStencilSteps() const { return 1; }
     virtual QudaDiracType getDiracType() const { return QUDA_DOMAIN_WALL_DIRAC; }
-    virtual bool isWilsonType() const { return false; }
-    virtual bool isStaggered() const { return false; }
-    virtual bool isDwf() const { return true; }
+    bool isWilsonType() const final { return false; }
+    bool isDwf() const final { return true; }
   };
 
   // 5d Even-odd preconditioned domain wall
@@ -875,9 +864,6 @@ namespace quda {
 
     virtual int getStencilSteps() const { return 2; }
     virtual QudaDiracType getDiracType() const { return QUDA_DOMAIN_WALLPC_DIRAC; }
-    virtual bool isWilsonType() const { return false; }
-    virtual bool isStaggered() const { return false; }
-    virtual bool isDwf() const { return true; }
   };
 
   // Full domain wall, but with 4-d parity ordered fields
@@ -908,9 +894,6 @@ namespace quda {
 
     virtual int getStencilSteps() const { return 1; }
     virtual QudaDiracType getDiracType() const { return QUDA_DOMAIN_WALL_4D_DIRAC; }
-    virtual bool isWilsonType() const { return false; }
-    virtual bool isStaggered() const { return false; }
-    virtual bool isDwf() const { return true; }
   };
 
   // 4d Even-odd preconditioned domain wall
@@ -938,9 +921,6 @@ namespace quda {
 
     virtual int getStencilSteps() const { return 2; }
     virtual QudaDiracType getDiracType() const { return QUDA_DOMAIN_WALL_4DPC_DIRAC; }
-    virtual bool isWilsonType() const { return false; }
-    virtual bool isStaggered() const { return false; }
-    virtual bool isDwf() const { return true; }
   };
 
   // Full Mobius
@@ -990,9 +970,6 @@ namespace quda {
 
       virtual int getStencilSteps() const { return 1; }
       virtual QudaDiracType getDiracType() const { return QUDA_MOBIUS_DOMAIN_WALL_DIRAC; }
-      virtual bool isWilsonType() const { return false; }
-      virtual bool isStaggered() const { return false; }
-      virtual bool isDwf() const { return true; }
   };
 
   // 4d even-odd preconditioned Mobius domain wall
@@ -1043,9 +1020,6 @@ namespace quda {
 
     virtual int getStencilSteps() const { return 2; }
     virtual QudaDiracType getDiracType() const { return QUDA_MOBIUS_DOMAIN_WALLPC_DIRAC; }
-    virtual bool isWilsonType() const { return false; }
-    virtual bool isStaggered() const { return false; }
-    virtual bool isDwf() const { return true; }
   };
 
   // Full Mobius EOFA
@@ -1083,9 +1057,6 @@ namespace quda {
 
     virtual int getStencilSteps() const { return 1; }
     virtual QudaDiracType getDiracType() const { return QUDA_MOBIUS_DOMAIN_WALL_EOFA_DIRAC; }
-    virtual bool isWilsonType() const { return false; }
-    virtual bool isStaggered() const { return false; }
-    virtual bool isDwf() const { return true; }
   };
 
   // 4d Even-odd preconditioned Mobius domain wall with EOFA
@@ -1113,9 +1084,6 @@ namespace quda {
 
     virtual int getStencilSteps() const { return 2; }
     virtual QudaDiracType getDiracType() const { return QUDA_MOBIUS_DOMAIN_WALLPC_EOFA_DIRAC; }
-    virtual bool isWilsonType() const { return false; }
-    virtual bool isStaggered() const { return false; }
-    virtual bool isDwf() const { return true; }
   };
 
   void gamma5(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in);
@@ -1160,9 +1128,8 @@ namespace quda {
 
     virtual int getStencilSteps() const { return 1; }
     virtual QudaDiracType getDiracType() const { return QUDA_TWISTED_MASS_DIRAC; }
-    virtual bool isWilsonType() const { return true; }
-    virtual bool isStaggered() const { return false; }
-    virtual bool isDwf() const { return false; }
+    bool isWilsonType() const final { return DiracWilson::isWilsonType(); }
+    bool isDwf() const final { return DiracWilson::isDwf(); }
 
     double Mu() const { return mu; }
 
@@ -1217,9 +1184,6 @@ namespace quda {
 
     virtual int getStencilSteps() const { return 2; }
     virtual QudaDiracType getDiracType() const { return QUDA_TWISTED_MASSPC_DIRAC; }
-    virtual bool isWilsonType() const { return true; }
-    virtual bool isStaggered() const { return false; }
-    virtual bool isDwf() const { return false; }
 
     /**
      * @brief Create the coarse even-odd preconditioned twisted-mass
@@ -1273,9 +1237,6 @@ namespace quda {
 
     virtual int getStencilSteps() const { return 1; }
     virtual QudaDiracType getDiracType() const { return QUDA_TWISTED_CLOVER_DIRAC; }
-    virtual bool isWilsonType() const { return true; }
-    virtual bool isStaggered() const { return false; }
-    virtual bool isDwf() const { return false; }
 
     double Mu() const { return mu; }
 
@@ -1369,9 +1330,6 @@ public:
 
     virtual int getStencilSteps() const { return 2; }
     virtual QudaDiracType getDiracType() const { return QUDA_TWISTED_CLOVERPC_DIRAC; }
-    virtual bool isWilsonType() const { return true; }
-    virtual bool isStaggered() const { return false; }
-    virtual bool isDwf() const { return false; }
 
     /**
      * @brief Create the coarse even-odd preconditioned twisted-clover
@@ -1429,9 +1387,9 @@ public:
 
     virtual int getStencilSteps() const { return 1; }
     virtual QudaDiracType getDiracType() const { return QUDA_STAGGERED_DIRAC; }
-    virtual bool isWilsonType() const { return false; }
-    virtual bool isStaggered() const { return true; }
-    virtual bool isDwf() const { return false; }
+    bool isWilsonType() const final { return false; }
+    bool isStaggered() const final { return true; }
+    bool isDwf() const final { return false; }
 
     /**
        @brief Return the one-hop field for staggered operators for MG setup
@@ -1501,9 +1459,6 @@ public:
 
     virtual int getStencilSteps() const { return 2; }
     virtual QudaDiracType getDiracType() const { return QUDA_STAGGEREDPC_DIRAC; }
-    virtual bool isWilsonType() const { return false; }
-    virtual bool isStaggered() const { return true; }
-    virtual bool isDwf() const { return false; }
 
     virtual bool hermitian() const { return true; }
 
@@ -1573,9 +1528,6 @@ public:
 
     virtual int getStencilSteps() const { return 1; }
     virtual QudaDiracType getDiracType() const { return QUDA_STAGGEREDKD_DIRAC; }
-    virtual bool isWilsonType() const { return false; }
-    virtual bool isStaggered() const { return true; }
-    virtual bool isDwf() const { return false; }
 
     /**
      *  @brief Update the internal gauge, fat gauge, long gauge, clover field pointer as appropriate.
@@ -1651,9 +1603,9 @@ public:
 
     virtual int getStencilSteps() const { return 1; }
     virtual QudaDiracType getDiracType() const { return QUDA_ASQTAD_DIRAC; }
-    virtual bool isWilsonType() const { return false; }
-    virtual bool isStaggered() const { return true; }
-    virtual bool isDwf() const { return false; }
+    bool isWilsonType() const final { return false; }
+    bool isStaggered() const final { return true; }
+    bool isDwf() const final { return false; }
 
     /**
         @brief Return the one-hop field for staggered operators for MG setup
@@ -1755,9 +1707,6 @@ public:
 
     virtual int getStencilSteps() const { return 2; }
     virtual QudaDiracType getDiracType() const { return QUDA_ASQTADPC_DIRAC; }
-    virtual bool isWilsonType() const { return false; }
-    virtual bool isStaggered() const { return true; }
-    virtual bool isDwf() const { return false; }
 
     virtual bool hermitian() const { return true; }
 
@@ -1826,9 +1775,6 @@ public:
 
     virtual int getStencilSteps() const { return 1; }
     virtual QudaDiracType getDiracType() const { return QUDA_ASQTADKD_DIRAC; }
-    virtual bool isWilsonType() const { return false; }
-    virtual bool isStaggered() const { return true; }
-    virtual bool isDwf() const { return false; }
 
     /**
      *  @brief Update the internal gauge, fat gauge, long gauge, clover field pointer as appropriate.
@@ -2037,9 +1983,9 @@ public:
 
     virtual int getStencilSteps() const { return 1; }
     virtual QudaDiracType getDiracType() const { return QUDA_COARSE_DIRAC; }
-    virtual bool isWilsonType() const { return false; }
-    virtual bool isStaggered() const { return false; }
-    virtual bool isDwf() const { return false; }
+    bool isWilsonType() const final { return false; }
+    bool isStaggered() const final { return false; }
+    bool isDwf() const final { return false; }
 
     virtual void updateFields(GaugeField *gauge_in, GaugeField *, GaugeField *, CloverField *)
     {
@@ -2167,9 +2113,6 @@ public:
 
     virtual int getStencilSteps() const { return 2; }
     virtual QudaDiracType getDiracType() const { return QUDA_COARSEPC_DIRAC; }
-    virtual bool isWilsonType() const { return false; }
-    virtual bool isStaggered() const { return false; }
-    virtual bool isDwf() const { return false; }
 
     /**
      * @brief Create the coarse even-odd preconditioned coarse
@@ -2229,9 +2172,9 @@ public:
 
     virtual int getStencilSteps() const { return 1; }
     virtual QudaDiracType getDiracType() const { return QUDA_GAUGE_LAPLACE_DIRAC; }
-    virtual bool isWilsonType() const { return false; }
-    virtual bool isStaggered() const { return false; }
-    virtual bool isDwf() const { return false; }
+    bool isWilsonType() const final { return false; }
+    bool isStaggered() const final { return false; }
+    bool isDwf() const final { return false; }
   };
 
   /**
@@ -2257,9 +2200,6 @@ public:
 
     virtual int getStencilSteps() const { return 2; }
     virtual QudaDiracType getDiracType() const { return QUDA_GAUGE_LAPLACEPC_DIRAC; }
-    virtual bool isWilsonType() const { return false; }
-    virtual bool isStaggered() const { return false; }
-    virtual bool isDwf() const { return false; }
   };
 
   /**
@@ -2300,9 +2240,9 @@ public:
 
     virtual int getStencilSteps() const { return 1; }
     virtual QudaDiracType getDiracType() const { return QUDA_GAUGE_COVDEV_DIRAC; }
-    virtual bool isWilsonType() const { return false; }
-    virtual bool isStaggered() const { return false; }
-    virtual bool isDwf() const { return false; }
+    bool isWilsonType() const final { return false; }
+    bool isStaggered() const final { return false; }
+    bool isDwf() const final { return false; }
   };
 
   // Functor base class for applying a given Dirac matrix (M, MdagM, etc.)

--- a/include/dirac_quda.h
+++ b/include/dirac_quda.h
@@ -822,7 +822,8 @@ namespace quda {
     virtual ~DiracDomainWall();
     DiracDomainWall& operator=(const DiracDomainWall &dirac);
 
-    void Dslash(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in, QudaParity parity) const override;
+    void Dslash(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in,
+                QudaParity parity) const override;
 
     void DslashXpay(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in, QudaParity parity,
                     cvector_ref<const ColorSpinorField> &x, double k) const override;
@@ -876,7 +877,8 @@ namespace quda {
     virtual ~DiracDomainWall4D();
     DiracDomainWall4D &operator=(const DiracDomainWall4D &dirac);
 
-    void Dslash4(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in, QudaParity parity) const override;
+    void Dslash4(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in,
+                 QudaParity parity) const override;
     void Dslash5(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
     void Dslash4Xpay(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in, QudaParity parity,
                      cvector_ref<const ColorSpinorField> &x, double k) const;
@@ -948,25 +950,26 @@ namespace quda {
     // virtual ~DiracMobius();
     // DiracMobius& operator=(const DiracMobius &dirac);
 
-    void Dslash4(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in, QudaParity parity) const override;
+    void Dslash4(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in,
+                 QudaParity parity) const override;
     void Dslash4pre(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
     void Dslash5(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
 
     void Dslash4Xpay(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in, QudaParity parity,
-                      cvector_ref<const ColorSpinorField> &x, double k) const;
+                     cvector_ref<const ColorSpinorField> &x, double k) const;
     void Dslash4preXpay(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in,
                         cvector_ref<const ColorSpinorField> &x, double k) const;
     void Dslash5Xpay(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in,
-                      cvector_ref<const ColorSpinorField> &x, double k) const;
+                     cvector_ref<const ColorSpinorField> &x, double k) const;
 
     virtual void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
     virtual void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const override;
 
     virtual void prepare(cvector_ref<ColorSpinorField> &out, cvector_ref<ColorSpinorField> &in,
-                          cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                          const QudaSolutionType solType) const override;
+                         cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
+                         const QudaSolutionType solType) const override;
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
-                              const QudaSolutionType solType) const override;
+                             const QudaSolutionType solType) const override;
 
     virtual int getStencilSteps() const override { return 1; }
     virtual QudaDiracType getDiracType() const override { return QUDA_MOBIUS_DOMAIN_WALL_DIRAC; }
@@ -2078,7 +2081,8 @@ public:
        @param[in] in Input field
        @param[parity] parity Parity which we are applying the operator to
      */
-    void Dslash(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in, QudaParity parity) const override;
+    void Dslash(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in,
+                QudaParity parity) const override;
 
     /**
        @brief Apply preconditioned DslashXpay out = (x + k * D * in)
@@ -2323,10 +2327,7 @@ public:
         if (shift != 0.0) blas::axpy(shift, in[i], out[i]);
     }
 
-    int getStencilSteps() const override
-    {
-      return dirac->getStencilSteps();
-    }
+    int getStencilSteps() const override { return dirac->getStencilSteps(); }
   };
 
   /* Gloms onto a DiracOp and provides an operator() which applies its MdagM */
@@ -2427,10 +2428,7 @@ public:
         if (shift != 0.0) blas::axpy(shift, in[i], out[i]);
     }
 
-    int getStencilSteps() const override
-    {
-      return dirac->getStencilSteps();
-    }
+    int getStencilSteps() const override { return dirac->getStencilSteps(); }
   };
 
   /* Gloms onto a dirac matrix and gives back the dagger of whatever that was originally.
@@ -2456,10 +2454,7 @@ public:
       dirac->flipDagger();
     }
 
-    int getStencilSteps() const override
-    {
-      return mat.getStencilSteps();
-    }
+    int getStencilSteps() const override { return mat.getStencilSteps(); }
   };
 
   /**

--- a/include/dirac_quda.h
+++ b/include/dirac_quda.h
@@ -206,6 +206,21 @@ namespace quda {
     virtual bool isCoarse() const { return false; }
 
     /**
+      @brief return if the operator is a Wilson-type 4-d operator
+     */
+    virtual bool isWilsonType() const = 0;
+
+    /**
+      @brief return if the operator is a staggered operator
+     */
+    virtual bool isStaggered() const = 0;
+
+    /**
+      @brief return if the operator is a domain wall operator, that is, 5-dimensional
+     */
+    virtual bool isDwf() const = 0;
+
+    /**
         @brief Check parity spinors are usable (check geometry ?)
     */
     virtual void checkParitySpinor(cvector_ref<const ColorSpinorField> &, cvector_ref<const ColorSpinorField> &) const;
@@ -488,6 +503,9 @@ namespace quda {
                              const QudaSolutionType solType) const;
 
     virtual QudaDiracType getDiracType() const { return QUDA_WILSON_DIRAC; }
+    virtual bool isWilsonType() const { return true; }
+    virtual bool isStaggered() const { return false; }
+    virtual bool isDwf() const { return false; }
 
     /**
      * @brief Create the coarse Wilson operator.
@@ -531,6 +549,9 @@ namespace quda {
                              const QudaSolutionType solType) const;
 
     virtual QudaDiracType getDiracType() const { return QUDA_WILSONPC_DIRAC; }
+    virtual bool isWilsonType() const { return true; }
+    virtual bool isStaggered() const { return false; }
+    virtual bool isDwf() const { return false; }
   };
 
   // Full clover
@@ -563,6 +584,9 @@ namespace quda {
                              const QudaSolutionType solType) const;
 
     virtual QudaDiracType getDiracType() const { return QUDA_CLOVER_DIRAC; }
+    virtual bool isWilsonType() const { return true; }
+    virtual bool isStaggered() const { return false; }
+    virtual bool isDwf() const { return false; }
 
     /**
      *  @brief Update the internal gauge, fat gauge, long gauge, clover field pointer as appropriate.
@@ -645,6 +669,9 @@ namespace quda {
                              const QudaSolutionType solType) const;
 
     virtual QudaDiracType getDiracType() const { return QUDA_CLOVERPC_DIRAC; }
+    virtual bool isWilsonType() const { return true; }
+    virtual bool isStaggered() const { return false; }
+    virtual bool isDwf() const { return false; }
 
     /**
      * @brief Create the coarse even-odd preconditioned clover
@@ -697,6 +724,9 @@ namespace quda {
     virtual void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
 
     virtual QudaDiracType getDiracType() const { return QUDA_CLOVER_HASENBUSCH_TWIST_DIRAC; }
+    virtual bool isWilsonType() const { return true; }
+    virtual bool isStaggered() const { return false; }
+    virtual bool isDwf() const { return false; }
 
     /**
      * @brief Create the coarse clover operator
@@ -748,6 +778,9 @@ namespace quda {
     void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
 
     virtual QudaDiracType getDiracType() const { return QUDA_CLOVER_HASENBUSCH_TWISTPC_DIRAC; }
+    virtual bool isWilsonType() const { return true; }
+    virtual bool isStaggered() const { return false; }
+    virtual bool isDwf() const { return false; }
 
     /**
      * @brief Create the coarse even-odd preconditioned clover
@@ -802,6 +835,9 @@ namespace quda {
                              const QudaSolutionType solType) const;
 
     virtual QudaDiracType getDiracType() const { return QUDA_DOMAIN_WALL_DIRAC; }
+    virtual bool isWilsonType() const { return false; }
+    virtual bool isStaggered() const { return false; }
+    virtual bool isDwf() const { return true; }
   };
 
   // 5d Even-odd preconditioned domain wall
@@ -825,6 +861,9 @@ namespace quda {
                              const QudaSolutionType solType) const;
 
     virtual QudaDiracType getDiracType() const { return QUDA_DOMAIN_WALLPC_DIRAC; }
+    virtual bool isWilsonType() const { return false; }
+    virtual bool isStaggered() const { return false; }
+    virtual bool isDwf() const { return true; }
   };
 
   // Full domain wall, but with 4-d parity ordered fields
@@ -854,6 +893,9 @@ namespace quda {
                              const QudaSolutionType solType) const;
 
     virtual QudaDiracType getDiracType() const { return QUDA_DOMAIN_WALL_4D_DIRAC; }
+    virtual bool isWilsonType() const { return false; }
+    virtual bool isStaggered() const { return false; }
+    virtual bool isDwf() const { return true; }
   };
 
   // 4d Even-odd preconditioned domain wall
@@ -880,6 +922,9 @@ namespace quda {
                              const QudaSolutionType solType) const;
 
     virtual QudaDiracType getDiracType() const { return QUDA_DOMAIN_WALL_4DPC_DIRAC; }
+    virtual bool isWilsonType() const { return false; }
+    virtual bool isStaggered() const { return false; }
+    virtual bool isDwf() const { return true; }
   };
 
   // Full Mobius
@@ -928,6 +973,9 @@ namespace quda {
                                const QudaSolutionType solType) const;
 
       virtual QudaDiracType getDiracType() const { return QUDA_MOBIUS_DOMAIN_WALL_DIRAC; }
+      virtual bool isWilsonType() const { return false; }
+    virtual bool isStaggered() const { return false; }
+    virtual bool isDwf() const { return true; }
   };
 
   // 4d even-odd preconditioned Mobius domain wall
@@ -977,6 +1025,9 @@ namespace quda {
                              const QudaSolutionType solType) const;
 
     virtual QudaDiracType getDiracType() const { return QUDA_MOBIUS_DOMAIN_WALLPC_DIRAC; }
+    virtual bool isWilsonType() const { return false; }
+    virtual bool isStaggered() const { return false; }
+    virtual bool isDwf() const { return true; }
   };
 
   // Full Mobius EOFA
@@ -1013,6 +1064,9 @@ namespace quda {
                              const QudaSolutionType solType) const;
 
     virtual QudaDiracType getDiracType() const { return QUDA_MOBIUS_DOMAIN_WALL_EOFA_DIRAC; }
+    virtual bool isWilsonType() const { return false; }
+    virtual bool isStaggered() const { return false; }
+    virtual bool isDwf() const { return true; }
   };
 
   // 4d Even-odd preconditioned Mobius domain wall with EOFA
@@ -1039,6 +1093,9 @@ namespace quda {
                              const QudaSolutionType solType) const;
 
     virtual QudaDiracType getDiracType() const { return QUDA_MOBIUS_DOMAIN_WALLPC_EOFA_DIRAC; }
+    virtual bool isWilsonType() const { return false; }
+    virtual bool isStaggered() const { return false; }
+    virtual bool isDwf() const { return true; }
   };
 
   void gamma5(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in);
@@ -1082,6 +1139,9 @@ namespace quda {
                              const QudaSolutionType solType) const;
 
     virtual QudaDiracType getDiracType() const { return QUDA_TWISTED_MASS_DIRAC; }
+    virtual bool isWilsonType() const { return true; }
+    virtual bool isStaggered() const { return false; }
+    virtual bool isDwf() const { return false; }
 
     double Mu() const { return mu; }
 
@@ -1135,6 +1195,9 @@ namespace quda {
                              const QudaSolutionType solType) const;
 
     virtual QudaDiracType getDiracType() const { return QUDA_TWISTED_MASSPC_DIRAC; }
+    virtual bool isWilsonType() const { return true; }
+    virtual bool isStaggered() const { return false; }
+    virtual bool isDwf() const { return false; }
 
     /**
      * @brief Create the coarse even-odd preconditioned twisted-mass
@@ -1187,6 +1250,9 @@ namespace quda {
                              const QudaSolutionType solType) const;
 
     virtual QudaDiracType getDiracType() const { return QUDA_TWISTED_CLOVER_DIRAC; }
+    virtual bool isWilsonType() const { return true; }
+    virtual bool isStaggered() const { return false; }
+    virtual bool isDwf() const { return false; }
 
     double Mu() const { return mu; }
 
@@ -1279,6 +1345,9 @@ public:
                              const QudaSolutionType solType) const;
 
     virtual QudaDiracType getDiracType() const { return QUDA_TWISTED_CLOVERPC_DIRAC; }
+    virtual bool isWilsonType() const { return true; }
+    virtual bool isStaggered() const { return false; }
+    virtual bool isDwf() const { return false; }
 
     /**
      * @brief Create the coarse even-odd preconditioned twisted-clover
@@ -1335,6 +1404,9 @@ public:
                              const QudaSolutionType solType) const;
 
     virtual QudaDiracType getDiracType() const { return QUDA_STAGGERED_DIRAC; }
+    virtual bool isWilsonType() const { return false; }
+    virtual bool isStaggered() const { return true; }
+    virtual bool isDwf() const { return false; }
 
     /**
        @brief Return the one-hop field for staggered operators for MG setup
@@ -1402,6 +1474,9 @@ public:
                              const QudaSolutionType solType) const;
 
     virtual QudaDiracType getDiracType() const { return QUDA_STAGGEREDPC_DIRAC; }
+    virtual bool isWilsonType() const { return false; }
+    virtual bool isStaggered() const { return true; }
+    virtual bool isDwf() const { return false; }
 
     virtual bool hermitian() const { return true; }
 
@@ -1470,6 +1545,9 @@ public:
     virtual bool hasSpecialMG() const { return true; }
 
     virtual QudaDiracType getDiracType() const { return QUDA_STAGGEREDKD_DIRAC; }
+    virtual bool isWilsonType() const { return false; }
+    virtual bool isStaggered() const { return true; }
+    virtual bool isDwf() const { return false; }
 
     /**
      *  @brief Update the internal gauge, fat gauge, long gauge, clover field pointer as appropriate.
@@ -1544,6 +1622,9 @@ public:
                              const QudaSolutionType solType) const;
 
     virtual QudaDiracType getDiracType() const { return QUDA_ASQTAD_DIRAC; }
+    virtual bool isWilsonType() const { return false; }
+    virtual bool isStaggered() const { return true; }
+    virtual bool isDwf() const { return false; }
 
     /**
         @brief Return the one-hop field for staggered operators for MG setup
@@ -1644,6 +1725,9 @@ public:
                              const QudaSolutionType solType) const;
 
     virtual QudaDiracType getDiracType() const { return QUDA_ASQTADPC_DIRAC; }
+    virtual bool isWilsonType() const { return false; }
+    virtual bool isStaggered() const { return true; }
+    virtual bool isDwf() const { return false; }
 
     virtual bool hermitian() const { return true; }
 
@@ -1711,6 +1795,9 @@ public:
     virtual bool hasSpecialMG() const { return true; }
 
     virtual QudaDiracType getDiracType() const { return QUDA_ASQTADKD_DIRAC; }
+    virtual bool isWilsonType() const { return false; }
+    virtual bool isStaggered() const { return true; }
+    virtual bool isDwf() const { return false; }
 
     /**
      *  @brief Update the internal gauge, fat gauge, long gauge, clover field pointer as appropriate.
@@ -1918,6 +2005,9 @@ public:
                              const QudaSolutionType solType) const;
 
     virtual QudaDiracType getDiracType() const { return QUDA_COARSE_DIRAC; }
+    virtual bool isWilsonType() const { return false; }
+    virtual bool isStaggered() const { return false; }
+    virtual bool isDwf() const { return false; }
 
     virtual void updateFields(GaugeField *gauge_in, GaugeField *, GaugeField *, CloverField *)
     {
@@ -2044,6 +2134,9 @@ public:
                              const QudaSolutionType solType) const;
 
     virtual QudaDiracType getDiracType() const { return QUDA_COARSEPC_DIRAC; }
+    virtual bool isWilsonType() const { return false; }
+    virtual bool isStaggered() const { return false; }
+    virtual bool isDwf() const { return false; }
 
     /**
      * @brief Create the coarse even-odd preconditioned coarse
@@ -2103,6 +2196,9 @@ public:
     virtual bool hermitian() const { return true; }
 
     virtual QudaDiracType getDiracType() const { return QUDA_GAUGE_LAPLACE_DIRAC; }
+    virtual bool isWilsonType() const { return false; }
+    virtual bool isStaggered() const { return false; }
+    virtual bool isDwf() const { return false; }
   };
 
   /**
@@ -2127,6 +2223,9 @@ public:
     virtual bool hermitian() const { return true; }
 
     virtual QudaDiracType getDiracType() const { return QUDA_GAUGE_LAPLACEPC_DIRAC; }
+    virtual bool isWilsonType() const { return false; }
+    virtual bool isStaggered() const { return false; }
+    virtual bool isDwf() const { return false; }
   };
 
   /**
@@ -2164,6 +2263,9 @@ public:
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
                              const QudaSolutionType solType) const;
     virtual QudaDiracType getDiracType() const { return QUDA_GAUGE_COVDEV_DIRAC; }
+    virtual bool isWilsonType() const { return false; }
+    virtual bool isStaggered() const { return false; }
+    virtual bool isDwf() const { return false; }
   };
 
   // Functor base class for applying a given Dirac matrix (M, MdagM, etc.)
@@ -2199,42 +2301,17 @@ public:
     /**
        @brief return if the operator is a Wilson-type 4-d operator
     */
-    bool isWilsonType() const
-    {
-      return (Type() == typeid(DiracWilson).name() || Type() == typeid(DiracWilsonPC).name()
-              || Type() == typeid(DiracClover).name() || Type() == typeid(DiracCloverPC).name()
-              || Type() == typeid(DiracCloverHasenbuschTwist).name()
-              || Type() == typeid(DiracCloverHasenbuschTwistPC).name() || Type() == typeid(DiracTwistedMass).name()
-              || Type() == typeid(DiracTwistedMassPC).name() || Type() == typeid(DiracTwistedClover).name()
-              || Type() == typeid(DiracTwistedCloverPC).name()) ?
-        true :
-        false;
-    }
+    bool isWilsonType() const { return dirac->isWilsonType(); }
 
     /**
        @brief return if the operator is a staggered operator
     */
-    bool isStaggered() const
-    {
-      return (Type() == typeid(DiracStaggeredPC).name() || Type() == typeid(DiracStaggered).name()
-              || Type() == typeid(DiracImprovedStaggeredPC).name() || Type() == typeid(DiracImprovedStaggered).name()
-              || Type() == typeid(DiracStaggeredKD).name() || Type() == typeid(DiracImprovedStaggeredKD).name()) ?
-        true :
-        false;
-    }
+    bool isStaggered() const { return dirac->isStaggered(); }
 
     /**
        @brief return if the operator is a domain wall operator, that is, 5-dimensional
     */
-    bool isDwf() const
-    {
-      return (Type() == typeid(DiracDomainWall).name() || Type() == typeid(DiracDomainWallPC).name()
-              || Type() == typeid(DiracDomainWall4D).name() || Type() == typeid(DiracDomainWall4DPC).name()
-              || Type() == typeid(DiracMobius).name() || Type() == typeid(DiracMobiusPC).name()
-              || Type() == typeid(DiracMobiusEofa).name() || Type() == typeid(DiracMobiusEofaPC).name()) ?
-        true :
-        false;
-    }
+    bool isDwf() const { return dirac->isDwf(); }
 
     /**
        @brief return if the operator is a coarse operator

--- a/include/dirac_quda.h
+++ b/include/dirac_quda.h
@@ -383,7 +383,9 @@ namespace quda {
     QudaMatPCType getMatPCType() const { return matpcType; }
 
     /**
-       @brief returns the number of stencil applications per dslash application; 1 for fused operators, generally 2 otherwise
+       @brief returns the number of stencil applications per dslash application; 1 for operators with
+              a single hopping term (generally full operators), 2 for composite operators
+              that consist of two hopping terms (generally PC operators)
     */
     virtual int getStencilSteps() const = 0;
 
@@ -1402,7 +1404,8 @@ public:
   };
 
   // Full staggered
-  class DiracStaggered : public Dirac {
+  class DiracStaggered : public Dirac
+  {
 
   protected:
   public:

--- a/include/dirac_quda.h
+++ b/include/dirac_quda.h
@@ -727,7 +727,8 @@ namespace quda {
     virtual void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
     virtual void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
 
-    virtual int getStencilSteps() const {
+    virtual int getStencilSteps() const
+    {
       // implemented as separate even, odd D_{eo} D_{oe}
       return 2;
     }
@@ -985,11 +986,11 @@ namespace quda {
       virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
                                const QudaSolutionType solType) const;
 
-    virtual int getStencilSteps() const { return 1; }
+      virtual int getStencilSteps() const { return 1; }
       virtual QudaDiracType getDiracType() const { return QUDA_MOBIUS_DOMAIN_WALL_DIRAC; }
       virtual bool isWilsonType() const { return false; }
-    virtual bool isStaggered() const { return false; }
-    virtual bool isDwf() const { return true; }
+      virtual bool isStaggered() const { return false; }
+      virtual bool isDwf() const { return true; }
   };
 
   // 4d even-odd preconditioned Mobius domain wall

--- a/include/dirac_quda.h
+++ b/include/dirac_quda.h
@@ -383,9 +383,9 @@ namespace quda {
     QudaMatPCType getMatPCType() const { return matpcType; }
 
     /**
-       @brief  I have no idea what this does
+       @brief returns the number of stencil applications per dslash application; 1 for fused operators, generally 2 otherwise
     */
-    int getStencilSteps() const;
+    virtual int getStencilSteps() const = 0;
 
     /**
        @brief sets whether operator is daggered or not
@@ -502,6 +502,7 @@ namespace quda {
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
                              const QudaSolutionType solType) const;
 
+    virtual int getStencilSteps() const { return 1; }
     virtual QudaDiracType getDiracType() const { return QUDA_WILSON_DIRAC; }
     virtual bool isWilsonType() const { return true; }
     virtual bool isStaggered() const { return false; }
@@ -548,6 +549,7 @@ namespace quda {
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
                              const QudaSolutionType solType) const;
 
+    virtual int getStencilSteps() const { return 2; }
     virtual QudaDiracType getDiracType() const { return QUDA_WILSONPC_DIRAC; }
     virtual bool isWilsonType() const { return true; }
     virtual bool isStaggered() const { return false; }
@@ -583,6 +585,7 @@ namespace quda {
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
                              const QudaSolutionType solType) const;
 
+    virtual int getStencilSteps() const { return 1; }
     virtual QudaDiracType getDiracType() const { return QUDA_CLOVER_DIRAC; }
     virtual bool isWilsonType() const { return true; }
     virtual bool isStaggered() const { return false; }
@@ -668,6 +671,7 @@ namespace quda {
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
                              const QudaSolutionType solType) const;
 
+    virtual int getStencilSteps() const { return 2; }
     virtual QudaDiracType getDiracType() const { return QUDA_CLOVERPC_DIRAC; }
     virtual bool isWilsonType() const { return true; }
     virtual bool isStaggered() const { return false; }
@@ -723,6 +727,10 @@ namespace quda {
     virtual void M(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
     virtual void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
 
+    virtual int getStencilSteps() const {
+      // implemented as separate even, odd D_{eo} D_{oe}
+      return 2;
+    }
     virtual QudaDiracType getDiracType() const { return QUDA_CLOVER_HASENBUSCH_TWIST_DIRAC; }
     virtual bool isWilsonType() const { return true; }
     virtual bool isStaggered() const { return false; }
@@ -777,6 +785,7 @@ namespace quda {
     // squared op
     void MdagM(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
 
+    virtual int getStencilSteps() const { return 2; }
     virtual QudaDiracType getDiracType() const { return QUDA_CLOVER_HASENBUSCH_TWISTPC_DIRAC; }
     virtual bool isWilsonType() const { return true; }
     virtual bool isStaggered() const { return false; }
@@ -834,6 +843,7 @@ namespace quda {
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
                              const QudaSolutionType solType) const;
 
+    virtual int getStencilSteps() const { return 1; }
     virtual QudaDiracType getDiracType() const { return QUDA_DOMAIN_WALL_DIRAC; }
     virtual bool isWilsonType() const { return false; }
     virtual bool isStaggered() const { return false; }
@@ -860,6 +870,7 @@ namespace quda {
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
                              const QudaSolutionType solType) const;
 
+    virtual int getStencilSteps() const { return 2; }
     virtual QudaDiracType getDiracType() const { return QUDA_DOMAIN_WALLPC_DIRAC; }
     virtual bool isWilsonType() const { return false; }
     virtual bool isStaggered() const { return false; }
@@ -892,6 +903,7 @@ namespace quda {
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
                              const QudaSolutionType solType) const;
 
+    virtual int getStencilSteps() const { return 1; }
     virtual QudaDiracType getDiracType() const { return QUDA_DOMAIN_WALL_4D_DIRAC; }
     virtual bool isWilsonType() const { return false; }
     virtual bool isStaggered() const { return false; }
@@ -921,6 +933,7 @@ namespace quda {
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
                              const QudaSolutionType solType) const;
 
+    virtual int getStencilSteps() const { return 2; }
     virtual QudaDiracType getDiracType() const { return QUDA_DOMAIN_WALL_4DPC_DIRAC; }
     virtual bool isWilsonType() const { return false; }
     virtual bool isStaggered() const { return false; }
@@ -972,6 +985,7 @@ namespace quda {
       virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
                                const QudaSolutionType solType) const;
 
+    virtual int getStencilSteps() const { return 1; }
       virtual QudaDiracType getDiracType() const { return QUDA_MOBIUS_DOMAIN_WALL_DIRAC; }
       virtual bool isWilsonType() const { return false; }
     virtual bool isStaggered() const { return false; }
@@ -1024,6 +1038,7 @@ namespace quda {
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
                              const QudaSolutionType solType) const;
 
+    virtual int getStencilSteps() const { return 2; }
     virtual QudaDiracType getDiracType() const { return QUDA_MOBIUS_DOMAIN_WALLPC_DIRAC; }
     virtual bool isWilsonType() const { return false; }
     virtual bool isStaggered() const { return false; }
@@ -1063,6 +1078,7 @@ namespace quda {
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
                              const QudaSolutionType solType) const;
 
+    virtual int getStencilSteps() const { return 1; }
     virtual QudaDiracType getDiracType() const { return QUDA_MOBIUS_DOMAIN_WALL_EOFA_DIRAC; }
     virtual bool isWilsonType() const { return false; }
     virtual bool isStaggered() const { return false; }
@@ -1092,6 +1108,7 @@ namespace quda {
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
                              const QudaSolutionType solType) const;
 
+    virtual int getStencilSteps() const { return 2; }
     virtual QudaDiracType getDiracType() const { return QUDA_MOBIUS_DOMAIN_WALLPC_EOFA_DIRAC; }
     virtual bool isWilsonType() const { return false; }
     virtual bool isStaggered() const { return false; }
@@ -1138,6 +1155,7 @@ namespace quda {
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
                              const QudaSolutionType solType) const;
 
+    virtual int getStencilSteps() const { return 1; }
     virtual QudaDiracType getDiracType() const { return QUDA_TWISTED_MASS_DIRAC; }
     virtual bool isWilsonType() const { return true; }
     virtual bool isStaggered() const { return false; }
@@ -1177,7 +1195,7 @@ namespace quda {
     DiracTwistedMassPC(const DiracParam &param, const int nDim);
 
     virtual ~DiracTwistedMassPC();
-    DiracTwistedMassPC& operator=(const DiracTwistedMassPC &dirac);
+    DiracTwistedMassPC &operator=(const DiracTwistedMassPC &dirac);
 
     void TwistInv(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in) const;
 
@@ -1194,6 +1212,7 @@ namespace quda {
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
                              const QudaSolutionType solType) const;
 
+    virtual int getStencilSteps() const { return 2; }
     virtual QudaDiracType getDiracType() const { return QUDA_TWISTED_MASSPC_DIRAC; }
     virtual bool isWilsonType() const { return true; }
     virtual bool isStaggered() const { return false; }
@@ -1232,7 +1251,7 @@ namespace quda {
     DiracTwistedClover(const DiracTwistedClover &dirac);
     DiracTwistedClover(const DiracParam &param, const int nDim);
     virtual ~DiracTwistedClover();
-    DiracTwistedClover& operator=(const DiracTwistedClover &dirac);
+    DiracTwistedClover &operator=(const DiracTwistedClover &dirac);
 
     void TwistClover(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in, QudaParity parity) const;
 
@@ -1249,6 +1268,7 @@ namespace quda {
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
                              const QudaSolutionType solType) const;
 
+    virtual int getStencilSteps() const { return 1; }
     virtual QudaDiracType getDiracType() const { return QUDA_TWISTED_CLOVER_DIRAC; }
     virtual bool isWilsonType() const { return true; }
     virtual bool isStaggered() const { return false; }
@@ -1344,6 +1364,7 @@ public:
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
                              const QudaSolutionType solType) const;
 
+    virtual int getStencilSteps() const { return 2; }
     virtual QudaDiracType getDiracType() const { return QUDA_TWISTED_CLOVERPC_DIRAC; }
     virtual bool isWilsonType() const { return true; }
     virtual bool isStaggered() const { return false; }
@@ -1383,7 +1404,6 @@ public:
   class DiracStaggered : public Dirac {
 
   protected:
-
   public:
     DiracStaggered(const DiracParam &param);
     DiracStaggered(const DiracStaggered &dirac);
@@ -1403,6 +1423,7 @@ public:
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
                              const QudaSolutionType solType) const;
 
+    virtual int getStencilSteps() const { return 1; }
     virtual QudaDiracType getDiracType() const { return QUDA_STAGGERED_DIRAC; }
     virtual bool isWilsonType() const { return false; }
     virtual bool isStaggered() const { return true; }
@@ -1454,7 +1475,8 @@ public:
   };
 
   // Even-odd preconditioned staggered
-  class DiracStaggeredPC : public DiracStaggered {
+  class DiracStaggeredPC : public DiracStaggered
+  {
 
   protected:
 
@@ -1473,6 +1495,7 @@ public:
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
                              const QudaSolutionType solType) const;
 
+    virtual int getStencilSteps() const { return 2; }
     virtual QudaDiracType getDiracType() const { return QUDA_STAGGEREDPC_DIRAC; }
     virtual bool isWilsonType() const { return false; }
     virtual bool isStaggered() const { return true; }
@@ -1544,6 +1567,7 @@ public:
 
     virtual bool hasSpecialMG() const { return true; }
 
+    virtual int getStencilSteps() const { return 1; }
     virtual QudaDiracType getDiracType() const { return QUDA_STAGGEREDKD_DIRAC; }
     virtual bool isWilsonType() const { return false; }
     virtual bool isStaggered() const { return true; }
@@ -1621,6 +1645,7 @@ public:
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
                              const QudaSolutionType solType) const;
 
+    virtual int getStencilSteps() const { return 1; }
     virtual QudaDiracType getDiracType() const { return QUDA_ASQTAD_DIRAC; }
     virtual bool isWilsonType() const { return false; }
     virtual bool isStaggered() const { return true; }
@@ -1724,6 +1749,7 @@ public:
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
                              const QudaSolutionType solType) const;
 
+    virtual int getStencilSteps() const { return 2; }
     virtual QudaDiracType getDiracType() const { return QUDA_ASQTADPC_DIRAC; }
     virtual bool isWilsonType() const { return false; }
     virtual bool isStaggered() const { return true; }
@@ -1794,6 +1820,7 @@ public:
 
     virtual bool hasSpecialMG() const { return true; }
 
+    virtual int getStencilSteps() const { return 1; }
     virtual QudaDiracType getDiracType() const { return QUDA_ASQTADKD_DIRAC; }
     virtual bool isWilsonType() const { return false; }
     virtual bool isStaggered() const { return true; }
@@ -2004,6 +2031,7 @@ public:
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
                              const QudaSolutionType solType) const;
 
+    virtual int getStencilSteps() const { return 1; }
     virtual QudaDiracType getDiracType() const { return QUDA_COARSE_DIRAC; }
     virtual bool isWilsonType() const { return false; }
     virtual bool isStaggered() const { return false; }
@@ -2133,6 +2161,7 @@ public:
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
                              const QudaSolutionType solType) const;
 
+    virtual int getStencilSteps() const { return 2; }
     virtual QudaDiracType getDiracType() const { return QUDA_COARSEPC_DIRAC; }
     virtual bool isWilsonType() const { return false; }
     virtual bool isStaggered() const { return false; }
@@ -2166,7 +2195,6 @@ public:
     virtual void prefetch(QudaFieldLocation mem_space, qudaStream_t stream = device::get_default_stream()) const;
   };
 
-
   /**
      @brief Full Gauge Laplace operator.  Although not a Dirac
      operator per se, it's a linear operator so it's conventient to
@@ -2195,6 +2223,7 @@ public:
                              const QudaSolutionType solType) const;
     virtual bool hermitian() const { return true; }
 
+    virtual int getStencilSteps() const { return 1; }
     virtual QudaDiracType getDiracType() const { return QUDA_GAUGE_LAPLACE_DIRAC; }
     virtual bool isWilsonType() const { return false; }
     virtual bool isStaggered() const { return false; }
@@ -2222,6 +2251,7 @@ public:
                              const QudaSolutionType solType) const;
     virtual bool hermitian() const { return true; }
 
+    virtual int getStencilSteps() const { return 2; }
     virtual QudaDiracType getDiracType() const { return QUDA_GAUGE_LAPLACEPC_DIRAC; }
     virtual bool isWilsonType() const { return false; }
     virtual bool isStaggered() const { return false; }
@@ -2233,7 +2263,8 @@ public:
      operator per se, it's a linear operator so it's conventient to
      put in the Dirac operator abstraction.
   */
-  class GaugeCovDev : public Dirac {
+  class GaugeCovDev : public Dirac
+  {
 
   protected:
     int covdev_mu;
@@ -2262,6 +2293,8 @@ public:
                          const QudaSolutionType solType) const;
     virtual void reconstruct(cvector_ref<ColorSpinorField> &x, cvector_ref<const ColorSpinorField> &b,
                              const QudaSolutionType solType) const;
+
+    virtual int getStencilSteps() const { return 1; }
     virtual QudaDiracType getDiracType() const { return QUDA_GAUGE_COVDEV_DIRAC; }
     virtual bool isWilsonType() const { return false; }
     virtual bool isStaggered() const { return false; }
@@ -2273,7 +2306,8 @@ public:
   // and provides for several operator() operations to apply it, perhaps to apply
   // AXPYs etc. Once we have this, further classes diracM diracMdag etc
   // can implement the operator()-s as needed to apply the operator, MdagM etc etc.
-  class DiracMatrix {
+  class DiracMatrix
+  {
 
   protected:
     const Dirac *dirac;

--- a/include/dirac_quda.h
+++ b/include/dirac_quda.h
@@ -201,6 +201,21 @@ namespace quda {
     }
 
     /**
+      @brief static function that returns if a Dirac type is staggered-type depending on a QudaDiracType
+     */
+    static bool is_staggered(QudaDiracType);
+
+    /**
+      @brief static function that returns if a Dirac type is staggered-type depending on a QudaDiracType
+     */
+    static bool is_wilson_type(QudaDiracType);
+
+    /**
+      @brief static function that returns if a Dirac type is a domain wall operator (5-dimensional) depending on a QudaDiracType
+     */
+    static bool is_dwf(QudaDiracType);
+
+    /**
       @brief Whether the Dirac object is the DiracCoarse.
     */
     virtual bool isCoarse() const { return false; }
@@ -208,17 +223,17 @@ namespace quda {
     /**
       @brief return if the operator is a Wilson-type 4-d operator
      */
-    virtual bool isWilsonType() const = 0;
+    bool isWilsonType() const { return Dirac::is_wilson_type(getDiracType()); }
 
     /**
       @brief return if the operator is a staggered operator
      */
-    virtual bool isStaggered() const = 0;
+    virtual bool isStaggered() const { return Dirac::is_staggered(getDiracType()); }
 
     /**
       @brief return if the operator is a domain wall operator, that is, 5-dimensional
      */
-    virtual bool isDwf() const = 0;
+    virtual bool isDwf() const { return Dirac::is_dwf(getDiracType()); }
 
     /**
         @brief Check parity spinors are usable (check geometry ?)
@@ -506,10 +521,6 @@ namespace quda {
 
     virtual int getStencilSteps() const override { return 1; }
     virtual QudaDiracType getDiracType() const override { return QUDA_WILSON_DIRAC; }
-    // neither isWilsonType nor isDwf are final because DiracDomainWall inherits from DiracWilson
-    virtual bool isWilsonType() const override { return true; }
-    virtual bool isDwf() const override { return false; }
-    bool isStaggered() const final { return false; }
 
     /**
      * @brief Create the coarse Wilson operator.
@@ -554,8 +565,6 @@ namespace quda {
 
     virtual int getStencilSteps() const override { return 2; }
     virtual QudaDiracType getDiracType() const override { return QUDA_WILSONPC_DIRAC; }
-    bool isWilsonType() const final { return DiracWilson::isWilsonType(); }
-    bool isDwf() const final { return DiracWilson::isDwf(); }
   };
 
   // Full clover
@@ -589,8 +598,6 @@ namespace quda {
 
     virtual int getStencilSteps() const override { return 1; }
     virtual QudaDiracType getDiracType() const override { return QUDA_CLOVER_DIRAC; }
-    bool isWilsonType() const final { return DiracWilson::isWilsonType(); }
-    bool isDwf() const final { return DiracWilson::isDwf(); }
 
     /**
      *  @brief Update the internal gauge, fat gauge, long gauge, clover field pointer as appropriate.
@@ -839,8 +846,6 @@ namespace quda {
 
     virtual int getStencilSteps() const override { return 1; }
     virtual QudaDiracType getDiracType() const override { return QUDA_DOMAIN_WALL_DIRAC; }
-    bool isWilsonType() const final { return false; }
-    bool isDwf() const final { return true; }
   };
 
   // 5d Even-odd preconditioned domain wall
@@ -1131,8 +1136,6 @@ namespace quda {
 
     virtual int getStencilSteps() const override { return 1; }
     virtual QudaDiracType getDiracType() const override { return QUDA_TWISTED_MASS_DIRAC; }
-    bool isWilsonType() const final { return DiracWilson::isWilsonType(); }
-    bool isDwf() const final { return DiracWilson::isDwf(); }
 
     double Mu() const override { return mu; }
 
@@ -1390,9 +1393,6 @@ public:
 
     virtual int getStencilSteps() const override { return 1; }
     virtual QudaDiracType getDiracType() const override { return QUDA_STAGGERED_DIRAC; }
-    bool isWilsonType() const final { return false; }
-    bool isStaggered() const final { return true; }
-    bool isDwf() const final { return false; }
 
     /**
        @brief Return the one-hop field for staggered operators for MG setup
@@ -1606,9 +1606,6 @@ public:
 
     virtual int getStencilSteps() const override { return 1; }
     virtual QudaDiracType getDiracType() const override { return QUDA_ASQTAD_DIRAC; }
-    bool isWilsonType() const final { return false; }
-    bool isStaggered() const final { return true; }
-    bool isDwf() const final { return false; }
 
     /**
         @brief Return the one-hop field for staggered operators for MG setup
@@ -1986,9 +1983,6 @@ public:
 
     virtual int getStencilSteps() const override { return 1; }
     virtual QudaDiracType getDiracType() const override { return QUDA_COARSE_DIRAC; }
-    bool isWilsonType() const final { return false; }
-    bool isStaggered() const final { return false; }
-    bool isDwf() const final { return false; }
 
     virtual void updateFields(GaugeField *gauge_in, GaugeField *, GaugeField *, CloverField *) override
     {
@@ -2176,9 +2170,6 @@ public:
 
     virtual int getStencilSteps() const override { return 1; }
     virtual QudaDiracType getDiracType() const override { return QUDA_GAUGE_LAPLACE_DIRAC; }
-    bool isWilsonType() const final { return false; }
-    bool isStaggered() const final { return false; }
-    bool isDwf() const final { return false; }
   };
 
   /**
@@ -2244,9 +2235,6 @@ public:
 
     virtual int getStencilSteps() const override { return 1; }
     virtual QudaDiracType getDiracType() const override { return QUDA_GAUGE_COVDEV_DIRAC; }
-    bool isWilsonType() const final { return false; }
-    bool isStaggered() const final { return false; }
-    bool isDwf() const final { return false; }
   };
 
   // Functor base class for applying a given Dirac matrix (M, MdagM, etc.)

--- a/include/dirac_quda.h
+++ b/include/dirac_quda.h
@@ -507,8 +507,8 @@ namespace quda {
     virtual int getStencilSteps() const { return 1; }
     virtual QudaDiracType getDiracType() const { return QUDA_WILSON_DIRAC; }
     // neither isWilsonType nor isDwf are final because DiracDomainWall inherits from DiracWilson
-    virtual bool isWilsonType() const override { return true; }
-    virtual bool isDwf() const override { return false; }
+    virtual bool isWilsonType() const { return true; }
+    virtual bool isDwf() const { return false; }
     bool isStaggered() const final { return false; }
 
     /**

--- a/include/dirac_quda.h
+++ b/include/dirac_quda.h
@@ -236,6 +236,21 @@ namespace quda {
     bool isStaggered() const { return Dirac::is_staggered_type(getDiracType()); }
 
     /**
+      @brief static function that returns if a Dirac type is asqtad depending on a QudaDiracType
+     */
+    static bool is_asqtad(QudaDiracType);
+
+    /**
+      @brief static function that returns if a Dslash type is asqtaddepending on a QudaDslashType
+     */
+    static bool is_asqtad(QudaDslashType);
+
+    /**
+      @brief return if the operator is a staggered operator
+     */
+    bool isAsqtad() const { return Dirac::is_asqtad(getDiracType()); }
+
+    /**
       @brief static function that returns if a Dirac type is a domain wall operator (5-dimensional) depending on a QudaDiracType
      */
     static bool is_dwf(QudaDiracType);

--- a/lib/dirac.cpp
+++ b/lib/dirac.cpp
@@ -255,6 +255,123 @@ namespace quda {
     return nullptr;
   }
 
+  bool Dirac::is_wilson_type(QudaDiracType type) {
+    switch (type) {
+    case QUDA_WILSON_DIRAC:
+    case QUDA_WILSONPC_DIRAC:
+    case QUDA_CLOVER_DIRAC:
+    case QUDA_CLOVERPC_DIRAC:
+    case QUDA_CLOVER_HASENBUSCH_TWIST_DIRAC:
+    case QUDA_CLOVER_HASENBUSCH_TWISTPC_DIRAC:
+    case QUDA_TWISTED_CLOVER_DIRAC:
+    case QUDA_TWISTED_CLOVERPC_DIRAC:
+    case QUDA_TWISTED_MASS_DIRAC:
+    case QUDA_TWISTED_MASSPC_DIRAC:
+      return true;
+    case QUDA_DOMAIN_WALL_DIRAC:
+    case QUDA_DOMAIN_WALLPC_DIRAC:
+    case QUDA_DOMAIN_WALL_4D_DIRAC:
+    case QUDA_DOMAIN_WALL_4DPC_DIRAC:
+    case QUDA_MOBIUS_DOMAIN_WALL_DIRAC:
+    case QUDA_MOBIUS_DOMAIN_WALLPC_DIRAC:
+    case QUDA_MOBIUS_DOMAIN_WALL_EOFA_DIRAC:
+    case QUDA_MOBIUS_DOMAIN_WALLPC_EOFA_DIRAC:
+    case QUDA_STAGGERED_DIRAC:
+    case QUDA_STAGGEREDPC_DIRAC:
+    case QUDA_STAGGEREDKD_DIRAC:
+    case QUDA_ASQTAD_DIRAC:
+    case QUDA_ASQTADPC_DIRAC:
+    case QUDA_ASQTADKD_DIRAC:
+    case QUDA_COARSE_DIRAC:
+    case QUDA_COARSEPC_DIRAC:
+    case QUDA_GAUGE_COVDEV_DIRAC:
+    case QUDA_GAUGE_LAPLACE_DIRAC:
+    case QUDA_GAUGE_LAPLACEPC_DIRAC:
+      return false;
+    default:
+      errorQuda("Invalid QudaDiracType %d", type);
+    }
+    return false;
+  }
+
+  bool Dirac::is_staggered(QudaDiracType type) {
+    switch (type) {
+    case QUDA_STAGGERED_DIRAC:
+    case QUDA_STAGGEREDPC_DIRAC:
+    case QUDA_STAGGEREDKD_DIRAC:
+    case QUDA_ASQTAD_DIRAC:
+    case QUDA_ASQTADPC_DIRAC:
+    case QUDA_ASQTADKD_DIRAC:
+      return true;
+    case QUDA_WILSON_DIRAC:
+    case QUDA_WILSONPC_DIRAC:
+    case QUDA_CLOVER_DIRAC:
+    case QUDA_CLOVERPC_DIRAC:
+    case QUDA_CLOVER_HASENBUSCH_TWIST_DIRAC:
+    case QUDA_CLOVER_HASENBUSCH_TWISTPC_DIRAC:
+    case QUDA_TWISTED_CLOVER_DIRAC:
+    case QUDA_TWISTED_CLOVERPC_DIRAC:
+    case QUDA_TWISTED_MASS_DIRAC:
+    case QUDA_TWISTED_MASSPC_DIRAC:
+    case QUDA_DOMAIN_WALL_DIRAC:
+    case QUDA_DOMAIN_WALLPC_DIRAC:
+    case QUDA_DOMAIN_WALL_4D_DIRAC:
+    case QUDA_DOMAIN_WALL_4DPC_DIRAC:
+    case QUDA_MOBIUS_DOMAIN_WALL_DIRAC:
+    case QUDA_MOBIUS_DOMAIN_WALLPC_DIRAC:
+    case QUDA_MOBIUS_DOMAIN_WALL_EOFA_DIRAC:
+    case QUDA_MOBIUS_DOMAIN_WALLPC_EOFA_DIRAC:
+    case QUDA_COARSE_DIRAC:
+    case QUDA_COARSEPC_DIRAC:
+    case QUDA_GAUGE_COVDEV_DIRAC:
+    case QUDA_GAUGE_LAPLACE_DIRAC:
+    case QUDA_GAUGE_LAPLACEPC_DIRAC:
+      return false;
+    default:
+      errorQuda("Invalid QudaDiracType %d", type);
+    }
+    return false;
+  }
+
+  bool Dirac::is_dwf(QudaDiracType type) {
+    switch (type) {
+    case QUDA_DOMAIN_WALL_DIRAC:
+    case QUDA_DOMAIN_WALLPC_DIRAC:
+    case QUDA_DOMAIN_WALL_4D_DIRAC:
+    case QUDA_DOMAIN_WALL_4DPC_DIRAC:
+    case QUDA_MOBIUS_DOMAIN_WALL_DIRAC:
+    case QUDA_MOBIUS_DOMAIN_WALLPC_DIRAC:
+    case QUDA_MOBIUS_DOMAIN_WALL_EOFA_DIRAC:
+    case QUDA_MOBIUS_DOMAIN_WALLPC_EOFA_DIRAC:
+      return true;
+    case QUDA_WILSON_DIRAC:
+    case QUDA_WILSONPC_DIRAC:
+    case QUDA_CLOVER_DIRAC:
+    case QUDA_CLOVERPC_DIRAC:
+    case QUDA_CLOVER_HASENBUSCH_TWIST_DIRAC:
+    case QUDA_CLOVER_HASENBUSCH_TWISTPC_DIRAC:
+    case QUDA_TWISTED_CLOVER_DIRAC:
+    case QUDA_TWISTED_CLOVERPC_DIRAC:
+    case QUDA_TWISTED_MASS_DIRAC:
+    case QUDA_TWISTED_MASSPC_DIRAC:
+    case QUDA_STAGGERED_DIRAC:
+    case QUDA_STAGGEREDPC_DIRAC:
+    case QUDA_STAGGEREDKD_DIRAC:
+    case QUDA_ASQTAD_DIRAC:
+    case QUDA_ASQTADPC_DIRAC:
+    case QUDA_ASQTADKD_DIRAC:
+    case QUDA_COARSE_DIRAC:
+    case QUDA_COARSEPC_DIRAC:
+    case QUDA_GAUGE_COVDEV_DIRAC:
+    case QUDA_GAUGE_LAPLACE_DIRAC:
+    case QUDA_GAUGE_LAPLACEPC_DIRAC:
+      return false;
+    default:
+      errorQuda("Invalid QudaDiracType %d", type);
+    }
+    return false;
+  }
+
   void Dirac::prefetch(QudaFieldLocation mem_space, qudaStream_t stream) const
   {
     if (gauge) gauge->prefetch(mem_space, stream);

--- a/lib/dirac.cpp
+++ b/lib/dirac.cpp
@@ -267,7 +267,7 @@ namespace quda {
     case QUDA_TWISTED_CLOVERPC_DIRAC:
     case QUDA_TWISTED_MASS_DIRAC:
     case QUDA_TWISTED_MASSPC_DIRAC:
-      return true;
+      return true; break;
     case QUDA_DOMAIN_WALL_DIRAC:
     case QUDA_DOMAIN_WALLPC_DIRAC:
     case QUDA_DOMAIN_WALL_4D_DIRAC:
@@ -287,14 +287,37 @@ namespace quda {
     case QUDA_GAUGE_COVDEV_DIRAC:
     case QUDA_GAUGE_LAPLACE_DIRAC:
     case QUDA_GAUGE_LAPLACEPC_DIRAC:
-      return false;
+      return false; break;
     default:
-      errorQuda("Invalid QudaDiracType %d", type);
+      errorQuda("Invalid QudaDiracType %d", type); break;
     }
     return false;
   }
 
-  bool Dirac::is_staggered(QudaDiracType type) {
+  bool Dirac::is_wilson_type(QudaDslashType type) {
+    switch (type) {
+    case QUDA_WILSON_DSLASH:
+    case QUDA_CLOVER_WILSON_DSLASH:
+    case QUDA_CLOVER_HASENBUSCH_TWIST_DSLASH:
+    case QUDA_TWISTED_MASS_DSLASH:
+    case QUDA_TWISTED_CLOVER_DSLASH:
+      return true; break;
+    case QUDA_DOMAIN_WALL_DSLASH:
+    case QUDA_DOMAIN_WALL_4D_DSLASH:
+    case QUDA_MOBIUS_DWF_DSLASH:
+    case QUDA_MOBIUS_DWF_EOFA_DSLASH:
+    case QUDA_STAGGERED_DSLASH:
+    case QUDA_ASQTAD_DSLASH:
+    case QUDA_LAPLACE_DSLASH:
+    case QUDA_COVDEV_DSLASH:
+      return false; break;
+    default:
+      errorQuda("Invalid QudaDslashType %d", type); break;
+    }
+    return false;
+  }
+
+  bool Dirac::is_staggered_type(QudaDiracType type) {
     switch (type) {
     case QUDA_STAGGERED_DIRAC:
     case QUDA_STAGGEREDPC_DIRAC:
@@ -302,7 +325,7 @@ namespace quda {
     case QUDA_ASQTAD_DIRAC:
     case QUDA_ASQTADPC_DIRAC:
     case QUDA_ASQTADKD_DIRAC:
-      return true;
+      return true; break;
     case QUDA_WILSON_DIRAC:
     case QUDA_WILSONPC_DIRAC:
     case QUDA_CLOVER_DIRAC:
@@ -326,9 +349,32 @@ namespace quda {
     case QUDA_GAUGE_COVDEV_DIRAC:
     case QUDA_GAUGE_LAPLACE_DIRAC:
     case QUDA_GAUGE_LAPLACEPC_DIRAC:
-      return false;
+      return false; break;
     default:
-      errorQuda("Invalid QudaDiracType %d", type);
+      errorQuda("Invalid QudaDiracType %d", type); break;
+    }
+    return false;
+  }
+
+  bool Dirac::is_staggered_type(QudaDslashType type) {
+    switch (type) {
+    case QUDA_STAGGERED_DSLASH:
+    case QUDA_ASQTAD_DSLASH:
+      return true; break;
+    case QUDA_WILSON_DSLASH:
+    case QUDA_CLOVER_WILSON_DSLASH:
+    case QUDA_CLOVER_HASENBUSCH_TWIST_DSLASH:
+    case QUDA_TWISTED_MASS_DSLASH:
+    case QUDA_TWISTED_CLOVER_DSLASH:
+    case QUDA_DOMAIN_WALL_DSLASH:
+    case QUDA_DOMAIN_WALL_4D_DSLASH:
+    case QUDA_MOBIUS_DWF_DSLASH:
+    case QUDA_MOBIUS_DWF_EOFA_DSLASH:
+    case QUDA_LAPLACE_DSLASH:
+    case QUDA_COVDEV_DSLASH:
+      return false; break;
+    default:
+      errorQuda("Invalid QudaDslashType %d", type); break;
     }
     return false;
   }
@@ -343,7 +389,7 @@ namespace quda {
     case QUDA_MOBIUS_DOMAIN_WALLPC_DIRAC:
     case QUDA_MOBIUS_DOMAIN_WALL_EOFA_DIRAC:
     case QUDA_MOBIUS_DOMAIN_WALLPC_EOFA_DIRAC:
-      return true;
+      return true; break;
     case QUDA_WILSON_DIRAC:
     case QUDA_WILSONPC_DIRAC:
     case QUDA_CLOVER_DIRAC:
@@ -365,11 +411,85 @@ namespace quda {
     case QUDA_GAUGE_COVDEV_DIRAC:
     case QUDA_GAUGE_LAPLACE_DIRAC:
     case QUDA_GAUGE_LAPLACEPC_DIRAC:
-      return false;
+      return false; break;
     default:
-      errorQuda("Invalid QudaDiracType %d", type);
+      errorQuda("Invalid QudaDiracType %d", type); break;
     }
     return false;
+  }
+
+  bool Dirac::is_dwf(QudaDslashType type) {
+    switch (type) {
+    case QUDA_DOMAIN_WALL_DSLASH:
+    case QUDA_DOMAIN_WALL_4D_DSLASH:
+    case QUDA_MOBIUS_DWF_DSLASH:
+    case QUDA_MOBIUS_DWF_EOFA_DSLASH:
+      return true; break;
+    case QUDA_WILSON_DSLASH:
+    case QUDA_CLOVER_WILSON_DSLASH:
+    case QUDA_CLOVER_HASENBUSCH_TWIST_DSLASH:
+    case QUDA_TWISTED_MASS_DSLASH:
+    case QUDA_TWISTED_CLOVER_DSLASH:
+    case QUDA_STAGGERED_DSLASH:
+    case QUDA_ASQTAD_DSLASH:
+    case QUDA_LAPLACE_DSLASH:
+    case QUDA_COVDEV_DSLASH:
+      return false; break;
+    default:
+      errorQuda("Invalid QudaDslashType %d", type); break;
+    }
+    return false;
+  }
+
+  QudaDslashType Dirac::dirac_to_dslash_type(QudaDiracType type) {
+    switch (type) {
+    case QUDA_WILSON_DIRAC:
+    case QUDA_WILSONPC_DIRAC:
+      return QUDA_WILSON_DSLASH; break;
+    case QUDA_CLOVER_DIRAC:
+    case QUDA_CLOVERPC_DIRAC:
+      return QUDA_CLOVER_WILSON_DSLASH; break;
+    case QUDA_CLOVER_HASENBUSCH_TWIST_DIRAC:
+    case QUDA_CLOVER_HASENBUSCH_TWISTPC_DIRAC:
+      return QUDA_CLOVER_HASENBUSCH_TWIST_DSLASH; break;
+    case QUDA_TWISTED_CLOVER_DIRAC:
+    case QUDA_TWISTED_CLOVERPC_DIRAC:
+      return QUDA_TWISTED_CLOVER_DSLASH; break;
+    case QUDA_TWISTED_MASS_DIRAC:
+    case QUDA_TWISTED_MASSPC_DIRAC:
+      return QUDA_TWISTED_MASS_DSLASH; break;
+    case QUDA_DOMAIN_WALL_DIRAC:
+    case QUDA_DOMAIN_WALLPC_DIRAC:
+      return QUDA_DOMAIN_WALL_DSLASH; break;
+    case QUDA_DOMAIN_WALL_4D_DIRAC:
+    case QUDA_DOMAIN_WALL_4DPC_DIRAC:
+      return QUDA_DOMAIN_WALL_4D_DSLASH; break;
+    case QUDA_MOBIUS_DOMAIN_WALL_DIRAC:
+    case QUDA_MOBIUS_DOMAIN_WALLPC_DIRAC:
+      return QUDA_MOBIUS_DWF_DSLASH; break;
+    case QUDA_MOBIUS_DOMAIN_WALL_EOFA_DIRAC:
+    case QUDA_MOBIUS_DOMAIN_WALLPC_EOFA_DIRAC:
+      return QUDA_MOBIUS_DWF_EOFA_DSLASH; break;
+    case QUDA_STAGGERED_DIRAC:
+    case QUDA_STAGGEREDPC_DIRAC:
+    case QUDA_STAGGEREDKD_DIRAC:
+      return QUDA_STAGGERED_DSLASH; break;
+    case QUDA_ASQTAD_DIRAC:
+    case QUDA_ASQTADPC_DIRAC:
+    case QUDA_ASQTADKD_DIRAC:
+      return QUDA_ASQTAD_DSLASH; break;
+    case QUDA_GAUGE_COVDEV_DIRAC:
+      return QUDA_COVDEV_DSLASH; break;
+    case QUDA_GAUGE_LAPLACE_DIRAC:
+    case QUDA_GAUGE_LAPLACEPC_DIRAC:
+      return QUDA_LAPLACE_DSLASH; break;
+    case QUDA_COARSE_DIRAC:
+    case QUDA_COARSEPC_DIRAC:
+      return QUDA_INVALID_DSLASH; break;
+    default:
+      errorQuda("Invalid QudaDiracType %d", type); break;
+    }
+    return QUDA_INVALID_DSLASH;
   }
 
   void Dirac::prefetch(QudaFieldLocation mem_space, qudaStream_t stream) const

--- a/lib/dirac.cpp
+++ b/lib/dirac.cpp
@@ -379,6 +379,68 @@ namespace quda {
     return false;
   }
 
+  bool Dirac::is_asqtad(QudaDiracType type) {
+    switch (type) {
+    case QUDA_ASQTAD_DIRAC:
+    case QUDA_ASQTADPC_DIRAC:
+    case QUDA_ASQTADKD_DIRAC:
+      return true; break;
+    case QUDA_WILSON_DIRAC:
+    case QUDA_WILSONPC_DIRAC:
+    case QUDA_CLOVER_DIRAC:
+    case QUDA_CLOVERPC_DIRAC:
+    case QUDA_CLOVER_HASENBUSCH_TWIST_DIRAC:
+    case QUDA_CLOVER_HASENBUSCH_TWISTPC_DIRAC:
+    case QUDA_TWISTED_CLOVER_DIRAC:
+    case QUDA_TWISTED_CLOVERPC_DIRAC:
+    case QUDA_TWISTED_MASS_DIRAC:
+    case QUDA_TWISTED_MASSPC_DIRAC:
+    case QUDA_DOMAIN_WALL_DIRAC:
+    case QUDA_DOMAIN_WALLPC_DIRAC:
+    case QUDA_DOMAIN_WALL_4D_DIRAC:
+    case QUDA_DOMAIN_WALL_4DPC_DIRAC:
+    case QUDA_MOBIUS_DOMAIN_WALL_DIRAC:
+    case QUDA_MOBIUS_DOMAIN_WALLPC_DIRAC:
+    case QUDA_MOBIUS_DOMAIN_WALL_EOFA_DIRAC:
+    case QUDA_MOBIUS_DOMAIN_WALLPC_EOFA_DIRAC:
+    case QUDA_STAGGERED_DIRAC:
+    case QUDA_STAGGEREDPC_DIRAC:
+    case QUDA_STAGGEREDKD_DIRAC:
+    case QUDA_COARSE_DIRAC:
+    case QUDA_COARSEPC_DIRAC:
+    case QUDA_GAUGE_COVDEV_DIRAC:
+    case QUDA_GAUGE_LAPLACE_DIRAC:
+    case QUDA_GAUGE_LAPLACEPC_DIRAC:
+      return false; break;
+    default:
+      errorQuda("Invalid QudaDiracType %d", type); break;
+    }
+    return false;
+  }
+
+  bool Dirac::is_asqtad(QudaDslashType type) {
+    switch (type) {
+    case QUDA_ASQTAD_DSLASH:
+      return true; break;
+    case QUDA_WILSON_DSLASH:
+    case QUDA_CLOVER_WILSON_DSLASH:
+    case QUDA_CLOVER_HASENBUSCH_TWIST_DSLASH:
+    case QUDA_TWISTED_MASS_DSLASH:
+    case QUDA_TWISTED_CLOVER_DSLASH:
+    case QUDA_DOMAIN_WALL_DSLASH:
+    case QUDA_DOMAIN_WALL_4D_DSLASH:
+    case QUDA_MOBIUS_DWF_DSLASH:
+    case QUDA_MOBIUS_DWF_EOFA_DSLASH:
+    case QUDA_STAGGERED_DSLASH:
+    case QUDA_LAPLACE_DSLASH:
+    case QUDA_COVDEV_DSLASH:
+      return false; break;
+    default:
+      errorQuda("Invalid QudaDslashType %d", type); break;
+    }
+    return false;
+  }
+
   bool Dirac::is_dwf(QudaDiracType type) {
     switch (type) {
     case QUDA_DOMAIN_WALL_DIRAC:

--- a/lib/dirac.cpp
+++ b/lib/dirac.cpp
@@ -254,56 +254,6 @@ namespace quda {
 
     return nullptr;
   }
-  
-  // Count the number of stencil applications per dslash application.
-  int Dirac::getStencilSteps() const
-  {
-    int steps = 0;
-    switch (type)
-    {
-      case QUDA_WILSON_DIRAC:
-      case QUDA_CLOVER_DIRAC:
-      case QUDA_DOMAIN_WALL_DIRAC:
-      case QUDA_DOMAIN_WALL_4D_DIRAC:
-      case QUDA_MOBIUS_DOMAIN_WALL_DIRAC:
-      case QUDA_MOBIUS_DOMAIN_WALL_EOFA_DIRAC:
-      case QUDA_TWISTED_CLOVER_DIRAC:
-      case QUDA_TWISTED_MASS_DIRAC:
-      case QUDA_STAGGERED_DIRAC:
-      case QUDA_ASQTAD_DIRAC:
-      case QUDA_STAGGEREDKD_DIRAC:
-      case QUDA_ASQTADKD_DIRAC:
-      case QUDA_COARSE_DIRAC:
-      case QUDA_GAUGE_LAPLACE_DIRAC:
-      case QUDA_GAUGE_COVDEV_DIRAC:
-        steps = 1; // single fused operator
-        break;
-      case QUDA_CLOVER_HASENBUSCH_TWIST_DIRAC: // implemented as separate even, odd
-        steps = 2; // For D_{eo} and D_{oe} piece.
-        break;
-      case QUDA_WILSONPC_DIRAC:
-      case QUDA_CLOVERPC_DIRAC:
-      case QUDA_CLOVER_HASENBUSCH_TWISTPC_DIRAC:
-      case QUDA_DOMAIN_WALLPC_DIRAC:
-      case QUDA_DOMAIN_WALL_4DPC_DIRAC:
-      case QUDA_MOBIUS_DOMAIN_WALLPC_DIRAC:
-      case QUDA_MOBIUS_DOMAIN_WALLPC_EOFA_DIRAC:
-      case QUDA_STAGGEREDPC_DIRAC:
-      case QUDA_ASQTADPC_DIRAC:
-      case QUDA_TWISTED_CLOVERPC_DIRAC:
-      case QUDA_TWISTED_MASSPC_DIRAC:
-      case QUDA_COARSEPC_DIRAC:
-      case QUDA_GAUGE_LAPLACEPC_DIRAC:
-        steps = 2;
-        break;
-      default:
-        errorQuda("Unsupported Dslash type %d.\n", type);
-        steps = 0;
-        break;
-    }
-
-    return steps;
-  }
 
   void Dirac::prefetch(QudaFieldLocation mem_space, qudaStream_t stream) const
   {

--- a/lib/dirac.cpp
+++ b/lib/dirac.cpp
@@ -267,7 +267,7 @@ namespace quda {
     case QUDA_TWISTED_CLOVER_DIRAC:
     case QUDA_TWISTED_CLOVERPC_DIRAC:
     case QUDA_TWISTED_MASS_DIRAC:
-    case QUDA_TWISTED_MASSPC_DIRAC: return true; break;
+    case QUDA_TWISTED_MASSPC_DIRAC: return true;
     case QUDA_DOMAIN_WALL_DIRAC:
     case QUDA_DOMAIN_WALLPC_DIRAC:
     case QUDA_DOMAIN_WALL_4D_DIRAC:
@@ -286,7 +286,7 @@ namespace quda {
     case QUDA_COARSEPC_DIRAC:
     case QUDA_GAUGE_COVDEV_DIRAC:
     case QUDA_GAUGE_LAPLACE_DIRAC:
-    case QUDA_GAUGE_LAPLACEPC_DIRAC: return false; break;
+    case QUDA_GAUGE_LAPLACEPC_DIRAC: return false;
     default: errorQuda("Invalid QudaDiracType %d", type); break;
     }
     return false;
@@ -299,7 +299,7 @@ namespace quda {
     case QUDA_CLOVER_WILSON_DSLASH:
     case QUDA_CLOVER_HASENBUSCH_TWIST_DSLASH:
     case QUDA_TWISTED_MASS_DSLASH:
-    case QUDA_TWISTED_CLOVER_DSLASH: return true; break;
+    case QUDA_TWISTED_CLOVER_DSLASH: return true;
     case QUDA_DOMAIN_WALL_DSLASH:
     case QUDA_DOMAIN_WALL_4D_DSLASH:
     case QUDA_MOBIUS_DWF_DSLASH:
@@ -307,7 +307,7 @@ namespace quda {
     case QUDA_STAGGERED_DSLASH:
     case QUDA_ASQTAD_DSLASH:
     case QUDA_LAPLACE_DSLASH:
-    case QUDA_COVDEV_DSLASH: return false; break;
+    case QUDA_COVDEV_DSLASH: return false;
     default: errorQuda("Invalid QudaDslashType %d", type); break;
     }
     return false;
@@ -321,7 +321,7 @@ namespace quda {
     case QUDA_STAGGEREDKD_DIRAC:
     case QUDA_ASQTAD_DIRAC:
     case QUDA_ASQTADPC_DIRAC:
-    case QUDA_ASQTADKD_DIRAC: return true; break;
+    case QUDA_ASQTADKD_DIRAC: return true;
     case QUDA_WILSON_DIRAC:
     case QUDA_WILSONPC_DIRAC:
     case QUDA_CLOVER_DIRAC:
@@ -344,7 +344,7 @@ namespace quda {
     case QUDA_COARSEPC_DIRAC:
     case QUDA_GAUGE_COVDEV_DIRAC:
     case QUDA_GAUGE_LAPLACE_DIRAC:
-    case QUDA_GAUGE_LAPLACEPC_DIRAC: return false; break;
+    case QUDA_GAUGE_LAPLACEPC_DIRAC: return false;
     default: errorQuda("Invalid QudaDiracType %d", type); break;
     }
     return false;
@@ -354,7 +354,7 @@ namespace quda {
   {
     switch (type) {
     case QUDA_STAGGERED_DSLASH:
-    case QUDA_ASQTAD_DSLASH: return true; break;
+    case QUDA_ASQTAD_DSLASH: return true;
     case QUDA_WILSON_DSLASH:
     case QUDA_CLOVER_WILSON_DSLASH:
     case QUDA_CLOVER_HASENBUSCH_TWIST_DSLASH:
@@ -365,7 +365,7 @@ namespace quda {
     case QUDA_MOBIUS_DWF_DSLASH:
     case QUDA_MOBIUS_DWF_EOFA_DSLASH:
     case QUDA_LAPLACE_DSLASH:
-    case QUDA_COVDEV_DSLASH: return false; break;
+    case QUDA_COVDEV_DSLASH: return false;
     default: errorQuda("Invalid QudaDslashType %d", type); break;
     }
     return false;
@@ -376,7 +376,7 @@ namespace quda {
     switch (type) {
     case QUDA_ASQTAD_DIRAC:
     case QUDA_ASQTADPC_DIRAC:
-    case QUDA_ASQTADKD_DIRAC: return true; break;
+    case QUDA_ASQTADKD_DIRAC: return true;
     case QUDA_WILSON_DIRAC:
     case QUDA_WILSONPC_DIRAC:
     case QUDA_CLOVER_DIRAC:
@@ -402,7 +402,7 @@ namespace quda {
     case QUDA_COARSEPC_DIRAC:
     case QUDA_GAUGE_COVDEV_DIRAC:
     case QUDA_GAUGE_LAPLACE_DIRAC:
-    case QUDA_GAUGE_LAPLACEPC_DIRAC: return false; break;
+    case QUDA_GAUGE_LAPLACEPC_DIRAC: return false;
     default: errorQuda("Invalid QudaDiracType %d", type); break;
     }
     return false;
@@ -411,7 +411,7 @@ namespace quda {
   bool Dirac::is_asqtad(QudaDslashType type)
   {
     switch (type) {
-    case QUDA_ASQTAD_DSLASH: return true; break;
+    case QUDA_ASQTAD_DSLASH: return true;
     case QUDA_WILSON_DSLASH:
     case QUDA_CLOVER_WILSON_DSLASH:
     case QUDA_CLOVER_HASENBUSCH_TWIST_DSLASH:
@@ -423,7 +423,7 @@ namespace quda {
     case QUDA_MOBIUS_DWF_EOFA_DSLASH:
     case QUDA_STAGGERED_DSLASH:
     case QUDA_LAPLACE_DSLASH:
-    case QUDA_COVDEV_DSLASH: return false; break;
+    case QUDA_COVDEV_DSLASH: return false;
     default: errorQuda("Invalid QudaDslashType %d", type); break;
     }
     return false;
@@ -439,7 +439,7 @@ namespace quda {
     case QUDA_MOBIUS_DOMAIN_WALL_DIRAC:
     case QUDA_MOBIUS_DOMAIN_WALLPC_DIRAC:
     case QUDA_MOBIUS_DOMAIN_WALL_EOFA_DIRAC:
-    case QUDA_MOBIUS_DOMAIN_WALLPC_EOFA_DIRAC: return true; break;
+    case QUDA_MOBIUS_DOMAIN_WALLPC_EOFA_DIRAC: return true;
     case QUDA_WILSON_DIRAC:
     case QUDA_WILSONPC_DIRAC:
     case QUDA_CLOVER_DIRAC:
@@ -460,7 +460,7 @@ namespace quda {
     case QUDA_COARSEPC_DIRAC:
     case QUDA_GAUGE_COVDEV_DIRAC:
     case QUDA_GAUGE_LAPLACE_DIRAC:
-    case QUDA_GAUGE_LAPLACEPC_DIRAC: return false; break;
+    case QUDA_GAUGE_LAPLACEPC_DIRAC: return false;
     default: errorQuda("Invalid QudaDiracType %d", type); break;
     }
     return false;
@@ -472,7 +472,7 @@ namespace quda {
     case QUDA_DOMAIN_WALL_DSLASH:
     case QUDA_DOMAIN_WALL_4D_DSLASH:
     case QUDA_MOBIUS_DWF_DSLASH:
-    case QUDA_MOBIUS_DWF_EOFA_DSLASH: return true; break;
+    case QUDA_MOBIUS_DWF_EOFA_DSLASH: return true;
     case QUDA_WILSON_DSLASH:
     case QUDA_CLOVER_WILSON_DSLASH:
     case QUDA_CLOVER_HASENBUSCH_TWIST_DSLASH:
@@ -481,7 +481,7 @@ namespace quda {
     case QUDA_STAGGERED_DSLASH:
     case QUDA_ASQTAD_DSLASH:
     case QUDA_LAPLACE_DSLASH:
-    case QUDA_COVDEV_DSLASH: return false; break;
+    case QUDA_COVDEV_DSLASH: return false;
     default: errorQuda("Invalid QudaDslashType %d", type); break;
     }
     return false;
@@ -491,34 +491,34 @@ namespace quda {
   {
     switch (type) {
     case QUDA_WILSON_DIRAC:
-    case QUDA_WILSONPC_DIRAC: return QUDA_WILSON_DSLASH; break;
+    case QUDA_WILSONPC_DIRAC: return QUDA_WILSON_DSLASH;
     case QUDA_CLOVER_DIRAC:
-    case QUDA_CLOVERPC_DIRAC: return QUDA_CLOVER_WILSON_DSLASH; break;
+    case QUDA_CLOVERPC_DIRAC: return QUDA_CLOVER_WILSON_DSLASH;
     case QUDA_CLOVER_HASENBUSCH_TWIST_DIRAC:
-    case QUDA_CLOVER_HASENBUSCH_TWISTPC_DIRAC: return QUDA_CLOVER_HASENBUSCH_TWIST_DSLASH; break;
+    case QUDA_CLOVER_HASENBUSCH_TWISTPC_DIRAC: return QUDA_CLOVER_HASENBUSCH_TWIST_DSLASH;
     case QUDA_TWISTED_CLOVER_DIRAC:
-    case QUDA_TWISTED_CLOVERPC_DIRAC: return QUDA_TWISTED_CLOVER_DSLASH; break;
+    case QUDA_TWISTED_CLOVERPC_DIRAC: return QUDA_TWISTED_CLOVER_DSLASH;
     case QUDA_TWISTED_MASS_DIRAC:
-    case QUDA_TWISTED_MASSPC_DIRAC: return QUDA_TWISTED_MASS_DSLASH; break;
+    case QUDA_TWISTED_MASSPC_DIRAC: return QUDA_TWISTED_MASS_DSLASH;
     case QUDA_DOMAIN_WALL_DIRAC:
-    case QUDA_DOMAIN_WALLPC_DIRAC: return QUDA_DOMAIN_WALL_DSLASH; break;
+    case QUDA_DOMAIN_WALLPC_DIRAC: return QUDA_DOMAIN_WALL_DSLASH;
     case QUDA_DOMAIN_WALL_4D_DIRAC:
-    case QUDA_DOMAIN_WALL_4DPC_DIRAC: return QUDA_DOMAIN_WALL_4D_DSLASH; break;
+    case QUDA_DOMAIN_WALL_4DPC_DIRAC: return QUDA_DOMAIN_WALL_4D_DSLASH;
     case QUDA_MOBIUS_DOMAIN_WALL_DIRAC:
-    case QUDA_MOBIUS_DOMAIN_WALLPC_DIRAC: return QUDA_MOBIUS_DWF_DSLASH; break;
+    case QUDA_MOBIUS_DOMAIN_WALLPC_DIRAC: return QUDA_MOBIUS_DWF_DSLASH;
     case QUDA_MOBIUS_DOMAIN_WALL_EOFA_DIRAC:
-    case QUDA_MOBIUS_DOMAIN_WALLPC_EOFA_DIRAC: return QUDA_MOBIUS_DWF_EOFA_DSLASH; break;
+    case QUDA_MOBIUS_DOMAIN_WALLPC_EOFA_DIRAC: return QUDA_MOBIUS_DWF_EOFA_DSLASH;
     case QUDA_STAGGERED_DIRAC:
     case QUDA_STAGGEREDPC_DIRAC:
-    case QUDA_STAGGEREDKD_DIRAC: return QUDA_STAGGERED_DSLASH; break;
+    case QUDA_STAGGEREDKD_DIRAC: return QUDA_STAGGERED_DSLASH;
     case QUDA_ASQTAD_DIRAC:
     case QUDA_ASQTADPC_DIRAC:
-    case QUDA_ASQTADKD_DIRAC: return QUDA_ASQTAD_DSLASH; break;
-    case QUDA_GAUGE_COVDEV_DIRAC: return QUDA_COVDEV_DSLASH; break;
+    case QUDA_ASQTADKD_DIRAC: return QUDA_ASQTAD_DSLASH;
+    case QUDA_GAUGE_COVDEV_DIRAC: return QUDA_COVDEV_DSLASH;
     case QUDA_GAUGE_LAPLACE_DIRAC:
-    case QUDA_GAUGE_LAPLACEPC_DIRAC: return QUDA_LAPLACE_DSLASH; break;
+    case QUDA_GAUGE_LAPLACEPC_DIRAC: return QUDA_LAPLACE_DSLASH;
     case QUDA_COARSE_DIRAC:
-    case QUDA_COARSEPC_DIRAC: return QUDA_INVALID_DSLASH; break;
+    case QUDA_COARSEPC_DIRAC: return QUDA_INVALID_DSLASH;
     default: errorQuda("Invalid QudaDiracType %d", type); break;
     }
     return QUDA_INVALID_DSLASH;

--- a/lib/dirac.cpp
+++ b/lib/dirac.cpp
@@ -255,7 +255,8 @@ namespace quda {
     return nullptr;
   }
 
-  bool Dirac::is_wilson_type(QudaDiracType type) {
+  bool Dirac::is_wilson_type(QudaDiracType type)
+  {
     switch (type) {
     case QUDA_WILSON_DIRAC:
     case QUDA_WILSONPC_DIRAC:
@@ -266,8 +267,7 @@ namespace quda {
     case QUDA_TWISTED_CLOVER_DIRAC:
     case QUDA_TWISTED_CLOVERPC_DIRAC:
     case QUDA_TWISTED_MASS_DIRAC:
-    case QUDA_TWISTED_MASSPC_DIRAC:
-      return true; break;
+    case QUDA_TWISTED_MASSPC_DIRAC: return true; break;
     case QUDA_DOMAIN_WALL_DIRAC:
     case QUDA_DOMAIN_WALLPC_DIRAC:
     case QUDA_DOMAIN_WALL_4D_DIRAC:
@@ -286,22 +286,20 @@ namespace quda {
     case QUDA_COARSEPC_DIRAC:
     case QUDA_GAUGE_COVDEV_DIRAC:
     case QUDA_GAUGE_LAPLACE_DIRAC:
-    case QUDA_GAUGE_LAPLACEPC_DIRAC:
-      return false; break;
-    default:
-      errorQuda("Invalid QudaDiracType %d", type); break;
+    case QUDA_GAUGE_LAPLACEPC_DIRAC: return false; break;
+    default: errorQuda("Invalid QudaDiracType %d", type); break;
     }
     return false;
   }
 
-  bool Dirac::is_wilson_type(QudaDslashType type) {
+  bool Dirac::is_wilson_type(QudaDslashType type)
+  {
     switch (type) {
     case QUDA_WILSON_DSLASH:
     case QUDA_CLOVER_WILSON_DSLASH:
     case QUDA_CLOVER_HASENBUSCH_TWIST_DSLASH:
     case QUDA_TWISTED_MASS_DSLASH:
-    case QUDA_TWISTED_CLOVER_DSLASH:
-      return true; break;
+    case QUDA_TWISTED_CLOVER_DSLASH: return true; break;
     case QUDA_DOMAIN_WALL_DSLASH:
     case QUDA_DOMAIN_WALL_4D_DSLASH:
     case QUDA_MOBIUS_DWF_DSLASH:
@@ -309,23 +307,21 @@ namespace quda {
     case QUDA_STAGGERED_DSLASH:
     case QUDA_ASQTAD_DSLASH:
     case QUDA_LAPLACE_DSLASH:
-    case QUDA_COVDEV_DSLASH:
-      return false; break;
-    default:
-      errorQuda("Invalid QudaDslashType %d", type); break;
+    case QUDA_COVDEV_DSLASH: return false; break;
+    default: errorQuda("Invalid QudaDslashType %d", type); break;
     }
     return false;
   }
 
-  bool Dirac::is_staggered_type(QudaDiracType type) {
+  bool Dirac::is_staggered_type(QudaDiracType type)
+  {
     switch (type) {
     case QUDA_STAGGERED_DIRAC:
     case QUDA_STAGGEREDPC_DIRAC:
     case QUDA_STAGGEREDKD_DIRAC:
     case QUDA_ASQTAD_DIRAC:
     case QUDA_ASQTADPC_DIRAC:
-    case QUDA_ASQTADKD_DIRAC:
-      return true; break;
+    case QUDA_ASQTADKD_DIRAC: return true; break;
     case QUDA_WILSON_DIRAC:
     case QUDA_WILSONPC_DIRAC:
     case QUDA_CLOVER_DIRAC:
@@ -348,19 +344,17 @@ namespace quda {
     case QUDA_COARSEPC_DIRAC:
     case QUDA_GAUGE_COVDEV_DIRAC:
     case QUDA_GAUGE_LAPLACE_DIRAC:
-    case QUDA_GAUGE_LAPLACEPC_DIRAC:
-      return false; break;
-    default:
-      errorQuda("Invalid QudaDiracType %d", type); break;
+    case QUDA_GAUGE_LAPLACEPC_DIRAC: return false; break;
+    default: errorQuda("Invalid QudaDiracType %d", type); break;
     }
     return false;
   }
 
-  bool Dirac::is_staggered_type(QudaDslashType type) {
+  bool Dirac::is_staggered_type(QudaDslashType type)
+  {
     switch (type) {
     case QUDA_STAGGERED_DSLASH:
-    case QUDA_ASQTAD_DSLASH:
-      return true; break;
+    case QUDA_ASQTAD_DSLASH: return true; break;
     case QUDA_WILSON_DSLASH:
     case QUDA_CLOVER_WILSON_DSLASH:
     case QUDA_CLOVER_HASENBUSCH_TWIST_DSLASH:
@@ -371,20 +365,18 @@ namespace quda {
     case QUDA_MOBIUS_DWF_DSLASH:
     case QUDA_MOBIUS_DWF_EOFA_DSLASH:
     case QUDA_LAPLACE_DSLASH:
-    case QUDA_COVDEV_DSLASH:
-      return false; break;
-    default:
-      errorQuda("Invalid QudaDslashType %d", type); break;
+    case QUDA_COVDEV_DSLASH: return false; break;
+    default: errorQuda("Invalid QudaDslashType %d", type); break;
     }
     return false;
   }
 
-  bool Dirac::is_asqtad(QudaDiracType type) {
+  bool Dirac::is_asqtad(QudaDiracType type)
+  {
     switch (type) {
     case QUDA_ASQTAD_DIRAC:
     case QUDA_ASQTADPC_DIRAC:
-    case QUDA_ASQTADKD_DIRAC:
-      return true; break;
+    case QUDA_ASQTADKD_DIRAC: return true; break;
     case QUDA_WILSON_DIRAC:
     case QUDA_WILSONPC_DIRAC:
     case QUDA_CLOVER_DIRAC:
@@ -410,18 +402,16 @@ namespace quda {
     case QUDA_COARSEPC_DIRAC:
     case QUDA_GAUGE_COVDEV_DIRAC:
     case QUDA_GAUGE_LAPLACE_DIRAC:
-    case QUDA_GAUGE_LAPLACEPC_DIRAC:
-      return false; break;
-    default:
-      errorQuda("Invalid QudaDiracType %d", type); break;
+    case QUDA_GAUGE_LAPLACEPC_DIRAC: return false; break;
+    default: errorQuda("Invalid QudaDiracType %d", type); break;
     }
     return false;
   }
 
-  bool Dirac::is_asqtad(QudaDslashType type) {
+  bool Dirac::is_asqtad(QudaDslashType type)
+  {
     switch (type) {
-    case QUDA_ASQTAD_DSLASH:
-      return true; break;
+    case QUDA_ASQTAD_DSLASH: return true; break;
     case QUDA_WILSON_DSLASH:
     case QUDA_CLOVER_WILSON_DSLASH:
     case QUDA_CLOVER_HASENBUSCH_TWIST_DSLASH:
@@ -433,15 +423,14 @@ namespace quda {
     case QUDA_MOBIUS_DWF_EOFA_DSLASH:
     case QUDA_STAGGERED_DSLASH:
     case QUDA_LAPLACE_DSLASH:
-    case QUDA_COVDEV_DSLASH:
-      return false; break;
-    default:
-      errorQuda("Invalid QudaDslashType %d", type); break;
+    case QUDA_COVDEV_DSLASH: return false; break;
+    default: errorQuda("Invalid QudaDslashType %d", type); break;
     }
     return false;
   }
 
-  bool Dirac::is_dwf(QudaDiracType type) {
+  bool Dirac::is_dwf(QudaDiracType type)
+  {
     switch (type) {
     case QUDA_DOMAIN_WALL_DIRAC:
     case QUDA_DOMAIN_WALLPC_DIRAC:
@@ -450,8 +439,7 @@ namespace quda {
     case QUDA_MOBIUS_DOMAIN_WALL_DIRAC:
     case QUDA_MOBIUS_DOMAIN_WALLPC_DIRAC:
     case QUDA_MOBIUS_DOMAIN_WALL_EOFA_DIRAC:
-    case QUDA_MOBIUS_DOMAIN_WALLPC_EOFA_DIRAC:
-      return true; break;
+    case QUDA_MOBIUS_DOMAIN_WALLPC_EOFA_DIRAC: return true; break;
     case QUDA_WILSON_DIRAC:
     case QUDA_WILSONPC_DIRAC:
     case QUDA_CLOVER_DIRAC:
@@ -472,21 +460,19 @@ namespace quda {
     case QUDA_COARSEPC_DIRAC:
     case QUDA_GAUGE_COVDEV_DIRAC:
     case QUDA_GAUGE_LAPLACE_DIRAC:
-    case QUDA_GAUGE_LAPLACEPC_DIRAC:
-      return false; break;
-    default:
-      errorQuda("Invalid QudaDiracType %d", type); break;
+    case QUDA_GAUGE_LAPLACEPC_DIRAC: return false; break;
+    default: errorQuda("Invalid QudaDiracType %d", type); break;
     }
     return false;
   }
 
-  bool Dirac::is_dwf(QudaDslashType type) {
+  bool Dirac::is_dwf(QudaDslashType type)
+  {
     switch (type) {
     case QUDA_DOMAIN_WALL_DSLASH:
     case QUDA_DOMAIN_WALL_4D_DSLASH:
     case QUDA_MOBIUS_DWF_DSLASH:
-    case QUDA_MOBIUS_DWF_EOFA_DSLASH:
-      return true; break;
+    case QUDA_MOBIUS_DWF_EOFA_DSLASH: return true; break;
     case QUDA_WILSON_DSLASH:
     case QUDA_CLOVER_WILSON_DSLASH:
     case QUDA_CLOVER_HASENBUSCH_TWIST_DSLASH:
@@ -495,61 +481,45 @@ namespace quda {
     case QUDA_STAGGERED_DSLASH:
     case QUDA_ASQTAD_DSLASH:
     case QUDA_LAPLACE_DSLASH:
-    case QUDA_COVDEV_DSLASH:
-      return false; break;
-    default:
-      errorQuda("Invalid QudaDslashType %d", type); break;
+    case QUDA_COVDEV_DSLASH: return false; break;
+    default: errorQuda("Invalid QudaDslashType %d", type); break;
     }
     return false;
   }
 
-  QudaDslashType Dirac::dirac_to_dslash_type(QudaDiracType type) {
+  QudaDslashType Dirac::dirac_to_dslash_type(QudaDiracType type)
+  {
     switch (type) {
     case QUDA_WILSON_DIRAC:
-    case QUDA_WILSONPC_DIRAC:
-      return QUDA_WILSON_DSLASH; break;
+    case QUDA_WILSONPC_DIRAC: return QUDA_WILSON_DSLASH; break;
     case QUDA_CLOVER_DIRAC:
-    case QUDA_CLOVERPC_DIRAC:
-      return QUDA_CLOVER_WILSON_DSLASH; break;
+    case QUDA_CLOVERPC_DIRAC: return QUDA_CLOVER_WILSON_DSLASH; break;
     case QUDA_CLOVER_HASENBUSCH_TWIST_DIRAC:
-    case QUDA_CLOVER_HASENBUSCH_TWISTPC_DIRAC:
-      return QUDA_CLOVER_HASENBUSCH_TWIST_DSLASH; break;
+    case QUDA_CLOVER_HASENBUSCH_TWISTPC_DIRAC: return QUDA_CLOVER_HASENBUSCH_TWIST_DSLASH; break;
     case QUDA_TWISTED_CLOVER_DIRAC:
-    case QUDA_TWISTED_CLOVERPC_DIRAC:
-      return QUDA_TWISTED_CLOVER_DSLASH; break;
+    case QUDA_TWISTED_CLOVERPC_DIRAC: return QUDA_TWISTED_CLOVER_DSLASH; break;
     case QUDA_TWISTED_MASS_DIRAC:
-    case QUDA_TWISTED_MASSPC_DIRAC:
-      return QUDA_TWISTED_MASS_DSLASH; break;
+    case QUDA_TWISTED_MASSPC_DIRAC: return QUDA_TWISTED_MASS_DSLASH; break;
     case QUDA_DOMAIN_WALL_DIRAC:
-    case QUDA_DOMAIN_WALLPC_DIRAC:
-      return QUDA_DOMAIN_WALL_DSLASH; break;
+    case QUDA_DOMAIN_WALLPC_DIRAC: return QUDA_DOMAIN_WALL_DSLASH; break;
     case QUDA_DOMAIN_WALL_4D_DIRAC:
-    case QUDA_DOMAIN_WALL_4DPC_DIRAC:
-      return QUDA_DOMAIN_WALL_4D_DSLASH; break;
+    case QUDA_DOMAIN_WALL_4DPC_DIRAC: return QUDA_DOMAIN_WALL_4D_DSLASH; break;
     case QUDA_MOBIUS_DOMAIN_WALL_DIRAC:
-    case QUDA_MOBIUS_DOMAIN_WALLPC_DIRAC:
-      return QUDA_MOBIUS_DWF_DSLASH; break;
+    case QUDA_MOBIUS_DOMAIN_WALLPC_DIRAC: return QUDA_MOBIUS_DWF_DSLASH; break;
     case QUDA_MOBIUS_DOMAIN_WALL_EOFA_DIRAC:
-    case QUDA_MOBIUS_DOMAIN_WALLPC_EOFA_DIRAC:
-      return QUDA_MOBIUS_DWF_EOFA_DSLASH; break;
+    case QUDA_MOBIUS_DOMAIN_WALLPC_EOFA_DIRAC: return QUDA_MOBIUS_DWF_EOFA_DSLASH; break;
     case QUDA_STAGGERED_DIRAC:
     case QUDA_STAGGEREDPC_DIRAC:
-    case QUDA_STAGGEREDKD_DIRAC:
-      return QUDA_STAGGERED_DSLASH; break;
+    case QUDA_STAGGEREDKD_DIRAC: return QUDA_STAGGERED_DSLASH; break;
     case QUDA_ASQTAD_DIRAC:
     case QUDA_ASQTADPC_DIRAC:
-    case QUDA_ASQTADKD_DIRAC:
-      return QUDA_ASQTAD_DSLASH; break;
-    case QUDA_GAUGE_COVDEV_DIRAC:
-      return QUDA_COVDEV_DSLASH; break;
+    case QUDA_ASQTADKD_DIRAC: return QUDA_ASQTAD_DSLASH; break;
+    case QUDA_GAUGE_COVDEV_DIRAC: return QUDA_COVDEV_DSLASH; break;
     case QUDA_GAUGE_LAPLACE_DIRAC:
-    case QUDA_GAUGE_LAPLACEPC_DIRAC:
-      return QUDA_LAPLACE_DSLASH; break;
+    case QUDA_GAUGE_LAPLACEPC_DIRAC: return QUDA_LAPLACE_DSLASH; break;
     case QUDA_COARSE_DIRAC:
-    case QUDA_COARSEPC_DIRAC:
-      return QUDA_INVALID_DSLASH; break;
-    default:
-      errorQuda("Invalid QudaDiracType %d", type); break;
+    case QUDA_COARSEPC_DIRAC: return QUDA_INVALID_DSLASH; break;
+    default: errorQuda("Invalid QudaDiracType %d", type); break;
     }
     return QUDA_INVALID_DSLASH;
   }

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -3468,37 +3468,34 @@ void callMultiSrcQuda(void **_hp_x, void **_hp_b, QudaInvertParam *param, // col
 
     checkInvertParam(param, _hp_x[0], _hp_b[0]);
 
-    bool is_staggered = false;
-    bool is_asqtad = false;
+    // Asqtad loads fat and long links; all others (including naive staggered) load thin links
+    bool is_asqtad = Dirac::is_asqtad(param->dslash_type);
 
     GaugeBundleBackup thin_links_bkup;
     GaugeBundleBackup fat_links_bkup;
     GaugeBundleBackup long_links_bkup;
 
-    if (gaugePrecise) {
-      is_staggered = false;
+    if (is_asqtad) {
+      if (!gaugeFatPrecise || !gaugeLongPrecise)
+        errorQuda("Both milc_fatlinks and milc_longlinks need to be non-null for asqtad-type dslash");
+
+      fat_links_bkup.backup(gaugeFatPrecise, gaugeFatSloppy, gaugeFatPrecondition, gaugeFatRefinement,
+                            gaugeFatEigensolver, gaugeFatExtended);
+      long_links_bkup.backup(gaugeLongPrecise, gaugeLongSloppy, gaugeLongPrecondition, gaugeLongRefinement,
+                             gaugeLongEigensolver, gaugeLongExtended);
+    } else {
+      if (!gaugePrecise)
+        errorQuda("h_gauge is null for a Wilson-type or naive staggered dslash");
       thin_links_bkup.backup(gaugePrecise, gaugeSloppy, gaugePrecondition, gaugeRefinement, gaugeEigensolver,
                              gaugeExtended);
 
-    } else if (gaugeFatPrecise) {
-      is_staggered = true;
-      fat_links_bkup.backup(gaugeFatPrecise, gaugeFatSloppy, gaugeFatPrecondition, gaugeFatRefinement,
-                            gaugeFatEigensolver, gaugeFatExtended);
-      if (param->dslash_type == QUDA_ASQTAD_DSLASH) {
-        if (!gaugeLongPrecise) errorQuda("milc_longlinks is null for an asqtad dslash");
-        is_asqtad = true;
-        long_links_bkup.backup(gaugeLongPrecise, gaugeLongSloppy, gaugeLongPrecondition, gaugeLongRefinement,
-                               gaugeLongEigensolver, gaugeLongExtended);
-      }
-    } else {
-      errorQuda("Both h_gauge and milc_fatlinks are null.");
     }
 
     // Deal with Spinors
     bool pc_solution
       = (param->solution_type == QUDA_MATPC_SOLUTION) || (param->solution_type == QUDA_MATPCDAG_MATPC_SOLUTION);
 
-    lat_dim_t X = is_staggered ? gaugeFatPrecise->X() : gaugePrecise->X();
+    lat_dim_t X = is_asqtad ? gaugeFatPrecise->X() : gaugePrecise->X();
 
     ColorSpinorParam spinorParam(_hp_b[0], *param, X, pc_solution, param->input_location);
     std::vector<ColorSpinorField> _h_b(param->num_src);
@@ -3523,23 +3520,23 @@ void callMultiSrcQuda(void **_hp_x, void **_hp_b, QudaInvertParam *param, // col
     logQuda(QUDA_DEBUG_VERBOSE, "Spliting the grid into sub-partitions: (%2d,%2d,%2d,%2d) / (%2d,%2d,%2d,%2d)\n",
             comm_dim(0), comm_dim(1), comm_dim(2), comm_dim(3), split_key[0], split_key[1], split_key[2], split_key[3]);
 
-    if (!is_staggered)
+    if (!is_asqtad)
       gf_param = GaugeFieldParam(*(thin_links_bkup.precise));
     else {
       milc_fatlink_param = GaugeFieldParam(*(fat_links_bkup.precise));
-      if (is_asqtad) milc_longlink_param = GaugeFieldParam(*(long_links_bkup.precise));
+      milc_longlink_param = GaugeFieldParam(*(long_links_bkup.precise));
     }
 
     for (int d = 0; d < CommKey::n_dim; d++) {
       if (comm_dim(d) % split_key[d] != 0) {
         errorQuda("Split not possible: %2d %% %2d != 0", comm_dim(d), split_key[d]);
       }
-      if (!is_staggered) {
+      if (!is_asqtad) {
         gf_param.x[d] *= split_key[d];
         gf_param.pad *= split_key[d];
       } else {
         milc_fatlink_param.x[d] *= split_key[d];
-        if (is_asqtad) milc_longlink_param.x[d] *= split_key[d];
+        milc_longlink_param.x[d] *= split_key[d];
       }
     }
 
@@ -3547,7 +3544,7 @@ void callMultiSrcQuda(void **_hp_x, void **_hp_b, QudaInvertParam *param, // col
     quda::GaugeField *collected_milc_fatlink_field = nullptr;
     quda::GaugeField *collected_milc_longlink_field = nullptr;
 
-    if (!is_staggered) {
+    if (!is_asqtad) {
       gf_param.create = QUDA_NULL_FIELD_CREATE;
       collected_gauge = new quda::GaugeField(gf_param);
       quda::split_field(*collected_gauge, {*(thin_links_bkup.precise)}, split_key);
@@ -3558,12 +3555,9 @@ void callMultiSrcQuda(void **_hp_x, void **_hp_b, QudaInvertParam *param, // col
       collected_milc_fatlink_field = new GaugeField(milc_fatlink_param);
       quda::split_field(*collected_milc_fatlink_field, {*(fat_links_bkup.precise)}, split_key);
 
-      if (is_asqtad) {
-        milc_longlink_param.create = QUDA_NULL_FIELD_CREATE;
-        collected_milc_longlink_field = new GaugeField(milc_longlink_param);
-        v_g[0] = long_links_bkup.precise;
-        quda::split_field(*collected_milc_longlink_field, {*(long_links_bkup.precise)}, split_key);
-      }
+      milc_longlink_param.create = QUDA_NULL_FIELD_CREATE;
+      collected_milc_longlink_field = new GaugeField(milc_longlink_param);
+      quda::split_field(*collected_milc_longlink_field, {*(long_links_bkup.precise)}, split_key);
     }
 
     //  ------ Clover field
@@ -3630,7 +3624,7 @@ void callMultiSrcQuda(void **_hp_x, void **_hp_b, QudaInvertParam *param, // col
 
     // Load 'collected gauge field'
     logQuda(QUDA_DEBUG_VERBOSE, "Split grid loading gauge field...\n");
-    if (!is_staggered) {
+    if (!is_asqtad) {
       setupGaugeFields(collected_gauge, gaugePrecise, gaugeSloppy, gaugePrecondition, gaugeRefinement, gaugeEigensolver,
                        gaugeExtended, thin_links_bkup, profile.profile);
 
@@ -3638,10 +3632,8 @@ void callMultiSrcQuda(void **_hp_x, void **_hp_b, QudaInvertParam *param, // col
       setupGaugeFields(collected_milc_fatlink_field, gaugeFatPrecise, gaugeFatSloppy, gaugeFatPrecondition,
                        gaugeFatRefinement, gaugeFatEigensolver, gaugeFatExtended, fat_links_bkup, profile.profile);
 
-      if (is_asqtad) {
-        setupGaugeFields(collected_milc_longlink_field, gaugeLongPrecise, gaugeLongSloppy, gaugeLongPrecondition,
-                         gaugeLongRefinement, gaugeLongEigensolver, gaugeLongExtended, long_links_bkup, profile.profile);
-      }
+      setupGaugeFields(collected_milc_longlink_field, gaugeLongPrecise, gaugeLongSloppy, gaugeLongPrecondition,
+                       gaugeLongRefinement, gaugeLongEigensolver, gaugeLongExtended, long_links_bkup, profile.profile);
     }
     logQuda(QUDA_DEBUG_VERBOSE, "Split grid loaded gauge field...\n");
 
@@ -3693,7 +3685,7 @@ void callMultiSrcQuda(void **_hp_x, void **_hp_b, QudaInvertParam *param, // col
     profileInvertMultiSrc.TPSTOP(QUDA_PROFILE_EPILOGUE);
 
     // Restore the gauge field
-    if (!is_staggered) {
+    if (!is_asqtad) {
 
       freeUniqueGaugeQuda(QUDA_WILSON_LINKS);
       gaugePrecise = thin_links_bkup.precise;
@@ -3713,16 +3705,14 @@ void callMultiSrcQuda(void **_hp_x, void **_hp_b, QudaInvertParam *param, // col
       gaugeFatRefinement = fat_links_bkup.refinement;
       gaugeFatEigensolver = fat_links_bkup.eigensolver;
       gaugeFatExtended = fat_links_bkup.extended;
-      if (is_asqtad) {
 
-        freeUniqueGaugeQuda(QUDA_ASQTAD_LONG_LINKS);
-        gaugeLongPrecise = long_links_bkup.precise;
-        gaugeLongSloppy = long_links_bkup.sloppy;
-        gaugeLongPrecondition = long_links_bkup.precondition;
-        gaugeLongRefinement = long_links_bkup.refinement;
-        gaugeLongEigensolver = long_links_bkup.eigensolver;
-        gaugeLongExtended = long_links_bkup.extended;
-      }
+      freeUniqueGaugeQuda(QUDA_ASQTAD_LONG_LINKS);
+      gaugeLongPrecise = long_links_bkup.precise;
+      gaugeLongSloppy = long_links_bkup.sloppy;
+      gaugeLongPrecondition = long_links_bkup.precondition;
+      gaugeLongRefinement = long_links_bkup.refinement;
+      gaugeLongEigensolver = long_links_bkup.eigensolver;
+      gaugeLongExtended = long_links_bkup.extended;
     }
 
     if (is_clover) {

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -3484,11 +3484,9 @@ void callMultiSrcQuda(void **_hp_x, void **_hp_b, QudaInvertParam *param, // col
       long_links_bkup.backup(gaugeLongPrecise, gaugeLongSloppy, gaugeLongPrecondition, gaugeLongRefinement,
                              gaugeLongEigensolver, gaugeLongExtended);
     } else {
-      if (!gaugePrecise)
-        errorQuda("h_gauge is null for a Wilson-type or naive staggered dslash");
+      if (!gaugePrecise) errorQuda("h_gauge is null for a Wilson-type or naive staggered dslash");
       thin_links_bkup.backup(gaugePrecise, gaugeSloppy, gaugePrecondition, gaugeRefinement, gaugeEigensolver,
                              gaugeExtended);
-
     }
 
     // Deal with Spinors

--- a/tests/utils/host_utils.cpp
+++ b/tests/utils/host_utils.cpp
@@ -13,6 +13,7 @@
 // QUDA headers
 #include <color_spinor_field.h>
 #include <unitarization_links.h>
+#include <dirac_quda.h>
 
 // External headers
 #include <llfat_utils.h>
@@ -371,22 +372,12 @@ bool is_normal_residual(QudaInverterType type)
 
 bool is_staggered(QudaDslashType type)
 {
-  switch (type) {
-  case QUDA_STAGGERED_DSLASH:
-  case QUDA_ASQTAD_DSLASH: return true;
-  default: return false;
-  }
+  return Dirac::is_staggered_type(type);
 }
 
 bool is_chiral(QudaDslashType type)
 {
-  switch (type) {
-  case QUDA_DOMAIN_WALL_DSLASH:
-  case QUDA_DOMAIN_WALL_4D_DSLASH:
-  case QUDA_MOBIUS_DWF_DSLASH:
-  case QUDA_MOBIUS_DWF_EOFA_DSLASH: return true;
-  default: return false;
-  }
+  return Dirac::is_dwf(type);
 }
 
 bool is_laplace(QudaDslashType type)

--- a/tests/utils/host_utils.cpp
+++ b/tests/utils/host_utils.cpp
@@ -370,15 +370,9 @@ bool is_normal_residual(QudaInverterType type)
   }
 }
 
-bool is_staggered(QudaDslashType type)
-{
-  return Dirac::is_staggered_type(type);
-}
+bool is_staggered(QudaDslashType type) { return Dirac::is_staggered_type(type); }
 
-bool is_chiral(QudaDslashType type)
-{
-  return Dirac::is_dwf(type);
-}
+bool is_chiral(QudaDslashType type) { return Dirac::is_dwf(type); }
 
 bool is_laplace(QudaDslashType type)
 {


### PR DESCRIPTION
This PR addresses issue #1098 and extends it to the `getStencilSteps` function as well, replacing various functions that look like this:

```
bool isWilsonType() const
    {
      return (Type() == typeid(DiracWilson).name() || Type() == typeid(DiracWilsonPC).name()
              || Type() == typeid(DiracClover).name() || Type() == typeid(DiracCloverPC).name()
              || Type() == typeid(DiracCloverHasenbuschTwist).name()
              || Type() == typeid(DiracCloverHasenbuschTwistPC).name() || Type() == typeid(DiracTwistedMass).name()
              || Type() == typeid(DiracTwistedMassPC).name() || Type() == typeid(DiracTwistedClover).name()
              || Type() == typeid(DiracTwistedCloverPC).name()) ?
        true :
        false;
    }
```

~And turning them into `Dirac` abstract functions so each individual class is "forced" to define it so functions like `isWilsonType`, etc, don't need to be manually updated each time (or, more realistically, don't accidentally get forgotten).~

~There are some other functions that could this be applied to, `hermitian()` and `hasSpecialMG()`, but it seemed reasonable to leave those as false unless proven otherwise.~

This PR now replaces those above functions with one-stop shop static `Dirac::[...]` functions that can query if various `QudaDslashType` or `QudaDiracType` enums correspond to Wilson, dwf, or staggered operators. The various `Dirac*` classes then query these `static` functions as appropriate. There is scope to apply these functions elsewhere in QUDA.

This PR also fixes a small bug in split grid for staggered vs asqtad type fermions.
