### PR TITLE
Mods to allow copy in/out of full QDP-JIT spinors

### DIFF
--- a/include/color_spinor_field_order.h
+++ b/include/color_spinor_field_order.h
@@ -1799,8 +1799,8 @@ namespace quda
       {
         for (int s = 0; s < Ns; s++) {
           for (int c = 0; c < Nc; c++) {
-            v[s * Nc + c] = complex(field[(((0 * Nc + c) * Ns + s) * 2 + (1 - parity)) * volumeCB + x],
-                                    field[(((1 * Nc + c) * Ns + s) * 2 + (1 - parity)) * volumeCB + x]);
+            v[s * Nc + c] = complex(field[(((0 * Nc + c) * Ns + s) * 2 + parity) * volumeCB + x],
+                                    field[(((1 * Nc + c) * Ns + s) * 2 + parity) * volumeCB + x]);
           }
         }
       }
@@ -1809,8 +1809,8 @@ namespace quda
       {
         for (int s = 0; s < Ns; s++) {
           for (int c = 0; c < Nc; c++) {
-            field[(((0 * Nc + c) * Ns + s) * 2 + (1 - parity)) * volumeCB + x] = v[s * Nc + c].real();
-            field[(((1 * Nc + c) * Ns + s) * 2 + (1 - parity)) * volumeCB + x] = v[s * Nc + c].imag();
+            field[(((0 * Nc + c) * Ns + s) * 2 + parity) * volumeCB + x] = v[s * Nc + c].real();
+            field[(((1 * Nc + c) * Ns + s) * 2 + parity) * volumeCB + x] = v[s * Nc + c].imag();
           }
         }
       }

--- a/include/kernels/copy_color_spinor.cuh
+++ b/include/kernels/copy_color_spinor.cuh
@@ -21,7 +21,7 @@ namespace quda
    * @details Pick parity from input field site order. Addditionally QDPJIT fields
    *  may need a relative parity flip compared to what is expected when dealing with
    *  only the odd parity since the pointer is always to the top of the full spinort.
-   * @param f[in] Reference to the field for parity computation
+   * @param[in] f Reference to the field for parity computation
    * @return the computed parity
    */
   inline int computeParity(const ColorSpinorField &f)

--- a/include/kernels/copy_color_spinor.cuh
+++ b/include/kernels/copy_color_spinor.cuh
@@ -24,7 +24,9 @@ namespace quda
     int ret_val = f.SiteOrder() == QUDA_ODD_EVEN_SITE_ORDER ? 1 : 0;
 
     // Account for potential parity flip to access single parity subset QDP-JIT fields
-    if (f.FieldOrder() == QUDA_QDPJIT_FIELD_ORDER && f.SiteSubset() == QUDA_PARITY_SITE_SUBSET) {
+    // The Flip is only needed fir offsetting into Odd Parity Fields
+    if (f.FieldOrder() == QUDA_QDPJIT_FIELD_ORDER && f.SiteSubset() == QUDA_PARITY_SITE_SUBSET
+        && f.SuggestedParity() == QUDA_ODD_PARITY) {
       ret_val = 1 - ret_val;
     }
 

--- a/include/kernels/copy_color_spinor.cuh
+++ b/include/kernels/copy_color_spinor.cuh
@@ -16,7 +16,14 @@ namespace quda
 
   using namespace colorspinor;
 
-  /** Helper function for parity computation */
+  /**
+   * @brief A helper function to figure out what parity to use for input and output.
+   * @details Pick parity from input field site order. Addditionally QDPJIT fields
+   *  may need a relative parity flip compared to what is expected when dealing with
+   *  only the odd parity since the pointer is always to the top of the full spinort.
+   * @param f[in] Reference to the field for parity computation
+   * @return the computed parity
+   */
   inline int computeParity(const ColorSpinorField &f)
   {
 

--- a/lib/copy_color_spinor.cuh
+++ b/lib/copy_color_spinor.cuh
@@ -181,11 +181,6 @@ namespace quda
       errorQuda("Copying to full fields with lexicographical ordering is not currently supported");
     }
 
-    if (dst.SiteSubset() == QUDA_FULL_SITE_SUBSET
-        && (src.FieldOrder() == QUDA_QDPJIT_FIELD_ORDER || dst.FieldOrder() == QUDA_QDPJIT_FIELD_ORDER)) {
-      errorQuda("QDPJIT field ordering not supported for full site fields");
-    }
-
     genericCopyColorSpinor<Ns, Nc>(param);
   }
 


### PR DESCRIPTION
Mods to allow copy-in of full (both parities) of QDP-JIT fields. This should allow the use of unpreconditioned actions from Chroma (allowing QUDA to take care of source creation and reconstruction on device). 