### PR TITLE
Simplify return statement in get_tensor_descriptor

### DIFF
--- a/include/targets/generic/tma_helper.hpp
+++ b/include/targets/generic/tma_helper.hpp
@@ -17,6 +17,6 @@ namespace quda
     };
   } // namespace gauge
 
-  inline gauge::tensor_desc_t get_tensor_descriptor(const GaugeField &, uint32_t) { return gauge::tensor_desc_t {}; }
+  inline gauge::tensor_desc_t get_tensor_descriptor(const GaugeField &, uint32_t) { return {}; }
 
 } // namespace quda


### PR DESCRIPTION
Works around a compiler issue with CUDA 13.3.