### PR TITLE
Properly init gauge field in su3_fermion test

### DIFF
--- a/tests/su3_fermion_test.cpp
+++ b/tests/su3_fermion_test.cpp
@@ -49,6 +49,11 @@ void run(test_t param)
 
   constructHostGaugeField(gauge, gauge_param, argc_copy, argv_copy);
   // Load the gauge field to the device
+  gauge_param.cuda_prec = prec;
+  gauge_param.cuda_prec_sloppy = prec;
+  gauge_param.cuda_prec_precondition = prec;
+  gauge_param.cuda_prec_refinement_sloppy = prec;
+  gauge_param.cuda_prec_eigensolver = prec;
   loadGaugeQuda((void *)gauge, &gauge_param);
   saveGaugeQuda(new_gauge, &gauge_param);
   // start the timer


### PR DESCRIPTION
Fixes an erroneous test failure that complains when QUDA is only built with double precision support, for example.