### PR TITLE
Make the docstring of the gamma basis consistent with the code.

### DIFF
--- a/include/enum_quda.h
+++ b/include/enum_quda.h
@@ -373,17 +373,16 @@ typedef enum QudaFieldCreate_s {
 } QudaFieldCreate;
 
 typedef enum QudaGammaBasis_s { // gamj=((top 2 rows)(bottom 2 rows))  s1,s2,s3 are Pauli spin matrices, 1 is 2x2 identity
-  QUDA_DEGRAND_ROSSI_GAMMA_BASIS, // gam1=((0,i*s1)(-i*s1,0)) gam2=((0,-i*s2)(i*s2,0)) gam3=((0,i*s3)(-i*s3,0))
-                                  // gam4=((0,1)(1,0))  gam5=((-1,0)(0,1))
-  QUDA_UKQCD_GAMMA_BASIS, // gam1=((0,i*s1)(-i*s1,0)) gam2=((0,i*s2)(-i*s2,0)) gam3=((0,i*s3)(-i*s3,0)) gam4=((1,0)(0,-1)) gam5=((0,-1)(-1,0))
-  QUDA_CHIRAL_GAMMA_BASIS, // gam1=((0,-i*s1)(i*s1,0)) gam2=((0,-i*s2)(i*s2,0)) gam3=((0,-i*s3)(i*s3,0)) gam4=((0,-1)(-1,0))gam5=((1,0)(0,-1))
-  QUDA_DIRAC_PAULI_GAMMA_BASIS, // gam1=((0,-i*s1)(i*s1,0)) gam2=((0,-i*s2)(i*s2,0)) gam3=((0,-i*s3)(i*s3,0))
-                                // gam4=((1,0)(0,-1)) gam5=((0,1)(1,0))
-  QUDA_INVALID_GAMMA_BASIS = QUDA_INVALID_ENUM //  gam5=gam4*gam1*gam2*gam3
+  QUDA_DEGRAND_ROSSI_GAMMA_BASIS, // gam1=((0,i*s1)(-i*s1,0)) gam2=((0,-i*s2)(i*s2,0)) gam3=((0,i*s3)(-i*s3,0)) gam4=((0,1)(1,0))  gam5=((1,0)(0,-1))
+  QUDA_UKQCD_GAMMA_BASIS,         // gam1=((0,i*s1)(-i*s1,0)) gam2=((0,i*s2)(-i*s2,0)) gam3=((0,i*s3)(-i*s3,0)) gam4=((1,0)(0,-1)) gam5=((0,1)(1,0))
+  QUDA_CHIRAL_GAMMA_BASIS,        // gam1=((0,-i*s1)(i*s1,0)) gam2=((0,-i*s2)(i*s2,0)) gam3=((0,-i*s3)(i*s3,0)) gam4=((0,-1)(-1,0))gam5=((-1,0)(0,1))
+  QUDA_DIRAC_PAULI_GAMMA_BASIS,   // gam1=((0,-i*s1)(i*s1,0)) gam2=((0,-i*s2)(i*s2,0)) gam3=((0,-i*s3)(i*s3,0)) gam4=((1,0)(0,-1)) gam5=((0,-1)(-1,0))
+  QUDA_INVALID_GAMMA_BASIS = QUDA_INVALID_ENUM //  gam5=gam1*gam2*gam3*gam4
 } QudaGammaBasis;
 //  Dirac-Pauli -> DeGrand-Rossi   T = i/sqrt(2)*((s2,-s2)(s2,s2))     field_DR = T * field_DP
-//  UKQCD -> DeGrand-Rossi         T = i/sqrt(2)*((-s2,-s2)(-s2,s2))   field_DR = T * field_UK
-//  Chiral -> DeGrand-Rossi        T = i*((0,-s2)(s2,0))               field_DR = T * field_chiral
+//  UKQCD       -> DeGrand-Rossi   T = i/sqrt(2)*((-s2,-s2)(-s2,s2))   field_DR = T * field_UK
+//  Chiral      -> DeGrand-Rossi   T = i*((0,-s2)(s2,0))               field_DR = T * field_chiral
+
 typedef enum QudaSourceType_s {
   QUDA_POINT_SOURCE,
   QUDA_RANDOM_SOURCE,


### PR DESCRIPTION
The docstring of the gamma basis shows the detailed definition of gamma matrices used by QUDA and other apps. $\gamma_1$, $\gamma_2$, $\gamma_3$, $\gamma_4$ are defined as usual, but $\gamma_5=\gamma_4\gamma_1\gamma_2\gamma_3$ has an extra minus compared to the other usual definition $\gamma_5=\gamma_1\gamma_2\gamma_3\gamma_4$.

QUDA actually uses the latter one as its implementation. See https://github.com/lattice/quda/blob/5f703bf5d1d4f352be69117b2fbe425b28d0ea33/include/color_spinor.h#L194-L201
it uses `((0,1)(1,0))` as the $\gamma_5$ under the UKQCD basis. So I think we should modify the docstring of `QudaGammaBasis` to match the code.

We are working on the chiral fermion, which means only two of the four spin elements are non-zero. The extra sign of $\gamma_5$ will affect the definition of the chirality. (Whether the upper two elements or the lower two elements should be defined as the left chirality part of a spinor under the DeGrand-Rossi basis?) So I try to modify the docstring here.

Though this is a pretty small PR, I made it a separate one to avoid applying clang-format, as it's more readable when manually formatted.