### PR TITLE
Use newer hipblas API from v3 onwards

### DIFF
--- a/lib/targets/hip/blas_lapack_hipblas.cpp
+++ b/lib/targets/hip/blas_lapack_hipblas.cpp
@@ -162,7 +162,12 @@ namespace quda
           pool_pinned_free(A_h);
 #endif
         } else if (prec == QUDA_DOUBLE_PRECISION) {
+#if hipblasVersionMajor >= 3
+          typedef hipDoubleComplex Z;
+#else
+          // The hipblas v1 interface, deprecated in v2, and removed in v3
           typedef hipblasDoubleComplex Z;
+#endif
           Z **A_array = static_cast<Z **>(pool_device_malloc(2 * batch * sizeof(Z *)));
           Z **Ainv_array = A_array + batch;
           Z **A_array_h = static_cast<Z **>(pool_pinned_malloc(2 * batch * sizeof(Z *)));
@@ -406,7 +411,12 @@ namespace quda
         //-------------------------------------------------------------------------
         if (blas_param.data_type == QUDA_BLAS_DATATYPE_Z) {
 
+#if hipblasVersionMajor >= 3
+          typedef hipDoubleComplex Z;
+#else
+          // The hipblas v1 interface, deprecated in v2, and removed in v3
           typedef hipblasDoubleComplex Z;
+#endif
           const std::complex<double> al = static_cast<const std::complex<double>>(blas_param.alpha);
           const std::complex<double> be = static_cast<const std::complex<double>>(blas_param.beta);
 


### PR DESCRIPTION
The hipblasComplexDouble type is the old hipblas v1 interface.  It was deprecated in v2 (ROCm 6.x), but still usable, and in v3 (ROCm 7.x) it disappears completely in favour of hipComplexDouble.

The hipblas function interfaces followed suit.  QUDA never bothered trying to use the newer v2 interface, but it has no choice for v3, so now QUDA understands the new interface for new enough hipblas libraries and does so with the intention of not breaking existing users that, for a variety of reasons, may be using much older ROCm software stacks.

The documentation for the deprecated interface is here: https://rocm.docs.amd.com/projects/hipBLAS/en/docs-6.4.1/reference/hipblas-api-functions.html#hipblas-v2-and-deprecations