### PR TITLE
Cap `max_dynamic_shared_memory()` with `QUDA_MAX_SHARED_MEMORY` CMake override

### DIFF
--- a/include/targets/cuda/device.in.hpp
+++ b/include/targets/cuda/device.in.hpp
@@ -9,7 +9,7 @@ namespace quda
     constexpr int maximum_dynamic_shared_memory_override = @QUDA_MAX_SHARED_MEMORY@;
 
     /**
-      @brief A constexpr function to returns the maximum dyanmic shared memory per block.
+      @brief A constexpr function to returns the maximum dynamic shared memory per block.
         See https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#feature-availability
      */
     constexpr int maximum_dynamic_shared_memory()

--- a/lib/targets/cuda/device.cpp
+++ b/lib/targets/cuda/device.cpp
@@ -4,6 +4,7 @@
 #include <quda_internal.h>
 #include <quda_cuda_api.h>
 #include <nvml.h>
+#include <algorithm>
 #include "monitor.h"
 
 static cudaDeviceProp deviceProp;
@@ -348,7 +349,17 @@ namespace quda
       static int max_shared_bytes = 0;
       if (!max_shared_bytes)
         CHECK_CUDA_ERROR(cudaDeviceGetAttribute(&max_shared_bytes, cudaDevAttrMaxSharedMemoryPerBlockOptin, comm_gpuid()));
+      // If the user has set QUDA_MAX_SHARED_MEMORY at cmake time, cap the runtime-queried value.
+      // This ensures that cuKernelSetAttribute(MAX_DYNAMIC_SHARED_SIZE_BYTES, ...) never records
+      // a value larger than the override into APIC traces (or actually requests more than the
+      // user-specified limit), making traces portable across chip families with different smem caps.
+      // Note: qudaLaunchKernel already subtracts static shared memory from this value before
+      // passing it to cuKernelSetAttribute, so the total (static + dynamic) stays within the limit.
+#if defined(QUDA_MAX_SHARED_MEMORY_OVERRIDE) && QUDA_MAX_SHARED_MEMORY_OVERRIDE > 0
+      return std::min(max_shared_bytes, static_cast<int>(QUDA_MAX_SHARED_MEMORY_OVERRIDE));
+#else
       return max_shared_bytes;
+#endif
     }
 
     unsigned int max_threads_per_block() { return deviceProp.maxThreadsPerBlock; }

--- a/lib/targets/cuda/target_cuda.cmake
+++ b/lib/targets/cuda/target_cuda.cmake
@@ -410,6 +410,9 @@ set(QUDA_MAX_SHARED_MEMORY "0" CACHE STRING "Max shared memory per block, 0 corr
 mark_as_advanced(QUDA_MAX_SHARED_MEMORY)
 configure_file(${CMAKE_SOURCE_DIR}/include/targets/cuda/device.in.hpp
                ${CMAKE_BINARY_DIR}/include/targets/cuda/device.hpp @ONLY)
+# Expose the override to C++ translation units (e.g. device.cpp) that cannot
+# include the CUDA-only generated device.hpp but need to cap runtime queries.
+target_compile_definitions(quda_cpp PRIVATE QUDA_MAX_SHARED_MEMORY_OVERRIDE=${QUDA_MAX_SHARED_MEMORY})
 install(FILES "${CMAKE_BINARY_DIR}/include/targets/cuda/device.hpp" DESTINATION include/)
 
 target_include_directories(quda SYSTEM PUBLIC $<$<COMPILE_LANGUAGE:CUDA>:${CUDAToolkit_INCLUDE_DIRS}>)


### PR DESCRIPTION
## Problem

When `QUDA_MAX_SHARED_MEMORY` is set at cmake time, the compile-time `maximum_dynamic_shared_memory()` constexpr in `device.in.hpp` correctly respects it and bounds the tuner's shared memory search. However, the runtime `max_dynamic_shared_memory()` in `device.cpp` always returned the raw hardware-queried value, ignoring the override entirely.

This meant that `qudaLaunchKernel`'s `cuKernelSetAttribute(MAX_DYNAMIC_SHARED_SIZE_BYTES)` call was always set to the full hardware maximum, regardless of the user-specified cap. The cmake flag therefore had an incomplete effect: it constrained autotuning but not the actual attribute passed to the driver at launch time.

## Fix

`QUDA_MAX_SHARED_MEMORY` is now also passed to `device.cpp` as the preprocessor definition `QUDA_MAX_SHARED_MEMORY_OVERRIDE` via `target_compile_definitions` in cmake. (`device.cpp` compiles as C++, not CUDA, so it cannot include the generated `device.hpp` where the constexpr lives.) The runtime `max_dynamic_shared_memory()` then returns `min(hardware_max, override)` when the override is nonzero.

The existing code in `qudaLaunchKernel` (`quda_api.cpp:~153`) already correctly subtracts `sharedSizeBytes` (static shared memory) from the value returned by `max_dynamic_shared_memory()` before passing it to `cuKernelSetAttribute`. This means the fix is robust for kernels that mix static and dynamic shared memory — the total of the two will never exceed the user-specified limit.

## Testing

Compile with `-DQUDA_MAX_SHARED_MEMORY=102400` on a GPU with a higher hardware maximum (e.g. H100 at 228 KB) and verify that `cuKernelSetAttribute` is called with 100 KB rather than 228 KB minus static smem.
