### PR TITLE
Fix dash vs underscore in dslash-type cli param

### DIFF
--- a/tests/utils/misc.cpp
+++ b/tests/utils/misc.cpp
@@ -133,10 +133,10 @@ std::vector<const char *> get_dslash_str_list()
     dslash_str_list.push_back("staggered");
     dslash_str_list.push_back("asqtad");
     dslash_str_list.push_back("hisq");
-    dslash_str_list.push_back("domain_wall");
-    dslash_str_list.push_back("domain_wall_4d");
+    dslash_str_list.push_back("domain-wall");
+    dslash_str_list.push_back("domain-wall-4d");
     dslash_str_list.push_back("mobius");
-    dslash_str_list.push_back("mobius_eofa");
+    dslash_str_list.push_back("mobius-eofa");
     dslash_str_list.push_back("laplace");
     populated = true;
   }


### PR DESCRIPTION
These tests

dslash_domain-wall_policytune
dslash_domain-wall-4d_sym_policytune
dslash_domain-wall-4d_asym_policytune
dslash_mobius-eofa_sym_policytune
dslash_mobius-eofa_asym_policytune
invert_test_domain_wall
invert_test_domain_wall_4d_sym
invert_test_domain_wall_4d_asym
invert_test_mobius_eofa_sym
invert_test_mobius_eofa_asym
eigensolve_test_ndeg_twisted_mass_sym
eigensolve_test_domain_wall
eigensolve_test_domain_wall_4d_sym
eigensolve_test_domain_wall_4d_asym
eigensolve_test_mobius_eofa_sym
eigensolve_test_mobius_eofa_asym

all failed with an error message that looks like

--dslash-type:  not in {wilson,clover,clover-hasenbusch-twist,twisted-mass,twisted-clover,staggered,asqtad,hisq,domain_wall,domain_wall_ 4d,mobius,mobius_eofa,laplace}

This commit fixed up the expected name (dash versus underscore) for the dslash-type parameter.