### PR TITLE
hip: support multi-architecture builds in target_hip.cmake

### DIFF
--- a/lib/targets/hip/target_hip.cmake
+++ b/lib/targets/hip/target_hip.cmake
@@ -93,11 +93,14 @@ mark_as_advanced(QUDA_LARGE_KERNEL_ARG)
 
 # ######################################################################################################################
 # HIP specific variables
-set_target_properties(quda PROPERTIES HIP_ARCHITECTURES ${CMAKE_HIP_ARCHITECTURES})
+set_property(TARGET quda PROPERTY HIP_ARCHITECTURES ${CMAKE_HIP_ARCHITECTURES})
+
+# scalar spelling of the architecture list, for identifiers that cannot hold a ";"
+string(JOIN "+" QUDA_GPU_ARCH_TAG ${QUDA_GPU_ARCH})
 
 # QUDA_HASH for tunecache
-set(HASH cpu_arch=${CPU_ARCH},gpu_arch=${QUDA_GPU_ARCH},hip_version=${CMAKE_HIP_COMPILER_VERSION})
-set(GITVERSION "${PROJECT_VERSION}-${GITVERSION}-${QUDA_GPU_ARCH}")
+set(HASH cpu_arch=${CPU_ARCH},gpu_arch=${QUDA_GPU_ARCH_TAG},hip_version=${CMAKE_HIP_COMPILER_VERSION})
+set(GITVERSION "${PROJECT_VERSION}-${GITVERSION}-${QUDA_GPU_ARCH_TAG}")
 
 
 


### PR DESCRIPTION
QUDA_GPU_ARCH is a CMake list, but target_hip.cmake used it in two places that require a scalar, so a value such as "gfx942;gfx950" failed to configure.

set_target_properties() takes name/value pairs, so an unquoted list expanded into two arguments and CMake aborted with "called with incorrect number of arguments". set_property(TARGET ... PROPERTY ...) treats everything after the property name as the value, so the list reaches HIP_ARCHITECTURES intact and both architectures are compiled.

QUDA_HASH and GITVERSION embed the architecture in a scalar string that ends up in a -D compiler definition. COMPILE_DEFINITIONS is a list property, so an embedded semicolon split one definition into two, producing a malformed flag and a compile error where QUDA_HASH is consumed in lib/tune.cpp. Quoting does not help; the semicolon has to go. QUDA_GPU_ARCH_TAG joins the list with "+", which is safe in CMake strings, compiler definitions, filenames and version metadata. It is used only for those two identifiers -- HIP_ARCHITECTURES still gets the real list.

Single-architecture builds are unchanged: the tag of "gfx942" is "gfx942".

Verified on ROCm with QUDA_GPU_ARCH="gfx942;gfx950": configure succeeds, QUDA_HASH and GITVERSION are single well-formed definitions, and every HIP compile line carries both --offload-arch=gfx942 and --offload-arch=gfx950.