### PR TITLE
Feature/byte array

### DIFF
--- a/include/byte_array.h
+++ b/include/byte_array.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include <cstdint>
+
+namespace quda
+{
+
+  /**
+     @brief This is a class that emulates an array of 4x 8-bit types in
+     a single 32-bit word.  This provides an indexable array that can be
+     stored in registers without the overhead of branching.
+
+     In the future we could generalize this to a 64-bit array of
+     length 8, or use wider elements.
+  */
+  template <class T = int8_t, int n = 4> class byte_array
+  {
+    static_assert(4 * sizeof(T) == sizeof(uint32_t), "element size must be 8-bits");
+
+  private:
+    uint32_t data = 0;
+
+  public:
+    constexpr byte_array() = default;
+
+    /** Constructor from packed integer */
+    constexpr explicit byte_array(uint32_t packed) : data(packed) { }
+
+    /** Constructor from 4 individual 8-bit values */
+    constexpr byte_array(T v0, T v1, T v2, T v3)
+    {
+      data = (static_cast<uint32_t>(static_cast<uint8_t>(v0))) | (static_cast<uint32_t>(static_cast<uint8_t>(v1)) << 8)
+        | (static_cast<uint32_t>(static_cast<uint8_t>(v2)) << 16)
+        | (static_cast<uint32_t>(static_cast<uint8_t>(v3)) << 24);
+    }
+
+    /** Get at index (0-3) */
+    constexpr T get(int index) const { return static_cast<T>((data >> (index * 8)) & 0xFF); }
+
+    /** Set at index (0-3) */
+    constexpr void set(int index, T value)
+    {
+      int shift = index * 8;
+      data = (data & ~(0xFF << shift)) | (static_cast<uint32_t>(static_cast<uint8_t>(value)) << shift);
+    }
+
+    constexpr T operator[](int index) const { return get(index); } /** Array accessor */
+
+    class proxy
+    {
+    private:
+      byte_array &arr;
+      int idx;
+
+    public:
+      constexpr proxy(byte_array &a, int i) : arr(a), idx(i) { }
+
+      constexpr proxy &operator=(T value)
+      {
+        arr.set(idx, value);
+        return *this;
+      }
+
+      constexpr operator T() const { return arr.get(idx); } /** Conversion operator for getting value */
+
+      constexpr auto operator++(int)
+      {
+        arr.set(idx, arr.get(idx) + 1);
+        return arr.get(idx);
+      }
+
+      constexpr auto operator--(int)
+      {
+        arr.set(idx, arr.get(idx) - 1);
+        return arr.get(idx);
+      }
+    };
+
+    constexpr proxy operator[](int index) { return proxy(*this, index); }
+
+    constexpr uint32_t getPacked() const { return data; } /** Get packed integer */
+
+    constexpr void setPacked(uint32_t packed) { data = packed; } /** Set from packed integer */
+
+    constexpr void clear() { data = 0; } /** Clear contents */
+
+    /** Fill all positions with the same T value */
+    constexpr void fill(T value)
+    {
+      uint32_t byte = static_cast<uint8_t>(value);
+      data = (byte << 24) | (byte << 16) | (byte << 8) | byte;
+    }
+
+    /** Comparison operators */
+    constexpr bool operator==(const byte_array &other) const { return data == other.data; }
+    constexpr bool operator!=(const byte_array &other) const { return data != other.data; }
+  };
+
+} // namespace quda

--- a/include/byte_array.h
+++ b/include/byte_array.h
@@ -15,7 +15,8 @@ namespace quda
   */
   template <class T = int8_t, int n = 4> class byte_array
   {
-    static_assert(4 * sizeof(T) == sizeof(uint32_t), "element size must be 8-bits");
+    static_assert(sizeof(T) == 1, "element size must be 1 byte");
+    static_assert(n == 4, "array length of 4 required");
 
   private:
     uint32_t data = 0;

--- a/include/kernels/clover_deriv.cuh
+++ b/include/kernels/clover_deriv.cuh
@@ -1,7 +1,7 @@
 #include <gauge_field_order.h>
 #include <quda_matrix.h>
 #include <index_helper.cuh>
-#include <thread_array.h>
+#include <byte_array.h>
 #include <kernel.h>
 
 namespace quda
@@ -33,11 +33,9 @@ namespace quda
     }
   };
 
-  using computeForceOps = KernelOps<thread_array<int, 4>>;
-  template <typename Link, typename Force, typename Ftor>
-  __device__ __host__ void computeForce(Force &force_total, const Ftor &ftor, int xIndex, int parity, int mu, int nu)
+  template <typename Link, typename Force, typename Arg>
+  __device__ __host__ void computeForce(Force &force_total, const Arg &arg, int xIndex, int parity, int mu, int nu)
   {
-    const auto &arg = ftor.arg;
     const int otherparity = (1 - parity);
     const int tidx = mu > nu ? (mu - 1) * mu / 2 + nu : (nu - 1) * nu / 2 + mu;
 
@@ -46,7 +44,7 @@ namespace quda
 
     // U[mu](x) U[nu](x+mu) U[*mu](x+nu) U[*nu](x) Oprod(x)
     {
-      thread_array<int, 4> d {ftor};
+      byte_array<int8_t, 4> d = {};
 
       // load U(x)_(+mu)
       Link U1 = arg.gauge(mu, linkIndexShift(x, d, arg.E), parity);
@@ -80,7 +78,7 @@ namespace quda
     }
 
     {
-      thread_array<int, 4> d {ftor};
+      byte_array<int8_t, 4> d = {};
 
       // load U(x-nu)(+nu)
       d[nu]--;
@@ -119,7 +117,7 @@ namespace quda
     }
 
     {
-      thread_array<int, 4> d {ftor};
+      byte_array<int8_t, 4> d = {};
 
       // load U(x)_(+mu)
       Link U1 = arg.gauge(mu, linkIndexShift(x, d, arg.E), parity);
@@ -157,7 +155,7 @@ namespace quda
     // Lower leaf
     // U[nu*](x-nu) U[mu](x-nu) U[nu](x+mu-nu) Oprod(x+mu) U[*mu](x)
     {
-      thread_array<int, 4> d {ftor};
+      byte_array<int8_t, 4> d = {};
 
       // load U(x-nu)(+nu)
       d[nu]--;
@@ -196,12 +194,9 @@ namespace quda
     }
   }
 
-  template <typename Arg> struct CloverDerivative : computeForceOps {
+  template <typename Arg> struct CloverDerivative {
     const Arg &arg;
-    template <typename... OpsArgs>
-    constexpr CloverDerivative(const Arg &arg, const OpsArgs &...ops) : KernelOpsT(ops...), arg(arg)
-    {
-    }
+    constexpr CloverDerivative(const Arg &arg) : arg(arg) { }
     static constexpr const char *filename() { return KERNEL_FILE; }
 
     __host__ __device__ void operator()(int x_cb, int parity, int mu)
@@ -214,7 +209,7 @@ namespace quda
 
       for (int nu = 0; nu < 4; nu++) {
         if (nu == mu) continue;
-        computeForce<Link>(force, *this, x_cb, parity, mu, nu);
+        computeForce<Link>(force, arg, x_cb, parity, mu, nu);
       }
 
       // Write to array

--- a/include/kernels/contraction.cuh
+++ b/include/kernels/contraction.cuh
@@ -92,6 +92,7 @@ namespace quda
     template <typename U> static inline void comm_reduce(U &) { }
 
     // Final param is unused in the MultiReduce functor in this use case.
+    template <int s1>
     __device__ __host__ inline reduce_t operator()(reduce_t &result, int xyz, int, int t)
     {
       constexpr int nSpin = Arg::nSpin;
@@ -100,10 +101,9 @@ namespace quda
       using real = typename Arg::real;
       using Vector = ColorSpinor<real, nColor, nSpin>;
 
-      constexpr array<array<int, nSpin>, nSpin *nSpin> gm_i = get_dr_gm_i();
-      constexpr array<array<complex<real>, nSpin>, nSpin *nSpin> g5gm_z = get_dr_g5gm_z<real>();
+      constexpr array<array<int, nSpin>, nSpin * nSpin> gm_i = get_dr_gm_i();
+      constexpr array<array<complex<real>, nSpin>, nSpin * nSpin> g5gm_z = get_dr_g5gm_z<real>();
 
-      int s1 = arg.s1;
       int b1 = arg.b1;
 
       // The coordinate of the sink
@@ -126,7 +126,9 @@ namespace quda
 
       // loop over channels
       reduce_t result_all_channels = {};
+#pragma unroll
       for (int G_idx = 0; G_idx < 16; G_idx++) {
+#pragma unroll
         for (int s2 = 0; s2 < nSpin; s2++) {
 
           // We compute the contribution from s1,b1 and s2,b2 from props x and y respectively.
@@ -146,6 +148,18 @@ namespace quda
       }
 
       return operator()(result_all_channels, result);
+    }
+
+    __device__ __host__ inline reduce_t operator()(reduce_t &result, int xyz, int dummy, int t)
+    {
+      switch (arg.s1) {
+      case 0: return operator()<0>(result, xyz, dummy, t);
+      case 1: return operator()<1>(result, xyz, dummy, t);
+      case 2: return operator()<2>(result, xyz, dummy, t);
+      case 3:
+      default:
+        return operator()<3>(result, xyz, dummy, t);
+      }
     }
   };
 

--- a/include/kernels/field_strength_tensor.cuh
+++ b/include/kernels/field_strength_tensor.cuh
@@ -1,7 +1,7 @@
 #include <gauge_field_order.h>
 #include <index_helper.cuh>
 #include <quda_matrix.h>
-#include <thread_array.h>
+#include <byte_array.h>
 #include <kernel.h>
 
 namespace quda
@@ -35,13 +35,10 @@ namespace quda
     }
   };
 
-  using computeFmunuCoreOps = KernelOps<thread_array<int, 4>>;
-  template <typename Ftor>
-  __device__ __host__ inline void computeFmunuCore(const Ftor &ftor, int idx, int parity, int mu, int nu)
+  template <typename Arg>
+  __device__ __host__ inline void computeFmunuCore(const Arg &arg, int idx, int parity, int mu, int nu)
   {
-    using Arg = typename Ftor::Arg;
     using Link = Matrix<complex<typename Arg::Float>, 3>;
-    auto &arg = ftor.arg;
 
     int x[4];
     int X[4];
@@ -56,7 +53,7 @@ namespace quda
     { // U(x,mu) U(x+mu,nu) U[dagger](x+nu,mu) U[dagger](x,nu)
 
       // load U(x)_(+mu)
-      thread_array<int, 4> dx {ftor};
+      byte_array<int8_t, 4> dx = {};
       Link U1 = arg.u(mu, linkIndexShift(x, dx, X), parity);
 
       // load U(x+mu)_(+nu)
@@ -79,7 +76,7 @@ namespace quda
     { // U(x,nu) U[dagger](x+nu-mu,mu) U[dagger](x-mu,nu) U(x-mu, mu)
 
       // load U(x)_(+nu)
-      thread_array<int, 4> dx {ftor};
+      byte_array<int8_t, 4> dx = {};
       Link U1 = arg.u(nu, linkIndexShift(x, dx, X), parity);
 
       // load U(x+nu)_(-mu) = U(x+nu-mu)_(+mu)
@@ -106,7 +103,7 @@ namespace quda
     { // U[dagger](x-nu,nu) U(x-nu,mu) U(x+mu-nu,nu) U[dagger](x,mu)
 
       // load U(x)_(-nu)
-      thread_array<int, 4> dx {ftor};
+      byte_array<int8_t, 4> dx = {};
       dx[nu]--;
       Link U1 = arg.u(nu, linkIndexShift(x, dx, X), 1 - parity);
       dx[nu]++;
@@ -133,7 +130,7 @@ namespace quda
     { // U[dagger](x-mu,mu) U[dagger](x-mu-nu,nu) U(x-mu-nu,mu) U(x-nu,nu)
 
       // load U(x)_(-mu)
-      thread_array<int, 4> dx {ftor};
+      byte_array<int8_t, 4> dx = {};
       dx[mu]--;
       Link U1 = arg.u(mu, linkIndexShift(x, dx, X), 1 - parity);
       dx[mu]++;
@@ -177,11 +174,10 @@ namespace quda
     arg.f(munu_idx, idx, parity) = F;
   }
 
-  template <typename Arg_> struct ComputeFmunu : computeFmunuCoreOps {
+  template <typename Arg_> struct ComputeFmunu {
     using Arg = Arg_;
     const Arg &arg;
-    template <typename... OpsArgs>
-    constexpr ComputeFmunu(const Arg &arg, const OpsArgs &...ops) : KernelOpsT(ops...), arg(arg)
+    constexpr ComputeFmunu(const Arg &arg) : arg(arg)
     {
     }
     static constexpr const char* filename() { return KERNEL_FILE; }
@@ -197,7 +193,7 @@ namespace quda
       case 4: mu = 3, nu = 1; break;
       case 5: mu = 3, nu = 2; break;
       }
-      computeFmunuCore(*this, x_cb, parity, mu, nu);
+      computeFmunuCore(arg, x_cb, parity, mu, nu);
     }
   };
 

--- a/include/kernels/gauge_ape.cuh
+++ b/include/kernels/gauge_ape.cuh
@@ -8,25 +8,26 @@
 namespace quda
 {
 
-  template <typename Float_, int nColor_, QudaReconstructType recon_, int apeDim_> struct GaugeAPEArg : kernel_param<> {
-    using Float = Float_;
+  template <typename store_t, int nColor_, QudaReconstructType recon_, int apeDim_>
+  struct GaugeAPEArg : kernel_param<> {
+    using real = typename mapper<store_t>::type;
     static constexpr int nColor = nColor_;
     static_assert(nColor == 3, "Only nColor=3 enabled at this time");
     static constexpr QudaReconstructType recon = recon_;
     static constexpr int apeDim = apeDim_;
-    typedef typename gauge_mapper<Float, recon>::type Gauge;
+    typedef typename gauge_mapper<store_t, recon>::type Gauge;
 
     Gauge out;
     const Gauge in;
 
     int X[4]; // grid dimensions
     int border[4];
-    const Float alpha;
+    const real alpha;
     const int dir_ignore;
-    const Float anisotropy;
-    const Float tolerance;
+    const real anisotropy;
+    const real tolerance;
 
-    GaugeAPEArg(GaugeField &out, const GaugeField &in, double alpha, int dir_ignore, Float anisotropy) :
+    GaugeAPEArg(GaugeField &out, const GaugeField &in, double alpha, int dir_ignore, real anisotropy) :
       kernel_param(dim3(in.LocalVolumeCB(), 2, apeDim)),
       out(out),
       in(in),
@@ -42,16 +43,14 @@ namespace quda
     }
   };
 
-  template <typename Arg> struct APE : computeStapleOps {
+  template <typename Arg> struct APE {
     const Arg &arg;
-    using real = typename Arg::Float;
-    template <typename... OpsArgs> constexpr APE(const Arg &arg, const OpsArgs &...ops) : KernelOpsT(ops...), arg(arg)
-    {
-    }
+    constexpr APE(const Arg &arg) : arg(arg) { }
     static constexpr const char *filename() { return KERNEL_FILE; }
 
     __device__ __host__ inline void operator()(int x_cb, int parity, int dir)
     {
+      using real = typename Arg::real;
       typedef Matrix<complex<real>, Arg::nColor> Link;
 
       // compute spacetime and local coords
@@ -68,7 +67,7 @@ namespace quda
       int dx[4] = {0, 0, 0, 0};
       Link U, Stap, TestU, I;
       // This function gets stap = S_{mu,nu} i.e., the staple of length 3,
-      computeStaple(*this, x, X, parity, dir, Stap, arg.dir_ignore, arg.anisotropy);
+      computeStaple(arg, x, X, parity, dir, Stap, arg.dir_ignore, arg.anisotropy);
 
       // Get link U
       U = arg.in(dir, linkIndexShift(x, dx, X), parity);

--- a/include/kernels/gauge_force.cuh
+++ b/include/kernels/gauge_force.cuh
@@ -3,7 +3,7 @@
 #include <gauge_field_order.h>
 #include <quda_matrix.h>
 #include <index_helper.cuh>
-#include <thread_array.h>
+#include <byte_array.h>
 #include <kernel.h>
 #include <gauge_path_helper.cuh>
 
@@ -44,10 +44,9 @@ namespace quda {
     }
   };
 
-  template <typename Arg> struct GaugeForce : KernelOps<thread_array<int, 4>> {
+  template <typename Arg> struct GaugeForce {
     const Arg &arg;
-    template <typename... OpsArgs>
-    constexpr GaugeForce(const Arg &arg, const OpsArgs &...ops) : KernelOpsT(ops...), arg(arg)
+    constexpr GaugeForce(const Arg &arg) : arg(arg)
     {
     }
     static constexpr const char *filename() { return KERNEL_FILE; }
@@ -64,7 +63,7 @@ namespace quda {
       // prod: current matrix product
       // accum: accumulator matrix
       Link link_prod, accum;
-      thread_array<int, 4> dx {*this};
+      byte_array<int8_t, 4> dx = {};
 
       for (int i=0; i<arg.p.num_paths; i++) {
         real coeff = arg.p.path_coeff[i];

--- a/include/kernels/gauge_heatbath.cuh
+++ b/include/kernels/gauge_heatbath.cuh
@@ -17,7 +17,7 @@ namespace quda
   template <int nColor> __host__ __device__ constexpr int2 IndexBlock(int block)
   {
     int2 id;
-    int i1;
+    int i1 = 0;
     int found = 0;
     int del_i = 0;
     int index = -1;
@@ -56,7 +56,7 @@ namespace quda
         q = 2;
       }
     } else if constexpr (nColor > 3) {
-      int i1;
+      int i1 = 0;
       int found = 0;
       int del_i = 0;
       int index = -1;

--- a/include/kernels/gauge_heatbath.cuh
+++ b/include/kernels/gauge_heatbath.cuh
@@ -4,27 +4,28 @@
 #include <atomic_helper.h>
 #include <random_helper.h>
 #include <kernel.h>
+#include <byte_array.h>
 
-namespace quda {
+namespace quda
+{
 
   /**
     @brief Calculate the SU(2) index block in the SU(Nc) matrix
     @param block number to calculate the index's, the total number of blocks is Nc * (Nc - 1) / 2.
     @return Returns two index's in int2 type, accessed by .x and .y.
  */
-  template <int nColor>
-  __host__ __device__ inline int2 IndexBlock(int block)
+  template <int nColor> __host__ __device__ constexpr int2 IndexBlock(int block)
   {
     int2 id;
     int i1;
     int found = 0;
     int del_i = 0;
     int index = -1;
-    while ( del_i < (nColor - 1) && found == 0 ) {
+    while (del_i < (nColor - 1) && found == 0) {
       del_i++;
-      for ( i1 = 0; i1 < (nColor - del_i); i1++ ) {
+      for (i1 = 0; i1 < (nColor - del_i); i1++) {
         index++;
-        if ( index == block ) {
+        if (index == block) {
           found = 1;
           break;
         }
@@ -41,23 +42,29 @@ namespace quda {
     @param p store the first index
     @param q store the second index
  */
-  template<int nColor>
-  __host__ __device__ inline void IndexBlock(int block, int &p, int &q)
+  template <int nColor> __host__ __device__ constexpr void IndexBlock(int block, int &p, int &q)
   {
-    if ( nColor == 3 ) {
-      if ( block == 0 ) { p = 0; q = 1; }
-      else if ( block == 1 ) { p = 1; q = 2; }
-      else { p = 0; q = 2; }
-    } else if ( nColor > 3 ) {
+    if constexpr (nColor == 3) {
+      if (block == 0) {
+        p = 0;
+        q = 1;
+      } else if (block == 1) {
+        p = 1;
+        q = 2;
+      } else {
+        p = 0;
+        q = 2;
+      }
+    } else if constexpr (nColor > 3) {
       int i1;
       int found = 0;
       int del_i = 0;
       int index = -1;
-      while ( del_i < (nColor - 1) && found == 0 ) {
+      while (del_i < (nColor - 1) && found == 0) {
         del_i++;
-        for ( i1 = 0; i1 < (nColor - del_i); i1++ ) {
+        for (i1 = 0; i1 < (nColor - del_i); i1++) {
           index++;
-          if ( index == block ) {
+          if (index == block) {
             found = 1;
             break;
           }
@@ -74,8 +81,7 @@ namespace quda {
     @param al weight
     @param localstate CURAND rng state
  */
-  template <class T>
-  __device__ inline Matrix<T,2> generate_su2_matrix_milc(T al, RNGState& localState)
+  template <class T> __device__ inline Matrix<T, 2> generate_su2_matrix_milc(T al, RNGState &localState)
   {
     T xr1 = uniform<T>::rand(localState);
     xr1 = (log((xr1 + static_cast<T>(1.e-10))));
@@ -84,14 +90,14 @@ namespace quda {
     T xr3 = uniform<T>::rand(localState);
     T xr4 = uniform<T>::rand(localState);
     xr3 = cospi(static_cast<T>(2.0) * xr3);
-    T d = -(xr2 + xr1 * xr3 * xr3 ) / al;
-    //now  beat each  site into submission
+    T d = -(xr2 + xr1 * xr3 * xr3) / al;
+    // now  beat each  site into submission
     int nacd = 0;
-    if ((1.00 - 0.5 * d) > xr4 * xr4 ) nacd = 1;
-    if (nacd == 0 && al > 2.0 ) { //k-p algorithm
+    if ((1.00 - 0.5 * d) > xr4 * xr4) nacd = 1;
+    if (nacd == 0 && al > 2.0) { // k-p algorithm
 #pragma unroll
       for (int k = 0; k < 20; k++) {
-        //get four random numbers (add a small increment to prevent taking log(0.)
+        // get four random numbers (add a small increment to prevent taking log(0.)
         xr1 = uniform<T>::rand(localState);
         xr1 = (log((xr1 + 1.e-10)));
         xr2 = uniform<T>::rand(localState);
@@ -100,44 +106,44 @@ namespace quda {
         xr4 = uniform<T>::rand(localState);
         xr3 = cospi(static_cast<T>(2.0) * xr3);
         d = -(xr2 + xr1 * xr3 * xr3) / al;
-        if ((1.00 - 0.5 * d) > xr4 * xr4 ) break;
+        if ((1.00 - 0.5 * d) > xr4 * xr4) break;
       }
-    } //endif nacd
-    Matrix<T,2> a;
+    } // endif nacd
+    Matrix<T, 2> a;
     T r;
-    if (nacd == 0 && al <= 2.0 ) { //creutz algorithm
+    if (nacd == 0 && al <= 2.0) { // creutz algorithm
       xr3 = exp(-2.0 * al);
       xr4 = 1.0 - xr3;
 #pragma unroll
       for (int k = 0; k < 20; k++) {
-        //get two random numbers
+        // get two random numbers
         xr1 = uniform<T>::rand(localState);
         xr2 = uniform<T>::rand(localState);
         r = xr3 + xr4 * xr1;
-        a(0,0) = 1.00 + log(r) / al;
-        if ((1.0 - a(0,0) * a(0,0)) > xr2 * xr2) break;
+        a(0, 0) = 1.00 + log(r) / al;
+        if ((1.0 - a(0, 0) * a(0, 0)) > xr2 * xr2) break;
       }
-      d = 1.0 - a(0,0);
-    } //endif nacd
-      //generate the four su(2) elements
-      //find a0  = 1 - d
-    a(0,0) = 1.0 - d;
-    //compute r
-    xr3 = 1.0 - a(0,0) * a(0,0);
+      d = 1.0 - a(0, 0);
+    } // endif nacd
+      // generate the four su(2) elements
+      // find a0  = 1 - d
+    a(0, 0) = 1.0 - d;
+    // compute r
+    xr3 = 1.0 - a(0, 0) * a(0, 0);
     xr3 = abs(xr3);
     r = sqrt(xr3);
-    //compute a3
-    a(1,1) = (2.0 * uniform<T>::rand(localState) - 1.0) * r;
-    //compute a1 and a2
-    xr1 = xr3 - a(1,1) * a(1,1);
+    // compute a3
+    a(1, 1) = (2.0 * uniform<T>::rand(localState) - 1.0) * r;
+    // compute a1 and a2
+    xr1 = xr3 - a(1, 1) * a(1, 1);
     xr1 = abs(xr1);
     xr1 = sqrt(xr1);
-    //xr2 is a random number between 0 and 2*pi
+    // xr2 is a random number between 0 and 2*pi
     xr2 = static_cast<T>(2.0) * uniform<T>::rand(localState);
     T tmp[2];
     sincospi(xr2, &tmp[1], &tmp[0]);
-    a(0,1) = xr1 * tmp[0];
-    a(1,0) = xr1 * tmp[1];
+    a(0, 1) = xr1 * tmp[0];
+    a(1, 0) = xr1 * tmp[1];
     return a;
   }
 
@@ -147,28 +153,27 @@ namespace quda {
     @param block to retrieve from 0 to 2.
     @return 4 real numbers
  */
-  template < class T>
-  __host__ __device__ inline Matrix<T,2> get_block_su2( Matrix<complex<T>,3> tmp1, int block )
+  template <class T> __host__ __device__ inline Matrix<T, 2> get_block_su2(Matrix<complex<T>, 3> tmp1, int block)
   {
-    Matrix<T,2> r;
-    switch ( block ) {
+    Matrix<T, 2> r;
+    switch (block) {
     case 0:
-      r(0,0) = tmp1(0,0).x + tmp1(1,1).x;
-      r(0,1) = tmp1(0,1).y + tmp1(1,0).y;
-      r(1,0) = tmp1(0,1).x - tmp1(1,0).x;
-      r(1,1) = tmp1(0,0).y - tmp1(1,1).y;
+      r(0, 0) = tmp1(0, 0).x + tmp1(1, 1).x;
+      r(0, 1) = tmp1(0, 1).y + tmp1(1, 0).y;
+      r(1, 0) = tmp1(0, 1).x - tmp1(1, 0).x;
+      r(1, 1) = tmp1(0, 0).y - tmp1(1, 1).y;
       break;
     case 1:
-      r(0,0) = tmp1(1,1).x + tmp1(2,2).x;
-      r(0,1) = tmp1(1,2).y + tmp1(2,1).y;
-      r(1,0) = tmp1(1,2).x - tmp1(2,1).x;
-      r(1,1) = tmp1(1,1).y - tmp1(2,2).y;
+      r(0, 0) = tmp1(1, 1).x + tmp1(2, 2).x;
+      r(0, 1) = tmp1(1, 2).y + tmp1(2, 1).y;
+      r(1, 0) = tmp1(1, 2).x - tmp1(2, 1).x;
+      r(1, 1) = tmp1(1, 1).y - tmp1(2, 2).y;
       break;
     case 2:
-      r(0,0) = tmp1(0,0).x + tmp1(2,2).x;
-      r(0,1) = tmp1(0,2).y + tmp1(2,0).y;
-      r(1,0) = tmp1(0,2).x - tmp1(2,0).x;
-      r(1,1) = tmp1(0,0).y - tmp1(2,2).y;
+      r(0, 0) = tmp1(0, 0).x + tmp1(2, 2).x;
+      r(0, 1) = tmp1(0, 2).y + tmp1(2, 0).y;
+      r(1, 0) = tmp1(0, 2).x - tmp1(2, 0).x;
+      r(1, 1) = tmp1(0, 0).y - tmp1(2, 2).y;
       break;
     }
     return r;
@@ -181,13 +186,13 @@ namespace quda {
     @return 4 real numbers
  */
   template <class T, int nColor>
-  __host__ __device__ inline Matrix<T,2> get_block_su2( Matrix<complex<T>,nColor> tmp1, int2 id )
+  __host__ __device__ inline Matrix<T, 2> get_block_su2(Matrix<complex<T>, nColor> tmp1, int2 id)
   {
-    Matrix<T,2> r;
-    r(0,0) = tmp1(id.x,id.x).x + tmp1(id.y,id.y).x;
-    r(0,1) = tmp1(id.x,id.y).y + tmp1(id.y,id.x).y;
-    r(1,0) = tmp1(id.x,id.y).x - tmp1(id.y,id.x).x;
-    r(1,1) = tmp1(id.x,id.x).y - tmp1(id.y,id.y).y;
+    Matrix<T, 2> r;
+    r(0, 0) = tmp1(id.x, id.x).x + tmp1(id.y, id.y).x;
+    r(0, 1) = tmp1(id.x, id.y).y + tmp1(id.y, id.x).y;
+    r(1, 0) = tmp1(id.x, id.y).x - tmp1(id.y, id.x).x;
+    r(1, 1) = tmp1(id.x, id.x).y - tmp1(id.y, id.y).y;
     return r;
   }
 
@@ -198,14 +203,14 @@ namespace quda {
     @return SU(Nc) matrix
  */
   template <class T, int nColor>
-  __host__ __device__ inline Matrix<complex<T>,nColor> block_su2_to_sun( Matrix<T,2> rr, int2 id )
+  __host__ __device__ inline Matrix<complex<T>, nColor> block_su2_to_sun(Matrix<T, 2> rr, int2 id)
   {
-    Matrix<complex<T>,nColor> tmp1;
+    Matrix<complex<T>, nColor> tmp1;
     setIdentity(&tmp1);
-    tmp1(id.x,id.x) = complex<T>( rr(0,0), rr(1,1) );
-    tmp1(id.x,id.y) = complex<T>( rr(1,0), rr(0,1) );
-    tmp1(id.y,id.x) = complex<T>(-rr(1,0), rr(0,1) );
-    tmp1(id.y,id.y) = complex<T>( rr(0,0),-rr(1,1) );
+    tmp1(id.x, id.x) = complex<T>(rr(0, 0), rr(1, 1));
+    tmp1(id.x, id.y) = complex<T>(rr(1, 0), rr(0, 1));
+    tmp1(id.y, id.x) = complex<T>(-rr(1, 0), rr(0, 1));
+    tmp1(id.y, id.y) = complex<T>(rr(0, 0), -rr(1, 1));
     return tmp1;
   }
 
@@ -216,12 +221,12 @@ namespace quda {
     @param id indices
  */
   template <class T, int nColor>
-  __host__ __device__ inline void mul_block_sun( Matrix<T,2> u, Matrix<complex<T>,nColor> &link, int2 id )
+  __host__ __device__ inline void mul_block_sun(Matrix<T, 2> u, Matrix<complex<T>, nColor> &link, int2 id)
   {
 #pragma unroll
     for (int j = 0; j < nColor; j++) {
-      complex<T> tmp = complex<T>( u(0,0), u(1,1) ) * link(id.x, j) + complex<T>( u(1,0), u(0,1) ) * link(id.y, j);
-      link(id.y, j) = complex<T>(-u(1,0), u(0,1) ) * link(id.x, j) + complex<T>( u(0,0),-u(1,1) ) * link(id.y, j);
+      complex<T> tmp = complex<T>(u(0, 0), u(1, 1)) * link(id.x, j) + complex<T>(u(1, 0), u(0, 1)) * link(id.y, j);
+      link(id.y, j) = complex<T>(-u(1, 0), u(0, 1)) * link(id.x, j) + complex<T>(u(0, 0), -u(1, 1)) * link(id.y, j);
       link(id.x, j) = tmp;
     }
   }
@@ -236,55 +241,56 @@ namespace quda {
     @param block of the SU(3) matrix, 0,1 or 2
  */
   template <class Cmplx>
-  __host__ __device__ inline void block_su2_to_su3( Matrix<Cmplx,3> &U, Cmplx a00, Cmplx a01, Cmplx a10, Cmplx a11, int block )
+  __host__ __device__ inline void block_su2_to_su3(Matrix<Cmplx, 3> &U, Cmplx a00, Cmplx a01, Cmplx a10, Cmplx a11,
+                                                   int block)
   {
     Cmplx tmp;
-    switch ( block ) {
+    switch (block) {
     case 0:
-      tmp = a00 * U(0,0) + a01 * U(1,0);
-      U(1,0) = a10 * U(0,0) + a11 * U(1,0);
-      U(0,0) = tmp;
-      tmp = a00 * U(0,1) + a01 * U(1,1);
-      U(1,1) = a10 * U(0,1) + a11 * U(1,1);
-      U(0,1) = tmp;
-      tmp = a00 * U(0,2) + a01 * U(1,2);
-      U(1,2) = a10 * U(0,2) + a11 * U(1,2);
-      U(0,2) = tmp;
+      tmp = a00 * U(0, 0) + a01 * U(1, 0);
+      U(1, 0) = a10 * U(0, 0) + a11 * U(1, 0);
+      U(0, 0) = tmp;
+      tmp = a00 * U(0, 1) + a01 * U(1, 1);
+      U(1, 1) = a10 * U(0, 1) + a11 * U(1, 1);
+      U(0, 1) = tmp;
+      tmp = a00 * U(0, 2) + a01 * U(1, 2);
+      U(1, 2) = a10 * U(0, 2) + a11 * U(1, 2);
+      U(0, 2) = tmp;
       break;
     case 1:
-      tmp = a00 * U(1,0) + a01 * U(2,0);
-      U(2,0) = a10 * U(1,0) + a11 * U(2,0);
-      U(1,0) = tmp;
-      tmp = a00 * U(1,1) + a01 * U(2,1);
-      U(2,1) = a10 * U(1,1) + a11 * U(2,1);
-      U(1,1) = tmp;
-      tmp = a00 * U(1,2) + a01 * U(2,2);
-      U(2,2) = a10 * U(1,2) + a11 * U(2,2);
-      U(1,2) = tmp;
+      tmp = a00 * U(1, 0) + a01 * U(2, 0);
+      U(2, 0) = a10 * U(1, 0) + a11 * U(2, 0);
+      U(1, 0) = tmp;
+      tmp = a00 * U(1, 1) + a01 * U(2, 1);
+      U(2, 1) = a10 * U(1, 1) + a11 * U(2, 1);
+      U(1, 1) = tmp;
+      tmp = a00 * U(1, 2) + a01 * U(2, 2);
+      U(2, 2) = a10 * U(1, 2) + a11 * U(2, 2);
+      U(1, 2) = tmp;
       break;
     case 2:
-      tmp = a00 * U(0,0) + a01 * U(2,0);
-      U(2,0) = a10 * U(0,0) + a11 * U(2,0);
-      U(0,0) = tmp;
-      tmp = a00 * U(0,1) + a01 * U(2,1);
-      U(2,1) = a10 * U(0,1) + a11 * U(2,1);
-      U(0,1) = tmp;
-      tmp = a00 * U(0,2) + a01 * U(2,2);
-      U(2,2) = a10 * U(0,2) + a11 * U(2,2);
-      U(0,2) = tmp;
+      tmp = a00 * U(0, 0) + a01 * U(2, 0);
+      U(2, 0) = a10 * U(0, 0) + a11 * U(2, 0);
+      U(0, 0) = tmp;
+      tmp = a00 * U(0, 1) + a01 * U(2, 1);
+      U(2, 1) = a10 * U(0, 1) + a11 * U(2, 1);
+      U(0, 1) = tmp;
+      tmp = a00 * U(0, 2) + a01 * U(2, 2);
+      U(2, 2) = a10 * U(0, 2) + a11 * U(2, 2);
+      U(0, 2) = tmp;
       break;
     }
   }
 
   // v * u^dagger
   template <class Float>
-  __host__ __device__ inline Matrix<Float,2> mulsu2UVDagger(Matrix<Float,2> v, Matrix<Float,2> u)
+  __host__ __device__ inline Matrix<Float, 2> mulsu2UVDagger(Matrix<Float, 2> v, Matrix<Float, 2> u)
   {
-    Matrix<Float,2> b;
-    b(0,0) = v(0,0) * u(0,0) + v(0,1) * u(0,1) + v(1,0) * u(1,0) + v(1,1) * u(1,1);
-    b(0,1) = v(0,1) * u(0,0) - v(0,0) * u(0,1) + v(1,0) * u(1,1) - v(1,1) * u(1,0);
-    b(1,0) = v(1,0) * u(0,0) - v(0,0) * u(1,0) + v(1,1) * u(0,1) - v(0,1) * u(1,1);
-    b(1,1) = v(1,1) * u(0,0) - v(0,0) * u(1,1) + v(0,1) * u(1,0) - v(1,0) * u(0,1);
+    Matrix<Float, 2> b;
+    b(0, 0) = v(0, 0) * u(0, 0) + v(0, 1) * u(0, 1) + v(1, 0) * u(1, 0) + v(1, 1) * u(1, 1);
+    b(0, 1) = v(0, 1) * u(0, 0) - v(0, 0) * u(0, 1) + v(1, 0) * u(1, 1) - v(1, 1) * u(1, 0);
+    b(1, 0) = v(1, 0) * u(0, 0) - v(0, 0) * u(1, 0) + v(1, 1) * u(0, 1) - v(0, 1) * u(1, 1);
+    b(1, 1) = v(1, 1) * u(0, 0) - v(0, 0) * u(1, 1) + v(0, 1) * u(1, 0) - v(1, 0) * u(0, 1);
     return b;
   }
 
@@ -295,10 +301,10 @@ namespace quda {
     @param localstate CURAND rng state
   */
   template <class Float, int nColor>
-  __device__ inline void heatBathSUN( Matrix<complex<Float>,nColor>& U, Matrix<complex<Float>,nColor> F,
-                                      RNGState& localState, Float BetaOverNc )
+  __device__ inline void heatBathSUN(Matrix<complex<Float>, nColor> &U, Matrix<complex<Float>, nColor> F,
+                                     RNGState &localState, Float BetaOverNc)
   {
-    if (nColor == 3) {
+    if constexpr (nColor == 3) {
       //////////////////////////////////////////////////////////////////
       /*
          for( int block = 0; block < nColor; block++ ) {
@@ -312,14 +318,15 @@ namespace quda {
          Matrix<T,2> a = generate_su2_matrix_milc<T>(ap, localState);
          r = mulsu2UVDagger_4<T>( a, r);
          ///////////////////////////////////////
-         block_su2_to_su3<T>( U, complex( r(0,0), r(1,1) ), complex( r(1,0), r(0,1) ), complex(-r(1,0), r(0,1) ), complex( r(0,0),-r(1,1) ), block );
+         block_su2_to_su3<T>( U, complex( r(0,0), r(1,1) ), complex( r(1,0), r(0,1) ), complex(-r(1,0), r(0,1) ),
+         complex( r(0,0),-r(1,1) ), block );
          //FLOP_min = (198 + 4 + 15 + 28 + 28 + 84) * 3 = 1071
          }*/
       //////////////////////////////////////////////////////////////////
 
 #pragma unroll
       for (int block = 0; block < nColor; block++) {
-        int p,q;
+        int p, q;
         IndexBlock<nColor>(block, p, q);
         complex<Float> a0((Float)0.0, (Float)0.0);
         complex<Float> a1 = a0;
@@ -328,56 +335,56 @@ namespace quda {
 
 #pragma unroll
         for (int j = 0; j < nColor; j++) {
-          a0 += U(p,j) * F(j,p);
-          a1 += U(p,j) * F(j,q);
-          a2 += U(q,j) * F(j,p);
-          a3 += U(q,j) * F(j,q);
+          a0 += U(p, j) * F(j, p);
+          a1 += U(p, j) * F(j, q);
+          a2 += U(q, j) * F(j, p);
+          a3 += U(q, j) * F(j, q);
         }
-        Matrix<Float,2> r;
-        r(0,0) = a0.x + a3.x;
-        r(0,1) = a1.y + a2.y;
-        r(1,0) = a1.x - a2.x;
-        r(1,1) = a0.y - a3.y;
-        Float k = sqrt(r(0,0) * r(0,0) + r(0,1) * r(0,1) + r(1,0) * r(1,0) + r(1,1) * r(1,1));;
+        Matrix<Float, 2> r;
+        r(0, 0) = a0.x + a3.x;
+        r(0, 1) = a1.y + a2.y;
+        r(1, 0) = a1.x - a2.x;
+        r(1, 1) = a0.y - a3.y;
+        Float k = sqrt(r(0, 0) * r(0, 0) + r(0, 1) * r(0, 1) + r(1, 0) * r(1, 0) + r(1, 1) * r(1, 1));
         Float ap = BetaOverNc * k;
         k = 1.0 / k;
         r *= k;
-        Matrix<Float,2> a = generate_su2_matrix_milc<Float>(ap, localState);
-        r = mulsu2UVDagger<Float>( a, r);
+        Matrix<Float, 2> a = generate_su2_matrix_milc<Float>(ap, localState);
+        r = mulsu2UVDagger<Float>(a, r);
         ///////////////////////////////////////
-        a0 = complex<Float>( r(0,0), r(1,1) );
-        a1 = complex<Float>( r(1,0), r(0,1) );
-        a2 = complex<Float>(-r(1,0), r(0,1) );
-        a3 = complex<Float>( r(0,0),-r(1,1) );
+        a0 = complex<Float>(r(0, 0), r(1, 1));
+        a1 = complex<Float>(r(1, 0), r(0, 1));
+        a2 = complex<Float>(-r(1, 0), r(0, 1));
+        a3 = complex<Float>(r(0, 0), -r(1, 1));
         complex<Float> tmp0;
 
 #pragma unroll
         for (int j = 0; j < nColor; j++) {
-          tmp0 = a0 * U(p,j) + a1 * U(q,j);
-          U(q,j) = a2 * U(p,j) + a3 * U(q,j);
-          U(p,j) = tmp0;
+          tmp0 = a0 * U(p, j) + a1 * U(q, j);
+          U(q, j) = a2 * U(p, j) + a3 * U(q, j);
+          U(p, j) = tmp0;
         }
-        //FLOP_min = (nColor * 64 + 19 + 28 + 28) * 3 = nColor * 192 + 225
+        // FLOP_min = (nColor * 64 + 19 + 28 + 28) * 3 = nColor * 192 + 225
       }
       //////////////////////////////////////////////////////////////////
-    } else if ( nColor > 3 ) {
+    } else if constexpr (nColor > 3) {
       //////////////////////////////////////////////////////////////////
-      //TESTED IN SU(4) SP THIS IS WORST
-      Matrix<complex<Float>,nColor> M = U * F;
+      // TESTED IN SU(4) SP THIS IS WORST
+      Matrix<complex<Float>, nColor> M = U * F;
 
 #pragma unroll
-      for (int block = 0; block < nColor * ( nColor - 1) / 2; block++) {
-        int2 id = IndexBlock<nColor>( block );
-        Matrix<Float,2> r = get_block_su2<Float>(M, id);
-        Float k = sqrt(r(0,0) * r(0,0) + r(0,1) * r(0,1) + r(1,0) * r(1,0) + r(1,1) * r(1,1));
+      for (int block = 0; block < nColor * (nColor - 1) / 2; block++) {
+        int2 id = IndexBlock<nColor>(block);
+        Matrix<Float, 2> r = get_block_su2<Float>(M, id);
+        Float k = sqrt(r(0, 0) * r(0, 0) + r(0, 1) * r(0, 1) + r(1, 0) * r(1, 0) + r(1, 1) * r(1, 1));
         Float ap = BetaOverNc * k;
         k = 1.0 / k;
         r *= k;
-        Matrix<Float,2> a = generate_su2_matrix_milc<Float>(ap, localState);
-        Matrix<Float,2> rr = mulsu2UVDagger<Float>( a, r);
+        Matrix<Float, 2> a = generate_su2_matrix_milc<Float>(ap, localState);
+        Matrix<Float, 2> rr = mulsu2UVDagger<Float>(a, r);
         ///////////////////////////////////////
-        mul_block_sun<Float, nColor>( rr, U, id);
-        mul_block_sun<Float, nColor>( rr, M, id);
+        mul_block_sun<Float, nColor>(rr, U, id);
+        mul_block_sun<Float, nColor>(rr, M, id);
         ///////////////////////////////////////
       }
       /* / TESTED IN SU(4) SP THIS IS FASTER
@@ -407,20 +414,19 @@ namespace quda {
          Matrix<T,2> a = generate_su2_matrix_milc<T>(ap, localState);
          r = mulsu2UVDagger<T>( a, r);
          mul_block_sun<T>( r, U, id); */
-         /*
-           a0 = complex( r(0,0), r(1,1) );
-           a1 = complex( r(1,0), r(0,1) );
-           a2 = complex(-r(1,0), r(0,1) );
-           a3 = complex( r(0,0),-r(1,1) );
-           complex tmp0;
+      /*
+        a0 = complex( r(0,0), r(1,1) );
+        a1 = complex( r(1,0), r(0,1) );
+        a2 = complex(-r(1,0), r(0,1) );
+        a3 = complex( r(0,0),-r(1,1) );
+        complex tmp0;
 
-           for ( int j = 0; j < nColor; j++ ) {
-           tmp0 = a0 * U(id.x, j) + a1 * U(id.y, j);
-           U(id.y, j) = a2 * U(id.x, j) + a3 * U(id.y, j);
-           U(id.x, j) = tmp0;
-           } */
+        for ( int j = 0; j < nColor; j++ ) {
+        tmp0 = a0 * U(id.x, j) + a1 * U(id.y, j);
+        U(id.y, j) = a2 * U(id.x, j) + a3 * U(id.y, j);
+        U(id.x, j) = tmp0;
+        } */
       // }
-
     }
     //////////////////////////////////////////////////////////////////
   }
@@ -432,9 +438,9 @@ namespace quda {
      @param F staple
    */
   template <class Float, int nColor>
-  __device__ inline void overrelaxationSUN( Matrix<complex<Float>,nColor>& U, Matrix<complex<Float>,nColor> F )
+  __device__ inline void overrelaxationSUN(Matrix<complex<Float>, nColor> &U, Matrix<complex<Float>, nColor> F)
   {
-    if (nColor == 3) {
+    if constexpr (nColor == 3) {
       //////////////////////////////////////////////////////////////////
       /*
          for( int block = 0; block < 3; block++ ) {
@@ -457,12 +463,12 @@ namespace quda {
          //FLOP = (198 + 17 + 84 * 2) * 3 = 1149
          }*/
       ///////////////////////////////////////////////////////////////////
-      //This version does not need to multiply all matrix at each block: tmp1 = U * F;
+      // This version does not need to multiply all matrix at each block: tmp1 = U * F;
       //////////////////////////////////////////////////////////////////
 
 #pragma unroll
       for (int block = 0; block < 3; block++) {
-        int p,q;
+        int p, q;
         IndexBlock<nColor>(block, p, q);
         complex<Float> a0((Float)0., (Float)0.);
         complex<Float> a1 = a0;
@@ -470,61 +476,59 @@ namespace quda {
         complex<Float> a3 = a0;
 
 #pragma unroll
-        for ( int j = 0; j < nColor; j++ ) {
-          a0 += U(p,j) * F(j,p);
-          a1 += U(p,j) * F(j,q);
-          a2 += U(q,j) * F(j,p);
-          a3 += U(q,j) * F(j,q);
+        for (int j = 0; j < nColor; j++) {
+          a0 += U(p, j) * F(j, p);
+          a1 += U(p, j) * F(j, q);
+          a2 += U(q, j) * F(j, p);
+          a3 += U(q, j) * F(j, q);
         }
-        Matrix<Float,2> r;
-        r(0,0) = a0.x + a3.x;
-        r(0,1) = a1.y + a2.y;
-        r(1,0) = a1.x - a2.x;
-        r(1,1) = a0.y - a3.y;
-        //normalize and conjugate
-        //r = r.conj_normalize();
-        Float norm = 1.0 / sqrt(r(0,0) * r(0,0) + r(0,1) * r(0,1) + r(1,0) * r(1,0) + r(1,1) * r(1,1));;
-        r(0,0) *= norm;
-        r(0,1) *= -norm;
-        r(1,0) *= -norm;
-        r(1,1) *= -norm;
-
+        Matrix<Float, 2> r;
+        r(0, 0) = a0.x + a3.x;
+        r(0, 1) = a1.y + a2.y;
+        r(1, 0) = a1.x - a2.x;
+        r(1, 1) = a0.y - a3.y;
+        // normalize and conjugate
+        // r = r.conj_normalize();
+        Float norm = rsqrt(r(0, 0) * r(0, 0) + r(0, 1) * r(0, 1) + r(1, 0) * r(1, 0) + r(1, 1) * r(1, 1));
+        r(0, 0) *= norm;
+        r(0, 1) *= -norm;
+        r(1, 0) *= -norm;
+        r(1, 1) *= -norm;
 
         ///////////////////////////////////////
-        a0 = complex<Float>( r(0,0), r(1,1) );
-        a1 = complex<Float>( r(1,0), r(0,1) );
-        a2 = complex<Float>(-r(1,0), r(0,1) );
-        a3 = complex<Float>( r(0,0),-r(1,1) );
+        a0 = complex<Float>(r(0, 0), r(1, 1));
+        a1 = complex<Float>(r(1, 0), r(0, 1));
+        a2 = complex<Float>(-r(1, 0), r(0, 1));
+        a3 = complex<Float>(r(0, 0), -r(1, 1));
         complex<Float> tmp0, tmp1;
 
 #pragma unroll
-        for ( int j = 0; j < nColor; j++ ) {
-          tmp0 = a0 * U(p,j) + a1 * U(q,j);
-          tmp1 = a2 * U(p,j) + a3 * U(q,j);
-          U(p,j) = a0 * tmp0 + a1 * tmp1;
-          U(q,j) = a2 * tmp0 + a3 * tmp1;
+        for (int j = 0; j < nColor; j++) {
+          tmp0 = a0 * U(p, j) + a1 * U(q, j);
+          tmp1 = a2 * U(p, j) + a3 * U(q, j);
+          U(p, j) = a0 * tmp0 + a1 * tmp1;
+          U(q, j) = a2 * tmp0 + a3 * tmp1;
         }
-        //FLOP = (nColor * 88 + 17) * 3
+        // FLOP = (nColor * 88 + 17) * 3
       }
       ///////////////////////////////////////////////////////////////////
-    }
-    else if ( nColor > 3 ) {
+    } else if constexpr (nColor > 3) {
       ///////////////////////////////////////////////////////////////////
-      Matrix<complex<Float>,nColor> M = U * F;
+      Matrix<complex<Float>, nColor> M = U * F;
 #pragma unroll
-      for ( int block = 0; block < nColor * ( nColor - 1) / 2; block++ ) {
-        int2 id = IndexBlock<nColor>( block );
-        Matrix<Float,2> r = get_block_su2<Float, nColor>(M, id);
-        //normalize and conjugate
-        Float norm = 1.0 / sqrt(r(0,0) * r(0,0) + r(0,1) * r(0,1) + r(1,0) * r(1,0) + r(1,1) * r(1,1));;
-        r(0,0) *= norm;
-        r(0,1) *= -norm;
-        r(1,0) *= -norm;
-        r(1,1) *= -norm;
-        mul_block_sun<Float, nColor>( r, U, id);
-        mul_block_sun<Float, nColor>( r, U, id);
-        mul_block_sun<Float, nColor>( r, M, id);
-        mul_block_sun<Float, nColor>( r, M, id);
+      for (int block = 0; block < nColor * (nColor - 1) / 2; block++) {
+        int2 id = IndexBlock<nColor>(block);
+        Matrix<Float, 2> r = get_block_su2<Float, nColor>(M, id);
+        // normalize and conjugate
+        Float norm = rsqrt(r(0, 0) * r(0, 0) + r(0, 1) * r(0, 1) + r(1, 0) * r(1, 0) + r(1, 1) * r(1, 1));
+        r(0, 0) *= norm;
+        r(0, 1) *= -norm;
+        r(1, 0) *= -norm;
+        r(1, 1) *= -norm;
+        mul_block_sun<Float, nColor>(r, U, id);
+        mul_block_sun<Float, nColor>(r, U, id);
+        mul_block_sun<Float, nColor>(r, M, id);
+        mul_block_sun<Float, nColor>(r, M, id);
         ///////////////////////////////////////
       }
       /*  //TESTED IN SU(4) SP THIS IS WORST
@@ -572,14 +576,13 @@ namespace quda {
     }
   }
 
-  template <typename Float_, int nColor_, QudaReconstructType recon, bool heatbath_>
-  struct MonteArg : kernel_param<> {
+  template <typename Float_, int nColor_, QudaReconstructType recon, bool heatbath_> struct MonteArg : kernel_param<> {
     using Float = Float_;
     static constexpr int nColor = nColor_;
     using Gauge = typename gauge_mapper<Float, recon>::type;
     static constexpr bool heatbath = heatbath_;
 
-    int X[4];       // grid dimensions
+    int X[4]; // grid dimensions
     int border[4];
     Gauge dataOr;
     Float BetaOverNc;
@@ -587,24 +590,19 @@ namespace quda {
     int mu;
     int parity;
     MonteArg(GaugeField &data, Float Beta, RNGState *rng, int mu, int parity) :
-      kernel_param(dim3(data.LocalVolumeCB(), 1, 1)),
-      dataOr(data),
-      rng(rng),
-      mu(mu),
-      parity(parity)
+      kernel_param(dim3(data.LocalVolumeCB(), 1, 1)), dataOr(data), rng(rng), mu(mu), parity(parity)
     {
       BetaOverNc = Beta / (Float)nColor;
       for (int dir = 0; dir < 4; dir++) {
         border[dir] = data.R()[dir];
         X[dir] = data.X()[dir] - border[dir] * 2;
-      } 
+      }
     }
   };
 
-  template <typename Arg> struct HB
-  {
+  template <typename Arg> struct HB {
     const Arg &arg;
-    constexpr HB(const Arg &arg) : arg(arg) {}
+    constexpr HB(const Arg &arg) : arg(arg) { }
     static constexpr const char *filename() { return KERNEL_FILE; }
 
     __device__ __host__ void operator()(int x_cb)
@@ -630,37 +628,39 @@ namespace quda {
 
       Link U;
 #pragma unroll
-      for (int nu = 0; nu < 4; nu++) if (mu != nu) {
-          int dx[4] = { 0, 0, 0, 0 };
+      for (int nu = 0; nu < 4; nu++)
+        if (mu != nu) {
+          byte_array dx = {};
           Link link = arg.dataOr(nu, e_cb, parity);
           dx[nu]++;
-          U = arg.dataOr(mu, linkIndexShift(x,dx,X), 1 - parity);
+          U = arg.dataOr(mu, linkIndexShift(x, dx, X), 1 - parity);
           link *= U;
           dx[nu]--;
           dx[mu]++;
-          U = arg.dataOr(nu, linkIndexShift(x,dx,X), 1 - parity);
+          U = arg.dataOr(nu, linkIndexShift(x, dx, X), 1 - parity);
           link *= conj(U);
           staple += link;
           dx[mu]--;
           dx[nu]--;
-          link = arg.dataOr(nu, linkIndexShift(x,dx,X), 1 - parity);
-          U = arg.dataOr(mu, linkIndexShift(x,dx,X), 1 - parity);
+          link = arg.dataOr(nu, linkIndexShift(x, dx, X), 1 - parity);
+          U = arg.dataOr(mu, linkIndexShift(x, dx, X), 1 - parity);
           link = conj(link) * U;
           dx[mu]++;
-          U = arg.dataOr(nu, linkIndexShift(x,dx,X), parity);
+          U = arg.dataOr(nu, linkIndexShift(x, dx, X), parity);
           link *= U;
           staple += link;
         }
       U = arg.dataOr(mu, e_cb, parity);
-      if (Arg::heatbath) {
+
+      if constexpr (Arg::heatbath) {
         RNGState localState = arg.rng[x_cb];
-        heatBathSUN( U, conj(staple), localState, arg.BetaOverNc );
+        heatBathSUN(U, conj(staple), localState, arg.BetaOverNc);
         arg.rng[x_cb] = localState;
       } else {
-        overrelaxationSUN( U, conj(staple) );
+        overrelaxationSUN(U, conj(staple));
       }
       arg.dataOr(mu, e_cb, parity) = U;
     }
   };
 
-}
+} // namespace quda

--- a/include/kernels/gauge_hyp.cuh
+++ b/include/kernels/gauge_hyp.cuh
@@ -9,15 +9,15 @@
 namespace quda
 {
 
-  template <typename Float_, int nColor_, QudaReconstructType recon_, int level_, int hypDim_>
+  template <typename store_t, int nColor_, QudaReconstructType recon_, int level_, int hypDim_>
   struct GaugeHYPArg : kernel_param<> {
-    using Float = Float_;
+    using real = typename mapper<store_t>::type;
     static constexpr int nColor = nColor_;
     static_assert(nColor == 3, "Only nColor=3 enabled at this time");
     static constexpr QudaReconstructType recon = recon_;
     static constexpr int hypDim = hypDim_;
     static constexpr int level = level_;
-    typedef typename gauge_mapper<Float, recon>::type Gauge;
+    typedef typename gauge_mapper<store_t, recon>::type Gauge;
 
     Gauge out;
     Gauge tmp[4];
@@ -26,9 +26,9 @@ namespace quda
     int_fastdiv E[4]; // extended grid dimensions
     int_fastdiv X[4]; // grid dimensions
     int border[4];
-    const Float alpha;
+    const real alpha;
     const int dir_ignore;
-    const Float tolerance;
+    const real tolerance;
 
     GaugeHYPArg(GaugeField &out, GaugeField *tmp[4], const GaugeField &in, double alpha, int dir_ignore) :
       kernel_param(dim3(in.LocalVolumeCB(), 2, hypDim)),
@@ -61,11 +61,11 @@ namespace quda
      @return The computed staple
   */
   template <typename Arg>
-  __host__ __device__ inline Matrix<complex<typename Arg::Float>, Arg::nColor>
+  __host__ __device__ inline Matrix<complex<typename Arg::real>, Arg::nColor>
   accumulateStaple(const Arg &arg, const typename Arg::Gauge &gauge_mu, const typename Arg::Gauge &gauge_nu, int x[],
-                   thread_array<int, 4> &dx, int parity, int2 tensor_arg, int2 shifts)
+                   byte_array<int8_t, 4> &dx, int parity, int2 tensor_arg, int2 shifts)
   {
-    using Link = Matrix<complex<typename Arg::Float>, Arg::nColor>;
+    using Link = Matrix<complex<typename Arg::real>, Arg::nColor>;
     Link staple;
 
     // for readability
@@ -124,10 +124,10 @@ namespace quda
   }
 
   template <typename Arg>
-  __host__ __device__ inline void computeStapleLevel1(const Arg &arg, int x[], thread_array<int, 4> &dx, int parity,
-                                                      int mu, Matrix<complex<typename Arg::Float>, Arg::nColor> staple[3])
+  __host__ __device__ inline void computeStapleLevel1(const Arg &arg, int x[], byte_array<int8_t, 4> &dx, int parity,
+                                                      int mu, Matrix<complex<typename Arg::real>, Arg::nColor> staple[3])
   {
-    using Link = Matrix<complex<typename Arg::Float>, Arg::nColor>;
+    using Link = Matrix<complex<typename Arg::real>, Arg::nColor>;
     for (int i = 0; i < 3; ++i) staple[i] = Link();
 
     int cnt = 0;
@@ -146,10 +146,10 @@ namespace quda
   }
 
   template <typename Arg>
-  __host__ __device__ inline void computeStapleLevel2(const Arg &arg, int x[], thread_array<int, 4> &dx, int parity,
-                                                      int mu, Matrix<complex<typename Arg::Float>, Arg::nColor> staple[3])
+  __host__ __device__ inline void computeStapleLevel2(const Arg &arg, int x[], byte_array<int8_t, 4> &dx, int parity,
+                                                      int mu, Matrix<complex<typename Arg::real>, Arg::nColor> staple[3])
   {
-    using Link = Matrix<complex<typename Arg::Float>, Arg::nColor>;
+    using Link = Matrix<complex<typename Arg::real>, Arg::nColor>;
     for (int i = 0; i < 3; ++i) staple[i] = Link();
 
     int cnt = 0;
@@ -181,8 +181,8 @@ namespace quda
   }
 
   template <typename Arg>
-  __host__ __device__ inline void computeStapleLevel3(const Arg &arg, int x[], thread_array<int, 4> &dx, int parity,
-                                                      int mu, Matrix<complex<typename Arg::Float>, Arg::nColor> &staple)
+  __host__ __device__ inline void computeStapleLevel3(const Arg &arg, int x[], byte_array<int8_t, 4> &dx, int parity,
+                                                      int mu, Matrix<complex<typename Arg::real>, Arg::nColor> &staple)
   {
 #pragma unroll
     for (int nu = 0; nu < 4; nu++) {
@@ -197,17 +197,15 @@ namespace quda
     }
   }
 
-  template <typename Arg> struct HYP : KernelOps<thread_array<int, 4>> {
+  template <typename Arg> struct HYP {
     const Arg &arg;
-    template <typename... OpsArgs> constexpr HYP(const Arg &arg, const OpsArgs &...ops) : KernelOpsT(ops...), arg(arg)
-    {
-    }
+    constexpr HYP(const Arg &arg) : arg(arg) { }
     static constexpr const char *filename() { return KERNEL_FILE; }
 
     __device__ __host__ inline void operator()(int x_cb, int parity, int dir)
     {
-      using real = typename Arg::Float;
-      using Link = Matrix<complex<typename Arg::Float>, Arg::nColor>;
+      using real = typename Arg::real;
+      using Link = Matrix<complex<real>, Arg::nColor>;
 
       // compute spacetime and local coords
       int x[4];
@@ -215,7 +213,7 @@ namespace quda
 #pragma unroll
       for (int dr = 0; dr < 4; ++dr) x[dr] += arg.border[dr]; // extended grid coordinates
 
-      thread_array<int, 4> dx {*this};
+      byte_array<int8_t, 4> dx = {};
 
       Link U, Stap[3], TestU, I;
 
@@ -253,10 +251,10 @@ namespace quda
 
   template <typename Arg>
   __host__ __device__ inline void
-  computeStaple3DLevel1(const Arg &arg, int x[], thread_array<int, 4> &dx, int parity, int mu,
-                        Matrix<complex<typename Arg::Float>, Arg::nColor> staple[2], const int dir_ignore)
+  computeStaple3DLevel1(const Arg &arg, int x[], byte_array<int8_t, 4> &dx, int parity, int mu,
+                        Matrix<complex<typename Arg::real>, Arg::nColor> staple[2], const int dir_ignore)
   {
-    using Link = Matrix<complex<typename Arg::Float>, Arg::nColor>;
+    using Link = Matrix<complex<typename Arg::real>, Arg::nColor>;
     for (int i = 0; i < 2; ++i) staple[i] = Link();
 
     int cnt = 0;
@@ -276,11 +274,11 @@ namespace quda
   }
 
   template <typename Arg>
-  __host__ __device__ inline void computeStaple3DLevel2(const Arg &arg, int x[], thread_array<int, 4> &dx, int parity,
-                                                        int mu, Matrix<complex<typename Arg::Float>, Arg::nColor> &staple,
+  __host__ __device__ inline void computeStaple3DLevel2(const Arg &arg, int x[], byte_array<int8_t, 4> &dx, int parity,
+                                                        int mu, Matrix<complex<typename Arg::real>, Arg::nColor> &staple,
                                                         int dir_ignore)
   {
-    using Link = Matrix<complex<typename Arg::Float>, Arg::nColor>;
+    using Link = Matrix<complex<typename Arg::real>, Arg::nColor>;
     staple = Link();
 
 #pragma unroll
@@ -302,16 +300,15 @@ namespace quda
     }
   }
 
-  template <typename Arg> struct HYP3D : KernelOps<thread_array<int, 4>> {
+  template <typename Arg> struct HYP3D {
     const Arg &arg;
-    template <typename... OpsArgs> constexpr HYP3D(const Arg &arg, const OpsArgs &...ops) : KernelOpsT(ops...), arg(arg)
-    {
-    }
+    constexpr HYP3D(const Arg &arg) : arg(arg) { }
+
     static constexpr const char *filename() { return KERNEL_FILE; }
 
     __device__ __host__ inline void operator()(int x_cb, int parity, int dir)
     {
-      using real = typename Arg::Float;
+      using real = typename Arg::real;
       typedef Matrix<complex<real>, Arg::nColor> Link;
 
       // compute spacetime and local coords
@@ -320,7 +317,7 @@ namespace quda
 #pragma unroll
       for (int dr = 0; dr < 4; ++dr) x[dr] += arg.border[dr]; // extended grid coordinates
 
-      thread_array<int, 4> dx {*this};
+      byte_array<int8_t, 4> dx = {};
 
       int dir_ = dir;
       dir = dir + (dir >= arg.dir_ignore);

--- a/include/kernels/gauge_loop_trace.cuh
+++ b/include/kernels/gauge_loop_trace.cuh
@@ -4,7 +4,7 @@
 #include <quda_matrix.h>
 #include <index_helper.cuh>
 #include <kernel.h>
-#include <thread_array.h>
+#include <byte_array.h>
 #include <array.h>
 #include <reduce_helper.h>
 #include <reduction_kernel.h>
@@ -52,15 +52,12 @@ namespace quda {
     }
   };
 
-  template <typename Arg> struct GaugeLoop : plus<typename Arg::reduce_t>, KernelOps<thread_array<int, 4>> {
+  template <typename Arg> struct GaugeLoop : plus<typename Arg::reduce_t> {
     using reduce_t = typename Arg::reduce_t;
     using plus<reduce_t>::operator();
     static constexpr int reduce_block_dim = 2; // x_cb and parity are mapped to x
     const Arg &arg;
-    template <typename... OpsArgs>
-    constexpr GaugeLoop(const Arg &arg, const OpsArgs &...ops) : KernelOpsT(ops...), arg(arg)
-    {
-    }
+    constexpr GaugeLoop(const Arg &arg) : arg(arg) { }
     static constexpr const char *filename() { return KERNEL_FILE; }
 
     __device__ __host__ inline reduce_t operator()(reduce_t &value, int x_cb, int parity, int path_id)
@@ -73,7 +70,7 @@ namespace quda {
       getCoords(x, x_cb, arg.X, parity);
       for (int dr=0; dr<4; ++dr) x[dr] += arg.border[dr]; // extended grid coordinates
 
-      thread_array<int, 4> dx {*this};
+      byte_array<int8_t, 4> dx = {};
 
       double coeff_loop = arg.factor * arg.p.path_coeff[path_id];
       if (coeff_loop == 0) return operator()(loop_trace, value);

--- a/include/kernels/gauge_plaqrect.cuh
+++ b/include/kernels/gauge_plaqrect.cuh
@@ -4,6 +4,7 @@
 #include <quda_matrix.h>
 #include <index_helper.cuh>
 #include <array.h>
+#include <byte_array.h>
 #include <reduction_kernel.h>
 
 namespace quda
@@ -50,7 +51,7 @@ namespace quda
     // There are 10 unique links to be fetched, with two of the links
     // being common to all three objects.
     double plaq, rect;
-    int dx[4] = {0, 0, 0, 0};
+    byte_array<int8_t, 4> dx = {};
 
     // Accumulate the two common links U_mu(x) and U_nu(x) in U1
     Link U1 = arg.U(mu, linkIndexShift(x, dx, arg.E), parity);                          // U_mu(x)
@@ -92,7 +93,7 @@ namespace quda
     // Sum of the two rectangles
     rect = getTrace(U4 + U3).real();
 
-    return make_double2(plaq, rect);
+    return {plaq, rect};
   }
 
   template <typename Arg> struct PlaquetteRectangle : plus<typename Arg::reduce_t> {
@@ -107,23 +108,20 @@ namespace quda
     __device__ __host__ inline reduce_t operator()(reduce_t &value, int x_cb, int parity)
     {
       reduce_t plaqRect {0, 0, 0, 0};
-      double2 tmp;
       int x[4];
       getCoords(x, x_cb, arg.X, parity);
 #pragma unroll
       for (int dr = 0; dr < 4; ++dr) x[dr] += arg.border[dr]; // extended grid coordinates
 
-#pragma unroll
       for (int mu = 0; mu < 3; mu++) {
-#pragma unroll
         for (int nu = 0; nu < 3; nu++) {
           if (nu >= mu + 1) {
-            tmp = plaquetteRectangle(arg, x, parity, mu, nu);
+            auto tmp = plaquetteRectangle(arg, x, parity, mu, nu);
             plaqRect[0] += tmp.x; // Spatial plaquette
             plaqRect[2] += tmp.y; // Spatial rectangle
           }
         }
-        tmp = plaquetteRectangle(arg, x, parity, mu, 3);
+        auto tmp = plaquetteRectangle(arg, x, parity, mu, 3);
         plaqRect[1] += tmp.x; // Temporal plaquette
         plaqRect[3] += tmp.y; // Temporal rectangle
       }

--- a/include/kernels/gauge_stout.cuh
+++ b/include/kernels/gauge_stout.cuh
@@ -137,7 +137,6 @@ namespace quda
     __device__ __host__ inline void operator()(int x_cb, int parity, int dir)
     {
       using real = typename Arg::real;
-      using Complex = complex<real>;
       using Link = Matrix<complex<real>, Arg::nColor>;
 
       // Compute spacetime and local coords

--- a/include/kernels/gauge_stout.cuh
+++ b/include/kernels/gauge_stout.cuh
@@ -11,26 +11,26 @@
 namespace quda
 {
 
-  template <typename Float_, int nColor_, QudaReconstructType recon_, int stoutDim_> struct STOUTArg : kernel_param<> {
-    using Float = Float_;
+  template <typename store_t, int nColor_, QudaReconstructType recon_, int stoutDim_> struct STOUTArg : kernel_param<> {
+    using real = typename mapper<store_t>::type;
     static constexpr int nColor = nColor_;
     static_assert(nColor == 3, "Only nColor=3 enabled at this time");
     static constexpr QudaReconstructType recon = recon_;
     static constexpr int stoutDim = stoutDim_;
-    typedef typename gauge_mapper<Float, recon>::type Gauge;
+    typedef typename gauge_mapper<store_t, recon>::type Gauge;
 
     Gauge out;
     const Gauge in;
 
     int X[4]; // grid dimensions
     int border[4];
-    const Float rho;
-    const Float staple_coeff;
-    const Float rectangle_coeff;
+    const real rho;
+    const real staple_coeff;
+    const real rectangle_coeff;
     const int dir_ignore;
-    const Float anisotropy;
+    const real anisotropy;
 
-    STOUTArg(GaugeField &out, const GaugeField &in, Float rho, Float epsilon, int dir_ignore, Float anisotropy) :
+    STOUTArg(GaugeField &out, const GaugeField &in, real rho, real epsilon, int dir_ignore, real anisotropy) :
       kernel_param(dim3(1, 2, stoutDim)),
       out(out),
       in(in),
@@ -49,19 +49,17 @@ namespace quda
     }
   };
 
-  template <typename Arg> struct STOUT : computeStapleOps {
-    using real = typename Arg::Float;
-    using Complex = complex<real>;
-    using Link = Matrix<complex<real>, Arg::nColor>;
+  template <typename Arg> struct STOUT {
 
     const Arg &arg;
-    template <typename... OpsArgs> constexpr STOUT(const Arg &arg, const OpsArgs &...ops) : KernelOpsT(ops...), arg(arg)
-    {
-    }
+    constexpr STOUT(const Arg &arg) : arg(arg) { }
     static constexpr const char *filename() { return KERNEL_FILE; }
 
     __device__ __host__ inline void operator()(int x_cb, int parity, int dir)
     {
+      using real = typename Arg::real;
+      using Link = Matrix<complex<real>, Arg::nColor>;
+
       // Compute spacetime and local coords
       int X[4];
       for (int dr = 0; dr < 4; ++dr) X[dr] = arg.X[dr];
@@ -76,7 +74,7 @@ namespace quda
       Link U, Stap, Q;
 
       // This function gets stap = S_{mu,nu} i.e., the staple of length 3,
-      computeStaple(*this, x, X, parity, dir, Stap, arg.dir_ignore, arg.anisotropy);
+      computeStaple(arg, x, X, parity, dir, Stap, arg.dir_ignore, arg.anisotropy);
 
       // Get link U
       U = arg.in(dir, linkIndex(x, X), parity);
@@ -118,18 +116,15 @@ namespace quda
   // Over-Improved routines //
   //------------------------//
   template <typename Arg> struct OvrImpSTOUTOps {
-    using real = typename Arg::Float;
+    using real = typename Arg::real;
     using Complex = complex<real>;
     using Link = Matrix<complex<real>, Arg::nColor>;
-    using StapCacheT = ThreadLocalCache<Link, 0, computeStapleRectangleOps>; // offset by computeStapleRectangleOps
+    using StapCacheT = ThreadLocalCache<Link>;                               // zero offset
     using RectCacheT = ThreadLocalCache<Link, 0, StapCacheT>;                // offset by StapCacheT
-    using Ops = combineOps<computeStapleRectangleOps, KernelOps<StapCacheT, RectCacheT>>;
+    using Ops = KernelOps<StapCacheT, RectCacheT>;
   };
 
   template <typename Arg> struct OvrImpSTOUT : OvrImpSTOUTOps<Arg>::Ops {
-    using real = typename Arg::Float;
-    using Complex = complex<real>;
-    using Link = Matrix<complex<real>, Arg::nColor>;
     using typename OvrImpSTOUTOps<Arg>::Ops::KernelOpsT;
 
     const Arg &arg;
@@ -141,6 +136,10 @@ namespace quda
 
     __device__ __host__ inline void operator()(int x_cb, int parity, int dir)
     {
+      using real = typename Arg::real;
+      using Complex = complex<real>;
+      using Link = Matrix<complex<real>, Arg::nColor>;
+
       // Compute spacetime and local coords
       int X[4];
       for (int dr = 0; dr < 4; ++dr) X[dr] = arg.X[dr];
@@ -159,7 +158,7 @@ namespace quda
       // This function gets stap = S_{mu,nu} i.e., the staple of length 3,
       // and the 1x2 and 2x1 rectangles of length 5. From the following paper:
       // https://arxiv.org/abs/0801.1165
-      computeStapleRectangle(*this, x, X, parity, dir, Stap, Rect, arg.dir_ignore, arg.anisotropy);
+      computeStapleRectangle(arg, x, X, parity, dir, Stap, Rect, arg.dir_ignore, arg.anisotropy);
 
       // Get link U
       U = arg.in(dir, linkIndex(x, X), parity);

--- a/include/kernels/gauge_utils.cuh
+++ b/include/kernels/gauge_utils.cuh
@@ -1,8 +1,7 @@
 #include <gauge_field_order.h>
 #include <index_helper.cuh>
 #include <quda_matrix.h>
-#include <thread_local_cache.h>
-#include <thread_array.h>
+#include <byte_array.h>
 
 namespace quda
 {
@@ -21,19 +20,17 @@ namespace quda
   // => Total number of floating point ops per function call
   // dims * (2*18 + 4*198) = dims*828
   // Note: ops count does not include scalar-matrix mults coming from anisotropy implementation
-  using computeStapleOps = KernelOps<thread_array<int, 4>>;
-  template <typename Ftor, typename Staple, typename Int>
-  __host__ __device__ inline void computeStaple(const Ftor &ftor, const int *x, const Int *X, const int parity,
+  template <typename Arg, typename Staple, typename Int>
+  __host__ __device__ inline void computeStaple(const Arg &arg, const int *x, const Int *X, const int parity,
                                                 const int nu, Staple &staple, const int dir_ignore,
                                                 const double anisotropy = 1.0)
   {
-    const auto &arg = ftor.arg;
     using Link = typename get_type<Staple>::type;
-    using real = typename Ftor::real;
+    using real = typename Arg::real;
     real coeff;
     staple = Link();
 
-    thread_array<int, 4> dx {ftor};
+    byte_array<int8_t, 4> dx = {};
 #pragma unroll
     for (int mu = 0; mu < 4; mu++) {
       // Identify directions orthogonal to the link and
@@ -107,20 +104,18 @@ namespace quda
   // => Total number of floating point ops per function call
   // dims * (8*18 + 28*198) = dims*5688
   // Note: ops count does not include scalar-matrix mults coming from anisotropy implementation
-  using computeStapleRectangleOps = KernelOps<thread_array<int, 4>>;
-  template <typename Ftor, typename Staple, typename Rectangle, typename Int>
-  __host__ __device__ inline void computeStapleRectangle(const Ftor &ftor, const int *x, const Int *X, const int parity,
+  template <typename Arg, typename Staple, typename Rectangle, typename Int>
+  __host__ __device__ inline void computeStapleRectangle(const Arg &arg, const int *x, const Int *X, const int parity,
                                                          const int nu, Staple &staple, Rectangle &rectangle,
                                                          const int dir_ignore, const double anisotropy = 1.0)
   {
-    const auto &arg = ftor.arg;
     using Link = typename get_type<Staple>::type;
-    using real = typename Ftor::real;
+    using real = typename Arg::real;
     real coeff;
     staple = Link();
     rectangle = Link();
 
-    thread_array<int, 4> dx {ftor};
+    byte_array<int8_t, 4> dx = {};
     for (int mu = 0; mu < 4; mu++) { // do not unroll loop to prevent register spilling
       // Identify directions orthogonal to the link.
       // Over-Improved stout is usually done for topological

--- a/include/kernels/gauge_wilson_flow.cuh
+++ b/include/kernels/gauge_wilson_flow.cuh
@@ -9,18 +9,18 @@
 namespace quda
 {
 
-  template <typename Float, int nColor_, QudaReconstructType recon_, int wflow_dim_, QudaGaugeSmearType wflow_type_,
+  template <typename store_t, int nColor_, QudaReconstructType recon_, int wflow_dim_, QudaGaugeSmearType wflow_type_,
             QudaWFlowStepType step_type_>
   struct GaugeWFlowArg : kernel_param<> {
-    using real = typename mapper<Float>::type;
+    using real = typename mapper<store_t>::type;
     static constexpr int nColor = nColor_;
     static_assert(nColor == 3, "Only nColor=3 enabled at this time");
     static constexpr QudaReconstructType recon = recon_;
     static constexpr int wflow_dim = wflow_dim_;
     static constexpr QudaGaugeSmearType wflow_type = wflow_type_;
     static constexpr QudaWFlowStepType step_type = step_type_;
-    typedef typename gauge_mapper<Float, recon>::type Gauge;
-    typedef typename gauge_mapper<Float, QUDA_RECONSTRUCT_NO>::type Matrix; // temp field not on the manifold
+    typedef typename gauge_mapper<store_t, recon>::type Gauge;
+    typedef typename gauge_mapper<store_t, QUDA_RECONSTRUCT_NO>::type Matrix; // temp field not on the manifold
 
     Gauge out;
     Matrix temp;
@@ -55,10 +55,10 @@ namespace quda
   template <typename Arg> struct computeStapleOpsWF {
     using real = typename Arg::real;
     using Link = Matrix<complex<real>, Arg::nColor>;
-    using WilsonOps = computeStapleOps;                                  // Ops for case of QUDA_GAUGE_SMEAR_WILSON_FLOW
-    using StapOp = ThreadLocalCache<Link, 0, computeStapleRectangleOps>; // offset by computeStapleRectangleOps
-    using RectOp = ThreadLocalCache<Link, 0, StapOp>;                    // offset by StapOp
-    using SymanzikOps = combineOps<computeStapleRectangleOps, KernelOps<StapOp, RectOp>>; // GAUGE_SMEAR_SYMANZIK_FLOW
+    using WilsonOps = NoKernelOps;                    // Ops for case of QUDA_GAUGE_SMEAR_WILSON_FLOW
+    using StapOp = ThreadLocalCache<Link>;            // zero offset
+    using RectOp = ThreadLocalCache<Link, 0, StapOp>; // offset by StapOp
+    using SymanzikOps = KernelOps<StapOp, RectOp>;    // GAUGE_SMEAR_SYMANZIK_FLOW
     using Ops = std::conditional_t<Arg::wflow_type == QUDA_GAUGE_SMEAR_SYMANZIK_FLOW, SymanzikOps, WilsonOps>;
   };
 
@@ -74,14 +74,14 @@ namespace quda
     static_assert(Arg::wflow_type == QUDA_GAUGE_SMEAR_WILSON_FLOW || Arg::wflow_type == QUDA_GAUGE_SMEAR_SYMANZIK_FLOW);
     if constexpr (Arg::wflow_type == QUDA_GAUGE_SMEAR_WILSON_FLOW) {
       // This function gets stap = S_{mu,nu} i.e., the staple of length 3,
-      computeStaple(ftor, x, arg.E, parity, dir, Z, Arg::wflow_dim, arg.anisotropy);
+      computeStaple(arg, x, arg.E, parity, dir, Z, Arg::wflow_dim, arg.anisotropy);
     } else if constexpr (Arg::wflow_type == QUDA_GAUGE_SMEAR_SYMANZIK_FLOW) {
       // This function gets stap = S_{mu,nu} i.e., the staple of length 3,
       // and the 1x2 and 2x1 rectangles of length 5. From the following paper:
       // https://arxiv.org/abs/0801.1165
       typename computeStapleOpsWF<Arg>::StapOp Stap {ftor};
       typename computeStapleOpsWF<Arg>::RectOp Rect {ftor};
-      computeStapleRectangle(ftor, x, arg.E, parity, dir, Stap, Rect, Arg::wflow_dim, arg.anisotropy);
+      computeStapleRectangle(arg, x, arg.E, parity, dir, Stap, Rect, Arg::wflow_dim, arg.anisotropy);
       Z = arg.coeff1x1 * static_cast<const Link &>(Stap) + arg.coeff2x1 * static_cast<const Link &>(Rect);
     }
     return Z;

--- a/include/kernels/llfat.cuh
+++ b/include/kernels/llfat.cuh
@@ -4,6 +4,7 @@
 #include <gauge_field_order.h>
 #include <fast_intdiv.h>
 #include <kernel.h>
+#include <byte_array.h>
 
 namespace quda {
 
@@ -160,11 +161,12 @@ namespace quda {
     }
   };
 
-  template <int mu, int nu, typename Arg>
-  __device__ inline void computeStaple(Matrix<complex<typename Arg::Float>, Arg::nColor> &staple, const Arg &arg, int x[], int parity)
+  template <typename Arg>
+  __device__ inline void computeStaple(Matrix<complex<typename Arg::Float>, Arg::nColor> &staple, const Arg &arg,
+                                       int x[], int parity, int mu, int nu)
   {
     using Link = Matrix<complex<typename Arg::Float>, Arg::nColor>;
-    int dx[4] = {0, 0, 0, 0};
+    byte_array<int8_t, 4> dx = {};
 
     /* Computes the upper staple :
      *                 mu (B)
@@ -236,32 +238,7 @@ namespace quda {
 
       using Link = Matrix<complex<typename Arg::Float>, Arg::nColor>;
       Link staple;
-      switch (mu) {
-      case 0:
-        switch (arg.nu) {
-        case 1: computeStaple<0,1>(staple, arg, x, parity); break;
-        case 2: computeStaple<0,2>(staple, arg, x, parity); break;
-        case 3: computeStaple<0,3>(staple, arg, x, parity); break;
-        } break;
-      case 1:
-        switch (arg.nu) {
-        case 0: computeStaple<1,0>(staple, arg, x, parity); break;
-        case 2: computeStaple<1,2>(staple, arg, x, parity); break;
-        case 3: computeStaple<1,3>(staple, arg, x, parity); break;
-        } break;
-      case 2:
-        switch (arg.nu) {
-        case 0: computeStaple<2,0>(staple, arg, x, parity); break;
-        case 1: computeStaple<2,1>(staple, arg, x, parity); break;
-        case 3: computeStaple<2,3>(staple, arg, x, parity); break;
-      } break;
-      case 3:
-        switch (arg.nu) {
-        case 0: computeStaple<3,0>(staple, arg, x, parity); break;
-        case 1: computeStaple<3,1>(staple, arg, x, parity); break;
-        case 2: computeStaple<3,2>(staple, arg, x, parity); break;
-        } break;
-      }
+      computeStaple(staple, arg, x, parity, mu, arg.nu);
 
       // exclude inner halo
       if ( !(x[0] < arg.inner_border[0] || x[0] >= arg.inner_X[0] + arg.inner_border[0] ||

--- a/lib/clover_deriv_quda.cu
+++ b/lib/clover_deriv_quda.cu
@@ -13,7 +13,6 @@ namespace quda {
     const GaugeField &oprod;
     double coeff;
     unsigned int minThreads() const override { return gauge.LocalVolumeCB(); }
-    unsigned int sharedBytesPerThread() const override { return 4 * sizeof(int); } // for thread_array
 
   public:
     DerivativeClover(const GaugeField &gauge, GaugeField &force, const GaugeField &oprod, double coeff) :

--- a/lib/gauge_ape.cu
+++ b/lib/gauge_ape.cu
@@ -15,7 +15,6 @@ namespace quda {
     const Float anisotropy;
     const int apeDim;
     unsigned int minThreads() const { return in.LocalVolumeCB(); }
-    unsigned int sharedBytesPerThread() const { return 4 * sizeof(int); } // for thread_array
 
   public:
     // (2,3/4): 2 for parity in the y thread dim, 3 or 4 corresponds to mapping direction to the z thread dim

--- a/lib/gauge_field_strength_tensor.cu
+++ b/lib/gauge_field_strength_tensor.cu
@@ -11,7 +11,6 @@ namespace quda
     GaugeField &f;
     const GaugeField &u;
     unsigned int minThreads() const { return f.VolumeCB(); }
-    unsigned int sharedBytesPerThread() const { return 4 * sizeof(int); } // for thread_array
 
   public:
     Fmunu(const GaugeField &u, GaugeField &f) :

--- a/lib/gauge_force.cu
+++ b/lib/gauge_force.cu
@@ -12,7 +12,6 @@ namespace quda {
     double epsilon;
     const paths<4> &p;
     unsigned int minThreads() const { return mom.VolumeCB(); }
-    unsigned int sharedBytesPerThread() const { return 4 * sizeof(int); } // for thread_array
 
   public:
     ForceGauge(const GaugeField &u, GaugeField &mom, double epsilon, const paths<4> &p) :

--- a/lib/gauge_hyp.cu
+++ b/lib/gauge_hyp.cu
@@ -17,7 +17,6 @@ namespace quda
     const int dir_ignore;
     const int hypDim;
     unsigned int minThreads() const { return in.LocalVolumeCB(); }
-    unsigned int sharedBytesPerThread() const { return 4 * sizeof(int); } // for thread_array
 
   public:
     // (2,3/4): 2 for parity in the y thread dim, 3 or 4 corresponds to mapping direction to the z thread dim

--- a/lib/gauge_loop_trace.cu
+++ b/lib/gauge_loop_trace.cu
@@ -13,7 +13,6 @@ namespace quda {
     std::vector<reduce_t>& loop_traces;
     double factor;
     const paths<1> p;
-    unsigned int sharedBytesPerThread() const override { return 4 * sizeof(int); } // for thread_array
 
   public:
     // max block size of 8 is arbitrary for now

--- a/lib/gauge_stout.cu
+++ b/lib/gauge_stout.cu
@@ -22,8 +22,7 @@ namespace quda
     unsigned int sharedBytesPerThread() const
     {
       // use ThreadLocalCache if using over improvement for two link fields
-      return (improved ? 2 * in.Ncolor() * in.Ncolor() * 2 * sizeof(typename mapper<Float>::type) : 0)
-        + 4 * sizeof(int); // for thread_array
+      return improved ? 2 * in.Ncolor() * in.Ncolor() * 2 * sizeof(typename mapper<Float>::type) : 0;
     }
 
   public:

--- a/lib/gauge_wilson_flow.cu
+++ b/lib/gauge_wilson_flow.cu
@@ -29,10 +29,9 @@ namespace quda
     unsigned int sharedBytesPerThread() const
     {
       // use ThreadLocalCache if using Symanzik improvement for two Link fields
-      return (wflow_type == QUDA_GAUGE_SMEAR_SYMANZIK_FLOW ?
-                2 * in.Ncolor() * in.Ncolor() * 2 * sizeof(typename mapper<Float>::type) :
-                0)
-        + 4 * sizeof(int); // for thread_array
+      return wflow_type == QUDA_GAUGE_SMEAR_SYMANZIK_FLOW ?
+        2 * in.Ncolor() * in.Ncolor() * 2 * sizeof(typename mapper<Float>::type) :
+        0;
     }
 
   public:

--- a/lib/llfat_quda.cu
+++ b/lib/llfat_quda.cu
@@ -15,7 +15,6 @@ namespace quda {
   class LongLink : public TunableKernel3D {
     LinkArg<Float, nColor, recon> arg;
     unsigned int minThreads() const { return arg.threads.x; }
-    unsigned int sharedBytesPerThread() const { return 4 * sizeof(int); } // for thread_array
 
   public:
     LongLink(const GaugeField &u, GaugeField &lng, double coeff) :


### PR DESCRIPTION
Small feature PR that adds a new class `byte_array` which is an indexable array type for 8-bit types (signed / unsigned chars) of length 8.  This is useful, as it's exactly what we use for the various kernels that do path tracing around the links of the lattice.

With this class, we can use it instead of `thread_array`, the advantages of `byte_array` being that it is lower latency, and does not consume any shared memory.  E.g., saving more L1 cache which can be helpful for performance.  On the kernels I tested, I saw either performance neutrality or a perf uplift.

Also included here:
* Remove use of KernelOps where possible due to removal of shared-memory storage from using `byte_array` instead of `thread_array`
* Fix stack frame induced in `DeGrandRossi` contraction kernel (was due to some run-time indexing)
* Fix stack frame induced in pure-gauge heath bath kernel (was due to run-time indexing in local array)
* Fix stack frame in plaquette rectangle action (run-time indexing and running out of registers)