### PR TITLE
Fixed a compile-time error when compiling the openqcd interface QUDA_INTERFACE_NVTX

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -101,7 +101,7 @@ set (QUDA_OBJS
   copy_gauge_offset.cu copy_color_spinor_offset.cu copy_clover_offset.cu
   staggered_oprod.cu clover_trace_quda.cu
   hisq_paths_force_quda.cu
-  unitarize_force_quda.cu unitarize_links_quda.cu openqcd_interface.cpp milc_interface.cpp milc_interface_internal.cpp
+  unitarize_force_quda.cu unitarize_links_quda.cu milc_interface.cpp milc_interface_internal.cpp
   tune.cpp
   device_vector.cu
   inv_gmresdr_quda.cpp
@@ -114,6 +114,11 @@ set (QUDA_OBJS
   instantiate.cpp version.cpp
   block_transpose.cu )
 # cmake-format: on
+
+# only add the OpenQCD interface file if we're compiling with it enabled
+if(QUDA_INTERFACE_OPENQCD)
+  list(APPEND QUDA_OBJS openqcd_interface.cpp)
+endif()
 
 # current workaround for nvshmem
 set(QUDA_DSLASH_OBJS 

--- a/lib/openqcd_interface.cpp
+++ b/lib/openqcd_interface.cpp
@@ -1628,15 +1628,24 @@ static void *openQCD_qudaSolverReadIn(int id)
 void *openQCD_qudaSolverGetHandle(int id)
 {
   check_solver_id(id);
-  if (qudaState.inv_handles[id] == nullptr) {
+
+  void *ptr = id == -1 ? qudaState.dirac_handle : qudaState.inv_handles[id];
+
+  if (ptr == nullptr) {
     if (id != -1) {
       WITH_COMM(logQuda(QUDA_VERBOSE, "Read in solver parameters from file %s for solver (id=%d)\n", qudaState.infile, id));
     }
-    qudaState.inv_handles[id] = openQCD_qudaSolverReadIn(id);
+    ptr = openQCD_qudaSolverReadIn(id);
   }
 
-  openQCD_qudaSolverUpdate(qudaState.inv_handles[id]);
-  return qudaState.inv_handles[id];
+  if (id == -1) {
+    qudaState.dirac_handle = ptr;
+  } else {
+    qudaState.inv_handles[id] = ptr;
+  }
+
+  openQCD_qudaSolverUpdate(ptr);
+  return ptr;
 }
 
 void openQCD_qudaDw_deprecated(void *src, void *dst, openQCD_QudaDiracParam_t p)

--- a/lib/openqcd_interface.cpp
+++ b/lib/openqcd_interface.cpp
@@ -91,32 +91,26 @@ using namespace quda;
  */
 
 #ifdef INTERFACE_NVTX
-
-#if QUDA_NVTX_VERSION == 3
 #include "nvtx3/nvToolsExt.h"
-#else
-#include "nvToolsExt.h"
-#endif
 
-static const uint32_t colors[] = {0x0000ff00, 0x000000ff, 0x00ffff00, 0x00ff00ff, 0x0000ffff, 0x00ff0000, 0x00ffffff};
-static const int num_colors = sizeof(colors) / sizeof(uint32_t);
+static const uint32_t colors[] = { 0x0000ff00, 0x000000ff, 0x00ffff00, 0x00ff00ff, 0x0000ffff, 0x00ff0000, 0x00ffffff };
+static const int num_colors = sizeof(colors)/sizeof(uint32_t);
 
-#define PUSH_RANGE(name, cid)                                                                                          \
-  {                                                                                                                    \
-    int color_id = cid;                                                                                                \
-    color_id = color_id % num_colors;                                                                                  \
-    nvtxEventAttributes_t eventAttrib = {0};                                                                           \
-    eventAttrib.version = NVTX_VERSION;                                                                                \
-    eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;                                                                  \
-    eventAttrib.colorType = NVTX_COLOR_ARGB;                                                                           \
-    eventAttrib.color = colors[color_id];                                                                              \
-    eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;                                                                 \
-    eventAttrib.message.ascii = name;                                                                                  \
-    nvtxRangePushEx(&eventAttrib);                                                                                     \
-  }
+#define PUSH_RANGE(name,cid) { \
+  int color_id = cid; \
+  color_id = color_id%num_colors;\
+  nvtxEventAttributes_t eventAttrib = {}; \
+  eventAttrib.version = NVTX_VERSION; \
+  eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE; \
+  eventAttrib.colorType = NVTX_COLOR_ARGB; \
+  eventAttrib.color = colors[color_id]; \
+  eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII; \
+  eventAttrib.message.ascii = name; \
+  nvtxRangePushEx(&eventAttrib); \
+}
 #define POP_RANGE nvtxRangePop();
 #else
-#define PUSH_RANGE(name, cid)
+#define PUSH_RANGE(name,cid)
 #define POP_RANGE
 #endif
 


### PR DESCRIPTION
It appears that a change that was made in `milc_interface.cpp` at some point wasn't propagated into `openqcd_interface.cpp`, so I just copy+pasted over the code from https://github.com/lattice/quda/blob/develop/lib/milc_interface.cpp#L23-L45 and called it a day. @chaoos , can you confirm these fixes work for you?

Also---I saw there are some warnings in `openQCD_qudaSolverGetHandle`:

```
/scratch/local/quda/lib/openqcd_interface.cpp: In function ‘void* openQCD_qudaSolverGetHandle(int)’:
/scratch/local/quda/lib/openqcd_interface.cpp:1631:31: warning: array subscript [-1, 31] is outside array bounds of ‘void* [32]’ [-Warray-bounds=]
 1631 |   if (qudaState.inv_handles[id] == nullptr) {
      |       ~~~~~~~~~~~~~~~~~~~~~~~~^
/scratch/local/quda/lib/openqcd_interface.cpp:65:9: note: while referencing ‘openQCD_QudaState_t::inv_handles’
   65 |   void *inv_handles[OPENQCD_MAX_INVERTERS]; /** Array of void-pointers to QudaInvertParam structs for the solver(s) */
      |         ^~~~~~~~~~~
/scratch/local/quda/lib/openqcd_interface.cpp:1631:31: warning: array subscript [-1, 31] is outside array bounds of ‘void* [32]’ [-Warray-bounds=]
 1631 |   if (qudaState.inv_handles[id] == nullptr) {
      |       ~~~~~~~~~~~~~~~~~~~~~~~~^
/scratch/local/quda/lib/openqcd_interface.cpp:65:9: note: while referencing ‘openQCD_QudaState_t::inv_handles’
   65 |   void *inv_handles[OPENQCD_MAX_INVERTERS]; /** Array of void-pointers to QudaInvertParam structs for the solver(s) */
      |         ^~~~~~~~~~~
```

I'm not sure how I missed this warning before. The code that checks if a solver id is valid, `check_solver_id`, expressly permits `-1`, so a value of `-1` won't trigger a runtime error... but `qudaState.inv_handles[-1]` is unambiguously out of bounds (there's no array pointer offset calculations). @chaoos can you sanity check this? Feel free to push any changes directly to my branch.
