### PR TITLE
Fix `is_native` in `PackGhostArg`

### DIFF
--- a/include/kernels/color_spinor_pack.cuh
+++ b/include/kernels/color_spinor_pack.cuh
@@ -76,7 +76,7 @@ namespace quda {
     // disable ghost to reduce arg size
     using F = typename colorspinor::FieldOrderCB<real, nSpin, nColor, 1, order, store_t, ghost_store_t, true>;
 
-    static constexpr bool is_native = order <= 8;
+    static constexpr bool is_native = (order == QUDA_NATIVE_FIELD_ORDER);
     static constexpr int max_n_src = 64;
     const int_fastdiv n_src;
     G out;

--- a/include/targets/cuda/target_device.h
+++ b/include/targets/cuda/target_device.h
@@ -13,7 +13,7 @@
 #define QUDA_CUDA_CC
 #endif
 
-#if defined(__NVCC__) || (defined(__clang__) && (__clang_major__ >= 20))
+#if (__COMPUTE_CAPABILITY__ >= 700) && (defined(__NVCC__) || (defined(__clang__) && (__clang_major__ >= 20)))
 #define GRID_CONSTANT __grid_constant__
 #else
 #define GRID_CONSTANT


### PR DESCRIPTION
In `PackGhostArg`, the old way is still used to decide if a field order is native:
```c
    static constexpr bool is_native = order <= 8;
```

We should use the new value to set the value:
```c
    static constexpr bool is_native = (order == QUDA_NATIVE_FIELD_ORDER);
```

Another minor change in this PR is disabling `__grid_constant__` attribute on pre-Volta devices (with compute capability less than 7.0).