### PR TITLE
Use constexpr logic for constexpr warp_size function

### DIFF
--- a/include/targets/hip/target_device.h
+++ b/include/targets/hip/target_device.h
@@ -144,7 +144,13 @@ namespace quda
        @brief Helper function that returns the warp-size of the
        architecture we are running on.
     */
-    constexpr int warp_size() { return warpSize; }
+    constexpr int warp_size() {
+      #if defined(__GFX9__)
+      return 64;
+      #else
+      return 32;
+      #endif
+    }
 
     /**
        @brief Return the thread mask for a converged warp.


### PR DESCRIPTION
In ROCm 7.0, the warpSize variable is losing its constexpr-ness.  This commit replaces the variable use with the correct values based on the architecture we're running on.

Thanks to Ioannis Assiouras for the fix.

Edit: the documentation for the deprecation is [here](https://rocm.docs.amd.com/en/docs-6.4.0/about/release-notes.html#amdgpu-wavefront-size-compiler-macro-deprecation).