### PR TITLE
QUDA_KDINVERSE_GEOMETRY allocates gauge fields 4x too large

### DIFF
--- a/lib/gauge_field.cpp
+++ b/lib/gauge_field.cpp
@@ -116,7 +116,7 @@ namespace quda {
       length = 2*2*nDim*stride*nInternal;  //two comes from being full lattice
     } else if (geometry == QUDA_KDINVERSE_GEOMETRY) {
       real_length = (1 << nDim) * volume * nInternal;
-      length = 2 * (1 << nDim) * nDim * stride * nInternal; // two comes from being full lattice
+      length = 2 * (1 << nDim) * stride * nInternal; // two comes from being full lattice
     }
 
     switch (geometry) {


### PR DESCRIPTION
The `QUDA_KDINVERSE_GEOMETRY` gauge fields appear to be allocated 4x too large (unnecessary factor of `ndim`) in `lib/gauge_field.cpp`.

For all other geometries in this block, `length` can be obtained from `real_length` by replacing `volume` with `2 * stride`, but for `QUDA_KDINVERSE_GEOMETRY` there is a seemingly unnecessary factor of `ndim` thrown in. Claude Opus 5, who discovered this discrepancy after being asked to construct a model for multigrid's device memory usage, thinks the `ndim` is unnecessary here.  @weinbe2 probably knows better than Claude whether that's true or not.

The cost of the `ndim` is two gauge fields per MG solve that are 4x too large. A real test at 0.04 fm with and without this fix shows that the fix saved ~4.6 GB of device memory per GPU and had no adverse effect on solve conversion, iteration count, or time.