### PR TITLE
Use `host_pinned_malloc` for all host ghost buffer allocations

### DIFF
--- a/lib/color_spinor_field.cpp
+++ b/lib/color_spinor_field.cpp
@@ -964,9 +964,8 @@ namespace quda
       if (!initGhostFaceBuffer || resize) {
         freeGhostBuffer();
         for (int i = 0; i < nDimComms; i++) {
-          // Host communication buffers use host-pinned (registered) memory so that a CUDA-aware
-          // MPI/UCX registration cache does not register these pages itself and leave a stale
-          // mapping behind after they are freed (see cudaErrorHostMemoryAlreadyRegistered with UCX).
+          // Use host-pinned memory for host communication buffers so the `cuda_copy` transport in
+          // UCX doesn't own the pinning; see https://github.com/lattice/quda/pull/1639 for more context
           fwdGhostFaceBuffer[i] = host_pinned_malloc(ghostFaceBytes[i]);
           backGhostFaceBuffer[i] = host_pinned_malloc(ghostFaceBytes[i]);
           fwdGhostFaceSendBuffer[i] = host_pinned_malloc(ghostFaceBytes[i]);

--- a/lib/color_spinor_field.cpp
+++ b/lib/color_spinor_field.cpp
@@ -964,10 +964,13 @@ namespace quda
       if (!initGhostFaceBuffer || resize) {
         freeGhostBuffer();
         for (int i = 0; i < nDimComms; i++) {
-          fwdGhostFaceBuffer[i] = safe_malloc(ghostFaceBytes[i]);
-          backGhostFaceBuffer[i] = safe_malloc(ghostFaceBytes[i]);
-          fwdGhostFaceSendBuffer[i] = safe_malloc(ghostFaceBytes[i]);
-          backGhostFaceSendBuffer[i] = safe_malloc(ghostFaceBytes[i]);
+          // Host communication buffers use host-pinned (registered) memory so that a CUDA-aware
+          // MPI/UCX registration cache does not register these pages itself and leave a stale
+          // mapping behind after they are freed (see cudaErrorHostMemoryAlreadyRegistered with UCX).
+          fwdGhostFaceBuffer[i] = host_pinned_malloc(ghostFaceBytes[i]);
+          backGhostFaceBuffer[i] = host_pinned_malloc(ghostFaceBytes[i]);
+          fwdGhostFaceSendBuffer[i] = host_pinned_malloc(ghostFaceBytes[i]);
+          backGhostFaceSendBuffer[i] = host_pinned_malloc(ghostFaceBytes[i]);
         }
         initGhostFaceBuffer = 1;
       }

--- a/lib/gauge_field.cpp
+++ b/lib/gauge_field.cpp
@@ -577,8 +577,12 @@ namespace quda {
     } else { // cpu field
       void *send[2 * QUDA_MAX_DIM];
       for (int d = 0; d < nDim; d++) {
-        send[d] = safe_malloc(nFace * surface[d] * nInternal * precision);
-        if (geometry == QUDA_COARSE_GEOMETRY) send[d + 4] = safe_malloc(nFace * surface[d] * nInternal * precision);
+        // Use host-pinned (registered) memory for host communication buffers so that a CUDA-aware
+        // MPI/UCX registration cache does not register these pages itself and leave a stale mapping
+        // behind after they are freed (see cudaErrorHostMemoryAlreadyRegistered with UCX rcache).
+        send[d] = host_pinned_malloc(nFace * surface[d] * nInternal * precision);
+        if (geometry == QUDA_COARSE_GEOMETRY)
+          send[d + 4] = host_pinned_malloc(nFace * surface[d] * nInternal * precision);
       }
 
       void *ghost_[2 * QUDA_MAX_DIM];
@@ -696,7 +700,7 @@ namespace quda {
       qudaDeviceSynchronize();
     } else {
       void *recv[QUDA_MAX_DIM];
-      for (int d = 0; d < nDim; d++) recv[d] = safe_malloc(nFace * surface[d] * nInternal * precision);
+      for (int d = 0; d < nDim; d++) recv[d] = host_pinned_malloc(nFace * surface[d] * nInternal * precision);
 
       void *ghost_[] = {ghost[0].data(), ghost[1].data(), ghost[2].data(), ghost[3].data(),
                         ghost[4].data(), ghost[5].data(), ghost[6].data(), ghost[7].data()};
@@ -787,8 +791,8 @@ namespace quda {
       for (int d = 0; d < nDim; d++) {
         if (!(comm_dim_partitioned(d) || (no_comms_fill && R[d]))) continue;
         bytes[d] = surface[d] * R[d] * geometry * nInternal * precision;
-        send[d] = safe_malloc(2 * bytes[d]);
-        recv[d] = safe_malloc(2 * bytes[d]);
+        send[d] = host_pinned_malloc(2 * bytes[d]);
+        recv[d] = host_pinned_malloc(2 * bytes[d]);
       }
 
       for (int d = 0; d < nDim; d++) {

--- a/lib/gauge_field.cpp
+++ b/lib/gauge_field.cpp
@@ -577,9 +577,8 @@ namespace quda {
     } else { // cpu field
       void *send[2 * QUDA_MAX_DIM];
       for (int d = 0; d < nDim; d++) {
-        // Use host-pinned (registered) memory for host communication buffers so that a CUDA-aware
-        // MPI/UCX registration cache does not register these pages itself and leave a stale mapping
-        // behind after they are freed (see cudaErrorHostMemoryAlreadyRegistered with UCX rcache).
+        // Use host-pinned memory for host communication buffers so the `cuda_copy` transport in
+        // UCX doesn't own the pinning; see https://github.com/lattice/quda/pull/1639 for more context
         send[d] = host_pinned_malloc(nFace * surface[d] * nInternal * precision);
         if (geometry == QUDA_COARSE_GEOMETRY)
           send[d + 4] = host_pinned_malloc(nFace * surface[d] * nInternal * precision);

--- a/tests/utils/face_gauge.cpp
+++ b/tests/utils/face_gauge.cpp
@@ -386,7 +386,7 @@ void exchange_sitelink_diag(lat_dim_t &X, Float **sitelink, Float **ghost_siteli
 
       if (dir1 == 4 || dir2 == 4) { errorQuda("Invalid dir1/dir2"); }
       int len = X[dir1] * X[dir2] * gauge_site_size * sizeof(Float);
-      void *sendbuf = safe_malloc(len);
+      void *sendbuf = host_pinned_malloc(len);
 
       pack_gauge_diag(sendbuf, X, (void **)sitelink, nu, mu, dir1, dir2, (QudaPrecision)sizeof(Float));
 
@@ -471,8 +471,8 @@ void exchange_cpu_sitelink(lat_dim_t &X, void **sitelink, void **ghost_sitelink,
 
   for (int i = 0; i < 4; i++) {
     int nbytes = 4 * Vs[i] * gauge_site_size * gPrecision;
-    sitelink_fwd_sendbuf[i] = safe_malloc(nbytes);
-    sitelink_back_sendbuf[i] = safe_malloc(nbytes);
+    sitelink_fwd_sendbuf[i] = host_pinned_malloc(nbytes);
+    sitelink_back_sendbuf[i] = host_pinned_malloc(nbytes);
     memset(sitelink_fwd_sendbuf[i], 0, nbytes);
     memset(sitelink_back_sendbuf[i], 0, nbytes);
   }
@@ -633,10 +633,10 @@ void exchange_cpu_sitelink_ex(lat_dim_t &X, lat_dim_t &R, void **sitelink, QudaG
 
   for (int i = 0; i < 4; i++) {
     if (!commDimPartitioned(i)) continue;
-    ghost_sitelink_fwd_sendbuf[i] = safe_malloc(len[i]);
-    ghost_sitelink_back_sendbuf[i] = safe_malloc(len[i]);
-    ghost_sitelink_fwd[i] = safe_malloc(len[i]);
-    ghost_sitelink_back[i] = safe_malloc(len[i]);
+    ghost_sitelink_fwd_sendbuf[i] = host_pinned_malloc(len[i]);
+    ghost_sitelink_back_sendbuf[i] = host_pinned_malloc(len[i]);
+    ghost_sitelink_fwd[i] = host_pinned_malloc(len[i]);
+    ghost_sitelink_back[i] = host_pinned_malloc(len[i]);
   }
 
   int gaugebytes = gauge_site_size * gPrecision;
@@ -938,8 +938,8 @@ void exchange_cpu_staple(lat_dim_t &X, void *staple, void **ghost_staple, QudaPr
   void *staple_back_sendbuf[4];
 
   for (int i = 0; i < 4; i++) {
-    staple_fwd_sendbuf[i] = safe_malloc(Vs[i] * gauge_site_size * gPrecision);
-    staple_back_sendbuf[i] = safe_malloc(Vs[i] * gauge_site_size * gPrecision);
+    staple_fwd_sendbuf[i] = host_pinned_malloc(Vs[i] * gauge_site_size * gPrecision);
+    staple_back_sendbuf[i] = host_pinned_malloc(Vs[i] * gauge_site_size * gPrecision);
   }
 
   if (gPrecision == QUDA_DOUBLE_PRECISION) {


### PR DESCRIPTION
FYI, Claude Opus 4.8 helped me debug this.

In some rare, reproducible but somewhat non-deterministic across machines, etc, circumstances that could only be reproduced in a container so far (but are technically always on the table...), we would see a "double registration" error when performing a pinned host allocation: `cudaErrorHostMemoryAlreadyRegistered` while running QUDA test executables. Opus traced this down to an interesting intersection between how the `cuda_copy` transport in UCX registers and unregisters host pointers (yes, you read this correctly, host pointers) and the conditions under which `glibc`'s `free()` also calls `munmap()`.

First: for sufficiently small allocations, `free()` doesn't call `munmap()`.
Second: when the `cuda_copy` transport is passed an un-registered host pointer, it will register it: https://github.com/openucx/ucx/blob/ab1f057f9921955d59c5aa86a1cd801cf6ab3d71/src/uct/cuda/cuda_copy/cuda_copy_md.c#L140-L178 . It figures out when it should _de-register_ it by intercepting system calls, however, it doesn't intercept `free` --- it only intercepts `munmap`.

This means you can end up in a circumstance like this:
1. A program creates a "small enough" host (heap) allocation using `malloc`
2. The program passes it to an MPI call; the `cuda_copy` transport registers it
3. The program frees the allocation using `free` --- but, because it's "small enough", there's no `munmap` call; it doesn't get unregistered.
4. Life goes on, and later the program creates another heap allocation using `malloc` that _happens to, potentially completely coincidentally_ live in the same, already registered heap allocation.
5. This time, the program tries to register it using `cudaHostRegister` ... and we get the `cudaErrorHostMemoryAlreadyRegistered`.

...and that's what was happening. The first "small enough" allocation was a ghost buffer allocation, which is a `safe_malloc` -> technically a `posix_memalign`. The second allocation was a pinned allocation for a reduction buffer, which is a `host_pinned_malloc`.

Yes, this is bizarre, but it was verified in two ways.
1. Disabling the host registration cache: `export UCX_RCACHE_ENABLE=n` --- note this is `*_RCACHE`, not `*_CACHE`. No cache, no registration of the first allocation, no issue on the second allocation.
2. Forcing the `munmap` by inserting `malloc_trip(0);` at the start `host_pinned_malloc_`---this is the "nuclear" option since it kills of **every** mapped but not `malloc`'d allocation, so this is just a proof point and not a solution.

The solution in QUDA is straightforward: make sure the host communications buffers are `host_pinned_malloc`'d instead of just `safe_malloc`'d. If the host buffer is already pinned, UCX doesn't pin it/cache it, no opportunity for harm.