### PR TITLE
Function to write gauge fields to disk

### DIFF
--- a/include/quda.h
+++ b/include/quda.h
@@ -1175,6 +1175,13 @@ extern "C" {
   void saveGaugeQuda(void *h_gauge, QudaGaugeParam *param);
 
   /**
+   * Write the gauge field to disk
+   * @param file Filename to write to
+   * @param param   Contains all metadata regarding host and device storage
+   */
+  void writeGaugeQuda(const char *file, QudaGaugeParam *param);
+
+  /**
    * Load the clover term and/or the clover inverse from the host.
    * Either h_clover or h_clovinv may be set to NULL.
    * @param h_clover    Base pointer to host clover field

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -909,7 +909,7 @@ void writeGaugeQuda(const char *file, QudaGaugeParam *param)
   gauge_param.ghostExchange = QUDA_GHOST_EXCHANGE_NO;
   gauge_param.location = QUDA_CUDA_FIELD_LOCATION;
   gauge_param.create = QUDA_NULL_FIELD_CREATE;
-  gauge_param.setPrecision(param->cuda_prec, true);
+  gauge_param.setPrecision(param->cuda_prec);
   GaugeField *cudaGauge = nullptr;
   switch (param->type) {
   case QUDA_WILSON_LINKS:
@@ -937,6 +937,7 @@ void writeGaugeQuda(const char *file, QudaGaugeParam *param)
   cpu_param.location      = QUDA_CPU_FIELD_LOCATION;
   cpu_param.order         = QUDA_QDP_GAUGE_ORDER;
   cpu_param.create        = QUDA_NULL_FIELD_CREATE;
+  cpu_param.setPrecision(param->cpu_prec);
   quda::GaugeField cpuGauge(cpu_param);
   cpuGauge.copy(*cudaGauge);
 

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -927,21 +927,19 @@ void writeGaugeQuda(const char *file, QudaGaugeParam *param)
     if (gaugeLongPrecise == nullptr) errorQuda("gaugeLongPrecise is not loaded");
     cpuGauge.copy(*gaugeLongPrecise);
     break;
-  case QUDA_SMEARED_LINKS:
-    {
-      if (gaugeSmeared == nullptr) errorQuda("gaugeSmeared is not loaded");
-      // Copy to intermediate non-extended field before copying to cpuGauge
-      GaugeFieldParam cuda_param(*param);
-      cuda_param.location = QUDA_CUDA_FIELD_LOCATION;
-      cuda_param.create = QUDA_NULL_FIELD_CREATE;
-      cuda_param.ghostExchange = QUDA_GHOST_EXCHANGE_NO;
-      cuda_param.pad = 0;
-      cuda_param.setPrecision(param->cuda_prec);
-      GaugeField cudaGauge(cuda_param);
-      copyExtendedGauge(cudaGauge, *gaugeSmeared, QUDA_CUDA_FIELD_LOCATION);
-      cpuGauge.copy(cudaGauge);
-    }
-    break;
+  case QUDA_SMEARED_LINKS: {
+    if (gaugeSmeared == nullptr) errorQuda("gaugeSmeared is not loaded");
+    // Copy to intermediate non-extended field before copying to cpuGauge
+    GaugeFieldParam cuda_param(*param);
+    cuda_param.location = QUDA_CUDA_FIELD_LOCATION;
+    cuda_param.create = QUDA_NULL_FIELD_CREATE;
+    cuda_param.ghostExchange = QUDA_GHOST_EXCHANGE_NO;
+    cuda_param.pad = 0;
+    cuda_param.setPrecision(param->cuda_prec);
+    GaugeField cudaGauge(cuda_param);
+    copyExtendedGauge(cudaGauge, *gaugeSmeared, QUDA_CUDA_FIELD_LOCATION);
+    cpuGauge.copy(cudaGauge);
+  } break;
   default: errorQuda("Invalid gauge type");
   }
 

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -927,20 +927,21 @@ void writeGaugeQuda(const char *file, QudaGaugeParam *param)
     if (gaugeLongPrecise == nullptr) errorQuda("gaugeLongPrecise is not loaded");
     cpuGauge.copy(*gaugeLongPrecise);
     break;
-  case QUDA_SMEARED_LINKS: {
-    if (gaugeSmeared == nullptr) errorQuda("gaugeSmeared is not loaded");
-    // Copy to intermediate non-extended field before copying to cpuGauge
-    GaugeFieldParam cuda_param(*param);
-    cuda_param.location = QUDA_CUDA_FIELD_LOCATION;
-    cuda_param.create = QUDA_NULL_FIELD_CREATE;
-    cuda_param.ghostExchange = QUDA_GHOST_EXCHANGE_NO;
-    cuda_param.pad = 0;
-    cuda_param.setPrecision(param->cuda_prec);
-    GaugeField cudaGauge(cuda_param);
-    copyExtendedGauge(cudaGauge, *gaugeSmeared, QUDA_CUDA_FIELD_LOCATION);
-    cpuGauge.copy(cudaGauge);
+  case QUDA_SMEARED_LINKS:
+    {
+      if (gaugeSmeared == nullptr) errorQuda("gaugeSmeared is not loaded");
+      // Copy to intermediate non-extended field before copying to cpuGauge
+      GaugeFieldParam cuda_param(*param);
+      cuda_param.location = QUDA_CUDA_FIELD_LOCATION;
+      cuda_param.create = QUDA_NULL_FIELD_CREATE;
+      cuda_param.ghostExchange = QUDA_GHOST_EXCHANGE_NO;
+      cuda_param.pad = 0;
+      cuda_param.setPrecision(param->cuda_prec);
+      GaugeField cudaGauge(cuda_param);
+      copyExtendedGauge(cudaGauge, *gaugeSmeared, QUDA_CUDA_FIELD_LOCATION);
+      cpuGauge.copy(cudaGauge);
+    }
     break;
-  }
   default: errorQuda("Invalid gauge type");
   }
 

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -903,50 +903,50 @@ void writeGaugeQuda(const char *file, QudaGaugeParam *param)
 
   if (!initialized) errorQuda("QUDA not initialized");
 
-  // Set the device field parameters
-  GaugeFieldParam gauge_param(*param);
-  gauge_param.pad = 0;
-  gauge_param.ghostExchange = QUDA_GHOST_EXCHANGE_NO;
-  gauge_param.location = QUDA_CUDA_FIELD_LOCATION;
-  gauge_param.create = QUDA_NULL_FIELD_CREATE;
-  gauge_param.setPrecision(param->cuda_prec);
-  GaugeField *cudaGauge = nullptr;
-  switch (param->type) {
-  case QUDA_WILSON_LINKS:
-    if (gaugePrecise == nullptr) errorQuda("gaugePrecise is not loaded");
-    cudaGauge = gaugePrecise;
-    break;
-  case QUDA_ASQTAD_FAT_LINKS:
-    if (gaugeFatPrecise == nullptr) errorQuda("gaugeFatPrecise is not loaded");
-    cudaGauge = gaugeFatPrecise;
-    break;
-  case QUDA_ASQTAD_LONG_LINKS:
-    if (gaugeLongPrecise == nullptr) errorQuda("gaugeLongPrecise is not loaded");
-    cudaGauge = gaugeLongPrecise;
-    break;
-  case QUDA_SMEARED_LINKS:
-    if (gaugeSmeared == nullptr) errorQuda("gaugeSmeared is not loaded");
-    cudaGauge = new GaugeField(gauge_param);
-    copyExtendedGauge(*cudaGauge, *gaugeSmeared, QUDA_CUDA_FIELD_LOCATION);
-    break;
-  default: errorQuda("Invalid gauge type");
-  }
-
-  // Copy device field to host
-  quda::GaugeFieldParam cpu_param(gauge_param);
+  // Create CPU field
+  GaugeFieldParam cpu_param(*param);
+  cpu_param.pad = 0;
+  cpu_param.ghostExchange = QUDA_GHOST_EXCHANGE_NO;
   cpu_param.location = QUDA_CPU_FIELD_LOCATION;
   cpu_param.order = QUDA_QDP_GAUGE_ORDER;
   cpu_param.create = QUDA_NULL_FIELD_CREATE;
   cpu_param.setPrecision(param->cpu_prec);
-  quda::GaugeField cpuGauge(cpu_param);
-  cpuGauge.copy(*cudaGauge);
+  GaugeField cpuGauge(cpu_param);
+
+  // Select source and copy into cpuGauge
+  switch (param->type) {
+  case QUDA_WILSON_LINKS:
+    if (gaugePrecise == nullptr) errorQuda("gaugePrecise is not loaded");
+    cpuGauge.copy(*gaugePrecise);
+    break;
+  case QUDA_ASQTAD_FAT_LINKS:
+    if (gaugeFatPrecise == nullptr) errorQuda("gaugeFatPrecise is not loaded");
+    cpuGauge.copy(*gaugeFatPrecise);
+    break;
+  case QUDA_ASQTAD_LONG_LINKS:
+    if (gaugeLongPrecise == nullptr) errorQuda("gaugeLongPrecise is not loaded");
+    cpuGauge.copy(*gaugeLongPrecise);
+    break;
+  case QUDA_SMEARED_LINKS: {
+    if (gaugeSmeared == nullptr) errorQuda("gaugeSmeared is not loaded");
+    // Copy to intermediate non-extended field before copying to cpuGauge
+    GaugeFieldParam cuda_param(*param);
+    cuda_param.location = QUDA_CUDA_FIELD_LOCATION;
+    cuda_param.create = QUDA_NULL_FIELD_CREATE;
+    cuda_param.ghostExchange = QUDA_GHOST_EXCHANGE_NO;
+    cuda_param.pad = 0;
+    cuda_param.setPrecision(param->cuda_prec);
+    GaugeField cudaGauge(cuda_param);
+    copyExtendedGauge(cudaGauge, *gaugeSmeared, QUDA_CUDA_FIELD_LOCATION);
+    cpuGauge.copy(cudaGauge);
+    break;
+  }
+  default: errorQuda("Invalid gauge type");
+  }
 
   // Write to disk using QIO writer
   write_gauge_field(file, reinterpret_cast<void **>(cpuGauge.raw_pointer()), cpuGauge.Precision(), param->X, 0,
                     (char **)0);
-
-  // Clean up
-  if (param->type == QUDA_SMEARED_LINKS) { delete cudaGauge; }
 
 } // writeGaugeQuda
 

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -897,6 +897,58 @@ void saveGaugeQuda(void *h_gauge, QudaGaugeParam *param)
   if (param->type == QUDA_SMEARED_LINKS) { delete cudaGauge; }
 }
 
+/** Write gauge field to disk **/
+void writeGaugeQuda(const char *file, QudaGaugeParam *param)
+{
+
+  if (!initialized) errorQuda("QUDA not initialized");
+
+  // Set the device field parameters
+  GaugeFieldParam gauge_param(*param);
+  gauge_param.pad = 0;
+  gauge_param.ghostExchange = QUDA_GHOST_EXCHANGE_NO;
+  gauge_param.location = QUDA_CUDA_FIELD_LOCATION;
+  gauge_param.create = QUDA_NULL_FIELD_CREATE;
+  gauge_param.setPrecision(param->cuda_prec, true);
+  GaugeField *cudaGauge = nullptr;
+  switch (param->type) {
+  case QUDA_WILSON_LINKS:
+    if (gaugePrecise == nullptr) errorQuda("gaugePrecise is not loaded");
+    cudaGauge = gaugePrecise;
+    break;
+  case QUDA_ASQTAD_FAT_LINKS:
+    if (gaugeFatPrecise == nullptr) errorQuda("gaugeFatPrecise is not loaded");
+    cudaGauge = gaugeFatPrecise;
+    break;
+  case QUDA_ASQTAD_LONG_LINKS:
+    if (gaugeLongPrecise == nullptr) errorQuda("gaugeLongPrecise is not loaded");
+    cudaGauge = gaugeLongPrecise;
+    break;
+  case QUDA_SMEARED_LINKS:
+    if (gaugeSmeared == nullptr) errorQuda("gaugeSmeared is not loaded");
+    cudaGauge = new GaugeField(gauge_param);
+    copyExtendedGauge(*cudaGauge, *gaugeSmeared, QUDA_CUDA_FIELD_LOCATION);
+    break;
+  default: errorQuda("Invalid gauge type");
+  }
+
+  // Copy device field to host
+  quda::GaugeFieldParam cpu_param(gauge_param);
+  cpu_param.location      = QUDA_CPU_FIELD_LOCATION;
+  cpu_param.order         = QUDA_QDP_GAUGE_ORDER;
+  cpu_param.create        = QUDA_NULL_FIELD_CREATE;
+  quda::GaugeField cpuGauge(cpu_param);
+  cpuGauge.copy(*cudaGauge);
+
+  // Write to disk using QIO writer
+  write_gauge_field(file, reinterpret_cast<void **>(cpuGauge.raw_pointer()),
+                    cpuGauge.Precision(), param->X, 0, (char **)0);
+
+  // Clean up
+  if (param->type == QUDA_SMEARED_LINKS) { delete cudaGauge; }
+
+} // writeGaugeQuda
+
 void loadSloppyCloverQuda(const QudaPrecision prec[]);
 void freeSloppyCloverQuda();
 

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -934,16 +934,16 @@ void writeGaugeQuda(const char *file, QudaGaugeParam *param)
 
   // Copy device field to host
   quda::GaugeFieldParam cpu_param(gauge_param);
-  cpu_param.location      = QUDA_CPU_FIELD_LOCATION;
-  cpu_param.order         = QUDA_QDP_GAUGE_ORDER;
-  cpu_param.create        = QUDA_NULL_FIELD_CREATE;
+  cpu_param.location = QUDA_CPU_FIELD_LOCATION;
+  cpu_param.order = QUDA_QDP_GAUGE_ORDER;
+  cpu_param.create = QUDA_NULL_FIELD_CREATE;
   cpu_param.setPrecision(param->cpu_prec);
   quda::GaugeField cpuGauge(cpu_param);
   cpuGauge.copy(*cudaGauge);
 
   // Write to disk using QIO writer
-  write_gauge_field(file, reinterpret_cast<void **>(cpuGauge.raw_pointer()),
-                    cpuGauge.Precision(), param->X, 0, (char **)0);
+  write_gauge_field(file, reinterpret_cast<void **>(cpuGauge.raw_pointer()), cpuGauge.Precision(), param->X, 0,
+                    (char **)0);
 
   // Clean up
   if (param->type == QUDA_SMEARED_LINKS) { delete cudaGauge; }


### PR DESCRIPTION
Adds a function `writeGaugeQuda` to `lib/interface_quda.cpp`. This function is similar to `saveGaugeQuda` but writes the gauge field to disk instead of just copying it to host.

The motivation for this is a desire to be able to write a gradient flowed gauge field (i.e. `gaugeSmeared`) to disk after using `performWFlowQuda` or `performGFlowQuda`, without going through the rigamarole of allocating space from MILC, copying the flowed field back to MILC, and then writing it to disk. This will also allow us to write the fat and long links to disk, which is something we've been working on as well.