### PR TITLE
Hotfix/iram monitor covdev

### DIFF
--- a/lib/covariant_derivative.cu
+++ b/lib/covariant_derivative.cu
@@ -40,9 +40,10 @@ namespace quda
       if (arg.xpay) errorQuda("Covariant derivative operator only defined without xpay");
       if (arg.nParity != 2) errorQuda("Covariant derivative operator only defined for full field");
 
+      constexpr bool dagger = false;
       constexpr bool xpay = false;
       constexpr int nParity = 2;
-      Dslash::template instantiate<packStaggeredShmem, nParity, xpay>(tp, stream);
+      Dslash::template instantiate<packStaggeredShmem, nParity, xpay, dagger>(tp, stream);
     }
 
     long long flops() const override

--- a/lib/eig_iram.cpp
+++ b/lib/eig_iram.cpp
@@ -38,6 +38,7 @@ namespace quda
                   "if instability is observed (eig_tol = %e, qr_tol = %e)",
                   tol, qr_tol);
     }
+    if (qr_tol < 5e-15) qr_tol = 5e-15;
     getProfile().TPSTOP(QUDA_PROFILE_INIT);
   }
 

--- a/lib/eig_iram.cpp
+++ b/lib/eig_iram.cpp
@@ -38,7 +38,6 @@ namespace quda
                   "if instability is observed (eig_tol = %e, qr_tol = %e)",
                   tol, qr_tol);
     }
-    if (qr_tol < 5e-15) qr_tol = 5e-15;
     getProfile().TPSTOP(QUDA_PROFILE_INIT);
   }
 

--- a/lib/gauge_covdev.cpp
+++ b/lib/gauge_covdev.cpp
@@ -39,9 +39,8 @@ namespace quda {
   void GaugeCovDev::MdagMCD(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in, const int mu) const
   {
     auto tmp = getFieldTmp(out);
-
     MCD(tmp, in, mu);
-    MCD(out, tmp, (mu+4)%8);
+    MCD(out, tmp, (mu + 4) % 8);
   }
 
   void GaugeCovDev::Dslash(cvector_ref<ColorSpinorField> &out, cvector_ref<const ColorSpinorField> &in,

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -1916,7 +1916,7 @@ void dslashQuda(void *h_out, void *h_in, QudaInvertParam *inv_param, QudaParity 
 void shiftQuda(void *h_out, void *h_in, int dir, int sym, QudaInvertParam *param)
 {
   auto profile = pushProfile(profileCovDev, param);
-  const auto &gauge = *gaugePrecise; //(inv_param->dslash_type != QUDA_ASQTAD_DSLASH) ? *gaugePrecise : *gaugeFatPrecise;
+  const auto &gauge = *gaugePrecise;
 
   QudaInvertParam &inv_param = *param;
 
@@ -1945,12 +1945,7 @@ void shiftQuda(void *h_out, void *h_in, int dir, int sym, QudaInvertParam *param
   tmp = in;
 
   profileCovDev.TPSTART(QUDA_PROFILE_COMPUTE);
-
-  if (getVerbosity() >= QUDA_DEBUG_VERBOSE) {
-    double cpu = blas::norm2(in_h);
-    double gpu = blas::norm2(in);
-    printfQuda("In CPU %e CUDA %e\n", cpu, gpu);
-  }
+  logQuda(QUDA_DEBUG_VERBOSE, "In CPU %e CUDA %e\n", blas::norm2(in_h), blas::norm2(in));
 
   inv_param.dslash_type = QUDA_COVDEV_DSLASH; // ensure we use the correct dslash
   DiracParam diracParam;
@@ -1973,19 +1968,14 @@ void shiftQuda(void *h_out, void *h_in, int dir, int sym, QudaInvertParam *param
 
   out_h = out;
 
-  if (getVerbosity() >= QUDA_DEBUG_VERBOSE) {
-    double cpu = blas::norm2(out_h);
-    double gpu = blas::norm2(out);
-    printfQuda("Out CPU %e CUDA %e\n", cpu, gpu);
-  }
-
+  logQuda(QUDA_DEBUG_VERBOSE, "Out CPU %e CUDA %e\n", blas::norm2(out_h), blas::norm2(out));
   popVerbosity();
 }
 
 void spinTasteQuda(void *h_out, void *h_in, int spin_, int taste, QudaInvertParam *param)
 {
   auto profile = pushProfile(profileCovDev, param);
-  const auto &gauge = *gaugePrecise; //(inv_param->dslash_type != QUDA_ASQTAD_DSLASH) ? *gaugePrecise : *gaugeFatPrecise;
+  const auto &gauge = *gaugePrecise;
 
   QudaInvertParam &inv_param = *param;
 
@@ -2014,11 +2004,7 @@ void spinTasteQuda(void *h_out, void *h_in, int spin_, int taste, QudaInvertPara
 
   profileCovDev.TPSTART(QUDA_PROFILE_COMPUTE);
 
-  if (getVerbosity() >= QUDA_DEBUG_VERBOSE) {
-    double cpu = blas::norm2(in_h);
-    double gpu = blas::norm2(in);
-    printfQuda("In CPU %e CUDA %e\n", cpu, gpu);
-  }
+  logQuda(QUDA_DEBUG_VERBOSE, "In CPU %e CUDA %e\n", blas::norm2(in_h), blas::norm2(in));
 
   inv_param.dslash_type = QUDA_COVDEV_DSLASH; // ensure we use the correct dslash
   DiracParam diracParam;
@@ -2283,12 +2269,7 @@ void spinTasteQuda(void *h_out, void *h_in, int spin_, int taste, QudaInvertPara
 
   out_h = out;
 
-  if (getVerbosity() >= QUDA_DEBUG_VERBOSE) {
-    double cpu = blas::norm2(out_h);
-    double gpu = blas::norm2(out);
-    printfQuda("Out CPU %e CUDA %e\n", cpu, gpu);
-  }
-
+  logQuda(QUDA_DEBUG_VERBOSE, "Out CPU %e CUDA %e\n", blas::norm2(out_h), blas::norm2(out));
   popVerbosity();
 }
 

--- a/lib/targets/cuda/device.cpp
+++ b/lib/targets/cuda/device.cpp
@@ -117,7 +117,9 @@ namespace quda
 
       device_id = dev;
 
-      NVML_CHECK(nvmlDeviceGetHandleByIndex(device_id, &monitor_device_id));
+      char pciBusId[13];
+      CHECK_CUDA_ERROR(cudaDeviceGetPCIBusId(pciBusId, 13, device_id));
+      NVML_CHECK(nvmlDeviceGetHandleByPciBusId(pciBusId, &monitor_device_id));
       char name[NVML_DEVICE_NAME_BUFFER_SIZE];
       NVML_CHECK(nvmlDeviceGetName(monitor_device_id, name, NVML_DEVICE_NAME_BUFFER_SIZE));
 

--- a/lib/targets/cuda/device.cpp
+++ b/lib/targets/cuda/device.cpp
@@ -123,7 +123,7 @@ namespace quda
       char name[NVML_DEVICE_NAME_BUFFER_SIZE];
       NVML_CHECK(nvmlDeviceGetName(monitor_device_id, name, NVML_DEVICE_NAME_BUFFER_SIZE));
 
-      printfQuda("Initializing monitoring on device %d: %s\n", device_id, name);
+      printf("Initializing monitoring on device %d with pciBusId %s: %s\n", device_id, pciBusId, name);
       monitor::init();
     }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1118,7 +1118,7 @@ foreach(pol IN LISTS DSLASH_POLICIES)
   if(QUDA_DIRAC_COVDEV)
     add_test(NAME covdev_policy${pol2}
              COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:covdev_test> ${MPIEXEC_POSTFLAGS}
-                     --dim 6 8 10 12
+                     --dim 6 8 10 12 --enable-testing true
                      --gtest_output=xml:covdev_test_pol${pol2}.xml)
   endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1573,7 +1573,7 @@ if(QUDA_DIRAC_STAGGERED)
     add_test(NAME eigensolve_test_laplace
       COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:staggered_eigensolve_test> ${MPIEXEC_POSTFLAGS}
       --dslash-type laplace --compute-fat-long true
-      --dim 2 4 6 8 --eig-n-conv 24 --eig-n-ev 24 --eig-n-kr 96
+      --dim 2 4 6 8 --eig-n-conv 24 --eig-n-ev 24 --eig-n-kr 72
       --eig-max-restarts 1000
       --enable-testing true
       --gtest_output=xml:staggered_eigensolve_test_laplace.xml)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1392,7 +1392,7 @@ endif()
 if(QUDA_DIRAC_WILSON)    
   add_test(NAME eigensolve_test_wilson
     COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:eigensolve_test> ${MPIEXEC_POSTFLAGS}
-    --dslash-type wilson --eig-n-conv 24 --eig-n-ev 24 --eig-n-kr 72
+    --dslash-type wilson --eig-n-conv 16 --eig-n-ev 16 --eig-n-kr 48
     --dim 2 4 6 8 --eig-max-restarts 1000
     --enable-testing true 
     --gtest_output=xml:eigensolve_test_wilson.xml)
@@ -1401,14 +1401,14 @@ endif()
 if(QUDA_DIRAC_TWISTED_MASS)
   add_test(NAME eigensolve_test_twisted_mass_sym
     COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:eigensolve_test> ${MPIEXEC_POSTFLAGS}
-    --dslash-type twisted-mass --eig-n-conv 24 --eig-n-ev 24 --eig-n-kr 72
+    --dslash-type twisted-mass --eig-n-conv 16 --eig-n-ev 16 --eig-n-kr 48
     --dim 2 4 6 8 --eig-max-restarts 1000
     --matpc even-even --enable-testing true
     --gtest_output=xml:eigensolve_test_twisted_mass_sym.xml)
     
   add_test(NAME eigensolve_test_twisted_mass_asym
     COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:eigensolve_test> ${MPIEXEC_POSTFLAGS}
-    --dslash-type twisted-mass --eig-n-conv 24 --eig-n-ev 24 --eig-n-kr 72
+    --dslash-type twisted-mass --eig-n-conv 16 --eig-n-ev 16 --eig-n-kr 48
     --dim 2 4 6 8 --eig-max-restarts 1000
     --matpc even-even-asym --enable-testing true 
     --gtest_output=xml:eigensolve_test_twisted_mass_asym.xml)
@@ -1417,7 +1417,7 @@ endif()
 if(QUDA_DIRAC_TWISTED_MASS)
   add_test(NAME eigensolve_test_ndeg_twisted_mass_sym
     COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:eigensolve_test> ${MPIEXEC_POSTFLAGS}
-    --dslash-type twisted-mass --eig-n-conv 24 --eig-n-ev 24 --eig-n-kr 72
+    --dslash-type twisted-mass --eig-n-conv 16 --eig-n-ev 16 --eig-n-kr 48
     --dim 2 4 6 8 --eig-max-restarts 1000
     --matpc even-even --flavor nondeg-doublet 
     --enable-testing true --eig-use-eigen-qr false
@@ -1425,7 +1425,7 @@ if(QUDA_DIRAC_TWISTED_MASS)
 
   add_test(NAME eigensolve_test_ndeg_twisted_mass_asym
     COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:eigensolve_test> ${MPIEXEC_POSTFLAGS}
-    --dslash-type twisted-mass --eig-n-conv 24 --eig-n-ev 24 --eig-n-kr 72
+    --dslash-type twisted-mass --eig-n-conv 16 --eig-n-ev 16 --eig-n-kr 48
     --dim 2 4 6 8 --eig-max-restarts 1000
     --matpc even-even-asym --flavor nondeg-doublet
     --enable-testing true --eig-use-eigen-qr false
@@ -1436,7 +1436,7 @@ if(QUDA_DIRAC_CLOVER)
   add_test(NAME eigensolve_test_clover_sym
     COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:eigensolve_test> ${MPIEXEC_POSTFLAGS}
     --dslash-type clover --compute-clover true      
-    --dim 2 4 6 8 --eig-n-conv 24 --eig-n-ev 24 --eig-n-kr 72
+    --dim 2 4 6 8 --eig-n-conv 16 --eig-n-ev 16 --eig-n-kr 48
     --eig-max-restarts 1000
     --matpc even-even --enable-testing true 
     --gtest_output=xml:eigensolve_test_clover_sym.xml)
@@ -1444,7 +1444,7 @@ if(QUDA_DIRAC_CLOVER)
   add_test(NAME eigensolve_test_clover_asym
     COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:eigensolve_test> ${MPIEXEC_POSTFLAGS}
     --dslash-type clover --compute-clover true      
-    --dim 2 4 6 8 --eig-n-conv 24 --eig-n-ev 24 --eig-n-kr 72
+    --dim 2 4 6 8 --eig-n-conv 16 --eig-n-ev 16 --eig-n-kr 48
     --eig-max-restarts 1000
     --matpc even-even-asym --enable-testing true
     --gtest_output=xml:eigensolve_test_clover_asym.xml)
@@ -1454,7 +1454,7 @@ if(QUDA_DIRAC_TWISTED_CLOVER)
   add_test(NAME eigensolve_test_twisted_clover_sym
     COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:eigensolve_test> ${MPIEXEC_POSTFLAGS}
     --dslash-type twisted-clover --compute-clover true
-    --dim 2 4 6 8 --eig-n-conv 24 --eig-n-ev 24 --eig-n-kr 72
+    --dim 2 4 6 8 --eig-n-conv 16 --eig-n-ev 16 --eig-n-kr 48
     --eig-max-restarts 1000
     --matpc even-even --enable-testing true 
     --gtest_output=xml:eigensolve_test_twisted_clover_sym.xml)
@@ -1462,7 +1462,7 @@ if(QUDA_DIRAC_TWISTED_CLOVER)
   add_test(NAME eigensolve_test_twisted_clover_asym      
     COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:eigensolve_test> ${MPIEXEC_POSTFLAGS}
     --dslash-type twisted-clover --compute-clover true
-    --dim 2 4 6 8 --eig-n-conv 24 --eig-n-ev 24 --eig-n-kr 72
+    --dim 2 4 6 8 --eig-n-conv 16 --eig-n-ev 16 --eig-n-kr 48
     --eig-max-restarts 1000
     --matpc even-even-asym --enable-testing true 
     --gtest_output=xml:eigensolve_test_twisted_clover_asym.xml)
@@ -1472,7 +1472,7 @@ if(QUDA_DIRAC_TWISTED_CLOVER)
   add_test(NAME eigensolve_test_ndeg_twisted_clover_sym
     COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:eigensolve_test> ${MPIEXEC_POSTFLAGS}
     --dslash-type twisted-clover --compute-clover true
-    --dim 2 4 6 8 --eig-n-conv 24 --eig-n-ev 24 --eig-n-kr 72
+    --dim 2 4 6 8 --eig-n-conv 16 --eig-n-ev 16 --eig-n-kr 48
     --eig-max-restarts 1000
     --matpc even-even --flavor nondeg-doublet
     --enable-testing true 
@@ -1481,7 +1481,7 @@ if(QUDA_DIRAC_TWISTED_CLOVER)
   add_test(NAME eigensolve_test_ndeg_twisted_clover_asym
     COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:eigensolve_test> ${MPIEXEC_POSTFLAGS}
     --dslash-type twisted-clover --compute-clover true
-    --dim 2 4 6 8 --eig-n-conv 24 --eig-n-ev 24 --eig-n-kr 72
+    --dim 2 4 6 8 --eig-n-conv 16 --eig-n-ev 16 --eig-n-kr 48
     --eig-max-restarts 1000
     --matpc even-even-asym --flavor nondeg-doublet
     --enable-testing true 
@@ -1492,7 +1492,7 @@ if(QUDA_DIRAC_DOMAIN_WALL)
   add_test(NAME eigensolve_test_domain_wall
     COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:eigensolve_test> ${MPIEXEC_POSTFLAGS}
     --dslash-type domain-wall
-    --dim 2 4 6 8 --Lsdim 4 --eig-n-conv 24 --eig-n-ev 24 --eig-n-kr 72
+    --dim 2 4 6 8 --Lsdim 4 --eig-n-conv 16 --eig-n-ev 16 --eig-n-kr 48
     --eig-max-restarts 1000
     --matpc even-even --enable-testing true
     --gtest_output=xml:eigensolve_test_domain_wall.xml)
@@ -1500,7 +1500,7 @@ if(QUDA_DIRAC_DOMAIN_WALL)
   add_test(NAME eigensolve_test_domain_wall_4d_sym
     COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:eigensolve_test> ${MPIEXEC_POSTFLAGS}
     --dslash-type domain-wall-4d
-    --dim 2 4 6 8 --Lsdim 4 --eig-n-conv 24 --eig-n-ev 24 --eig-n-kr 72
+    --dim 2 4 6 8 --Lsdim 4 --eig-n-conv 16 --eig-n-ev 16 --eig-n-kr 48
     --eig-max-restarts 1000
     --matpc even-even --enable-testing true
     --gtest_output=xml:eigensolve_test_domain_wall_4d_sym.xml)
@@ -1508,7 +1508,7 @@ if(QUDA_DIRAC_DOMAIN_WALL)
   add_test(NAME eigensolve_test_domain_wall_4d_asym
     COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:eigensolve_test> ${MPIEXEC_POSTFLAGS}
     --dslash-type domain-wall-4d
-    --dim 2 4 6 8 --Lsdim 4 --eig-n-conv 24 --eig-n-ev 24 --eig-n-kr 72
+    --dim 2 4 6 8 --Lsdim 4 --eig-n-conv 16 --eig-n-ev 16 --eig-n-kr 48
     --eig-max-restarts 1000
     --matpc even-even-asym --enable-testing true
     --gtest_output=xml:eigensolve_test_domain_wall_4d_asym.xml)
@@ -1516,7 +1516,7 @@ if(QUDA_DIRAC_DOMAIN_WALL)
   add_test(NAME eigensolve_test_mobius_sym
     COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:eigensolve_test> ${MPIEXEC_POSTFLAGS}
     --dslash-type mobius
-    --dim 2 4 6 8 --Lsdim 4 --eig-n-conv 24 --eig-n-ev 24 --eig-n-kr 72
+    --dim 2 4 6 8 --Lsdim 4 --eig-n-conv 16 --eig-n-ev 16 --eig-n-kr 48
     --eig-max-restarts 1000
     --matpc even-even --enable-testing true
     --gtest_output=xml:eigensolve_test_mobius_sym.xml)
@@ -1524,7 +1524,7 @@ if(QUDA_DIRAC_DOMAIN_WALL)
   add_test(NAME eigensolve_test_mobius_asym
     COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:eigensolve_test> ${MPIEXEC_POSTFLAGS}
     --dslash-type mobius
-    --dim 2 4 6 8 --Lsdim 4 --eig-n-conv 24 --eig-n-ev 24 --eig-n-kr 72
+    --dim 2 4 6 8 --Lsdim 4 --eig-n-conv 16 --eig-n-ev 16 --eig-n-kr 48
     --eig-max-restarts 1000
     --matpc even-even-asym --enable-testing true
     --gtest_output=xml:eigensolve_test_mobius_asym.xml)
@@ -1532,7 +1532,7 @@ if(QUDA_DIRAC_DOMAIN_WALL)
   add_test(NAME eigensolve_test_mobius_eofa_sym
     COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:eigensolve_test> ${MPIEXEC_POSTFLAGS}
     --dslash-type mobius-eofa
-    --dim 2 4 6 8 --Lsdim 4 --eig-n-conv 24 --eig-n-ev 24 --eig-n-kr 72
+    --dim 2 4 6 8 --Lsdim 4 --eig-n-conv 16 --eig-n-ev 16 --eig-n-kr 48
     --eig-max-restarts 1000
     --matpc even-even --enable-testing true
     --gtest_output=xml:eigensolve_test_mobius_eofa_sym.xml)
@@ -1540,7 +1540,7 @@ if(QUDA_DIRAC_DOMAIN_WALL)
   add_test(NAME eigensolve_test_mobius_eofa_asym
     COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:eigensolve_test> ${MPIEXEC_POSTFLAGS}
     --dslash-type mobius-eofa
-    --dim 2 4 6 8 --Lsdim 4 --eig-n-conv 24 --eig-n-ev 24 --eig-n-kr 72
+    --dim 2 4 6 8 --Lsdim 4 --eig-n-conv 16 --eig-n-ev 16 --eig-n-kr 48
     --eig-max-restarts 1000
     --matpc even-even-asym --enable-testing true
     --gtest_output=xml:eigensolve_test_mobius_eofa_asym.xml)
@@ -1563,7 +1563,7 @@ if(QUDA_DIRAC_STAGGERED)
     add_test(NAME eigensolve_test_asqtad
       COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:staggered_eigensolve_test> ${MPIEXEC_POSTFLAGS}
       --dslash-type asqtad --compute-fat-long true
-      --dim 6 6 6 8 --eig-n-conv 24 --eig-n-ev 24 --eig-n-kr 128
+      --dim 6 6 6 8 --eig-n-conv 16 --eig-n-ev 16 --eig-n-kr 96
       --eig-max-restarts 1000
       --enable-testing true
       --gtest_output=xml:staggered_eigensolve_test_asqtad.xml)
@@ -1573,7 +1573,7 @@ if(QUDA_DIRAC_STAGGERED)
     add_test(NAME eigensolve_test_laplace
       COMMAND ${QUDA_CTEST_LAUNCH} $<TARGET_FILE:staggered_eigensolve_test> ${MPIEXEC_POSTFLAGS}
       --dslash-type laplace --compute-fat-long true
-      --dim 2 4 6 8 --eig-n-conv 24 --eig-n-ev 24 --eig-n-kr 72
+      --dim 2 4 6 8 --eig-n-conv 16 --eig-n-ev 16 --eig-n-kr 48
       --eig-max-restarts 1000
       --enable-testing true
       --gtest_output=xml:staggered_eigensolve_test_laplace.xml)

--- a/tests/covdev_test.cpp
+++ b/tests/covdev_test.cpp
@@ -3,7 +3,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <cassert>
-#include <test.h>
 #include <algorithm>
 
 #include <quda.h>
@@ -13,6 +12,8 @@
 #include <util_quda.h>
 #include <blas_quda.h>
 #include <gauge_field.h>
+#include <instantiate.h>
+#include <tune_quda.h>
 
 #include "misc.h"
 #include "host_utils.h"
@@ -20,35 +21,21 @@
 #include "command_line_params.h"
 #include "dslash_reference.h"
 #include "covdev_reference.h"
-#include "covdev_test_gtest.hpp"
+#include "test.h"
 
 using namespace quda;
 
+const int nColor = 3;
+
 QudaGaugeParam gauge_param;
-QudaInvertParam inv_param;
-
-GaugeField *cpuLink = nullptr;
-
-std::unique_ptr<ColorSpinorField> spinor, spinorOut, spinorRef;
-std::unique_ptr<ColorSpinorField> cudaSpinor, cudaSpinorOut;
-
-std::unique_ptr<ColorSpinorField> tmp;
-
+GaugeField cpuLink;
 void *links[4];
 
-QudaParity parity = QUDA_EVEN_PARITY;
-
-GaugeCovDev *dirac;
-
-const int nColor = 3;
+#include "covdev_test_gtest.hpp"
 
 void init(int argc, char **argv)
 {
   if (test_type != 0 and test_type != 1) errorQuda("Test type %d is not supported", test_type);
-
-  initQuda(device_ordinal);
-
-  setVerbosity(QUDA_VERBOSE);
 
   gauge_param = newQudaGaugeParam();
   setWilsonGaugeParam(gauge_param);
@@ -58,9 +45,61 @@ void init(int argc, char **argv)
 
   if (Nsrc != 1) warningQuda("The covariant derivative doesn't support 5-d indexing, only source 0 will be tested");
 
-  inv_param = newQudaInvertParam();
+  // Allocate host side memory for the gauge field.
+  for (int dir = 0; dir < 4; dir++) { links[dir] = safe_malloc(V * gauge_site_size * host_gauge_data_type_size); }
+  constructHostGaugeField(links, gauge_param, argc, argv);
+
+  // cpuLink is only used for ghost allocation
+  GaugeFieldParam cpuParam(gauge_param, links);
+  cpuParam.ghostExchange = QUDA_GHOST_EXCHANGE_PAD;
+  cpuLink = {cpuParam};
+}
+
+void end(void)
+{
+  for (int dir = 0; dir < 4; dir++) { host_free(links[dir]); }
+  cpuLink = {};
+}
+
+double dslashCUDA(GaugeCovDev &dirac, ColorSpinorField &out, const ColorSpinorField &in, int niter, int mu)
+{
+  device_timer_t timer;
+  timer.start();
+
+  for (int i = 0; i < niter; i++) dirac.MCD(out, in, mu);
+
+  timer.stop();
+  return timer.last();
+}
+
+void covdevRef(ColorSpinorField &out, const ColorSpinorField &in, bool dagger, int mu)
+{
+  // compare to dslash reference implementation
+  printfQuda("Calculating reference implementation...");
+  mat(out, cpuLink, in, dagger, mu);
+  printfQuda("done.\n");
+}
+
+std::array<double, 2> covdev_test(test_t param)
+{
+  QudaPrecision test_prec = ::testing::get<0>(param);
+  QudaDagType test_dagger = ::testing::get<1>(param);
+  int mu = ::testing::get<2>(param);
+
+  printfQuda("Links sending...");
+  gauge_param.cuda_prec = test_prec;
+  gauge_param.cuda_prec_sloppy = test_prec;
+  gauge_param.cuda_prec_precondition = test_prec;
+  gauge_param.cuda_prec_refinement_sloppy = test_prec;
+  gauge_param.cuda_prec_eigensolver = test_prec;
+  loadGaugeQuda(links, &gauge_param);
+  printfQuda("Links sent\n");
+
+  auto inv_param = newQudaInvertParam();
   setInvertParam(inv_param);
+  inv_param.cuda_prec = test_prec;
   inv_param.dslash_type = QUDA_COVDEV_DSLASH; // ensure we use the correct dslash
+  inv_param.solution_type = QUDA_MAT_SOLUTION;
 
   ColorSpinorParam csParam;
   csParam.nColor = nColor;
@@ -68,9 +107,8 @@ void init(int argc, char **argv)
   csParam.nDim = 4;
   for (int d = 0; d < 4; d++) { csParam.x[d] = gauge_param.X[d]; }
 
-  csParam.setPrecision(inv_param.cpu_prec);
+  csParam.setPrecision(cpu_prec);
   csParam.pad = 0;
-  inv_param.solution_type = QUDA_MAT_SOLUTION;
   csParam.siteSubset = QUDA_FULL_SITE_SUBSET;
   csParam.pc_type = QUDA_4D_PC;
   csParam.siteOrder = QUDA_EVEN_ODD_SITE_ORDER;
@@ -79,200 +117,98 @@ void init(int argc, char **argv)
   csParam.create = QUDA_ZERO_FIELD_CREATE;
   csParam.location = QUDA_CPU_FIELD_LOCATION;
 
-  spinor = std::make_unique<ColorSpinorField>(csParam);
-  spinorOut = std::make_unique<ColorSpinorField>(csParam);
-  spinorRef = std::make_unique<ColorSpinorField>(csParam);
+  ColorSpinorField spinor(csParam);
+  ColorSpinorField spinorOut(csParam);
+  ColorSpinorField spinorRef(csParam);
 
   csParam.siteSubset = QUDA_FULL_SITE_SUBSET;
   csParam.x[0] = gauge_param.X[0];
 
   printfQuda("Randomizing fields ...\n");
-  spinor->Source(QUDA_RANDOM_SOURCE);
-
-  // Allocate host side memory for the gauge field.
-  //----------------------------------------------------------------------------
-  for (int dir = 0; dir < 4; dir++) { links[dir] = safe_malloc(V * gauge_site_size * host_gauge_data_type_size); }
-  constructHostGaugeField(links, gauge_param, argc, argv);
-
-  // cpuLink is only used for ghost allocation
-  GaugeFieldParam cpuParam(gauge_param, links);
-  cpuParam.ghostExchange = QUDA_GHOST_EXCHANGE_PAD;
-  cpuLink = new GaugeField(cpuParam);
-
-  printfQuda("Links sending...");
-  loadGaugeQuda(links, &gauge_param);
-  printfQuda("Links sent\n");
+  spinor.Source(QUDA_RANDOM_SOURCE);
 
   printfQuda("Sending fields to GPU...");
-
-  csParam.gammaBasis = QUDA_UKQCD_GAMMA_BASIS;
-  csParam.setPrecision(inv_param.cuda_prec, inv_param.cuda_prec, true);
+  csParam.setPrecision(test_prec, test_prec, true);
   csParam.location = QUDA_CUDA_FIELD_LOCATION;
 
-  printfQuda("Creating cudaSpinor\n");
-  cudaSpinor = std::make_unique<ColorSpinorField>(csParam);
-
-  printfQuda("Creating cudaSpinorOut\n");
-  cudaSpinorOut = std::make_unique<ColorSpinorField>(csParam);
+  ColorSpinorField cudaSpinor(csParam);
+  ColorSpinorField cudaSpinorOut(csParam);
 
   printfQuda("Sending spinor field to GPU\n");
-  *cudaSpinor = *spinor;
+  cudaSpinor = spinor;
 
-  double spinor_norm2 = blas::norm2(*spinor);
-  double cuda_spinor_norm2 = blas::norm2(*cudaSpinor);
+  double spinor_norm2 = blas::norm2(spinor);
+  double cuda_spinor_norm2 = blas::norm2(cudaSpinor);
   printfQuda("Source CPU = %f, CUDA=%f\n", spinor_norm2, cuda_spinor_norm2);
-
-  csParam.siteSubset = QUDA_FULL_SITE_SUBSET;
-  tmp = std::make_unique<ColorSpinorField>(csParam);
 
   DiracParam diracParam;
   setDiracParam(diracParam, &inv_param, false);
+  GaugeCovDev dirac(diracParam);
 
-  dirac = new GaugeCovDev(diracParam);
+  int muQuda = mu + (test_dagger ? 4 : 0);
+
+  // Reference computation
+  covdevRef(spinorRef, spinor, test_dagger, mu);
+  printfQuda("\n\nChecking muQuda = %d\n", muQuda);
+
+  { // warm-up run
+    printfQuda("Tuning...\n");
+    dslashCUDA(dirac, cudaSpinorOut, cudaSpinor, 1, muQuda);
+  }
+  printfQuda("Executing %d kernel loop(s)...", niter);
+
+  auto flops0 = quda::Tunable::flops_global();
+  double secs = dslashCUDA(dirac, cudaSpinorOut, cudaSpinor, niter, muQuda);
+  auto flops = (quda::Tunable::flops_global() - flops0);
+
+  spinorOut = cudaSpinorOut;
+
+  printfQuda("\n%fms per loop\n", 1000 * secs);
+  printfQuda("GFLOPS = %f\n", 1.0e-9 * flops / secs);
+
+  auto spinor_ref_norm2 = blas::norm2(spinorRef);
+  auto spinor_out_norm2 = blas::norm2(spinorOut);
+  auto cuda_spinor_out_norm2 = blas::norm2(cudaSpinorOut);
+  printfQuda("Results mu = %d: CPU=%f, CUDA=%f, CPU-CUDA=%f\n", muQuda, spinor_ref_norm2, cuda_spinor_out_norm2,
+             spinor_out_norm2);
+
+  auto deviation = pow(10, -(double)(ColorSpinorField::Compare(spinorRef, spinorOut)));
+  double tol = getTolerance(test_prec);
+
+  return std::array<double, 2> {deviation, tol};
 }
 
-void end(void)
-{
-  for (int dir = 0; dir < 4; dir++) { host_free(links[dir]); }
+struct covdev_tester : quda_test {
+  void display_info() const override
+  {
+    quda_test::display_info();
+    printfQuda("S_dimension T_dimension Ls_dimension\n");
+    printfQuda("%3d/%3d/%3d     %3d         %2d\n", xdim, ydim, zdim, tdim, Lsdim);
+  }
 
-  delete dirac;
-  cudaSpinor.reset();
-  cudaSpinorOut.reset();
-  tmp.reset();
-  spinor.reset();
-  spinorOut.reset();
-  spinorRef.reset();
+  covdev_tester(int argc, char **argv) : quda_test("CovDev Test", argc, argv) { }
 
-  if (cpuLink) delete cpuLink;
-
-  endQuda();
-}
-
-double dslashCUDA(int niter, int mu)
-{
-  device_timer_t timer;
-  timer.start();
-
-  for (int i = 0; i < niter; i++) dirac->MCD(*cudaSpinorOut, *cudaSpinor, mu);
-
-  timer.stop();
-  return timer.last();
-}
-
-void covdevRef(int mu)
-{
-  // compare to dslash reference implementation
-  printfQuda("Calculating reference implementation...");
-#ifdef MULTI_GPU
-  mat_mg4dir(*spinorRef, *cpuLink, *spinor, dagger, mu);
-#else
-  mat(*spinorRef, *cpuLink, *spinor, dagger, mu);
-#endif
-  printfQuda("done.\n");
-}
-
-void display_test_info()
-{
-  printfQuda("running the following test:\n");
-
-  printfQuda("prec recon   test_type     dagger   S_dim         T_dimension\n");
-  printfQuda("%s   %s       %d           %d       %d/%d/%d        %d \n", get_prec_str(prec), get_recon_str(link_recon),
-             test_type, dagger, xdim, ydim, zdim, tdim);
-  printfQuda("Grid partition info:     X  Y  Z  T\n");
-  printfQuda("                         %d  %d  %d  %d\n", dimPartitioned(0), dimPartitioned(1), dimPartitioned(2),
-             dimPartitioned(3));
-}
+  void add_command_line_group(std::shared_ptr<QUDAApp> app) const override
+  {
+    quda_test::add_command_line_group(app);
+    add_covdev_option_group(app);
+  }
+};
 
 int main(int argc, char **argv)
 {
-  // initalize google test
-  ::testing::InitGoogleTest(&argc, argv);
-
-  // command line options
-  auto app = make_app();
-  add_covdev_option_group(app);
-
-  try {
-    app->parse(argc, argv);
-  } catch (const CLI::ParseError &e) {
-    return app->exit(e);
-  }
-
-  initComms(argc, argv, gridsize_from_cmdline);
-
-  // Ensure gtest prints only from rank 0
-  ::testing::TestEventListeners &listeners = ::testing::UnitTest::GetInstance()->listeners();
-  if (comm_rank() != 0) { delete listeners.Release(listeners.default_result_printer()); }
-
-  display_test_info();
+  covdev_tester test(argc, argv);
+  test.init();
 
   init(argc, argv);
-
   int result = 0;
 
   if (enable_testing) { // tests are defined in invert_test_gtest.hpp
-    ::testing::TestEventListeners &listeners = ::testing::UnitTest::GetInstance()->listeners();
-    if (quda::comm_rank() != 0) { delete listeners.Release(listeners.default_result_printer()); }
-    result = RUN_ALL_TESTS();
+    result = test.execute();
   } else { //
-    covdev_test(test_t {prec, dagger ? QUDA_DAG_YES : QUDA_DAG_NO});
+    covdev_test(test_t {prec, dagger ? QUDA_DAG_YES : QUDA_DAG_NO, covdev_mu});
   }
 
   end();
-  finalizeComms();
-
   return result;
-}
-
-std::array<double, 2> covdev_test(test_t param)
-{
-
-  // QudaPrecision    test_prec    = ::testing::get<0>(param);
-  QudaDagType test_dagger = ::testing::get<1>(param);
-
-  std::array<int, 4> mu_flags {covdev_mu};
-
-  if (std::all_of(mu_flags.begin(), mu_flags.end(), [](int x) { return x == 0; })) {
-    errorQuda("No direction was chosen, exiting...\n");
-  }
-
-  // Test forward directions, then backward
-  for (int mu = 0; mu < 4; mu++) {   // We test all directions in one go
-    if (mu_flags[mu] == 0) continue; // skip direction
-    int muCuda = mu + (test_dagger ? 4 : 0);
-    int muCpu = mu * 2 + (test_dagger ? 1 : 0);
-
-    // Reference computation
-    covdevRef(muCpu);
-    printfQuda("\n\nChecking muQuda = %d\n", muCuda);
-
-    { // warm-up run
-      printfQuda("Tuning...\n");
-      dslashCUDA(1, muCuda);
-    }
-    printfQuda("Executing %d kernel loop(s)...", niter);
-
-    double secs = dslashCUDA(niter, muCuda);
-
-    *spinorOut = *cudaSpinorOut;
-    printfQuda("\n%fms per loop\n", 1000 * secs);
-
-    unsigned long long flops = niter * cudaSpinor->Nspin() * (8 * nColor - 2) * nColor * (long long)cudaSpinor->Volume();
-    printfQuda("GFLOPS = %f\n", 1.0e-9 * flops / secs);
-
-    double spinor_ref_norm2 = blas::norm2(*spinorRef);
-    double spinor_out_norm2 = blas::norm2(*spinorOut);
-
-    double cuda_spinor_out_norm2 = blas::norm2(*cudaSpinorOut);
-    printfQuda("Results mu = %d: CPU=%f, CUDA=%f, CPU-CUDA=%f\n", muCuda, spinor_ref_norm2, cuda_spinor_out_norm2,
-               spinor_out_norm2);
-
-  } // Directions
-
-  double deviation = pow(10, -(double)(ColorSpinorField::Compare(*spinorRef, *spinorOut)));
-  double tol
-    = (inv_param.cuda_prec == QUDA_DOUBLE_PRECISION ? 1e-12 :
-                                                      (inv_param.cuda_prec == QUDA_SINGLE_PRECISION ? 1e-3 : 1e-1));
-
-  return std::array<double, 2> {deviation, tol};
 }

--- a/tests/covdev_test_gtest.hpp
+++ b/tests/covdev_test_gtest.hpp
@@ -2,7 +2,14 @@
 #include <quda_arch.h>
 #include <cmath>
 
-using test_t = ::testing::tuple<QudaPrecision, QudaDagType>;
+using test_t = ::testing::tuple<QudaPrecision, QudaDagType, int>;
+
+bool skip_test(test_t param)
+{
+  auto prec = ::testing::get<0>(param);
+  if (!quda::is_enabled(prec)) return true; // precision not enabled so skip
+  return false;
+}
 
 class CovDevTest : public ::testing::TestWithParam<test_t>
 {
@@ -12,16 +19,6 @@ protected:
 public:
   CovDevTest() : param(GetParam()) { }
 };
-
-bool skip_test(test_t param)
-{
-  auto prec = ::testing::get<0>(param);
-  // auto dag              = ::testing::get<1>(param);
-  // should we keep for all options?
-  if (!(QUDA_PRECISION & prec)) return true; // precision not enabled so skip i
-
-  return false;
-}
 
 std::array<double, 2> covdev_test(test_t param);
 
@@ -43,6 +40,7 @@ std::string gettestname(::testing::TestParamInfo<test_t> param)
 
   str += get_prec_str(::testing::get<0>(param.param));
   str += std::string("_") + get_dag_str(::testing::get<1>(param.param));
+  str += std::string("_mu") + std::to_string(::testing::get<2>(param.param));
 
   return str;
 }
@@ -52,5 +50,6 @@ using ::testing::Values;
 
 auto precisions = Values(QUDA_DOUBLE_PRECISION, QUDA_SINGLE_PRECISION, QUDA_HALF_PRECISION);
 auto dagger_opt = Values(QUDA_DAG_YES, QUDA_DAG_NO);
+auto mu_values = Values(0, 1, 2, 3);
 
-INSTANTIATE_TEST_SUITE_P(covdevtst, CovDevTest, Combine(precisions, dagger_opt), gettestname);
+INSTANTIATE_TEST_SUITE_P(covdevtst, CovDevTest, Combine(precisions, dagger_opt, mu_values), gettestname);

--- a/tests/eigensolve_test_gtest.hpp
+++ b/tests/eigensolve_test_gtest.hpp
@@ -77,6 +77,7 @@ TEST_P(EigensolveTest, verify)
   if (::testing::get<1>(GetParam()) == QUDA_EIG_IR_ARNOLDI || ::testing::get<1>(GetParam()) == QUDA_EIG_BLK_IR_ARNOLDI)
     tol *= 15;
 
+  // for Arnoldi we double the Krylov space size
   if (::testing::get<1>(GetParam()) == QUDA_EIG_IR_ARNOLDI) {
     eig_param.n_kr = 2 * eig_n_kr;
   } else {

--- a/tests/eigensolve_test_gtest.hpp
+++ b/tests/eigensolve_test_gtest.hpp
@@ -66,6 +66,7 @@ TEST_P(EigensolveTest, verify)
 
   auto tol = ::testing::get<0>(GetParam()) == QUDA_SINGLE_PRECISION ? 1e-5 : 1e-12;
   eig_param.tol = tol;
+  eig_param.require_convergence = QUDA_BOOLEAN_FALSE;
 
   // The IRAM eigensolver will sometimes report convergence with tolerances slightly
   // higher than requested. The same phenomenon occurs in ARPACK. This factor
@@ -75,6 +76,12 @@ TEST_P(EigensolveTest, verify)
   // or use a tighter than necessary tolerance.
   if (::testing::get<1>(GetParam()) == QUDA_EIG_IR_ARNOLDI || ::testing::get<1>(GetParam()) == QUDA_EIG_BLK_IR_ARNOLDI)
     tol *= 15;
+
+  if (::testing::get<1>(GetParam()) == QUDA_EIG_IR_ARNOLDI) {
+    eig_param.n_kr = 2 * eig_n_kr;
+  } else {
+    eig_param.n_kr = eig_n_kr;
+  }
 
   // account for summation error scaling with number of processors
   auto dof = 24lu * dim[0] * dim[1] * dim[2] * dim[3] * (is_chiral(dslash_type) ? Lsdim : 1);

--- a/tests/host_reference/covdev_reference.cpp
+++ b/tests/host_reference/covdev_reference.cpp
@@ -24,114 +24,14 @@
 //
 
 template <typename real_t>
-void covdevReference(real_t *res, real_t **link, const real_t *spinorField, int oddBit, int daggerBit, int mu)
-{
-#pragma omp parallel for
-  for (auto i = 0lu; i < Vh * spinor_site_size; i++) res[i] = 0.0;
-
-  real_t *linkEven[4], *linkOdd[4];
-
-  for (int dir = 0; dir < 4; dir++) {
-    linkEven[dir] = link[dir];
-    linkOdd[dir] = link[dir] + Vh * gauge_site_size;
-  }
-
-#pragma omp parallel for
-  for (int sid = 0; sid < Vh; sid++) {
-    auto offset = spinor_site_size * sid;
-
-    real_t gaugedSpinor[spinor_site_size];
-
-    const real_t *lnk = gaugeLink(sid, mu, oddBit, linkEven, linkOdd, 1);
-    const real_t *spinor = spinorNeighbor(sid, mu, oddBit, spinorField, 1);
-
-    if (daggerBit) {
-      for (int s = 0; s < 4; s++) su3Tmul(&gaugedSpinor[s * 6], lnk, &spinor[s * 6]);
-    } else {
-      for (int s = 0; s < 4; s++) su3Mul(&gaugedSpinor[s * 6], lnk, &spinor[s * 6]);
-    }
-
-    sum(&res[offset], &res[offset], gaugedSpinor, spinor_site_size);
-  } // 4-d volume
-}
-
-void covdev_dslash(void *res, void **link, void *spinorField, int oddBit, int daggerBit, int mu,
-                   QudaPrecision sPrecision, QudaPrecision gPrecision)
-{
-  if (sPrecision != gPrecision) errorQuda("Spinor and gauge field precision do not match");
-
-  if (sPrecision == QUDA_DOUBLE_PRECISION) {
-    covdevReference((double *)res, (double **)link, (double *)spinorField, oddBit, daggerBit, mu);
-  } else {
-    covdevReference((float *)res, (float **)link, (float *)spinorField, oddBit, daggerBit, mu);
-  }
-}
-
-template <typename real_t>
-void Mat(ColorSpinorField &out, const GaugeField &link, const ColorSpinorField &in, int daggerBit, int mu)
-{
-  // full dslash operator
-  void *data[4] = {link.data(0), link.data(1), link.data(2), link.data(3)};
-  covdevReference(reinterpret_cast<real_t *>(out.Odd().data()), reinterpret_cast<real_t **>(data),
-                  reinterpret_cast<real_t *>(in.Even().data()), 1, daggerBit, mu);
-  covdevReference(reinterpret_cast<real_t *>(out.Even().data()), reinterpret_cast<real_t **>(data),
-                  reinterpret_cast<real_t *>(in.Odd().data()), 0, daggerBit, mu);
-}
-
-void mat(ColorSpinorField &out, const GaugeField &link, const ColorSpinorField &in, int dagger_bit, int mu)
-{
-  if (checkPrecision(in, out, link) == QUDA_DOUBLE_PRECISION) {
-    Mat<double>(out, link, in, dagger_bit, mu);
-  } else {
-    Mat<float>(out, link, in, dagger_bit, mu);
-  }
-}
-
-template <typename real_t>
-void Matdagmat(real_t *out, real_t **link, real_t *in, int daggerBit, int mu, real_t *tmp, QudaParity parity)
-{
-  switch (parity) {
-  case QUDA_EVEN_PARITY: {
-    real_t *inEven = in;
-    real_t *outEven = out;
-    covdevReference(tmp, link, inEven, 1, daggerBit, mu);
-    covdevReference(outEven, link, tmp, 0, daggerBit, mu);
-    break;
-  }
-  case QUDA_ODD_PARITY: {
-    real_t *inOdd = in;
-    real_t *outOdd = out;
-    covdevReference(tmp, link, inOdd, 0, daggerBit, mu);
-    covdevReference(outOdd, link, tmp, 1, daggerBit, mu);
-    break;
-  }
-
-  default: fprintf(stderr, "ERROR: invalid parity in %s,line %d\n", __FUNCTION__, __LINE__); break;
-  }
-}
-
-void matdagmat(void *out, void **link, void *in, int dagger_bit, int mu, QudaPrecision sPrecision,
-               QudaPrecision gPrecision, void *tmp, QudaParity parity)
-{
-  if (sPrecision != gPrecision) errorQuda("Spinor and gauge field precision do not match");
-
-  if (sPrecision == QUDA_DOUBLE_PRECISION) {
-    Matdagmat((double *)out, (double **)link, (double *)in, dagger_bit, mu, (double *)tmp, parity);
-  } else {
-    Matdagmat((float *)out, (float **)link, (float *)in, dagger_bit, mu, (float *)tmp, parity);
-  }
-}
-
-#ifdef MULTI_GPU
-
-template <typename real_t>
-void covdevReference_mg4dir(real_t *res, real_t **link, real_t **ghostLink, const ColorSpinorField &in, int oddBit,
-                            int daggerBit, int mu)
+void covdevReference(real_t *res, real_t **link, real_t **ghostLink, const ColorSpinorField &in, int oddBit,
+                     int daggerBit, int mu)
 {
   auto fwd_nbr_spinor = reinterpret_cast<real_t **>(in.fwdGhostFaceBuffer);
   auto back_nbr_spinor = reinterpret_cast<real_t **>(in.backGhostFaceBuffer);
 
   const int my_spinor_site_size = in.Nspin() == 1 ? stag_spinor_site_size : spinor_site_size;
+  int muDagger = mu * 2 + daggerBit;
 
 #pragma omp parallel for
   for (int i = 0; i < Vh * my_spinor_site_size; i++) res[i] = 0.0;
@@ -151,8 +51,8 @@ void covdevReference_mg4dir(real_t *res, real_t **link, real_t **ghostLink, cons
   for (int sid = 0; sid < Vh; sid++) {
     int offset = my_spinor_site_size * sid;
 
-    const real_t *lnk = gaugeLink(sid, mu, oddBit, linkEven, linkOdd, ghostLinkEven, ghostLinkOdd, 1, 1);
-    const real_t *spinor = spinorNeighbor(sid, mu, oddBit, static_cast<const real_t *>(in.data()), fwd_nbr_spinor,
+    const real_t *lnk = gaugeLink(sid, muDagger, oddBit, linkEven, linkOdd, ghostLinkEven, ghostLinkOdd, 1, 1);
+    const real_t *spinor = spinorNeighbor(sid, muDagger, oddBit, static_cast<const real_t *>(in.data()), fwd_nbr_spinor,
                                           back_nbr_spinor, 1, 1, my_spinor_site_size);
 
     std::vector<real_t> gaugedSpinor(my_spinor_site_size);
@@ -163,11 +63,12 @@ void covdevReference_mg4dir(real_t *res, real_t **link, real_t **ghostLink, cons
       for (int s = 0; s < in.Nspin(); s++) su3Mul(&gaugedSpinor[s * 6], lnk, &spinor[s * 6]);
     }
     sum(&res[offset], &res[offset], gaugedSpinor.data(), spinor_site_size);
+
   } // 4-d volume
 }
 
-void covdev_dslash_mg4dir(ColorSpinorField &out, const GaugeField &link, const ColorSpinorField &in, int oddBit,
-                          int daggerBit, int mu, QudaPrecision sPrecision, QudaPrecision gPrecision)
+void covdev_dslash(ColorSpinorField &out, const GaugeField &link, const ColorSpinorField &in, int oddBit, int daggerBit,
+                   int mu, QudaPrecision sPrecision, QudaPrecision gPrecision)
 {
   if (sPrecision != gPrecision) errorQuda("Spinor and gauge field precision do not match");
 
@@ -177,7 +78,7 @@ void covdev_dslash_mg4dir(ColorSpinorField &out, const GaugeField &link, const C
   } else if (oddBit == QUDA_ODD_PARITY) {
     otherparity = QUDA_EVEN_PARITY;
   } else {
-    errorQuda("ERROR: full parity not supported in function %s", __FUNCTION__);
+    errorQuda("full parity not supported");
   }
   const int nFace = 1;
 
@@ -187,16 +88,16 @@ void covdev_dslash_mg4dir(ColorSpinorField &out, const GaugeField &link, const C
   void *ghostLink[4] = {link.Ghost()[0].data(), link.Ghost()[1].data(), link.Ghost()[2].data(), link.Ghost()[3].data()};
 
   if (sPrecision == QUDA_DOUBLE_PRECISION) {
-    covdevReference_mg4dir((double *)out.data(), reinterpret_cast<double **>(data), (double **)ghostLink, in, oddBit,
-                           daggerBit, mu);
+    covdevReference((double *)out.data(), reinterpret_cast<double **>(data), (double **)ghostLink, in, oddBit,
+                    daggerBit, mu);
   } else {
-    covdevReference_mg4dir((float *)out.data(), reinterpret_cast<float **>(data), (float **)ghostLink, in, oddBit,
-                           daggerBit, mu);
+    covdevReference((float *)out.data(), reinterpret_cast<float **>(data), (float **)ghostLink, in, oddBit, daggerBit,
+                    mu);
   }
 }
 
 template <typename real_t>
-void Mat_mg4dir(ColorSpinorField &out, const GaugeField &link, const ColorSpinorField &in, int daggerBit, int mu)
+void Mat(ColorSpinorField &out, const GaugeField &link, const ColorSpinorField &in, int daggerBit, int mu)
 {
   void *data[4] = {link.data(0), link.data(1), link.data(2), link.data(3)};
   void *ghostLink[4] = {link.Ghost()[0].data(), link.Ghost()[1].data(), link.Ghost()[2].data(), link.Ghost()[3].data()};
@@ -207,8 +108,8 @@ void Mat_mg4dir(ColorSpinorField &out, const GaugeField &link, const ColorSpinor
     auto &outOdd = out.Odd();
 
     inEven.exchangeGhost(QUDA_EVEN_PARITY, nFace, daggerBit);
-    covdevReference_mg4dir(reinterpret_cast<real_t *>(outOdd.data()), reinterpret_cast<real_t **>(data),
-                           reinterpret_cast<real_t **>(ghostLink), in.Even(), 1, daggerBit, mu);
+    covdevReference(reinterpret_cast<real_t *>(outOdd.data()), reinterpret_cast<real_t **>(data),
+                    reinterpret_cast<real_t **>(ghostLink), in.Even(), 1, daggerBit, mu);
   }
 
   {
@@ -216,22 +117,22 @@ void Mat_mg4dir(ColorSpinorField &out, const GaugeField &link, const ColorSpinor
     auto &outEven = out.Even();
 
     inOdd.exchangeGhost(QUDA_ODD_PARITY, nFace, daggerBit);
-    covdevReference_mg4dir(reinterpret_cast<real_t *>(outEven.data()), reinterpret_cast<real_t **>(data),
-                           reinterpret_cast<real_t **>(ghostLink), in.Odd(), 0, daggerBit, mu);
+    covdevReference(reinterpret_cast<real_t *>(outEven.data()), reinterpret_cast<real_t **>(data),
+                    reinterpret_cast<real_t **>(ghostLink), in.Odd(), 0, daggerBit, mu);
   }
 }
 
-void mat_mg4dir(ColorSpinorField &out, const GaugeField &link, const ColorSpinorField &in, int dagger_bit, int mu)
+void mat(ColorSpinorField &out, const GaugeField &link, const ColorSpinorField &in, int dagger_bit, int mu)
 {
   if (checkPrecision(in, out, link) == QUDA_DOUBLE_PRECISION) {
-    Mat_mg4dir<double>(out, link, in, dagger_bit, mu);
+    Mat<double>(out, link, in, dagger_bit, mu);
   } else {
-    Mat_mg4dir<float>(out, link, in, dagger_bit, mu);
+    Mat<float>(out, link, in, dagger_bit, mu);
   }
 }
 
-void matdagmat_mg4dir(ColorSpinorField &out, const GaugeField &link, const ColorSpinorField &in, int dagger_bit, int mu,
-                      QudaPrecision sPrecision, QudaPrecision gPrecision, ColorSpinorField &tmp, QudaParity parity)
+void matdagmat(ColorSpinorField &out, const GaugeField &link, const ColorSpinorField &in, int dagger_bit, int mu,
+               QudaPrecision sPrecision, QudaPrecision gPrecision, ColorSpinorField &tmp, QudaParity parity)
 {
   // assert sPrecision and gPrecision must be the same
   if (sPrecision != gPrecision) errorQuda("Spinor precision and gPrecison is not the same");
@@ -245,9 +146,7 @@ void matdagmat_mg4dir(ColorSpinorField &out, const GaugeField &link, const Color
     errorQuda("full parity not supported");
   }
 
-  covdev_dslash_mg4dir(tmp, link, in, otherparity, dagger_bit, mu, sPrecision, gPrecision);
+  covdev_dslash(tmp, link, in, otherparity, dagger_bit, mu, sPrecision, gPrecision);
 
-  covdev_dslash_mg4dir(out, link, tmp, parity, dagger_bit, mu, sPrecision, gPrecision);
+  covdev_dslash(out, link, tmp, parity, dagger_bit, mu, sPrecision, gPrecision);
 }
-
-#endif

--- a/tests/host_reference/covdev_reference.h
+++ b/tests/host_reference/covdev_reference.h
@@ -6,16 +6,9 @@ using namespace quda;
 
 void setDims(int *);
 
-void covdev_dslash(void *res, const GaugeField &link, void *spinorField, int oddBit, int daggerBit, int mu,
-                   QudaPrecision sPrecision, QudaPrecision gPrecision);
-void covdev_dslash_mg4dir(ColorSpinorField &out, const GaugeField &link, const ColorSpinorField &in, int oddBit,
-                          int daggerBit, int mu, QudaPrecision sPrecision, QudaPrecision gPrecision);
+void covdev_dslash(ColorSpinorField &out, const GaugeField &link, const ColorSpinorField &in, int oddBit, int daggerBit,
+                   int mu, QudaPrecision sPrecision, QudaPrecision gPrecision);
 
 void mat(ColorSpinorField &out, const GaugeField &link, const ColorSpinorField &in, int daggerBit, int mu);
-
-void matdagmat(void *out, const GaugeField &link, void *in, int dagger_bit, int mu, QudaPrecision sPrecision,
-               QudaPrecision gPrecision, void *tmp, QudaParity parity);
-
-void mat_mg4dir(ColorSpinorField &out, const GaugeField &link, const ColorSpinorField &in, int daggerBit, int mu);
-void matdagmat_mg4dir(ColorSpinorField &out, const GaugeField &link, const ColorSpinorField &in, int dagger_bit, int mu,
-                      QudaPrecision sPrecision, QudaPrecision gPrecision, ColorSpinorField &tmp, QudaParity parity);
+void matdagmat(ColorSpinorField &out, const GaugeField &link, const ColorSpinorField &in, int dagger_bit, int mu,
+               QudaPrecision sPrecision, QudaPrecision gPrecision, ColorSpinorField &tmp, QudaParity parity);

--- a/tests/staggered_eigensolve_test_gtest.hpp
+++ b/tests/staggered_eigensolve_test_gtest.hpp
@@ -122,6 +122,13 @@ public:
       // gauge fields with different parameters.
       void *qdp_inlink[4] = {cpuInQDP.data(0), cpuInQDP.data(1), cpuInQDP.data(2), cpuInQDP.data(3)};
 
+      // Load the gauge field to the device
+      gauge_param.cuda_prec = ::testing::get<0>(param);
+      gauge_param.cuda_prec_sloppy = ::testing::get<0>(param);
+      gauge_param.cuda_prec_precondition = ::testing::get<0>(param);
+      gauge_param.cuda_prec_refinement_sloppy = ::testing::get<0>(param);
+      gauge_param.cuda_prec_eigensolver = ::testing::get<0>(param);
+
       double plaq[3];
       computeStaggeredPlaquetteQDPOrder(qdp_inlink, plaq, gauge_param, dslash_type);
       printfQuda("Computed plaquette is %e (spatial = %e, temporal = %e)\n", plaq[0], plaq[1], plaq[2]);
@@ -135,12 +142,6 @@ public:
 
       freeGaugeQuda();
 
-      // Load the gauge field to the device
-      gauge_param.cuda_prec = ::testing::get<0>(param);
-      gauge_param.cuda_prec_sloppy = ::testing::get<0>(param);
-      gauge_param.cuda_prec_precondition = ::testing::get<0>(param);
-      gauge_param.cuda_prec_refinement_sloppy = ::testing::get<0>(param);
-      gauge_param.cuda_prec_eigensolver = ::testing::get<0>(param);
       loadFatLongGaugeQuda(cpuFatMILC.data(), cpuLongMILC.data(), gauge_param);
 
       last_prec = ::testing::get<0>(param);
@@ -175,6 +176,13 @@ TEST_P(StaggeredEigensolveTest, verify)
   // account for summation error scaling with number of processors
   auto dof = 6lu * dim[0] * dim[1] * dim[2] * dim[3];
   tol *= (1 + log(quda::comm_size()) / log(dof));
+
+  // for Arnoldi we double the Krylov space size
+  if (::testing::get<1>(GetParam()) == QUDA_EIG_IR_ARNOLDI) {
+    eig_param.n_kr = 2 * eig_n_kr;
+  } else {
+    eig_param.n_kr = eig_n_kr;
+  }
 
   // For the 3-d eigensolver, we need to set orthoDir
   if (dslash_type == QUDA_LAPLACE_DSLASH) laplace3D = (eig_type == QUDA_EIG_TR_LANCZOS_3D) ? 3 : 4;

--- a/tests/utils/command_line_params.cpp
+++ b/tests/utils/command_line_params.cpp
@@ -346,7 +346,7 @@ bool prop_read_sources = false;
 int prop_n_sources = 1;
 QudaPrecision prop_save_prec = QUDA_SINGLE_PRECISION;
 
-std::array<int, 4> covdev_mu = {1, 1, 1, 1};
+int covdev_mu = 3;
 
 // Parameters for the (gaussian) quark smearing operator
 int    smear_n_steps = 50;
@@ -1356,5 +1356,5 @@ void add_clover_force_option_group(std::shared_ptr<QUDAApp> quda_app)
 void add_covdev_option_group(std::shared_ptr<QUDAApp> quda_app)
 {
   auto opgroup = quda_app->add_option_group("Covdev", "Options controlling  cov derivative parameteres");
-  opgroup->add_option("--covdev-mu", covdev_mu, "Set the direction(s) (default 1 1 1 1 - all directions)")->expected(4);
+  opgroup->add_option("--covdev-mu", covdev_mu, "Set the direction for the covariant derivative");
 }

--- a/tests/utils/command_line_params.h
+++ b/tests/utils/command_line_params.h
@@ -606,4 +606,4 @@ extern bool enable_testing;
 
 extern bool detratio;
 
-extern std::array<int, 4> covdev_mu;
+extern int covdev_mu;


### PR DESCRIPTION
Fixes some bugs
* CUDA device monitoring wasn't guaranteed to map to the same device used for compute.  This is now fixed using the PCIe device id to guarantee the correct device is monitored
* Fixes a stability with IRAM: if too low a QR tolerance is used, the eigensolver will fail to converge (this fixes an issue with CI introduced in #1549.
* `covdev_test` was completely broken: gtests were ignored, reference dagger variant was broken, CI would fail for a uni-precision build.  These are all fixed now.  Closes #1576.