### PR TITLE
Block TRLM bugfix: Convergence test fails when using polynomial acceleration

### DIFF
--- a/lib/eig_block_trlm.cpp
+++ b/lib/eig_block_trlm.cpp
@@ -113,7 +113,7 @@ namespace quda
         if (eig_param->spectrum == QUDA_SPECTRUM_LR_EIG)
           return mat_norm;
         else
-          return sr_norm;
+          return fabs(sr_norm);
       };
 
       // Locking check


### PR DESCRIPTION
This PR fixes a bug with block TRLM where the convergence tests always fail when using polynomial acceleration and requesting the SR spectrum.

## Issue

The convergence tests fail because the alphas, a.k.a. the Ritz values in block TRLM are negative when using polynomial acceleration, and since the lambda `checknorm` in `lib/eig_block_trlm.cpp` does not ensure a positive norm, the locking check:

```cpp
if (residua[i + num_locked] < epsilon * check_norm(alpha[i + num_locked]))
```

and convergence check:

```cpp
if (residua[i + num_locked] < tol * check_norm(alpha[i + num_locked]))
```

are never satisfied. And so block TRLM runs until it hits the `max_restarts` value and gives up.

Why are the Ritz values negative for block TRLM, but positive for ordinary TRLM? In `eigensolveFromArrowMat()`, the spectrum is "inverted" (i.e. the alphas and betas are multiplied by -1.0) when using polynomial acceleration. At the end of the function, this is undone, i.e., the spectrum is put back in order by again multiplying the alphas by -1.0. In contrast, in `eigensolveFromBlockArrowMat()`, the spectrum is similarly inverted when using polynomial acceleration, but it's never undone, and so there remains a factor of -1.0 on the alphas.

## Simple solution

This can be resolved by modifying `checknorm` to return the absolute value of `sr_norm`, i.e., by simply adding the `fabs` in the following:

```cpp
auto check_norm = [&](double sr_norm) -> double {
  if (eig_param->spectrum == QUDA_SPECTRUM_LR_EIG)
    return mat_norm;
  else
    return fabs(sr_norm);
};
```

Note that `mat_norm`, which is used in the LR case, is already ensured to be positive by an earlier line.

## Comments

This issue is not caught by the automated tests because polynomial acceleration is explicitly disabled for those tests.

Looking at the history of `lib/eig_block_trlm.cpp`, we see that it used to check the absolute values of the alphas, but this was changed in commit `862896e` made on Dec. 12, 2023.

The better solution might be to modify the block TRLM to undo the spectrum inversion at the end of `eigensolveFromBlockArrowMat()` as is done in the non-block case. I leave that decision to someone else, partly because my understanding of the block algorithm is pretty shallow.