### PR TITLE
Bugfix/split gauge caching

### DIFF
--- a/include/enum_quda.h
+++ b/include/enum_quda.h
@@ -656,11 +656,11 @@ typedef enum QudaWFlowStepType_s {
 
 // Used by update_split_gauge
 typedef enum QudaUpdateSplitGauge_s {
-  QUDA_UPDATE_SPLIT_GAUGE_OFF, // will not use split gauge buffers
-  QUDA_UPDATE_SPLIT_GAUGE_TRUE
-  = 1, // the input gauge fields will be split and the buffered (split) gauges will be updated accordingly
+  QUDA_UPDATE_SPLIT_GAUGE_OFF = -1, // will not use split gauge buffers
   QUDA_UPDATE_SPLIT_GAUGE_FALSE
   = 0, // the input gauge fields will not be split and the buffered (split) gauges will be used for split grid solves
+  QUDA_UPDATE_SPLIT_GAUGE_TRUE
+  = 1, // the input gauge fields will be split and the buffered (split) gauges will be updated accordingly
 } QudaUpdateSplitGauge;
 
 #ifdef __cplusplus

--- a/lib/check_params.h
+++ b/lib/check_params.h
@@ -129,7 +129,7 @@ void printQudaGaugeParam(QudaGaugeParam *param) {
   P(staggered_phase_applied, INVALID_INT);
   P(i_mu, INVALID_DOUBLE);
   P(overlap, INVALID_INT);
-  P(use_split_gauge_bkup, QUDA_BOOLEAN_FALSE);
+  P(use_split_gauge_bkup, QUDA_BOOLEAN_INVALID);
 #endif
 
 #if defined INIT_PARAM

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -112,11 +112,11 @@ GaugeField *extendedGaugeResident = nullptr;
 /**
  * callMultiSrcQuda related gauge split
  * update_split_gauge :
- * - QUDA_UPDATE_SPLITE_GAUGE_TRUE: the input gauge fields will be split and the buffered (split) gauges will be updated
+ * - QUDA_UPDATE_SPLIT_GAUGE_TRUE: the input gauge fields will be split and the buffered (split) gauges will be updated
  accordingly;
- * - QUDA_UPDATE_SPLITE_GAUGE_FALSE: the input gauge fields will not be split and the buffered (split) gauges will be
+ * - QUDA_UPDATE_SPLIT_GAUGE_FALSE: the input gauge fields will not be split and the buffered (split) gauges will be
  used for split grid solves;
- * - QUDA_UPDATE_SPLITE_GAUGE_OFF: nothing will be done.
+ * - QUDA_UPDATE_SPLIT_GAUGE_OFF: nothing will be done.
 
  * split_grid_bkup will be used to check whether split layout is changed or not
  * change in gauge precsions will need loadGaugeQuda which results in re-distribute
@@ -3294,7 +3294,8 @@ void UpdateSplitGauge(QudaInvertParam *param, const int is_asqtad, const bool is
     // swap to the buffered split gauge
     swapGaugeSplit(true);
     return;
-  } else {
+  } else if (update_split_gauge != QUDA_UPDATE_SPLIT_GAUGE_OFF) {
+    // OFF must survive the split: it is what tells the epilogue to free the buffers again
     update_split_gauge = QUDA_UPDATE_SPLIT_GAUGE_TRUE;
   }
 
@@ -3584,7 +3585,7 @@ void callMultiSrcQuda(void **_hp_x, void **_hp_b, QudaInvertParam *param, // col
       for (int j = 0; j < num_sub_partition; j++) _h_x[n * num_sub_partition + j].copy(dev_buf[j]);
     }
 
-    // switch back to the original links, detete split gauge if update_split_gauge == QUDA_UPDATE_SPLITE_GAUGE_OFF
+    // switch back to the original links, delete split gauge if update_split_gauge == QUDA_UPDATE_SPLIT_GAUGE_OFF
     if (update_split_gauge == QUDA_UPDATE_SPLIT_GAUGE_OFF) {
       // do not use freeGaugeSplit which have additional swap
       swapGaugeSplit(false);


### PR DESCRIPTION
These bugs were found and fixed with the help of Claude Code (Opus 4.8).

## Summary

The enum `QudaUpdateSplitGauge` declared `OFF` with an implicit value of `0`, while `FALSE` was explicitly
`= 0`. The two enumerators were therefore the same value, collapsing an intended tri-state into two
states — and merging precisely the two that must be distinguished: *"reuse the buffered split gauge"*
(`FALSE`) and *"do not buffer the split gauge at all"* (`OFF`).

The consequence is that **split gauge caching has never worked**. Every `invertMultiSrcQuda` call
re-splits and re-uploads the full gauge / fat / long / clover fields, even when the caller explicitly
asked for the buffers to be reused. Results are correct; the cost is a redundant gauge
redistribution on every multi-RHS solve.

## The failure, step by step

With caching requested, `loadGaugeQuda` sets the flag to `TRUE` (`interface_quda.cpp:698`) and the
first solve splits the gauge correctly. Then:

1. `UpdateSplitGauge` ends by storing `FALSE` to mark the buffers warm (`:3425`).
2. The epilogue in `callMultiSrcQuda` tests `== OFF` (`:3588`). Because `FALSE == OFF`, **this
   matches**, and it calls `swapGaugeSplit(false)` — freeing the backups and zeroing
   `split_grid_bkup` (`:3261`).
3. The next solve sees the zeroed `split_grid_bkup`, flips itself back to `TRUE` (`:3282`), and
   re-splits from scratch.

The reuse branch at `:3291`, and its `"Reuse split Gauge."` message, are therefore **unreachable**.

## The fix

### 1. Give `OFF` a distinct value (`enum_quda.h`)

`OFF = -1`, with all three enumerators explicit and distinct, so the collision cannot silently
return.

This restores the semantics of the pre-enum flag, which was an `int` using `-1` / `0` / `1` (see the
comment still present at `interface_quda.cpp:112`). The enum was introduced in 938eb05, which
dropped the `-1` but translated every comparison site faithfully — `>= 0` became `!= OFF`, `< 0`
became `== OFF`. **No call site needs to change**; they were broken only because the constant
beneath them changed value.

### 2. Stop `OFF` being clobbered (`interface_quda.cpp:3298`)

Restoring `-1` alone is *not sufficient* — it regresses the `OFF` path.

`UpdateSplitGauge` unconditionally overwrote the flag with `TRUE` at `:3298`, destroying the `OFF`
marker. Under the collision that clobber was invisible: the subsequent write of `FALSE` at `:3425`
silently restored `OFF`, since the two were equal. Once the values are distinct the clobber sticks,
`OFF` decays into `FALSE`, the epilogue stops taking the free path, and a caller who asked for *no*
buffering silently retains a second copy of the gauge field.

The write is now guarded with `!= OFF`, matching the guards already present at `:3264` and `:3425`.

> **Note for reviewers:** this guard is a behavior change, not a restoration. The pre-enum code
> clobbered `-1` in the same place, so `OFF` likewise decayed into the caching state after the first
> solve and never freed, despite the flag being documented as *"delete buffer after usage"*. That
> latent bug was masked because `loadGaugeQuda` re-set the flag and called `freeGaugeSplit` on every
> gauge reload. The enum collision then inverted which of the two states worked. The two bugs are
> complements: the original honoured `FALSE` and broke `OFF`; `develop` today honours `OFF` and
> breaks `FALSE`. With this guard, both work — and `OFF`-mode behavior is left **identical to
> `develop` today** (see the test matrix below), so existing callers are unaffected.

### 3. Make `use_split_gauge_bkup = false` settable (`check_params.h:132`)

Separate bug, found while testing the above.

`checkGaugeParam` used `QUDA_BOOLEAN_FALSE` as the *invalid sentinel* for `use_split_gauge_bkup`.
Under `CHECK_PARAM`, the `P` macro errors when the field equals the sentinel:

```c
#define P(x, val) if (param->x == val) errorQuda("Parameter " #x " undefined")
```

So setting the parameter to `false` — a legal value, and the only way to ask QUDA not to buffer the
split gauge — aborted `loadGaugeQuda` with `Parameter use_split_gauge_bkup undefined`. The value has
been unusable since the field was added in cbcb26b, which means **the `OFF` path was unreachable
through the public API**.

Now uses `QUDA_BOOLEAN_INVALID`, as every other boolean in the file does. The default is unchanged:
still `QUDA_BOOLEAN_TRUE`, set in the `INIT_PARAM` branch at `:126`.

Also fixes the `SPLITE` typos left over from the rename in 0017931.

## Testing

Two ranks on a GH200 node, split into two sub-partitions, 93 gtest solver configurations × 4
`invertMultiSrcQuda` calls each = 372 multi-RHS solves against a single loaded gauge field
(`init()` is called once, before `RUN_ALL_TESTS()`):

```bash
srun -N 1 -n 2 ./staggered_invert_test \
    --dim 8 8 8 8 --gridsize 1 1 1 2 \
    --grid-partition 1 1 1 2 \
    --nsrc 8 --nsrc-tile 2 \
    --enable-testing 1 \
    --use-split-gauge-bkup {0,1} \
    --verbosity debug
```

| | gauge re-splits | `Reuse split Gauge.` | gtest |
|---|---|---|---|
| **caching** (`--use-split-gauge-bkup 1`), before | 372 | 0 | 93 PASSED |
| **caching**, after | **1** | **371** | 93 PASSED |
| **OFF** (`--use-split-gauge-bkup 0`), before | *aborted in `checkGaugeParam`* | — | — |
| **OFF**, after | 372 | 0 | 93 PASSED |

Reading the table:

- **Caching mode** is the fix: the gauge is split exactly once and reused on all 371 subsequent
  calls, against 372 redundant redistributions before.
- **OFF mode** could not previously be run at all (bug 3). Its post-fix numbers are *deliberately
  unchanged* from `develop`'s behavior — splitting and freeing on every solve — confirming that
  separating `OFF` from `FALSE` did not silently turn `OFF` into caching (bug 2).
- **93/93 gtest cases pass in both modes, before and after**, confirming the bug was always
  performance-only and that the fix does not alter results.

No timing claim is made here: at an 8⁴ local volume the split cost is small and wall-clock is
dominated by autotuning. The split count is the meaningful measure; the wall-clock impact scales
with lattice volume and sub-partition count.