### PR TITLE
Hotfix/nvshmem 3.7.0 new

### DIFF
--- a/include/malloc_quda.h
+++ b/include/malloc_quda.h
@@ -115,6 +115,12 @@ namespace quda {
     void init();
 
     /**
+       @brief Finalize the memory pool allocator.  Pairs with init(); when built
+       with NVSHMEM it also finalizes NVSHMEM (init() bootstraps NVSHMEM).
+    */
+    void finalize();
+
+    /**
        @brief Allocate device-memory.  If free pre-existing allocation exists
        reuse this.
        @param size Size of allocation

--- a/include/malloc_quda.h
+++ b/include/malloc_quda.h
@@ -115,10 +115,10 @@ namespace quda {
     void init();
 
     /**
-       @brief Finalize the memory pool allocator.  Pairs with init(); when built
+       @brief Destroy the memory pool subsystem.  Pairs with init(); when built
        with NVSHMEM it also finalizes NVSHMEM (init() bootstraps NVSHMEM).
     */
-    void finalize();
+    void destroy();
 
     /**
        @brief Allocate device-memory.  If free pre-existing allocation exists

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -1545,6 +1545,11 @@ void endQuda(void)
     initialized = false;
 
     assertAllMemFree();
+
+    // Finalize the pool allocator (and, with NVSHMEM, NVSHMEM itself) while the
+    // GPU context and MPI are still live, before the device is torn down.
+    pool::finalize();
+
     device::destroy();
   }
 

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -1546,9 +1546,9 @@ void endQuda(void)
 
     assertAllMemFree();
 
-    // Finalize the pool allocator (and, with NVSHMEM, NVSHMEM itself) while the
-    // GPU context and MPI are still live, before the device is torn down.
-    pool::finalize();
+    // Destroy the pool subsystem (and, with NVSHMEM, finalize NVSHMEM itself)
+    // while the GPU context and MPI are still live, before the device is torn down.
+    pool::destroy();
 
     device::destroy();
   }

--- a/lib/targets/cuda/malloc.cpp
+++ b/lib/targets/cuda/malloc.cpp
@@ -666,7 +666,7 @@ namespace quda
 #endif
     }
 
-    void finalize()
+    void destroy()
     {
 #if defined(NVSHMEM_COMMS)
       // Pairs with the NVSHMEM bootstrap in init().  NVSHMEM 3.7.0 defers the

--- a/lib/targets/cuda/malloc.cpp
+++ b/lib/targets/cuda/malloc.cpp
@@ -666,6 +666,18 @@ namespace quda
 #endif
     }
 
+    void finalize()
+    {
+#if defined(NVSHMEM_COMMS)
+      // Pairs with the NVSHMEM bootstrap in init().  NVSHMEM 3.7.0 defers the
+      // transport-plugin dlclose to an atexit handler, so without an explicit
+      // finalize the proxy progress thread outlives the transport module and
+      // segfaults when atexit dlcloses it.  Finalize here (collective, with the
+      // GPU context and MPI still live) before the transport is torn down.
+      nvshmem_finalize();
+#endif
+    }
+
     void *host_pinned_malloc_(const char *func, const char *file, int line, size_t nbytes)
     {
       void *ptr = nullptr;

--- a/lib/targets/cuda/target_cuda.cmake
+++ b/lib/targets/cuda/target_cuda.cmake
@@ -528,11 +528,11 @@ if(CUDAToolkit_FOUND)
   target_link_libraries(quda INTERFACE CUDA::cudart_static)
 endif()
 
-CPMAddPackage(
-    NAME CCCL
-    GITHUB_REPOSITORY nvidia/cccl
-    GIT_TAG v3.3.4 # Fetches this tagged commit
-)
+# QUDA/NCI patch: use the CUDA toolkit's CCCL (the one NVSHMEM 3.x links) rather
+# than CPM-downloading a second CCCL, so there is ONE consistent CCCL. QUDA
+# requires CUDAToolkit, so CUDAToolkit_LIBRARY_ROOT points at the toolkit here.
+find_package(CCCL REQUIRED CONFIG
+    HINTS "${CUDAToolkit_LIBRARY_ROOT}/lib/cmake/cccl")
 target_link_libraries(quda PRIVATE CCCL::CCCL)
 
 # nvshmem enabled parts need SEPARABLE_COMPILATION ...
@@ -588,10 +588,13 @@ if(QUDA_NVSHMEM)
     if("${QUDA_NVSHMEM_HOME}" STREQUAL "")
       message(FATAL_ERROR "QUDA_NVSHMEM_HOME must be defined if QUDA_NVSHMEM is set")
     endif()
-    find_library(
-      NVSHMEM_LIBS
-      NAMES nvshmem
-      PATHS "${QUDA_NVSHMEM_HOME}/lib/")
+    # NVSHMEM 3.x config-package linking (QUDA/NCI patch)
+    # NVSHMEM 3.x ships split host/device libs + a CMake config package. Its
+    # NVSHMEMConfig.cmake does find_dependency(CCCL); QUDA is built against the
+    # SAME (CUDA toolkit) CCCL just above (see the CCCL find_package patch), so
+    # this reuses it -> one consistent CCCL, no version clash.
+    find_package(NVSHMEM REQUIRED CONFIG
+      HINTS "${QUDA_NVSHMEM_HOME}/lib/cmake/nvshmem")
     find_path(
       NVSHMEM_INCLUDE
       NAMES nvshmem.h
@@ -600,11 +603,20 @@ if(QUDA_NVSHMEM)
 
   mark_as_advanced(NVSHMEM_LIBS)
   mark_as_advanced(NVSHMEM_INCLUDE)
-  add_library(nvshmem_lib STATIC IMPORTED)
-  set_target_properties(nvshmem_lib PROPERTIES IMPORTED_LOCATION ${NVSHMEM_LIBS})
-  set_target_properties(nvshmem_lib PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
-  set_target_properties(nvshmem_lib PROPERTIES CUDA_RESOLVE_DEVICE_SYMBOLS OFF)
-  set_target_properties(nvshmem_lib PROPERTIES IMPORTED_LINK_INTERFACE_LANGUAGES CUDA)
+  # Resolve NVSHMEM device/host targets across NVSHMEM 3.x config layouts.
+  if(TARGET nvshmem::nvshmem_device)
+    set(QUDA_NVSHMEM_DEVICE_TGT nvshmem::nvshmem_device)
+  elseif(TARGET nvshmem::nvshmem)
+    set(QUDA_NVSHMEM_DEVICE_TGT nvshmem::nvshmem)
+  else()
+    message(FATAL_ERROR "NVSHMEM config package found but no device target "
+                        "(nvshmem::nvshmem_device) is defined")
+  endif()
+  if(TARGET nvshmem::nvshmem_host)
+    set(QUDA_NVSHMEM_HOST_TGT nvshmem::nvshmem_host)
+  else()
+    set(QUDA_NVSHMEM_HOST_TGT ${QUDA_NVSHMEM_DEVICE_TGT})
+  endif()
 
   # set_target_properties(quda_pack PROPERTIES CUDA_ARCHITECTURES ${QUDA_COMPUTE_CAPABILITY})
   target_include_directories(quda_pack PRIVATE dslash_core)
@@ -626,8 +638,14 @@ if(QUDA_NVSHMEM)
     add_dependencies(quda_cpp NVSHMEM)
     add_dependencies(quda_pack NVSHMEM)
   endif()
-  get_filename_component(NVSHMEM_LIBPATH ${NVSHMEM_LIBS} DIRECTORY)
-  target_link_libraries(quda PUBLIC -L${NVSHMEM_LIBPATH} -lnvshmem)
+  # Device lib into quda_pack (device code) AND quda (device link); host into quda.
+  # PRIVATE, not PUBLIC: libquda.so is shared and fully absorbs the nvshmem
+  # device symbols + gets a DT_NEEDED on libnvshmem_host, so consumers (MILC via
+  # find_package(QUDA)) must NOT see nvshmem::* in QUDA's exported interface
+  # (PUBLIC leaked nvshmem::nvshmem_host into QUDATargets.cmake -> MILC configure
+  # failed: "target nvshmem::nvshmem_host not found").
+  target_link_libraries(quda_pack PRIVATE ${QUDA_NVSHMEM_DEVICE_TGT})
+  target_link_libraries(quda PRIVATE ${QUDA_NVSHMEM_HOST_TGT} ${QUDA_NVSHMEM_DEVICE_TGT})
   target_include_directories(quda SYSTEM PUBLIC $<BUILD_INTERFACE:${NVSHMEM_INCLUDE}>)
 endif()
 

--- a/lib/targets/cuda/target_cuda.cmake
+++ b/lib/targets/cuda/target_cuda.cmake
@@ -528,11 +528,20 @@ if(CUDAToolkit_FOUND)
   target_link_libraries(quda INTERFACE CUDA::cudart_static)
 endif()
 
-# QUDA/NCI patch: use the CUDA toolkit's CCCL (the one NVSHMEM 3.x links) rather
-# than CPM-downloading a second CCCL, so there is ONE consistent CCCL. QUDA
-# requires CUDAToolkit, so CUDAToolkit_LIBRARY_ROOT points at the toolkit here.
-find_package(CCCL REQUIRED CONFIG
-    HINTS "${CUDAToolkit_LIBRARY_ROOT}/lib/cmake/cccl")
+option(QUDA_DOWNLOAD_CCCL "Download CCCL v3.3.4 via CPM; OFF = use the CUDA toolkit's CCCL" ON)
+if(QUDA_DOWNLOAD_CCCL)
+  CPMAddPackage(
+      NAME CCCL
+      GITHUB_REPOSITORY nvidia/cccl
+      GIT_TAG v3.3.4 # Fetches this tagged commit
+  )
+else()
+  # Use the CUDA toolkit's CCCL (the same one NVSHMEM 3.x's config find_dependency
+  # resolves to) so QUDA and NVSHMEM share ONE CCCL -> no libcudacxx/cub clash.
+  # QUDA requires CUDAToolkit, so CUDAToolkit_LIBRARY_ROOT points at the toolkit.
+  find_package(CCCL REQUIRED CONFIG
+      HINTS "${CUDAToolkit_LIBRARY_ROOT}/lib/cmake/cccl")
+endif()
 target_link_libraries(quda PRIVATE CCCL::CCCL)
 
 # nvshmem enabled parts need SEPARABLE_COMPILATION ...

--- a/lib/targets/hip/malloc.cpp
+++ b/lib/targets/hip/malloc.cpp
@@ -615,9 +615,9 @@ namespace quda
       }
     }
 
-    void finalize()
+    void destroy()
     {
-      // Pairs with init() to satisfy the target-agnostic pool::finalize()
+      // Pairs with init() to satisfy the target-agnostic pool::destroy()
       // declaration.  The HIP target bootstraps no NVSHMEM in init(), so there
       // is nothing to tear down here -- this is a deliberate no-op stub (the
       // CUDA target finalizes NVSHMEM in its counterpart).

--- a/lib/targets/hip/malloc.cpp
+++ b/lib/targets/hip/malloc.cpp
@@ -615,6 +615,14 @@ namespace quda
       }
     }
 
+    void finalize()
+    {
+      // Pairs with init() to satisfy the target-agnostic pool::finalize()
+      // declaration.  The HIP target bootstraps no NVSHMEM in init(), so there
+      // is nothing to tear down here -- this is a deliberate no-op stub (the
+      // CUDA target finalizes NVSHMEM in its counterpart).
+    }
+
     void *host_pinned_malloc_(const char *func, const char *file, int line, size_t nbytes)
     {
       void *ptr = nullptr;


### PR DESCRIPTION
Minor changes to do with NVSHMEM-3.7 but which should work with 3.4.5 as well (3.6 had some header include issues). 
* CCCL Download option: Optionally download CCCL if not available in the toolkit. Currently QUDA downloads CCCL-3.1.4, but if available in toolkit, the toolkit version may be different. If NVSHMEM was built against the toolkit version of CCCL, then we may not want to download a different version
* Fix to use NVSHMEM's CMake support rather than using '-lnvshmem' flags
* Previously QUDA called nvshmem_initialize() in pool::init() and never explicitly called nvshmem_finalize(). With recent NVSHMEM versions it is a good idea to call nvshmem_finalize() otherwise finalization can occur in C++ __atexit() and this can result in segfaults in QUDA. I have added a pool::finalize() which explicitly calls nvshmem_finalize() -- guarded by #ifdef NVSHMEM_COMMS . I call pool::finalize() in endQuda(). This avoids the segfault.
* Rebased on QUDA develop.