### PR TITLE
Use newer hipblas API from v3 onwards: float version

### DIFF
--- a/lib/targets/hip/blas_lapack_hipblas.cpp
+++ b/lib/targets/hip/blas_lapack_hipblas.cpp
@@ -105,7 +105,12 @@ namespace quda
         memset(info_array, '0', batch * sizeof(int)); // silence memcheck warnings
 
         if (prec == QUDA_SINGLE_PRECISION) {
+#if hipblasVersionMajor >= 3
+          typedef hipComplex C;
+#else
+          // The hipblas v1 interface, deprecated in v2, and removed in v3
           typedef hipblasComplex C;
+#endif
           C **A_array = static_cast<C **>(pool_device_malloc(2 * batch * sizeof(C *)));
           C **Ainv_array = A_array + batch;
           C **A_array_h = static_cast<C **>(pool_pinned_malloc(2 * batch * sizeof(C *)));
@@ -442,7 +447,12 @@ namespace quda
           flops += batch * FLOPS_CGEMM(blas_param.m, blas_param.n, blas_param.k);
         } else if (blas_param.data_type == QUDA_BLAS_DATATYPE_C) {
 
+#if hipblasVersionMajor >= 3
+          typedef hipComplex C;
+#else
+          // The hipblas v1 interface, deprecated in v2, and removed in v3
           typedef hipblasComplex C;
+#endif
 
           const std::complex<float> al = static_cast<const std::complex<float>>(blas_param.alpha);
           const std::complex<float> be = static_cast<const std::complex<float>>(blas_param.beta);


### PR DESCRIPTION
I already addressed the double precision types.  This commit addresses the single precision types which I had forgotten about.

The hipblasComplex type is the old hipblas v1 interface.  It was deprecated in v2 (ROCm 6.x), but still usable, and in v3 (ROCm 7.x) it disappears completely in favour of hipComplex.

The hipblas function interfaces followed suit.  QUDA never bothered trying to use the newer v2 interface, but it has no choice for v3, so now QUDA understands the new interface for new enough hipblas libraries and does so with the intention of not breaking existing users that, for a variety of reasons, may be using much older ROCm software stacks.

The documentation for the deprecated interface is here: https://rocm.docs.amd.com/projects/hipBLAS/en/docs-6.4.1/reference/hipblas-api-functions.html#hipblas-v2-and-deprecations