### PR TITLE
Fixed bug causing NaN residuals in PCG solves

### DIFF
--- a/lib/inv_pcg_quda.cpp
+++ b/lib/inv_pcg_quda.cpp
@@ -171,9 +171,6 @@ namespace quda
     if (r_sloppy[0].Precision() != r[0].Precision()) blas::copy(r_sloppy, r);
 
     auto csParam(r_sloppy[0]);
-    std::vector<XUpdateBatch> x_update_batch(b.size());
-    for (auto i = 0u; i < b.size(); i++)
-      x_update_batch[i] = XUpdateBatch(Np, K ? minvr_sloppy[i] : r_sloppy[i], csParam);
 
     const bool use_heavy_quark_res = (param.residual_type & QUDA_HEAVY_QUARK_RESIDUAL) ? true : false;
 
@@ -184,6 +181,10 @@ namespace quda
       popVerbosity();
       blas::copy(minvr_sloppy, minvr_pre);
     }
+
+    std::vector<XUpdateBatch> x_update_batch(b.size());
+    for (auto i = 0u; i < b.size(); i++)
+      x_update_batch[i] = XUpdateBatch(Np, K ? minvr_sloppy[i] : r_sloppy[i], csParam);
 
     getProfile().TPSTOP(QUDA_PROFILE_INIT);
     getProfile().TPSTART(QUDA_PROFILE_PREAMBLE);


### PR DESCRIPTION
In previous version, `x_update_batch` was initialized before `minvr_sloppy`, so the first vector in `x_update_batch` was initialized to 0.  The result then had zero norm, and this is in the denominator of a computed result that was then NaN, crashing the code.  Moving the initialization of `x_update_batch` later fixes this and lets `invert_test` run to completion.