### PR TITLE
Cleanup stale IPC handles

### DIFF
--- a/lib/lattice_field.cpp
+++ b/lib/lattice_field.cpp
@@ -261,6 +261,13 @@ namespace quda {
           // before we free any comms buffers
           qudaDeviceSynchronize();
           comm_barrier();
+          // Tear down any existing IPC comms before freeing the ghost
+          // buffers.  Otherwise a peer rank can still hold an
+          // hipIpcOpenMemHandle mapping of a buffer we are about to
+          // hipFree, and a subsequent hipMalloc that lands at the same
+          // virtual address can then fail hipIpcGetMemHandle with
+          // hipErrorInvalidValue.
+          destroyIPCComms();
           for (int b=0; b<2; b++) {
             device_comms_pinned_free(ghost_recv_buffer_d[b]);
             device_comms_pinned_free(ghost_send_buffer_d[b]);
@@ -448,6 +455,13 @@ namespace quda {
   void LatticeField::createIPCComms() const
   {
     if ( initIPCComms && !ghost_field_reset ) return;
+
+    // If we already have IPC state and the ghost field has been reset,
+    // tear it down before recreating; otherwise the IPC mem/event handle
+    // arrays would be silently overwritten and the previous events
+    // (created with hipEventCreateWithFlags) and imported handles would
+    // leak.
+    if (initIPCComms && ghost_field_reset) destroyIPCComms();
 
     if (!initComms) errorQuda("Can only be called after create comms");
     if ((!ghost_recv_buffer_d[0] || !ghost_recv_buffer_d[1]) && comm_size() > 1)

--- a/lib/targets/cuda/comm_target.cpp
+++ b/lib/targets/cuda/comm_target.cpp
@@ -169,13 +169,28 @@ void comm_create_neighbor_event(array_2d<qudaEvent_t, QUDA_MAX_DIM, 2> &remote,
   }
 }
 
-void comm_destroy_neighbor_event(array_2d<qudaEvent_t, QUDA_MAX_DIM, 2> &, array_2d<qudaEvent_t, QUDA_MAX_DIM, 2> &local)
+void comm_destroy_neighbor_event(array_2d<qudaEvent_t, QUDA_MAX_DIM, 2> &remote,
+                                 array_2d<qudaEvent_t, QUDA_MAX_DIM, 2> &local)
 {
   for (int dim = 0; dim < 4; ++dim) {
     if (comm_dim(dim) == 1) continue;
     for (int dir = 0; dir < 2; dir++) {
+      if (!comm_peer2peer_enabled(dir, dim)) continue;
+      // First close our imported view of the neighbour's event (the
+      // counterpart to cudaIpcOpenEventHandle in
+      // comm_create_neighbor_event).  Without this, every IPC reset
+      // leaks the imported handle.
+      cudaEvent_t &remote_event = reinterpret_cast<cudaEvent_t &>(remote[dim][dir].event);
+      if (remote_event) {
+        CHECK_CUDA_ERROR(cudaEventDestroy(remote_event));
+        remote[dim][dir].event = nullptr;
+      }
+      // Then destroy the local interprocess event we exported.
       cudaEvent_t &event = reinterpret_cast<cudaEvent_t &>(local[dim][dir].event);
-      if (comm_peer2peer_enabled(dir, dim)) CHECK_CUDA_ERROR(cudaEventDestroy(event));
+      if (event) {
+        CHECK_CUDA_ERROR(cudaEventDestroy(event));
+        local[dim][dir].event = nullptr;
+      }
     }
   } // iterate over dim
 }

--- a/lib/targets/hip/comm_target.cpp
+++ b/lib/targets/hip/comm_target.cpp
@@ -156,13 +156,28 @@ namespace quda
     }
   }
 
-  void comm_destroy_neighbor_event(array_2d<qudaEvent_t, QUDA_MAX_DIM, 2> &, array_2d<qudaEvent_t, QUDA_MAX_DIM, 2> &local)
+  void comm_destroy_neighbor_event(array_2d<qudaEvent_t, QUDA_MAX_DIM, 2> &remote,
+                                   array_2d<qudaEvent_t, QUDA_MAX_DIM, 2> &local)
   {
     for (int dim = 0; dim < 4; ++dim) {
       if (comm_dim(dim) == 1) continue;
       for (int dir = 0; dir < 2; dir++) {
+        if (!comm_peer2peer_enabled(dir, dim)) continue;
+        // First close our imported view of the neighbour's event (the
+        // counterpart to hipIpcOpenEventHandle in
+        // comm_create_neighbor_event).  Without this, every IPC reset
+        // leaks the imported handle.
+        hipEvent_t &remote_event = reinterpret_cast<hipEvent_t &>(remote[dim][dir].event);
+        if (remote_event) {
+          CHECK_HIP_ERROR(hipEventDestroy(remote_event));
+          remote[dim][dir].event = nullptr;
+        }
+        // Then destroy the local interprocess event we exported.
         hipEvent_t &event = reinterpret_cast<hipEvent_t &>(local[dim][dir].event);
-        if (comm_peer2peer_enabled(dir, dim)) CHECK_HIP_ERROR(hipEventDestroy(event));
+        if (event) {
+          CHECK_HIP_ERROR(hipEventDestroy(event));
+          local[dim][dir].event = nullptr;
+        }
       }
     } // iterate over dim
   }


### PR DESCRIPTION
Disclaimer: I did use AI to help me diagnose this problem.  The analysis looks sound, and the patch is easy to verify and explain, and it fixes a whole slew of P2P test failures (in addition to the ongoing bugfixes that are happening in https://github.com/ROCm/rocm-systems/pull/5575).

This PR does three things.

First, it cleans up stale IPC handles that were not being cleaned up on the path that resizes ghost buffers in
`LatticeField::allocateGhostBuffer`.  This method was freeing device memory without calling `destroyIPCComms()` first.  Later, when the buffer is resized, we call `qudaMalloc` and can land on the same VMA. When this happens, a subsequent `hipIpcGetMemhandle` gets a stale view of inter-process memory and was returning `hipErrorInvalidValue`.  The fix simply adds a call to `destroyIPCComms()` in the that resizes ghost buffers before freeing memory.  For context,
`LatticeField::freeGhostBuffer` is correctly calling `destroyIPCComms` before freeing ghost buffers.

Second, `LatticeField::createIPCComms` is leaking events.  When `initIPCComms` is true and `ghost_field_reset` is true, we just overwrite `ipcRemoteCopyEvent[b]` and `ipcCopyEvent[b]` without freeing the old one first.  The fix just inserts branch when both of these flags are true and inserts a call to `destroyIPCComms`.

Third, `comm_destroy_neighbor_event` only destroys local events created with `hipEventCreateWithFlags` and it doesn't destroy IPC events imported with `hipIpcOpenEventHandle`.  This leaks events.  The fix is simply to call `hipEventDestroy` on the remote event.

This PR only makes these changes in the hip backend.  Would you like me to make the same changes in the cuda backend too?  The analysis is agnostic to green/red/blue teams, but I didn't want to step on any toes.  Let me know what you'd like me to do.