### PR TITLE
Quick fix for double4 ambiguous declaration in gcc 11.4

### DIFF
--- a/tests/blas_test.cpp
+++ b/tests/blas_test.cpp
@@ -791,7 +791,7 @@ protected:
       xD = xH;
       yD = yH;
       {
-        double4 d = blas::cDotProductNormAB(xD, yD);
+        auto d = blas::cDotProductNormAB(xD, yD);
         auto dot = blas::cDotProduct(xH, yH);
         auto x2 = blas::norm2(xH);
         auto y2 = blas::norm2(yH);


### PR DESCRIPTION
[see title]