### PR TITLE
print b5 and c5 MDWF params with QUDA_DEBUG_VERBOSE printing of params

### DIFF
--- a/lib/check_params.h
+++ b/lib/check_params.h
@@ -384,6 +384,19 @@ void printQudaInvertParam(QudaInvertParam *param) {
       param->dslash_type == QUDA_MOBIUS_DWF_DSLASH ) {
     P(m5, INVALID_DOUBLE);
     P(Ls, INVALID_INT);
+#ifdef PRINT_PARAM
+    // for MDWF, add b5, c5 to param print
+    for (int i = 0; i < param->Ls; i++) {
+      std::complex<double> b5;
+      memcpy(&b5, param->b_5, sizeof(std::complex<double>));
+      printfQuda("s = %2d b5 = (%16.15e %16.15e)\n", i, b5.real(), b5.imag());
+    }
+    for (int i = 0; i < param->Ls; i++) {
+      std::complex<double> c5;
+      memcpy(&c5, param->c_5, sizeof(std::complex<double>));
+      printfQuda("s = %2d c5 = (%16.15e %16.15e)\n", i, c5.real(), c5.imag());
+    }
+#endif
   }
   if (param->dslash_type == QUDA_TWISTED_MASS_DSLASH || param->dslash_type == QUDA_TWISTED_CLOVER_DSLASH) {
     P(mu, INVALID_DOUBLE);

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -1480,12 +1480,6 @@ namespace quda {
       }
       memcpy(diracParam.b_5, inv_param->b_5, sizeof(Complex) * inv_param->Ls);
       memcpy(diracParam.c_5, inv_param->c_5, sizeof(Complex) * inv_param->Ls);
-      logQuda(QUDA_DEBUG_VERBOSE, "Printing b_5 and c_5 values\n");
-      for (int i = 0; i < diracParam.Ls; i++) {
-        logQuda(QUDA_DEBUG_VERBOSE, "fromQUDA diracParam: b5[%d] = %f + i%f, c5[%d] = %f + i%f\n", i,
-                diracParam.b_5[i].real(), diracParam.b_5[i].imag(), i, diracParam.c_5[i].real(),
-                diracParam.c_5[i].imag());
-      }
       break;
     case QUDA_STAGGERED_DSLASH:
       diracParam.type = pc ? QUDA_STAGGEREDPC_DIRAC : QUDA_STAGGERED_DIRAC;


### PR DESCRIPTION
We cleaned up how the b5 and c5 params are printed.  They are now printed with the printing of the invert params instead of separately, and still printed only if verbosity = QUDA_DEBUG_VERBOSE