### PR TITLE
HMC: all fermion actions under all integrators (nested-FGI unification)

### DIFF
--- a/include/hmc_quda.h
+++ b/include/hmc_quda.h
@@ -190,4 +190,15 @@ namespace quda
   */
   int getMGNullVectorCount(void *mg_instance);
 
+  /**
+     @brief Full state-refresh discipline after any device-side write to
+     gaugePrecise: ghost pads, sloppy gauge copies, extended gauge, and (for
+     clover-type actions) the in-place clover recompute at double precision
+     plus the in-place sloppy-clover family refresh. Preserves all field
+     object identities (MG hierarchies hold pointers). Must be called after
+     every gauge update, restore, or displacement in the HMC path.
+     @param inv_param Inverter parameters (dslash type, clover coefficient)
+  */
+  void hmcRefreshResidentGaugeState(QudaInvertParam &inv_param);
+
 } // namespace quda

--- a/lib/hmc.cpp
+++ b/lib/hmc.cpp
@@ -389,12 +389,29 @@ namespace quda
     if (ip.preconditioner) {
       // MG γ₅ two-pass: (M†M)⁻¹ = M⁻¹ γ₅ M⁻¹ γ₅. Both passes are fast
       // because they're MG-preconditioned solves of M (not M†M).
+      //
+      // For twisted actions γ₅-hermiticity reads M̂(μ)† = γ₅M̂(-μ)γ₅, so the
+      // FIRST pass must solve M(-μ): x = M(+μ)⁻¹ γ₅ M(-μ)⁻¹ γ₅ φ = (M̂†M̂)⁻¹φ.
+      // The MG hierarchy (set up at +μ) remains a valid right-preconditioner
+      // for M(-μ) — the twist is a small diagonal shift, so only iteration
+      // counts are affected, never the converged solution. For μ-symmetric
+      // actions the flipped operator coincides with M and this reduces to
+      // the standard two-pass.
       ip.solve_type = QUDA_DIRECT_PC_SOLVE;
       bool pc_solve = true;
       Dirac *dirac = nullptr, *diracSloppy = nullptr, *diracPre = nullptr, *diracEig = nullptr;
       createDiracWithEig(dirac, diracSloppy, diracPre, diracEig, ip, pc_solve, false);
 
+      const bool twisted
+        = (ip.dslash_type == QUDA_TWISTED_MASS_DSLASH || ip.dslash_type == QUDA_TWISTED_CLOVER_DSLASH);
+      QudaInvertParam ip_minus = ip;
+      ip_minus.mu = -ip.mu;
+      Dirac *dirac_m = nullptr, *diracSloppy_m = nullptr, *diracPre_m = nullptr, *diracEig_m = nullptr;
+      if (twisted) createDiracWithEig(dirac_m, diracSloppy_m, diracPre_m, diracEig_m, ip_minus, pc_solve, false);
+
       DiracM m(*dirac), mSloppy(*diracSloppy), mPre(*diracPre), mEig(*diracEig);
+      DiracM mMinus(twisted ? *dirac_m : *dirac), mMinusSloppy(twisted ? *diracSloppy_m : *diracSloppy),
+        mMinusPre(twisted ? *diracPre_m : *diracPre), mMinusEig(twisted ? *diracEig_m : *diracEig);
       SolverParam solverParam(ip);
 
       // GCR-Krylov-residual capture, mirrors NestedFGI::computeOuterForce.
@@ -410,11 +427,11 @@ namespace quda
       std::vector<ColorSpinorField> b_vec(1, ColorSpinorField(phi));
       gamma5(z, b_vec);
 
-      // Step 2: solve M w = z
+      // Step 2: solve M(-μ) w = z (equals M for μ-symmetric actions)
       std::vector<ColorSpinorField> w(1, csParam);
       {
         TrackerScope<GCRTracker> scope(activeGCRTracker, gcrTracker.isActive() ? &gcrTracker : nullptr);
-        Solver *s = Solver::create(solverParam, m, mSloppy, mPre, mEig);
+        Solver *s = Solver::create(solverParam, mMinus, mMinusSloppy, mMinusPre, mMinusEig);
         (*s)(w, z);
         delete s;
         integratorBumpCGStats(solverParam.iter);
@@ -458,6 +475,12 @@ namespace quda
       if (diracSloppy && diracSloppy != dirac) delete diracSloppy;
       if (diracPre && diracPre != dirac && diracPre != diracSloppy) delete diracPre;
       if (diracEig && diracEig != dirac && diracEig != diracPre) delete diracEig;
+      if (twisted) {
+        delete dirac_m;
+        if (diracSloppy_m && diracSloppy_m != dirac_m) delete diracSloppy_m;
+        if (diracPre_m && diracPre_m != dirac_m && diracPre_m != diracSloppy_m) delete diracPre_m;
+        if (diracEig_m && diracEig_m != dirac_m && diracEig_m != diracPre_m) delete diracEig_m;
+      }
     } else {
       // Standard host-side path via invertQuda (no MG preconditioner).
       // Without MG the inv_type is typically CG / CGNE / CGNR, which

--- a/lib/hmc_integrator.cpp
+++ b/lib/hmc_integrator.cpp
@@ -54,6 +54,10 @@ extern quda::GaugeField *gaugeExtended;
 extern quda::GaugeField *extendedGaugeResident;
 extern quda::GaugeField momResident;
 extern quda::CloverField *cloverPrecise;
+extern quda::CloverField *cloverSloppy;
+extern quda::CloverField *cloverPrecondition;
+extern quda::CloverField *cloverRefinement;
+extern quda::CloverField *cloverEigensolver;
 
 void updateExtendedGaugeResident(bool new_gauge, const quda::lat_dim_t &R, quda::TimeProfile &profile,
                                  bool redundant_comms = false, QudaReconstructType recon = QUDA_RECONSTRUCT_INVALID);
@@ -237,6 +241,8 @@ namespace quda
      * corrupt clover (NaN / systematically wrong TrLog, "diagonal appears
      * unset" reads downstream).
      */
+    void refreshSloppyCloverFamily();
+
     void recomputeResidentClover(QudaInvertParam &inv_param)
     {
       if (!cloverPrecise) errorQuda("No resident clover field to recompute");
@@ -244,6 +250,7 @@ namespace quda
       if (cloverPrecise->Precision() >= QUDA_DOUBLE_PRECISION) {
         // createCloverQuda computes at the field precision (double): safe.
         createCloverQuda(&inv_param);
+        refreshSloppyCloverFamily();
         return;
       }
 
@@ -278,19 +285,34 @@ namespace quda
 
       // Demote into the resident field in place (copies TrLog + metadata)
       cloverPrecise->copy(tmp);
+      refreshSloppyCloverFamily();
 
       if (ex != gauge) delete ex;
     }
 
     /**
-     * @brief Sync sloppy/precondition copies from gaugePrecise after any
-     *        in-place gauge mutation.
+     * @brief In-place refresh of the sloppy clover family after a
+     *        cloverPrecise recompute.
+     *
+     * When the sloppy/precondition/refinement/eigensolver clovers are
+     * distinct objects (mixed precision), they hold now-stale copies. They
+     * must be refreshed IN PLACE — reallocation (freeSloppyCloverQuda +
+     * loadSloppyCloverQuda) would dangle the pointers an MG hierarchy
+     * captured at setup. CloverField::copy performs the precision-demoting
+     * conversion and refreshes the metadata (Diagonal, max) the compressed
+     * accessors require.
      */
-    void syncGaugeHierarchyFromPrecise()
+    void refreshSloppyCloverFamily()
     {
-      if (gaugeSloppy && gaugeSloppy != gaugePrecise) gaugeSloppy->copy(*gaugePrecise);
-      if (gaugePrecondition && gaugePrecondition != gaugePrecise && gaugePrecondition != gaugeSloppy)
-        gaugePrecondition->copy(*gaugePrecise);
+      if (cloverSloppy && cloverSloppy != cloverPrecise) cloverSloppy->copy(*cloverPrecise);
+      if (cloverPrecondition && cloverPrecondition != cloverPrecise && cloverPrecondition != cloverSloppy)
+        cloverPrecondition->copy(*cloverPrecise);
+      if (cloverRefinement && cloverRefinement != cloverPrecise && cloverRefinement != cloverSloppy
+          && cloverRefinement != cloverPrecondition)
+        cloverRefinement->copy(*cloverPrecise);
+      if (cloverEigensolver && cloverEigensolver != cloverPrecise && cloverEigensolver != cloverSloppy
+          && cloverEigensolver != cloverPrecondition && cloverEigensolver != cloverRefinement)
+        cloverEigensolver->copy(*cloverPrecise);
     }
 
     /**
@@ -348,6 +370,31 @@ namespace quda
       }
     }
   } // namespace
+
+  void hmcRefreshResidentGaugeState(QudaInvertParam &inv_param)
+  {
+    // Full state-refresh discipline after ANY device-side write to
+    // gaugePrecise. Each element guards against a distinct staleness bug
+    // observed in this codebase (see the ghost-pad / clover findings):
+    // 1. ghost pads: copy() fills only the local volume, the Dirac
+    //    operators read the pads;
+    gaugePrecise->exchangeGhost();
+    // 2. sloppy/precondition gauge copies (aliased at uniform precision);
+    if (gaugeSloppy && gaugeSloppy != gaugePrecise) gaugeSloppy->copy(*gaugePrecise);
+    if (gaugePrecondition && gaugePrecondition != gaugePrecise && gaugePrecondition != gaugeSloppy)
+      gaugePrecondition->copy(*gaugePrecise);
+    // 3. the cached extended gauge (createCloverQuda and the gauge force
+    //    read it; new_gauge = true forces the rebuild);
+    lat_dim_t R;
+    for (int d = 0; d < 4; d++) R[d] = (d == 0 ? 2 : 1) * commDimPartitioned(d);
+    updateExtendedGaugeResident(true, R, getProfile());
+    // 4. clover-type actions: in-place recompute at double + demote, plus
+    //    the in-place sloppy-clover family refresh (mixed precision).
+    if (cloverPrecise
+        && (inv_param.dslash_type == QUDA_CLOVER_WILSON_DSLASH || inv_param.dslash_type == QUDA_TWISTED_CLOVER_DSLASH)) {
+      recomputeResidentClover(inv_param);
+    }
+  }
 
   // --------------------------------------------------------------------
   // Primitive operations.
@@ -551,33 +598,7 @@ namespace quda
     updateGaugeField(u_out, dt, *gaugePrecise, momResident, false, true);
 
     gaugePrecise->copy(u_out);
-    // Refresh the ghost pads: copy() updates only the local volume, but
-    // gaugePrecise is a GHOST_EXCHANGE_PAD field whose pads loadGaugeQuda
-    // filled from the ORIGINAL gauge. Stale pads make the Dirac operator a
-    // mongrel of evolved bulk + initial-gauge boundary, i.e. a non-gradient
-    // force that grows along the trajectory (dt-independent dH plateau).
-    gaugePrecise->exchangeGhost();
-    syncGaugeHierarchyFromPrecise();
-
-    // Rebuild extended gauge (handles ghost exchange internally)
-    lat_dim_t R = hmcExtendedGaugeShell();
-    updateExtendedGaugeResident(true, R, getProfile());
-
-    // Rebuild clover from the updated gauge if this is a clover-type action.
-    // Must be IN PLACE (createCloverQuda: Fmunu from the extended gauge
-    // refreshed above with new_gauge = true, computeClover + cloverInvert/
-    // TrLog into the existing field): a free + reload would reallocate the
-    // clover and dangle the pointers an MG hierarchy captured at setup
-    // (observed as garbage "checkerboard volume" / "diagonal appears unset"
-    // aborts inside MG smoothers). Plain loadCloverQuda would no-op instead
-    // (its recompute triggers are parameter changes or loadGaugeQuda's
-    // invalidate_clover flag). Sloppy clover copies alias cloverPrecise at
-    // uniform precision; mixed-precision clover-sloppy refresh is a known
-    // gap shared with the pre-existing code.
-    if (cloverPrecise
-        && (inv_param.dslash_type == QUDA_CLOVER_WILSON_DSLASH || inv_param.dslash_type == QUDA_TWISTED_CLOVER_DSLASH)) {
-      recomputeResidentClover(inv_param);
-    }
+    hmcRefreshResidentGaugeState(inv_param);
     getProfile().TPSTOP(QUDA_PROFILE_COMPUTE);
   }
 
@@ -612,26 +633,10 @@ namespace quda
     GaugeField u_out(gfParam);
     updateGaugeField(u_out, 1.0, *gaugePrecise, momResident, false, true);
     gaugePrecise->copy(u_out);
-    // Refresh the ghost pads: copy() updates only the local volume, but
-    // gaugePrecise is a GHOST_EXCHANGE_PAD field whose pads loadGaugeQuda
-    // filled from the ORIGINAL gauge. Stale pads make the Dirac operator a
-    // mongrel of evolved bulk + initial-gauge boundary, i.e. a non-gradient
-    // force that grows along the trajectory (dt-independent dH plateau).
-    gaugePrecise->exchangeGhost();
-    syncGaugeHierarchyFromPrecise();
-    // Force-rebuild extended halo at the displaced gauge. Without this,
-    // the next kick consumes the pre-displacement halo and the FG
-    // correction silently degenerates to a plain Omelyan step (2nd-order
-    // instead of 4th — visible as p≈2 in HMC.dHScaling).
-    lat_dim_t R = hmcExtendedGaugeShell();
-    updateExtendedGaugeResident(true, R, getProfile());
-    // Recompute the clover at the displaced gauge (in place — see drift()):
-    // without this the excursion's force evaluation uses the pre-displacement
-    // clover, degrading the FG correction for clover-type actions.
-    if (cloverPrecise
-        && (inv_param.dslash_type == QUDA_CLOVER_WILSON_DSLASH || inv_param.dslash_type == QUDA_TWISTED_CLOVER_DSLASH)) {
-      recomputeResidentClover(inv_param);
-    }
+    // Full refresh at the displaced gauge: without it the excursion's force
+    // evaluation uses the pre-displacement halo/clover and the FG correction
+    // silently degenerates to 2nd order (p≈2 instead of 4 in HMC.dHScaling).
+    hmcRefreshResidentGaugeState(inv_param);
 
     // Restore momentum, compute full kick at displaced gauge
     momResident.copy(momSaved);
@@ -640,13 +645,7 @@ namespace quda
     // Restore gauge — and rebuild extended at the original gauge so the
     // outer schedule's subsequent kick sees a consistent halo.
     gaugePrecise->copy(gaugeSaved);
-    gaugePrecise->exchangeGhost();
-    syncGaugeHierarchyFromPrecise();
-    updateExtendedGaugeResident(true, R, getProfile());
-    if (cloverPrecise
-        && (inv_param.dslash_type == QUDA_CLOVER_WILSON_DSLASH || inv_param.dslash_type == QUDA_TWISTED_CLOVER_DSLASH)) {
-      recomputeResidentClover(inv_param);
-    }
+    hmcRefreshResidentGaugeState(inv_param);
   }
 
   // --------------------------------------------------------------------
@@ -737,24 +736,7 @@ namespace quda
     GaugeField u_out(gParam);
     updateGaugeField(u_out, dt, *gaugePrecise, momResident, false, true);
     gaugePrecise->copy(u_out);
-    // Refresh the ghost pads: copy() updates only the local volume, and the
-    // Dirac operators read the pads (same staleness class as the base-class
-    // drift — a mongrel evolved-bulk/stale-boundary operator otherwise).
-    gaugePrecise->exchangeGhost();
-
-    if (gaugeSloppy && gaugeSloppy != gaugePrecise) gaugeSloppy->copy(*gaugePrecise);
-    if (gaugePrecondition && gaugePrecondition != gaugePrecise && gaugePrecondition != gaugeSloppy)
-      gaugePrecondition->copy(*gaugePrecise);
-
-    // Clover rebuild: createCloverQuda computes from the cached
-    // extendedGaugeResident, so refresh it first (new_gauge = true). The
-    // recompute is IN PLACE — a free + reload would dangle the clover
-    // pointers held by the MG hierarchy (see drift()).
-    if (cloverPrecise) {
-      lat_dim_t R = hmcExtendedGaugeShell();
-      updateExtendedGaugeResident(true, R, getProfile());
-      recomputeResidentClover(inv_param);
-    }
+    hmcRefreshResidentGaugeState(inv_param);
   }
 
   /**

--- a/lib/hmc_integrator.cpp
+++ b/lib/hmc_integrator.cpp
@@ -342,6 +342,18 @@ namespace quda
     }
 
     // Solve x = (M†M)⁻¹ b
+    // Twisted actions: γ₅-hermiticity is M̂(μ)† = γ₅M̂(-μ)γ₅, so pass 1 of the
+    // two-pass below must solve M(-μ) (see computeFermionAction for the
+    // derivation; μ-symmetric actions alias the flipped set to the direct one).
+    const bool kick_twisted
+      = (ip.dslash_type == QUDA_TWISTED_MASS_DSLASH || ip.dslash_type == QUDA_TWISTED_CLOVER_DSLASH);
+    Dirac *dirac_m = nullptr, *diracSloppy_m = nullptr, *diracPre_m = nullptr, *diracEig_m = nullptr;
+    if (kick_twisted && ip.preconditioner && ip.solve_type == QUDA_DIRECT_PC_SOLVE) {
+      QudaInvertParam ip_minus = ip;
+      ip_minus.mu = -ip.mu;
+      createDiracWithEig(dirac_m, diracSloppy_m, diracPre_m, diracEig_m, ip_minus, pc_solve, false);
+    }
+
     if (ip.preconditioner && ip.solve_type == QUDA_DIRECT_PC_SOLVE) {
       // MG two-pass γ₅ trick: M† = γ₅ M γ₅, so (M†M)⁻¹ = M⁻¹ (γ₅ M γ₅)⁻¹ = M⁻¹ γ₅ M⁻¹ γ₅
       // Step 1: z = γ₅ b
@@ -370,11 +382,13 @@ namespace quda
       GCRTracker gcrTracker(gcrResCap, ip.cuda_prec);
       std::vector<ColorSpinorField> krylovVecs;
 
-      // Step 2: Solve M w = z
+      // Step 2: Solve M(-μ) w = z (equals M for μ-symmetric actions)
+      DiracM mMinus(dirac_m ? *dirac_m : *dirac), mMinusSloppy(diracSloppy_m ? *diracSloppy_m : *diracSloppy),
+        mMinusPre(diracPre_m ? *diracPre_m : *diracPre), mMinusEig(diracEig_m ? *diracEig_m : *diracEig);
       std::vector<ColorSpinorField> w(1, csParam);
       {
         TrackerScope<GCRTracker> scope(activeGCRTracker, gcrTracker.isActive() ? &gcrTracker : nullptr);
-        Solver *s = Solver::create(solverParam, m, mSloppy, mPre, mEig);
+        Solver *s = Solver::create(solverParam, mMinus, mMinusSloppy, mMinusPre, mMinusEig);
         (*s)(w, z);
         delete s;
         g_traj_cg_iters += solverParam.iter;
@@ -455,6 +469,12 @@ namespace quda
     delete diracSloppy;
     if (diracPre != diracSloppy) delete diracPre;
     if (diracEig != diracPre) delete diracEig;
+    if (dirac_m) {
+      delete dirac_m;
+      if (diracSloppy_m && diracSloppy_m != dirac_m) delete diracSloppy_m;
+      if (diracPre_m && diracPre_m != dirac_m && diracPre_m != diracSloppy_m) delete diracPre_m;
+      if (diracEig_m && diracEig_m != dirac_m && diracEig_m != diracPre_m) delete diracEig_m;
+    }
     getProfile().TPSTOP(QUDA_PROFILE_COMPUTE);
   }
 
@@ -483,16 +503,20 @@ namespace quda
     lat_dim_t R = hmcExtendedGaugeShell();
     updateExtendedGaugeResident(true, R, getProfile());
 
-    // Rebuild clover from updated gauge if this is a Wilson-clover action.
-    // loadCloverQuda alone would no-op here: its recompute trigger is a
-    // parameter change or the invalidate_clover flag (set only by
-    // loadGaugeQuda), neither of which fires after a device-side gauge
-    // update. Free first so the recompute is unconditional; it reads the
-    // extended gauge refreshed above with new_gauge = true.
+    // Rebuild clover from the updated gauge if this is a clover-type action.
+    // Must be IN PLACE (createCloverQuda: Fmunu from the extended gauge
+    // refreshed above with new_gauge = true, computeClover + cloverInvert/
+    // TrLog into the existing field): a free + reload would reallocate the
+    // clover and dangle the pointers an MG hierarchy captured at setup
+    // (observed as garbage "checkerboard volume" / "diagonal appears unset"
+    // aborts inside MG smoothers). Plain loadCloverQuda would no-op instead
+    // (its recompute triggers are parameter changes or loadGaugeQuda's
+    // invalidate_clover flag). Sloppy clover copies alias cloverPrecise at
+    // uniform precision; mixed-precision clover-sloppy refresh is a known
+    // gap shared with the pre-existing code.
     if (cloverPrecise
         && (inv_param.dslash_type == QUDA_CLOVER_WILSON_DSLASH || inv_param.dslash_type == QUDA_TWISTED_CLOVER_DSLASH)) {
-      freeCloverQuda();
-      loadCloverQuda(nullptr, nullptr, &inv_param);
+      createCloverQuda(&inv_param);
     }
     getProfile().TPSTOP(QUDA_PROFILE_COMPUTE);
   }
@@ -641,12 +665,24 @@ namespace quda
     GaugeField u_out(gParam);
     updateGaugeField(u_out, dt, *gaugePrecise, momResident, false, true);
     gaugePrecise->copy(u_out);
+    // Refresh the ghost pads: copy() updates only the local volume, and the
+    // Dirac operators read the pads (same staleness class as the base-class
+    // drift — a mongrel evolved-bulk/stale-boundary operator otherwise).
+    gaugePrecise->exchangeGhost();
 
     if (gaugeSloppy && gaugeSloppy != gaugePrecise) gaugeSloppy->copy(*gaugePrecise);
     if (gaugePrecondition && gaugePrecondition != gaugePrecise && gaugePrecondition != gaugeSloppy)
       gaugePrecondition->copy(*gaugePrecise);
 
-    if (cloverPrecise) createCloverQuda(&inv_param);
+    // Clover rebuild: createCloverQuda computes from the cached
+    // extendedGaugeResident, so refresh it first (new_gauge = true). The
+    // recompute is IN PLACE — a free + reload would dangle the clover
+    // pointers held by the MG hierarchy (see drift()).
+    if (cloverPrecise) {
+      lat_dim_t R = hmcExtendedGaugeShell();
+      updateExtendedGaugeResident(true, R, getProfile());
+      createCloverQuda(&inv_param);
+    }
   }
 
   /**
@@ -677,64 +713,72 @@ namespace quda
 
     QudaInvertParam ip = inv_param;
 
-    if (ip.dslash_type == QUDA_WILSON_DSLASH) {
-      ColorSpinorParam csParam(phi);
-      csParam.create = QUDA_ZERO_FIELD_CREATE;
-      std::vector<ColorSpinorField> x(1, csParam);
-      std::vector<ColorSpinorField> b(1, ColorSpinorField(phi));
+    // Action-generic fermion force: solve x = (M̂†M̂)⁻¹φ, then
+    // computeEOFermionForce assembles the hopping (+ clover sigma/TrLog,
+    // + twisted variants) force under the validated F = -2·∂S/∂u
+    // convention. This replaced a per-action branch whose clover leg
+    // called the tmLQCD-convention computeCloverForceQuda (which has no
+    // twist term and different normalizations).
+    ColorSpinorParam csParam(phi);
+    csParam.create = QUDA_ZERO_FIELD_CREATE;
+    std::vector<ColorSpinorField> x(1, csParam);
+    std::vector<ColorSpinorField> b(1, ColorSpinorField(phi));
 
-      bool pc_solve = (ip.solve_type == QUDA_DIRECT_PC_SOLVE) || (ip.solve_type == QUDA_NORMOP_PC_SOLVE);
-      Dirac *dirac = nullptr, *diracSloppy = nullptr, *diracPre = nullptr, *diracEig = nullptr;
-      createDiracWithEig(dirac, diracSloppy, diracPre, diracEig, ip, pc_solve, false);
+    bool pc_solve = (ip.solve_type == QUDA_DIRECT_PC_SOLVE) || (ip.solve_type == QUDA_NORMOP_PC_SOLVE);
+    Dirac *dirac = nullptr, *diracSloppy = nullptr, *diracPre = nullptr, *diracEig = nullptr;
+    createDiracWithEig(dirac, diracSloppy, diracPre, diracEig, ip, pc_solve, false);
 
-      if (ip.preconditioner && ip.solve_type == QUDA_DIRECT_PC_SOLVE) {
-        DiracM m(*dirac), mSloppy(*diracSloppy), mPre(*diracPre), mEig(*diracEig);
-        SolverParam solverParam(ip);
-        std::vector<ColorSpinorField> z(1, csParam);
-        gamma5(z, b);
-        std::vector<ColorSpinorField> w(1, csParam);
-        {
-          Solver *s = Solver::create(solverParam, m, mSloppy, mPre, mEig);
-          (*s)(w, z);
-          delete s;
-          solverParam.iter = 0;
-        }
-        std::vector<ColorSpinorField> y(1, csParam);
-        gamma5(y, w);
-        {
-          Solver *s = Solver::create(solverParam, m, mSloppy, mPre, mEig);
-          (*s)(x, y);
-          delete s;
-        }
-      } else {
-        solve(x, b, *dirac, *diracSloppy, *diracPre, *diracEig, ip);
+    // For twisted actions γ₅-hermiticity reads M̂(μ)† = γ₅M̂(-μ)γ₅, so the
+    // two-pass below must solve M(-μ) in its FIRST pass:
+    // x = M(+μ)⁻¹ γ₅ M(-μ)⁻¹ γ₅ φ = (M̂†M̂)⁻¹φ. The +μ MG hierarchy remains
+    // a valid preconditioner for M(-μ) (small diagonal shift — iteration
+    // counts, never the converged solution). μ-symmetric actions reduce to
+    // the standard two-pass (the flipped set aliases the direct one).
+    const bool twisted
+      = (ip.dslash_type == QUDA_TWISTED_MASS_DSLASH || ip.dslash_type == QUDA_TWISTED_CLOVER_DSLASH);
+    Dirac *dirac_m = nullptr, *diracSloppy_m = nullptr, *diracPre_m = nullptr, *diracEig_m = nullptr;
+    if (twisted && ip.preconditioner && ip.solve_type == QUDA_DIRECT_PC_SOLVE) {
+      QudaInvertParam ip_minus = ip;
+      ip_minus.mu = -ip.mu;
+      createDiracWithEig(dirac_m, diracSloppy_m, diracPre_m, diracEig_m, ip_minus, pc_solve, false);
+    }
+
+    if (ip.preconditioner && ip.solve_type == QUDA_DIRECT_PC_SOLVE) {
+      DiracM m(*dirac), mSloppy(*diracSloppy), mPre(*diracPre), mEig(*diracEig);
+      DiracM mMinus(dirac_m ? *dirac_m : *dirac), mMinusSloppy(diracSloppy_m ? *diracSloppy_m : *diracSloppy),
+        mMinusPre(diracPre_m ? *diracPre_m : *diracPre), mMinusEig(diracEig_m ? *diracEig_m : *diracEig);
+      SolverParam solverParam(ip);
+      std::vector<ColorSpinorField> z(1, csParam);
+      gamma5(z, b);
+      std::vector<ColorSpinorField> w(1, csParam);
+      {
+        Solver *s = Solver::create(solverParam, mMinus, mMinusSloppy, mMinusPre, mMinusEig);
+        (*s)(w, z);
+        delete s;
+        solverParam.iter = 0;
       }
-
-      computeEOFermionForce(momResident, x[0], ip, coeff);
-
-      delete dirac;
-      delete diracSloppy;
-      if (diracPre != diracSloppy) delete diracPre;
-      if (diracEig != diracPre) delete diracEig;
+      std::vector<ColorSpinorField> y(1, csParam);
+      gamma5(y, w);
+      {
+        Solver *s = Solver::create(solverParam, m, mSloppy, mPre, mEig);
+        (*s)(x, y);
+        delete s;
+      }
     } else {
-      ip.use_resident_solution = 1;
-      ip.make_resident_solution = 1;
+      solve(x, b, *dirac, *diracSloppy, *diracPre, *diracEig, ip);
+    }
 
-      ColorSpinorParam cpuParam(nullptr, ip, gaugePrecise->X(), true, QUDA_CPU_FIELD_LOCATION);
-      cpuParam.create = QUDA_ZERO_FIELD_CREATE;
-      ColorSpinorField h_x(cpuParam);
-      ColorSpinorField h_b(cpuParam);
-      h_b = phi;
+    computeEOFermionForce(momResident, x[0], ip, coeff);
 
-      invertQuda(h_x.data(), h_b.data(), &ip);
-
-      double fCoeff = 1.0;
-      double kappa2 = ip.kappa * ip.kappa;
-      double ck = ip.clover_csw * ip.kappa;
-      ip.use_resident_solution = 1;
-      gp.overwrite_mom = 0;
-      computeCloverForceQuda(nullptr, coeff, nullptr, nullptr, &fCoeff, kappa2, ck, 1, 1.0, nullptr, &gp, &ip);
-      solutionResident.clear();
+    delete dirac;
+    delete diracSloppy;
+    if (diracPre != diracSloppy) delete diracPre;
+    if (diracEig != diracPre) delete diracEig;
+    if (dirac_m) {
+      delete dirac_m;
+      if (diracSloppy_m && diracSloppy_m != dirac_m) delete diracSloppy_m;
+      if (diracPre_m && diracPre_m != dirac_m && diracPre_m != diracSloppy_m) delete diracPre_m;
+      if (diracEig_m && diracEig_m != dirac_m && diracEig_m != diracPre_m) delete diracEig_m;
     }
 
     // Subtract low-mode force so outer + inner = total

--- a/lib/hmc_integrator.cpp
+++ b/lib/hmc_integrator.cpp
@@ -20,6 +20,7 @@
 #include <dslash_quda.h>
 #include <gauge_field.h>
 #include <gauge_path_quda.h>
+#include <gauge_tools.h>
 #include <gauge_update_quda.h>
 #include <invert_quda.h>
 #include <malloc_quda.h>
@@ -220,6 +221,65 @@ namespace quda
       lat_dim_t R;
       for (int d = 0; d < 4; d++) R[d] = (d == 0 ? 2 : 1) * commDimPartitioned(d);
       return R;
+    }
+
+    /**
+     * @brief Recompute the resident clover (+ inverse metadata + TrLog)
+     *        from the current extendedGaugeResident, IN PLACE.
+     *
+     * In place is mandatory: reallocating (freeCloverQuda + loadCloverQuda)
+     * dangles the clover pointers an MG hierarchy captured at setup.
+     *
+     * The compute must run at double and demote into the resident field —
+     * mirroring loadCloverQuda, which creates at clover_cpu_prec (double),
+     * computes, then demotes. Direct single-precision computeClover +
+     * cloverInvert is a path loadCloverQuda never exercises and yields a
+     * corrupt clover (NaN / systematically wrong TrLog, "diagonal appears
+     * unset" reads downstream).
+     */
+    void recomputeResidentClover(QudaInvertParam &inv_param)
+    {
+      if (!cloverPrecise) errorQuda("No resident clover field to recompute");
+
+      if (cloverPrecise->Precision() >= QUDA_DOUBLE_PRECISION) {
+        // createCloverQuda computes at the field precision (double): safe.
+        createCloverQuda(&inv_param);
+        return;
+      }
+
+      if (!extendedGaugeResident) errorQuda("No extended gauge field for clover recompute");
+      GaugeField *gauge = extendedGaugeResident;
+
+      // Promote the extended gauge to double for the compute
+      GaugeField *ex = gauge;
+      if (gauge->Precision() < QUDA_DOUBLE_PRECISION) {
+        GaugeFieldParam param(*gauge);
+        param.setPrecision(QUDA_DOUBLE_PRECISION, true);
+        param.create = QUDA_NULL_FIELD_CREATE;
+        ex = GaugeField::Create(param);
+        ex->copy(*gauge);
+      }
+
+      GaugeFieldParam tensorParam(gaugePrecise->X(), QUDA_DOUBLE_PRECISION, QUDA_RECONSTRUCT_NO, 0,
+                                  QUDA_TENSOR_GEOMETRY);
+      tensorParam.location = QUDA_CUDA_FIELD_LOCATION;
+      tensorParam.siteSubset = QUDA_FULL_SITE_SUBSET;
+      tensorParam.setPrecision(tensorParam.Precision(), true);
+      tensorParam.ghostExchange = QUDA_GHOST_EXCHANGE_NO;
+      GaugeField Fmunu(tensorParam);
+      computeFmunu(Fmunu, *ex);
+
+      CloverFieldParam cParam(*cloverPrecise);
+      cParam.create = QUDA_NULL_FIELD_CREATE;
+      cParam.setPrecision(QUDA_DOUBLE_PRECISION, true);
+      CloverField tmp(cParam);
+      computeClover(tmp, Fmunu, inv_param.clover_coeff);
+      cloverInvert(tmp, tmp.Reconstruct());
+
+      // Demote into the resident field in place (copies TrLog + metadata)
+      cloverPrecise->copy(tmp);
+
+      if (ex != gauge) delete ex;
     }
 
     /**
@@ -516,7 +576,7 @@ namespace quda
     // gap shared with the pre-existing code.
     if (cloverPrecise
         && (inv_param.dslash_type == QUDA_CLOVER_WILSON_DSLASH || inv_param.dslash_type == QUDA_TWISTED_CLOVER_DSLASH)) {
-      createCloverQuda(&inv_param);
+      recomputeResidentClover(inv_param);
     }
     getProfile().TPSTOP(QUDA_PROFILE_COMPUTE);
   }
@@ -565,6 +625,13 @@ namespace quda
     // instead of 4th — visible as p≈2 in HMC.dHScaling).
     lat_dim_t R = hmcExtendedGaugeShell();
     updateExtendedGaugeResident(true, R, getProfile());
+    // Recompute the clover at the displaced gauge (in place — see drift()):
+    // without this the excursion's force evaluation uses the pre-displacement
+    // clover, degrading the FG correction for clover-type actions.
+    if (cloverPrecise
+        && (inv_param.dslash_type == QUDA_CLOVER_WILSON_DSLASH || inv_param.dslash_type == QUDA_TWISTED_CLOVER_DSLASH)) {
+      recomputeResidentClover(inv_param);
+    }
 
     // Restore momentum, compute full kick at displaced gauge
     momResident.copy(momSaved);
@@ -573,8 +640,13 @@ namespace quda
     // Restore gauge — and rebuild extended at the original gauge so the
     // outer schedule's subsequent kick sees a consistent halo.
     gaugePrecise->copy(gaugeSaved);
+    gaugePrecise->exchangeGhost();
     syncGaugeHierarchyFromPrecise();
     updateExtendedGaugeResident(true, R, getProfile());
+    if (cloverPrecise
+        && (inv_param.dslash_type == QUDA_CLOVER_WILSON_DSLASH || inv_param.dslash_type == QUDA_TWISTED_CLOVER_DSLASH)) {
+      recomputeResidentClover(inv_param);
+    }
   }
 
   // --------------------------------------------------------------------
@@ -681,7 +753,7 @@ namespace quda
     if (cloverPrecise) {
       lat_dim_t R = hmcExtendedGaugeShell();
       updateExtendedGaugeResident(true, R, getProfile());
-      createCloverQuda(&inv_param);
+      recomputeResidentClover(inv_param);
     }
   }
 

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -5052,7 +5052,20 @@ double hmcTrajectoryQuda(void *h_gauge, void *h_momentum, QudaHMCParam *hmc_para
   // For clover actions: compute from gauge. For pure Wilson: no clover needed.
   bool use_clover = (inv_param->dslash_type == QUDA_CLOVER_WILSON_DSLASH
                      || inv_param->dslash_type == QUDA_TWISTED_CLOVER_DSLASH);
-  if (use_clover) { loadCloverQuda(nullptr, nullptr, inv_param); }
+  if (use_clover) {
+    // Only (re)load when the clover is absent or its parameters changed.
+    // loadCloverQuda unconditionally frees and recreates the SLOPPY clover
+    // family even when the precise field is untouched — at mixed precision
+    // (distinct sloppy objects) that dangles the pointers an MG hierarchy
+    // captured at setup, corrupting the smoother from the second trajectory
+    // on. Within a run the HMC path keeps the clover current itself
+    // (hmcRefreshResidentGaugeState after every gauge update/restore).
+    double coeff = (inv_param->clover_coeff == 0.0 ? inv_param->kappa * inv_param->clover_csw : inv_param->clover_coeff);
+    double mu2 = 4.0 * inv_param->kappa * inv_param->kappa * inv_param->mu * inv_param->mu;
+    bool clover_current = cloverPrecise && cloverPrecise->Coeff() == coeff && cloverPrecise->Csw() == inv_param->clover_csw
+      && cloverPrecise->Mu2() == mu2 && cloverPrecise->Rho() == inv_param->clover_rho;
+    if (!clover_current) { loadCloverQuda(nullptr, nullptr, inv_param); }
+  }
 
   // --- 3. Momentum: load from host, use resident, or generate ---
   if (hmc_param->generate_momentum) {
@@ -5536,15 +5549,15 @@ void hmcRunQuda(void *h_gauge, QudaHMCParam *hmc_param, QudaGaugeParam *gauge_pa
         if (et_dE && et_dE != et_d && et_dE != et_dP) delete et_dE;
       }
     } else {
-      // Reject: restore gauge from backup
+      // Reject: restore gauge from backup, then run the FULL state-refresh
+      // discipline. The previous code skipped the ghost-pad exchange (the
+      // Dirac operators then read restored bulk links against the rejected
+      // trajectory's boundary links — a broken operator that showed up as a
+      // systematic O(500) dH offset on every post-rejection trajectory) and
+      // called createCloverQuda directly (corrupt single-precision TrLog
+      // path, no sloppy-clover refresh).
       gaugePrecise->copy(gaugeBkup);
-      if (gaugeSloppy && gaugeSloppy != gaugePrecise) gaugeSloppy->copy(*gaugePrecise);
-      if (gaugePrecondition && gaugePrecondition != gaugePrecise && gaugePrecondition != gaugeSloppy)
-        gaugePrecondition->copy(*gaugePrecise);
-
-      // Rebuild clover and extended gauge after restoring
-      updateExtendedGaugeResident(true, R, getProfile());
-      if (cloverPrecise) createCloverQuda(inv_param);
+      quda::hmcRefreshResidentGaugeState(*inv_param);
 
       // Verify restore
       {

--- a/lib/low_mode_force.cpp
+++ b/lib/low_mode_force.cpp
@@ -135,8 +135,8 @@ namespace quda
     }
   }
 
-  void LowModeForce::computeForce(GaugeField &mom, const ColorSpinorField &src, double coeff, GaugeField &gauge,
-                                   const CloverField *clover, QudaGaugeParam &, QudaInvertParam &invParam)
+  void LowModeForce::computeForce(GaugeField &mom, const ColorSpinorField &src, double coeff, GaugeField &,
+                                   const CloverField *, QudaGaugeParam &, QudaInvertParam &invParam)
   {
     auto profile = pushProfile(getEigenTrackProfile());
     ScopedComputePhase _scope_;
@@ -150,27 +150,18 @@ namespace quda
     // Project source onto low modes
     projectLowModes(fineSol, src);
 
-    // Compute fermion force using the projected solution. The low-mode fine-grid
-    // vector is the approximate (D†D)^{-1} φ, structurally equivalent to the CG
-    // solution used by the standard fermion force kernel.
-    if (invParam.dslash_type == QUDA_WILSON_DSLASH) {
-      // Wilson: internal EO force (matches the other integrators' convention).
-      computeEOFermionForce(mom, fineSol, invParam, coeff);
-    } else {
-      // Clover: preserve the established computeCloverForce call path.
-      std::vector<ColorSpinorField> xVec = {fineSol};
-      std::vector<ColorSpinorField> x0Vec(1);
-      std::vector<double> forceCoeff = {coeff};
-      std::vector<array<double, 2>> fermEpsilon = {{0.0, 0.0}};
-
-      lat_dim_t R;
-      for (int d = 0; d < 4; d++) R[d] = (d == 0 ? 2 : 1) * commDimPartitioned(d);
-      GaugeField *gaugeEx = createExtendedGauge(gauge, R, getProfile());
-
-      computeCloverForce(mom, *gaugeEx, gauge, *clover, xVec, x0Vec, forceCoeff, fermEpsilon, 0.0, false, invParam);
-
-      delete gaugeEx;
-    }
+    // Compute the fermion force from the projected solution via the
+    // action-generic internal EO force (Wilson, clover, twisted mass,
+    // twisted clover — all under the validated F = -2·∂S/∂u convention).
+    // The low-mode fine-grid vector is the approximate (M̂†M̂)⁻¹φ,
+    // structurally equivalent to the CG solution the force expects. The
+    // nested-FGI split only requires that the inner-added and
+    // outer-subtracted low-mode forces be the SAME functional — using the
+    // same convention as the outer full force additionally maximizes the
+    // high/low-mode cancellation. (This replaced a clover-only branch that
+    // called the tmLQCD-convention computeCloverForce with a parity field
+    // and a null clover for twisted mass.)
+    computeEOFermionForce(mom, fineSol, invParam, coeff);
   }
 
 } // namespace quda


### PR DESCRIPTION
Stacked on #1627 (base: `feature/fgi_hmc`). Two commits.

## What this adds

**Every supported action now runs under every integrator** — Wilson, Wilson-clover, twisted-mass (singlet), twisted-clover (singlet) × leapfrog, Omelyan, force-gradient, nested-FGI — with and without eigentracking.

- `NestedFGIIntegrator::computeOuterForce` and `LowModeForce::computeForce` are unified on the action-generic internal EO force (`computeEOFermionForce`). Their previous per-action branches called the tmLQCD-convention production clover force (no twist term; hard abort for twisted-mass; the low-mode leg passed a parity field and a null clover).
- γ₅ two-pass MG solves gain the μ-flip twisted actions require (`M̂(μ)† = γ₅M̂(−μ)γ₅` ⇒ pass 1 solves `M(−μ)`); μ-symmetric actions reduce to the standard two-pass. Verified: TM leapfrog × MG reproduces the no-MG dH to 4 digits.
- Nested-FGI inner `gaugeStep` gets the same state-refresh discipline as the outer drift (ghost pads, extended gauge).
- Mid-trajectory clover recomputes are **in place** and **computed at double then demoted** (`recomputeResidentClover`): reallocation dangles MG-held clover pointers, and the direct single-precision `computeClover`+`cloverInvert` path (never exercised by `loadCloverQuda`) yields a corrupt TrLog (csw²-scaled dH bias, NaN aborts).
- `fgStep` force-gradient excursions recompute the clover at the displaced and restored gauge (clover FGI `|⟨dH⟩|`: 5.5e-3 → 3.0e-4, matching Wilson).

## Validation (4⁴, double precision unless noted)

32-cell matrix (4 actions × 4 integrators × ET on/off, `HMC.Production`, 6 trajectories, fixed seed): **32/32 pass**, 5/5 acceptance everywhere, `|⟨dH⟩|` from 3e-4 (FGI) to 5e-2 (leapfrog); nested-FGI conserves at ~8e-4 for Wilson and twisted-mass. Full `ctest -R hmc` group: 26/26. Per-action force oracles (per-link vs numerical dS/dU at 1e-7, directional, exact heatbath identity) are registered in ctest on the base branch.

Known limitation (documented in the commits): clover-type nested-FGI matrix cells run pure single precision because double-precision MG is not compiled by default and the mixed d/s clover-sloppy in-place refresh is future work — they conserve at the honest single-precision level (~3e-1).