### PR TITLE
Added --nrepeat command line parameter

### DIFF
--- a/tests/invert_test.cpp
+++ b/tests/invert_test.cpp
@@ -470,9 +470,10 @@ int main(int argc, char **argv)
     if (quda::comm_rank() != 0) { delete listeners.Release(listeners.default_result_printer()); }
     result = RUN_ALL_TESTS();
   } else {
-    solve(test_t {prec, prec_sloppy, inv_type, solution_type, solve_type, multishift, solution_accumulator_pipeline,
-                  schwarz_t {precon_schwarz_type, inv_multigrid ? QUDA_MG_INVERTER : precon_type, prec_precondition},
-                  inv_param.residual_type});
+    for (int rep = 0; rep < nrepeat; rep++)
+      solve(test_t {prec, prec_sloppy, inv_type, solution_type, solve_type, multishift, solution_accumulator_pipeline,
+                    schwarz_t {precon_schwarz_type, inv_multigrid ? QUDA_MG_INVERTER : precon_type, prec_precondition},
+                    inv_param.residual_type});
   }
 
   // finalize the QUDA library

--- a/tests/utils/command_line_params.cpp
+++ b/tests/utils/command_line_params.cpp
@@ -53,6 +53,7 @@ int Msrc = 1;
 int Nsrc_tile = 1;
 int Msrc_tile = 1;
 int niter = 100;
+int nrepeat = 1;
 int maxiter_precondition = 10;
 QudaVerbosity verbosity_precondition = QUDA_SUMMARIZE;
 int gcrNkrylov = 8;
@@ -604,6 +605,7 @@ std::shared_ptr<QUDAApp> make_app(std::string app_description, std::string app_n
   quda_app->add_option("--ngcrkrylov", gcrNkrylov,
                        "The number of inner iterations to use for GCR, BiCGstab-l, CA-CG, CA-GCR (default 8)");
   quda_app->add_option("--niter", niter, "The number of iterations to perform (default 100)");
+  quda_app->add_option("--nrepeat", nrepeat, "The number of times to repeat the test (default 1)");
   quda_app->add_option("--max-res-increase", max_res_increase,
                        "The number of consecutive true residual incrases allowed (default 1)");
   quda_app->add_option("--max-res-increase-total", max_res_increase_total,

--- a/tests/utils/command_line_params.h
+++ b/tests/utils/command_line_params.h
@@ -312,6 +312,7 @@ extern int Msrc;
 extern int Nsrc_tile;
 extern int Msrc_tile;
 extern int niter;
+extern int nrepeat;
 extern int maxiter_precondition;
 extern QudaVerbosity verbosity_precondition;
 extern int gcrNkrylov;


### PR DESCRIPTION
 *) allows tests to be repeated in invert_test
    - The point of the feature is to allow repeated solves in invert_test e.g. for stress testing or debugging. It adds the (--nrepeat ) command line parameter to the `command_Line_param.[h.cpp]` files. Currently it only affects `invert_test` but could be applied more uniformlly in principle.