### PR TITLE
Added missing popVerbosity() to lib/interface_quda.cpp

### DIFF
--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -5605,6 +5605,7 @@ void performGFlowQuda(void **h_out, void **h_in, QudaInvertParam *inv_param, Qud
   }
 
   popOutputPrefix();
+  popVerbosity();
 
 } /* end of performGFlowQuda */
 
@@ -5742,6 +5743,7 @@ void performAdjGFlowSafe(void **h_out, void **h_in, QudaInvertParam *inv_param, 
   }
 
   popOutputPrefix();
+  popVerbosity();
 }
 
 void adjSafeEvolve(std::vector<std::reference_wrapper<std::vector<ColorSpinorField>>> sf_list,
@@ -6057,6 +6059,7 @@ void performAdjGFlowHier(void **h_out, void **h_in, QudaInvertParam *inv_param, 
 
   logQuda(QUDA_DEBUG_VERBOSE, "Spinor written to cpu \n");
   popOutputPrefix();
+  popVerbosity();
 }
 
 /* save list of gauge vectors */


### PR DESCRIPTION
In `lib/interface_quda.cpp`, three functions--`performGFlowQuda`, `performAdjGFlowSafe`, and `performAdjGFlowHier`--were missing the `popVerbosity()` at the end of the function after using `pushVerbosity()` at the beginning. Thus, when calling one of these functions repeatedly, one ends up with an output file containing thousands of warnings like:
```
performGFlowQuda: WARNING: Verbosity stack contains 189 elements.  Is there a missing popVerbosity() somewhere?
```