### PR TITLE
Remove VLAs and replace with std::vector

### DIFF
--- a/tests/host_reference/contract_ft_reference.h
+++ b/tests/host_reference/contract_ft_reference.h
@@ -117,10 +117,7 @@ void contractFTHost(Float **h_prop_array_flavor_1, Float **h_prop_array_flavor_2
       for (int dir = 0; dir < 4; ++dir) {
         double theta = 2. * M_PI / L[dir];
         theta *= (sink[dir] - source_position[dir]) * mom_modes[4 * mom_idx + dir];
-        double z[2];
-        z[0] = phase[2 * mom_idx];
-        z[1] = phase[2 * mom_idx + 1];
-        FourierPhase<double>(z, theta, fft_type[4 * mom_idx + dir]);
+        FourierPhase<double>(phase.data() + 2 * mom_idx, theta, fft_type[4 * mom_idx + dir]);
       }
     }
 

--- a/tests/host_reference/contract_ft_reference.h
+++ b/tests/host_reference/contract_ft_reference.h
@@ -88,8 +88,8 @@ void contractFTHost(Float **h_prop_array_flavor_1, Float **h_prop_array_flavor_2
   int L[4];
   for (int dir = 0; dir < 4; ++dir) L[dir] = X[dir] * comm_dim(dir);
 
-  double phase[n_mom * 2];
-  Float M[num_out_results * 2];
+  std::vector<double> phase(n_mom * 2);
+  std::vector<Float> M(num_out_results * 2);
   // size_t x ;
   int sink[4];
   int red_coord = -1;
@@ -117,7 +117,10 @@ void contractFTHost(Float **h_prop_array_flavor_1, Float **h_prop_array_flavor_2
       for (int dir = 0; dir < 4; ++dir) {
         double theta = 2. * M_PI / L[dir];
         theta *= (sink[dir] - source_position[dir]) * mom_modes[4 * mom_idx + dir];
-        FourierPhase<double>(phase + 2 * mom_idx, theta, fft_type[4 * mom_idx + dir]);
+        double z[2];
+        z[0] = phase[2 * mom_idx];
+        z[1] = phase[2 * mom_idx + 1];
+        FourierPhase<double>(z, theta, fft_type[4 * mom_idx + dir]);
       }
     }
 
@@ -127,7 +130,7 @@ void contractFTHost(Float **h_prop_array_flavor_1, Float **h_prop_array_flavor_2
           // color contraction
           size_t off = nSpin * 3 * 2 * (Vh * parity + cb_idx);
           contractColors<Float>(h_prop_array_flavor_1[s1 * src_colors + c1] + off,
-                                h_prop_array_flavor_2[s2 * src_colors + c1] + off, nSpin, M);
+                                h_prop_array_flavor_2[s2 * src_colors + c1] + off, nSpin, M.data());
 
           // apply gamma matrices here
 

--- a/tests/host_reference/covdev_reference.cpp
+++ b/tests/host_reference/covdev_reference.cpp
@@ -183,14 +183,14 @@ void covdevReference_mg4dir(sFloat *res, gFloat **link, gFloat **ghostLink, cons
     const sFloat *spinor = spinorNeighbor_mg4dir(sid, mu, oddBit, static_cast<const sFloat *>(in.data()),
                                                  fwd_nbr_spinor, back_nbr_spinor, 1, 1, my_spinor_site_size);
 
-    sFloat gaugedSpinor[my_spinor_site_size];
+    std::vector<sFloat> gaugedSpinor(my_spinor_site_size);
 
     if (daggerBit) {
       for (int s = 0; s < in.Nspin(); s++) su3Tmul(&gaugedSpinor[s * 6], lnk, &spinor[s * 6]);
     } else {
       for (int s = 0; s < in.Nspin(); s++) su3Mul(&gaugedSpinor[s * 6], lnk, &spinor[s * 6]);
     }
-    sum(&res[offset], &res[offset], gaugedSpinor, spinor_site_size);
+    sum(&res[offset], &res[offset], gaugedSpinor.data(), spinor_site_size);
   } // 4-d volume
 }
 

--- a/tests/laph_test.cpp
+++ b/tests/laph_test.cpp
@@ -105,17 +105,17 @@ auto laph_test(test_t param)
   comm_allreduce_sum(hostRes);
 
   // QUDA proper
-  void *snkPtr[nSink];
+  std::vector<void *> snkPtr(nSink);
   for (int iSink = 0; iSink < nSink; ++iSink) snkPtr[iSink] = sinkList[iSink].data();
 
-  void *evPtr[nEv];
+  std::vector<void *> evPtr(nEv);
   for (int iEv = 0; iEv < nEv; ++iEv) evPtr[iEv] = evList[iEv].data();
 
   std::vector<Complex> qudaRes(nSink * nEv * Lt * nSpin, 0.);
 
   int X[4] = {xdim, ydim, zdim, tdim};
-  laphSinkProject((__complex__ double *)qudaRes.data(), (void **)snkPtr, nSink, tileSink,
-                  (void **)evPtr, nEv, tileEv, &invParam, X);
+  laphSinkProject((__complex__ double *)qudaRes.data(), (void **)snkPtr.data(), nSink, tileSink,
+                  (void **)evPtr.data(), nEv, tileEv, &invParam, X);
   printfQuda("laphSinkProject Done: %g secs, %g Gflops\n", invParam.secs, invParam.gflops / invParam.secs);
 
   auto tol = getTolerance(cuda_prec);

--- a/tests/multigrid_evolve_test.cpp
+++ b/tests/multigrid_evolve_test.cpp
@@ -151,7 +151,7 @@ int main(int argc, char **argv)
   QudaInvertParam inv_param = newQudaInvertParam();
   QudaMultigridParam mg_param = newQudaMultigridParam();
   QudaInvertParam mg_inv_param = newQudaInvertParam();
-  QudaEigParam mg_eig_param[mg_levels];
+  std::vector<QudaEigParam> mg_eig_param(mg_levels);
 
   if (inv_multigrid) {
     setQudaMgSolveTypes();


### PR DESCRIPTION
VLAs were rejected by WG21 and, in light of this, recent-ish Clangs updated the warning set to include their use in C++ code.  See [here](https://github.com/llvm/llvm-project/commit/7339c0f782d5c70e0928f8991b0c05338a90c84c) for the relevant LLVM commit.

STRICT builds therefore fail to compile them.  This patch replaces their use with std::vector where appropriate.