### PR TITLE
Use __builtin_bit_cast instead of memcpy as the type punning

### DIFF
--- a/include/targets/hip/load_store.h
+++ b/include/targets/hip/load_store.h
@@ -25,14 +25,14 @@ namespace quda
     {
       float4 tmp;
       operator()(tmp, ptr, idx);
-      memcpy(&value, &tmp, sizeof(float4));
+      value = __builtin_bit_cast(short8, tmp);
     }
 
     __device__ inline void operator()(char8 &value, const void *ptr, int idx)
     {
       float2 tmp;
       operator()(tmp, ptr, idx);
-      memcpy(&value, &tmp, sizeof(float2));
+      value = __builtin_bit_cast(char8, tmp);
     }
   };
 

--- a/include/targets/hip/load_store.h
+++ b/include/targets/hip/load_store.h
@@ -2,6 +2,10 @@
 
 #include <register_traits.h>
 
+#ifndef __has_builtin
+#define __has_builtin(x) 0
+#endif
+
 namespace quda
 {
 
@@ -25,14 +29,22 @@ namespace quda
     {
       float4 tmp;
       operator()(tmp, ptr, idx);
+#if __has_builtin(__builtin_bit_cast)
       value = __builtin_bit_cast(short8, tmp);
+#else
+      __builtin_memcpy(&value, &tmp, sizeof(float4));
+#endif
     }
 
     __device__ inline void operator()(char8 &value, const void *ptr, int idx)
     {
       float2 tmp;
       operator()(tmp, ptr, idx);
+#if __has_builtin(__builtin_bit_cast)
       value = __builtin_bit_cast(char8, tmp);
+#else
+      __builtin_memcpy(&value, &tmp, sizeof(float2));
+#endif
     }
   };
 


### PR DESCRIPTION
Should fix #1620.

There are only two strictly standard-compliant ways to perform type punning without UB: `memcpy` and `std::bit_cast`. The latter one is introduced by C++20, which we cannot directly use in the project. However, there is a `__builtin_bit_cast` function introduced in LLVM 9 to implement the C++20 standard. Since ROCm started to use LLVM 9 from 3.x, I think it's a safe workaround of the issue.