### PR TITLE
Hardcode 64 wavefront size in the HIP backend

### DIFF
--- a/include/targets/hip/target_device.h
+++ b/include/targets/hip/target_device.h
@@ -145,11 +145,8 @@ namespace quda
        architecture we are running on.
     */
     constexpr int warp_size() {
-      #if defined(__GFX9__)
+      // FIXME: Need to handle devices with different wavefront sizes
       return 64;
-      #else
-      return 32;
-      #endif
     }
 
     /**


### PR DESCRIPTION
The `__GFX9__` macros (and friends) are only defined in the device pass.  Since the `warp_size` function is used on the host side, the `#else` branch was returning something different than what was returned on the device.

We need to be able to handle devices with different wavefront sizes, and we need to be able to expose those to the host.  The usual mechanism for host exposure is to probe the HIP runtime for the current device's `warpSize` property, but this approach isn't a constant expression.

In the future, we'll need an approach that either a) doesn't rely on constexpr-ness; or b) or can rely on constexpr-ness but simply isn't used on the host.

**Note**: This is only intended to be a short-term workaround.

@leonhostetler Can you give this a shot and see if it fixes your runtime error?