### PR TITLE
Tweak setting QR tolerances in IRAM

### DIFF
--- a/include/eigensolve_quda.h
+++ b/include/eigensolve_quda.h
@@ -28,6 +28,7 @@ namespace quda
     int n_conv = 0;       /** Number of converged eigenvalues requested */
     int n_ev_deflate = 0; /** Number of converged eigenvalues to use in deflation */
     double tol = 0.0;     /** Tolerance on eigenvalues */
+    double qr_tol = 0.0;  /** Tolerance on QR (IRAM) */
     bool reverse = false; /** True if using polynomial acceleration */
     std::string spectrum; /** Part of the spectrum to be computed */
     bool compute_svd; /** Compute the SVD if requested **/

--- a/lib/eig_iram.cpp
+++ b/lib/eig_iram.cpp
@@ -34,11 +34,13 @@ namespace quda
     // Set reasonable default for QR tol, supply warning if outside of this bound
     if (qr_tol == 0) { qr_tol = tol * 1e-2; }
     if (qr_tol > tol * 1e-2) {
-      warningQuda("QR tolerances greater than eig_tol * 1e-2 can cause instability in IRAM, please revise this option if instability is observed (eig_tol = %e, qr_tol = %e)", tol, qr_tol);
+      warningQuda("QR tolerances greater than eig_tol * 1e-2 can cause instability in IRAM, please revise this option "
+                  "if instability is observed (eig_tol = %e, qr_tol = %e)",
+                  tol, qr_tol);
     }
     getProfile().TPSTOP(QUDA_PROFILE_INIT);
   }
-  
+
   // Arnoldi Member functions
   //---------------------------------------------------------------------------
   void IRAM::arnoldiStep(std::vector<ColorSpinorField> &v, std::vector<ColorSpinorField> &r, double &beta, int j)

--- a/lib/eig_iram.cpp
+++ b/lib/eig_iram.cpp
@@ -32,9 +32,9 @@ namespace quda
     }
 
     // Set reasonable default for QR tol, supply warning if outside of this bound
-    if (qr_tol == 0) { qr_tol = tol * 1e-2; }
-    if (qr_tol > tol * 1e-2) {
-      warningQuda("QR tolerances greater than eig_tol * 1e-2 can cause instability in IRAM, please revise this option "
+    if (qr_tol == 0) { qr_tol = tol * 1e-3; }
+    if (qr_tol > tol * 1e-3) {
+      warningQuda("QR tolerances greater than eig_tol * 1e-3 can cause instability in IRAM, please revise this option "
                   "if instability is observed (eig_tol = %e, qr_tol = %e)",
                   tol, qr_tol);
     }

--- a/lib/eig_iram.cpp
+++ b/lib/eig_iram.cpp
@@ -31,11 +31,14 @@ namespace quda
       Rmat[i].resize(n_kr, 0.0);
     }
 
-    if (eig_param->qr_tol == 0) { eig_param->qr_tol = eig_param->tol * 1e-2; }
-
+    // Set reasonable default for QR tol, supply warning if outside of this bound
+    if (qr_tol == 0) { qr_tol = tol * 1e-2; }
+    if (qr_tol > tol * 1e-2) {
+      warningQuda("QR tolerances greater than eig_tol * 1e-2 can cause instability in IRAM, please revise this option if instability is observed (eig_tol = %e, qr_tol = %e)", tol, qr_tol);
+    }
     getProfile().TPSTOP(QUDA_PROFILE_INIT);
   }
-
+  
   // Arnoldi Member functions
   //---------------------------------------------------------------------------
   void IRAM::arnoldiStep(std::vector<ColorSpinorField> &v, std::vector<ColorSpinorField> &r, double &beta, int j)
@@ -217,7 +220,7 @@ namespace quda
     Complex T11, T12, T21, T22, U1, U2;
     double dV;
 
-    double tol = eig_param->qr_tol;
+    double tol = qr_tol;
 
     // Allocate the rotation matrices.
     std::vector<Complex> R11(n_kr - 1, 0.0);
@@ -342,16 +345,13 @@ namespace quda
         }
       }
 
-      // This is about as high as one cat get in double without causing
-      // the Arnoldi to compute more restarts.
-      double tol = eig_param->qr_tol;
       int max_iter = 100000;
       int iter = 0;
 
       Complex temp, discriminant, sol1, sol2, eval;
       for (int i = n_kr - 2; i >= 0; i--) {
         while (iter < max_iter) {
-          if (abs(Rmat[i + 1][i]) < tol) {
+          if (abs(Rmat[i + 1][i]) < qr_tol) {
             Rmat[i + 1][i] = 0.0;
             break;
           } else {

--- a/lib/eigensolve_quda.cpp
+++ b/lib/eigensolve_quda.cpp
@@ -197,7 +197,7 @@ namespace quda
 
     logQuda(QUDA_VERBOSE, "spectrum %s\n", spectrum.c_str());
     logQuda(QUDA_VERBOSE, "tol %.4e\n", tol);
-    if(qr_tol != 0) logQuda(QUDA_VERBOSE, "qr_tol %.4e\n", qr_tol);
+    if (qr_tol != 0) logQuda(QUDA_VERBOSE, "qr_tol %.4e\n", qr_tol);
     logQuda(QUDA_VERBOSE, "n_conv %d\n", n_conv);
     logQuda(QUDA_VERBOSE, "n_ev %d\n", n_ev);
     logQuda(QUDA_VERBOSE, "n_kr %d\n", n_kr);

--- a/lib/eigensolve_quda.cpp
+++ b/lib/eigensolve_quda.cpp
@@ -34,6 +34,7 @@ namespace quda
     n_conv = eig_param->n_conv;
     n_ev_deflate = (eig_param->n_ev_deflate == -1 ? n_conv : eig_param->n_ev_deflate);
     tol = eig_param->tol;
+    qr_tol = eig_param->qr_tol;
     reverse = false;
 
     // Algorithm variables
@@ -196,6 +197,7 @@ namespace quda
 
     logQuda(QUDA_VERBOSE, "spectrum %s\n", spectrum.c_str());
     logQuda(QUDA_VERBOSE, "tol %.4e\n", tol);
+    if(qr_tol != 0) logQuda(QUDA_VERBOSE, "qr_tol %.4e\n", qr_tol);
     logQuda(QUDA_VERBOSE, "n_conv %d\n", n_conv);
     logQuda(QUDA_VERBOSE, "n_ev %d\n", n_ev);
     logQuda(QUDA_VERBOSE, "n_kr %d\n", n_kr);

--- a/tests/utils/command_line_params.cpp
+++ b/tests/utils/command_line_params.cpp
@@ -226,7 +226,7 @@ int eig_check_interval = 10;
 int eig_max_restarts = 1000;
 int eig_max_ortho_attempts = 10;
 double eig_tol = 1e-6;
-double eig_qr_tol = 1e-11;
+double eig_qr_tol = 0;
 bool eig_use_eigen_qr = true;
 bool eig_use_poly_acc = true;
 int eig_poly_deg = 100;
@@ -833,7 +833,7 @@ void add_eigen_option_group(std::shared_ptr<QUDAApp> quda_app)
                  "The spectrum part to be calulated. S=smallest L=largest R=real M=modulus I=imaginary")
     ->transform(CLI::QUDACheckedTransformer(eig_spectrum_map));
   opgroup->add_option("--eig-tol", eig_tol, "The tolerance to use in the eigensolver (default 1e-6)");
-  opgroup->add_option("--eig-qr-tol", eig_qr_tol, "The tolerance to use in the qr (default 1e-11)");
+  opgroup->add_option("--eig-qr-tol", eig_qr_tol, "The tolerance to use in the qr (default eig_tol * 1e-2)");
 
   opgroup->add_option("--eig-type", eig_type, "The type of eigensolver to use (default trlm)")
     ->transform(CLI::QUDACheckedTransformer(eig_type_map));
@@ -970,7 +970,7 @@ void add_multigrid_option_group(std::shared_ptr<QUDAApp> quda_app)
   quda_app->add_mgoption(opgroup, "--mg-eig-tol", mg_eig_tol, CLI::PositiveNumber,
                          "The tolerance to use in the eigensolver (default 1e-6)");
   quda_app->add_mgoption(opgroup, "--mg-eig-qr-tol", mg_eig_qr_tol, CLI::PositiveNumber,
-                         "The tolerance to use in the QR (default 1e-11)");
+                         "The tolerance to use in the QR (default eig_tol * 1e-2)");
 
   quda_app->add_mgoption(opgroup, "--mg-eig-type", mg_eig_type, CLI::QUDACheckedTransformer(eig_type_map),
                          "The type of eigensolver to use (default trlm)");


### PR DESCRIPTION
This PR changes how the QR tolerance is set in `IRAM` when NOT using the EIGEN QR solver between restarts. The default value is set to `0` but can be set to a custom value by the user. `IRAM` will detect a `0` value in the `eig_qr_tol` field when the class is constructed and default to `eig_tol * 1e-2`. Warnings are issued when a QR tolerance greater than `eig_tol * 1e-2` is selected.