### PR TITLE
hip: drop the hardcoded hipfft include path

### DIFF
--- a/lib/targets/hip/target_hip.cmake
+++ b/lib/targets/hip/target_hip.cmake
@@ -135,7 +135,6 @@ set_source_files_properties( ${QUDA_CU_OBJS} PROPERTIES LANGUAGE HIP)
 target_link_libraries(quda PUBLIC hip::hiprand roc::rocrand hip::hipcub roc::rocprim_hip)
 target_link_libraries(quda PUBLIC roc::hipblas roc::rocblas)
 
-target_include_directories(quda PUBLIC ${ROCM_PATH}/hipfft/include)
 target_link_libraries(quda PUBLIC hip::hipfft)
 
 add_subdirectory(targets/hip)


### PR DESCRIPTION
`lib/targets/hip/target_hip.cmake` has:

```cmake
target_include_directories(quda PUBLIC ${ROCM_PATH}/hipfft/include)
```

`/opt/rocm/hipfft/include` has not existed since the ROCm 5 layout change; on ROCm 7.14 the headers are under `/opt/rocm/include/hipfft`.

Because the path is `PUBLIC` it ends up in the installed target's `INTERFACE_INCLUDE_DIRECTORIES`, and CMake hard-errors any project that consumes the QUDA package:

```
CMake Error in lib/CMakeLists.txt:
  Imported target "QUDA::quda" includes non-existent path

    "/opt/rocm/hipfft/include"

  in its INTERFACE_INCLUDE_DIRECTORIES.
```

QUDA itself builds and installs without a warning, so this is invisible until something downstream calls `find_package(QUDA)` — here, Chroma, which died three seconds into its configure after a 17-minute QUDA build. An application that links QUDA directly rather than through the CMake package never sees it, which is why it has gone unnoticed.

The line is also unnecessary on any ROCm: `hip::hipfft` on the next line carries its own include directories, and `include/targets/hip/FFT_Plans.h` includes `<hipfft/hipfft.h>`, which resolves from the default HIP include path. QUDA compiles clean with the line removed — the `-I` was already pointing at nothing during that 17-minute build.

## Testing

ROCm 7.14, MI355X, `QUDA_TARGET_TYPE=HIP`, `QUDA_GPU_ARCH=gfx942;gfx950`, built with `QUDA_QDPJIT=ON -DQUDA_INTERFACE_QDPJIT=ON` against QDP-JIT.

- QUDA configures, builds and installs; `libquda.so` carries both architectures.
- Chroma's `find_package(QUDA)` now succeeds, and Chroma builds and links against the installed package. It did not before this change.