### PR TITLE
Enable running fused Mobius kernels with NVSHMEM

### DIFF
--- a/include/dslash_helper.cuh
+++ b/include/dslash_helper.cuh
@@ -483,6 +483,10 @@ namespace quda
      classed.
    */
   struct dslash_default {
+
+    // By default the dslash types do not have __syncthreads() in their operator();
+    constexpr static bool use_syncthreads = false;
+
     constexpr QudaPCType pc_type() const { return QUDA_4D_PC; }
     constexpr int twist_pack() const { return 0; }
   };
@@ -515,16 +519,26 @@ namespace quda
    * @brief helper function for nvshmem uber kernel to signal that the interior kernel has completed.
       This function is supposed to be called only by the last thread of the block.
    */
-  template <KernelType kernel_type, typename Arg> void __device__ inline shmem_signalinterior(const Arg &arg)
+  template <typename Arg> void __device__ inline shmem_signalinterior(const Arg &arg)
   {
-    if (kernel_type == UBER_KERNEL) {
-        int amlast = arg.interior_count.fetch_add(1, cuda::std::memory_order_acq_rel); // ensure that my block is done
-        if (amlast == (target::grid_dim().x - arg.pack_blocks - arg.exterior_blocks) * target::grid_dim().y * target::grid_dim().z - 1) {
-          arg.interior_done.store(arg.counter, cuda::std::memory_order_release);
-          arg.interior_done.notify_all();
-          arg.interior_count.store(0, cuda::std::memory_order_relaxed);
-        }
+    int amlast = arg.interior_count.fetch_add(1, cuda::std::memory_order_acq_rel); // ensure that my block is done
+    if (amlast == (target::grid_dim().x - arg.pack_blocks - arg.exterior_blocks) * target::grid_dim().y * target::grid_dim().z - 1) {
+      arg.interior_done.store(arg.counter, cuda::std::memory_order_release);
+      arg.interior_done.notify_all();
+      arg.interior_count.store(0, cuda::std::memory_order_relaxed);
     }
+  }
+
+  template <KernelType kernel_type, class D>
+  __forceinline__ __device__ void apply_dslash(D &dslash, int x_cb, int s, int parity) {
+#ifdef QUDA_FAST_COMPILE_DSLASH
+    dslash.template operator()<kernel_type>(x_cb, s, parity);
+#else
+    switch (parity) {
+    case 0: dslash.template operator()<kernel_type>(x_cb, s, 0); break;
+    case 1: dslash.template operator()<kernel_type>(x_cb, s, 1); break;
+    }
+#endif
   }
 
   template <KernelType kernel_type, int nParity, class D, typename Arg>
@@ -634,14 +648,7 @@ namespace quda
       while (local_tid < threads_my_dir) {
         // for full fields set parity from z thread index else use arg setting
         int parity = nParity == 2 ? target::block_dim().z * target::block_idx().z + target::thread_idx().z : arg.parity;
-#ifdef QUDA_FAST_COMPILE_DSLASH
-        dslash.template operator()<EXTERIOR_KERNEL_ALL>(tid, s, parity);
-#else
-        switch (parity) {
-        case 0: dslash.template operator()<EXTERIOR_KERNEL_ALL>(tid, s, 0); break;
-        case 1: dslash.template operator()<EXTERIOR_KERNEL_ALL>(tid, s, 1); break;
-        }
-#endif
+        apply_dslash<EXTERIOR_KERNEL_ALL>(dslash, tid, s, parity);
         local_tid += target::block_dim().x * blocks_per_dir;
         tid += target::block_dim().x * blocks_per_dir;
       }
@@ -720,40 +727,40 @@ namespace quda
         const int dslash_block_offset
           = ((kernel_type == INTERIOR_KERNEL || kernel_type == UBER_KERNEL) ? arg.pack_blocks : 0);
         int x_cb = (target::block_idx().x - dslash_block_offset) * target::block_dim().x + target::thread_idx().x;
-#ifdef NVSHMEM_COMMS
-        // Initialize a shared memory counter for the threads int the block
-        __shared__ cuda::atomic<int, cuda::thread_scope_block> block_counter;
-        if (target::thread_idx().x == 0 && target::thread_idx().y == 0 && target::thread_idx().z == 0) {
-          block_counter.store(0, cuda::std::memory_order_relaxed);
-        }
-        __syncthreads();
-#endif
 
-        if (x_cb >= arg.threads) {
 #ifdef NVSHMEM_COMMS
-          // Need to increment the counter even for the exiting threads
-          block_counter.fetch_add(1, cuda::std::memory_order_acq_rel);
-#endif
-          return;
-        }
-        __syncthreads();
-
-#ifdef QUDA_FAST_COMPILE_DSLASH
-        dslash.template operator()<kernel_type == UBER_KERNEL ? INTERIOR_KERNEL : kernel_type>(x_cb, s, parity);
+        constexpr bool use_nvshmem_comms = true;
 #else
-        switch (parity) {
-        case 0: dslash.template operator()<kernel_type == UBER_KERNEL ? INTERIOR_KERNEL : kernel_type>(x_cb, s, 0); break;
-        case 1: dslash.template operator()<kernel_type == UBER_KERNEL ? INTERIOR_KERNEL : kernel_type>(x_cb, s, 1); break;
-        }
+        constexpr bool use_nvshmem_comms = false;
 #endif
-#ifdef NVSHMEM_COMMS
-        // Use the shared memory counter to see if is the last thread in the block.
-        // If yes, signal that interior is done for this block.
-        int am_last_thread = block_counter.fetch_add(1, cuda::std::memory_order_acq_rel);
-        if (kernel_type == UBER_KERNEL && am_last_thread == (target::block_dim().x * target::block_dim().y * target::block_dim().z - 1)) {
-          shmem_signalinterior<kernel_type>(arg);
+        if constexpr (use_nvshmem_comms && Arg::D::use_syncthreads) {
+          // Initialize a shared memory counter for the threads int the block
+          __shared__ cuda::atomic<int, cuda::thread_scope_block> block_counter;
+          if (target::thread_idx().x == 0 && target::thread_idx().y == 0 && target::thread_idx().z == 0) {
+            block_counter.store(0, cuda::std::memory_order_relaxed);
+          }
+          __syncthreads();
+
+          if (x_cb < arg.threads) {
+            apply_dslash<kernel_type == UBER_KERNEL ? INTERIOR_KERNEL : kernel_type>(dslash, x_cb, s, parity);
+          }
+          // Use the shared memory counter to see if is the last thread in the block.
+          // If yes, signal that interior is done for this block.
+          int am_last_thread = block_counter.fetch_add(1, cuda::std::memory_order_acq_rel);
+          if constexpr (kernel_type == UBER_KERNEL) {
+            if (am_last_thread == (target::block_dim().x * target::block_dim().y * target::block_dim().z - 1))
+              shmem_signalinterior(arg);
+          }
+        } else {
+          if (x_cb >= arg.threads) return;
+
+          apply_dslash<kernel_type == UBER_KERNEL ? INTERIOR_KERNEL : kernel_type>(dslash, x_cb, s, parity);
+          if constexpr (use_nvshmem_comms && kernel_type == UBER_KERNEL) {
+            __syncthreads();
+            if (target::thread_idx().x == 0 && target::thread_idx().y == 0 && target::thread_idx().z == 0)
+              shmem_signalinterior(arg);
+          }
         }
-#endif
       }
     }
   };

--- a/include/dslash_helper.cuh
+++ b/include/dslash_helper.cuh
@@ -737,7 +737,7 @@ namespace quda
         constexpr bool use_nvshmem_comms = false;
 #endif
         if constexpr (use_nvshmem_comms && Arg::D::use_syncthreads) {
-          // Initialize a shared memory counter for the threads int the block
+          // Initialize a shared memory counter for the threads in the block
           __shared__ cuda::atomic<int, cuda::thread_scope_block> block_counter;
           if (target::thread_idx().x == 0 && target::thread_idx().y == 0 && target::thread_idx().z == 0) {
             block_counter.store(0, cuda::std::memory_order_relaxed);

--- a/include/dslash_helper.cuh
+++ b/include/dslash_helper.cuh
@@ -522,7 +522,9 @@ namespace quda
   template <typename Arg> void __device__ inline shmem_signalinterior(const Arg &arg)
   {
     int amlast = arg.interior_count.fetch_add(1, cuda::std::memory_order_acq_rel); // ensure that my block is done
-    if (amlast == (target::grid_dim().x - arg.pack_blocks - arg.exterior_blocks) * target::grid_dim().y * target::grid_dim().z - 1) {
+    if (amlast
+        == (target::grid_dim().x - arg.pack_blocks - arg.exterior_blocks) * target::grid_dim().y * target::grid_dim().z
+          - 1) {
       arg.interior_done.store(arg.counter, cuda::std::memory_order_release);
       arg.interior_done.notify_all();
       arg.interior_count.store(0, cuda::std::memory_order_relaxed);
@@ -530,7 +532,8 @@ namespace quda
   }
 
   template <KernelType kernel_type, class D>
-  __forceinline__ __device__ void apply_dslash(D &dslash, int x_cb, int s, int parity) {
+  __forceinline__ __device__ void apply_dslash(D &dslash, int x_cb, int s, int parity)
+  {
 #ifdef QUDA_FAST_COMPILE_DSLASH
     dslash.template operator()<kernel_type>(x_cb, s, parity);
 #else

--- a/include/dslash_helper.cuh
+++ b/include/dslash_helper.cuh
@@ -514,6 +514,19 @@ namespace quda
     }   // parity
   }
 
+  template <KernelType kernel_type, class D>
+  __forceinline__ __device__ void apply_dslash(D &dslash, int x_cb, int s, int parity)
+  {
+#ifdef QUDA_FAST_COMPILE_DSLASH
+    dslash.template operator()<kernel_type>(x_cb, s, parity);
+#else
+    switch (parity) {
+    case 0: dslash.template operator()<kernel_type>(x_cb, s, 0); break;
+    case 1: dslash.template operator()<kernel_type>(x_cb, s, 1); break;
+    }
+#endif
+  }
+
 #ifdef NVSHMEM_COMMS
   /**
    * @brief helper function for nvshmem uber kernel to signal that the interior kernel has completed.
@@ -529,19 +542,6 @@ namespace quda
       arg.interior_done.notify_all();
       arg.interior_count.store(0, cuda::std::memory_order_relaxed);
     }
-  }
-
-  template <KernelType kernel_type, class D>
-  __forceinline__ __device__ void apply_dslash(D &dslash, int x_cb, int s, int parity)
-  {
-#ifdef QUDA_FAST_COMPILE_DSLASH
-    dslash.template operator()<kernel_type>(x_cb, s, parity);
-#else
-    switch (parity) {
-    case 0: dslash.template operator()<kernel_type>(x_cb, s, 0); break;
-    case 1: dslash.template operator()<kernel_type>(x_cb, s, 1); break;
-    }
-#endif
   }
 
   template <KernelType kernel_type, int nParity, class D, typename Arg>

--- a/include/dslash_helper.cuh
+++ b/include/dslash_helper.cuh
@@ -737,6 +737,7 @@ namespace quda
         constexpr bool use_nvshmem_comms = false;
 #endif
         if constexpr (use_nvshmem_comms && Arg::D::use_syncthreads) {
+#ifdef NVSHMEM_COMMS
           // Initialize a shared memory counter for the threads in the block
           __shared__ cuda::atomic<int, cuda::thread_scope_block> block_counter;
           if (target::thread_idx().x == 0 && target::thread_idx().y == 0 && target::thread_idx().z == 0) {
@@ -754,6 +755,7 @@ namespace quda
             if (am_last_thread == (target::block_dim().x * target::block_dim().y * target::block_dim().z - 1))
               shmem_signalinterior(arg);
           }
+#endif
         } else {
           if (x_cb >= arg.threads) return;
 

--- a/include/dslash_helper.cuh
+++ b/include/dslash_helper.cuh
@@ -512,20 +512,18 @@ namespace quda
 
 #ifdef NVSHMEM_COMMS
   /**
-   * @brief helper function for nvshmem uber kernel to signal that the interior kernel has completed
+   * @brief helper function for nvshmem uber kernel to signal that the interior kernel has completed.
+      This function is supposed to be called only by the last thread of the block.
    */
   template <KernelType kernel_type, typename Arg> void __device__ inline shmem_signalinterior(const Arg &arg)
   {
     if (kernel_type == UBER_KERNEL) {
-      __syncthreads();
-      if (target::thread_idx().x == 0 && target::thread_idx().y == 0 && target::thread_idx().z == 0) {
         int amlast = arg.interior_count.fetch_add(1, cuda::std::memory_order_acq_rel); // ensure that my block is done
         if (amlast == (target::grid_dim().x - arg.pack_blocks - arg.exterior_blocks) * target::grid_dim().y * target::grid_dim().z - 1) {
           arg.interior_done.store(arg.counter, cuda::std::memory_order_release);
           arg.interior_done.notify_all();
           arg.interior_count.store(0, cuda::std::memory_order_relaxed);
         }
-      }
     }
   }
 
@@ -722,7 +720,23 @@ namespace quda
         const int dslash_block_offset
           = ((kernel_type == INTERIOR_KERNEL || kernel_type == UBER_KERNEL) ? arg.pack_blocks : 0);
         int x_cb = (target::block_idx().x - dslash_block_offset) * target::block_dim().x + target::thread_idx().x;
-        if (x_cb >= arg.threads) return;
+#ifdef NVSHMEM_COMMS
+        // Initialize a shared memory counter for the threads int the block
+        __shared__ cuda::atomic<int, cuda::thread_scope_block> block_counter;
+        if (target::thread_idx().x == 0 && target::thread_idx().y == 0 && target::thread_idx().z == 0) {
+          block_counter.store(0, cuda::std::memory_order_relaxed);
+        }
+        __syncthreads();
+#endif
+
+        if (x_cb >= arg.threads) {
+#ifdef NVSHMEM_COMMS
+          // Need to increment the counter even for the exiting threads
+          block_counter.fetch_add(1, cuda::std::memory_order_acq_rel);
+#endif
+          return;
+        }
+        __syncthreads();
 
 #ifdef QUDA_FAST_COMPILE_DSLASH
         dslash.template operator()<kernel_type == UBER_KERNEL ? INTERIOR_KERNEL : kernel_type>(x_cb, s, parity);
@@ -733,7 +747,12 @@ namespace quda
         }
 #endif
 #ifdef NVSHMEM_COMMS
-        if (kernel_type == UBER_KERNEL) shmem_signalinterior<kernel_type>(arg);
+        // Use the shared memory counter to see if is the last thread in the block.
+        // If yes, signal that interior is done for this block.
+        int am_last_thread = block_counter.fetch_add(1, cuda::std::memory_order_acq_rel);
+        if (kernel_type == UBER_KERNEL && am_last_thread == (target::block_dim().x * target::block_dim().y * target::block_dim().z - 1)) {
+          shmem_signalinterior<kernel_type>(arg);
+        }
 #endif
       }
     }

--- a/include/kernels/dslash_domain_wall_4d_fused_m5.cuh
+++ b/include/kernels/dslash_domain_wall_4d_fused_m5.cuh
@@ -63,6 +63,9 @@ namespace quda
     static constexpr Dslash5Type dslash5_type = Arg::type;
     static constexpr bool shared = domainWall4DFusedM5shared;
 
+    // The fused kernel has __syncthreads in its operator()
+    constexpr static bool use_syncthreads = true;
+
     const Arg &arg;
     using typename d5Params<Arg_, shared>::Ops::KernelOpsT;
     template <typename Ftor> constexpr domainWall4DFusedM5(const Ftor &ftor) : KernelOpsT(ftor), arg(ftor.arg) { }

--- a/include/kernels/dslash_wilson.cuh
+++ b/include/kernels/dslash_wilson.cuh
@@ -4,7 +4,6 @@
 #include <color_spinor_field_order.h>
 #include <gauge_field_order.h>
 #include <color_spinor.h>
-#include <dslash_helper.cuh>
 #include <index_helper.cuh>
 #include <kernels/dslash_pack.cuh> // for the packing kernel
 #include <kernels/spinor_reweight.cuh>

--- a/lib/check_params.h
+++ b/lib/check_params.h
@@ -762,11 +762,7 @@ void printQudaInvertParam(QudaInvertParam *param) {
 #endif
 
 #ifdef INIT_PARAM
-#ifdef NVSHMEM_COMMS
-  P(use_mobius_fused_kernel, QUDA_BOOLEAN_FALSE);
-#else
   P(use_mobius_fused_kernel, QUDA_BOOLEAN_TRUE);
-#endif
 #else
   P(use_mobius_fused_kernel, QUDA_BOOLEAN_INVALID);
 #endif

--- a/lib/dslash_domain_wall_4d_fused_m5.hpp
+++ b/lib/dslash_domain_wall_4d_fused_m5.hpp
@@ -125,16 +125,12 @@ namespace quda
                              double m_5, int parity, bool dagger, const int *comm_override, double m_f,
                              Dslash5TypeList<dslash5_type_impl, N...>, TimeProfile &profile)
     {
-#ifdef NVSHMEM_COMMS
-      errorQuda("Fused Mobius/DWF-4D kernels do not currently work with NVSHMEM.");
-#else
       constexpr int nDim = 4;
       auto halo = ColorSpinorField::create_comms_batch(in);
       using Arg = DomainWall4DFusedM5Arg<Float, nColor, nDim, DDArg, recon, dslash5_type_impl>;
       Arg arg(out, in, halo, U, a, m_5, b_5, c_5, a != 0.0, x, y, parity, dagger, comm_override, m_f);
       DomainWall4DFusedM5<Arg> dwf(arg, out, in, halo, y);
       dslash::DslashPolicyTune<decltype(dwf)> policy(dwf, in, halo, profile);
-#endif
     }
   };
 

--- a/lib/dslash_mdw_fused.in.hpp
+++ b/lib/dslash_mdw_fused.in.hpp
@@ -22,6 +22,14 @@ namespace quda
                                  const Complex *b_5, const Complex *c_5, bool dagger, int parity, int shift[4],
                                  int halo_shift[4], MdwfFusedDslashType type);
 
+    void apply_fused_dslash_list(ColorSpinorField &, const ColorSpinorField &, const GaugeField &,
+                                 ColorSpinorField &, const ColorSpinorField &, double, double,
+                                 const Complex *, const Complex *, bool, int, int[4],
+                                 int[4], MdwfFusedDslashType, IntList<>)
+    {
+      errorQuda("No Ls has not been instantiated");
+    }
+
     template <int Ls, int... N>
     void apply_fused_dslash_list(ColorSpinorField &out, const ColorSpinorField &in, const GaugeField &U,
                                  ColorSpinorField &y, const ColorSpinorField &x, double m_f, double m_5,

--- a/lib/dslash_mdw_fused.in.hpp
+++ b/lib/dslash_mdw_fused.in.hpp
@@ -22,9 +22,9 @@ namespace quda
                                  const Complex *b_5, const Complex *c_5, bool dagger, int parity, int shift[4],
                                  int halo_shift[4], MdwfFusedDslashType type);
 
-    void apply_fused_dslash_list(ColorSpinorField &, const ColorSpinorField &, const GaugeField &, ColorSpinorField &,
-                                 const ColorSpinorField &, double, double, const Complex *, const Complex *, bool, int,
-                                 int[4], int[4], MdwfFusedDslashType, IntList<>)
+    inline void apply_fused_dslash_list(ColorSpinorField &, const ColorSpinorField &, const GaugeField &,
+                                        ColorSpinorField &, const ColorSpinorField &, double, double, const Complex *,
+                                        const Complex *, bool, int, int[4], int[4], MdwfFusedDslashType, IntList<>)
     {
       errorQuda("No Ls has not been instantiated");
     }
@@ -58,10 +58,9 @@ namespace quda
       apply_fused_dslash_list(out, in, U, y, x, m_f, m_5, b_5, c_5, dagger, parity, shift, halo_shift, type, int_list);
     }
 #else
-    void inline apply_fused_dslash(ColorSpinorField &, const ColorSpinorField &, const GaugeField &,
-                                   ColorSpinorField &, const ColorSpinorField &, double, double,
-                                   const Complex *, const Complex *, bool, int, int[4],
-                                   int[4], MdwfFusedDslashType)
+    void inline apply_fused_dslash(ColorSpinorField &, const ColorSpinorField &, const GaugeField &, ColorSpinorField &,
+                                   const ColorSpinorField &, double, double, const Complex *, const Complex *, bool,
+                                   int, int[4], int[4], MdwfFusedDslashType)
     {
       errorQuda("Domain wall dslash with tensor cores has not been built");
     }

--- a/lib/dslash_mdw_fused.in.hpp
+++ b/lib/dslash_mdw_fused.in.hpp
@@ -22,10 +22,9 @@ namespace quda
                                  const Complex *b_5, const Complex *c_5, bool dagger, int parity, int shift[4],
                                  int halo_shift[4], MdwfFusedDslashType type);
 
-    void apply_fused_dslash_list(ColorSpinorField &, const ColorSpinorField &, const GaugeField &,
-                                 ColorSpinorField &, const ColorSpinorField &, double, double,
-                                 const Complex *, const Complex *, bool, int, int[4],
-                                 int[4], MdwfFusedDslashType, IntList<>)
+    void apply_fused_dslash_list(ColorSpinorField &, const ColorSpinorField &, const GaugeField &, ColorSpinorField &,
+                                 const ColorSpinorField &, double, double, const Complex *, const Complex *, bool, int,
+                                 int[4], int[4], MdwfFusedDslashType, IntList<>)
     {
       errorQuda("No Ls has not been instantiated");
     }

--- a/lib/dslash_mdw_fused.in.hpp
+++ b/lib/dslash_mdw_fused.in.hpp
@@ -22,7 +22,7 @@ namespace quda
                                  const Complex *b_5, const Complex *c_5, bool dagger, int parity, int shift[4],
                                  int halo_shift[4], MdwfFusedDslashType type);
 
-    inline void apply_fused_dslash_list(ColorSpinorField &, const ColorSpinorField &, const GaugeField &,
+    void inline apply_fused_dslash_list(ColorSpinorField &, const ColorSpinorField &, const GaugeField &,
                                         ColorSpinorField &, const ColorSpinorField &, double, double, const Complex *,
                                         const Complex *, bool, int, int[4], int[4], MdwfFusedDslashType, IntList<>)
     {

--- a/tests/utils/command_line_params.cpp
+++ b/tests/utils/command_line_params.cpp
@@ -196,11 +196,7 @@ quda::mgarray<std::array<int, 4>> geo_block_size = {};
 bool mg_allow_truncation = false;
 bool mg_staggered_kd_dagger_approximation = false;
 
-#ifdef NVSHMEM_COMMS
-bool use_mobius_fused_kernel = false;
-#else
 bool use_mobius_fused_kernel = true;
-#endif
 
 int n_ev = 8;
 int max_search_dim = 64;


### PR DESCRIPTION
Avoid hangs due to `__syncthreads`/exiting threads for fused Mobius kernel + NVSHMEM.