### PR TITLE
Autotuning Enhancement

### DIFF
--- a/.github/workflows/cuda_13p0_githubactions_build.yml
+++ b/.github/workflows/cuda_13p0_githubactions_build.yml
@@ -16,7 +16,7 @@ jobs:
     build:
       strategy:
         matrix:
-          compiler: [g++-15]
+          compiler: [g++-14]
       runs-on: ubuntu-24.04
 
       steps:

--- a/.github/workflows/cuda_13p0_githubactions_build.yml
+++ b/.github/workflows/cuda_13p0_githubactions_build.yml
@@ -1,0 +1,65 @@
+name: cuda_13p0_build_ubuntu24.04
+
+on:
+  pull_request:
+    branches: [ "develop" ]
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  BUILD_TYPE: STRICT
+  CCACHE_COMPILERCHECK: content
+
+jobs:
+    build:
+      strategy:
+        matrix:
+          compiler: [g++-15]
+      runs-on: ubuntu-24.04
+
+      steps:
+      - name: Install software
+        run: |
+          wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb
+          sudo dpkg -i cuda-keyring_1.1-1_all.deb
+          sudo apt-get update -y
+          sudo apt-get install -y --no-install-recommends libopenmpi-dev  cuda-compiler-13-0 cuda-libraries-dev-13-0 cuda-nvml-dev-13-0
+     
+      # currently deactivated as it cuased build errors - maybe put in again later
+      # - uses: awalsh128/cache-apt-pkgs-action@latest
+      #   with:
+      #     packages:
+      #     execute_install_scripts: true
+
+      - uses: actions/checkout@v4
+
+      - name: Ccache for gh actions
+        uses: hendrikmuhs/ccache-action@v1.2.17
+        with:
+          key: ${{ github.job }}-${{ matrix.compiler }}
+          max-size: 2000M
+
+      - name: Configure CMake
+        run: >
+          cmake 
+          -DCMAKE_CUDA_COMPILER=/usr/local/cuda-13.0/bin/nvcc
+          -DCMAKE_CXX_COMPILER=${{matrix.compiler}}
+          -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          -DQUDA_GPU_ARCH=sm_100 -DQUDA_GPU_ARCH_SUFFIX=virtual -DQUDA_JITIFY=OFF
+          -DQUDA_MULTIGRID=ON
+          -DQUDA_MULTIGRID_NVEC_LIST=24
+          -DQUDA_MDW_FUSED_LS_LIST=4
+          -DQUDA_MPI=ON -DMPI_CXX_SKIP_MPICXX=ON 
+          -DQUDA_PRECISION=14 -DQUDA_FAST_COMPILE_REDUCE=ON
+          -GNinja
+          -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+
+      - name: Build
+        run: cmake --build ${{github.workspace}}/build
+
+      - name: Install
+        run: cmake --install ${{github.workspace}}/build 
+

--- a/include/device.h
+++ b/include/device.h
@@ -166,6 +166,11 @@ namespace quda
      */
     unsigned int max_blocks_per_processor();
 
+    /**
+       @return Whether shared carve out configuration is supported
+    */
+    bool shared_carve_out_supported();
+
     namespace profile
     {
 

--- a/include/dslash.h
+++ b/include/dslash.h
@@ -86,7 +86,7 @@ namespace quda
 
     bool tuneSharedCarveOut() const override
     {
-      static bool tune_shared = true; // default is to do carve out tuning
+      static bool tune_shared = device::shared_carve_out_supported(); // default is to do carve out tuning
       static bool init = false;
 
       if (!init) {

--- a/include/dslash.h
+++ b/include/dslash.h
@@ -86,7 +86,8 @@ namespace quda
 
     bool tuneSharedCarveOut() const override
     {
-      static bool tune_shared = device::shared_carve_out_supported(); // default is to do carve out tuning
+      // default is to do carve out tuning if the architecture supports it
+      static bool tune_shared = device::shared_carve_out_supported();
       static bool init = false;
 
       if (!init) {

--- a/include/targets/cuda/tunable_kernel.h
+++ b/include/targets/cuda/tunable_kernel.h
@@ -36,6 +36,22 @@ namespace quda
   protected:
     QudaFieldLocation location;
 
+    /**
+       @brief Set the maximum number of blocks that can reside on an
+       SM.  This is called when we are autotuning to allow us to work
+       out how many different shared memory over allocations we should
+       use to minimally cover all occupancy variations.
+     */
+    void setMaxActiveBlocks(const kernel_t &kernel, const TuneParam &tp) const
+    {
+      if (activeTuningWarmup() && tuneSharedBytes()) {
+        auto tp2 = tp;
+        setSharedBytes(tp2);
+        // only compute max number blocks when we have no shared memory over subscription
+        if (tp.shared_bytes == tp2.shared_bytes) max_active_blocks = qudaOccupancyMaxActiveBlocks(kernel, tp);
+      }
+    }
+
     template <template <typename> class Functor, bool grid_stride, typename Arg>
     std::enable_if_t<device::use_kernel_arg<Arg>(), qudaError_t>
     launch_device(const kernel_t &kernel, const TuneParam &tp, const qudaStream_t &stream, const Arg &arg)
@@ -44,6 +60,7 @@ namespace quda
 #ifdef JITIFY
       launch_error = launch_jitify<Functor, grid_stride, Arg>(kernel.name, tp, stream, arg);
 #else
+      setMaxActiveBlocks(kernel, tp);
       launch_error = qudaLaunchKernel(kernel, tp, stream, static_cast<const void *>(&arg));
 #endif
       return launch_error;
@@ -65,6 +82,7 @@ namespace quda
 #else
       check_arg_size(arg);
       qudaMemcpyAsync(device::get_constant_buffer<Arg>(), &arg, sizeof(Arg), qudaMemcpyHostToDevice, stream);
+      setMaxActiveBlocks(kernel, tp);
       launch_error = qudaLaunchKernel(kernel, tp, stream, static_cast<const void *>(&arg));
 #endif
       return launch_error;

--- a/include/targets/cuda/tunable_kernel.h
+++ b/include/targets/cuda/tunable_kernel.h
@@ -21,7 +21,14 @@ namespace quda
      @param[in] arg Host address of argument struct
      @param[in] stream Stream identifier
   */
-  qudaError_t qudaLaunchKernel(const void *func, const TuneParam &tp, const qudaStream_t &stream, const void *arg);
+  qudaError_t qudaLaunchKernel(const kernel_t &kernel, const TuneParam &tp, const qudaStream_t &stream, const void *arg);
+
+  /**
+     @brief Wrapper around cudaOccupancyMaxActiveBlocks
+     @param[in] func Device function symbol
+     @param[in] tp TuneParam containing the launch parameters
+  */
+  int qudaOccupancyMaxActiveBlocks(const kernel_t &kernel, const TuneParam &tp);
 
   class TunableKernel : public Tunable
   {
@@ -37,7 +44,7 @@ namespace quda
 #ifdef JITIFY
       launch_error = launch_jitify<Functor, grid_stride, Arg>(kernel.name, tp, stream, arg);
 #else
-      launch_error = qudaLaunchKernel(kernel.func, tp, stream, static_cast<const void *>(&arg));
+      launch_error = qudaLaunchKernel(kernel, tp, stream, static_cast<const void *>(&arg));
 #endif
       return launch_error;
     }
@@ -58,7 +65,7 @@ namespace quda
 #else
       check_arg_size(arg);
       qudaMemcpyAsync(device::get_constant_buffer<Arg>(), &arg, sizeof(Arg), qudaMemcpyHostToDevice, stream);
-      launch_error = qudaLaunchKernel(kernel.func, tp, stream, static_cast<const void *>(&arg));
+      launch_error = qudaLaunchKernel(kernel, tp, stream, static_cast<const void *>(&arg));
 #endif
       return launch_error;
     }

--- a/include/targets/hip/tunable_kernel.h
+++ b/include/targets/hip/tunable_kernel.h
@@ -33,11 +33,28 @@ namespace quda
   protected:
     QudaFieldLocation location;
 
+    /**
+       @brief Set the maximum number of blocks that can reside on an
+       SM.  This is called when we are autotuning to allow us to work
+       out how many different shared memory over allocations we should
+       use to minimally cover all occupancy variations.
+     */
+    void setMaxActiveBlocks(const kernel_t &kernel, const TuneParam &tp) const
+    {
+      if (activeTuningWarmup() && tuneSharedBytes()) {
+        auto tp2 = tp;
+        setSharedBytes(tp2);
+        // only compute max number blocks when we have no shared memory over subscription
+        if (tp.shared_bytes == tp2.shared_bytes) max_active_blocks = qudaOccupancyMaxActiveBlocks(kernel, tp);
+      }
+    }
+
     template <template <typename> class Functor, bool grid_stride, typename Arg>
     std::enable_if_t<device::use_kernel_arg<Arg>(), qudaError_t>
     launch_device(const kernel_t &kernel, const TuneParam &tp, const qudaStream_t &stream, const Arg &arg)
     {
       checkSharedBytes<Functor>(tp, arg);
+      setMaxActiveBlocks(kernel, tp);
       launch_error = qudaLaunchKernel(kernel, tp, stream, static_cast<const void *>(&arg));
       return launch_error;
     }
@@ -49,6 +66,7 @@ namespace quda
       checkSharedBytes<Functor>(tp, arg);
       static_assert(sizeof(Arg) <= device::max_constant_size(), "Parameter struct is greater than max constant size");
       qudaMemcpyAsync(device::get_constant_buffer<Arg>(), &arg, sizeof(Arg), qudaMemcpyHostToDevice, stream);
+      setMaxActiveBlocks(kernel, tp);
       launch_error = qudaLaunchKernel(kernel, tp, stream, static_cast<const void *>(&arg));
       return launch_error;
     }

--- a/include/targets/hip/tunable_kernel.h
+++ b/include/targets/hip/tunable_kernel.h
@@ -12,13 +12,20 @@ namespace quda
 {
 
   /**
-      @brief Wrapper around cudaLaunchKernel
-      @param[in] func Device function symbol
-      @param[in] tp TuneParam containing the launch parameters
-      @param[in] arg Host address of argument struct
-      @param[in] stream Stream identifier
-   */
-  qudaError_t qudaLaunchKernel(const void *func, const TuneParam &tp, const qudaStream_t &stream, const void *arg);
+     @brief Wrapper around hipLaunchKernel
+     @param[in] func Device function symbol
+     @param[in] tp TuneParam containing the launch parameters
+     @param[in] arg Host address of argument struct
+     @param[in] stream Stream identifier
+  */
+  qudaError_t qudaLaunchKernel(const kernel_t &kernel, const TuneParam &tp, const qudaStream_t &stream, const void *arg);
+
+  /**
+     @brief Wrapper around hipOccupancyMaxActiveBlocks
+     @param[in] func Device function symbol
+     @param[in] tp TuneParam containing the launch parameters
+  */
+  int qudaOccupancyMaxActiveBlocks(const kernel_t &kernel, const TuneParam &tp);
 
   class TunableKernel : public Tunable
   {
@@ -31,7 +38,7 @@ namespace quda
     launch_device(const kernel_t &kernel, const TuneParam &tp, const qudaStream_t &stream, const Arg &arg)
     {
       checkSharedBytes<Functor>(tp, arg);
-      launch_error = qudaLaunchKernel(kernel.func, tp, stream, static_cast<const void *>(&arg));
+      launch_error = qudaLaunchKernel(kernel, tp, stream, static_cast<const void *>(&arg));
       return launch_error;
     }
 
@@ -42,7 +49,7 @@ namespace quda
       checkSharedBytes<Functor>(tp, arg);
       static_assert(sizeof(Arg) <= device::max_constant_size(), "Parameter struct is greater than max constant size");
       qudaMemcpyAsync(device::get_constant_buffer<Arg>(), &arg, sizeof(Arg), qudaMemcpyHostToDevice, stream);
-      launch_error = qudaLaunchKernel(kernel.func, tp, stream, static_cast<const void *>(&arg));
+      launch_error = qudaLaunchKernel(kernel, tp, stream, static_cast<const void *>(&arg));
       return launch_error;
     }
 

--- a/include/tune_quda.h
+++ b/include/tune_quda.h
@@ -217,6 +217,14 @@ namespace quda {
      */
     virtual unsigned int maxSharedBytesPerBlock() const { return device::max_default_shared_memory(); }
 
+    mutable int max_active_blocks = 0;
+
+    /**
+       @brief Return the maximum number of blocks resident per SM
+       @param[in] param TuneParam containing the launch parameters
+    */
+    virtual int maxBlocksPerMultiprocessor(const TuneParam &) const { return max_active_blocks; }
+
     /**
      * The goal here is to throttle the number of thread blocks per SM
      * by over-allocating shared memory (in order to improve L2
@@ -228,9 +236,7 @@ namespace quda {
     {
       if (tuneSharedBytes()) {
         const auto max_shared = maxSharedBytesPerBlock();
-        const int max_blocks_per_sm
-          = std::min(device::max_threads_per_processor() / (param.block.x * param.block.y * param.block.z),
-                     device::max_blocks_per_processor());
+        int max_blocks_per_sm = maxBlocksPerMultiprocessor(param);
         int blocks_per_sm = max_shared / (param.shared_bytes ? param.shared_bytes : 1);
 	if (blocks_per_sm > max_blocks_per_sm) blocks_per_sm = max_blocks_per_sm;
 	param.shared_bytes = (blocks_per_sm > 0 ? max_shared / blocks_per_sm + 1 : max_shared + 1);
@@ -423,6 +429,12 @@ namespace quda {
      @return tuning in progress?
   */
   bool activeTuning();
+
+  /**
+     @brief query if tuning warmup is in progress
+     @return tuning warming up in progress?
+  */
+  bool activeTuningWarmup();
 
   void loadTuneCache();
   void saveTuneCache(bool error = false);

--- a/lib/coarse_op.cuh
+++ b/lib/coarse_op.cuh
@@ -713,6 +713,11 @@ namespace quda {
       return ((type == COMPUTE_VUV || type == COMPUTE_VLV) ? (advanceAtomic(param) || advanceParityFlip(param) || advanceSwizzle(param)) : false);
     }
 
+    bool tuneSharedBytes(TuneParam &param) const override
+    {
+      return (!arg.shared_atomic && !from_coarse && (type == COMPUTE_VUV || type == COMPUTE_VLV)) || type == COMPUTE_COARSE_CLOVER;
+    }
+
     bool advanceSharedBytes(TuneParam &param) const override
     {
       return ( (!arg.shared_atomic && !from_coarse && (type == COMPUTE_VUV || type == COMPUTE_VLV)) || type == COMPUTE_COARSE_CLOVER) ? false : Tunable::advanceSharedBytes(param);

--- a/lib/coarse_op.cuh
+++ b/lib/coarse_op.cuh
@@ -713,7 +713,7 @@ namespace quda {
       return ((type == COMPUTE_VUV || type == COMPUTE_VLV) ? (advanceAtomic(param) || advanceParityFlip(param) || advanceSwizzle(param)) : false);
     }
 
-    bool tuneSharedBytes(TuneParam &param) const override
+    bool tuneSharedBytes() const override
     {
       return (!arg.shared_atomic && !from_coarse && (type == COMPUTE_VUV || type == COMPUTE_VLV)) || type == COMPUTE_COARSE_CLOVER;
     }

--- a/lib/coarse_op_preconditioned.in.cu
+++ b/lib/coarse_op_preconditioned.in.cu
@@ -95,7 +95,7 @@ namespace quda
       }
     }
 
-    bool advanceSharedBytes(TuneParam &) const { return false; }
+    bool tuneSharedBytes() const { return false; }
 
     bool advanceAux(TuneParam &param) const
     {

--- a/lib/color_spinor_project_domain_decomp.cu
+++ b/lib/color_spinor_project_domain_decomp.cu
@@ -18,7 +18,7 @@ namespace quda
     using Arg = ProjectDDArg<Float, DDArg, nSpin, nColor, Order>;
     ColorSpinorField &out;
 
-    bool advanceSharedBytes(TuneParam &) const { return false; } // Don't tune shared mem
+    bool tuneSharedBytes() const { return false; }
     unsigned int minThreads() const { return out.VolumeCB(); }
 
   public:

--- a/lib/copy_color_spinor.cuh
+++ b/lib/copy_color_spinor.cuh
@@ -18,7 +18,7 @@ namespace quda
     ColorSpinorField &out;
     const ColorSpinorField &in;
 
-    bool advanceSharedBytes(TuneParam &) const { return false; } // Don't tune shared mem
+    bool tuneSharedBytes() const { return false; }
     unsigned int minThreads() const { return in.VolumeCB(); }
 
     std::string get_basis_str(QudaGammaBasis basis)

--- a/lib/copy_color_spinor_mg.in.hpp
+++ b/lib/copy_color_spinor_mg.in.hpp
@@ -25,7 +25,7 @@ namespace quda {
     FloatOut *Out;
     FloatIn *In;
 
-    bool advanceSharedBytes(TuneParam &) const { return false; } // Don't tune shared mem
+    bool tuneSharedBytes() const { return false; }
     unsigned int minThreads() const { return in.VolumeCB(); }
 
   public:

--- a/lib/copy_gauge_extended.cu
+++ b/lib/copy_gauge_extended.cu
@@ -12,7 +12,7 @@ namespace quda {
     FloatOut *Out;
     FloatIn *In;
 
-    bool advanceSharedBytes(TuneParam &) const { return false; } // Don't tune shared mem
+    bool tuneSharedBytes() const { return false; }
     unsigned int minThreads() const { return in.VolumeCB() == out.VolumeCB() ? in.VolumeCB() : in.LocalVolumeCB(); }
 
   public:

--- a/lib/copy_gauge_helper.hpp
+++ b/lib/copy_gauge_helper.hpp
@@ -15,7 +15,7 @@ namespace quda
     GaugeField &out;
     const GaugeField &in;
 
-    bool advanceSharedBytes(TuneParam &) const override { return false; } // Don't tune shared mem
+    bool tuneSharedBytes() const override { return false; }
     unsigned int minThreads() const override { return size; }
 
   public:

--- a/lib/gauge_observable.cpp
+++ b/lib/gauge_observable.cpp
@@ -19,7 +19,7 @@ namespace quda
     }
 
     if (param.compute_rectangle) {
-      double4 plqrct = plaquetteRectangle(u);
+      auto plqrct = plaquetteRectangle(u);
       param.plaquette[0] = 0.5 * (plqrct.x + plqrct.y);
       param.plaquette[1] = plqrct.x;
       param.plaquette[2] = plqrct.y;
@@ -27,7 +27,7 @@ namespace quda
       param.rectangle[1] = plqrct.z;
       param.rectangle[2] = plqrct.w;
     } else if (param.compute_plaquette) {
-      double3 plaq = plaquette(u);
+      auto plaq = plaquette(u);
       param.plaquette[0] = plaq.x;
       param.plaquette[1] = plaq.y;
       param.plaquette[2] = plaq.z;

--- a/lib/multi_reduce_quda.cu
+++ b/lib/multi_reduce_quda.cu
@@ -21,7 +21,7 @@ namespace quda {
       cvector_ref<ColorSpinorField> &x, &y, &z, &w;
       T &result;
       QudaFieldLocation location;
-      bool tuneSharedBytes() const { return false; }
+      bool tuneSharedBytes() const override { return false; }
 
     public:
       template <typename Vx, typename Vy, typename Vz, typename Vw>

--- a/lib/multi_reduce_quda.cu
+++ b/lib/multi_reduce_quda.cu
@@ -21,16 +21,7 @@ namespace quda {
       cvector_ref<ColorSpinorField> &x, &y, &z, &w;
       T &result;
       QudaFieldLocation location;
-
-      virtual bool advanceSharedBytes(TuneParam &param) const override
-      {
-        TuneParam next(param);
-        advanceBlockDim(next); // to get next blockDim
-        int nthreads = next.block.x * next.block.y * next.block.z;
-        param.shared_bytes = sharedBytesPerThread() * nthreads > sharedBytesPerBlock(param) ?
-          sharedBytesPerThread() * nthreads : sharedBytesPerBlock(param);
-        return false;
-      }
+      bool tuneSharedBytes() const { return false; }
 
     public:
       template <typename Vx, typename Vy, typename Vz, typename Vw>

--- a/lib/reduce_quda.cu
+++ b/lib/reduce_quda.cu
@@ -19,17 +19,7 @@ namespace quda {
       coeff_t a, b;
       cvector_ref<ColorSpinorField> &x, &y, &z, &w, &v;
       vector<host_reduce_t> &result;
-
-      bool advanceSharedBytes(TuneParam &param) const override
-      {
-        TuneParam next(param);
-        advanceBlockDim(next); // to get next blockDim
-        int nthreads = next.block.x * next.block.y * next.block.z;
-        param.shared_bytes = sharedBytesPerThread() * nthreads > sharedBytesPerBlock(param) ?
-            sharedBytesPerThread() * nthreads :
-            sharedBytesPerBlock(param);
-        return false;
-      }
+      bool tuneSharedBytes() const { return false; }
 
     public:
       template <typename Vx, typename Vy, typename Vz, typename Vw, typename Vv>

--- a/lib/reduce_quda.cu
+++ b/lib/reduce_quda.cu
@@ -19,7 +19,7 @@ namespace quda {
       coeff_t a, b;
       cvector_ref<ColorSpinorField> &x, &y, &z, &w, &v;
       vector<host_reduce_t> &result;
-      bool tuneSharedBytes() const { return false; }
+      bool tuneSharedBytes() const override { return false; }
 
     public:
       template <typename Vx, typename Vy, typename Vz, typename Vw, typename Vv>

--- a/lib/restrictor_mma.in.cu
+++ b/lib/restrictor_mma.in.cu
@@ -1,3 +1,5 @@
+#include <cub/block/block_reduce.cuh>
+
 #include <color_spinor_field.h>
 #include <multigrid.h>
 #include <power_of_two_array.h>

--- a/lib/restrictor_mma.in.cu
+++ b/lib/restrictor_mma.in.cu
@@ -1,4 +1,6 @@
+#ifdef QUDA_MMA_AVAILABLE
 #include <cub/block/block_reduce.cuh>
+#endif
 
 #include <color_spinor_field.h>
 #include <multigrid.h>

--- a/lib/restrictor_mma.in.cu
+++ b/lib/restrictor_mma.in.cu
@@ -1,3 +1,4 @@
+#include <quda_arch.h>
 #ifdef QUDA_MMA_AVAILABLE
 #include <cub/block/block_reduce.cuh>
 #endif

--- a/lib/targets/cuda/device.cpp
+++ b/lib/targets/cuda/device.cpp
@@ -361,6 +361,8 @@ namespace quda
       return max_blocks_per_sm;
     }
 
+    bool shared_carve_out_supported() { return true; }
+
     namespace profile
     {
 

--- a/lib/targets/cuda/quda_api.cpp
+++ b/lib/targets/cuda/quda_api.cpp
@@ -5,6 +5,7 @@
 #include <timer.h>
 #include <device.h>
 #include <quda_cuda_api.h>
+#include <kernel_helper.h>
 
 // if this macro is defined then we use the driver API, else use the
 // runtime API.  Typically the driver API has 10-20% less overhead
@@ -129,8 +130,9 @@ namespace quda
   static TimeProfile apiTimer("CUDA API calls (runtime)");
 #endif
 
-  qudaError_t qudaLaunchKernel(const void *func, const TuneParam &tp, const qudaStream_t &stream, const void *arg)
+  qudaError_t qudaLaunchKernel(const kernel_t &kernel, const TuneParam &tp, const qudaStream_t &stream, const void *arg)
   {
+    auto func = kernel.func;
     static std::unordered_set<const void *> cache;
     auto search = cache.find(func);
     if (search == cache.end()) {
@@ -179,7 +181,7 @@ namespace quda
               QUDA_PROFILE_LAUNCH_KERNEL);
     }
 
-    set_runtime_error(error, __func__, __func__, __FILE__, __STRINGIFY__(__LINE__), activeTuning());
+    set_runtime_error(error, __func__, kernel.name.c_str(), __FILE__, __STRINGIFY__(__LINE__), activeTuning());
     return error == cudaSuccess ? QUDA_SUCCESS : QUDA_ERROR;
   }
 
@@ -618,6 +620,15 @@ namespace quda
     // no driver API variant here since we have C++ functions
     PROFILE(cudaError_t error = cudaFuncGetAttributes(&attr, kernel), QUDA_PROFILE_FUNC_SET_ATTRIBUTE);
     set_runtime_error(error, __func__, func, file, line);
+  }
+
+  int qudaOccupancyMaxActiveBlocks(const kernel_t &kernel, const TuneParam &tp)
+  {
+    int numBlocks;
+    cudaError_t error = cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+      &numBlocks, kernel.func, tp.block.x * tp.block.y * tp.block.z, tp.shared_bytes);
+    set_runtime_error(error, __func__, kernel.name.c_str(), __FILE__, __STRINGIFY__(__LINE__), activeTuning());
+    return numBlocks;
   }
 
   void printAPIProfile()

--- a/lib/targets/cuda/target_cuda.cmake
+++ b/lib/targets/cuda/target_cuda.cmake
@@ -156,9 +156,9 @@ cmake_dependent_option(QUDA_LARGE_KERNEL_ARG "enable large kernel arg support" O
 message(STATUS "Large kernel arguments support: ${QUDA_LARGE_KERNEL_ARG}")
 mark_as_advanced(QUDA_LARGE_KERNEL_ARG)
 
-# single-precision vectorization requires CUDA 13 or above
+# single-precision vectorization presently disabled by default
 cmake_dependent_option(QUDA_VECTORIZE_SINGLE "use vector instructions for single precision device code" ON
-  "${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 13.0 AND ${QUDA_COMPUTE_CAPABILITY} GREATER_EQUAL 100"
+  "${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 99.0 AND ${QUDA_COMPUTE_CAPABILITY} GREATER_EQUAL 100"
   OFF)
 message(STATUS "Single-precision vectorization support: ${QUDA_VECTORIZE_SINGLE}")
 mark_as_advanced(QUDA_VECTORIZE_SINGLE)

--- a/lib/targets/hip/device.cpp
+++ b/lib/targets/hip/device.cpp
@@ -193,6 +193,8 @@ namespace quda
 
     unsigned int max_blocks_per_processor() { return 32; }
 
+    bool shared_carve_out_supported() { return false; }
+
     namespace profile
     {
 

--- a/lib/targets/hip/quda_api.cpp
+++ b/lib/targets/hip/quda_api.cpp
@@ -7,6 +7,7 @@
 #include <target_device.h>
 #include <hip/hip_runtime.h>
 #include <quda_hip_api.h>
+#include <kernel_helper.h>
 
 // if this macro is defined then we profile the HIP API calls
 //#define API_PROFILE

--- a/lib/targets/hip/quda_api.cpp
+++ b/lib/targets/hip/quda_api.cpp
@@ -95,10 +95,10 @@ namespace quda
     }
   } // namespace
 
-  // No need to abstract these across the library so keep these definitions local to CUDA target
+  // No need to abstract these across the library so keep these definitions local to HIP target
 
   /**
-     @brief Wrapper around cudaFuncSetAttribute with built-in error checking
+     @brief Wrapper around hipFuncSetAttribute with built-in error checking
      @param[in] kernel Kernel function for which we are setting the attribute
      @param[in] attr Attribute to set
      @param[in] value Value to set
@@ -107,8 +107,8 @@ namespace quda
                              const char *line);
 
   /**
-     @brief Wrapper around cudaFuncGetAttributes with built-in error checking
-     @param[in] attr the cudaFuncGetAttributes object to store the output
+     @brief Wrapper around hipFuncGetAttributes with built-in error checking
+     @param[in] attr the hipFuncGetAttributes object to store the output
      @param[in] kernel Kernel function for which we are setting the attribute
   */
   void qudaFuncGetAttributes_(hipFuncAttributes &attr, const void *kernel, const char *func, const char *file,
@@ -122,13 +122,13 @@ namespace quda
 
   static TimeProfile apiTimer("HIP API calls (runtime)");
 
-  qudaError_t qudaLaunchKernel(const void *func, const TuneParam &tp, const qudaStream_t &stream, const void *arg)
+  qudaError_t qudaLaunchKernel(const kernel_t &kernel, const TuneParam &tp, const qudaStream_t &stream, const void *arg)
   {
-    // no driver API variant here since we have C++ functions
+    auto func = kernel.func;
     void *args[] = {const_cast<void *>(arg)};
     PROFILE(hipError_t error = hipLaunchKernel(func, tp.grid, tp.block, args, tp.shared_bytes, get_stream(stream)),
             QUDA_PROFILE_LAUNCH_KERNEL);
-    set_runtime_error(error, __func__, __func__, __FILE__, __STRINGIFY__(__LINE__), activeTuning());
+    set_runtime_error(error, __func__, kernel.name.c_str(), __FILE__, __STRINGIFY__(__LINE__), activeTuning());
     return error == hipSuccess ? QUDA_SUCCESS : QUDA_ERROR;
   }
 
@@ -225,7 +225,7 @@ namespace quda
           case hipMemcpyHostToDevice: type = QUDA_PROFILE_MEMCPY_H2D_ASYNC; break;
           case hipMemcpyDeviceToDevice: type = QUDA_PROFILE_MEMCPY_D2D_ASYNC; break;
           case hipMemcpyDefault: type = QUDA_PROFILE_MEMCPY_DEFAULT_ASYNC; break;
-          default: errorQuda("Unsupported cudaMemcpyTypeAsync %d", kind);
+          default: errorQuda("Unsupported hipMemcpyTypeAsync %d", kind);
           }
 #endif
           hipError_t error;
@@ -455,6 +455,15 @@ namespace quda
     PROFILE(hipError_t error = hipFuncGetAttributes(&attr, reinterpret_cast<const void *>(kernel)),
             QUDA_PROFILE_FUNC_SET_ATTRIBUTE);
     set_runtime_error(error, "hipFuncGetAttributes", func, file, line);
+  }
+
+  int qudaOccupancyMaxActiveBlocks(const kernel_t &kernel, const TuneParam &tp)
+  {
+    int numBlocks;
+    hipError_t error = hipOccupancyMaxActiveBlocksPerMultiprocessor(
+      &numBlocks, kernel.func, tp.block.x * tp.block.y * tp.block.z, tp.shared_bytes);
+    set_runtime_error(error, __func__, kernel.name.c_str(), __FILE__, __STRINGIFY__(__LINE__), activeTuning());
+    return numBlocks;
   }
 
   void printAPIProfile()

--- a/lib/tune.cpp
+++ b/lib/tune.cpp
@@ -141,8 +141,10 @@ namespace quda
   /** tuning in progress? */
   static bool tuning = false;
   static bool candidatetuning = true;
+  static bool warmup_tuning = false;
 
   bool activeTuning() { return tuning; }
+  bool activeTuningWarmup() { return warmup_tuning; }
 
   static bool profile_count = true;
 
@@ -1102,7 +1104,9 @@ namespace quda
             static_cast<int>(param.shared_bytes), param.shared_carve_out, static_cast<int>(param.aux.x),
             static_cast<int>(param.aux.y), static_cast<int>(param.aux.z), static_cast<int>(param.aux.w));
 
+          warmup_tuning = true;
           tunable.apply(stream); // do initial call in case we need to jit compile for these parameters or if policy tuning
+          warmup_tuning = false;
 
           timer.start();
           for (int i = 0; i < candidate_iterations; i++) {

--- a/lib/tune.cpp
+++ b/lib/tune.cpp
@@ -729,6 +729,9 @@ namespace quda
 
   bool Tunable::tuneSharedCarveOut() const
   {
+    // if carve out tuning is not supported then just return false
+    if (!device::shared_carve_out_supported()) return false;
+
     static bool tune_carve_out = false; // default is not to do carve out tuning
     static bool init = false;
 


### PR DESCRIPTION
This PR seeks to reduce the autotuning overheads when doing shared memory throttling
* The advancement through shared memory over allocation was previously done in a dumb way, assuming that the only limiter for occupancy is dynamic shared memory and the number of threads in a block.
* Using this information, we then over allocate the shared memory to test `1..n` CTAs per SM, where `n` is the max blocks per SM.
* By computing `n` using only the shared memory, we end up testing many more configs than we should, since we may be much more limited by registers.
* By using the CUDA occupancy calculator, we can compute what `n` is exactly and use that to set the tuning space.  To do so, I've created an API wrapper `qudaOccupancyMaxActiveBlocksPerMultiprocessor`.
* For double precision kernels the space reduction factor is more like 4x and for single precision, it's closer to 2x (a statement of being more register limited with double than single).

This PR has a couple of other additions included as well
* Avoid shared carve out tuning on targets that don't support it, e.g., AMD
* WAR for CUDA 13 CUB compilation with MG enabled