### PR TITLE
Fix HIP debug flags to use -G only for NVIDIA compilers

### DIFF
--- a/lib/targets/hip/target_hip.cmake
+++ b/lib/targets/hip/target_hip.cmake
@@ -54,9 +54,15 @@ set(CMAKE_HIP_FLAGS_RELEASE
 set(CMAKE_HIP_FLAGS_HOSTDEBUG
     "-g"
     CACHE STRING "Flags used by the C++ compiler during host-debug builds.")
-set(CMAKE_HIP_FLAGS_DEBUG
-    "-g -G"
-    CACHE STRING "Flags used by the C++ compiler during full (host+device) debug builds.")
+if(CMAKE_HIP_COMPILER_ID STREQUAL "NVIDIA")
+    set(CMAKE_HIP_FLAGS_DEBUG
+        "-g -G"
+        CACHE STRING "Flags used by the HIP compiler during debug builds (with device debug support for NVIDIA).")
+else()
+    set(CMAKE_HIP_FLAGS_DEBUG
+        "-g"
+        CACHE STRING "Flags used by the HIP compiler during debug builds (with device debug support for Clang).")
+endif()
 set(CMAKE_HIP_FLAGS_SANITIZE
     "-g "
     CACHE STRING "Flags used by the C++ compiler during sanitizer debug builds.")


### PR DESCRIPTION
- Updated CMake configuration to set `-g -G` only when the HIP compiler is NVIDIA (`nvcc`).
- For Clang-based HIP compilers, use `-g` alone as it supports both host and device debugging.
- Improved flag descriptions in CMake cache to reflect the specific behavior of each compiler.
- This ensures compatibility and avoids unsupported flag errors with Clang.