### PR TITLE
Eigensolver fixes

### DIFF
--- a/include/quda.h
+++ b/include/quda.h
@@ -483,13 +483,20 @@ extern "C" {
     /** Type of eigensolver algorithm to employ **/
     QudaEigType eig_type;
 
-    /** Use Polynomial Acceleration **/
+    /** Use Polynomial Acceleration.  The Chebyshev polynomial applied by the
+        eigensolver is small on [a_min, a_max] and large only below a_min, so it
+        accelerates the smallest-real spectrum alone.  Combining this with
+        spectrum = QUDA_SPECTRUM_LR_EIG is an error. **/
     QudaBoolean use_poly_acc;
 
     /** Degree of the Chebysev polynomial **/
     int poly_deg;
 
-    /** Range used in polynomial acceleration **/
+    /** Range suppressed by the polynomial acceleration.  a_max should bound the
+        largest eigenvalue of the operator from above; if it is zero it is estimated
+        by power iteration.  a_min is the cut below which eigenvalues are amplified,
+        and should be strictly positive -- a_min = 0 yields a degenerate polynomial
+        that neither suppresses nor amplifies. **/
     double a_min;
     double a_max;
 

--- a/lib/eig_block_trlm.cpp
+++ b/lib/eig_block_trlm.cpp
@@ -117,7 +117,7 @@ namespace quda
         if (eig_param->spectrum == QUDA_SPECTRUM_LR_EIG)
           return mat_norm;
         else
-          return fabs(sr_norm);
+          return sr_norm;
       };
 
       // Locking check
@@ -419,14 +419,10 @@ namespace quda
       }
     }
 
-    // Invert the spectrum due to Chebyshev (except the arrow diagonal)
+    // Invert the spectrum due to Chebyshev
     if (reverse) {
       for (int b = 0; b < dim; b++) {
-        for (int c = 0; c < dim; c++) {
-          T(c, b) *= -1.0;
-          if (restart_iter > 0)
-            if (b == c && b < arrow_pos && c < arrow_pos) T(c, b) *= -1.0;
-        }
+        for (int c = 0; c < dim; c++) { T(c, b) *= -1.0; }
       }
     }
 
@@ -436,6 +432,11 @@ namespace quda
 
     // Populate the alpha array with eigenvalues
     for (int i = 0; i < dim; i++) alpha[i + num_locked] = eigensolver.eigenvalues()[i];
+
+    // Put spectrum back in order
+    if (reverse) {
+      for (int i = num_locked; i < n_kr; i++) { alpha[i] *= -1.0; }
+    }
 
     // Repopulate ritz matrix: COLUMN major
     for (int i = 0; i < dim; i++)

--- a/lib/eigensolve_quda.cpp
+++ b/lib/eigensolve_quda.cpp
@@ -187,7 +187,7 @@ namespace quda
       if (eig_param->a_min >= eig_param->a_max)
         errorQuda("Invalid a_min = %e a_max = %e combination", eig_param->a_min, eig_param->a_max);
       if (eig_param->a_min <= 0.0)
-	warningQuda("Chebyshev minimum a_min = %e is non-positive. Acceleration may be ineffective.", eig_param->a_min);
+        warningQuda("Chebyshev minimum a_min = %e is non-positive. Acceleration may be ineffective.", eig_param->a_min);
     }
   }
 

--- a/lib/eigensolve_quda.cpp
+++ b/lib/eigensolve_quda.cpp
@@ -75,12 +75,13 @@ namespace quda
     if (spectrum.compare(0, 1, "L") == 0 && !eig_param->use_poly_acc) {
       reverse = true;
     } else if (spectrum.compare(0, 1, "S") == 0 && eig_param->use_poly_acc) {
+      // The polynomial in chebyOp() is small on [a_min, a_max] and large below a_min,
+      // so the smallest-real eigenvalues of the operator are the largest-real
+      // eigenvalues of the accelerated operator.
       reverse = true;
       spectrum[0] = 'L';
-    } else if (spectrum.compare(0, 1, "L") == 0 && eig_param->use_poly_acc) {
-      reverse = true;
-      spectrum[0] = 'S';
     }
+    // LR under polynomial acceleration is rejected in EigenSolver::create().
 
     // For normal operators (MdagM, MMdag) the SVD of the
     // underlying operators (M, Mdag) is computed.
@@ -127,6 +128,10 @@ namespace quda
     if (eig_param->use_poly_acc) {
       if (!mat.hermitian()) errorQuda("Cannot use polynomial acceleration with non-Hermitian operator");
       if (!eig_solver->hermitian()) errorQuda("Polynomial acceleration not supported with non-Hermitian solver");
+      // chebyOp() builds a polynomial that is small on [a_min, a_max] and large only
+      // below a_min, so it can accelerate the smallest-real spectrum alone.
+      if (eig_param->spectrum != QUDA_SPECTRUM_SR_EIG)
+        errorQuda("Polynomial acceleration is supported for the smallest-real (SR) spectrum only");
     }
 
     // Cannot solve for imaginary spectrum of hermitian systems

--- a/lib/eigensolve_quda.cpp
+++ b/lib/eigensolve_quda.cpp
@@ -335,10 +335,8 @@ namespace quda
     // Power iteration
     double norm = 0.0;
     for (int i = 0; i < 100; i++) {
-      if ((i + 1) % 10 == 0) {
-        norm = sqrt(blas::norm2(in));
-        blas::ax(1.0 / norm, in);
-      }
+      norm = sqrt(blas::norm2(in));
+      blas::ax(1.0 / norm, in);
       mat(out, in);
       std::swap(out, in);
     }

--- a/lib/eigensolve_quda.cpp
+++ b/lib/eigensolve_quda.cpp
@@ -182,8 +182,12 @@ namespace quda
         eig_param->a_max = estimateChebyOpMax(kSpace[block_size + 2], kSpace[block_size + 1]);
         logQuda(QUDA_SUMMARIZE, "Chebyshev maximum estimate: %e.\n", eig_param->a_max);
       }
+      if (!std::isfinite(eig_param->a_max))
+        errorQuda("Chebyshev maximum estimate is not finite (a_max = %e)", eig_param->a_max);
       if (eig_param->a_min >= eig_param->a_max)
         errorQuda("Invalid a_min = %e a_max = %e combination", eig_param->a_min, eig_param->a_max);
+      if (eig_param->a_min <= 0.0)
+	warningQuda("Chebyshev minimum a_min = %e is non-positive. Acceleration may be ineffective.", eig_param->a_min);
     }
   }
 

--- a/tests/utils/command_line_params.cpp
+++ b/tests/utils/command_line_params.cpp
@@ -238,7 +238,9 @@ bool eig_use_dagger = false;
 bool eig_use_pc = false;
 bool eig_compute_svd = false;
 bool eig_compute_gamma5 = false;
-QudaEigSpectrumType eig_spectrum = QUDA_SPECTRUM_LR_EIG;
+// SR is the default because polynomial acceleration, which defaults to on above,
+// supports the smallest-real spectrum only.
+QudaEigSpectrumType eig_spectrum = QUDA_SPECTRUM_SR_EIG;
 QudaEigType eig_type = QUDA_EIG_TR_LANCZOS;
 bool eig_arpack_check = false;
 std::string eig_arpack_logfile = "arpack_logfile.log";
@@ -802,7 +804,8 @@ void add_eigen_option_group(std::shared_ptr<QUDAApp> quda_app)
   opgroup->add_option("--eig-n-kr", eig_n_kr, "The size of the Krylov subspace to use in the eigensolver");
   opgroup->add_option("--eig-batched-rotate", eig_batched_rotate,
                       "The maximum number of extra eigenvectors the solver may allocate to perform a Ritz rotation.");
-  opgroup->add_option("--eig-poly-deg", eig_poly_deg, "TODO");
+  opgroup->add_option("--eig-poly-deg", eig_poly_deg,
+                      "Degree of the Chebyshev polynomial used for acceleration (default 100)");
   opgroup->add_option(
     "--eig-require-convergence",
     eig_require_convergence, "If true, the solver will error out if convergence is not attained. If false, a warning will be given (default true)");
@@ -838,7 +841,8 @@ void add_eigen_option_group(std::shared_ptr<QUDAApp> quda_app)
   opgroup->add_option(
     "--eig-use-pc", eig_use_pc,
     "Solve the Even-Odd preconditioned problem (default false for Wilson-type, true for staggered-type)");
-  opgroup->add_option("--eig-use-poly-acc", eig_use_poly_acc, "Use Chebyshev polynomial acceleration in the eigensolver");
+  opgroup->add_option("--eig-use-poly-acc", eig_use_poly_acc,
+                      "Use Chebyshev polynomial acceleration in the eigensolver (smallest-real spectrum only)");
 }
 
 void add_deflation_option_group(std::shared_ptr<QUDAApp> quda_app)


### PR DESCRIPTION
This PR implements several eigensolver fixes for issues that I ran into over the past ~2 years when tuning staggered multigrid (at the coarsest level an eigensolve and deflation are done). I had fixed some of these locally but never upstreamed those fixes. I'm finally getting around to fix them with a little help from Claude Code.

## Issue 1: Requesting LR spectrum with `use_poly_acc` silently returns the SR spectrum

In QUDA, Chebyshev acceleration is only supported for the smallest-real (SR) spectrum. In principle, we could add support for the largest-real (LR) spectrum rather easily, however, it may not be worth the work given that we generally want the SR spectrum. The issue was that if the LR spectrum was requested with polynomial acceleration enabled, then QUDA returned the SR spectrum with no warning. It returned correct eigenvalues but the wrong end of the spectrum.

### What this PR does:

1. **`lib/eigensolve_quda.cpp`** — `errorQuda` on LR + `use_poly_acc`, in the existing
   polynomial-acceleration sanity block in `EigenSolver::create()`. Every construction
   site routes through `create()` (`multigrid.cpp` ×4, `solver.cpp:269`,
   `interface_quda.cpp:2829`, `quda_arpack_interface.cpp:35`), so one guard also covers
   ARPACK, which has the same latent bug at `quda_arpack_interface.cpp:97` — it maps
   `SR` → `LR` for the polynomial operator but leaves `LR` untouched.
2. **`lib/eigensolve_quda.cpp`** — remove the now-unreachable constructor branch and
   its misleading `spectrum[0] = 'S'`.
3. **`tests/utils/command_line_params.cpp`** — default `eig_spectrum` to
   `QUDA_SPECTRUM_SR_EIG`. Required: without it, change 1 makes `eigensolve_test` and
   `staggered_eigensolve_test` abort with no arguments. The numbers don't change. This
   previously defaulted to LR + poly acc which in reality was returning SR. It now
   defaults to SR + poly acc.
4. **`include/quda.h`, `tests/utils/command_line_params.cpp`** — document the SR-only
   restriction on `use_poly_acc`, document `a_min`/`a_max` as the *suppressed* range,
   and replace the `"TODO"` help string on `--eig-poly-deg`.

Testing afterward shows that LR + poly acc now correctly errors. LR without poly acc
and SR with poly acc run as before.

## Issue 2: Block TRLM doesn't restore the Ritz-value sign after the Chebyshev inversion

When the SR spectrum is requested with polynomial acceleration, both TRLM and BlockTRLM
negate the tridiagonal/arrow matrix to invert the Chebyshev spectrum. Then
`TRLM::eigensolveFromArrowMat` negates the resulting eigenvalues back (`lib/eig_trlm.cpp:311–314`).
However, `BlockTRLM::eigensolveFromBlockArrowMat` performs the same inversion
(`lib/eig_block_trlm.cpp:422–430`) but has no counterpart to reverse the spectrum. The
Ritz values in the block path are therefore sign inverted.

The consequence that was noted was a negative `check_norm` resulting in the locking and
convergence tests never being satisfiable and BlockTRLM spinning forever. The *symptom* was
fixed in PR #1564 by simply using the absolute value of `check_norm`. This unblocked the
solver. However, the better fix would be for BlockTRLM to reverse the final spectrum
to mirror what TRLM does.

### What this PR does:

1. **`lib/eig_block_trlm.cpp`** — Remove the old "symptom fix" `fabs(sr_norm)` --> `sr_norm`
2. **`lib/eig_block_trlm.cpp`** — If (reverse) revert the spectrum including now the arrow
   diagonal.
3. **`lib/eig_block_trlm.cpp`** — Put the spectrum back in order as is done in regular TRLM.

Testing afterwards shows that eigenvalues/residuals are identical but Ritz values are all
positive now. Previously, BlockTRLM showed negative Ritz values.

## Issue 3: `estimateChebyOpMax()` renormalizes only every 10th power iteration

The upper Chebyshev bound `a_max` is estimated (when passed a value of 0) via power iterations
by a call to `estimateChebyOpMax()`. Here, only every 10th iteration is renormalized, which
means ten applications of `mat` occur between renormalizations. In typical usage, where `mat`
is e.g. the staggered normal operator with maximum eigenvalues ~21, this is fine. However, with
staggered multigrid, this is definitely not fine!

In staggered MG, the Kahler-Dirac blocks can get pathological resulting in inverses with very
large eigenvalues. This was seen in practice during multigrid tuning of the 0.04 fm lattice
where the value of `norm2` was observed growing 1.77e6 → … → 1.1e77, then 0, then NaN. The
resulting eigensolve fails and not even in a good way (see next issue).

### What this PR does:

1. **`lib/eigensolve_quda.cpp`** — Have `estimateChebyOpMax()` renormalize every power iteration
   instead of every 10th.

The extra work per iteration should be small relative to the application of `mat`.

## Issue 4: Insufficient sanity checks on `a_max` and `a_min`

Previously, `a_max = nan` could occur (see Issue 3), and when this happens, the TRLM converges
zero eigenvalues at every restart and the job runs until it hits the max TRLM restarts or the
wall clock.

Also, `checkChebyOpMax` errors if `a_min >= a_max` but it never checks that `a_min > 0`. Is
`a_min < 0` ever useful? Perhaps for a different operator? Regardless, a value of exactly
`a_min = 0` (which is the default) results in a Chebyshev polynomial that does all the work
but gives no suppression/acceleration--i.e. there's nothing in `[0, a_min]` to be amplified.

### What this PR does:

1. **`lib/eigensolve_quda.cpp`** — Have `checkChebyOpMax()` fail with a loud `errorQuda` if
   `a_max` is not finite.
2. **`lib/eigensolve_quda.cpp`** — Have `checkChebyOpMax()` warn if `a_min <= 0`.