### PR TITLE
Modifications to add use_smeared_gauge to InvertParam

### DIFF
--- a/include/quda.h
+++ b/include/quda.h
@@ -464,8 +464,8 @@ extern "C" {
     /** The t0 parameter for distance preconditioning, the timeslice where the source is located */
     int distance_pc_t0;
 
-    /** Whether to use the smeared gauge field for the Dirac operator
-        for whose eigenvalues are are computing. */
+    /** Whether to use the smeared gauge field for the Dirac operator, usually
+        when defined as a spatial Laplacian: mainly used in computing Laplacian eigenvectors */
     QudaBoolean use_smeared_gauge;
 
   } QudaInvertParam;
@@ -508,10 +508,6 @@ extern "C" {
         than the one used to generate the space, then this should be
         false, but preserve_deflation would be true */
     QudaBoolean preserve_evals;
-
-    /** Whether to use the smeared gauge field for the Dirac operator
-        for whose eigenvalues are are computing. */
-    QudaBoolean use_smeared_gauge;
 
     /** What type of Dirac operator we are using **/
     /** If !(use_norm_op) && !(use_dagger) use M. **/

--- a/include/quda.h
+++ b/include/quda.h
@@ -464,6 +464,10 @@ extern "C" {
     /** The t0 parameter for distance preconditioning, the timeslice where the source is located */
     int distance_pc_t0;
 
+    /** Whether to use the smeared gauge field for the Dirac operator
+        for whose eigenvalues are are computing. */
+    QudaBoolean use_smeared_gauge;
+
   } QudaInvertParam;
 
   // Parameter set for solving eigenvalue problems.
@@ -507,7 +511,7 @@ extern "C" {
 
     /** Whether to use the smeared gauge field for the Dirac operator
         for whose eigenvalues are are computing. */
-    bool use_smeared_gauge;
+    QudaBoolean use_smeared_gauge;
 
     /** What type of Dirac operator we are using **/
     /** If !(use_norm_op) && !(use_dagger) use M. **/

--- a/lib/check_params.h
+++ b/lib/check_params.h
@@ -175,7 +175,7 @@ void printQudaEigParam(QudaEigParam *param) {
   P(preserve_deflation, QUDA_BOOLEAN_FALSE);
   P(preserve_deflation_space, 0);
   P(preserve_evals, QUDA_BOOLEAN_TRUE);
-  P(use_smeared_gauge, false);
+  P(use_smeared_gauge, QUDA_BOOLEAN_FALSE);
   P(use_dagger, QUDA_BOOLEAN_FALSE);
   P(use_norm_op, QUDA_BOOLEAN_FALSE);
   P(compute_svd, QUDA_BOOLEAN_FALSE);
@@ -373,6 +373,7 @@ void printQudaInvertParam(QudaInvertParam *param) {
   P(twist_flavor, QUDA_TWIST_INVALID);
   P(laplace3D, INVALID_INT);
   P(covdev_mu, INVALID_INT);
+  P(use_smeared_gauge, QUDA_BOOLEAN_FALSE);
 #else
   // asqtad and domain wall use mass parameterization
   if (param->dslash_type == QUDA_STAGGERED_DSLASH || param->dslash_type == QUDA_ASQTAD_DSLASH

--- a/lib/check_params.h
+++ b/lib/check_params.h
@@ -175,7 +175,6 @@ void printQudaEigParam(QudaEigParam *param) {
   P(preserve_deflation, QUDA_BOOLEAN_FALSE);
   P(preserve_deflation_space, 0);
   P(preserve_evals, QUDA_BOOLEAN_TRUE);
-  P(use_smeared_gauge, QUDA_BOOLEAN_FALSE);
   P(use_dagger, QUDA_BOOLEAN_FALSE);
   P(use_norm_op, QUDA_BOOLEAN_FALSE);
   P(compute_svd, QUDA_BOOLEAN_FALSE);

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -2577,8 +2577,6 @@ void eigensolveQuda(void **host_evecs, double _Complex *host_evals, QudaEigParam
   // Ensure that the parameter structures are sound.
   checkInvertParam(inv_param);
   checkEigParam(eig_param);
-  if (inv_param->use_smeared_gauge != eig_param->use_smeared_gauge){
-     errorQuda("Parameter use_smeared_gauge should be same in eig_param and *(eig_param.invert_param)\n");}
 
   // Check that the gauge field is valid
   GaugeField *cudaGauge = checkGauge(inv_param);

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -2577,6 +2577,8 @@ void eigensolveQuda(void **host_evecs, double _Complex *host_evals, QudaEigParam
   // Ensure that the parameter structures are sound.
   checkInvertParam(inv_param);
   checkEigParam(eig_param);
+  if (inv_param->use_smeared_gauge != eig_param->use_smeared_gauge){
+     errorQuda("Parameter use_smeared_gauge should be same in eig_param and *(eig_param.invert_param)\n");}
 
   // Check that the gauge field is valid
   GaugeField *cudaGauge = checkGauge(inv_param);

--- a/lib/solve.cpp
+++ b/lib/solve.cpp
@@ -317,8 +317,7 @@ namespace quda
     getProfile().TPSTOP(QUDA_PROFILE_EPILOGUE);
   }
 
-  void createDiracWithEig(Dirac *&d, Dirac *&dSloppy, Dirac *&dPre, Dirac *&dEig, QudaInvertParam &param, bool pc_solve,
-                          bool use_smeared_gauge);
+  void createDiracWithEig(Dirac *&d, Dirac *&dSloppy, Dirac *&dPre, Dirac *&dEig, QudaInvertParam &param, bool pc_solve);
 
   extern std::vector<ColorSpinorField> solutionResident;
 
@@ -349,8 +348,7 @@ namespace quda
 
     // Create the dirac operator and operators for sloppy, precondition,
     // and an eigensolver
-    createDiracWithEig(dirac, diracSloppy, diracPre, diracEig, param, pc_solve,
-                       param.eig_param ? static_cast<QudaEigParam *>(param.eig_param)->use_smeared_gauge : false);
+    createDiracWithEig(dirac, diracSloppy, diracPre, diracEig, param, pc_solve);
 
     // wrap CPU host side pointers
     ColorSpinorParam cpuParam(hp_b[0], param, u.X(), pc_solution, param.input_location);

--- a/tests/staggered_eigensolve_test.cpp
+++ b/tests/staggered_eigensolve_test.cpp
@@ -163,7 +163,7 @@ std::vector<double> eigensolve(test_t test_param)
   eig_inv_param.solution_type = eig_param.use_pc ? QUDA_MATPC_SOLUTION : QUDA_MAT_SOLUTION;
 
   // whether we are using the resident smeared gauge or not
-  eig_param.use_smeared_gauge = gauge_smear;
+  eig_param.use_smeared_gauge = (gauge_smear ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE);
 
   if (dslash_type == QUDA_LAPLACE_DSLASH) {
     int dimension = laplace3D < 4 ? 3 : 4;

--- a/tests/staggered_eigensolve_test.cpp
+++ b/tests/staggered_eigensolve_test.cpp
@@ -164,6 +164,7 @@ std::vector<double> eigensolve(test_t test_param)
 
   // whether we are using the resident smeared gauge or not
   eig_param.use_smeared_gauge = (gauge_smear ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE);
+  eig_param.invert_param->use_smeared_gauge = (gauge_smear ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE);
 
   if (dslash_type == QUDA_LAPLACE_DSLASH) {
     int dimension = laplace3D < 4 ? 3 : 4;

--- a/tests/staggered_eigensolve_test.cpp
+++ b/tests/staggered_eigensolve_test.cpp
@@ -163,7 +163,6 @@ std::vector<double> eigensolve(test_t test_param)
   eig_inv_param.solution_type = eig_param.use_pc ? QUDA_MATPC_SOLUTION : QUDA_MAT_SOLUTION;
 
   // whether we are using the resident smeared gauge or not
-  eig_param.use_smeared_gauge = (gauge_smear ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE);
   eig_param.invert_param->use_smeared_gauge = (gauge_smear ? QUDA_BOOLEAN_TRUE : QUDA_BOOLEAN_FALSE);
 
   if (dslash_type == QUDA_LAPLACE_DSLASH) {


### PR DESCRIPTION
Added use_smeared_gauge to QudaInvertParam  to get rid of awkward extra bool in some routines.  In setDiracEigParam(...), added code to allow this to run without needing gaugePrecise having already been set.   Some first tests have been done, but would like feedback on how this was done!   These changes facilitate computation of the LapH eigenvectors using the smeared gauge field.