### PR TITLE
Enable double complex support in BatchInvertMatrix

### DIFF
--- a/lib/targets/hip/blas_lapack_hipblas.cpp
+++ b/lib/targets/hip/blas_lapack_hipblas.cpp
@@ -161,6 +161,63 @@ namespace quda
           pool_pinned_free(Ainv_h);
           pool_pinned_free(A_h);
 #endif
+        } else if (prec == QUDA_DOUBLE_PRECISION) {
+          typedef hipblasDoubleComplex Z;
+          Z **A_array = static_cast<Z **>(pool_device_malloc(2 * batch * sizeof(Z *)));
+          Z **Ainv_array = A_array + batch;
+          Z **A_array_h = static_cast<Z **>(pool_pinned_malloc(2 * batch * sizeof(Z *)));
+          Z **Ainv_array_h = A_array_h + batch;
+          for (uint64_t i = 0; i < batch; i++) {
+            A_array_h[i] = static_cast<Z *>(A_d) + i * n * n;
+            Ainv_array_h[i] = static_cast<Z *>(Ainv_d) + i * n * n;
+          }
+          qudaMemcpy(A_array, A_array_h, 2 * batch * sizeof(Z *), qudaMemcpyHostToDevice);
+
+          hipblasStatus_t error = hipblasZgetrfBatched(handle, n, A_array, n, dipiv, dinfo_array, batch);
+          flops += batch * FLOPS_ZGETRF(n, n);
+
+          if (error != HIPBLAS_STATUS_SUCCESS)
+            errorQuda("\nError in LU decomposition (hipblasZgetrfBatched), error code = %d\n", error);
+
+          qudaMemcpy(info_array, dinfo_array, batch * sizeof(int), qudaMemcpyDeviceToHost);
+          for (uint64_t i = 0; i < batch; i++) {
+            if (info_array[i] < 0) {
+              errorQuda("%lu argument had an illegal value or another error occured, such as memory allocation failed",
+                        i);
+            } else if (info_array[i] > 0) {
+              errorQuda("%lu factorization completed but the factor U is exactly singular", i);
+            }
+          }
+
+          error = hipblasZgetriBatched(handle, n, A_array, n, dipiv, Ainv_array, n, dinfo_array, batch);
+          flops += batch * FLOPS_CGETRI(n);
+
+          if (error != HIPBLAS_STATUS_SUCCESS)
+            errorQuda("\nError in matrix inversion (hipblasCgetriBatched), error code = %d\n", error);
+
+          qudaMemcpy(info_array, dinfo_array, batch * sizeof(int), qudaMemcpyDeviceToHost);
+
+          for (uint64_t i = 0; i < batch; i++) {
+            if (info_array[i] < 0) {
+              errorQuda("%lu argument had an illegal value or another error occured, such as memory allocation failed",
+                        i);
+            } else if (info_array[i] > 0) {
+              errorQuda("%lu factorization completed but the factor U is exactly singular", i);
+            }
+          }
+
+          pool_device_free(A_array);
+          pool_pinned_free(A_array_h);
+
+#ifdef _DEBUG
+          // Debug code: Copy computed Ainv to host
+          std::complex<double> *Ainv_h = static_cast<std::complex<double> *>(pool_pinned_malloc(size));
+          qudaMemcpy((void *)Ainv_h, Ainv_d, size, qudaMemcpyDeviceToHost);
+
+          for (uint64_t i = 0; i < batch; i++) { checkEigen<MatrixXcd, double>(A_h, Ainv_h, n, i); }
+          pool_pinned_free(Ainv_h);
+          pool_pinned_free(A_h);
+#endif
         } else {
           errorQuda("%s not implemented for precision=%d", __func__, prec);
         }


### PR DESCRIPTION
I think this was removed way back when (roc|hip)blas didn't have support for double complex types.  The support exists now, so I re-hipified the apropriate branch of the cu target.

This fixes a failing blas_interface_test that complained double precision wasn't supported.